### PR TITLE
Document issue 49730 in release notes for 7.5.0

### DIFF
--- a/docs/reference/release-notes/7.5.asciidoc
+++ b/docs/reference/release-notes/7.5.asciidoc
@@ -4,11 +4,12 @@
 coming[7.5.0]
 
 Also see <<breaking-changes-7.5,Breaking changes in 7.5>>.
-
+[[known-issues-7.5.0]]
+[float]
 === Known issues
 
-* Stop all data frame transforms during a rolling upgrade to 7.5.
-If a transform is running during upgrade the transform audit index might disappear.
+* Stop all {transforms} during a rolling upgrade to 7.5.
+If a {transform} is running during upgrade, the {transform} audit index might disappear.
 (issue: {issue}/49730[#49730])
 
 [[breaking-7.5.0]]

--- a/docs/reference/release-notes/7.5.asciidoc
+++ b/docs/reference/release-notes/7.5.asciidoc
@@ -5,6 +5,12 @@ coming[7.5.0]
 
 Also see <<breaking-changes-7.5,Breaking changes in 7.5>>.
 
+=== Known issues
+
+* Stop all data frame transforms during a rolling upgrade to 7.5.
+If a transform is running during upgrade the transform audit index might disappear.
+(issue: {issue}/49730[#49730])
+
 [[breaking-7.5.0]]
 [float]
 === Breaking changes


### PR DESCRIPTION
document low severity issue about transform audit index potentially disappearing during rolling upgrade

See #49730 for details

Preview: http://elasticsearch_49733.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.5/release-notes-7.5.0.html