### PR TITLE
[ML][Inference] add allow_missing_fields option to processor

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
@@ -39,26 +39,34 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
         private final List<Map<String, Object>> objectsToInfer;
         private final InferenceConfig config;
         private final boolean previouslyLicensed;
+        private final boolean allowMissingFields;
 
         public Request(String modelId, boolean previouslyLicensed) {
-            this(modelId, Collections.emptyList(), new RegressionConfig(), previouslyLicensed);
+            this(modelId, Collections.emptyList(), new RegressionConfig(), previouslyLicensed, true);
         }
 
         public Request(String modelId,
                        List<Map<String, Object>> objectsToInfer,
                        InferenceConfig inferenceConfig,
-                       boolean previouslyLicensed) {
+                       boolean previouslyLicensed,
+                       boolean allowMissingFields) {
             this.modelId = ExceptionsHelper.requireNonNull(modelId, TrainedModelConfig.MODEL_ID);
             this.objectsToInfer = Collections.unmodifiableList(ExceptionsHelper.requireNonNull(objectsToInfer, "objects_to_infer"));
             this.config = ExceptionsHelper.requireNonNull(inferenceConfig, "inference_config");
             this.previouslyLicensed = previouslyLicensed;
+            this.allowMissingFields = allowMissingFields;
         }
 
-        public Request(String modelId, Map<String, Object> objectToInfer, InferenceConfig config, boolean previouslyLicensed) {
+        public Request(String modelId,
+                       Map<String, Object> objectToInfer,
+                       InferenceConfig config,
+                       boolean previouslyLicensed,
+                       boolean allowMissingFields) {
             this(modelId,
                 Arrays.asList(ExceptionsHelper.requireNonNull(objectToInfer, "objects_to_infer")),
                 config,
-                previouslyLicensed);
+                previouslyLicensed,
+                allowMissingFields);
         }
 
         public Request(StreamInput in) throws IOException {
@@ -67,6 +75,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             this.objectsToInfer = Collections.unmodifiableList(in.readList(StreamInput::readMap));
             this.config = in.readNamedWriteable(InferenceConfig.class);
             this.previouslyLicensed = in.readBoolean();
+            this.allowMissingFields = in.readBoolean();
         }
 
         public String getModelId() {
@@ -85,6 +94,10 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             return previouslyLicensed;
         }
 
+        public boolean isAllowMissingFields() {
+            return allowMissingFields;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             return null;
@@ -97,6 +110,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             out.writeCollection(objectsToInfer, StreamOutput::writeMap);
             out.writeNamedWriteable(config);
             out.writeBoolean(previouslyLicensed);
+            out.writeBoolean(allowMissingFields);
         }
 
         @Override
@@ -107,12 +121,13 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             return Objects.equals(modelId, that.modelId)
                 && Objects.equals(config, that.config)
                 && Objects.equals(previouslyLicensed, that.previouslyLicensed)
+                && Objects.equals(allowMissingFields, that.allowMissingFields)
                 && Objects.equals(objectsToInfer, that.objectsToInfer);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, objectsToInfer, config, previouslyLicensed);
+            return Objects.hash(modelId, objectsToInfer, config, previouslyLicensed, allowMissingFields);
         }
 
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
@@ -14,8 +14,6 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConf
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -31,11 +29,13 @@ public class InternalInferModelActionRequestTests extends AbstractWireSerializin
                 randomAlphaOfLength(10),
                 Stream.generate(InternalInferModelActionRequestTests::randomMap).limit(randomInt(10)).collect(Collectors.toList()),
                 randomInferenceConfig(),
+                randomBoolean(),
                 randomBoolean()) :
             new Request(
                 randomAlphaOfLength(10),
                 randomMap(),
                 randomInferenceConfig(),
+                randomBoolean(),
                 randomBoolean());
     }
 
