### PR TITLE
Fix SLMSnapshotBlockingIntegTests.testSnapshotInProgress

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -109,7 +109,8 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
             SnapshotLifecyclePolicyItem.SnapshotInProgress inProgress = item.getSnapshotInProgress();
             assertThat(inProgress.getSnapshotId().getName(), equalTo(snapshotName));
             assertThat(inProgress.getStartTime(), greaterThan(0L));
-            assertThat(inProgress.getState(), anyOf(equalTo(SnapshotsInProgress.State.INIT), equalTo(SnapshotsInProgress.State.STARTED)));
+            assertThat(inProgress.getState(), anyOf(equalTo(SnapshotsInProgress.State.INIT), equalTo(SnapshotsInProgress.State.STARTED),
+                equalTo(SnapshotsInProgress.State.SUCCESS)));
             assertNull(inProgress.getFailure());
         });
 


### PR DESCRIPTION
This test must check for state `SUCCESS` as well. `SUCESS` in
`SnapshotsInProgress` means "all data nodes finished snapshotting sucessfully but master must still finalize the snapshot in the repo".
`SUCCESS` does not mean that the snapshot is actually fully finished in this object. (since this is now the third time this has come up in SLM related test I think we should improve naming/documentation of this and will look into that in a separate PR ... it's not so trivial though to do this in a BwC way)

You can easily reporduce the scenario in #49303 that has an in-progress snapshot in `SUCCESS` state by waiting 20s before running the busy assert loop on the snapshot status so that all steps but the blocked finalization can finish.

Closes #49303
