### PR TITLE
Run build-tools test with Gradle jdk (#49459)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import org.gradle.internal.jvm.Jvm
 import org.gradle.util.GradleVersion
 
 plugins {
@@ -225,8 +226,13 @@ if (project != rootProject) {
   }
   check.dependsOn(integTest)
 
+  // for now we hardcode the tests for our build to use the gradle jvm.
+  tasks.withType(Test).configureEach {
+    it.executable = Jvm.current().getJavaExecutable()
+  }
+
   /*
-   * We alread configure publication and we don't need or want this one that
+   * We already configure publication and we don't need or want this one that
    * comes from the java-gradle-plugin.
    */
   afterEvaluate {

--- a/gradle/runtime-jdk-provision.gradle
+++ b/gradle/runtime-jdk-provision.gradle
@@ -12,16 +12,13 @@ jdks {
   }
 }
 
-allprojects {
-  if (project.path != ":build-tools") {
-    //  Build tools doesn't support java 8 still used in CI
-    project.tasks.withType(Test).configureEach { Test test ->
-      if (BuildParams.getIsRuntimeJavaHomeSet()) {
-        test.executable = "${BuildParams.runtimeJavaHome}/bin/java"
-      } else {
-        test.dependsOn(rootProject.jdks.provisioned_runtime)
-        test.executable = rootProject.jdks.provisioned_runtime.getBinJavaPath()
-      }
+configure(allprojects - project(':build-tools')) {
+  project.tasks.withType(Test).configureEach { Test test ->
+    if (BuildParams.getIsRuntimeJavaHomeSet()) {
+      test.executable = "${BuildParams.runtimeJavaHome}/bin/java"
+    } else {
+      test.dependsOn(rootProject.jdks.provisioned_runtime)
+      test.executable = rootProject.jdks.provisioned_runtime.getBinJavaPath()
     }
   }
 }


### PR DESCRIPTION
The test task is configured to use the runtime java version, but there
are issues with the version of groovy used by gradle pre 6.0. In order
to workaround this, we use the Gradle JDK to execute the build-tools
tests.

Closes #49404
Closes #49253