### PR TITLE
[DOCS] Fixes typo in the ML anomaly detection time functions docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/functions/time.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/time.asciidoc
@@ -27,7 +27,7 @@ are not affected by the bucket span, but a shorter bucket span enables quicker
 alerting on unusual events.
 * Unusual events are flagged based on the previous pattern of the data, not on
 what we might think of as unusual based on human experience. So, if events
-typically occur between 3 a.m. and 5 a.m., and event occurring at 3 p.m. is be
+typically occur between 3 a.m. and 5 a.m., an event occurring at 3 p.m. is 
 flagged as unusual.
 * When Daylight Saving Time starts or stops, regular events can be flagged as
 anomalous. This situation occurs because the actual time of the event (as


### PR DESCRIPTION
Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-536019752