### PR TITLE
Bootstrap the elastic user via script

### DIFF
--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -91,6 +91,14 @@ new bootstrap password:
 bin/elasticsearch-keystore add "bootstrap.password"
 ----------------------------------------------------
 
+Alternatively you can set the bootstrap password by passing the password to stdin.
+This can be useful for scripted or automated deployments.
+
+[source,shell]
+------------------------------------------------------------------------------------------
+bash -c 'printf <PASSWORD> | bin/elasticsearch-keystore add bootstrap.password -x -f -v'
+------------------------------------------------------------------------------------------
+
 You can then start {es} and {kib} and use the `elastic` user and bootstrap
 password to log into {kib} and change the passwords. Alternatively, you can
 submit Change Password API requests for each built-in user. These methods are


### PR DESCRIPTION
Added in an example that will allow users who cannot use the interactive version to set a bootstrap user password. This is handy for users who need to deploy elasticsearch via an automated method.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines] (https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
