### PR TITLE
Run build-tools test with Gradle jdk

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -215,28 +215,22 @@ if (project != rootProject) {
     }
   }
 
-  // use an object to lazy initialize the executable to avoid accessing the runtime java
-  // version during configuration
-  Object testExecutableEvaluator = new Object() {
-    @Override
-    public String toString() {
-      return org.elasticsearch.gradle.info.BuildParams.runtimeJavaVersion > JavaVersion.VERSION_12 ?
-        org.elasticsearch.gradle.info.BuildParams.compilerJavaHome.toString() + "/bin/java" :
-        org.elasticsearch.gradle.info.BuildParams.runtimeJavaHome.toString() + "/bin/java"
-    }
-  }
 
   test {
-    // run build-tools tests with the compiler Java to workaround issues with JDK13+ and Groovy pre 2.5.7
-    executable = testExecutableEvaluator
+    // build-tools tests are not compatible with JDKs > 12 until we upgrade to Gradle 6.0+. Our current bundled JDK is always newer
+    // than 12 so unless runtime java home is set, we cannot run the build-tools tests
+    onlyIf { org.elasticsearch.gradle.info.BuildParams.getIsRuntimeJavaHomeSet() }
+    onlyIf { org.elasticsearch.gradle.info.BuildParams.runtimeJavaVersion <= JavaVersion.VERSION_12 }
   }
 
   task integTest(type: Test) {
     inputs.dir(file("src/testKit")).withPropertyName("testkit dir").withPathSensitivity(PathSensitivity.RELATIVE)
     systemProperty 'test.version_under_test', version
     onlyIf { org.elasticsearch.gradle.info.BuildParams.inFipsJvm == false }
-    // run build-tools tests with the compiler Java to workaround issues with JDK13+ and Groovy pre 2.5.7
-    executable = testExecutableEvaluator
+    // build-tools tests are not compatible with JDKs > 12 until we upgrade to Gradle 6.0+. Our current bundled JDK is always newer
+    // than 12 so unless runtime java home is set, we cannot run the build-tools tests
+    onlyIf { org.elasticsearch.gradle.info.BuildParams.getIsRuntimeJavaHomeSet() }
+    onlyIf { org.elasticsearch.gradle.info.BuildParams.runtimeJavaVersion <= JavaVersion.VERSION_12 }
     maxParallelForks = System.getProperty('tests.jvms', org.elasticsearch.gradle.info.BuildParams.defaultParallel.toString()) as Integer
   }
   check.dependsOn(integTest)

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -215,16 +215,34 @@ if (project != rootProject) {
     }
   }
 
+  // use an object to lazy initialize the executable to avoid accessing the runtime java
+  // version during configuration
+  Object testExecutableEvaluator = new Object() {
+    @Override
+    public String toString() {
+      return org.elasticsearch.gradle.info.BuildParams.runtimeJavaVersion > JavaVersion.VERSION_12 ?
+        org.elasticsearch.gradle.info.BuildParams.compilerJavaHome.toString() + "/bin/java" :
+        org.elasticsearch.gradle.info.BuildParams.runtimeJavaHome.toString() + "/bin/java"
+    }
+  }
+
+  test {
+    // run build-tools tests with the compiler Java to workaround issues with JDK13+ and Groovy pre 2.5.7
+    executable = testExecutableEvaluator
+  }
+
   task integTest(type: Test) {
     inputs.dir(file("src/testKit")).withPropertyName("testkit dir").withPathSensitivity(PathSensitivity.RELATIVE)
     systemProperty 'test.version_under_test', version
     onlyIf { org.elasticsearch.gradle.info.BuildParams.inFipsJvm == false }
+    // run build-tools tests with the compiler Java to workaround issues with JDK13+ and Groovy pre 2.5.7
+    executable = testExecutableEvaluator
     maxParallelForks = System.getProperty('tests.jvms', org.elasticsearch.gradle.info.BuildParams.defaultParallel.toString()) as Integer
   }
   check.dependsOn(integTest)
 
   /*
-   * We alread configure publication and we don't need or want this one that
+   * We already configure publication and we don't need or want this one that
    * comes from the java-gradle-plugin.
    */
   afterEvaluate {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -226,7 +226,7 @@ if (project != rootProject) {
 
   // for now we hardcode the tests for our build to use the gradle jvm.
   tasks.withType(Test).configureEach {
-    it.executable = Jvm.current().getJavaHome().toPath().resolve("bin").resolve("java").toAbsolutePath()
+    it.executable = Jvm.current().getJavaExecutable()
   }
 
   /*

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import org.gradle.internal.jvm.Jvm
 import org.gradle.util.GradleVersion
 
 plugins {
@@ -215,25 +216,18 @@ if (project != rootProject) {
     }
   }
 
-
-  test {
-    // build-tools tests are not compatible with JDKs > 12 until we upgrade to Gradle 6.0+. Our current bundled JDK is always newer
-    // than 12 so unless runtime java home is set, we cannot run the build-tools tests
-    onlyIf { org.elasticsearch.gradle.info.BuildParams.getIsRuntimeJavaHomeSet() }
-    onlyIf { org.elasticsearch.gradle.info.BuildParams.runtimeJavaVersion <= JavaVersion.VERSION_12 }
-  }
-
   task integTest(type: Test) {
     inputs.dir(file("src/testKit")).withPropertyName("testkit dir").withPathSensitivity(PathSensitivity.RELATIVE)
     systemProperty 'test.version_under_test', version
     onlyIf { org.elasticsearch.gradle.info.BuildParams.inFipsJvm == false }
-    // build-tools tests are not compatible with JDKs > 12 until we upgrade to Gradle 6.0+. Our current bundled JDK is always newer
-    // than 12 so unless runtime java home is set, we cannot run the build-tools tests
-    onlyIf { org.elasticsearch.gradle.info.BuildParams.getIsRuntimeJavaHomeSet() }
-    onlyIf { org.elasticsearch.gradle.info.BuildParams.runtimeJavaVersion <= JavaVersion.VERSION_12 }
     maxParallelForks = System.getProperty('tests.jvms', org.elasticsearch.gradle.info.BuildParams.defaultParallel.toString()) as Integer
   }
   check.dependsOn(integTest)
+
+  // for now we hardcode the tests for our build to use the gradle jvm.
+  tasks.withType(Test).configureEach {
+    it.executable = Jvm.current().getJavaHome().toPath().resolve("bin").resolve("java").toAbsolutePath()
+  }
 
   /*
    * We already configure publication and we don't need or want this one that

--- a/gradle/runtime-jdk-provision.gradle
+++ b/gradle/runtime-jdk-provision.gradle
@@ -12,7 +12,7 @@ jdks {
     }
 }
 
-allprojects {
+configure(allprojects - project(':build-tools')) {
     project.tasks.withType(Test).configureEach { Test test ->
         if (BuildParams.getIsRuntimeJavaHomeSet()) {
             test.executable = "${BuildParams.runtimeJavaHome}/bin/java"


### PR DESCRIPTION
The test task is configured to use the runtime java version, but there
are issues with the version of groovy used by gradle pre 6.0. In order
to workaround this, we use the Gradle JDK to execute the build-tools
tests.

Closes #49404
Closes #49253