### PR TITLE
Fix TimedRunnable Executing onAfter Twice (#49910)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TimedRunnable.java
@@ -58,20 +58,9 @@ class TimedRunnable extends AbstractRunnable implements WrappedRunnable {
     }
 
     @Override
-    public void onAfter() {
-        if (original instanceof AbstractRunnable) {
-            ((AbstractRunnable) original).onAfter();
-        }
-    }
-
-    @Override
     public void onFailure(final Exception e) {
         this.failedOrRejected = true;
-        if (original instanceof AbstractRunnable) {
-            ((AbstractRunnable) original).onFailure(e);
-        } else {
-            ExceptionsHelper.reThrowIfNotNull(e);
-        }
+        ExceptionsHelper.reThrowIfNotNull(e);
     }
 
     @Override


### PR DESCRIPTION
If we have a nested `AbstractRunnable` inside of `TimedRunnable`
it's executed twice on `run` (once when its own `run` method is invoked and once when
the `onAfter` in the `TimedRunnable` is executed).
Simply removing the `onAfter` override in `TimedRunnable` makes sure that the `onAfter`
is only called once by the `run` on the nested `AbstractRunnable` itself.
Same was done for `onFailure` as it was double-triggering as well on exceptions in the inner `onFailure`.

backport of #49910 