### PR TITLE
Add full extent to the triangle tree to support geo_bounds aggregation

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/Extent.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/Extent.java
@@ -32,12 +32,21 @@ import java.util.Objects;
 public class Extent implements Writeable {
     static final int WRITEABLE_SIZE_IN_BYTES = 24;
 
-    public final int top;
-    public final int bottom;
-    public final int negLeft;
-    public final int negRight;
-    public final int posLeft;
-    public final int posRight;
+    public int top;
+    public int bottom;
+    public int negLeft;
+    public int negRight;
+    public int posLeft;
+    public int posRight;
+
+    public Extent() {
+        this.top = Integer.MIN_VALUE;
+        this.bottom = Integer.MAX_VALUE;
+        this.negLeft = Integer.MAX_VALUE;
+        this.negRight = Integer.MIN_VALUE;
+        this.posLeft = Integer.MAX_VALUE;
+        this.posRight = Integer.MIN_VALUE;
+    }
 
     public Extent(int top, int bottom, int negLeft, int negRight, int posLeft, int posRight) {
         this.top = top;
@@ -50,6 +59,43 @@ public class Extent implements Writeable {
 
     Extent(StreamInput input) throws IOException {
         this(input.readInt(), input.readInt(), input.readInt(), input.readInt(), input.readInt(), input.readInt());
+    }
+
+    public void reset(int top, int bottom, int negLeft, int negRight, int posLeft, int posRight) {
+        this.top = top;
+        this.bottom = bottom;
+        this.negLeft = negLeft;
+        this.negRight = negRight;
+        this.posLeft = posLeft;
+        this.posRight = posRight;
+    }
+
+    /**
+     * Adds the extent of two points representing a bounding box's bottom-left
+     * and top-right points. The bounding box must not cross the dateline.
+     *
+     * @param bottomLeftX the bottom-left x-coordinate
+     * @param bottomLeftY the bottom-left y-coordinate
+     * @param topRightX   the top-right x-coordinate
+     * @param topRightY   the top-right y-coordinate
+     */
+    public void addRectangle(int bottomLeftX, int bottomLeftY, int topRightX, int topRightY) {
+        assert bottomLeftX <= topRightX;
+        assert bottomLeftY <= topRightY;
+        this.bottom = Math.min(this.bottom, bottomLeftY);
+        this.top = Math.max(this.top, topRightY);
+        if (bottomLeftX < 0 && topRightX < 0) {
+            this.negLeft = Math.min(this.negLeft, bottomLeftX);
+            this.negRight = Math.max(this.negRight, topRightX);
+        } else if (bottomLeftX < 0) {
+            this.negLeft = Math.min(this.negLeft, bottomLeftX);
+            this.negRight = Math.max(this.negRight, bottomLeftX);
+            this.posLeft = Math.min(this.posLeft, topRightX);
+            this.posRight = Math.max(this.posRight, topRightX);
+        } else {
+            this.posLeft = Math.min(this.posLeft, bottomLeftX);
+            this.posRight = Math.max(this.posRight, topRightX);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeReader.java
@@ -39,26 +39,38 @@ public class TriangleTreeReader implements ShapeTreeReader {
     private ByteBufferStreamInput input;
     private final CoordinateEncoder coordinateEncoder;
     private final Rectangle2D rectangle2D;
+    private final Extent extent;
+    private int treeOffset;
 
     public TriangleTreeReader(CoordinateEncoder coordinateEncoder) {
         this.coordinateEncoder = coordinateEncoder;
         this.rectangle2D = new Rectangle2D();
+        this.extent = new Extent();
     }
 
-    public void reset(BytesRef bytesRef) {
+    public void reset(BytesRef bytesRef) throws IOException {
         this.input = new ByteBufferStreamInput(ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length));
+        treeOffset = 0;
     }
 
     /**
      * returns the bounding box of the geometry in the format [minX, maxX, minY, maxY].
      */
     public Extent getExtent() throws IOException {
-        input.position(extentOffset);
-        int thisMaxX = input.readInt();
-        int thisMinX = Math.toIntExact(thisMaxX - input.readVLong());
-        int thisMaxY = input.readInt();
-        int thisMinY = Math.toIntExact(thisMaxY - input.readVLong());
-        return Extent.fromPoints(thisMinX, thisMinY, thisMaxX, thisMaxY);
+        if (treeOffset == 0) {
+            input.position(extentOffset);
+            int top = input.readInt();
+            int bottom = Math.toIntExact(top - input.readVLong());
+            int posRight = input.readInt();
+            int posLeft = input.readInt();
+            int negRight = input.readInt();
+            int negLeft = input.readInt();
+            extent.reset(top, bottom, negLeft, negRight, posLeft, posRight);
+            treeOffset = input.position();
+        } else {
+            input.position(treeOffset);
+        }
+        return extent;
     }
 
     /**
@@ -85,11 +97,11 @@ public class TriangleTreeReader implements ShapeTreeReader {
      */
     @Override
     public GeoRelation relate(int minX, int minY, int maxX, int maxY) throws IOException {
-        input.position(extentOffset);
-        int thisMaxX = input.readInt();
-        int thisMinX = Math.toIntExact(thisMaxX - input.readVLong());
-        int thisMaxY = input.readInt();
-        int thisMinY = Math.toIntExact(thisMaxY - input.readVLong());
+        Extent extent = getExtent();
+        int thisMaxX = extent.maxX();
+        int thisMinX = extent.minX();
+        int thisMaxY = extent.maxY();
+        int thisMinY = extent.minY();
         if (minX <= thisMinX && maxX >= thisMaxX && minY <= thisMinY && maxY >= thisMaxY) {
             // the rectangle fully contains the shape
             return GeoRelation.QUERY_CROSSES;

--- a/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeWriter.java
@@ -55,10 +55,12 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
     private final CoordinateEncoder coordinateEncoder;
     private final CentroidCalculator centroidCalculator;
     private final ShapeType type;
+    private Extent extent;
 
     public TriangleTreeWriter(Geometry geometry, CoordinateEncoder coordinateEncoder) {
         this.coordinateEncoder = coordinateEncoder;
         this.centroidCalculator = new CentroidCalculator();
+        this.extent = new Extent();
         this.type = geometry.type();
         TriangleTreeBuilder builder = new TriangleTreeBuilder(coordinateEncoder);
         geometry.visit(builder);
@@ -69,13 +71,18 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeInt(coordinateEncoder.encodeX(centroidCalculator.getX()));
         out.writeInt(coordinateEncoder.encodeY(centroidCalculator.getY()));
+        out.writeInt(extent.top);
+        out.writeVLong((long) extent.top - extent.bottom);
+        out.writeInt(extent.posRight);
+        out.writeInt(extent.posLeft);
+        out.writeInt(extent.negRight);
+        out.writeInt(extent.negLeft);
         node.writeTo(out);
     }
 
     @Override
     public Extent getExtent() {
-        // do it right
-        return Extent.fromPoints(node.minX, node.minY, node.maxX, node.maxY);
+        return extent;
     }
 
     @Override
@@ -93,8 +100,9 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
      */
     class TriangleTreeBuilder implements GeometryVisitor<Void, RuntimeException> {
 
-        private List<TriangleTreeLeaf> triangles;
+        private final List<TriangleTreeLeaf> triangles;
         private final CoordinateEncoder coordinateEncoder;
+
 
         TriangleTreeBuilder(CoordinateEncoder coordinateEncoder) {
             this.coordinateEncoder = coordinateEncoder;
@@ -115,10 +123,12 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
 
         @Override
         public Void visit(Line line) {
-            for (int i =0; i < line.length(); i++) {
+            for (int i = 0; i < line.length(); i++) {
                 centroidCalculator.addCoordinate(line.getX(i), line.getY(i));
             }
-            addTriangles(TriangleTreeLeaf.fromLine(coordinateEncoder, line));
+            org.apache.lucene.geo.Line luceneLine = GeoShapeIndexer.toLuceneLine(line);
+            addToExtent(luceneLine.minLon, luceneLine.maxLon, luceneLine.minLat, luceneLine.maxLat);
+            addTriangles(TriangleTreeLeaf.fromLine(coordinateEncoder, luceneLine));
             return null;
         }
 
@@ -136,7 +146,9 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
             for (int i =0; i < polygon.getPolygon().length() - 1; i++) {
                 centroidCalculator.addCoordinate(polygon.getPolygon().getX(i), polygon.getPolygon().getY(i));
             }
-            addTriangles(TriangleTreeLeaf.fromPolygon(coordinateEncoder, polygon));
+            org.apache.lucene.geo.Polygon lucenePolygon = GeoShapeIndexer.toLucenePolygon(polygon);
+            addToExtent(lucenePolygon.minLon, lucenePolygon.maxLon, lucenePolygon.minLat, lucenePolygon.maxLat);
+            addTriangles(TriangleTreeLeaf.fromPolygon(coordinateEncoder, lucenePolygon));
             return null;
         }
 
@@ -152,6 +164,7 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
         public Void visit(Rectangle r) {
             centroidCalculator.addCoordinate(r.getMinX(), r.getMinY());
             centroidCalculator.addCoordinate(r.getMaxX(), r.getMaxY());
+            addToExtent(r.getMinLon(), r.getMaxLon(), r.getMinLat(), r.getMaxLat());
             addTriangles(TriangleTreeLeaf.fromRectangle(coordinateEncoder, r));
             return null;
         }
@@ -159,6 +172,7 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
         @Override
         public Void visit(Point point) {
             centroidCalculator.addCoordinate(point.getX(), point.getY());
+            addToExtent(point.getLon(), point.getLon(), point.getLat(), point.getLat());
             addTriangles(TriangleTreeLeaf.fromPoints(coordinateEncoder, point));
             return null;
         }
@@ -181,6 +195,14 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
             throw new IllegalArgumentException("invalid shape type found [Circle]");
         }
 
+        private void addToExtent(double minLon, double maxLon, double minLat, double maxLat) {
+            int minX = coordinateEncoder.encodeX(minLon);
+            int maxX = coordinateEncoder.encodeX(maxLon);
+            int minY = coordinateEncoder.encodeY(minLat);
+            int maxY = coordinateEncoder.encodeY(maxLat);
+            extent.addRectangle(minX, minY, maxX, maxY);
+        }
+
 
         public TriangleTreeNode build() {
             if (triangles.size() == 1) {
@@ -191,10 +213,10 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
                 nodes[i] = new TriangleTreeNode(triangles.get(i));
             }
             TriangleTreeNode root =  createTree(nodes, 0, triangles.size() - 1, true);
-            for (TriangleTreeNode node : nodes) {
-                root.minX = Math.min(root.minX, node.minX);
-                root.minY = Math.min(root.minY, node.minY);
-            }
+//            for (TriangleTreeNode node : nodes) {
+//                root.minX = Math.min(root.minX, node.minX);
+//                root.minY = Math.min(root.minY, node.minY);
+//            }
             return root;
         }
 
@@ -274,10 +296,6 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             BytesStreamOutput scratchBuffer = new BytesStreamOutput();
-            out.writeInt(maxX);
-            out.writeVLong((long) maxX - minX);
-            out.writeInt(maxY);
-            out.writeVLong((long) maxY - minY);
             writeMetadata(out);
             writeComponent(out);
             if (left != null) {
@@ -593,19 +611,19 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
             return triangles;
         }
 
-        private static List<TriangleTreeLeaf> fromLine(CoordinateEncoder encoder, Line line) {
-            List<TriangleTreeLeaf> triangles = new ArrayList<>(line.length() - 1);
-            for (int i = 0, j = 1; i < line.length() - 1; i++, j++) {
-                triangles.add(new TriangleTreeLeaf(encoder.encodeX(line.getX(i)), encoder.encodeY(line.getY(i)),
-                    encoder.encodeX(line.getX(j)), encoder.encodeY(line.getY(j))));
+        private static List<TriangleTreeLeaf> fromLine(CoordinateEncoder encoder, org.apache.lucene.geo.Line line) {
+            List<TriangleTreeLeaf> triangles = new ArrayList<>(line.numPoints() - 1);
+            for (int i = 0, j = 1; i < line.numPoints() - 1; i++, j++) {
+                triangles.add(new TriangleTreeLeaf(encoder.encodeX(line.getLon(i)), encoder.encodeY(line.getLat(i)),
+                    encoder.encodeX(line.getLon(j)), encoder.encodeY(line.getLat(j))));
             }
             return triangles;
         }
 
-        private static List<TriangleTreeLeaf> fromPolygon(CoordinateEncoder encoder, Polygon polygon) {
+        private static List<TriangleTreeLeaf> fromPolygon(CoordinateEncoder encoder, org.apache.lucene.geo.Polygon polygon) {
             // TODO: We are going to be tessellating the polygon twice, can we do something?
             // TODO: Tessellator seems to have some reference to the encoding but does not need to have.
-            List<Tessellator.Triangle> tessellation = Tessellator.tessellate(GeoShapeIndexer.toLucenePolygon(polygon));
+            List<Tessellator.Triangle> tessellation = Tessellator.tessellate(polygon);
             List<TriangleTreeLeaf> triangles = new ArrayList<>(tessellation.size());
             for (Tessellator.Triangle t : tessellation) {
                 triangles.add(new TriangleTreeLeaf(encoder.encodeX(t.getX(0)), encoder.encodeY(t.getY(0)), t.isEdgefromPolygon(0),

--- a/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeWriter.java
@@ -213,10 +213,6 @@ public class TriangleTreeWriter extends ShapeTreeWriter {
                 nodes[i] = new TriangleTreeNode(triangles.get(i));
             }
             TriangleTreeNode root =  createTree(nodes, 0, triangles.size() - 1, true);
-//            for (TriangleTreeNode node : nodes) {
-//                root.minX = Math.min(root.minX, node.minX);
-//                root.minY = Math.min(root.minY, node.minY);
-//            }
             return root;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
@@ -1084,6 +1084,10 @@ public final class GeoShapeIndexer implements AbstractGeometryFieldMapper.Indexe
         return new org.apache.lucene.geo.Polygon(polygon.getPolygon().getY(), polygon.getPolygon().getX(), holes);
     }
 
+    public static org.apache.lucene.geo.Line toLuceneLine(Line line) {
+        return new org.apache.lucene.geo.Line(line.getLats(), line.getLons());
+    }
+
     /**
      * Normalizes longitude while accepting -180 degrees as a valid value
      */

--- a/server/src/test/java/org/elasticsearch/common/geo/ExtentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/ExtentTests.java
@@ -68,6 +68,28 @@ public class ExtentTests extends AbstractWireSerializingTestCase {
         }
     }
 
+    public void testAddRectangle() {
+        Extent extent = new Extent();
+        int bottomLeftX = GeoShapeCoordinateEncoder.INSTANCE.encodeX(-175);
+        int bottomLeftY = GeoShapeCoordinateEncoder.INSTANCE.encodeY(-10);
+        int topRightX =  GeoShapeCoordinateEncoder.INSTANCE.encodeX(-170);
+        int topRightY = GeoShapeCoordinateEncoder.INSTANCE.encodeY(10);
+        extent.addRectangle(bottomLeftX, bottomLeftY, topRightX, topRightY);
+        assertThat(extent.minX(), equalTo(bottomLeftX));
+        assertThat(extent.maxX(), equalTo(topRightX));
+        assertThat(extent.minY(), equalTo(bottomLeftY));
+        assertThat(extent.maxY(), equalTo(topRightY));
+        int bottomLeftX2 = GeoShapeCoordinateEncoder.INSTANCE.encodeX(170);
+        int bottomLeftY2 = GeoShapeCoordinateEncoder.INSTANCE.encodeY(-20);
+        int topRightX2 =  GeoShapeCoordinateEncoder.INSTANCE.encodeX(175);
+        int topRightY2 = GeoShapeCoordinateEncoder.INSTANCE.encodeY(20);
+        extent.addRectangle(bottomLeftX2, bottomLeftY2, topRightX2, topRightY2);
+        assertThat(extent.minX(), equalTo(bottomLeftX));
+        assertThat(extent.maxX(), equalTo(topRightX2));
+        assertThat(extent.minY(), equalTo(bottomLeftY2));
+        assertThat(extent.maxY(), equalTo(topRightY2));
+    }
+
     @Override
     protected Extent createTestInstance() {
         return new Extent(randomIntBetween(-10, 10), randomIntBetween(-10, 10), randomIntBetween(-10, 10),


### PR DESCRIPTION
 This PR adds the full Extent to the triangle tree in order to support geo_bounds aggregation wrapping the dateline.