@@ -56,8 +56,6 @@ public class InternalInferModelActionRequestTests extends AbstractWireSerializin
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
-        List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
-        entries.addAll(new MlInferenceNamedXContentProvider().getNamedWriteables());
-        return new NamedWriteableRegistry(entries);
+        return new NamedWriteableRegistry(new MlInferenceNamedXContentProvider().getNamedWriteables());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -62,7 +62,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                     ex -> true);
                 request.getObjectsToInfer().forEach(stringObjectMap ->
                     typedChainTaskExecutor.add(chainedTask ->
-                        model.infer(stringObjectMap, request.getConfig(), chainedTask)));
+                        model.infer(stringObjectMap, request.getConfig(), request.isAllowMissingFields(), chainedTask)));
 
                 typedChainTaskExecutor.execute(ActionListener.wrap(
                     inferenceResultsInterfaces ->

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
@@ -16,6 +16,8 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.license.License;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.Classification;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
@@ -27,6 +29,7 @@ import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -163,6 +166,13 @@ public class AnalyticsResultProcessor {
         Instant createTime = Instant.now();
         String modelId = analytics.getId() + "-" + createTime.toEpochMilli();
         TrainedModelDefinition definition = inferenceModel.build();
+        List<String> fieldNamesWithoutDependentVariable = new ArrayList<>(fieldNames.size());
+        String dependentVariable = getDependentVariable();
+        for (String fieldName : fieldNames) {
+            if (fieldName.equals(dependentVariable) == false) {
+                fieldNamesWithoutDependentVariable.add(fieldName);
+            }
+        }
         return TrainedModelConfig.builder()
             .setModelId(modelId)
             .setCreatedBy("data-frame-analytics")
@@ -175,7 +185,7 @@ public class AnalyticsResultProcessor {
             .setEstimatedHeapMemory(definition.ramBytesUsed())
             .setEstimatedOperations(definition.getTrainedModel().estimatedNumOperations())
             .setParsedDefinition(inferenceModel)
-            .setInput(new TrainedModelInput(fieldNames))
+            .setInput(new TrainedModelInput(fieldNamesWithoutDependentVariable))
             .setLicenseLevel(License.OperationMode.PLATINUM.description())
             .build();
     }
@@ -203,5 +213,15 @@ public class AnalyticsResultProcessor {
         LOGGER.error(new ParameterizedMessage("[{}] Error processing results; ", analytics.getId()), e);
         failure = "error processing results; " + e.getMessage();
         auditor.error(analytics.getId(), "Error processing results; " + e.getMessage());
+    }
+
+    private String getDependentVariable() {
+        if (analytics.getAnalysis() instanceof Classification) {
+            return ((Classification)analytics.getAnalysis()).getDependentVariable();
+        }
+        if (analytics.getAnalysis() instanceof Regression) {
+            return ((Regression)analytics.getAnalysis()).getDependentVariable();
+        }
+        return null;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
@@ -15,7 +15,17 @@ public interface Model {
 
     String getResultsType();
 
-    void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener);
+    /**
+     * Infers against the defined model and alerts the listener of the result
+     * @param fields The field map indicating the values to infer against
+     * @param inferenceConfig The configuration containing inference type specific parameters
+     * @param allowMissingFields When {@code false}, an error is returned to the listener when fields are missing
+     * @param listener The listener to alert when inference is complete.
+     */
+    void infer(Map<String, Object> fields,
+               InferenceConfig inferenceConfig,
+               boolean allowMissingFields,
+               ActionListener<InferenceResults> listener);
 
     String getModelId();
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -141,6 +141,7 @@ public class ModelLoadingService implements ClusterStateListener {
                 trainedModelConfig ->
                     modelActionListener.onResponse(new LocalModel(
                         trainedModelConfig.getModelId(),
+                        trainedModelConfig.getInput().getFieldNames(),
                         trainedModelConfig.ensureParsedDefinition(namedXContentRegistry).getModelDefinition())),
                 modelActionListener::onFailure
             ));
@@ -198,6 +199,7 @@ public class ModelLoadingService implements ClusterStateListener {
         Queue<ActionListener<Model>> listeners;
         LocalModel loadedModel = new LocalModel(
             trainedModelConfig.getModelId(),
+            trainedModelConfig.getInput().getFieldNames(),
             trainedModelConfig.ensureParsedDefinition(namedXContentRegistry).getModelDefinition());
         synchronized (loadingListeners) {
             listeners = loadingListeners.remove(modelId);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
@@ -620,7 +620,8 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
             modelId,
             Collections.singletonList(Collections.emptyMap()),
             new RegressionConfig(),
-            false
+            false,
+            true
         ), inferModelSuccess);
         InternalInferModelAction.Response response = inferModelSuccess.actionGet();
         assertThat(response.getInferenceResults(), is(not(empty())));
@@ -637,7 +638,8 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 new RegressionConfig(),
-                false
+                false,
+                true
             )).actionGet();
         });
         assertThat(e.status(), is(RestStatus.FORBIDDEN));
