### PR TITLE
Fix handling of circles in legacy geo_shape queries

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryIO.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryIO.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.geo;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
@@ -49,7 +50,10 @@ public final class GeometryIO {
         geometry.visit(new GeometryVisitor<Void, IOException>() {
             @Override
             public Void visit(Circle circle) throws IOException {
-                throw new UnsupportedOperationException("circle is not supported");
+                writeCoordinate(circle.getLat(), circle.getLon(), circle.getAlt());
+                out.writeDouble(circle.getRadiusMeters());
+                DistanceUnit.METERS.writeTo(out);
+                return null;
             }
 
             @Override
@@ -161,6 +165,8 @@ public final class GeometryIO {
                 return readMultiPolygon(in);
             case "envelope":
                 return readRectangle(in);
+            case "circle":
+                return readCircle(in);
             default:
                 throw new UnsupportedOperationException("unsupported shape type " + type);
         }
@@ -303,5 +309,14 @@ public final class GeometryIO {
         } else {
             return alt;
         }
+    }
+
+    private static Circle readCircle(StreamInput in) throws IOException {
+        double lon = in.readDouble();
+        double lat = in.readDouble();
+        double alt = readAlt(in);
+        double radius = in.readDouble();
+        DistanceUnit distanceUnit = DistanceUnit.readFromStream(in);
+        return new Circle(lon, lat, alt, distanceUnit.toMeters(radius));
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/builders/CircleBuilder.java
@@ -165,7 +165,7 @@ public class CircleBuilder extends ShapeBuilder<Circle, org.elasticsearch.geomet
 
     @Override
     public org.elasticsearch.geometry.Circle buildGeometry() {
-        throw new UnsupportedOperationException("CIRCLE geometry is not supported");
+       return new org.elasticsearch.geometry.Circle(center.x, center.y, unit.toMeters(radius));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -28,6 +28,7 @@ import org.apache.lucene.spatial.query.SpatialArgs;
 import org.apache.lucene.spatial.query.SpatialOperation;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
+import org.elasticsearch.common.geo.builders.CircleBuilder;
 import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
 import org.elasticsearch.common.geo.builders.GeometryCollectionBuilder;
 import org.elasticsearch.common.geo.builders.LineStringBuilder;
@@ -37,6 +38,7 @@ import org.elasticsearch.common.geo.builders.MultiPolygonBuilder;
 import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
@@ -123,7 +125,7 @@ public class LegacyGeoShapeQueryProcessor implements AbstractGeometryFieldMapper
         ShapeBuilder<?, ?, ?> shapeBuilder = geometry.visit(new GeometryVisitor<>() {
             @Override
             public ShapeBuilder<?, ?, ?> visit(Circle circle) {
-                throw new UnsupportedOperationException("circle is not supported");
+                return new CircleBuilder().center(circle.getLon(), circle.getLat()).radius(circle.getRadiusMeters(), DistanceUnit.METERS);
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryIOTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryIOTests.java
@@ -88,10 +88,6 @@ public class GeometryIOTests extends ESTestCase {
             return false;
         }
 
-        if (geometry.type() == ShapeType.CIRCLE) {
-            return false;
-        }
-
         if (geometry.type() == ShapeType.GEOMETRYCOLLECTION) {
             GeometryCollection<?> collection = (GeometryCollection<?>) geometry;
             for (Geometry g : collection) {

--- a/server/src/test/java/org/elasticsearch/search/geo/LegacyGeoShapeIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/LegacyGeoShapeIntegrationIT.java
@@ -23,8 +23,10 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.LegacyGeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -158,6 +160,29 @@ public class LegacyGeoShapeIntegrationIT extends ESIntegTestCase {
             geoShapeQuery("shape", "0").indexedShapeIndex("test").indexedShapeRouting("ABC")
         ).get();
 
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+    }
+
+    /**
+     * Test that the circle is still supported for the legacy shapes
+     */
+    public void testLegacyCircle() throws Exception {
+        // create index
+        assertAcked(client().admin().indices().prepareCreate("test")
+            .addMapping("geometry", "shape", "type=geo_shape,strategy=recursive,tree=geohash").get());
+        ensureGreen();
+
+        indexRandom(true, client().prepareIndex("test").setId("0").setSource("shape", (ToXContent) (builder, params) -> {
+            builder.startObject().field("type", "circle")
+                .startArray("coordinates").value(30).value(50).endArray()
+                .field("radius","77km")
+                .endObject();
+            return builder;
+        }));
+
+        // test self crossing of circles
+        SearchResponse searchResponse = client().prepareSearch("test").setQuery(geoShapeQuery("shape",
+            new Circle(30, 50, 77000))).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
     }
 


### PR DESCRIPTION
Brings back support for circles in legacy geo_shape queries that
was accidentally lost during query refactoring.

Fixes #49296 
