### PR TITLE
Dump wildfly log on start failure

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -190,6 +190,10 @@ if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
   final TaskExecutionAdapter logDumpListener = new TaskExecutionAdapter() {
     @Override
     void afterExecute(final Task task, final TaskState state) {
+      if (task != startWildfly && task != integTestRunner) {
+        // we might have been called from a parallel, unrelated task
+        return
+      }
       if (state.failure != null) {
         final File logFile = new File(wildflyInstall, "standalone/log/server.log")
         println("\nWildfly server log (from ${logFile}):")

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -163,8 +163,10 @@ task startWildfly {
         }
       }
 
-      assert httpPort > 0
-      assert managementPort > 0
+      if (httpPort == 0 || managementPort == 0) {
+        String portType = httpPort == 0 ? "http" : "management"
+        throw new GradleException("Failed to find ${portType} port in wildfly log")
+      }
     }
   }
 }
@@ -204,10 +206,16 @@ if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
       }
     }
   }
+  startWildfly.doFirst {
+    project.gradle.addListener(logDumpListener)
+  }
   integTestRunner.doFirst {
     project.gradle.addListener(logDumpListener)
   }
   integTestRunner.doLast {
+    project.gradle.removeListener(logDumpListener)
+  }
+  startWildfly.doLast {
     project.gradle.removeListener(logDumpListener)
   }
   integTestRunner.finalizedBy(stopWildfly)


### PR DESCRIPTION
When testing wildfly with Elasticsearch, we currently dump the wildfly
log if the test fails. However, when starting wildfly we may fail to
find the port number wildfly started on, and fail with no output. This
change dumps the wildflog log when failing to find the http or
management ports.

relates #49374