### PR TITLE
[DOCS] Document CCR compatibility requirements

### DIFF
--- a/docs/reference/ccr/overview.asciidoc
+++ b/docs/reference/ccr/overview.asciidoc
@@ -17,7 +17,18 @@ Replication is pull-based. This means that replication is driven by the
 follower index. This simplifies state management on the leader index and means
 that {ccr} does not interfere with indexing on the leader index.
 
-IMPORTANT: {ccr-cap} requires <<modules-remote-clusters, remote clusters>>.
+In {ccr}, the cluster performing this pull is known as the _local cluster_. The
+cluster being replicated is known as the _remote cluster_.
+
+==== Prerequisites
+
+* {ccr-cap} requires <<modules-remote-clusters, remote clusters>>.
+
+* The {es} version of the local cluster must be **the same as or newer** than
+the remote cluster. If newer, the versions must also be compatible as outlined
+in the following matrix.
+
+include::../modules/remote-clusters.asciidoc[tag=remote-cluster-compatibility-matrix]
 
 ==== Configuring replication
 

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -43,6 +43,7 @@ node, while 6.7 can only communicate with 7.0. Version compatibility  is
 symmetric, meaning that if 6.7 can communicate with 7.0, 7.0 can also
 communicate with 6.7. The matrix below summarizes compatibility as described above.
 
+// tag::remote-cluster-compatibility-matrix[]
 [cols="^,^,^,^,^,^,^,^"]
 |====
 | Compatibility | 5.0->5.5 | 5.6 | 6.0->6.6 | 6.7 | 6.8 | 7.0 | 7.1->7.x
@@ -54,6 +55,7 @@ communicate with 6.7. The matrix below summarizes compatibility as described abo
 | 7.0           |    No    | No  |    No    | Yes | Yes | Yes |    Yes
 | 7.1->7.x      |    No    | No  |    No    | No  | Yes | Yes |    Yes
 |====
+// end::remote-cluster-compatibility-matrix[]
 
 - *role*: Dedicated master nodes never get selected.
 - *attributes*: You can tag which nodes should be selected


### PR DESCRIPTION
* Creates a prerequisites section in the cross-cluster replication (CCR)  overview.
* Adds concise definitions for local and remote cluster in a CCR context.
* Documents that the ES version of the local cluster must be the same  or a newer compatible version as the remote cluster. Reuses the remote clusters matrix table.

Closes #47218. Relates to #47185 and #47331.