### PR TITLE
Fix TimedRunnable Executing onAfter Twice

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -58,13 +58,6 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
     }
 
     @Override
-    public void onAfter() {
-        if (original instanceof AbstractRunnable) {
-            ((AbstractRunnable) original).onAfter();
-        }
-    }
-
-    @Override
     public void onFailure(final Exception e) {
         this.failedOrRejected = true;
         if (original instanceof AbstractRunnable) {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -60,11 +60,7 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
     @Override
     public void onFailure(final Exception e) {
         this.failedOrRejected = true;
-        if (original instanceof AbstractRunnable) {
-            ((AbstractRunnable) original).onFailure(e);
-        } else {
-            ExceptionsHelper.reThrowIfNotNull(e);
-        }
+        ExceptionsHelper.reThrowIfNotNull(e);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/TimedRunnableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/TimedRunnableTests.java
@@ -33,7 +33,6 @@ public final class TimedRunnableTests extends ESTestCase {
         final boolean isForceExecution = randomBoolean();
         final AtomicBoolean onAfter = new AtomicBoolean();
         final AtomicReference<Exception> onRejection = new AtomicReference<>();
-        final AtomicReference<Exception> onFailure = new AtomicReference<>();
         final AtomicBoolean doRun = new AtomicBoolean();
 
         final AbstractRunnable runnable = new AbstractRunnable() {
@@ -54,7 +53,6 @@ public final class TimedRunnableTests extends ESTestCase {
 
             @Override
             public void onFailure(final Exception e) {
-                onFailure.set(e);
             }
 
             @Override
@@ -70,10 +68,6 @@ public final class TimedRunnableTests extends ESTestCase {
         final Exception rejection = new RejectedExecutionException();
         timedRunnable.onRejection(rejection);
         assertThat(onRejection.get(), equalTo(rejection));
-
-        final Exception failure = new Exception();
-        timedRunnable.onFailure(failure);
-        assertThat(onFailure.get(), equalTo(failure));
 
         timedRunnable.run();
         assertTrue(doRun.get());


### PR DESCRIPTION
If we have a nested `AbstractRunnable` inside of `TimedRunnable`
it's executed twice on `run` (once when its own `run` method is invoked and once when
the `onAfter` in the `TimedRunnable` is executed).
Simply removing the `onAfter` override in `TimedRunnable` makes sure that the `onAfter`
is only called once by the `run` on the nested `AbstractRunnable` itself.

I don't know of any bug this has caused  so far, but it's unexpected behavior and I noticed it when trying to use the `onAfter` for some non-idempotent resource release.