### PR TITLE
Make Snapshot Metadata Javadocs Clearer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -335,6 +335,9 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
         }
     }
 
+    /**
+     * Snapshot name
+     */
     private final String snapshot;
 
     private final long indexVersion;
@@ -352,7 +355,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
     /**
      * Constructs new shard snapshot metadata from snapshot metadata
      *
-     * @param snapshot              snapshot id
+     * @param snapshot              snapshot name
      * @param indexVersion          index version
      * @param indexFiles            list of files in the shard
      * @param startTime             snapshot start time
@@ -377,9 +380,9 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
     }
 
     /**
-     * Returns snapshot id
+     * Returns snapshot name
      *
-     * @return snapshot id
+     * @return snapshot name
      */
     public String snapshot() {
         return snapshot;

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
@@ -35,10 +35,19 @@ public class SnapshotFiles {
 
     private Map<String, FileInfo> physicalFiles = null;
 
+    /**
+     * Returns snapshot name
+     *
+     * @return snapshot name
+     */
     public String snapshot() {
         return snapshot;
     }
 
+    /**
+     * @param snapshot   snapshot name
+     * @param indexFiles index files
+     */
     public SnapshotFiles(String snapshot, List<FileInfo> indexFiles ) {
         this.snapshot = snapshot;
         this.indexFiles = indexFiles;


### PR DESCRIPTION
We are always using the snapshot name on the shard level, let's make it crystal clear in the docs as this is really trappy since we're also using the actual snapshot uuid for shard level file naming ...