### PR TITLE
Fix link for `datatype` in templates.asciidoc

### DIFF
--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -4,7 +4,7 @@
 Dynamic templates allow you to define custom mappings that can be applied to
 dynamically added fields based on:
 
-* the <<dynamic-mapping,datatype>> detected by Elasticsearch, with <<match-mapping-type,`match_mapping_type`>>.
+* the <<mapping-types,datatype>> detected by Elasticsearch, with <<match-mapping-type,`match_mapping_type`>>.
 * the name of the field, with <<match-unmatch,`match` and `unmatch`>> or <<match-pattern,`match_pattern`>>.
 * the full dotted path to the field, with <<path-match-unmatch,`path_match` and `path_unmatch`>>.
 


### PR DESCRIPTION
I think, than `datatype` should point to https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html page, not to https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-mapping.html