### PR TITLE
Collect results in a local list when notifying partial results

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -636,7 +636,11 @@ public final class SearchPhaseController {
                 numReducePhases++;
                 index = 1;
                 if (hasAggs) {
-                    progressListener.notifyPartialReduce(progressListener.searchShards(results.asList()),
+                    List<SearchPhaseResult> results = new ArrayList<>();
+                    for (int i = 0; i < this.results.length(); i++) {
+                        results.add(this.results.get(i));
+                    }
+                    progressListener.notifyPartialReduce(progressListener.searchShards(results),
                         topDocsStats.getTotalHits(), aggsBuffer[0], numReducePhases);
                 }
             }


### PR DESCRIPTION
Currently we use the list generated by the AtomicArray in ArraySearchPhaseResults but this List is shared between threads and can get nullify. This change collects results in a local list to prevent concurrent issues.

fixes #49778