### PR TITLE
Add note how to run locale sensitive unit test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,10 @@ For IntelliJ, go to
 For Eclipse, go to `Preferences->Java->Installed JREs` and add `-ea` to
 `VM Arguments`.
 
+Some tests related to locale testing also require the flag 
+`-Djava.locale.providers` to be set. Set the VM options/VM arguments for
+IntelliJ or Eclipse like describe above to use 
+`-Djava.locale.providers=SPI,COMPAT`.
 
 ### Java Language Formatting Guidelines
 

--- a/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1573,7 +1573,7 @@ public class SearchQueryIT extends ESIntegTestCase {
      * as "Mi" for "Mittwoch (Wednesday" and "Do" for "Donnerstag (Thursday)" and the month in the query
      * as "Dez" for "Dezember (December)".
      * Note: this test currently needs the JVM arg `-Djava.locale.providers=SPI,COMPAT` to be set.
-     * When running with gradle this is done implicitely through the BuildPlugin, but when running from
+     * When running with gradle this is done implicitly through the BuildPlugin, but when running from
      * an IDE this might need to be set manually in the run configuration. See also CONTRIBUTING.md section
      * on "Configuring IDEs And Running Tests".
      */

--- a/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1579,6 +1579,7 @@ public class SearchQueryIT extends ESIntegTestCase {
      */
     public void testRangeQueryWithLocaleMapping() throws Exception {
         assumeTrue("need java 9 for testing ",JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0);
+        assert ("SPI,COMPAT".equals(System.getProperty("java.locale.providers"))) : "`-Djava.locale.providers=SPI,COMPAT` needs to be set";
 
         assertAcked(prepareCreate("test")
             .addMapping("type1", jsonBuilder().startObject().startObject("properties").startObject("date_field")

--- a/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1568,6 +1568,15 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getAt(0).getId(), is("4"));
     }
 
+    /**
+     * Test range with a custom locale, e.g. "de" in this case. Documents here mention the day of week
+     * as "Mi" for "Mittwoch (Wednesday" and "Do" for "Donnerstag (Thursday)" and the month in the query
+     * as "Dez" for "Dezember (December)".
+     * Note: this test currently needs the JVM arg `-Djava.locale.providers=SPI,COMPAT` to be set.
+     * When running with gradle this is done implicitely through the BuildPlugin, but when running from
+     * an IDE this might need to be set manually in the run configuration. See also CONTRIBUTING.md section
+     * on "Configuring IDEs And Running Tests".
+     */
     public void testRangeQueryWithLocaleMapping() throws Exception {
         assumeTrue("need java 9 for testing ",JavaVersion.current().compareTo(JavaVersion.parse("9")) >= 0);
 


### PR DESCRIPTION
Some unit test checking locale sensitive functionality require the
-Djava.locale.providers=SPI,COMPAT flag to be set. When running tests though
gradle we pass this already to the BuildPlugin, but running from the IDE this
might need to be set manually. Adding a note explaining this to the
CONTRIBUTING.md doc and leave a note on
SearchQueryIT.testRangeQueryWithLocaleMapping which is a test we know suffers
from this.