### PR TITLE
[DOCS] Fixes usage of xpack-ref attribute

### DIFF
--- a/docs/reference/commands/certutil.asciidoc
+++ b/docs/reference/commands/certutil.asciidoc
@@ -224,7 +224,7 @@ Alternatively, you can specify the `--ca-pass`, `--out`, and `--pass` parameters
 By default, this command generates a file called `elastic-certificates.p12`,
 which you can copy to the relevant configuration directory for each Elastic
 product that you want to configure. For more information, see
-{xpack-ref}/ssl-tls.html[Setting Up TLS on a Cluster].
+<<ssl-tls>>.
 
 [float]
 [[certutil-silent]]

--- a/docs/reference/commands/users-command.asciidoc
+++ b/docs/reference/commands/users-command.asciidoc
@@ -33,7 +33,7 @@ Leading or trailing whitespace is not allowed.
 
 Passwords must be at least 6 characters long.
 
-For more information, see {xpack-ref}/file-realm.html[File-based User Authentication].
+For more information, see <<file-realm>>.
 
 TIP: To ensure that {es} can read the user and role information at startup, run
 `elasticsearch-users useradd` as the same user you use to run {es}. Running the

--- a/docs/reference/licensing/delete-license.asciidoc
+++ b/docs/reference/licensing/delete-license.asciidoc
@@ -17,14 +17,13 @@ This API enables you to delete licensing information.
 ==== Description
 
 When your license expires, {xpack} operates in a degraded mode.  For more
-information, see {xpack-ref}/license-expiration.html[License Expiration].
+information, see {stack-ov}/license-expiration.html[License expiration].
 
 [float]
 ==== Authorization
 
 You must have `manage` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/get-basic-status.asciidoc
+++ b/docs/reference/licensing/get-basic-status.asciidoc
@@ -25,8 +25,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `monitor` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/get-license.asciidoc
+++ b/docs/reference/licensing/get-license.asciidoc
@@ -35,8 +35,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `monitor` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 [float]

--- a/docs/reference/licensing/get-trial-status.asciidoc
+++ b/docs/reference/licensing/get-trial-status.asciidoc
@@ -31,8 +31,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `monitor` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/start-basic.asciidoc
+++ b/docs/reference/licensing/start-basic.asciidoc
@@ -31,8 +31,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `manage` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/start-trial.asciidoc
+++ b/docs/reference/licensing/start-trial.asciidoc
@@ -34,8 +34,7 @@ https://www.elastic.co/subscriptions.
 ==== Authorization
 
 You must have `manage` cluster privileges to use this API.
-For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -162,4 +162,4 @@ curl -XPUT -u elastic 'http://<host>:<port>/_xpack/license?acknowledge=true' -H 
 // NOTCONSOLE
 
 For more information about the features that are disabled when you downgrade
-your license, see {xpack-ref}/license-expiration.html[License Expiration].
+your license, see {stack-ov}/license-expiration.html[License expiration].

--- a/docs/reference/ml/apis/calendarresource.asciidoc
+++ b/docs/reference/ml/apis/calendarresource.asciidoc
@@ -12,4 +12,4 @@ A calendar resource has the following properties:
   (array) An array of job identifiers. For example: `["total-requests"]`.
 
 For more information, see 
-{xpack-ref}/ml-calendars.html[Calendars and Scheduled Events].
+{stack-ov}/ml-calendars.html[Calendars and scheduled events].

