### PR TITLE
[7.x][ML][HLRC] DF analytics setVersion and setCreateTime should not …

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -283,12 +283,12 @@ public class DataFrameAnalyticsConfig implements ToXContentObject {
             return this;
         }
 
-        public Builder setCreateTime(Instant createTime) {
+        Builder setCreateTime(Instant createTime) {
             this.createTime = createTime;
             return this;
         }
 
-        public Builder setVersion(Version version) {
+        Builder setVersion(Version version) {
             this.version = version;
             return this;
         }


### PR DESCRIPTION
…be public (#49826)

`version` and `create_time` are assigned from the action itself and thus should not
be able to be set from the client.

Backport of #49826
