### PR TITLE
[DOCS] Adds EOL banner to ES Ref

### DIFF
--- a/docs/reference/page_header.html
+++ b/docs/reference/page_header.html
@@ -1,0 +1,10 @@
+<p>
+  <strong>WARNING</strong>: Version 6.2 of Elasticsearch has passed its 
+  <a href="https://www.elastic.co/support/eol">EOL date</a>. 
+</p>  
+<p>
+  This documentation is no longer being maintained and may be removed. 
+  If you are running this version, we strongly advise you to upgrade. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>


### PR DESCRIPTION
Related to elastic/docs#1426

Preview: http://elasticsearch_49415.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/6.2/index.html

Applies to 6.2 and earlier. Version needs to be updated for each branch.

