### PR TITLE
Fix synced-flush docs

### DIFF
--- a/docs/reference/indices/synced-flush.asciidoc
+++ b/docs/reference/indices/synced-flush.asciidoc
@@ -170,7 +170,7 @@ A replica shard failed to sync-flush.
 
 [source,console]
 ----
-POST /kimchy/_flush
+POST /kimchy/_flush/synced
 ----
 // TEST[s/^/PUT kimchy\n/]
 


### PR DESCRIPTION
Uses actual synced flush instead of flush.

Relates #46634