### PR TITLE
Coordinating node search stats with end-to-end search qps and latency

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingIndiceStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingIndiceStats.java
@@ -1,0 +1,100 @@
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.metrics.CounterMetric;
+import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author kyra.wkh
+ **/
+public class CoordinatingIndiceStats implements Writeable, ToXContentFragment {
+
+    public String indexName;
+    public final Map<String, CounterMetric> counterMetricMap;
+    public final Map<String, MeanMetric> meanMatricMap;
+
+    public CoordinatingIndiceStats(String indexName, Map<String, CounterMetric> counterMetricMap, Map<String, MeanMetric> meanMetricMap) {
+        this.indexName = indexName;
+        this.counterMetricMap = (counterMetricMap == null ? new ConcurrentHashMap<>() : counterMetricMap);
+        this.meanMatricMap = (meanMetricMap == null ? new ConcurrentHashMap<>() : meanMetricMap);
+    }
+
+    public CoordinatingIndiceStats(StreamInput in) throws IOException {
+        this.counterMetricMap = new ConcurrentHashMap<>();
+        this.meanMatricMap = new ConcurrentHashMap<>();
+
+        this.indexName = in.readString();
+        counterMetricMap.putAll(in.readMap(StreamInput::readString, stream -> {
+            long value = stream.readVLong();
+            CounterMetric counterMetric = new CounterMetric();
+            counterMetric.inc(value);
+            return counterMetric;
+        }));
+
+        meanMatricMap.putAll(in.readMap(StreamInput::readString, stream ->
+            new MeanMetric(stream.readVLong(), stream.readVLong())
+        ));
+    }
+
+    public CoordinatingIndiceStats add(CoordinatingIndiceStats other) {
+        for(String metricName : other.meanMatricMap.keySet()) {
+            MeanMetric current = meanMatricMap.get(metricName);
+            MeanMetric otherValue = other.meanMatricMap.get(metricName);
+            if (current == null) {
+                meanMatricMap.put(metricName, new MeanMetric(otherValue.count(), otherValue.sum()));
+            } else {
+                current.merge(otherValue);
+            }
+        }
+
+        for(String metricName : other.counterMetricMap.keySet()) {
+            CounterMetric current = counterMetricMap.get(metricName);
+            CounterMetric otherValue = other.counterMetricMap.get(metricName);
+            if (current == null) {
+                CounterMetric counterMetric = new CounterMetric();
+                counterMetric.inc(otherValue.count());
+                counterMetricMap.put(metricName, counterMetric);
+            } else {
+                current.inc(otherValue.count());
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(indexName);
+        out.writeMap(counterMetricMap, StreamOutput::writeString, (stream, counterMetric) -> stream.writeVLong(counterMetric.count()));
+        out.writeMap(meanMatricMap, StreamOutput::writeString, (stream, meanMetric) -> {
+            stream.writeVLong(meanMetric.count());
+            stream.writeVLong(meanMetric.sum());
+        });
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("index", indexName);
+        builder.startObject("stats");
+        for(Entry<String, CounterMetric> counterMetricEntry : counterMetricMap.entrySet()) {
+            String metricName = counterMetricEntry.getKey();
+            CounterMetric metric = counterMetricEntry.getValue();
+            builder.field(metricName, metric.count());
+        }
+        for(Entry<String, MeanMetric> counterMetricEntry : meanMatricMap.entrySet()) {
+            String metricName = counterMetricEntry.getKey();
+            MeanMetric meanMetric = counterMetricEntry.getValue();
+            builder.field(metricName, meanMetric.sum());
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingStats.java
@@ -1,0 +1,71 @@
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.metrics.MetricsConstant;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author kyra.wkh
+ */
+public class CoordinatingStats implements Writeable, ToXContentFragment {
+
+    private final List<CoordinatingIndiceStats> indiceStatsList;
+
+    public CoordinatingStats(List<CoordinatingIndiceStats> indiceStatsList) {
+        this.indiceStatsList = indiceStatsList;
+    }
+
+    public CoordinatingStats(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        this.indiceStatsList = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            indiceStatsList.add(new CoordinatingIndiceStats(in));
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(indiceStatsList.size());
+        for (CoordinatingIndiceStats stats : indiceStatsList) {
+            stats.writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(MetricsConstant.COORDINATING);
+        builder.startObject("total");
+        CoordinatingIndiceStats totalStats = getTotal();
+        totalStats.toXContent(builder, params);
+        builder.endObject();
+        builder.startArray("indices");
+        for (CoordinatingIndiceStats stats : getIndiceStats()) {
+            builder.startObject();
+            stats.toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+
+    protected CoordinatingIndiceStats getTotal() {
+        CoordinatingIndiceStats totalIndiceStats = new CoordinatingIndiceStats("_all", new HashMap<>(), new HashMap<>());
+        for (CoordinatingIndiceStats stats : indiceStatsList) {
+            totalIndiceStats.add(stats);
+        }
+        return totalIndiceStats;
+    }
+
+    protected List<CoordinatingIndiceStats> getIndiceStats() {
+        return indiceStatsList;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -88,6 +88,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     private IngestStats ingestStats;
 
     @Nullable
+    private CoordinatingStats coordinatingStats;
+
+    @Nullable
     private AdaptiveSelectionStats adaptiveSelectionStats;
 
     public NodeStats(StreamInput in) throws IOException {
@@ -107,6 +110,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         scriptStats = in.readOptionalWriteable(ScriptStats::new);
         discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
         ingestStats = in.readOptionalWriteable(IngestStats::new);
+        coordinatingStats = in.readOptionalWriteable(CoordinatingStats::new);
         adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
     }
 
@@ -117,6 +121,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
                      @Nullable ScriptStats scriptStats,
                      @Nullable DiscoveryStats discoveryStats,
                      @Nullable IngestStats ingestStats,
+                     @Nullable CoordinatingStats coordinatingStats,
                      @Nullable AdaptiveSelectionStats adaptiveSelectionStats) {
         super(node);
         this.timestamp = timestamp;
@@ -132,6 +137,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         this.scriptStats = scriptStats;
         this.discoveryStats = discoveryStats;
         this.ingestStats = ingestStats;
+        this.coordinatingStats = coordinatingStats;
         this.adaptiveSelectionStats = adaptiveSelectionStats;
     }
 
@@ -223,6 +229,11 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     }
 
     @Nullable
+    public CoordinatingStats getCoordinatingStats() {
+        return coordinatingStats;
+    }
+
+    @Nullable
     public AdaptiveSelectionStats getAdaptiveSelectionStats() {
         return adaptiveSelectionStats;
     }
@@ -248,6 +259,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(scriptStats);
         out.writeOptionalWriteable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);
+        out.writeOptionalWriteable(coordinatingStats);
         out.writeOptionalWriteable(adaptiveSelectionStats);
     }
 
@@ -308,6 +320,9 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         }
         if (getIngestStats() != null) {
             getIngestStats().toXContent(builder, params);
+        }
+        if (getCoordinatingStats() != null) {
+            getCoordinatingStats().toXContent(builder, params);
         }
         if (getAdaptiveSelectionStats() != null) {
             getAdaptiveSelectionStats().toXContent(builder, params);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -43,6 +43,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
     private boolean script;
     private boolean discovery;
     private boolean ingest;
+    private boolean coordinating;
     private boolean adaptiveSelection;
 
     public NodesStatsRequest() {
@@ -63,6 +64,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         script = in.readBoolean();
         discovery = in.readBoolean();
         ingest = in.readBoolean();
+        coordinating = in.readBoolean();
         adaptiveSelection = in.readBoolean();
     }
 
@@ -90,6 +92,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         this.script = true;
         this.discovery = true;
         this.ingest = true;
+        this.coordinating = true;
         this.adaptiveSelection = true;
         return this;
     }
@@ -110,6 +113,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         this.script = false;
         this.discovery = false;
         this.ingest = false;
+        this.coordinating = false;
         this.adaptiveSelection = false;
         return this;
     }
@@ -286,6 +290,15 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         return this;
     }
 
+    public boolean coordinating() {
+        return coordinating;
+    }
+
+    public NodesStatsRequest coordinating(boolean coordinating) {
+        this.coordinating = coordinating;
+        return this;
+    }
+
     public boolean adaptiveSelection() {
         return adaptiveSelection;
     }
@@ -313,6 +326,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         out.writeBoolean(script);
         out.writeBoolean(discovery);
         out.writeBoolean(ingest);
+        out.writeBoolean(coordinating);
         out.writeBoolean(adaptiveSelection);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -70,7 +70,7 @@ public class TransportNodesStatsAction extends TransportNodesAction<NodesStatsRe
         NodesStatsRequest request = nodeStatsRequest.request;
         return nodeService.stats(request.indices(), request.os(), request.process(), request.jvm(), request.threadPool(),
                 request.fs(), request.transport(), request.http(), request.breaker(), request.script(), request.discovery(),
-                request.ingest(), request.adaptiveSelection());
+                request.ingest(), request.coordinating(), request.adaptiveSelection());
     }
 
     public static class NodeStatsRequest extends BaseNodeRequest {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -95,7 +95,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<ClusterSta
     protected ClusterStatsNodeResponse nodeOperation(ClusterStatsNodeRequest nodeRequest, Task task) {
         NodeInfo nodeInfo = nodeService.info(true, true, false, true, false, true, false, true, false, false);
         NodeStats nodeStats = nodeService.stats(CommonStatsFlags.NONE,
-                true, true, true, false, true, false, false, false, false, false, true, false);
+                true, true, true, false, true, false, false, false, false, false, true, false, false);
         List<ShardStats> shardsStats = new ArrayList<>();
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.transport.Transport;
@@ -54,11 +55,12 @@ final class CanMatchPreFilterSearchPhase extends AbstractSearchAsyncAction<Searc
                                         ActionListener<SearchResponse> listener, GroupShardsIterator<SearchShardIterator> shardsIts,
                                         TransportSearchAction.SearchTimeProvider timeProvider, long clusterStateVersion,
                                         SearchTask task, Function<GroupShardsIterator<SearchShardIterator>, SearchPhase> phaseFactory,
-                                        SearchResponse.Clusters clusters) {
+                                        SearchResponse.Clusters clusters,
+                                        CoordinatingIndicesStatsCollector coordinatingIndicesStatsCollector) {
         //We set max concurrent shard requests to the number of shards so no throttling happens for can_match requests
         super("can_match", logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, indexRoutings,
                 executor, request, listener, shardsIts, timeProvider, clusterStateVersion, task,
-                new BitSetSearchPhaseResults(shardsIts.size()), shardsIts.size(), clusters);
+                new BitSetSearchPhaseResults(shardsIts.size()), shardsIts.size(), clusters, coordinatingIndicesStatsCollector);
         this.phaseFactory = phaseFactory;
         this.shardsIts = shardsIts;
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.search.dfs.DfsSearchResult;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.transport.Transport;
@@ -42,11 +43,12 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
             final SearchPhaseController searchPhaseController, final Executor executor,
             final SearchRequest request, final ActionListener<SearchResponse> listener,
             final GroupShardsIterator<SearchShardIterator> shardsIts, final TransportSearchAction.SearchTimeProvider timeProvider,
-            final long clusterStateVersion, final SearchTask task, SearchResponse.Clusters clusters) {
+            final long clusterStateVersion, final SearchTask task, SearchResponse.Clusters clusters,
+            final CoordinatingIndicesStatsCollector coordinatingIndicesStatsCollector) {
         super("dfs", logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, indexRoutings,
                 executor, request, listener,
                 shardsIts, timeProvider, clusterStateVersion, task, new ArraySearchPhaseResults<>(shardsIts.size()),
-                request.getMaxConcurrentShardRequests(), clusters);
+                request.getMaxConcurrentShardRequests(), clusters, coordinatingIndicesStatsCollector);
         this.searchPhaseController = searchPhaseController;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.transport.Transport;