@@ -650,6 +652,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
             modelId,
             Collections.singletonList(Collections.emptyMap()),
             new RegressionConfig(),
+            true,
             true
         ), inferModelSuccess);
         response = inferModelSuccess.actionGet();
@@ -666,7 +669,8 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
             modelId,
             Collections.singletonList(Collections.emptyMap()),
             new RegressionConfig(),
-            false
+            false,
+            true
         ), listener);
         assertThat(listener.actionGet().getInferenceResults(), is(not(empty())));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
@@ -170,7 +170,8 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
         assertThat(storedModel.getTags(), contains(JOB_ID));
         assertThat(storedModel.getDescription(), equalTo(JOB_DESCRIPTION));
         assertThat(storedModel.getModelDefinition(), equalTo(inferenceModel.build()));
-        assertThat(storedModel.getInput().getFieldNames(), equalTo(expectedFieldNames));
+        // The dependent variable `foo` should not be included in the resulting field names
+        assertThat(storedModel.getInput().getFieldNames(), equalTo(Arrays.asList("bar", "baz")));
         assertThat(storedModel.getEstimatedHeapMemory(), equalTo(inferenceModel.build().ramBytesUsed()));
         assertThat(storedModel.getEstimatedOperations(), equalTo(inferenceModel.build().getTrainedModel().estimatedNumOperations()));
         Map<String, Object> metadata = storedModel.getMetadata();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -233,6 +234,42 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
 
         try {
             processorFactory.create(Collections.emptyMap(), "my_inference_processor", classification);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    public void testCreateProcessor_DefaultValueForMissingFields() {
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
+            clusterService,
+            Settings.EMPTY,
+            ingestService);
+
+        Map<String, Object> regression = new HashMap<>() {{
+            put(InferenceProcessor.FIELD_MAPPINGS, Collections.emptyMap());
+            put(InferenceProcessor.MODEL_ID, "my_model");
+            put(InferenceProcessor.TARGET_FIELD, "result");
+            put(InferenceProcessor.INFERENCE_CONFIG, Collections.singletonMap(RegressionConfig.NAME, Collections.emptyMap()));
+        }};
+
+        try {
+            InferenceProcessor processor = processorFactory.create(Collections.emptyMap(), "my_inference_processor", regression);
+            assertThat(processor.isAllowMissingFields(), is(true));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        regression = new HashMap<>() {{
+            put(InferenceProcessor.FIELD_MAPPINGS, Collections.emptyMap());
+            put(InferenceProcessor.MODEL_ID, "my_model");
+            put(InferenceProcessor.TARGET_FIELD, "result");
+            put(InferenceProcessor.ALLOW_MISSING_FIELDS, false);
+            put(InferenceProcessor.INFERENCE_CONFIG, Collections.singletonMap(RegressionConfig.NAME, Collections.emptyMap()));
+        }};
+
+        try {
+            InferenceProcessor processor = processorFactory.create(Collections.emptyMap(), "my_inference_processor", regression);
+            assertThat(processor.isAllowMissingFields(), is(false));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
@@ -54,6 +54,7 @@ public class InferenceProcessorTests extends ESTestCase {
             new ClassificationConfig(0),
             Collections.emptyMap(),
             "ml.my_processor",
+            true,
             true);
 
         Map<String, Object> source = new HashMap<>();
@@ -81,6 +82,7 @@ public class InferenceProcessorTests extends ESTestCase {
             new ClassificationConfig(2),
             Collections.emptyMap(),
             "ml.my_processor",
+            true,
             true);
 
         Map<String, Object> source = new HashMap<>();
@@ -112,6 +114,7 @@ public class InferenceProcessorTests extends ESTestCase {
             new RegressionConfig(),
             Collections.emptyMap(),
             "ml.my_processor",
+            true,
             true);
 
         Map<String, Object> source = new HashMap<>();
@@ -137,7 +140,8 @@ public class InferenceProcessorTests extends ESTestCase {
             new RegressionConfig(),
             Collections.emptyMap(),
             "ml.my_processor",
-            false);
+            false,
+            true);
 
         Map<String, Object> source = new HashMap<>();
         Map<String, Object> ingestMetadata = new HashMap<>();
@@ -161,6 +165,7 @@ public class InferenceProcessorTests extends ESTestCase {
             new RegressionConfig(),
             Collections.emptyMap(),
             "ml.my_processor",
+            true,
             true);
 
         //cannot use singleton map as attempting to mutate later
@@ -197,7 +202,8 @@ public class InferenceProcessorTests extends ESTestCase {
             new ClassificationConfig(topNClasses),
             Collections.emptyMap(),
             "ml.my_processor",
-            false);
+            false,
+            true);
 
         Map<String, Object> source = new HashMap<>(){{
             put("value1", 1);
@@ -228,7 +234,8 @@ public class InferenceProcessorTests extends ESTestCase {
             new ClassificationConfig(topNClasses),
             fieldMapping,
             "ml.my_processor",
-            false);
+            false,
+            true);
 
         Map<String, Object> source = new HashMap<>(3){{
             put("value1", 1);
@@ -246,6 +253,43 @@ public class InferenceProcessorTests extends ESTestCase {
         assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(expectedMap));
     }
 
+    public void testGenerateRequestWithChangingAllowMissingFields() {
+        String modelId = "model";
+        InferenceProcessor processor = new InferenceProcessor(client,
+            auditor,
+            "my_processor",
+            "my_field",
+            modelId,
+            new RegressionConfig(),
+            Collections.emptyMap(),
+            "ml.my_processor",
+            false,
+            true);
+
+        Map<String, Object> source = new HashMap<>(){{
+            put("value1", 1);
+            put("value2", 4);
+            put("categorical", "foo");
+        }};
+        Map<String, Object> ingestMetadata = new HashMap<>();
+        IngestDocument document = new IngestDocument(source, ingestMetadata);
+
+        assertThat(processor.buildRequest(document).isAllowMissingFields(), is(true));
+
+        processor = new InferenceProcessor(client,
+            auditor,
+            "my_processor",
+            "my_field",
+            modelId,
+            new RegressionConfig(),
+            Collections.emptyMap(),
+            "ml.my_processor",
+            false,
+            false);
+
+        assertThat(processor.buildRequest(document).isAllowMissingFields(), is(false));
+    }
+
     public void testHandleResponseLicenseChanged() {
         String targetField = "regression_value";
         InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
@@ -256,6 +300,7 @@ public class InferenceProcessorTests extends ESTestCase {
             new RegressionConfig(),
             Collections.emptyMap(),
             "ml.my_processor",
+            true,
             true);
 
         Map<String, Object> source = new HashMap<>();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.inference.loadingservice;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.inference.loadingservice;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
@@ -38,12 +39,13 @@ public class LocalModelTests extends ESTestCase {
 
     public void testClassificationInfer() throws Exception {
         String modelId = "classification_model";
+        List<String> fieldNames = Arrays.asList("foo", "bar", "categorical");
         TrainedModelDefinition definition = new TrainedModelDefinition.Builder()
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildClassification(false))
             .build();
 
-        Model model = new LocalModel(modelId, definition);
+        Model model = new LocalModel(modelId, fieldNames, definition);
         Map<String, Object> fields = new HashMap<>() {{
             put("foo", 1.0);
             put("bar", 0.5);
@@ -64,7 +66,7 @@ public class LocalModelTests extends ESTestCase {
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildClassification(true))
             .build();
-        model = new LocalModel(modelId, definition);
+        model = new LocalModel(modelId, fieldNames, definition);
         result = getSingleValue(model, fields, new ClassificationConfig(0));
         assertThat(result.value(), equalTo(0.0));
         assertThat(result.valueAsString(), equalTo("not_to_be"));
@@ -81,11 +83,12 @@ public class LocalModelTests extends ESTestCase {
     }
 
     public void testRegression() throws Exception {
+        List<String> fieldNames = Arrays.asList("foo", "bar", "categorical");
         TrainedModelDefinition trainedModelDefinition = new TrainedModelDefinition.Builder()
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildRegression())
             .build();
-        Model model = new LocalModel("regression_model", trainedModelDefinition);
+        Model model = new LocalModel("regression_model", fieldNames, trainedModelDefinition);
 
         Map<String, Object> fields = new HashMap<>() {{
             put("foo", 1.0);
@@ -97,17 +100,40 @@ public class LocalModelTests extends ESTestCase {
         assertThat(results.value(), equalTo(1.3));
 
         PlainActionFuture<InferenceResults> failedFuture = new PlainActionFuture<>();
-        model.infer(fields, new ClassificationConfig(2), failedFuture);
+        model.infer(fields, new ClassificationConfig(2), true, failedFuture);
         ExecutionException ex = expectThrows(ExecutionException.class, failedFuture::get);
         assertThat(ex.getCause().getMessage(),
             equalTo("Cannot infer using configuration for [classification] when model target_type is [regression]"));
+    }
+
+    public void testInferWithMissingFields() throws Exception {
+        List<String> fieldNames = Arrays.asList("foo", "bar", "categorical");
+        TrainedModelDefinition trainedModelDefinition = new TrainedModelDefinition.Builder()
+            .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
+            .setTrainedModel(buildRegression())
+            .build();
+        Model model = new LocalModel("regression_model", fieldNames, trainedModelDefinition);
+
+        Map<String, Object> fields = new HashMap<>() {{
+            put("foo", 1.0);
+            put("bar", 0.5);
+        }};
+
+        SingleValueInferenceResults results = getSingleValue(model, fields, new RegressionConfig());
+        assertThat(results.value(), equalTo(1.0));
+
+        PlainActionFuture<InferenceResults> failedFuture = new PlainActionFuture<>();
+        model.infer(fields, new RegressionConfig(), false, failedFuture);
+        ExecutionException ex = expectThrows(ExecutionException.class, failedFuture::get);
+        assertThat(ex.getCause().getMessage(),
+            equalTo("Not all expected fields for model [regression_model] have been supplied. Missing fields [categorical]."));
     }
 
     private static SingleValueInferenceResults getSingleValue(Model model,
                                                               Map<String, Object> fields,
                                                               InferenceConfig config) throws Exception {
         PlainActionFuture<InferenceResults> future = new PlainActionFuture<>();
-        model.infer(fields, config, future);
+        model.infer(fields, config, true, future);
         return (SingleValueInferenceResults)future.get();
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
@@ -45,6 +46,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -308,6 +310,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         when(definition.ramBytesUsed()).thenReturn(size);
         TrainedModelConfig trainedModelConfig = mock(TrainedModelConfig.class);
         when(trainedModelConfig.getModelDefinition()).thenReturn(definition);
+        when(trainedModelConfig.getInput()).thenReturn(new TrainedModelInput(Arrays.asList("foo", "bar", "baz")));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
             ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];


### PR DESCRIPTION
By default inference actions allow missing fields. But, certain users might want to know if fields are missing in the processor pipeline.

This PR adds a new boolean option to the ingest processor called `allow_missing_fields`. By default this value is `true`. When set to `false`, the processor will fail on inference when there are fields missing in the ingested doc. 