### PR TITLE
Fix concurrent issue in SearchPhaseController

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
@@ -25,8 +25,10 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.search.SearchPhaseResult;
+import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -165,6 +167,13 @@ abstract class SearchProgressListener {
         return results.stream()
             .filter(Objects::nonNull)
             .map(SearchPhaseResult::getSearchShardTarget)
+            .map(e -> new SearchShard(e.getClusterAlias(), e.getShardId()))
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    final List<SearchShard> searchShards(SearchShardTarget[] results) {
+        return Arrays.stream(results)
+            .filter(Objects::nonNull)
             .map(e -> new SearchShard(e.getClusterAlias(), e.getShardId()))
             .collect(Collectors.toUnmodifiableList());
     }


### PR DESCRIPTION
The list used by the search progress listener can be nullified by another thread that
reports a query result. This change replaces  the usage of this list with a new array that is synchronously modified.

I tagged this pr with non-issue because it only affects master and 7.x, all non-released branches.

Closes #49778