### PR TITLE
Reindex search response fix again

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFailureTests.java
@@ -121,7 +121,7 @@ public class ReindexFailureTests extends ReindexTestCase {
                         either(containsString("all shards failed"))
                         .or(containsString("No search context found"))
                         .or(containsString("no such index [source]"))
-                        .or(containsString("Failed to execute phase [query], Partial shards failure"))
+                        .or(containsString("Partial shards failure"))
                 );
                 return;
             }


### PR DESCRIPTION
Fixed test case to more broadly accept all messages with "Partial
shards failure" in it, to hopefully catch all relevant search messages
now that reindex does not allow searching against red shards.

Closes #49295
