### PR TITLE
Disable sort optimization when index is sorted

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -412,6 +412,10 @@ public class QueryPhase implements SearchPhase {
         if (searchContext.collapse() != null) return null;
         if (searchContext.trackScores()) return null;
         if (searchContext.aggregations() != null) return null;
+        if (canEarlyTerminate(reader, searchContext.sort())) {
+            // disable this optimization if index sorting matches the query sort since it's already optimized by index searcher
+            return null;
+        }
         Sort sort = searchContext.sort().sort;
         SortField sortField = sort.getSort()[0];
         if (SortField.Type.LONG.equals(IndexSortConfig.getSortFieldType(sortField)) == false) return null;


### PR DESCRIPTION
Don't run long sort optimization when index is already
sorted on the same field as the sort query parameter.

Relates to #37043, follow up for  #48804