--- a/docs/reference/ml/apis/close-job.asciidoc
+++ b/docs/reference/ml/apis/close-job.asciidoc
@@ -25,7 +25,7 @@ operations, but you can still explore and navigate results.
 ==== {api-prereq-title}
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 [[ml-close-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/apis/datafeedresource.asciidoc
+++ b/docs/reference/ml/apis/datafeedresource.asciidoc
@@ -9,7 +9,7 @@ A {dfeed} resource has the following properties:
   (object) If set, the {dfeed} performs aggregation searches.
   Support for aggregations is limited and should only be used with
   low cardinality data. For more information, see
-  {xpack-ref}/ml-configuring-aggregation.html[Aggregating Data for Faster Performance].
+  {stack-ov}/ml-configuring-aggregation.html[Aggregating data for faster performance].
 
 `chunking_config`::
   (object) Specifies how data searches are split into time chunks.
@@ -53,7 +53,7 @@ A {dfeed} resource has the following properties:
   The <<ml-detectorconfig,detector configuration objects>> in a job can contain
   functions that use these script fields.
   For more information, see
-  {xpack-ref}/ml-configuring-transform.html[Transforming Data With Script Fields].
+  {stack-ov}/ml-configuring-transform.html[Transforming data with script fields].
 
 `scroll_size`::
   (unsigned integer) The `size` parameter that is used in {es} searches.

--- a/docs/reference/ml/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/apis/delete-calendar-event.asciidoc
@@ -33,7 +33,7 @@ events and delete the calendar, see the
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ml/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/apis/delete-calendar-job.asciidoc
@@ -27,7 +27,7 @@ Deletes jobs from a calendar.
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/ml/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/apis/delete-calendar.asciidoc
@@ -29,7 +29,7 @@ calendar.
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/apis/delete-datafeed.asciidoc
@@ -37,8 +37,7 @@ NOTE: Unless the `force` parameter is used, the {dfeed} must be stopped before i
 ===== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
+For more information, see <<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/apis/delete-filter.asciidoc
@@ -30,7 +30,7 @@ update or delete the job before you can delete the filter.
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/apis/delete-snapshot.asciidoc
@@ -32,7 +32,7 @@ the `model_snapshot_id` in the results from the get jobs API.
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/eventresource.asciidoc
+++ b/docs/reference/ml/apis/eventresource.asciidoc
@@ -24,4 +24,4 @@ An events resource has the following properties:
  string is in ISO 8601 format.
 
 For more information, see
-{xpack-ref}/ml-calendars.html[Calendars and Scheduled Events].
+{stack-ov}/ml-calendars.html[Calendars and scheduled events].

--- a/docs/reference/ml/apis/flush-job.asciidoc
+++ b/docs/reference/ml/apis/flush-job.asciidoc
@@ -60,7 +60,7 @@ opened again before analyzing further data.
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/forecast.asciidoc
+++ b/docs/reference/ml/apis/forecast.asciidoc
@@ -15,7 +15,7 @@ Predicts the future behavior of a time series by using its historical behavior.
 
 ==== Description
 
-See {xpack-ref}/ml-overview.html#ml-forecasting[Forecasting the Future].
+See {stack-ov}/ml-overview.html#ml-forecasting[Forecasting the future].
 
 [NOTE]
 ===============================
@@ -48,7 +48,7 @@ forecast. For more information about this property, see <<ml-job-resource>>.
 ==== Authorization
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
-For more information, see {xpack-ref}/security-privileges.html[Security Privileges].
+For more information, see <<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/apis/get-bucket.asciidoc
@@ -80,8 +80,7 @@ You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. You also need `read` index privilege on the index
 that stores the results. The `machine_learning_admin` and `machine_learning_user`
 roles provide these privileges. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
+<<security-privileges>> and <<built-in-roles>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/apis/get-calendar-event.asciidoc
@@ -54,7 +54,7 @@ The API returns the following information:
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/apis/get-calendar.asciidoc
@@ -50,7 +50,7 @@ The API returns the following information:
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-category.asciidoc
+++ b/docs/reference/ml/apis/get-category.asciidoc
@@ -18,7 +18,7 @@ Retrieves job results for one or more categories.
 ==== Description
 
 For more information about categories, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 ==== Path Parameters
 
@@ -54,8 +54,8 @@ You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. You also need `read` index privilege on the index
 that stores the results. The `machine_learning_admin` and `machine_learning_user`
 roles provide these privileges. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
+<<security-privileges>> and
+<<built-in-roles>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed-stats.asciidoc
@@ -79,7 +79,7 @@ The API returns the following information:
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/apis/get-datafeed.asciidoc
@@ -74,7 +74,7 @@ The API returns the following information:
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-filter.asciidoc
+++ b/docs/reference/ml/apis/get-filter.asciidoc
@@ -50,7 +50,7 @@ The API returns the following information:
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/apis/get-influencer.asciidoc
@@ -64,9 +64,7 @@ You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. You also need `read` index privilege on the index
 that stores the results. The `machine_learning_admin` and `machine_learning_user`
 roles provide these privileges. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
-//<<security-privileges>> and <<built-in-roles>>.
+<<security-privileges>> and <<built-in-roles>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/apis/get-job-stats.asciidoc
@@ -26,7 +26,7 @@ Retrieves usage information for jobs.
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [[ml-get-job-stats-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/apis/get-job.asciidoc
+++ b/docs/reference/ml/apis/get-job.asciidoc
@@ -24,7 +24,7 @@ Retrieves configuration information for jobs.
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [[ml-get-job-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/apis/get-overall-buckets.asciidoc
@@ -89,8 +89,8 @@ You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. You also need `read` index privilege on the index
 that stores the results. The `machine_learning_admin` and `machine_learning_user`
 roles provide these privileges. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
+<<security-privileges>> and
+<<built-in-roles>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-record.asciidoc
+++ b/docs/reference/ml/apis/get-record.asciidoc
@@ -65,9 +65,7 @@ You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. You also need `read` index privilege on the index
 that stores the results. The `machine_learning_admin` and `machine_learning_user`
 roles provide these privileges. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
-//<<security-privileges>> and <<built-in-roles>>.
+<<security-privileges>> and <<built-in-roles>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/apis/get-snapshot.asciidoc
@@ -61,8 +61,7 @@ The API returns the following information:
 
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/jobresource.asciidoc
+++ b/docs/reference/ml/apis/jobresource.asciidoc
@@ -33,7 +33,7 @@ so do not set the `background_persist_interval` value too low.
 `custom_settings`::
   (object) Advanced configuration option. Contains custom meta data about the
   job. For example, it can contain custom URL information as shown in
-  {xpack-ref}/ml-configuring-url.html[Adding Custom URLs to Machine Learning Results].
+  {stack-ov}/ml-configuring-url.html[Adding custom URLs to {ml} results].
 
 `data_description`::
   (object) Describes the data format and how APIs parse timestamp fields.
@@ -115,7 +115,7 @@ An analysis configuration object has the following properties:
   be categorized. The resulting categories must be used in a detector by setting
   `by_field_name`, `over_field_name`, or `partition_field_name` to the keyword
   `mlcategory`. For more information, see
-  {xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+  {stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 `categorization_filters`::
   (array of strings) If `categorization_field_name` is specified,
@@ -125,7 +125,7 @@ An analysis configuration object has the following properties:
   tune the categorization by excluding sequences from consideration when
   categories are defined. For example, you can exclude SQL statements that
   appear in your log files. For more information, see
-  {xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+  {stack-ov}/ml-configuring-categories.html[Categorizing log messages].
   This property cannot be used at the same time as `categorization_analyzer`.
   If you only want to define simple regular expression filters that are applied
   prior to tokenization, setting this property is the easiest method.
@@ -248,14 +248,14 @@ NOTE: The `field_name` cannot contain double quotes or backslashes.
 `function`::
   (string) The analysis function that is used. 
   For example, `count`, `rare`, `mean`, `min`, `max`, and `sum`. For more
-  information, see {xpack-ref}/ml-functions.html[Function Reference].
+  information, see {stack-ov}/ml-functions.html[Function reference].
 
 `over_field_name`::
   (string) The field used to split the data.
   In particular, this property is used for analyzing the splits with respect to
   the history of all splits. It is used for finding unusual values in the
   population of all splits. For more information, see
-  {xpack-ref}/ml-configuring-pop.html[Performing Population Analysis].
+  {stack-ov}/ml-configuring-pop.html[Performing population analysis].
 
 `partition_field_name`::
   (string) The field used to segment the analysis.
@@ -412,7 +412,7 @@ the categorization analyzer produces then you find the original document that
 the categorization field value came from.
 
 For more information, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 [float]
 [[ml-detector-custom-rule]]
@@ -495,7 +495,7 @@ The `analysis_limits` object has the following properties:
 --
 NOTE: The `categorization_examples_limit` only applies to analysis that uses categorization.
 For more information, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 --
 

--- a/docs/reference/ml/apis/open-job.asciidoc
+++ b/docs/reference/ml/apis/open-job.asciidoc
@@ -41,7 +41,7 @@ The job is ready to resume its analysis from where it left off, once new data is
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/apis/post-calendar-event.asciidoc
@@ -15,7 +15,7 @@ Posts scheduled events in a calendar.
 
 ==== Description
 
-This API accepts a list of {xpack-ref}/ml-calendars.html[scheduled events], each
+This API accepts a list of {stack-ov}/ml-calendars.html[scheduled events], each
 of which must have a start time, end time, and description.
 
 ==== Path Parameters
@@ -34,7 +34,7 @@ of which must have a start time, end time, and description.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/post-data.asciidoc
+++ b/docs/reference/ml/apis/post-data.asciidoc
@@ -68,8 +68,7 @@ Only whitespace characters are permitted in between the documents.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/apis/put-calendar-job.asciidoc
@@ -26,7 +26,7 @@ Adds a job to a calendar.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/apis/put-calendar.asciidoc
@@ -15,7 +15,7 @@ Instantiates a calendar.
 ===== Description
 
 For more information, see
-{xpack-ref}/ml-calendars.html[Calendars and Scheduled Events].
+{stack-ov}/ml-calendars.html[Calendars and scheduled events].
 
 ==== Path Parameters
 
@@ -33,7 +33,7 @@ For more information, see
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/put-filter.asciidoc
+++ b/docs/reference/ml/apis/put-filter.asciidoc
@@ -40,7 +40,7 @@ the `custom_rules` property of <<ml-detectorconfig,detector configuration object
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/put-job.asciidoc
+++ b/docs/reference/ml/apis/put-job.asciidoc
@@ -82,7 +82,7 @@ IMPORTANT: You must use {kib} or this API to create a {ml} job. Do not put a job
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/resultsresource.asciidoc
+++ b/docs/reference/ml/apis/resultsresource.asciidoc
@@ -38,7 +38,7 @@ Categorization results contain the definitions of _categories_ that have been
 identified. These are only applicable for jobs that are configured to analyze
 unstructured log data using categorization. These results do not contain a
 timestamp or any calculated scores. For more information, see
-{xpack-ref}/ml-configuring-categories.html[Categorizing Log Messages].
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
 
 * <<ml-results-buckets,Buckets>>
 * <<ml-results-influencers,Influencers>>

--- a/docs/reference/ml/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/apis/revert-snapshot.asciidoc
@@ -50,7 +50,7 @@ If you want to resend data, then delete the intervening results.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/apis/stop-datafeed.asciidoc
@@ -72,7 +72,7 @@ are no matches or only partial matches.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/update-filter.asciidoc
+++ b/docs/reference/ml/apis/update-filter.asciidoc
@@ -36,7 +36,7 @@ Updates the description of a filter, adds items, or removes items.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/update-job.asciidoc
+++ b/docs/reference/ml/apis/update-job.asciidoc
@@ -85,7 +85,7 @@ want to re-run this job with an increased `model_memory_limit`.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security privileges].
+<<security-privileges>>.
 
 [[ml-update-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/apis/update-snapshot.asciidoc
@@ -42,8 +42,7 @@ The following properties can be updated after the model snapshot is created:
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/apis/validate-detector.asciidoc
@@ -28,7 +28,7 @@ see <<ml-detectorconfig,detector configuration objects>>.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/ml/apis/validate-job.asciidoc
+++ b/docs/reference/ml/apis/validate-job.asciidoc
@@ -28,7 +28,7 @@ see <<ml-job-resource,Job Resources>>.
 
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -57,7 +57,7 @@ There is no request body for the Delete Job API.
 
 You must have `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -36,7 +36,7 @@ There is no request body for the Get Jobs API.
 
 You must have `monitor`, `monitor_rollup`, `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -50,7 +50,7 @@ For more details about the job configuration, see <<rollup-job-config>>.
 
 You must have `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -43,7 +43,7 @@ There is no request body for the Get Rollup Caps API.
 
 You must have `monitor`, `monitor_rollup`, `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -35,7 +35,7 @@ There is no request body for the Get Jobs API.
 
 You must have the `read` index privilege on the index that stores the rollup results.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -31,7 +31,7 @@ There is no request body for the Start Job API.
 
 You must have `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 ==== Examples
 

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -43,7 +43,7 @@ There is no request body for the Stop Job API.
 
 You must have `manage` or `manage_rollup` cluster privileges to use this API.
 For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 
 ==== Examples

--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -7,7 +7,7 @@
 
 All of these settings can be added to the `elasticsearch.yml` configuration
 file. For more information, see
-{xpack-ref}/auditing.html[Auditing Security Events].
+<<auditing>>.
 
 [[general-audit-settings]]
 ==== General Auditing Settings
@@ -152,7 +152,7 @@ Controls how often to roll over to a new index: `hourly`, `daily`, `weekly`, or
 `xpack.security.audit.index.events.include`::
 Specifies the audit events to be indexed. The default value is
 `anonymous_access_denied, authentication_failed, realm_authentication_failed, access_granted, access_denied, tampered_request, connection_granted, connection_denied, run_as_granted, run_as_denied`.
-See {xpack-ref}/audit-event-types.html[Audit Entry Types] for the
+See <<audit-event-types>> for the
 complete list. deprecated[6.7.0]
 
 `xpack.security.audit.index.events.exclude`::

--- a/x-pack/docs/en/rest-api/security/clear-cache.asciidoc
+++ b/x-pack/docs/en/rest-api/security/clear-cache.asciidoc
@@ -20,7 +20,7 @@ the cache or evict specific users.
 User credentials are cached in memory on each node to avoid connecting to a
 remote authentication service or hitting the disk for every incoming request.
 There are realm settings that you can use to configure the user cache. For more
-information, see {xpack-ref}/controlling-user-cache.html[Controlling the User Cache].
+information, see <<controlling-user-cache>>.
 
 To evict roles from the role cache, see the 
 <<security-api-clear-role-cache,Clear Roles Cache API>>.

--- a/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/has-privileges.asciidoc
@@ -52,7 +52,7 @@ should be checked
 All users can use this API, but only to determine their own privileges.
 To check the privileges of other users, you must use the run as feature. For
 more information, see
-{xpack-ref}/run-as-privilege.html[Submitting Requests on Behalf of Other Users].
+<<run-as-privilege>>.
 
 
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/ack-watch.asciidoc
@@ -35,7 +35,7 @@ execution.
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 
 [float]

--- a/x-pack/docs/en/rest-api/watcher/activate-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/activate-watch.asciidoc
@@ -23,7 +23,7 @@ API enables you to activate a currently inactive watch.
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/deactivate-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/deactivate-watch.asciidoc
@@ -22,7 +22,7 @@ API enables you to deactivate a currently active watch.
 [float]
 ==== Authorization
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/delete-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/delete-watch.asciidoc
@@ -37,7 +37,7 @@ IMPORTANT:  Deleting a watch must be done via this API only. Do not delete the
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/get-watch.asciidoc
@@ -23,7 +23,7 @@ This API retrieves a watch by its ID.
 
 You must have `manage_watcher` or `monitor_watcher` cluster privileges to use
 this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/restart.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/restart.asciidoc
@@ -15,7 +15,7 @@ The `restart` API stops then starts the {watcher} service.
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 
 [float]

--- a/x-pack/docs/en/rest-api/watcher/start.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/start.asciidoc
@@ -16,7 +16,7 @@ running.
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/stats.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stats.asciidoc
@@ -63,7 +63,7 @@ To include this metric, the `metric` option should include `queued_watches` or
 
 You must have `manage_watcher` or `monitor_watcher` cluster privileges to use
 this API. For more information, see
-{xpack-ref}/security-privileges.html[Security Privileges].
+<<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/rest-api/watcher/stop.asciidoc
+++ b/x-pack/docs/en/rest-api/watcher/stop.asciidoc
@@ -16,7 +16,7 @@ The `stop` API stops the {watcher} service if the service is running.
 ==== Authorization
 
 You must have `manage_watcher` cluster privileges to use this API. For more
-information, see {xpack-ref}/security-privileges.html[Security Privileges].
+information, see <<security-privileges>>.
 
 [float]
 ==== Examples

--- a/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-active-directory-realm.asciidoc
@@ -243,5 +243,5 @@ include extra properties in the user's metadata.
 --
 By default, `ldap_dn` and `ldap_groups` are populated in the user's metadata. 
 For more information, see 
-{xpack-ref}/active-directory-realm.html#ad-user-metadata[User Metadata in Active Directory Realms]. 
+<<ad-user-metadata>>. 
 --

--- a/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
@@ -23,7 +23,7 @@ The `file` realm is added to the realm chain by default. You don't need to
 explicitly configure a `file` realm.
 
 For more information about file realms, see 
-{xpack-ref}/file-realm.html[File-based user authentication].
+<<file-realm>>.
 
 . (Optional) Add a realm configuration of type `file` to `elasticsearch.yml` 
 under the `xpack.security.authc.realms` namespace. At a minimum, you must set 

--- a/x-pack/docs/en/security/gs-index.asciidoc
+++ b/x-pack/docs/en/security/gs-index.asciidoc
@@ -27,8 +27,8 @@ way to _authenticate_ users. This simply means that you need a way to validate
 that a user is who they claim to be. For example, you have to make sure only
 the person named _Kelsey Andorra_ can sign in as the user `kandorra`. {security} 
 provides a standalone authentication mechanism that enables you to
-quickly password-protect your cluster. If you're already using {xpack-ref}/ldap-realm.html[LDAP],
-{xpack-ref}/active-directory-realm.html[ Active Directory], or {xpack-ref}/pki-realm.html[ PKI] to manage
+quickly password-protect your cluster. If you're already using <<ldap-realm,LDAP>>,
+<<active-directory-realm,Active Directory>>, or <<pki-realm,PKI>> to manage
 users in your organization, {security} is able to integrate with those
 systems to perform user authentication.
 
@@ -36,11 +36,11 @@ In many cases, simply authenticating users isn't enough. You also need a way to
 control what data users have access to and what tasks they can perform. {security}
 enables you to _authorize_ users by assigning access _privileges_ to _roles_,
 and assigning those roles to users. For example, this
-{xpack-ref}/authorization.html[role-based access control] mechanism (a.k.a RBAC) enables
+<<authorization,role-based access control>> mechanism (a.k.a RBAC) enables
 you to specify that the user `kandorra` can only perform read operations on the
 `events` index and can't do anything at all with other indices.
 
-{security} also supports {xpack-ref}/ip-filtering.html[ IP-based authorization]. You can
+{security} also supports <<ip-filtering,IP-based authorization>>. You can
 whitelist and blacklist specific IP addresses or subnets to control network-level
 access to a server.
 
@@ -52,12 +52,12 @@ A critical part of security is keeping confidential data confidential.
 Elasticsearch has built-in protections against accidental data loss and
 corruption. However, there's nothing to stop deliberate tampering or data
 interception. {security} preserves the integrity of your data by
-{xpack-ref}/ssl-tls.html[encrypting communications] to and from nodes and
-{xpack-ref}/enable-message-authentication.html[authenticating message] to verify that they
+<<ssl-tls,encrypting communications>> to and from nodes and
+<<enable-message-authentication,authenticating message>> to verify that they
 have not been tampered with or corrupted in transit during node-to-node
 communication. For even greater protection, you can increase the
-{xpack-ref}/ciphers.html[encryption strength] and
-{xpack-ref}/separating-node-client-traffic.html[separate client traffic from node-to-node communications].
+<<ciphers,encryption strength>> and
+<<separating-node-client-traffic,separate client traffic from node-to-node communications>>.
 
 
 [float]
@@ -77,15 +77,15 @@ issues.
 * <<security-getting-started, Getting Started>>
   steps through how to install and start using Security for basic authentication.
 
-* {xpack-ref}/how-security-works.html[How Security Works]
+* <<how-security-works>>
   provides more information about how Security supports user authentication,
   authorization, and encryption.
 
-* {xpack-ref}/tribe-clients-integrations.html[Integrations]
+* <<tribe-clients-integrations>>
   shows you how to interact with an Elasticsearch cluster protected by
   {security}.
 
-* {xpack-ref}/security-reference.html[Reference]
+* <<security-reference>>
   provides detailed information about the access privileges you can grant to
   users, the settings you can configure for Security in `elasticsearch.yml`,
   and the files where Security configuration information is stored.


### PR DESCRIPTION
This PR fixes links that are incorrectly sending users to the X-Pack Reference or Stack Overview.

It also fixes the following links that will break in  https://github.com/elastic/docs/pull/1490

> 12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.3/auditing-settings.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/audit-event-types.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.4/auditing-settings.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/audit-event-types.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.5/auditing-settings.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/audit-event-types.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.6/auditing-settings.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/audit-event-types.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.7/auditing-settings.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/audit-event-types.html
12:47:37 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/6.8/auditing-settings.html:
12:47:37 INFO:build_docs:   - en/x-pack/6.2/audit-event-types.html