### PR TITLE
[DOCS] Fixes attribute in transforms overview

### DIFF
--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -39,7 +39,7 @@ The {transform} performs a composite aggregation that paginates through all the
 data defined by the source index query. The output of the aggregation is stored 
 in a destination index. Each time the {transform} queries the source index, it 
 creates a _checkpoint_. You can decide whether you want the {transform} to run 
-once (batch {transform}) or continuously ({transform}). A batch {transform} is a 
+once (batch {transform}) or continuously ({ctransform}). A batch {transform} is a 
 single operation that has a single checkpoint. {ctransforms-cap} continually 
 increment and process checkpoints as new source data is ingested.
 


### PR DESCRIPTION
This PR changes {transform} to {ctransform} (continuous transform) in the paragraph that explains the differences between batch transforms and contiunous transforms.