### PR TITLE
[DOCS] Replaces deprecated ScriptService.ScriptType.INLINE with supported script in Java update docs

### DIFF
--- a/docs/java-api/docs/update.asciidoc
+++ b/docs/java-api/docs/update.asciidoc
@@ -24,7 +24,7 @@ Or you can use `prepareUpdate()` method:
 client.prepareUpdate("ttl", "doc", "1")
         .setScript(new Script(
             "ctx._source.gender = \"male\"", <1>
-            ScriptService.ScriptType.INLINE, null, null))
+            ScriptType.INLINE, null, null))
         .get();
 
 client.prepareUpdate("ttl", "doc", "1")
@@ -35,7 +35,7 @@ client.prepareUpdate("ttl", "doc", "1")
         .get();
 --------------------------------------------------
 <1> Your script. It could also be a locally stored script name.
-In that case, you'll need to use `ScriptService.ScriptType.FILE`
+In that case, you'll need to use `ScriptType.FILE`.
 <2> Document which will be merged to the existing one.
 
 Note that you can't provide both `script` and `doc`.


### PR DESCRIPTION
This PR updates the Java update API documentation which contains an example snippet with a script type that is claimed to be unsupported.

Related issue: https://github.com/elastic/elasticsearch/issues/48790