### PR TITLE
Fix Lucene Version Constant

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -71,7 +71,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_4_2 = new Version(7040299, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version V_7_4_3 = new Version(7040399, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version V_7_5_0 = new Version(7050099, org.apache.lucene.util.Version.LUCENE_8_3_0);
-    public static final Version V_7_6_0 = new Version(7060099, org.apache.lucene.util.Version.LUCENE_8_3_0);
+    public static final Version V_7_6_0 = new Version(7060099, org.apache.lucene.util.Version.LUCENE_8_4_0);
     public static final Version V_8_0_0 = new Version(8000099, org.apache.lucene.util.Version.LUCENE_8_4_0);
     public static final Version CURRENT = V_8_0_0;
 


### PR DESCRIPTION
Lucene in `7.x` is at `8.4` and this constant being off is failing BwC tests.

E.g. https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request+default-distro/11303/console
