### PR TITLE
Explicitly include only testcluster config and log files

### DIFF
--- a/gradle/build-complete.gradle
+++ b/gradle/build-complete.gradle
@@ -16,11 +16,8 @@ if (buildNumber) {
           Set<File> fileSet = fileTree(projectDir) {
             include("**/*.hprof")
             include("**/reaper.log")
-            include("**/build/testclusters/**")
-            exclude("**/build/testclusters/**/data/**")
-            exclude("**/build/testclusters/**/distro/**")
-            exclude("**/build/testclusters/**/repo/**")
-            exclude("**/build/testclusters/**/extract/**")
+            include("**/build/testclusters/**/config/**")
+            include("**/build/testclusters/**/logs/**")
           }
             .files
             .findAll { Files.isRegularFile(it.toPath()) }


### PR DESCRIPTION
This fixes an issue with our build artifact and log upload to GCP in the `7.4` branch which is a result of slight differences in the way we setup testcluster node directories in that branch versus later branches. This PR explicitly includes only config and log files in the upload archive to avoid us from including the entire testcluster distribution in the archive, slowing down builds and blowing out disk usage.