### PR TITLE
Persist cluster states asynchronously on data-only nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -107,10 +107,12 @@ public class GatewayMetaState {
                 transportService.getThreadPool()::relativeTimeInMillis);
         if (DiscoveryNode.isMasterNode(settings) == false) {
             if (DiscoveryNode.isDataNode(settings)) {
-                persistedState.set(new DataOnlyNodePersistedState(settings, incrementalClusterStateWriter, transportService.getThreadPool()));
+                persistedState.set(new DataOnlyNodePersistedState(settings, incrementalClusterStateWriter,
+                    transportService.getThreadPool()));
             } else {
                 // Non-master non-data nodes do not need to persist the cluster state as they do not use a persistent store
-                persistedState.set(new InMemoryPersistedState(manifestClusterStateTuple.v1().getCurrentTerm(), manifestClusterStateTuple.v2()));
+                persistedState.set(new InMemoryPersistedState(manifestClusterStateTuple.v1().getCurrentTerm(),
+                    manifestClusterStateTuple.v2()));
             }
         } else {
             // Master-ineligible nodes must persist the cluster state when accepting it because they must reload the (complete, fresh)
@@ -313,7 +315,7 @@ public class GatewayMetaState {
 
         private volatile ClusterState lastCommittedStateWithPersistence;
 
-        public DataOnlyNodePersistedState(Settings settings, IncrementalClusterStateWriter incrementalClusterStateWriter,
+        DataOnlyNodePersistedState(Settings settings, IncrementalClusterStateWriter incrementalClusterStateWriter,
                                           ThreadPool threadPool) {
             super(incrementalClusterStateWriter.getPreviousManifest().getCurrentTerm(),
                 incrementalClusterStateWriter.getPreviousClusterState());

--- a/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
+++ b/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
-import java.util.function.Predicate;
 
 /**
  * Tracks the metadata written to disk, allowing updated metadata to be written incrementally (i.e. only writing out the changed metadata).

--- a/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
+++ b/server/src/main/java/org/elasticsearch/gateway/IncrementalClusterStateWriter.java
@@ -53,9 +53,8 @@ public class IncrementalClusterStateWriter {
 
     private final MetaStateService metaStateService;
 
-    // On master-eligible nodes we call updateClusterState under the Coordinator's mutex; on master-ineligible data nodes we call
-    // updateClusterState on the (unique) cluster applier thread; on other nodes we never call updateClusterState. In all cases there's
-    // no need to synchronize access to these fields.
+    // On master-eligible nodes we call updateClusterStateForMasterEligibleNode under the Coordinator's mutex;
+    // on master-ineligible data nodes we call retainIndicesOnDataOnlyNode and updateClusterStateForDataOnlyNode which are synchronized
     private Manifest previousManifest;
     private ClusterState previousClusterState;
     private final LongSupplier relativeTimeMillisSupplier;

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -687,8 +687,9 @@ public class Node implements Closeable {
 
         // Load (and maybe upgrade) the metadata stored on disk
         final GatewayMetaState gatewayMetaState = injector.getInstance(GatewayMetaState.class);
-        gatewayMetaState.start(settings(), transportService, clusterService, injector.getInstance(MetaStateService.class),
-            injector.getInstance(MetaDataIndexUpgradeService.class), injector.getInstance(MetaDataUpgrader.class));
+        gatewayMetaState.start(settings(), transportService, clusterService.getClusterSettings(),
+            injector.getInstance(MetaStateService.class), injector.getInstance(MetaDataIndexUpgradeService.class),
+            injector.getInstance(MetaDataUpgrader.class));
         // we load the global state here (the persistent part of the cluster state stored on disk) to
         // pass it to the bootstrap checks to allow plugins to enforce certain preconditions based on the recovered state.
         final MetaData onDiskMetadata = gatewayMetaState.getPersistedState().getLastAcceptedState().metaData();

--- a/test/framework/src/main/java/org/elasticsearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/elasticsearch/gateway/MockGatewayMetaState.java
@@ -22,7 +22,6 @@ package org.elasticsearch.gateway;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -54,7 +53,7 @@ public class MockGatewayMetaState extends GatewayMetaState {
     }
 
     @Override
-    ClusterState prepareInitialClusterState(TransportService transportService, ClusterService clusterService, ClusterState clusterState) {
+    ClusterState prepareInitialClusterState(TransportService transportService, ClusterSettings clusterSettings, ClusterState clusterState) {
         // Just set localNode here, not to mess with ClusterService and IndicesService mocking
         return ClusterStateUpdaters.setLocalNode(clusterState, localNode);
     }
@@ -62,10 +61,8 @@ public class MockGatewayMetaState extends GatewayMetaState {
     public void start(Settings settings, NodeEnvironment nodeEnvironment, NamedXContentRegistry xContentRegistry) {
         final TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
-        final ClusterService clusterService = mock(ClusterService.class);
-        when(clusterService.getClusterSettings())
-            .thenReturn(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
-        start(settings, transportService, clusterService, new MetaStateService(nodeEnvironment, xContentRegistry),
+        start(settings, transportService, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            new MetaStateService(nodeEnvironment, xContentRegistry),
             null, null);
     }
 }


### PR DESCRIPTION
This PR moves persistence of cluster states on data-only nodes to be asynchronous, which means that cluster state updates can be applied more quickly on data-only nodes, reducing the risk of those data-only nodes to run into the default 90s `cluster.follower_lag.timeout` when they're running on hardware with slow IO. The cluster state is currently persisted on data-only nodes mainly for the dangling indices functionality. As this functionality is best effort already today, delaying the writes of the index metadata will not impact the existing functionality of Elasticsearch.