### PR TITLE
[7.x] Slm set operation mode to RUNNING on first run (#49236)

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -193,6 +193,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             components.add(indexLifecycleInitialisationService.get());
         }
         if (slmEnabled) {
+            // the template registry is a cluster state listener
+            @SuppressWarnings("unused")
             SnapshotLifecycleTemplateRegistry templateRegistry = new SnapshotLifecycleTemplateRegistry(settings, clusterService, threadPool,
                 client, xContentRegistry);
             snapshotHistoryStore.set(new SnapshotHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportGetSnapshotLifecycleAction.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class TransportGetSnapshotLifecycleAction extends
     TransportMasterNodeAction<GetSnapshotLifecycleAction.Request, GetSnapshotLifecycleAction.Response> {
 
-    private static final Logger logger = LogManager.getLogger(TransportPutSnapshotLifecycleAction.class);
+    private static final Logger logger = LogManager.getLogger(TransportGetSnapshotLifecycleAction.class);
 
     @Inject
     public TransportGetSnapshotLifecycleAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
@@ -37,7 +36,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TransportPutSnapshotLifecycleAction extends
@@ -89,12 +87,8 @@ public class TransportPutSnapshotLifecycleAction extends
                             .setHeaders(filteredHeaders)
                             .setModifiedDate(Instant.now().toEpochMilli())
                             .build();
-                        IndexLifecycleMetadata ilmMeta = currentState.metaData().custom(IndexLifecycleMetadata.TYPE);
-                        OperationMode mode = Optional.ofNullable(ilmMeta)
-                            .map(IndexLifecycleMetadata::getOperationMode)
-                            .orElse(OperationMode.RUNNING);
                         lifecycleMetadata = new SnapshotLifecycleMetadata(Collections.singletonMap(id, meta),
-                            mode, new SnapshotLifecycleStats());
+                            OperationMode.RUNNING, new SnapshotLifecycleStats());
                         logger.info("adding new snapshot lifecycle [{}]", id);
                     } else {
                         Map<String, SnapshotLifecyclePolicyMetadata> snapLifecycles = new HashMap<>(snapMeta.getSnapshotConfigurations());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/package-info.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/package-info.java
@@ -5,8 +5,8 @@
  */
 
 /**
- * This is the Snapshot Lifecycle Management (SLM) main package. SLM is part of the wider ILM feature, reusing quite a bit of the
- * functionality for itself in some places, which is why the two features are contained in the same plugin.
+ * This is the Snapshot Lifecycle Management (SLM) main package. SLM is part of the wider ILM feature, which is why the two features are
+ * contained in the same plugin. However SLM is enabled, configured and run independently of ILM.
  *
  * This package contains the {@link org.elasticsearch.xpack.slm.SnapshotLifecycleService} and
  * {@link org.elasticsearch.xpack.slm.SnapshotLifecycleTask}, as well as the Rest and Transport actions for the
@@ -18,7 +18,7 @@
  * <p>{@link org.elasticsearch.xpack.slm.SnapshotLifecycleService} maintains an internal
  * {@link org.elasticsearch.xpack.core.scheduler.SchedulerEngine SchedulerEngine} that handles scheduling snapshots. The service
  * executes on the currently elected master node. It listens to the cluster state, detecting new policies to schedule, and unscheduling
- * policies when they are deleted or if ILM is stopped. The bulk of this scheduling management is handled within
+ * policies when they are deleted or if SLM is stopped. The bulk of this scheduling management is handled within
  * {@link org.elasticsearch.xpack.slm.SnapshotLifecycleService#maybeScheduleSnapshot(SnapshotLifecyclePolicyMetadata)}
  * which is executed on all snapshot policies each update.
  *

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleInitialisationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.slm;
+
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryAction;
+import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ilm.OperationMode;
+import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
+import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
+import org.elasticsearch.xpack.core.slm.SnapshotRetentionConfiguration;
+import org.elasticsearch.xpack.core.slm.action.PutSnapshotLifecycleAction;
+import org.elasticsearch.xpack.core.slm.action.PutSnapshotLifecycleAction.Request;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.junit.BeforeClass;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.core.Is.is;
+
+public class SnapshotLifecycleInitialisationTests extends ESSingleNodeTestCase {
+
+    private static Path repositoryLocation;
+
+    @BeforeClass
+    public static void setupRepositoryPath() {
+        repositoryLocation = createTempDir();
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        Settings.Builder settings = Settings.builder().put(super.nodeSettings());
+        settings.put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false);
+        settings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
+        settings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
+        settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
+        settings.put(XPackSettings.MONITORING_ENABLED.getKey(), false);
+        settings.put(XPackSettings.GRAPH_ENABLED.getKey(), false);
+        settings.put(XPackSettings.LOGSTASH_ENABLED.getKey(), false);
+        settings.put(Environment.PATH_REPO_SETTING.getKey(), repositoryLocation);
+
+        settings.put(XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED.getKey(), true);
+        return settings.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(LocalStateCompositeXPackPlugin.class, IndexLifecycle.class);
+    }
+
+    public void testSLMIsInRunningModeWhenILMIsDisabled() throws Exception {
+        client().execute(PutRepositoryAction.INSTANCE,
+            new PutRepositoryRequest().name("repo").type("fs")
+                .settings(Settings.builder().put("repositories.fs.location", repositoryLocation).build())
+        ).get(10, TimeUnit.SECONDS);
+
+        client().execute(PutSnapshotLifecycleAction.INSTANCE,
+            new Request("snapshot-policy", new SnapshotLifecyclePolicy("test-policy", "snap",
+                "*/1 * * * * ?", "repo", Collections.emptyMap(), SnapshotRetentionConfiguration.EMPTY))
+        ).get(10, TimeUnit.SECONDS);
+
+        ClusterState state = getInstanceFromNode(ClusterService.class).state();
+        SnapshotLifecycleMetadata snapMeta = state.metaData().custom(SnapshotLifecycleMetadata.TYPE);
+        assertThat(snapMeta.getOperationMode(), is(OperationMode.RUNNING));
+    }
+}


### PR DESCRIPTION
* SLM set the operation mode to RUNNING on first run

Set the SLM operation mode to RUNNING when setting the first SLM lifecycle
policy. Historically, SLM was not decoupled from ILM but now they are
independent components. Setting the SLM operation mode to what the ILM running
mode was when we set the first SLM lifecycle policy was a remain from those
times.

* SLM update package info

* SLM suppress unusued warning

* SLM use logger for the correct class

* SLM Add integration test for operation mode

* Use ESSingleNodeTestCase instead of ESIntegTestCase

(cherry picked from commit 4ad3d93f89d03bf9a25685a990d1a439f33ce0e6)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of https://github.com/elastic/elasticsearch/pull/49236
