### PR TITLE
[DOCS] Fixes endpoint schema in PUT app privileges API docs

### DIFF
--- a/x-pack/docs/en/rest-api/security/put-app-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/put-app-privileges.asciidoc
@@ -81,8 +81,8 @@ been created or updated.
 [[security-api-put-privileges-example]]
 ==== {api-examples-title}
 
-To add a single privilege, submit a PUT or POST request to the
-`/_security/privilege/<application>/<privilege>` endpoint. For example:
+To add a single privilege, submit a PUT or POST request to the 
+`/_security/privilege/` endpoint. For example:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
This PR fixes the endpoint schema of PUT app privileges API in the example description. There was a contradiction between the example request and the example description regarding the endpoint schema.

Related issue: https://github.com/elastic/elasticsearch/issues/48846