### PR TITLE
[DOCS] Adds deprecation notice for ML estimation API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/estimate-memory-usage-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/estimate-memory-usage-dfanalytics.asciidoc
@@ -10,6 +10,8 @@
 
 Estimates memory usage for the given {dataframe-analytics-config}.
 
+deprecated::[7.5,Replaced by the `explain {dfanalytics} API` in later releases.]
+
 experimental[]
 
 [[ml-estimate-memory-usage-dfanalytics-request]]


### PR DESCRIPTION
This PR adds a [deprecation notification](https://github.com/elastic/docs#additions-and-deprecations) for the [estimate memory usage API](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/estimate-memory-usage-dfanalytics.html), which is replaced by the [explain data frame analytics API](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/explain-dfanalytics.html).

Preview: http://elasticsearch_49572.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.5/estimate-memory-usage-dfanalytics.html