### PR TITLE
Reindex source types disregarded in 7.x

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -504,6 +504,10 @@ Valid values: `index`, `create`. Defaults to `index`.
 (Optional, enum) The script language: `painless`, `expression`, `mustache`, `java`. 
 For more information, see <<modules-scripting>>.
 
+NOTE: Types in source indices are always ignored, also when not specifying a
+destination `type`. If explicitly specifying destination `type`, the specified
+type must match the type in the destination index or be either unspecified or
+the special value `_doc`. See <<removal-of-types>> for further details.
 
 [[docs-reindex-api-response-body]]
 ==== {api-response-body-title}

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -484,18 +484,6 @@ Use in conjunction with `max_docs` to control what documents are reindexed.
 Set to a list to reindex select fields. 
 Defaults to `true`. 
 
-`type`:::
-(Optional, string)
-deprecated:[6.0.0,Types are deprecated and in the process of being removed. See <<removal-of-types>>.]
-<<mapping-type-field,Document type>> to reindex.
-+
-[WARNING]
-====
-By default, all reindexed documents are assigned the `_doc` document type. To
-preserve other document types during a reindex, specify the `type` in the `dest`
-index.
-====
-
 `dest`::
 `index`:::
 (Required, string) The name of the index you are copying _to_.
@@ -517,8 +505,10 @@ Defaults to `_doc`.
 +
 [WARNING]
 ====
-By default, all reindexed documents are assigned the `_doc` document type.
-To preserve other document types, this parameter must be specified.
+Types in source indices are always ignored, also when not specifying a
+destination `type`. If explicitly specifying destination `type`, the specified
+type must match the type in the destination index or be either unspecified or
+the special value `_doc`. See <<removal-of-types>> for further details.
 ====
 
 `script`::

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -484,6 +484,18 @@ Use in conjunction with `max_docs` to control what documents are reindexed.
 Set to a list to reindex select fields. 
 Defaults to `true`. 
 
+`type`:::
+(Optional, string)
+deprecated:[6.0.0,Types are deprecated and in the process of being removed. See <<removal-of-types>>.]
+<<mapping-type-field,Document type>> to reindex.
++
+[WARNING]
+====
+By default, all reindexed documents are assigned the `_doc` document type. To
+preserve other document types during a reindex, specify the `type` in the `dest`
+index.
+====
+
 `dest`::
 `index`:::
 (Required, string) The name of the index you are copying _to_.
@@ -497,9 +509,22 @@ See <<index-version-types>> for more information.
 (Optional, enum) Set to create to only index documents that do not already exist (put if absent). 
 Valid values: `index`, `create`. Defaults to `index`.
 
+`type`:::
+(Optional, string)
+deprecated:[6.0.0,Types are deprecated and in the process of being removed. See <<removal-of-types>>.]
+<<mapping-type-field,Document type>> for reindexed documents.
+Defaults to `_doc`.
++
+[WARNING]
+====
+By default, all reindexed documents are assigned the `_doc` document type.
+To preserve other document types, this parameter must be specified.
+====
+
 `script`::
 `source`::: 
 (Optional, string) The script to run to update the document source or metadata when reindexing. 
+
 `lang`:::
 (Optional, enum) The script language: `painless`, `expression`, `mustache`, `java`. 
 For more information, see <<modules-scripting>>.

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -529,10 +529,6 @@ To preserve other document types, this parameter must be specified.
 (Optional, enum) The script language: `painless`, `expression`, `mustache`, `java`. 
 For more information, see <<modules-scripting>>.
 
-NOTE: Types in source indices are always ignored, also when not specifying a
-destination `type`. If explicitly specifying destination `type`, the specified
-type must match the type in the destination index or be either unspecified or
-the special value `_doc`. See <<removal-of-types>> for further details.
 
 [[docs-reindex-api-response-body]]
 ==== {api-response-body-title}


### PR DESCRIPTION
Clarify that types in source index are disregarded.

Closes #48460
