### PR TITLE
[DOCS] Document `index.queries.cache.enabled` as a static setting

### DIFF
--- a/docs/reference/modules/indices/query_cache.asciidoc
+++ b/docs/reference/modules/indices/query_cache.asciidoc
@@ -18,7 +18,8 @@ the cluster:
     either a percentage value, like `5%`, or an exact value, like `512mb`.
 
 The following setting is an _index_ setting that can be configured on a
-per-index basis:
+per-index basis. Can only be set at index creation time or on a
+<<indices-open-close,closed index>>:
 
 `index.queries.cache.enabled`::
 


### PR DESCRIPTION
Explicitly documents `index.queries.cache.enabled` as a static setting, meaning it can only be changed during index creation or on a closed index.