### PR TITLE
Increase timeout while checking for no snapshotted commit

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1230,7 +1230,7 @@ public final class InternalTestCluster extends TestCluster {
                     }
                 }
             }
-        });
+        }, 60, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
If some replica is performing a file-based recovery, then the check `assertNoSnapshottedIndexCommit` would fail. We should increase the timeout for this check so that we can wait until all recoveries done or aborted.

Closes #49403