### PR TITLE
Enable LicenceServiceTests for all jdks (#49440)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.license;
 
 
-import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.test.ESTestCase;
 
 import java.time.LocalDate;
@@ -22,8 +21,6 @@ import static org.hamcrest.Matchers.startsWith;
 public class LicenseServiceTests extends ESTestCase {
 
     public void testLogExpirationWarning() {
-        assumeTrue("this is for JDK8 only", JavaVersion.current().equals(JavaVersion.parse("8")));
-
         long time = LocalDate.of(2018, 11, 15).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
         final boolean expired = randomBoolean();
         final String message = LicenseService.buildExpirationMessage(time, expired).toString();


### PR DESCRIPTION
This test no longer relies on jdk version, so the assume should be removed
relates #48209

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
