### PR TITLE
[Docs] Correct `max_doc_freq` default value

### DIFF
--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -198,7 +198,8 @@ input document. Defaults to `5`.
 `max_doc_freq`::
 The maximum document frequency above which the terms will be ignored from the
 input document. This could be useful in order to ignore highly frequent words
-such as stop words. Defaults to unbounded (`0`).
+such as stop words. Defaults to unbounded (`Integer.MAX_VALUE`, which is `2^31-1`
+or 2147483647).
 
 `min_word_length`::
 The minimum word length below which the terms will be ignored. The old name


### PR DESCRIPTION
The default is set to Integer.MAX_VALUE but is reported to be `0` in the docs.
With the current implementation a value of 0 would mean all terms are filtered
out, which is the opposite of "unbounded".

Closes #49520
