### PR TITLE
Add the REST API specifications for SLM Status / Start / Stop endpoints.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
@@ -1,0 +1,19 @@
+{
+  "slm.get_status":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html"
+    },
+    "stability":"stable",
+    "url":{
+      "paths":[
+        {
+          "path":"/_slm/status",
+          "methods":[
+            "GET"
+          ]
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
@@ -1,0 +1,19 @@
+{
+  "slm.start":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html"
+    },
+    "stability":"stable",
+    "url":{
+      "paths":[
+        {
+          "path":"/_slm/start",
+          "methods":[
+            "POST"
+          ]
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
@@ -1,0 +1,19 @@
+{
+  "slm.stop":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html"
+    },
+    "stability":"stable",
+    "url":{
+      "paths":[
+        {
+          "path":"/_slm/stop",
+          "methods":[
+            "POST"
+          ]
+        }
+      ]
+    },
+    "params":{}
+  }
+}


### PR DESCRIPTION
Was originally missed in PR #47710, supposed to be included in `7.5.0`