### PR TITLE
add note for allocation during hot phase

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -127,6 +127,8 @@ For more information about how {es} uses replicas for scaling, see
 <<scalability>>. See <<shard-allocation-filtering>> for more information about
 controlling where Elasticsearch allocates shards of a particular index.
 
+Note: As allocate action is not allowed in `hot` phase, the initial allocation for the index should be done manually or via index templates, as ILM won't take care of index allocation during `hot` phase.
+
 [[ilm-allocate-options]]
 .Allocate Options
 [options="header"]


### PR DESCRIPTION
ILM takes care of allocation during warm and cold phases, but it doesn't take care of it for new indices (hot phase). We should add a note mentioning that fact, as if the user wants a hot / warm architecture they should ensure new indices are allocated by default on hot nodes, or they might end up on warm/cold nodes.
