### PR TITLE
Make docker build task incremental

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -72,7 +72,7 @@ project.ext {
 
 void addCopyDockerContextTask(final boolean oss, final boolean ubi) {
   task(taskName("copy", oss, ubi, "DockerContext"), type: Sync) {
-    expansions(oss, ubi, true).each { k, v ->
+    expansions(oss, ubi, true).findAll { it.key != 'build_date' }.each { k, v ->
       inputs.property(k, { v.toString() })
     }
     into buildPath(oss, ubi)
@@ -173,6 +173,11 @@ void addBuildDockerImage(final boolean oss, final boolean ubi) {
       dockerArgs.add(tag)
     }
     args dockerArgs.toArray()
+    File markerFile = file("build/markers/${it.name}.marker")
+    outputs.file(markerFile)
+    doLast {
+      markerFile.setText('', 'UTF-8')
+    }
   }
   assemble.dependsOn(buildDockerImageTask)
   BuildPlugin.requireDocker(buildDockerImageTask)

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -214,6 +214,7 @@ subprojects { Project subProject ->
 
     final Task exportDockerImageTask = task(exportTaskName, type: LoggedExec) {
       executable 'docker'
+      outputs.file(tarFile)
       args "save",
         "-o",
         tarFile,


### PR DESCRIPTION
This commits sets an output marker file for the docker build tasks so
that it can be tracked as up to date. It also fixes the docker build
context task to omit the build date as in input property which always
left the task as out of date.

Closes #49359
