### PR TITLE
remove usage of Extent in ShapeTreeReader#relate logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryTreeReader.java
@@ -24,7 +24,6 @@ import org.elasticsearch.geometry.ShapeType;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 /**
  * A reusable tree reader.
@@ -81,14 +80,26 @@ public class GeometryTreeReader implements ShapeTreeReader {
     }
 
     @Override
-    public GeoRelation relate(Extent extent) throws IOException {
+    public GeoRelation relate(int minX, int minY, int maxX, int maxY) throws IOException {
         GeoRelation relation = GeoRelation.QUERY_DISJOINT;
         input.position(startPosition + EXTENT_OFFSET);
         boolean hasExtent = input.readBoolean();
         if (hasExtent) {
-            Optional<Boolean> extentCheck = EdgeTreeReader.checkExtent(new Extent(input), extent);
-            if (extentCheck.isPresent()) {
-                return extentCheck.get() ? GeoRelation.QUERY_INSIDE : GeoRelation.QUERY_DISJOINT;
+            int thisMaxY = input.readInt();
+            int thisMinY = input.readInt();
+            int negLeft = input.readInt();
+            int negRight = input.readInt();
+            int posLeft = input.readInt();
+            int posRight = input.readInt();
+            int thisMinX = Math.min(negLeft, posLeft);
+            int thisMaxX = Math.max(negRight, posRight);
+
+            // check extent
+            if (thisMinY > maxY || thisMaxX < minX || thisMaxY < minY || thisMinX > maxX) {
+                return GeoRelation.QUERY_DISJOINT; // tree and bbox-query are disjoint
+            }
+            if (minX <= thisMinX && minY <= thisMinY && maxX >= thisMaxX && maxY >= thisMaxY) {
+                return GeoRelation.QUERY_CROSSES; // bbox-query fully contains tree's
             }
         }
 
@@ -104,7 +115,7 @@ public class GeometryTreeReader implements ShapeTreeReader {
             }
             ShapeType shapeType = input.readEnum(ShapeType.class);
             ShapeTreeReader reader = getReader(shapeType, coordinateEncoder, input);
-            GeoRelation shapeRelation = reader.relate(extent);
+            GeoRelation shapeRelation = reader.relate(minX, minY, maxX, maxY);
             if (GeoRelation.QUERY_CROSSES == shapeRelation ||
                 (GeoRelation.QUERY_DISJOINT == shapeRelation && GeoRelation.QUERY_INSIDE == relation)
             ) {

--- a/server/src/main/java/org/elasticsearch/common/geo/Point2DReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/Point2DReader.java
@@ -63,7 +63,7 @@ class Point2DReader implements ShapeTreeReader {
 
 
     @Override
-    public GeoRelation relate(Extent extent) throws IOException {
+    public GeoRelation relate(int minX, int minY, int maxX, int maxY) throws IOException {
         Deque<Integer> stack = new ArrayDeque<>();
         stack.push(0);
         stack.push(size - 1);
@@ -78,7 +78,7 @@ class Point2DReader implements ShapeTreeReader {
                     // TODO serialize to re-usable array instead of serializing in each step
                     int x = readX(i);
                     int y = readY(i);
-                    if (x >= extent.minX() && x <= extent.maxX() && y >= extent.minY() && y <= extent.maxY()) {
+                    if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
                         return GeoRelation.QUERY_CROSSES;
                     }
                 }
@@ -88,15 +88,15 @@ class Point2DReader implements ShapeTreeReader {
             int middle = (right + left) >> 1;
             int x = readX(middle);
             int y = readY(middle);
-            if (x >= extent.minX() && x <= extent.maxX() && y >= extent.minY() && y <= extent.maxY()) {
+            if (x >= minX && x <= maxX && y >= minY && y <= maxY) {
                 return GeoRelation.QUERY_CROSSES;
             }
-            if ((axis == 0 && extent.minX() <= x) || (axis == 1 && extent.minY() <= y)) {
+            if ((axis == 0 && minX <= x) || (axis == 1 && minY <= y)) {
                 stack.push(left);
                 stack.push(middle - 1);
                 stack.push(1 - axis);
             }
-            if ((axis == 0 && extent.maxX() >= x) || (axis == 1 && extent.maxY() >= y)) {
+            if ((axis == 0 && maxX >= x) || (axis == 1 && maxY >= y)) {
                 stack.push(middle + 1);
                 stack.push(right);
                 stack.push(1 - axis);

--- a/server/src/main/java/org/elasticsearch/common/geo/PolygonTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/PolygonTreeReader.java
@@ -61,9 +61,9 @@ public class PolygonTreeReader implements ShapeTreeReader {
      * Returns true if the rectangle query and the edge tree's shape overlap
      */
     @Override