@@ -42,10 +43,11 @@ final class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<Se
             final SearchPhaseController searchPhaseController, final Executor executor,
             final SearchRequest request, final ActionListener<SearchResponse> listener,
             final GroupShardsIterator<SearchShardIterator> shardsIts, final TransportSearchAction.SearchTimeProvider timeProvider,
-            long clusterStateVersion, SearchTask task, SearchResponse.Clusters clusters) {
+            long clusterStateVersion, SearchTask task, SearchResponse.Clusters clusters,
+            final CoordinatingIndicesStatsCollector coordinatingIndicesStatsCollector) {
         super("query", logger, searchTransportService, nodeIdToConnection, aliasFilter, concreteIndexBoosts, indexRoutings,
                 executor, request, listener, shardsIts, timeProvider, clusterStateVersion, task,
-                searchPhaseController.newSearchPhaseResults(request, shardsIts.size()), request.getMaxConcurrentShardRequests(), clusters);
+                searchPhaseController.newSearchPhaseResults(request, shardsIts.size()), request.getMaxConcurrentShardRequests(), clusters, coordinatingIndicesStatsCollector);
         this.searchPhaseController = searchPhaseController;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/metrics/MeanMetric.java
+++ b/server/src/main/java/org/elasticsearch/common/metrics/MeanMetric.java
@@ -26,6 +26,15 @@ public class MeanMetric implements Metric {
     private final LongAdder counter = new LongAdder();
     private final LongAdder sum = new LongAdder();
 
+    public MeanMetric() {
+
+    }
+
+    public MeanMetric(long count, long sum) {
+        this.counter.add(count);
+        this.sum.add(sum);
+    }
+
     public void inc(long n) {
         counter.increment();
         sum.add(n);
@@ -34,6 +43,11 @@ public class MeanMetric implements Metric {
     public void dec(long n) {
         counter.decrement();
         sum.add(-n);
+    }
+
+    public void merge(MeanMetric other) {
+        this.counter.add(other.count());
+        this.sum.add(other.sum());
     }
 
     public long count() {

--- a/server/src/main/java/org/elasticsearch/metrics/CoordinatingIndicesStatsCollector.java
+++ b/server/src/main/java/org/elasticsearch/metrics/CoordinatingIndicesStatsCollector.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CoordinatingIndicesStatsCollector {
 
     /**
-     * indexName --> collector
+     * indexName -- collector
      */
     private final Map<String, StatsCollector> collectorMap = new ConcurrentHashMap<>();
 

--- a/server/src/main/java/org/elasticsearch/metrics/CoordinatingIndicesStatsCollector.java
+++ b/server/src/main/java/org/elasticsearch/metrics/CoordinatingIndicesStatsCollector.java
@@ -1,0 +1,112 @@
+package org.elasticsearch.metrics;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.metrics.CounterMetric;
+import org.elasticsearch.common.metrics.MeanMetric;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author kyra.wkh
+ */
+public class CoordinatingIndicesStatsCollector {
+
+    /**
+     * indexName --> collector
+     */
+    private final Map<String, StatsCollector> collectorMap = new ConcurrentHashMap<>();
+
+    public void register(String metricsName, MetricsConstant.MetricsType metricsType, String indexName) {
+        assert indexName != null;
+
+        StatsCollector collector = collectorMap.get(indexName);
+        if (collector == null) {
+            Map<String, CounterMetric> counterMetricMap = new ConcurrentHashMap<>();
+            Map<String, MeanMetric> meanMetricMap = new ConcurrentHashMap<>();
+            StatsCollector statsCollector = new StatsCollector(counterMetricMap, meanMetricMap);
+            collectorMap.put(indexName, statsCollector);
+            collector = statsCollector;
+        }
+
+        collector.register(metricsName, metricsType);
+    }
+
+    public void removeIndex(String indexName) {
+        if (Strings.isNullOrEmpty(indexName)) {
+            return;
+        }
+        collectorMap.remove(indexName);
+    }
+
+
+    public void collectCount(String indexName, String metricsName, long value) {
+        StatsCollector collector = findStatsCollector(indexName);
+        if (collector == null) {
+            return;
+        }
+        collector.collectCount(metricsName, value);
+    }
+
+    public void collectMean(String indexName, String metricsName, long value) {
+        StatsCollector collector = findStatsCollector(indexName);
+        if (collector == null) {
+            return;
+        }
+        collector.collectMean(metricsName, value);
+    }
+
+    public Map<String, StatsCollector> getCollectorMap() {
+        return collectorMap;
+    }
+
+    private StatsCollector findStatsCollector(String indexName) {
+        return collectorMap.get(indexName);
+    }
+
+    public class StatsCollector {
+
+        public final Map<String, CounterMetric> counterMetricMap;
+        public final Map<String, MeanMetric> meanMetricMap;
+
+        public StatsCollector(Map<String, CounterMetric> counterMetricMap, Map<String, MeanMetric> meanMetricMap) {
+            this.counterMetricMap = counterMetricMap;
+            this.meanMetricMap = meanMetricMap;
+        }
+
+        public void collectCount(String metricsName, long value) {
+            if (Strings.isNullOrEmpty(metricsName)) {
+                return;
+            }
+            CounterMetric counterMetric = counterMetricMap.get(metricsName);
+            if (counterMetric == null) {
+                return;
+            }
+            counterMetric.inc(value);
+        }
+
+        public void collectMean(String metricsName, long value) {
+            if (Strings.isNullOrEmpty(metricsName)) {
+                return;
+            }
+            MeanMetric meanMetric = meanMetricMap.get(metricsName);
+            if (meanMetric == null) {
+                return;
+            }
+            meanMetric.inc(value);
+        }
+
+        public void register(String metricsName, MetricsConstant.MetricsType metricsType) {
+            switch (metricsType) {
+                case COUNTER:
+                    counterMetricMap.putIfAbsent(metricsName, new CounterMetric());
+                    break;
+                case MEAN:
+                    meanMetricMap.putIfAbsent(metricsName, new MeanMetric());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/metrics/MetricsConstant.java
+++ b/server/src/main/java/org/elasticsearch/metrics/MetricsConstant.java
@@ -1,0 +1,15 @@
+package org.elasticsearch.metrics;
+
+/**
+ * @author kyra.wkh
+ **/
+public class MetricsConstant {
+    public static final String SEARCH_TOTAL = "search_total";
+    public static final String SEARCH_LATENCY_MILLIS = "search_time_in_millis";
+    public static final String COORDINATING = "coordinating";
+
+    public enum MetricsType {
+        COUNTER,
+        MEAN
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -110,6 +110,7 @@ import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.monitor.MonitorService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
@@ -500,10 +501,12 @@ public class Node implements Closeable {
                 networkService, clusterService.getMasterService(), clusterService.getClusterApplierService(),
                 clusterService.getClusterSettings(), pluginsService.filterPlugins(DiscoveryPlugin.class),
                 clusterModule.getAllocationService(), environment.configFile(), gatewayMetaState, rerouteService);
+
+            final CoordinatingIndicesStatsCollector coordinatingIndicesStatsCollector = new CoordinatingIndicesStatsCollector();
             this.nodeService = new NodeService(settings, threadPool, monitorService, discoveryModule.getDiscovery(),
                 transportService, indicesService, pluginsService, circuitBreakerService, scriptModule.getScriptService(),
                 httpServerTransport, ingestService, clusterService, settingsModule.getSettingsFilter(), responseCollectorService,
-                searchTransportService);
+                searchTransportService, coordinatingIndicesStatsCollector);
 
             final SearchService searchService = newSearchService(clusterService, indicesService,
                 threadPool, scriptModule.getScriptService(), bigArrays, searchModule.getFetchPhase(),
@@ -556,6 +559,7 @@ public class Node implements Closeable {
                     b.bind(ClusterInfoService.class).toInstance(clusterInfoService);
                     b.bind(GatewayMetaState.class).toInstance(gatewayMetaState);
                     b.bind(Discovery.class).toInstance(discoveryModule.getDiscovery());
+                    b.bind(CoordinatingIndicesStatsCollector.class).toInstance(coordinatingIndicesStatsCollector);
                     {
                         RecoverySettings recoverySettings = new RecoverySettings(settings, settingsModule.getClusterSettings());
                         processRecoverySettings(settingsModule.getClusterSettings(), recoverySettings);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingIndicesStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingIndicesStatsTests.java
@@ -1,0 +1,62 @@
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.metrics.CounterMetric;
+import org.elasticsearch.common.metrics.MeanMetric;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author kyra.wkh
+ **/
+public class CoordinatingIndicesStatsTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        String index = "test";
+        CoordinatingIndiceStats coordinatingIndiceStats = new CoordinatingIndiceStats(index, new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
+        CounterMetric counterMetric1 = new CounterMetric();
+        MeanMetric meanMetric1 = new MeanMetric();
+        counterMetric1.inc(randomIntBetween(0, 10));
+        int count = randomIntBetween(0, 10);
+        for(int i=0; i<count; i++) {
+            meanMetric1.inc(randomIntBetween(0, 10));
+        }
+
+        coordinatingIndiceStats.counterMetricMap.put("count1", counterMetric1);
+        coordinatingIndiceStats.meanMatricMap.put("mean1", meanMetric1);
+
+        CounterMetric counterMetric2 = new CounterMetric();
+        MeanMetric meanMetric2 = new MeanMetric();
+        counterMetric2.inc(randomIntBetween(0, 10));
+        int count2 = randomIntBetween(0, 10);
+        for(int i=0; i<count2; i++) {
+            meanMetric2.inc(randomIntBetween(0, 10));
+        }
+        coordinatingIndiceStats.counterMetricMap.put("count2", counterMetric2);
+        coordinatingIndiceStats.meanMatricMap.put("mean2", meanMetric2);
+
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            coordinatingIndiceStats.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                CoordinatingIndiceStats deserializedStats = new CoordinatingIndiceStats(in);
+                assertEquals(index, deserializedStats.indexName);
+                assertEquals(2, deserializedStats.counterMetricMap.size());
+                assertNotNull(deserializedStats.counterMetricMap.get("count1"));
+                assertNotNull(deserializedStats.counterMetricMap.get("count2"));
+                assertEquals(coordinatingIndiceStats.counterMetricMap.get("count1").count(), deserializedStats.counterMetricMap.get("count1").count());
+                assertEquals(coordinatingIndiceStats.counterMetricMap.get("count2").count(), deserializedStats.counterMetricMap.get("count2").count());
+                assertEquals(2, deserializedStats.meanMatricMap.size());
+                assertNotNull(deserializedStats.meanMatricMap.get("mean1"));
+                assertNotNull(deserializedStats.meanMatricMap.get("mean2"));
+                assertEquals(coordinatingIndiceStats.meanMatricMap.get("mean1").sum(), deserializedStats.meanMatricMap.get("mean1").sum());
+                assertEquals(coordinatingIndiceStats.meanMatricMap.get("mean1").count(), deserializedStats.meanMatricMap.get("mean1").count());
+                assertEquals(coordinatingIndiceStats.meanMatricMap.get("mean2").sum(), deserializedStats.meanMatricMap.get("mean2").sum());
+                assertEquals(coordinatingIndiceStats.meanMatricMap.get("mean2").count(), deserializedStats.meanMatricMap.get("mean2").count());
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/CoordinatingStatsIT.java
@@ -1,0 +1,115 @@
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.metrics.MetricsConstant;
+import org.elasticsearch.node.NodeService;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+
+/**
+ * @author kyra.wkh
+ */
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class CoordinatingStatsIT extends ESIntegTestCase {
+
+    public void testCoordinatingMetric() throws Exception {
+        internalCluster().startMasterOnlyNodes(1);
+        String dataNode = internalCluster().startDataOnlyNode();
+        String coordinatingNode = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+
+        String index1 = "index1";
+        createIndex(index1);
+        ensureGreen(index1);
+
+        String index2 = "index2";
+        createIndex(index2);
+        ensureGreen(index2);
+
+        client(coordinatingNode).prepareSearch(index1).get();
+        client(coordinatingNode).prepareSearch(index2).get();
+        CoordinatingStats coordinatingStats = getNodeCoordinatingStats(coordinatingNode);
+        // check total qps
+        CoordinatingIndiceStats totalCoordinatingNode = coordinatingStats.getTotal();
+        assertEquals(2, totalCoordinatingNode.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+        // check indices qps
+        assertEquals(2, coordinatingStats.getIndiceStats().size());
+        for (CoordinatingIndiceStats indiceStats : coordinatingStats.getIndiceStats()) {
+            assertEquals(1, indiceStats.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+        }
+
+        // check total latency
+        assertTrue(totalCoordinatingNode.meanMatricMap.get(MetricsConstant.SEARCH_LATENCY_MILLIS).sum() > 0);
+        // check index latency
+        for (CoordinatingIndiceStats indiceStats : getNodeCoordinatingStats(coordinatingNode).getIndiceStats()) {
+            assertTrue(indiceStats.meanMatricMap.get(MetricsConstant.SEARCH_LATENCY_MILLIS).sum() > 0);
+        }
+
+        // check data node cannot record
+        CoordinatingIndiceStats totalDataNode = getNodeCoordinatingStats(dataNode).getTotal();
+        assertEquals(0, totalDataNode.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+        assertEquals(0, totalDataNode.meanMatricMap.get(MetricsConstant.SEARCH_LATENCY_MILLIS).sum());
+
+        // restart coordinating only node
+        internalCluster().restartNode(coordinatingNode, InternalTestCluster.EMPTY_CALLBACK);
+        Thread.sleep(5000);
+        totalCoordinatingNode = getNodeCoordinatingStats(coordinatingNode).getTotal();
+        // check restart clears metric
+        assertEquals(0, totalCoordinatingNode.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+        client(coordinatingNode).prepareSearch(index1).get();
+        client(coordinatingNode).prepareSearch(index2).get();
+        // check total
+        totalCoordinatingNode = getNodeCoordinatingStats(coordinatingNode).getTotal();
+        assertEquals(2, totalCoordinatingNode.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+
+        // check total qps
+        totalCoordinatingNode = getNodeCoordinatingStats(coordinatingNode).getTotal();
+        assertEquals(2, totalCoordinatingNode.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+        // check indices qps
+        assertEquals(2, getNodeCoordinatingStats(coordinatingNode).getIndiceStats().size());
+        for (CoordinatingIndiceStats indiceStats : getNodeCoordinatingStats(coordinatingNode).getIndiceStats()) {
+            assertEquals(1, indiceStats.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+        }
+
+        // check total latency
+        assertTrue(totalCoordinatingNode.meanMatricMap.get(MetricsConstant.SEARCH_LATENCY_MILLIS).sum() > 0);
+        // check index latency
+        for (CoordinatingIndiceStats indiceStats : getNodeCoordinatingStats(coordinatingNode).getIndiceStats()) {
+            assertTrue(indiceStats.meanMatricMap.get(MetricsConstant.SEARCH_LATENCY_MILLIS).sum() > 0);
+        }
+
+        // check delete index removes related metric
+        ElasticsearchAssertions.assertAcked(client().admin().indices().prepareDelete(index1).get());
+        assertEquals(1, getNodeCoordinatingStats(coordinatingNode).getIndiceStats().size());
+        assertEquals(index2, getNodeCoordinatingStats(coordinatingNode).getIndiceStats().get(0).indexName);
+
+        logger.info("start new coordinating node");
+        // start another coordinating ndoe
+        String coordinatingNode2 = internalCluster().startCoordinatingOnlyNode(Settings.EMPTY);
+        client(coordinatingNode2).prepareSearch(index2).get();
+        // check total qps
+        CoordinatingIndiceStats totalCoordinatingNode2 = getNodeCoordinatingStats(coordinatingNode2).getTotal();
+        assertEquals(1, totalCoordinatingNode2.counterMetricMap.get(MetricsConstant.SEARCH_TOTAL).count());
+    }
+
+
+    private void indexDoc(String index, String contentJson) {
+        IndexResponse response = client().prepareIndex(index)
+            .setSource(contentJson, XContentType.JSON)
+            .get();
+        if (!response.status().equals(RestStatus.OK) && !response.status().equals(RestStatus.CREATED)) {
+            fail("Bad response while adding doc");
+        }
+    }
+
+
+    private CoordinatingStats getNodeCoordinatingStats(String nodeName) {
+        return internalCluster().getInstance(NodeService.class, nodeName)
+            .stats(CommonStatsFlags.ALL, true, true, true, true, true, true, true, true, true, true, true, true, true)
+            .getCoordinatingStats();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -92,7 +93,7 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
                     )
                 ), timeProvider, 0, null,
                 results, request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY) {
+                SearchResponse.Clusters.EMPTY, new CoordinatingIndicesStatsCollector()) {
             @Override
             protected SearchPhase getNextPhase(final SearchPhaseResults<SearchPhaseResult> results, final SearchPhaseContext context) {
                 return null;

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -85,7 +86,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                     public void run() throws IOException {
                         result.set(iter);
                         latch.countDown();
-                    }}, SearchResponse.Clusters.EMPTY);
+                    }}, SearchResponse.Clusters.EMPTY, new CoordinatingIndicesStatsCollector());
 
         canMatchPhase.start();
         latch.await();
@@ -153,7 +154,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 public void run() throws IOException {
                     result.set(iter);
                     latch.countDown();
-                }}, SearchResponse.Clusters.EMPTY);
+                }}, SearchResponse.Clusters.EMPTY, new CoordinatingIndicesStatsCollector());
 
         canMatchPhase.start();
         latch.await();
@@ -236,7 +237,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 null,
                 new ArraySearchPhaseResults<>(iter.size()),
                 randomIntBetween(1, 32),
-                SearchResponse.Clusters.EMPTY) {
+                SearchResponse.Clusters.EMPTY,
+                new CoordinatingIndicesStatsCollector()) {
 
                 @Override
                 protected SearchPhase getNextPhase(SearchPhaseResults<SearchPhaseResult> results, SearchPhaseContext context) {
@@ -259,7 +261,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                         listener.onFailure(new Exception("failure"));
                     }
                 }
-            }, SearchResponse.Clusters.EMPTY);
+            }, SearchResponse.Clusters.EMPTY,
+            new CoordinatingIndicesStatsCollector());
 
         canMatchPhase.start();
         latch.await();

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.InternalSearchResponse;
@@ -110,7 +111,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY) {
+                SearchResponse.Clusters.EMPTY,
+                new CoordinatingIndicesStatsCollector()) {
 
                 @Override
                 protected void executePhaseOnShard(SearchShardIterator shardIt, ShardRouting shard,
@@ -215,7 +217,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY) {
+                SearchResponse.Clusters.EMPTY,
+                new CoordinatingIndicesStatsCollector()) {
 
                 @Override
                 protected void executePhaseOnShard(SearchShardIterator shardIt, ShardRouting shard,
@@ -318,7 +321,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                         null,
                         new ArraySearchPhaseResults<>(shardsIter.size()),
                         request.getMaxConcurrentShardRequests(),
-                        SearchResponse.Clusters.EMPTY) {
+                        SearchResponse.Clusters.EMPTY,
+                        new CoordinatingIndicesStatsCollector()) {
             TestSearchResponse response = new TestSearchResponse();
 
             @Override
@@ -423,7 +427,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY) {
+                SearchResponse.Clusters.EMPTY,
+                new CoordinatingIndicesStatsCollector()) {
 
                 @Override
                 protected void executePhaseOnShard(SearchShardIterator shardIt, ShardRouting shard,

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -151,11 +151,11 @@ public class DiskUsageTests extends ESTestCase {
         };
         List<NodeStats> nodeStats = Arrays.asList(
                 new NodeStats(new DiscoveryNode("node_1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null),
+                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null, null),
                 new NodeStats(new DiscoveryNode("node_2", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null),
+                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null, null),
                 new NodeStats(new DiscoveryNode("node_3", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null)
+                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null, null)
         );
         InternalClusterInfoService.fillDiskUsagePerNode(logger, nodeStats, newLeastAvaiableUsages, newMostAvaiableUsages);
         DiskUsage leastNode_1 = newLeastAvaiableUsages.get("node_1");
@@ -192,11 +192,11 @@ public class DiskUsageTests extends ESTestCase {
         };
         List<NodeStats> nodeStats = Arrays.asList(
                 new NodeStats(new DiscoveryNode("node_1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null),
+                        null,null,null,null,null,new FsInfo(0, null, node1FSInfo), null,null,null,null,null, null, null, null),
                 new NodeStats(new DiscoveryNode("node_2", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null),
+                        null,null,null,null,null, new FsInfo(0, null, node2FSInfo), null,null,null,null,null, null, null, null),
                 new NodeStats(new DiscoveryNode("node_3", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT), 0,
-                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null)
+                        null,null,null,null,null, new FsInfo(0, null, node3FSInfo), null,null,null,null,null, null, null, null)
         );
         InternalClusterInfoService.fillDiskUsagePerNode(logger, nodeStats, newLeastAvailableUsages, newMostAvailableUsages);
         DiskUsage leastNode_1 = newLeastAvailableUsages.get("node_1");

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -153,6 +153,7 @@ import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.metrics.CoordinatingIndicesStatsCollector;
 import org.elasticsearch.node.ResponseCollectorService;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -1158,7 +1159,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 actions.put(SearchAction.INSTANCE,
                     new TransportSearchAction(threadPool, transportService, searchService,
                         searchTransportService, new SearchPhaseController(searchService::createReduceContext), clusterService,
-                        actionFilters, indexNameExpressionResolver));
+                        actionFilters, indexNameExpressionResolver, new CoordinatingIndicesStatsCollector()));
                 actions.put(RestoreSnapshotAction.INSTANCE,
                     new TransportRestoreSnapshotAction(transportService, clusterService, threadPool, restoreService, actionFilters,
                         indexNameExpressionResolver));

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -74,7 +74,7 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                     .map(fsInfoPath -> diskUsageFunction.apply(discoveryNode, fsInfoPath))
                     .toArray(FsInfo.Path[]::new)), nodeStats.getTransport(),
                 nodeStats.getHttp(), nodeStats.getBreaker(), nodeStats.getScriptStats(), nodeStats.getDiscoveryStats(),
-                nodeStats.getIngestStats(), nodeStats.getAdaptiveSelectionStats());
+                nodeStats.getIngestStats(), nodeStats.getCoordinatingStats(), nodeStats.getAdaptiveSelectionStats());
         }).collect(Collectors.toList());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2259,7 +2259,7 @@ public final class InternalTestCluster extends TestCluster {
                 NodeService nodeService = getInstanceFromNode(NodeService.class, nodeAndClient.node);
                 CommonStatsFlags flags = new CommonStatsFlags(Flag.FieldData, Flag.QueryCache, Flag.Segments);
                 NodeStats stats = nodeService.stats(flags,
-                        false, false, false, false, false, false, false, false, false, false, false, false);
+                        false, false, false, false, false, false, false, false, false, false, false, false, false);
                 assertThat("Fielddata size must be 0 on node: " + stats.getNode(),
                         stats.getIndices().getFieldData().getMemorySizeInBytes(), equalTo(0L));
                 assertThat("Query cache size must be 0 on node: " + stats.getNode(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -571,7 +571,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             IntStream.range(0, pipelineNames.size()).boxed().collect(Collectors.toMap(pipelineNames::get, processorStats::get)));
         return new NodeStats(mock(DiscoveryNode.class),
             Instant.now().toEpochMilli(), null, null, null, null, null, null, null, null,
-            null, null, null, ingestStats, null);
+            null, null, null, ingestStats, null, null);
 
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -282,7 +282,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
             IntStream.range(0, pipelineids.size()).boxed().collect(Collectors.toMap(pipelineids::get, processorStats::get)));
         return new NodeStats(mock(DiscoveryNode.class),
             Instant.now().toEpochMilli(), null, null, null, null, null, null, null, null,
-            null, null, null, ingestStats, null);
+            null, null, null, ingestStats, null, null);
 
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -366,6 +366,6 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
                                                                 emptySet(),
                                                                 Version.CURRENT);
 
-        return new NodeStats(discoveryNode, no, indices, os, process, jvm, threadPool, fs, null, null, null, null, null, null, null);
+        return new NodeStats(discoveryNode, no, indices, os, process, jvm, threadPool, fs, null, null, null, null, null, null, null, null);
     }
 }


### PR DESCRIPTION
This PR adds the coordinating stats section in _nodes/stats api, including end-to-end query qps and latency information.

The purpose for this enhancement is to help tracing user-aspect information on coordinating node, especially on OLAP scenario with heavy aggregations slowing down queries on coordinating node, but no stats recorded. This PR can help OLAP-users to realize heavy calculation is on-going on coordinating node, thus can help them further optimizing their use-case.

Example output:

```
{
    "nodes": {
        "fs": {...},
        "ingest": {...},
        "coordinating": {
            "total": {
                "index": "_all",
                "stats": {
                    "search_total": 11809106,
                    "search_time_in_millis": 22286903
                }
            },
            "indices": [
                {
                    "index": "geonames",
                    "stats": {
                        "search_total": 10060843,
                        "search_time_in_millis": 20269235
                    }
                }
            ]
        }
    }
}
```

Closes #49024
