### PR TITLE
Remove Awaitsfix that seems outdated

### DIFF
--- a/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -37,7 +37,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
 public class DieWithDignityIT extends ESRestTestCase {
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43413")
     public void testDieWithDignity() throws Exception {
         expectThrows(
             IOException.class,


### PR DESCRIPTION
This test seems to be fixed on 7.x with https://github.com/elastic/elasticsearch/pull/43871 so the muting annotation can
most likely be removed.