### PR TITLE
[DOCS] Fixes security links

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -338,7 +338,7 @@ connections are unreliable or slow, it is not optimised for this case and its
 performance may suffer. If you wish to geographically distribute your data, you
 should provision multiple clusters and use features such as
 {ref}/modules-cross-cluster-search.html[cross-cluster search] and
-{stack-ov}/xpack-ccr.html[cross-cluster replication].
+{ref}/xpack-ccr.html[cross-cluster replication].
 
 ===== Other recommendations
 

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -57,7 +57,7 @@ DELETE /_enrich/policy/my-policy
 If you use {es} {security-features}, you must have:
 
 * `read` index privileges for any indices used
-* The `enrich_user` {stack-ov}/built-in-roles.html[built-in role]
+* The `enrich_user` <<built-in-roles,built-in role>>
 // end::enrich-policy-api-prereqs[]
 
 

--- a/docs/reference/monitoring/esms.asciidoc
+++ b/docs/reference/monitoring/esms.asciidoc
@@ -78,7 +78,7 @@ output.elasticsearch:
 <1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL for {esms-init},
 which was provided by the Elastic support team.
 <2> The Elastic support team creates this user in {esms-init} and grants it the
-{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
+<<built-in-roles,`remote_monitoring_agent` built-in role>>. 
 <3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
 Elastic support team.
 // end::metricbeat-config[]
@@ -180,7 +180,7 @@ If the Elastic {security-features} are enabled, you must also provide a user
 ID and password so that {metricbeat} can collect metrics successfully: 
 
 .. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
+`remote_monitoring_collector` <<built-in-roles,built-in role>>. 
 Alternatively, use the `remote_monitoring_user` 
 <<built-in-users,built-in user>>.
 
@@ -337,9 +337,9 @@ If the Elastic {security-features} are enabled, you must also provide a user
 ID and password so that {metricbeat} can collect metrics successfully: 
 
 .. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
+`remote_monitoring_collector` <<built-in-roles,built-in role>>. 
 Alternatively, if it's available in your environment, use the
-`remote_monitoring_user` {ref}/built-in-users.html[built-in user].
+`remote_monitoring_user` <<built-in-users,built-in user>>.
 
 .. Add the `username` and `password` settings to the beat module configuration 
 file.


### PR DESCRIPTION
Related to elastic/elasticsearch#46880

This PR fixes links to content that has moved from the Stack Overview to the Elasticsearch Reference.

In particular, it fixes the following broken links in https://github.com/elastic/stack-docs/pull/700:

> /tmp/docsbuild/target_repo/html/en/elasticsearch/plugins/master/cloud-aws-best-practices.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/xpack-ccr.html
11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/delete-enrich-policy-api.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/enrich-setup.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/esms.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/execute-enrich-policy-api.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/get-enrich-policy-api.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:08:36 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/put-enrich-policy-api.html:
11:08:36 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html