### PR TITLE
Fix RepositoriesService Cluster State Application

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -293,6 +293,9 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
 
             // Check if repositories got changed
             if ((oldMetaData == null && newMetaData == null) || (oldMetaData != null && oldMetaData.equals(newMetaData))) {
+                for (Repository repo : repositories.values()) {
+                    repo.updateState(state);
+                }
                 return;
             }
 


### PR DESCRIPTION
The current forwarding of the state is disabled if the repo metadata
did not change, so it's somewhat useless.
Obviously missed the fact that this comment https://github.com/elastic/elasticsearch/pull/49639#discussion_r351866431 relates here in the initial PR.
Tests in #49060 caught this right away, but we don't have the relevant infrastructure in `master` yet unfortunately (since it's a lot of noise to add it, I'd suggest merging this without tests as it's just a best-effort solution for until #49060  anyway).

Relates #49639
