### PR TITLE
Fix task input for docker build

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -151,7 +151,7 @@ check.dependsOn integTest
 
 void addBuildDockerImage(final boolean oss, final boolean ubi) {
   final Task buildDockerImageTask = task(taskName("build", oss, ubi, "DockerImage"), type: LoggedExec) {
-    dependsOn taskName("copy", oss, ubi, "DockerContext")
+    inputs.files(tasks.named(taskName("copy", oss, ubi, "DockerContext")))
     List<String> tags
     if (oss) {
       tags = [


### PR DESCRIPTION
The docker build task depends on the docker context being built, but it
was not explicitly setup as an input. This commit adds the task as an
input to the docker build.

relates #49613
