### PR TITLE
[DOCS] Correct inline shape snippet in shape query docs

### DIFF
--- a/docs/reference/query-dsl/shape-query.asciidoc
+++ b/docs/reference/query-dsl/shape-query.asciidoc
@@ -37,10 +37,10 @@ PUT /example
     }
 }
 
-POST /example/_doc?refresh
+PUT /example/_doc/1?refresh=wait_for
 {
     "name": "Lucky Landing",
-    "location": {
+    "geometry": {
         "type": "point",
         "coordinates": [1355.400544, 5255.530286]
     }
@@ -68,6 +68,47 @@ GET /example/_search
     }
 }
 --------------------------------------------------
+
+////
+[source,console-result]
+--------------------------------------------------
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 0.0,
+    "hits": [
+      {
+        "_index": "example",
+        "_id": "1",
+        "_score": 0.0,
+        "_source": {
+          "name": "Lucky Landing",
+          "geometry": {
+            "type": "point",
+            "coordinates": [
+              1355.400544,
+              5255.530286
+            ]
+          }
+        }
+      }
+    ]
+  }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/"took": 3/"took": $body.took/]
+////
 
 ==== Pre-Indexed Shape
 


### PR DESCRIPTION
In the shape query docs, the index mapping snippet uses the "geometry" shape field mapping. However, the doc index snippet uses the "location" property.

This changes the "location" property to "geometry" in the doc index snippet. It also adds a comment containing the search result snippet. This should prevent similar issues in the future.

Closes #49919.