### PR TITLE
Optimize numeric sort on match_all queries

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -130,7 +130,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    static final class SeqNoFieldType extends SimpleMappedFieldType {
+    public static final class SeqNoFieldType extends SimpleMappedFieldType {
 
         SeqNoFieldType() {
         }

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -427,6 +427,9 @@ public class QueryPhase implements SearchPhase {
         final IndexReader reader = context.searcher().getIndexReader();
         final int numDocs = reader.numDocs();
         final SortField sortField = sort.getSort()[0];
+        if (sortField.getField() == null) {
+            return false;
+        }
         final MappedFieldType fieldType = context.mapperService().fullName(sortField.getField());
         final String fieldName = fieldType.name();
 

--- a/server/src/main/java/org/elasticsearch/search/query/SortedLongQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/query/SortedLongQuery.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.query;
+
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.CollectionTerminatedException;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FutureArrays;
+import org.apache.lucene.util.SparseFixedBitSet;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A query that matches only the first <code>topN</code> documents
+ * sorted by a {@link LongPoint} field and discards the other ones.
+ * This query can be used to retrieve the topN documents sorted by
+ * a field efficiently when there is no other clause in the query.
+ */
+class SortedLongQuery extends Query {
+    private final String field;
+    private final long from;
+    private final int fromMinDoc;
+    private final int size;
+
+    SortedLongQuery(String field, int size) {
+        this(field, size, Long.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    SortedLongQuery(String field, int size, long from, int fromMinDoc) {
+        this.field = Objects.requireNonNull(field);
+        this.from = from;
+        this.fromMinDoc = fromMinDoc;
+        this.size = size;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), from, fromMinDoc, size);
+    }
+
+
+    @Override
+    public Query rewrite(IndexReader reader) throws IOException {
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (sameClassAs(o) == false) {
+            return false;
+        }
+        SortedLongQuery that = (SortedLongQuery) o;
+        return from == that.from &&
+            fromMinDoc == that.fromMinDoc &&
+            size == that.size &&
+            field.equals(that.field);
+    }
+
+    @Override
+    public String toString(String field) {
+        return "SortedLongQuery(" +
+            "field='" + field + '\'' +
+            ", from=" + from +
+            ", fromMinDoc=" + fromMinDoc +
+            ", size=" + size +
+            ')';
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                final PointValues pointValues = context.reader().getPointValues(field);
+                if (pointValues == null) {
+                    return null;
+                }
+                final Bits liveDocs = context.reader().getLiveDocs();
+                byte[] minBytes = new byte[Long.SIZE];
+                LongPoint.encodeDimension(from, minBytes, 0);
+                final SparseFixedBitSet bitSet = new SparseFixedBitSet(context.reader().numDocs());
+                final int[] count = new int[1];
+                try {
+                    pointValues.intersect(new PointValues.IntersectVisitor() {
+                        @Override
+                        public void visit(int docID) {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public void visit(int docID, byte[] packedValue) {
+                            int cmp = FutureArrays.compareUnsigned(packedValue, 0, Long.BYTES, minBytes, 0, Long.BYTES);
+                            if (cmp == 0 && fromMinDoc >= docID + context.docBase) {
+                                return;
+                            } else if (cmp < 0) {
+                                return;
+                            }
+                            if (liveDocs == null || liveDocs.get(docID)) {
+                                bitSet.set(docID);
+                                if (++count[0] == size) {
+                                    throw new CollectionTerminatedException();
+                                }
+                            }
+                        }
+
+                        @Override
+                        public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                            if (FutureArrays.compareUnsigned(maxPackedValue, 0, Long.BYTES, minBytes, 0, Long.BYTES) < 0) {
+                                return PointValues.Relation.CELL_OUTSIDE_QUERY;
+                            }
+                            return PointValues.Relation.CELL_CROSSES_QUERY;
+                        }
+                    });
+                } catch (CollectionTerminatedException exc) {}
+                if (count[0] == 0) {
+                    return null;
+                }
+                return new ConstantScoreScorer(this, score(), scoreMode, new BitSetIterator(bitSet, count[0]));
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/query/SortedLongQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SortedLongQueryTests.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.query;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.QueryUtils;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class SortedLongQueryTests extends ESTestCase {
+
+    public void testBasics() {
+        SortedLongQuery query1 = new SortedLongQuery("field", 1, 1, 1);
+        SortedLongQuery query2 = new SortedLongQuery("field", 1, 1, 1);
+        SortedLongQuery query3 = new SortedLongQuery("field", 2, 1, 1);
+        SortedLongQuery query4 = new SortedLongQuery("field", 1, 2, 1);
+        SortedLongQuery query5 = new SortedLongQuery("field", 1, 1, 2);
+        SortedLongQuery query6 = new SortedLongQuery("field2", 1, 1, 1);
+        QueryUtils.check(query1);
+        QueryUtils.checkEqual(query1, query2);
+        QueryUtils.checkUnequal(query1, query3);
+        QueryUtils.checkUnequal(query1, query4);
+        QueryUtils.checkUnequal(query1, query5);
+        QueryUtils.checkUnequal(query1, query6);
+    }
+
+    public void testRandom() throws IOException {
+        final int numDocs = randomIntBetween(100, 200);
+        final Document doc = new Document();
+        final Directory dir = newDirectory();
+        final IndexWriterConfig config = new IndexWriterConfig();
+        final RandomIndexWriter w = new RandomIndexWriter(random(), dir, config);
+        long[] values = new long[numDocs];
+        for (int i = 0; i < numDocs; ++i) {
+            long rand = randomLong();
+            values[i] = rand;
+            doc.add(new SortedNumericDocValuesField("number", rand));
+            doc.add(new LongPoint("number", rand));
+            w.addDocument(doc);
+            doc.clear();
+            if (rarely()) {
+                w.commit();
+            }
+        }
+        Arrays.sort(values);
+        final IndexReader reader = w.getReader();
+        final IndexSearcher searcher = new IndexSearcher(reader);
+
+        Sort sort = new Sort(new SortedNumericSortField("number", SortField.Type.LONG));
+        for (int size = 1; size < numDocs; size++) {
+            TopFieldDocs topDocs = searcher.search(new SortedLongQuery("number", size, Long.MIN_VALUE, Integer.MAX_VALUE), size, sort);
+            assert(topDocs.scoreDocs.length == size);
+            for (int j = 0; j < topDocs.scoreDocs.length; j++) {
+                assertEquals(values[j], ((FieldDoc) topDocs.scoreDocs[j]).fields[0]);
+            }
+        }
+        w.close();
+        reader.close();
+        dir.close();
+    }
+}


### PR DESCRIPTION
This is a follow up of #48804 where we rewrite numeric sort to use the DistanceFeatureQuery.
This change adds another optimization if the query is a `match_all` that instead of using a distance feature query will simply extract the documents directly from the indexed point and early terminate as soon as enough docs have been collected. This optimization has a constant cost so it can be considerably faster than the other optimization since it only needs to visit the BKD-tree of a field and can early terminate as soon as it collected the number of requested hits. Note that this optimization can only work when the query is a match_all and the numeric sort order is not reversed.
The pr is in WIP state, it needs more tests and some cleanup but I wanted to open it early in order to discuss whether we should pursue this path or not.