### PR TITLE
Improve coverage of equals/hashCode tests for IntervalQueryBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/IntervalQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalQueryBuilder.java
@@ -55,6 +55,14 @@ public class IntervalQueryBuilder extends AbstractQueryBuilder<IntervalQueryBuil
         this.sourceProvider = in.readNamedWriteable(IntervalsSourceProvider.class);
     }
 
+    public String getField() {
+        return field;
+    }
+
+    public IntervalsSourceProvider getSourceProvider() {
+        return sourceProvider;
+    }
+
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(field);

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -773,10 +773,13 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(type);
-            builder.startObject();
-            filter.toXContent(builder, params);
-            builder.endObject();
+            if (filter != null) {
+                builder.startObject(type);
+                filter.toXContent(builder, params);
+                builder.endObject();
+            } else {
+                builder.field(Script.SCRIPT_PARSE_FIELD.getPreferredName(), script);
+            }
             builder.endObject();
             return builder;
         }

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -749,12 +749,13 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             if (o == null || getClass() != o.getClass()) return false;
             IntervalFilter that = (IntervalFilter) o;
             return Objects.equals(type, that.type) &&
+                Objects.equals(script, that.script) &&
                 Objects.equals(filter, that.filter);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(type, filter);
+            return Objects.hash(type, filter, script);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
@@ -114,7 +115,11 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
 
     private IntervalsSourceProvider.IntervalFilter createRandomFilter(int depth) {
         if (depth < 3 && randomInt(20) > 18) {
-            return new IntervalsSourceProvider.IntervalFilter(createRandomSource(depth + 1), randomFrom(filters));
+            if (randomBoolean()) {
+                return new IntervalsSourceProvider.IntervalFilter(createRandomSource(depth + 1), randomFrom(filters));
+            }
+            return new IntervalsSourceProvider.IntervalFilter(
+                new Script(ScriptType.INLINE, "mockscript", "1", Collections.emptyMap()));
         }
         return null;
     }

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -143,6 +143,17 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         assertThat(query, instanceOf(IntervalQuery.class));
     }
 
+    @Override
+    public IntervalQueryBuilder mutateInstance(IntervalQueryBuilder instance) throws IOException {
+        if (randomBoolean()) {
+            return super.mutateInstance(instance); // just change name/boost
+        }
+        if (randomBoolean()) {
+            return new IntervalQueryBuilder(STRING_FIELD_NAME_2, instance.getSourceProvider());
+        }
+        return new IntervalQueryBuilder(STRING_FIELD_NAME, createRandomSource(0));
+    }
+
     public void testMatchInterval() throws IOException {
 
         String json = "{ \"intervals\" : " +


### PR DESCRIPTION
By default, AbstractQueryTestCase only changes name and boost in its mutateInstance
method, used when checking equals and hashcode implementations.  This commit adds
a mutateInstance method to InveralQueryBuilderTests that will check hashcode and 
equality when the field or intervals source are changed.