### PR TITLE
Avoid double-wrapping allocator

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/NettyAllocator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/NettyAllocator.java
@@ -44,7 +44,7 @@ public class NettyAllocator {
         } else {
             ByteBufAllocator delegate;
             if (useUnpooled()) {
-                delegate = new NoDirectBuffers(UnpooledByteBufAllocator.DEFAULT);
+                delegate = UnpooledByteBufAllocator.DEFAULT;
             } else {
                 int nHeapArena = PooledByteBufAllocator.defaultNumHeapArena();
                 int pageSize = PooledByteBufAllocator.defaultPageSize();


### PR DESCRIPTION
When using unpooled, the allocator is wrapped twice in a `NoDirectBuffers`.