### PR TITLE
Add support for geometrycollections to GeometryTreeReader and Writer

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
@@ -34,42 +34,50 @@ import java.util.Optional;
  */
 public class GeometryTreeReader implements ShapeTreeReader {
 
-    private final int extentOffset = 8;
+    private static final int EXTENT_OFFSET = 8;
+    private final int extentPosition;
     private final ByteBufferStreamInput input;
     private final CoordinateEncoder coordinateEncoder;
 
     public GeometryTreeReader(BytesRef bytesRef, CoordinateEncoder coordinateEncoder) {
         this.input = new ByteBufferStreamInput(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length));
+        extentPosition = 0;
+        this.coordinateEncoder = coordinateEncoder;
+    }
+
+    private GeometryTreeReader(ByteBufferStreamInput input, CoordinateEncoder coordinateEncoder) throws IOException {
+        this.input = input;
+        extentPosition = input.position();
         this.coordinateEncoder = coordinateEncoder;
     }
 
     public double getCentroidX() throws IOException {
-        input.position(0);
+        input.position(extentPosition);
         return coordinateEncoder.decodeX(input.readInt());
     }
 
     public double getCentroidY() throws IOException {
-        input.position(4);
+        input.position(extentPosition + 4);
         return coordinateEncoder.decodeY(input.readInt());
     }
 
     @Override
     public Extent getExtent() throws IOException {
-        input.position(extentOffset);
+        input.position(extentPosition + EXTENT_OFFSET);
         Extent extent = input.readOptionalWriteable(Extent::new);
         if (extent != null) {
             return extent;
         }
         assert input.readVInt() == 1;
         ShapeType shapeType = input.readEnum(ShapeType.class);
-        ShapeTreeReader reader = getReader(shapeType, input);
+        ShapeTreeReader reader = getReader(shapeType, coordinateEncoder, input);
         return reader.getExtent();
     }
 
     @Override
     public GeoRelation relate(Extent extent) throws IOException {
         GeoRelation relation = GeoRelation.QUERY_DISJOINT;
-        input.position(extentOffset);
+        input.position(extentPosition + EXTENT_OFFSET);
         boolean hasExtent = input.readBoolean();
         if (hasExtent) {
             Optional<Boolean> extentCheck = EdgeTreeReader.checkExtent(new Extent(input), extent);
@@ -79,9 +87,17 @@ public class GeometryTreeReader implements ShapeTreeReader {
         }
 
         int numTrees = input.readVInt();
+        int nextPosition = input.position();
         for (int i = 0; i < numTrees; i++) {
+            if (numTrees > 1) {
+                if (i > 0) {
+                    input.position(nextPosition);
+                }
+                int pos = input.readVInt();
+                nextPosition = input.position() + pos;
+            }
             ShapeType shapeType = input.readEnum(ShapeType.class);
-            ShapeTreeReader reader = getReader(shapeType, input);
+            ShapeTreeReader reader = getReader(shapeType, coordinateEncoder, input);
             GeoRelation shapeRelation = reader.relate(extent);
             if (GeoRelation.QUERY_CROSSES == shapeRelation ||
                 (GeoRelation.QUERY_DISJOINT == shapeRelation && GeoRelation.QUERY_INSIDE == relation)
@@ -95,7 +111,8 @@ public class GeometryTreeReader implements ShapeTreeReader {
         return relation;
     }
 
-    private static ShapeTreeReader getReader(ShapeType shapeType, ByteBufferStreamInput input) throws IOException {
+    private static ShapeTreeReader getReader(ShapeType shapeType, CoordinateEncoder coordinateEncoder, ByteBufferStreamInput input)
+            throws IOException {
         switch (shapeType) {
             case POLYGON:
                 return new PolygonTreeReader(input);
@@ -105,6 +122,8 @@ public class GeometryTreeReader implements ShapeTreeReader {
             case LINESTRING:
             case MULTILINESTRING:
                 return new EdgeTreeReader(input, false);
+            case GEOMETRYCOLLECTION:
+                return new GeometryTreeReader(input, coordinateEncoder);
             default:
                 throw new UnsupportedOperationException("unsupported shape type [" + shapeType + "]");
         }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
@@ -41,7 +41,7 @@ public class GeometryTreeReader implements ShapeTreeReader {
 
     public GeometryTreeReader(BytesRef bytesRef, CoordinateEncoder coordinateEncoder) {
         this.input = new ByteBufferStreamInput(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length));
-        startPosition = 0;
+        this.startPosition = 0;
         this.coordinateEncoder = coordinateEncoder;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
@@ -35,35 +35,35 @@ import java.util.Optional;
 public class GeometryTreeReader implements ShapeTreeReader {
 
     private static final int EXTENT_OFFSET = 8;
-    private final int extentPosition;
+    private final int startPosition;
     private final ByteBufferStreamInput input;
     private final CoordinateEncoder coordinateEncoder;
 
     public GeometryTreeReader(BytesRef bytesRef, CoordinateEncoder coordinateEncoder) {
         this.input = new ByteBufferStreamInput(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length));
-        extentPosition = 0;
+        startPosition = 0;
         this.coordinateEncoder = coordinateEncoder;
     }
 
     private GeometryTreeReader(ByteBufferStreamInput input, CoordinateEncoder coordinateEncoder) throws IOException {
         this.input = input;
-        extentPosition = input.position();
+        startPosition = input.position();
         this.coordinateEncoder = coordinateEncoder;
     }
 
     public double getCentroidX() throws IOException {
-        input.position(extentPosition);
+        input.position(startPosition);
         return coordinateEncoder.decodeX(input.readInt());
     }
 
     public double getCentroidY() throws IOException {
-        input.position(extentPosition + 4);
+        input.position(startPosition + 4);
         return coordinateEncoder.decodeY(input.readInt());
     }
 
     @Override
     public Extent getExtent() throws IOException {
-        input.position(extentPosition + EXTENT_OFFSET);
+        input.position(startPosition + EXTENT_OFFSET);
         Extent extent = input.readOptionalWriteable(Extent::new);
         if (extent != null) {
             return extent;
@@ -77,7 +77,7 @@ public class GeometryTreeReader implements ShapeTreeReader {
     @Override
     public GeoRelation relate(Extent extent) throws IOException {
         GeoRelation relation = GeoRelation.QUERY_DISJOINT;
-        input.position(extentPosition + EXTENT_OFFSET);
+        input.position(startPosition + EXTENT_OFFSET);
         boolean hasExtent = input.readBoolean();
         if (hasExtent) {
             Optional<Boolean> extentCheck = EdgeTreeReader.checkExtent(new Extent(input), extent);

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeWriter.java
@@ -98,7 +98,8 @@ public class GeometryTreeWriter extends ShapeTreeWriter {
                     bytesStream.writeEnum(writer.getShapeType());
                     writer.writeTo(bytesStream);
                     BytesReference bytes = bytesStream.bytes();
-                    out.writeBytesReference(bytes);
+                    out.writeVInt(bytes.length());
+                    bytes.writeTo(out);
                 }
             }
         } else {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
@@ -185,7 +185,7 @@ public abstract class MultiGeoValues {
             try {
                 Geometry geometry = MISSING_GEOMETRY_PARSER.fromWKT(missing);
                 GeometryTreeWriter writer = new GeometryTreeWriter(geometry, GeoShapeCoordinateEncoder.INSTANCE);
-                return new GeoShapeValue(writer.extent());
+                return new GeoShapeValue(writer.getExtent());
             } catch (IOException | ParseException e) {
                 throw new IllegalArgumentException("Can't apply missing value [" + missing + "]", e);
             }

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.geometry.MultiPolygon;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.index.query.LegacyGeoShapeQueryProcessor;
 import org.elasticsearch.test.ESTestCase;

--- a/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeometryTreeTests.java
@@ -308,12 +308,6 @@ public class GeometryTreeTests extends ESTestCase {
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         Geometry preparedGeometry = indexer.prepareForIndexing(geometry);
 
-        // TODO: support multi-polygons
-        assumeTrue("polygon crosses dateline",
-            fold(preparedGeometry, 0, (g, c) -> c + (ShapeType.POLYGON == g.type() ? 1 : 0)).equals(
-                fold(geometry, 0, (g, c) -> c + (ShapeType.POLYGON == g.type() ? 1 : 0)))
-        );
-
         for (int i = 0; i < testPointCount; i++) {
             int cur = i;
             intersects[cur] = fold(preparedGeometry, false, (g, s) -> s || intersects(g, testPoints[cur], extentSize));


### PR DESCRIPTION
Adds support geometry collections to GeometryTreeReader
and GeometryTreeWriter.

Relates #37206
