### PR TITLE
Add allow_overlaps parameter to all_of interval producer

### DIFF
--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -98,7 +98,7 @@ set to `0`, the terms must appear next to each other.
 --
 
 `ordered`::
-(Optional, boolean) 
+(Optional, boolean)
 If `true`, matching terms must appear in their specified order. Defaults to
 `false`.
 
@@ -201,6 +201,10 @@ set to `0`, the terms must appear next to each other.
 `ordered`::
 (Optional, boolean) If `true`, intervals produced by the rules should appear in
 the order in which they are specified. Defaults to `false`.
+
+`allow_overlaps`::
+(Optional, boolean) If `false`, ensures that unordered intervals produced by the
+rules do not overlap. Defaults to `true`.  Can only be used with exactly two rules.
 
 `filter`::
 (Optional, <<interval_filter,interval filter>> rule object) Rule used to filter

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -186,6 +186,29 @@ setup:
   - match: { hits.total.value: 2 }
 
 ---
+"Test unordered combination without overlaps":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            intervals:
+              text:
+                all_of:
+                  intervals:
+                    - match:
+                        query: cold outside
+                    - any_of:
+                        intervals:
+                          - match:
+                              query: there
+                          - match:
+                              query: theres
+                  ordered: false
+                  allow_overlaps: false
+  - match: { hits.total.value: 1 }
+
+---
 "Test block combination":
   - do:
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/230_interval_query.yml
@@ -187,6 +187,9 @@ setup:
 
 ---
 "Test unordered combination without overlaps":
+  - skip:
+      version: "- 8.0.0"
+      reason:  "allow_overlaps parameter added in 7.6"
   - do:
       search:
         index: test

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -358,7 +358,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
 
         public Combine(StreamInput in) throws IOException {
             this.ordered = in.readBoolean();
-            if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
                 this.allowOverlaps = in.readBoolean();
             } else {
                 this.allowOverlaps = true;
@@ -413,7 +413,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(ordered);
-            if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
                 out.writeBoolean(allowOverlaps);
             }
             out.writeNamedWriteableList(subSources);

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -347,7 +347,8 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         private final int maxGaps;
         private final IntervalFilter filter;
 
-        public Combine(List<IntervalsSourceProvider> subSources, boolean ordered, boolean allowOverlaps, int maxGaps, IntervalFilter filter) {
+        public Combine(List<IntervalsSourceProvider> subSources, boolean ordered, boolean allowOverlaps,
+                       int maxGaps, IntervalFilter filter) {
             this.subSources = subSources;
             this.ordered = ordered;
             this.allowOverlaps = allowOverlaps;


### PR DESCRIPTION
By default, unordered intervals produced by an `all_of` interval rule will 
match even if their sub-intervals are overlapping; for example, the interval
`UNORDERED(ORDERED(take, sea), ORDERED(arms, troubles))` will match
the phrase `take up arms against a sea of troubles`.  In some cases, this
is not wanted.  This commit adds an `allow_overlaps` parameter to the 
`all_of` interval producer that defaults to `true`, and will prevent the above
example matching if set to `false`.