### PR TITLE
WIP Enable copy_to on date_range fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -45,10 +45,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.stream.StreamSupport;
 
@@ -310,7 +310,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     protected abstract void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException;
 
     protected void createFieldNamesField(ParseContext context, List<IndexableField> fields) {
-        FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context.docMapper()
+        FieldNamesFieldType fieldNamesFieldType = context.docMapper()
                 .metadataMapper(FieldNamesFieldMapper.class).fieldType();
         if (fieldNamesFieldType != null && fieldNamesFieldType.isEnabled()) {
             for (String fieldName : FieldNamesFieldMapper.extractFieldNames(fieldType().name())) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectObjectHashMap;
 import com.carrotsearch.hppc.ObjectObjectMap;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
@@ -30,6 +31,7 @@ import org.elasticsearch.index.IndexSettings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -299,6 +301,16 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
         public Collection<String> getIgnoredFields() {
             return in.getIgnoredFields();
         }
+
+        @Override
+        public void setStoredValue(Object value, String fieldName) {
+            in.setStoredValue(value, fieldName);
+        }
+
+        @Override
+        public Object getStoredValue(String fieldName) {
+            return in.getStoredValue(fieldName);
+        }
     }
 
     public static class InternalParseContext extends ParseContext {
@@ -332,6 +344,8 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
         private boolean docsReversed = false;
 
         private final Set<String> ignoredFields = new HashSet<>();
+
+        private final HashMap<String, Object> storedValues = new HashMap<String, Object>();
 
         public InternalParseContext(IndexSettings indexSettings, DocumentMapperParser docMapperParser, DocumentMapper docMapper,
                                     SourceToParse source, XContentParser parser) {
@@ -495,6 +509,16 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
         @Override
         public Collection<String> getIgnoredFields() {
             return Collections.unmodifiableCollection(ignoredFields);
+        }
+
+        @Override
+        public void setStoredValue(Object value, String fieldName) {
+            this.storedValues.put(fieldName, value);
+        }
+
+        @Override
+        public Object getStoredValue(String fieldName) {
+            return this.storedValues.get(fieldName);
         }
     }
 
@@ -660,4 +684,8 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
      * Get dynamic mappers created while parsing.
      */
     public abstract List<Mapper> getDynamicMappers();
+
+    public abstract void setStoredValue(Object value, String fieldName);
+
+    public abstract Object getStoredValue(String fieldName);
 }


### PR DESCRIPTION
We currently break when `copy_to` is defined for `date_range` fields because the xContent parser
already read past the range definition when we call the document mappers `parseCopy` method again.
We somehow need a way to store and later restore the already parsed range. This is a first shot at
fixing this by adding a way to store the range value in the ParseContext. Opening as a WIP mainly to get
some feedback and testing since I'm not sure if this is the best way to solve this.

Closes #49344 