### PR TITLE
Fix extraction of notarized Elasticsearch release distribution

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -35,12 +35,14 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.credentials.HttpHeaderCredentials;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RelativePath;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.authentication.http.HttpHeaderAuthentication;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -144,6 +146,14 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
                         return rootProject.tarTree(rootProject.getResources().gzip(archiveFile));
                     }
                     throw new IllegalStateException("unexpected file extension on [" + archivePath + "]");
+                });
+
+                // Workaround for https://github.com/elastic/elasticsearch/issues/49417
+                syncTask.eachFile(details -> {
+                    String[] segments = details.getRelativePath().getSegments();
+                    if (segments[0].equals(".")) {
+                        details.setRelativePath(new RelativePath(true, Arrays.copyOfRange(segments, 1, segments.length)));
+                    }
                 });
             });
             rootProject.getArtifacts().add(extractedConfigName,


### PR DESCRIPTION
This commit introduces a workaround for an issue related to our recent
notarization of distributions starting with the 6.8.5 release. An
unintended side effect of notarization was that the file entries of the
release tar all have a `./` prefix in the path. This causes a number of
issues, not least of which is that our Gradle extract tasks end up
copying an empty fileset to the destination directory. The workaround
here is imply to remove the leading `./` path segment from each file
when performing the extraction. For more details see this issue:
https://github.com/elastic/elasticsearch/issues/49417