### PR TITLE
Slash missed in indices.put_mapping url

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -8,7 +8,7 @@
     "url":{
       "paths":[
         {
-          "path":"{index}/_mapping",
+          "path":"/{index}/_mapping",
           "methods":[
             "PUT",
             "POST"


### PR DESCRIPTION
The REST API specification of `indices.put_mapping` is missing the first slash in the url.
This is causing a failure in the code generation of `elasticsearch-php` (see https://github.com/elastic/elasticsearch-php/pull/970) and potentially for other clients.

This fix should be backported also in 7.x branches.

cc @elastic/es-clients 