### PR TITLE
BoolQueryBuilder - remove adjust_pure_negative:true from XContent rendering

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yml
@@ -69,7 +69,6 @@
   - gte: { indices.test_index.filter.bool.should.0.term.field.boost: 1.0 }
   - lte: { indices.test_index.filter.bool.should.1.term.field.boost: 1.0 }
   - gte: { indices.test_index.filter.bool.should.1.term.field.boost: 1.0 }
-  - match: { indices.test_index.filter.bool.adjust_pure_negative: true}
   - lte: { indices.test_index.filter.bool.boost: 1.0 }
   - gte: { indices.test_index.filter.bool.boost: 1.0 }
 

--- a/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -250,7 +250,9 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
         doXArrayContent(FILTER, filterClauses, builder, params);
         doXArrayContent(MUST_NOT, mustNotClauses, builder, params);
         doXArrayContent(SHOULD, shouldClauses, builder, params);
-        builder.field(ADJUST_PURE_NEGATIVE.getPreferredName(), adjustPureNegative);
+        if (adjustPureNegative != ADJUST_PURE_NEGATIVE_DEFAULT) {
+            builder.field(ADJUST_PURE_NEGATIVE.getPreferredName(), adjustPureNegative);
+        }
         if (minimumShouldMatch != null) {
             builder.field(MINIMUM_SHOULD_MATCH.getPreferredName(), minimumShouldMatch);
         }

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -263,7 +263,6 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
                 "      }" +
                 "    }" +
                 "  } ]," +
-                "  \"adjust_pure_negative\" : true," +
                 "  \"minimum_should_match\" : \"23\"," +
                 "  \"boost\" : 42.0" +
                 "}" +

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -166,7 +166,6 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
                 "            }\n" +
                 "          }\n" +
                 "        } ],\n" +
-                "        \"adjust_pure_negative\" : true,\n" +
                 "        \"boost\" : 1.0\n" +
                 "      }\n" +
                 "    },\n" +


### PR DESCRIPTION
Remove serialisation of default value - no point and only serves to publicise a setting that we don’t document or encourage people to use.

Closes #49530