### PR TITLE
[DOCS] {integer) -> (integer)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -549,7 +549,7 @@ the reindex returned a `noop` value for `ctx.op`.
 
 `version_conflicts`::
 
-(integer)The number of version conflicts that reindex hit.
+(integer) The number of version conflicts that reindex hits.
 
 `retries`::
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -549,7 +549,7 @@ the reindex returned a `noop` value for `ctx.op`.
 
 `version_conflicts`::
 
-{integer)The number of version conflicts that reindex hit.
+(integer)The number of version conflicts that reindex hit.
 
 `retries`::
 


### PR DESCRIPTION
Noticed an incorrect start parenthesis in the docs for the the reindex API.