### PR TITLE
[Transform] reenable warning checks in pivot tests

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -86,16 +86,6 @@ public class PivotTests extends ESTestCase {
         return namedXContentRegistry;
     }
 
-
-    /*
-      Had to disable warnings because tests get random date histo configs, and changing to
-      new interval format was non-trivial.  Best for ML team to fix
-     */
-    @Override
-    protected boolean enableWarningsCheck() {
-        return false;
-    }
-
     public void testValidateExistingIndex() throws Exception {
         SourceConfig source = new SourceConfig(new String[]{"existing_source_index"}, QueryConfig.matchAll());
         Pivot pivot = new Pivot(getValidPivotConfig());


### PR DESCRIPTION
reenable warning checks(deprecation warnings) in pivot tests

Note: 
- this is a leftover when the old interval was deprecated and split into fixed and calendar in #33727, transforms adjusted in #42297, but the to be removed loc stayed
- #42297 removed the support of the old interval, therefore the implementation can't run into deprecation warnings for the old interval parameter