### PR TITLE
Remove outdated Todo

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -174,8 +174,6 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
     public Map<String, AnalysisProvider<AnalyzerProvider<? extends Analyzer>>> getAnalyzers() {
         Map<String, AnalysisProvider<AnalyzerProvider<? extends Analyzer>>> analyzers = new TreeMap<>();
         analyzers.put("fingerprint", FingerprintAnalyzerProvider::new);
-
-        // TODO remove in 8.0
         analyzers.put("pattern", PatternAnalyzerProvider::new);
         analyzers.put("snowball", SnowballAnalyzerProvider::new);
 


### PR DESCRIPTION
This comment in the CommonAnalysisPlugin code took me by suprise because I don't think we planned to remove neither snowball nor the pattern analyzer. Did some digging and the comment was introduced with the deprecation of the `stabdard_html_strip` analyzer in 
38b698d4554d196ecc4f6fcfb52ae5bdeb24ff5b and then not removed with the actual removal in 8af01dfa3cff896a4c90490d8aabf0945677395b. 
Now it looks like there's something to do while there isn't, I think.
