### PR TITLE
Corrected property name

### DIFF
--- a/docs/reference/query-dsl/shape-query.asciidoc
+++ b/docs/reference/query-dsl/shape-query.asciidoc
@@ -40,7 +40,7 @@ PUT /example
 POST /example/_doc?refresh
 {
     "name": "Lucky Landing",
-    "location": {
+    "geometry": {
         "type": "point",
         "coordinates": [1355.400544, 5255.530286]
     }


### PR DESCRIPTION
The document needs to be created with the property "geometry" instead of "location" for a working example.