### PR TITLE
Add JAVA_HOME env override location to docs

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -240,7 +240,8 @@ locations for a Debian-based system:
 
 | jdk
   | The bundled Java Development Kit used to run Elasticsearch. Can
-    be overriden by setting the `JAVA_HOME` environment variable.
+    be overriden by setting the `JAVA_HOME` environment variable
+    in `/etc/default/elasticsearch`.
   | /usr/share/elasticsearch/jdk
  d|
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -227,7 +227,8 @@ locations for an RPM-based system:
 
 | jdk
   | The bundled Java Development Kit used to run Elasticsearch. Can
-    be overriden by setting the `JAVA_HOME` environment variable.
+    be overriden by setting the `JAVA_HOME` environment variable
+    in `/etc/sysconfig/elasticsearch`.
   | /usr/share/elasticsearch/jdk
  d|
 


### PR DESCRIPTION
This commit clarifies how to override JAVA_HOME from the bundled jdk for
deb and rpm installs, which each have their own file that is sourced
upon service startup.

closes #49068