### PR TITLE
Small fix in ICUCollationKeywordFieldMapperIT

### DIFF
--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
@@ -189,7 +189,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             client().prepareIndex(index).setId("1")
                 .setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[0] + "\"}", XContentType.JSON),
             client().prepareIndex(index).setId("2")
-                .setSource("{\"id\":\"1\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
+                .setSource("{\"id\":\"2\",\"collate\":\"" + equivalent[1] + "\"}", XContentType.JSON)
         );
 
         // searching for either of the terms should return both results since they collate to the same value


### PR DESCRIPTION
The test was slightly modified with #49166, the two test documents in
`testNormalization` look like they should mirror the document id in the "id"
field in order for it to work as a tie breaker.

Closes #49654