### PR TITLE
[DOCS] Document `script_score` float precision limit

### DIFF
--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -153,8 +153,16 @@ GET /_search
 --------------------------------------------------
 // TEST[setup:twitter]
 
-NOTE: Scores produced by the `script_score` function must be non-negative,
-otherwise an error will be thrown.
+[IMPORTANT]
+====
+{es} stores scores produced by the `script_score` function as positive
+32-bit floating point numbers in the `_score` meta-field.
+
+As a result, scores are limited to 32-bits of precision. Larger numbers will
+lose precision during storage.
+
+Similarly, scores must be non-negative. Otherwise, {es} returns an error.
+====
 
 On top of the different scripting field values and expression, the
 `_score` script parameter can be used to retrieve the score based on the

--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -155,11 +155,10 @@ GET /_search
 
 [IMPORTANT]
 ====
-{es} stores scores produced by the `script_score` function as positive
-32-bit floating point numbers in the `_score` meta-field.
+In {es}, all document scores are positive 32-bit floating point numbers.
 
-As a result, scores are limited to 32-bits of precision. Larger numbers will
-lose precision during storage.
+If the `script_score` function produces a score with greater precision, it is
+converted to the nearest 32-bit float. 
 
 Similarly, scores must be non-negative. Otherwise, {es} returns an error.
 ====

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -309,7 +309,7 @@ Returned values are:
 (Float)
 Highest returned document `_score`.
 +
-The `_score` parameter is a floating point number
+The `_score` parameter is a 32-bit floating point number
 used to determine the relevance of the returned document.
 +
 This parameter value is `null` for requests
@@ -323,8 +323,8 @@ Returned parameters include:
 * `_index`: Name of the index containing the returned document.
 * `_id`: Unique identifier for the returned document.
   This ID is only unique within the returned index.
-* `_score`: Floating point number
-  used to determine the relevance of the returned document.
+* `_score`: Positive 32-bit floating point number used to determine the
+  relevance of the returned document.
 * `_source`: Object containing the original JSON body
   passed for the document at index time.
 --


### PR DESCRIPTION
Scores produced by the `script_score` function are stored as positive, 32-bit floats in the `_score` field.

This updates an existing admonition in the function score query docs to document the 32-bits of precision limit.

Closes #48845.