### PR TITLE
re-categorize things that appeared in multiple area labels

### DIFF
--- a/docs/reference/release-notes/7.5.asciidoc
+++ b/docs/reference/release-notes/7.5.asciidoc
@@ -141,9 +141,6 @@ Infra/Settings::
 * Clarify error message on keystore write permissions {pull}46321[#46321]
 * Add more meaningful keystore version mismatch errors {pull}46291[#46291] (issue: {issue}44624[#44624])
 
-MULTIPLE AREA LABELS::
-* SQL: Add support for shape type {pull}46464[#46464] (issues: {issue}43644[#43644], {issue}46412[#46412])
-
 Machine Learning::
 * Throw an exception when memory usage estimation endpoint encounters empty data frame. {pull}49143[#49143] (issue: {issue}49140[#49140])
 * Change format of MulticlassConfusionMatrix result to be more self-explanatory {pull}48174[#48174] (issue: {issue}46735[#46735])
@@ -173,6 +170,7 @@ SQL::
 * SQL: make date/datetime and interval types compatible in conditional functions {pull}47595[#47595] (issue: {issue}46674[#46674])
 * SQL: use calendar interval of 1y instead of fixed interval for grouping by YEAR and HISTOGRAMs {pull}47558[#47558] (issue: {issue}40162[#40162])
 * SQL: Support queries with HAVING over SELECT {pull}46709[#46709] (issue: {issue}37051[#37051])
+* SQL: Add support for shape type {pull}46464[#46464] (issues: {issue}43644[#43644], {issue}46412[#46412])
 
 Search::
 * Remove response search phase from ExpandSearchPhase {pull}48401[#48401]
@@ -296,6 +294,8 @@ Features/Monitoring::
 Features/Watcher::
 * Fix class used to initialize logger in Watcher {pull}46467[#46467]
 * Fix wrong URL encoding in watcher HTTP client {pull}45894[#45894] (issue: {issue}44970[#44970])
+* Prevent deadlock by using separate schedulers {pull}48697[#48697] (issues: {issue}41451[#41451], {issue}47599[#47599])
+* Fix cluster alert for watcher/monitoring IndexOutOfBoundsExcep… {pull}45308[#45308] (issue: {issue}43184[#43184])
 
 Geo::
 * Geo: implement proper handling of out of bounds geo points {pull}47734[#47734] (issue: {issue}43916[#43916])
@@ -318,11 +318,6 @@ Infra/Logging::
 
 Infra/Scripting::
 * Drop stored scripts with the old style-id {pull}48078[#48078] (issue: {issue}47593[#47593])
-
-MULTIPLE AREA LABELS::
-* Prevent deadlock by using separate schedulers {pull}48697[#48697] (issues: {issue}41451[#41451], {issue}47599[#47599])
-* Don't apply the plugin's reader wrapper in can_match phase {pull}47816[#47816] (issue: {issue}46817[#46817])
-* Fix cluster alert for watcher/monitoring IndexOutOfBoundsExcep… {pull}45308[#45308] (issue: {issue}43184[#43184])
 
 Machine Learning::
 * [ML] Fixes for stop datafeed edge cases {pull}49191[#49191] (issues: {issue}43670[#43670], {issue}48931[#48931])
@@ -370,6 +365,7 @@ Search::
 * Fix alias field resolution in match query {pull}47369[#47369]
 * Multi-get requests should wait for search active {pull}46283[#46283] (issue: {issue}27500[#27500])
 * Resolve the incorrect scroll_current when delete or close index {pull}45226[#45226]
+* Don't apply the plugin's reader wrapper in can_match phase {pull}47816[#47816] (issue: {issue}46817[#46817])
 
 Security::
 * Remove uniqueness constraint for API key name and make it optional {pull}47549[#47549] (issue: {issue}46646[#46646])


### PR DESCRIPTION
The release notes had a few sections with "MULTIPLE AREA LABELS", so I've re-categorized those things as I think this will be easier for users to grok.