### PR TITLE
Add reusable HistogramValue object  

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -21,7 +21,6 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.settings.Settings;
@@ -368,7 +367,7 @@ public class HistogramFieldMapper extends FieldMapper {
                     } else if (count > 0) {
                         // we do not add elements with count == 0
                         dataOutput.writeVInt(count);
-                        dataOutput.writeLong(NumericUtils.doubleToSortableLong(values.get(i)));
+                        dataOutput.writeLong(Double.doubleToRawLongBits(values.get(i)));
                     }
                 }
                 BytesRef docValue = new BytesRef(dataOutput.toArrayCopy(), 0, Math.toIntExact(dataOutput.size()));
@@ -426,7 +425,7 @@ public class HistogramFieldMapper extends FieldMapper {
         public boolean next() {
             if (streamInput.eof() == false) {
                 count = streamInput.readVInt();
-                value = NumericUtils.sortableLongToDouble(streamInput.readLong());
+                value = Double.longBitsToDouble(streamInput.readLong());
                 return true;
             }
             isExhausted = true;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -411,11 +411,11 @@ public class HistogramFieldMapper extends FieldMapper {
         boolean isExhausted;
         ByteBufferStreamInput streamInput;
 
-        public InternalHistogramValue() {
+        InternalHistogramValue() {
         }
 
         /** reset the value for the histogram */
-        public void reset(BytesRef bytesRef) {
+        void reset(BytesRef bytesRef) {
             streamInput = new ByteBufferStreamInput(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length));
             isExhausted = false;
             value = 0;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -407,15 +407,15 @@ public class HistogramFieldMapper extends FieldMapper {
         double value;
         int count;
         boolean isExhausted;
-        ByteArrayDataInput streamInput;
+        ByteArrayDataInput dataInput;
 
         InternalHistogramValue() {
-            streamInput = new ByteArrayDataInput();
+            dataInput = new ByteArrayDataInput();
         }
 
         /** reset the value for the histogram */
         void reset(BytesRef bytesRef) {
-            streamInput.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+            dataInput.reset(bytesRef.bytes, bytesRef.offset, bytesRef.length);
             isExhausted = false;
             value = 0;
             count = 0;
@@ -423,9 +423,9 @@ public class HistogramFieldMapper extends FieldMapper {
 
         @Override
         public boolean next() {
-            if (streamInput.eof() == false) {
-                count = streamInput.readVInt();
-                value = Double.longBitsToDouble(streamInput.readLong());
+            if (dataInput.eof() == false) {
+                count = dataInput.readVInt();
+                value = Double.longBitsToDouble(dataInput.readLong());
                 return true;
             }
             isExhausted = true;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -19,7 +19,6 @@ import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Explicit;
@@ -51,7 +50,6 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
In #49683 a new field mapper was introduced which supports percentile aggregations via binary doc values. Those are complex values that are interface to the user via HistogramValue interface.

This field mapper generates the doc values and it currently creates an object per doc value of type HistogramValue. This PR adds a new class InternalHistogramValue that implements HistogramValue which can be reused so we create one object per segment instead of per document.