### PR TITLE
[7.x] [ML] Stop timing stats failure propagation (#49495)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -117,13 +117,7 @@ class DatafeedJob {
     }
 
     public void finishReportingTimingStats() {
-        try {
-            timingStatsReporter.finishReporting();
-        } catch (Exception e) {
-            // We don't want the exception to propagate out of this method as it can leave the datafeed in the "stopping" state forever.
-            // Since persisting datafeed timing stats is not critical, we just log a warning here.
-            LOGGER.warn("[{}] Datafeed timing stats could not be reported due to: {}", jobId, e);
-        }
+        timingStatsReporter.finishReporting();
     }
 
     Long runLookBack(long startTime, Long endTime) throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -61,7 +60,6 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -454,15 +452,6 @@ public class DatafeedJobTests extends ESTestCase {
         DatafeedJob.AnalysisProblemException analysisProblemException =
                 expectThrows(DatafeedJob.AnalysisProblemException.class, () -> datafeedJob.runRealtime());
         assertThat(analysisProblemException.shouldStop, is(true));
-    }
-
-    public void testFinishReportingTimingStats() {
-        doThrow(new EsRejectedExecutionException()).when(timingStatsReporter).finishReporting();
-
-        long frequencyMs = 100;
-        long queryDelayMs = 1000;
-        DatafeedJob datafeedJob = createDatafeedJob(frequencyMs, queryDelayMs, 1000, -1, randomBoolean());
-        datafeedJob.finishReportingTimingStats();
     }
 
     private DatafeedJob createDatafeedJob(long frequencyMs, long queryDelayMs, long latestFinalBucketEndTimeMs,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] Stop timing stats failure propagation  (#49495)