### PR TITLE
Fix testPeerRecoveryTrimsLocalTranslog

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1558,7 +1558,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
                             .setSource(Collections.singletonMap("f" + randomIntBetween(1, 10), randomNonNegativeLong()), XContentType.JSON)
                             .get();
                         assertThat(response.getResult(), isOneOf(CREATED, UPDATED));
-                    } catch (ElasticsearchException ignored) {
+                    } catch (IllegalStateException | ElasticsearchException ignored) {
                     }
                 }
             });


### PR DESCRIPTION
7.x uses the transport client, which, when being closed, can throw an IllegalStateException

Closes #49375