### PR TITLE
Fix Incorrect Repo Start in SnapshotResiliencyTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1226,23 +1226,15 @@ public class SnapshotResiliencyTests extends ESTestCase {
             private Repository.Factory getRepoFactory(Environment environment) {
                 // Run half the tests with the eventually consistent repository
                 if (blobStoreContext == null) {
-                    return metaData -> {
-                        final Repository repository = new FsRepository(metaData, environment, xContentRegistry(), threadPool) {
-                            @Override
-                            protected void assertSnapshotOrGenericThread() {
-                                // eliminate thread name check as we create repo in the test thread
-                            }
-                        };
-                        repository.start();
-                        return repository;
+                    return metaData -> new FsRepository(metaData, environment, xContentRegistry(), threadPool) {
+                        @Override
+                        protected void assertSnapshotOrGenericThread() {
+                            // eliminate thread name check as we create repo in the test thread
+                        }
                     };
                 } else {
-                    return metaData -> {
-                        final Repository repository = new MockEventuallyConsistentRepository(
-                            metaData, xContentRegistry(), deterministicTaskQueue.getThreadPool(), blobStoreContext, random());
-                        repository.start();
-                        return repository;
-                    };
+                    return metaData -> new MockEventuallyConsistentRepository(
+                        metaData, xContentRegistry(), deterministicTaskQueue.getThreadPool(), blobStoreContext, random());
                 }
             }
             public void restart() {


### PR DESCRIPTION
The repo factories aren't supposed to start the repository
they create, that happens in `RepositoriesService`. This has
no effect in `master` currently but I noticed it in #49060
which will introduce logic to the repo start.
