### PR TITLE
Make Snapshot Metadata Javadocs Clearer (#49697)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -337,6 +337,9 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
         }
     }
 
+    /**
+     * Snapshot name
+     */
     private final String snapshot;
 
     private final long indexVersion;
@@ -354,7 +357,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
     /**
      * Constructs new shard snapshot metadata from snapshot metadata
      *
-     * @param snapshot              snapshot id
+     * @param snapshot              snapshot name
      * @param indexVersion          index version
      * @param indexFiles            list of files in the shard
      * @param startTime             snapshot start time
@@ -379,18 +382,9 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
     }
 
     /**
-     * Returns index version
+     * Returns snapshot name
      *
-     * @return index version
-     */
-    public long indexVersion() {
-        return indexVersion;
-    }
-
-    /**
-     * Returns snapshot id
-     *
-     * @return snapshot id
+     * @return snapshot name
      */
     public String snapshot() {
         return snapshot;

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/SnapshotFiles.java
@@ -35,10 +35,19 @@ public class SnapshotFiles {
 
     private Map<String, FileInfo> physicalFiles = null;
 
+    /**
+     * Returns snapshot name
+     *
+     * @return snapshot name
+     */
     public String snapshot() {
         return snapshot;
     }
 
+    /**
+     * @param snapshot   snapshot name
+     * @param indexFiles index files
+     */
     public SnapshotFiles(String snapshot, List<FileInfo> indexFiles ) {
         this.snapshot = snapshot;
         this.indexFiles = indexFiles;


### PR DESCRIPTION
We are always using the snapshot name on the shard level,
lets make it crystal clear in the docs.

backport of #49697 