-    public GeoRelation relate(Extent extent) throws IOException {
+    public GeoRelation relate(int minX, int minY, int maxX, int maxY) throws IOException {
         if (holes != null) {
-            GeoRelation relation = holes.relate(extent);
+            GeoRelation relation = holes.relate(minX, minY, maxX, maxY);
             if (GeoRelation.QUERY_CROSSES == relation) {
                 return GeoRelation.QUERY_CROSSES;
             }
@@ -71,6 +71,6 @@ public class PolygonTreeReader implements ShapeTreeReader {
                 return GeoRelation.QUERY_DISJOINT;
             }
         }
-        return outerShell.relate(extent);
+        return outerShell.relate(minX, minY, maxX, maxY);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/ShapeTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/ShapeTreeReader.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 public interface ShapeTreeReader {
 
     Extent getExtent() throws IOException;
-    GeoRelation relate(Extent extent) throws IOException;
+    GeoRelation relate(int minX, int minY, int maxX, int maxY) throws IOException;
     double getCentroidX() throws IOException;
     double getCentroidY() throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeReader.java
@@ -79,16 +79,12 @@ public class TriangleTreeReader implements ShapeTreeReader {
         return coordinateEncoder.decodeY(input.readInt());
     }
 
-    @Override
-    public GeoRelation relate(Extent extent) throws IOException {
-        return relate(extent.minX(), extent.maxX(), extent.minY(), extent.maxY());
-    }
-
     /**
      * Compute the relation with the provided bounding box. If the result is CELL_INSIDE_QUERY
      * then the bounding box is within the shape.
      */
-    private GeoRelation relate(int minX, int maxX, int minY, int maxY) throws IOException {
+    @Override
+    public GeoRelation relate(int minX, int minY, int maxX, int maxY) throws IOException {
         input.position(extentOffset);
         int thisMaxX = input.readInt();
         int thisMinX = Math.toIntExact(thisMaxX - input.readVLong());

--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
@@ -151,9 +151,8 @@ public abstract class MultiGeoValues {
             int maxX = GeoShapeCoordinateEncoder.INSTANCE.encodeX(rectangle.getMaxX());
             int minY = GeoShapeCoordinateEncoder.INSTANCE.encodeY(rectangle.getMinY());
             int maxY = GeoShapeCoordinateEncoder.INSTANCE.encodeY(rectangle.getMaxY());
-            Extent extent = new Extent(maxY, minY, minX, maxX, minX, maxX);
             try {
-                return reader.relate(extent);
+                return reader.relate(minX, minY, maxX, maxY);
             } catch (IOException e) {
                 throw new IllegalStateException("unable to check intersection", e);
             }

--- a/server/src/test/java/org/elasticsearch/common/geo/AbstractTreeTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/AbstractTreeTestCase.java
@@ -326,8 +326,10 @@ public abstract class AbstractTreeTestCase extends ESTestCase {
     }
 
     private boolean intersects(Geometry g, Point p, double extentSize) throws IOException {
+
+        Extent bufferBounds = bufferedExtentFromGeoPoint(p.getX(), p.getY(), extentSize);
         GeoRelation relation = geometryTreeReader(g, GeoShapeCoordinateEncoder.INSTANCE)
-            .relate(bufferedExtentFromGeoPoint(p.getX(), p.getY(), extentSize));
+            .relate(bufferBounds.minX(), bufferBounds.minY(), bufferBounds.maxX(), bufferBounds.maxY());
         return relation == GeoRelation.QUERY_CROSSES || relation == GeoRelation.QUERY_INSIDE;
     }
 

--- a/server/src/test/java/org/elasticsearch/common/geo/EncodingComparisonTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/EncodingComparisonTests.java
@@ -171,11 +171,10 @@ public class EncodingComparisonTests extends ESTestCase {
         String[] hashes = GeohashUtils.getSubGeohashes(hash);
         for (int i =0; i < hashes.length; i++) {
             Rectangle r = Geohash.toBoundingBox(hashes[i]);
-            Extent extent = Extent.fromPoints(encoder.encodeX(r.getMinLon()),
+            GeoRelation rel = reader.relate(encoder.encodeX(r.getMinLon()),
                 encoder.encodeY(r.getMinLat()),
                 encoder.encodeX(r.getMaxLon()),
                 encoder.encodeY(r.getMaxLat()));
-            GeoRelation rel = reader.relate(extent);
             if (rel == GeoRelation.QUERY_CROSSES) {
                 if (hashes[i].length() == maxPrecision) {
                     hits++;

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoTestUtils.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class GeoTestUtils {
 
     public static void assertRelation(GeoRelation expectedRelation, ShapeTreeReader reader, Extent extent) throws IOException {
-        GeoRelation actualRelation = reader.relate(extent);
+        GeoRelation actualRelation = reader.relate(extent.minX(), extent.minY(), extent.maxX(), extent.maxY());
         assertThat(actualRelation, equalTo(expectedRelation));
     }
 


### PR DESCRIPTION
Extent is mostly existing for the bounding-box queries
because it keeps track of more information for easy
arithmetic. Since shape readers do not need to be concerned
with date-line crossing, its usage is not required and
by avoiding it, fewer allocations are made at runtime

This does not get rid of Extent entirely, that may be done as a follow-up