### PR TITLE
EngineTestCase#getDocIds should use internal reader

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1010,7 +1010,7 @@ public abstract class EngineTestCase extends ESTestCase {
         if (refresh) {
             engine.refresh("test_get_doc_ids");
         }
-        try (Engine.Searcher searcher = engine.acquireSearcher("test_get_doc_ids")) {
+        try (Engine.Searcher searcher = engine.acquireSearcher("test_get_doc_ids", Engine.SearcherScope.INTERNAL)) {
             List<DocIdSeqNoAndSource> docs = new ArrayList<>();
             for (LeafReaderContext leafContext : searcher.getIndexReader().leaves()) {
                 LeafReader reader = leafContext.reader();


### PR DESCRIPTION
We do not guarantee that EngineTestCase#getDocIds is called after the engine has been externally refreshed. Hence, we trip an assertion `assertSearcherIsWarmedUp`.

CI: https://gradle-enterprise.elastic.co/s/pm2at5qmfm2iu

Relates #48605