### PR TITLE
SQL: Add TRUNC alias for TRUNCATE

### DIFF
--- a/docs/reference/sql/functions/math.asciidoc
+++ b/docs/reference/sql/functions/math.asciidoc
@@ -385,7 +385,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[mathInlineSqrt]
 --------------------------------------------------
 
 [[sql-functions-math-truncate]]
-==== `TRUNCATE`
+==== `TRUNCATE/TRUNC`
 
 .Synopsis:
 [source, sql]

--- a/x-pack/plugin/sql/qa/src/main/resources/command.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/command.csv-spec
@@ -122,8 +122,9 @@ SIN              |SCALAR
 SINH             |SCALAR         
 SQRT             |SCALAR         
 TAN              |SCALAR         
-TRUNCATE         |SCALAR         
-ASCII            |SCALAR         
+TRUNC            |SCALAR
+TRUNCATE         |SCALAR
+ASCII            |SCALAR
 BIT_LENGTH       |SCALAR         
 CHAR             |SCALAR         
 CHARACTER_LENGTH |SCALAR         

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -318,8 +318,9 @@ SIN              |SCALAR
 SINH             |SCALAR         
 SQRT             |SCALAR         
 TAN              |SCALAR         
-TRUNCATE         |SCALAR         
-ASCII            |SCALAR         
+TRUNC            |SCALAR
+TRUNCATE         |SCALAR
+ASCII            |SCALAR
 BIT_LENGTH       |SCALAR         
 CHAR             |SCALAR         
 CHARACTER_LENGTH |SCALAR         
@@ -2032,7 +2033,7 @@ SELECT TRUNCATE(-345.153, -1) AS trimmed;
 
 mathTruncateWithPositiveParameter
 // tag::mathTruncateWithPositiveParameter
-SELECT TRUNCATE(-345.153, 1) AS trimmed;
+SELECT TRUNC(-345.153, 1) AS trimmed;
 
     trimmed
 ---------------

--- a/x-pack/plugin/sql/qa/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/math.csv-spec
@@ -2,9 +2,9 @@
 
 // this one doesn't work in H2 at all
 truncateWithAsciiHavingAndOrderBy
-SELECT TRUNCATE(ASCII(LEFT(first_name, 1)), 1), COUNT(*) count FROM test_emp GROUP BY ASCII(LEFT(first_name, 1)) HAVING COUNT(*) > 5 ORDER BY TRUNCATE(ASCII(LEFT(first_name, 1)), 1) DESC;
+SELECT TRUNC(ASCII(LEFT(first_name, 1)), 1), COUNT(*) count FROM test_emp GROUP BY ASCII(LEFT(first_name, 1)) HAVING COUNT(*) > 5 ORDER BY TRUNCATE(ASCII(LEFT(first_name, 1)), 1) DESC;
 
-TRUNCATE(ASCII(LEFT(first_name, 1)), 1):i|     count:l
+TRUNC(ASCII(LEFT(first_name, 1)), 1):i   |     count:l
 -----------------------------------------+---------------
 null                                     |10             
 66                                       |7              
@@ -45,7 +45,7 @@ SELECT ROUND(salary, 2) ROUNDED, salary FROM test_emp GROUP BY ROUNDED, salary O
 ;
 
 truncateWithGroupByAndOrderBy
-SELECT TRUNCATE(salary, 2) TRUNCATED, salary FROM test_emp GROUP BY TRUNCATED, salary ORDER BY TRUNCATED LIMIT 10;
+SELECT TRUNC(salary, 2) TRUNCATED, salary FROM test_emp GROUP BY TRUNCATED, salary ORDER BY TRUNCATED LIMIT 10;
 
    TRUNCATED   |    salary     
 ---------------+---------------
@@ -129,9 +129,9 @@ SELECT MIN(salary) mi, MAX(salary) ma, YEAR(hire_date) year, ROUND(AVG(languages
 ;
 
 groupByAndOrderByTruncateWithPositiveParameter
-SELECT TRUNCATE(AVG(salary),2), AVG(salary), COUNT(*) FROM test_emp GROUP BY TRUNCATE(salary, 2) ORDER BY TRUNCATE(salary, 2) DESC LIMIT 10;
+SELECT TRUNC(AVG(salary),2), AVG(salary), COUNT(*) FROM test_emp GROUP BY TRUNC(salary, 2) ORDER BY TRUNCATE(salary, 2) DESC LIMIT 10;
 
-TRUNCATE(AVG(salary),2):d| AVG(salary):d |   COUNT(*):l    
+TRUNC(AVG(salary),2):d   | AVG(salary):d |   COUNT(*):l
 -------------------------+---------------+---------------
 74999.0                  |74999.0        |1              
 74970.0                  |74970.0        |1              

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistry.java
@@ -242,7 +242,7 @@ public class FunctionRegistry {
                 def(Sinh.class, Sinh::new, "SINH"),
                 def(Sqrt.class, Sqrt::new, "SQRT"),
                 def(Tan.class, Tan::new, "TAN"),
-                def(Truncate.class, Truncate::new, "TRUNCATE"));
+                def(Truncate.class, Truncate::new, "TRUNCATE", "TRUNC"));
         // String
         addToMap(def(Ascii.class, Ascii::new, "ASCII"),
                 def(BitLength.class, BitLength::new, "BIT_LENGTH"),


### PR DESCRIPTION
Add TRUNC as alias to already implemented TRUNCATE
numeric function which is the flavour supported by
Oracle and PostgreSQL.

Relates to: #41195
