### PR TITLE
Fix test for index phrases shortcut with multi-term synonyms

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -771,7 +771,6 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47777")
     public void testFastPhraseMapping() throws IOException {
 
         QueryShardContext queryShardContext = indexService.newQueryShardContext(
@@ -841,8 +840,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(q7, is(new BooleanQuery.Builder().add(new BooleanQuery.Builder()
             .add(new TermQuery(new Term("synfield", "foo")), BooleanClause.Occur.SHOULD)
             .add(new PhraseQuery.Builder()
-                .add(new Term("synfield", "bar"))
-                .add(new Term("synfield", "baz"))
+                .add(new Term("synfield._index_phrase", "bar baz"))
                 .build(), BooleanClause.Occur.SHOULD)
             .build(), BooleanClause.Occur.SHOULD).build()));
 


### PR DESCRIPTION
Lucene 8.3 included a root fix for #43976, which was temporarily fixed in elasticsearch
by #44340.  Since we have upgraded to 8.3 we no longer need this workaround.  This
commit fixes the test that was added to check the workaround, and instead checks that
fields with `index_phrases` enabled correctly build queries when used with multi-term
synonyms.

Closes #47777