### PR TITLE
Fix build failure when attempting to export UBI Docker image

### DIFF
--- a/distribution/docker/ubi-docker-export/build.gradle
+++ b/distribution/docker/ubi-docker-export/build.gradle
@@ -1,0 +1,2 @@
+// This file is intentionally blank. All configuration of the
+// export is done in the parent project.


### PR DESCRIPTION
This PR fixes `7.x` [release tests](https://elasticsearch-ci.elastic.co/view/Elasticsearch%207.x/job/elastic+elasticsearch+7.x+release-tests/) which have been failing due to a missing project directory for the `:distribution:docker:ubi-docker-export` project.