### PR TITLE
fixes assertion of shape-count in GeometryTreeReader

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
@@ -74,9 +74,7 @@ public class GeometryTreeReader implements ShapeTreeReader {
             return extent;
         }
         int numShapes = input.readVInt();
-        if (numShapes != 1) {
-            throw new IllegalStateException("geoshape doc-value contains more than one geometry");
-        }
+        assert numShapes == 1;
         ShapeType shapeType = input.readEnum(ShapeType.class);
         ShapeTreeReader reader = getReader(shapeType, coordinateEncoder, input);
         return reader.getExtent();

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
@@ -73,7 +73,10 @@ public class GeometryTreeReader implements ShapeTreeReader {
         if (extent != null) {
             return extent;
         }
-        assert input.readVInt() == 1;
+        int numShapes = input.readVInt();
+        if (numShapes != 1) {
+            throw new IllegalStateException("geoshape doc-value contains more than one geometry");
+        }
         ShapeType shapeType = input.readEnum(ShapeType.class);
         ShapeTreeReader reader = getReader(shapeType, coordinateEncoder, input);
         return reader.getExtent();


### PR DESCRIPTION
There is an assertion of the number of shapes that
exist in a geometry with no prepended extent. This is
because it is owned by the sub-tree to read the extent.

This assertion is run at test-time, but not at run-time.
Somehow runtime tests never caught this issue

this commit changes the behavior to throw an IllegalStateException
if not valid