### PR TITLE
Fix incorrect GET path in tasks.asciidoc

### DIFF
--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -13,9 +13,9 @@ similar to the <<tasks,task management>> API.
 [[cat-tasks-api-request]]
 ==== {api-request-title}
 
-`GET /_cat/_tasks/<task_id>`
+`GET /_cat/tasks/<task_id>`
 
-`GET /_cat/_tasks`
+`GET /_cat/tasks`
 
 
 [[cat-tasks-api-desc]]


### PR DESCRIPTION
Using GET `/_cat/_tasks` returns this error:
```
{"error":"Incorrect HTTP method for uri [/_cat/_tasks?v] and method [GET], allowed: [POST]","status":405}
```
Looking at the examples further down on the page, it should be `tasks` without the underscore.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
