### PR TITLE
Minor Painless Clean Up

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ERegex.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ERegex.java
@@ -63,7 +63,7 @@ public final class ERegex extends AExpression {
 
     @Override
     void analyze(ScriptRoot scriptRoot, Locals locals) {
-        if (false == scriptRoot.getCompilerSettings().areRegexesEnabled()) {
+        if (scriptRoot.getCompilerSettings().areRegexesEnabled() == false) {
             throw createError(new IllegalStateException("Regexes are disabled. Set [script.painless.regex.enabled] to [true] "
                     + "in elasticsearch.yaml to allow them. Be careful though, regexes break out of Painless's protection against deep "
                     + "recursion and long loops."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.ClassWriter;
-import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Parameter;
@@ -54,7 +53,7 @@ public final class SFunction extends AStatement {
     private final SBlock block;
     public final boolean synthetic;
 
-    private CompilerSettings settings;
+    private int maxLoopCounter;
 
     Class<?> returnType;
     List<Class<?>> typeParameters;
@@ -121,7 +120,7 @@ public final class SFunction extends AStatement {
 
     @Override
     void analyze(ScriptRoot scriptRoot, Locals locals) {
-        this.settings = scriptRoot.getCompilerSettings();
+        maxLoopCounter = scriptRoot.getCompilerSettings().getMaxLoopCounter();
 
         if (block.statements.isEmpty()) {
             throw createError(new IllegalArgumentException("Cannot generate an empty function [" + name + "]."));
@@ -137,7 +136,7 @@ public final class SFunction extends AStatement {
             throw createError(new IllegalArgumentException("Not all paths provide a return value for method [" + name + "]."));
         }
 
-        if (settings.getMaxLoopCounter() > 0) {
+        if (maxLoopCounter > 0) {
             loop = locals.getVariable(null, Locals.LOOP);
         }
     }
@@ -156,10 +155,10 @@ public final class SFunction extends AStatement {
 
     @Override
     void write(ClassWriter classWriter, MethodWriter methodWriter, Globals globals) {
-        if (settings.getMaxLoopCounter() > 0) {
+        if (maxLoopCounter > 0) {
             // if there is infinite loop protection, we do this once:
             // int #loop = settings.getMaxLoopCounter()
-            methodWriter.push(settings.getMaxLoopCounter());
+            methodWriter.push(maxLoopCounter);
             methodWriter.visitVarInsn(Opcodes.ISTORE, loop.getSlot());
         }
 


### PR DESCRIPTION
This cleans up two minor things.
1. Cleans up style of `== false`
2. Pulls `maxLoopCounter` into a member variable instead of accessing `CompilerSettings` multiple times in the `SFunction` node