### PR TITLE
Drop snapshot instructions for autobootstrap fix

### DIFF
--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -138,14 +138,10 @@ clusters together without a risk of data loss. You can tell that you have formed
 separate clusters by checking the cluster UUID reported by `GET /` on each node.
 If you intended to form a single cluster then you should start again:
 
-* Take a <<modules-snapshots,snapshot>> of each of the single-host clusters if
-  you do not want to lose any data that they hold. Note that each cluster must
-  use its own snapshot repository.
 * Shut down all the nodes.
 * Completely wipe each node by deleting the contents of their
   <<data-path,data folders>>.
 * Configure `cluster.initial_master_nodes` as described above.
 * Restart all the nodes and verify that they have formed a single cluster.
-* <<modules-snapshots,Restore>> any snapshots as required.
 
 ==================================================

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -68,7 +68,9 @@ include::set-paths-tip.asciidoc[]
 [[rolling-upgrades-bootstrapping]]
 NOTE: You should leave `cluster.initial_master_nodes` unset while performing a
 rolling upgrade. Each upgraded node is joining an existing cluster so there is
-no need for <<modules-discovery-bootstrap-cluster,cluster bootstrapping>>.
+no need for <<modules-discovery-bootstrap-cluster,cluster bootstrapping>>. You
+must configure <<built-in-hosts-providers,either `discovery.seed_hosts` or
+`discovery.seed_providers`>> on every node.
 --
 
 . *Upgrade any plugins.*


### PR DESCRIPTION
The "Restore any snapshots as required" step is a trap: it's somewhere between
tricky and impossible to restore multiple clusters into a single one.

Also add a note about configuring discovery during a rolling upgrade to
proscribe any rare cases where you might accidentally autobootstrap during the
upgrade.