### PR TITLE
Introduce a caching mechanism for files in Searchable Snapshot Directory

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -62,14 +62,6 @@ public interface BlobContainer {
         }
     }
 
-    default void readBlob(String blobName, long from, int length, byte[] buffer, int offset) throws IOException {
-        try (InputStream stream = readBlob(blobName)) {
-            stream.skip(from);
-            int read = stream.read(buffer, offset, length);
-            assert read == length;
-        }
-    }
-
     /**
      * Reads blob content from the input stream and writes it to the container in a new blob with the given name.
      * This method assumes the container does not already contain a blob of the same blobName.  If a blob by the

--- a/server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/RepositoryPlugin.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.repositories.RepositoriesModule;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -57,5 +58,8 @@ public interface RepositoryPlugin {
     default Map<String, Repository.Factory> getInternalRepositories(Environment env, NamedXContentRegistry namedXContentRegistry,
                                                                     ThreadPool threadPool) {
         return Collections.emptyMap();
+    }
+
+    default void onRepositoriesModule(RepositoriesModule repositoriesModule) {
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesModule.java
@@ -73,6 +73,10 @@ public final class RepositoriesModule {
         Map<String, Repository.Factory> internalRepositoryTypes = Collections.unmodifiableMap(internalFactories);
         repositoriesService = new RepositoriesService(settings, clusterService, transportService, repositoryTypes,
             internalRepositoryTypes, threadPool);
+
+        for (RepositoryPlugin repoPlugin : repoPlugins) {
+            repoPlugin.onRepositoriesModule(this);
+        }
     }
 
     public RepositoriesService getRepositoryService() {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -854,7 +854,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return blobStore().blobContainer(indicesPath().add(indexId.getId()));
     }
 
-    private BlobContainer shardContainer(IndexId indexId, ShardId shardId) {
+    BlobContainer shardContainer(IndexId indexId, ShardId shardId) {
         return shardContainer(indexId, shardId.getId());
     }
 
@@ -1402,6 +1402,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             snapshot.incrementalSize(), snapshot.totalSize(), null); // Not adding a real generation here as it doesn't matter to callers
     }
 
+    /*public BlobStoreIndexShardSnapshot loadShardSnapshot(SnapshotId snapshotId, IndexId indexId, ShardId shardId) {
+        return loadShardSnapshot(shardContainer(indexId, shardId), snapshotId);
+    }*/
+
     @Override
     public void verify(String seed, DiscoveryNode localNode) {
         assertSnapshotOrGenericThread();
@@ -1513,7 +1517,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     /**
      * Loads information about shard snapshot
      */
-    private BlobStoreIndexShardSnapshot loadShardSnapshot(BlobContainer shardContainer, SnapshotId snapshotId) {
+    BlobStoreIndexShardSnapshot loadShardSnapshot(BlobContainer shardContainer, SnapshotId snapshotId) {
         try {
             return indexShardSnapshotFormat.read(shardContainer, snapshotId.getUUID());
         } catch (NoSuchFileException ex) {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1402,10 +1402,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             snapshot.incrementalSize(), snapshot.totalSize(), null); // Not adding a real generation here as it doesn't matter to callers
     }
 
-    /*public BlobStoreIndexShardSnapshot loadShardSnapshot(SnapshotId snapshotId, IndexId indexId, ShardId shardId) {
-        return loadShardSnapshot(shardContainer(indexId, shardId), snapshotId);
-    }*/
-
     @Override
     public void verify(String seed, DiscoveryNode localNode) {
         assertSnapshotOrGenericThread();

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -1,0 +1,20 @@
+evaluationDependsOn(xpackModule('core'))
+
+apply plugin: 'elasticsearch.esplugin'
+esplugin {
+  name 'searchable-snapshots'
+  description 'A plugin for the searchable snapshots functionality'
+  classname 'org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots'
+  extendedPlugins = ['x-pack-core']
+}
+archivesBaseName = 'x-pack-searchable-snapshots'
+
+dependencies {
+  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+}
+
+// xpack modules are installed in real clusters as the meta plugin, so
+// installing them as individual plugins for integ tests doesn't make sense,
+// so we disable integ tests
+integTest.enabled = false

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.index.store;
+
+import org.apache.lucene.store.BaseDirectory;
+import org.apache.lucene.store.BufferedIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.SingleInstanceLockFactory;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotShard;
+
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A read-only {@link org.apache.lucene.store.Directory} implementation that uses a {@link SearchableSnapshotShard}
+ * to list and to read shard files stored in a snapshot.
+ */
+public class SearchableSnapshotDirectory extends BaseDirectory {
+
+    private final SearchableSnapshotShard snapshotShard;
+    private final int bufferSize;
+
+    public SearchableSnapshotDirectory(final SearchableSnapshotShard snapshotShard, final int bufferSize) {
+        super(new SingleInstanceLockFactory());
+        this.snapshotShard = Objects.requireNonNull(snapshotShard);
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public String[] listAll() throws IOException {
+        ensureOpen();
+        return snapshotShard.listSnapshotFiles().keySet().stream()
+            .sorted(String::compareTo)
+            .toArray(String[]::new);
+    }
+
+    @Override
+    public long fileLength(String name) throws IOException {
+        ensureOpenAndFileExists(name);
+        final FileInfo fileInfo = snapshotShard.listSnapshotFiles().get(name);
+        assert fileInfo != null;
+        return fileInfo.length();
+    }
+
+    @Override
+    public IndexInput openInput(final String name, final IOContext context) throws IOException {
+        return new SearchableSnapshotIndexInput(name, bufferSize, fileLength(name));
+    }
+
+    private void ensureOpenAndFileExists(final String name) throws IOException {
+        ensureOpen();
+        if (snapshotShard.listSnapshotFiles().containsKey(name) == false) {
+            throw new FileNotFoundException(name);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        isOpen = false;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName()
+            + ", lockFactory=" + lockFactory
+            + ", bufferSize=" + bufferSize;
+    }
+
+    @Override
+    public Set<String> getPendingDeletions() throws IOException {
+        throw unsupportedException();
+    }
+
+    @Override
+    public void sync(Collection<String> names) throws IOException {
+        throw unsupportedException();
+    }
+
+    @Override
+    public void syncMetaData() throws IOException {
+        throw unsupportedException();
+    }
+
+    @Override
+    public void deleteFile(String name) throws IOException {
+        throw unsupportedException();
+    }
+
+    @Override
+    public IndexOutput createOutput(String name, IOContext context) throws IOException {
+        throw unsupportedException();
+    }
+
+    @Override
+    public IndexOutput createTempOutput(String prefix, String suffix, IOContext context) throws IOException {
+        throw unsupportedException();
+    }
+
+    @Override
+    public void rename(String source, String dest) throws IOException {
+        throw unsupportedException();
+    }
+
+    private static UnsupportedOperationException unsupportedException() {
+        return new UnsupportedOperationException("Searchable snapshot directory does not support this operation");
+    }
+
+    /**
+     * A {@link BufferedIndexInput} implementation that uses the directory's {@link SearchableSnapshotShard} to read a snapshot file
+     */
+    class SearchableSnapshotIndexInput extends BufferedIndexInput {
+
+        private String name;
+        private long length;
+        private boolean closed;
+
+        SearchableSnapshotIndexInput(String name, int bufferSize, long length) {
+            super("SearchableSnapshotIndexInput(" + name + ")", bufferSize);
+            this.name = Objects.requireNonNull(name);
+            this.length = length;
+            this.closed = false;
+        }
+
+        @Override
+        protected void readInternal(byte[] b, int offset, int length) throws IOException {
+            if (closed) {
+                throw new IOException(toString() + " is closed");
+            }
+            final ByteBuffer buffer = snapshotShard.readSnapshotFile(name, getFilePointer(), length);
+            buffer.get(b, offset, length);
+        }
+
+        @Override
+        protected void seekInternal(long pos) throws IOException {
+            if (pos > length()) {
+                throw new EOFException("Reading past end of file [position=" + pos + ", length=" + length() + "] for " + toString());
+            } else if (pos < 0L) {
+                throw new IOException("Seeking to negative position [" + pos + "] for " + toString());
+            }
+        }
+
+        @Override
+        public long length() {
+            return length;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+
+        @Override
+        public String toString() {
+            return "SearchableSnapshotIndexInput{name='" + name + ", length=" + length + '}' + System.identityHashCode(this);
+        }
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreSearchableSnapshotShard.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreSearchableSnapshotShard.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.repositories.blobstore;
+
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotContext;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotShard;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * {@link BlobStoreSearchableSnapshotShard} exposes shard files stored in a snapshot by accessing directly to the blob store repository
+ * where the snapshot is stored.
+ */
+public class BlobStoreSearchableSnapshotShard extends SearchableSnapshotShard {
+
+    private final RepositoriesService repositories;
+    private final ThreadPool threadPool;
+
+    public BlobStoreSearchableSnapshotShard(final SearchableSnapshotContext context,
+                                            final RepositoriesService repositories,
+                                            final ThreadPool threadPool) {
+        super(context);
+        this.repositories = Objects.requireNonNull(repositories);
+        this.threadPool = Objects.requireNonNull(threadPool);
+    }
+
+    @Override
+    public Map<String, FileInfo> listSnapshotFiles() throws IOException {
+        try {
+            BlobStoreIndexShardSnapshot snapshot = execute((blobStoreRepository, blobContainer) ->
+                blobStoreRepository.loadShardSnapshot(blobContainer, new SnapshotId("_na", getContext().getSnapshot())));
+            return snapshot.indexFiles().stream().collect(Collectors.toMap(FileInfo::physicalName, Function.identity()));
+        } catch (final Exception e) {
+            throw new IOException("Failed to list snapshot files", e);
+        }
+    }
+
+    @Override
+    public ByteBuffer readSnapshotFile(final String name, final long position, final int length) throws IOException {
+        final FileInfo fileInfo = listSnapshotFiles().get(name);
+
+        //
+        //    .-------------------------.
+        //    |    PARENTAL ADVISORY    |
+        //    |                         |
+        //    |     over-simplistic     |
+        //    |         buggy           |
+        //    |     implementation      |
+        //    |                         |
+        //    '-------------------------'
+        //
+
+        try {
+            if (fileInfo.numberOfParts() == 1) {
+                return execute((blobStoreRepository, blobContainer) ->
+                    blobContainer.readBlob(fileInfo.partName(0), position, Math.min(length, (int) fileInfo.partBytes(0))));
+            }
+
+            final ByteBuffer buffer = ByteBuffer.allocate(length);
+
+            long pos = position;
+            int len = length;
+            while (len > 0) {
+                final long currentPart = pos / fileInfo.partSize().getBytes();
+                int remainingBytesInPart;
+                if (currentPart < (fileInfo.numberOfParts() - 1)) {
+                    remainingBytesInPart = Math.toIntExact(((currentPart + 1L) * fileInfo.partSize().getBytes()) - pos);
+                } else {
+                    remainingBytesInPart = Math.toIntExact(fileInfo.length() - pos);
+                }
+                final int read = Math.min(len, remainingBytesInPart);
+                if (read == 0) {
+                    break;
+                }
+
+                final long from = pos % fileInfo.partSize().getBytes();
+                ByteBuffer partBytes = execute((blobStoreRepository, blobContainer) ->
+                    blobContainer.readBlob(fileInfo.partName(currentPart), from, read));
+                buffer.put(partBytes);
+
+                pos += read;
+                len -= read;
+            }
+
+            return buffer.limit(length).position(0);
+        } catch (final Exception e) {
+            throw new IOException("Failed to read [" + length + "] bytes from snapshot file [name: " + name + "] at [" + position + "]", e);
+        }
+    }
+
+    /**
+     * This method uses the {@link SearchableSnapshotContext} to retrieve the appropriate {@link BlobStoreRepository} and
+     * {@link BlobContainer} instances to pass to the given function {@code func}. The function is executed using the
+     * snapshot thread pool.
+     */
+    private <T> T execute(final CheckedBiFunction<BlobStoreRepository, BlobContainer, T, IOException> func) throws Exception {
+        final Repository repository = repositories.repository(getContext().getRepository());
+        if (repository instanceof BlobStoreRepository == false) {
+            throw new IllegalArgumentException("Repository [" + repository.getMetadata().name() + "] is not supported");
+        }
+
+        final BlobStoreRepository blobStoreRepository = (BlobStoreRepository) repository;
+        final IndexId indexId = new IndexId("_na", getContext().getIndex());
+        final ShardId shardId = new ShardId("_na", "_na", getContext().getShard());
+
+        final PlainActionFuture<T> future = new PlainActionFuture<>();
+        threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
+            @Override
+            protected void doRun() throws Exception {
+                future.onResponse(func.apply(blobStoreRepository, blobStoreRepository.shardContainer(indexId, shardId)));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                future.onFailure(e);
+            }
+        });
+        return future.get();
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/FilterSearchableSnapshotShard.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/FilterSearchableSnapshotShard.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+
+public class FilterSearchableSnapshotShard extends SearchableSnapshotShard {
+
+    private final SearchableSnapshotShard in;
+
+    public FilterSearchableSnapshotShard(SearchableSnapshotShard in) {
+        super(Objects.requireNonNull(in).getContext());
+        this.in = in;
+    }
+
+    @Override
+    public SearchableSnapshotContext getContext() {
+        return in.getContext();
+    }
+
+    @Override
+    public Map<String, FileInfo> listSnapshotFiles() throws IOException {
+        return in.listSnapshotFiles();
+    }
+
+    @Override
+    public ByteBuffer readSnapshotFile(String name, long position, int length) throws IOException {
+        return in.readSnapshotFile(name, position, length);
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotContext.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotContext.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import java.util.Objects;
+
+/**
+ * {@link SearchableSnapshotContext} contains all the information required to access the files of a shard that has been snapshotted.
+ */
+public class SearchableSnapshotContext {
+
+    private final String repository;
+    private final String snapshot;
+    private final String index;
+    private final int shard;
+
+    public SearchableSnapshotContext(String repository, String snapshot, String index, int shard) {
+        this.repository = Objects.requireNonNull(repository, "repository name must not be null");
+        this.snapshot = Objects.requireNonNull(snapshot, "snapshot id must not be null");
+        this.index = Objects.requireNonNull(index, "index id must not be null");
+        this.shard = shard;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getSnapshot() {
+        return snapshot;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public int getShard() {
+        return shard;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchableSnapshotContext that = (SearchableSnapshotContext) o;
+        return shard == that.shard &&
+            Objects.equals(repository, that.repository) &&
+            Objects.equals(snapshot, that.snapshot) &&
+            Objects.equals(index, that.index);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(repository, snapshot, index, shard);
+    }
+
+    @Override
+    public String toString() {
+        return "SearchableSnapshotContext{" +
+            "repository='" + repository + '\'' +
+            ", snapshot='" + snapshot + '\'' +
+            ", index='" + index + '\'' +
+            ", shard=" + shard +
+            '}';
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotShard.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotShard.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A {@link SearchableSnapshotShard} exposes shard files stored in a snapshot.
+ */
+public abstract class SearchableSnapshotShard {
+
+    private final SearchableSnapshotContext context;
+
+    protected SearchableSnapshotShard(final SearchableSnapshotContext context) {
+        this.context = Objects.requireNonNull(context);
+    }
+
+    /**
+     * @return the shard snapshot context
+     */
+    public SearchableSnapshotContext getContext() {
+        return context;
+    }
+
+    /**
+     * Returns all the files contained in the shard snapshot
+     *
+     * @return a {@link Map} of {@link String} file names with their corresponding {@link FileInfo}
+     *
+     * @throws IOException if something went wrong during snapshot files listing
+     */
+    public abstract Map<String, FileInfo> listSnapshotFiles() throws IOException;
+
+    /**
+     * Reads {@code length} bytes starting from the position {@code position} of the file named {@code name}
+     *
+     * @param name     the name of the file to read
+     * @param position the starting position in the file to start reading from
+     * @param length   the number of bytes to read
+     * @return a {@link ByteBuffer} instance that can used to read the file
+     *
+     * @throws IOException if something went wrong during snapshot file reading
+     */
+    public abstract ByteBuffer readSnapshotFile(String name, long position, int length) throws IOException;
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.store.SearchableSnapshotDirectory;
+import org.elasticsearch.plugins.IndexStorePlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.RepositoryPlugin;
+import org.elasticsearch.repositories.RepositoriesModule;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.blobstore.BlobStoreSearchableSnapshotShard;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CachedSearchableSnapshotShard;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class SearchableSnapshots extends Plugin implements IndexStorePlugin, RepositoryPlugin {
+
+    /** Setting for enabling or disabling searchable snapshots. Defaults to true. */
+    private static final Setting<Boolean> SEARCHABLE_SNAPSHOTS_ENABLED =
+        Setting.boolSetting("xpack.searchablesnapshots.enabled", true, Setting.Property.NodeScope);
+
+    public static final Setting<String> EPHEMERAL_INDEX_REPOSITORY_SETTING =
+        Setting.simpleString("index.ephemeral.repository", Setting.Property.IndexScope, Setting.Property.PrivateIndex);
+
+    public static final Setting<String> EPHEMERAL_INDEX_SNAPSHOT_SETTING =
+        Setting.simpleString("index.ephemeral.snapshot", Setting.Property.IndexScope, Setting.Property.PrivateIndex);
+
+    public static final Setting<ByteSizeValue> EPHEMERAL_INDEX_BUFFER_SIZE_SETTING =
+        Setting.byteSizeSetting("index.ephemeral.buffer_size", new ByteSizeValue(1, ByteSizeUnit.KB), new ByteSizeValue(1, ByteSizeUnit.KB),
+            new ByteSizeValue(1, ByteSizeUnit.GB), Setting.Property.IndexScope);
+
+    private final SetOnce<RepositoriesService> repositoriesService;
+    private final SetOnce<CacheService> cacheService;
+    private final SetOnce<ThreadPool> threadPool;
+    private final Settings settings;
+    private final boolean enabled;
+
+    public SearchableSnapshots(Settings settings) {
+        this.settings = settings;
+        this.enabled = SEARCHABLE_SNAPSHOTS_ENABLED.get(settings);
+        this.repositoriesService = new SetOnce<>();
+        this.cacheService = new SetOnce<>();
+        this.threadPool = new SetOnce<>();
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(SEARCHABLE_SNAPSHOTS_ENABLED,
+            CacheService.CACHE_ENABLED_SETTING,
+            CacheService.CACHE_SIZE_SETTING,
+            CacheService.CACHE_SEGMENT_SIZE_SETTING);
+    }
+
+    private boolean isCacheEnabled() {
+        return enabled && CacheService.CACHE_ENABLED_SETTING.get(settings);
+    }
+
+    @Override
+    public Collection<Object> createComponents(
+            final Client client,
+            final ClusterService clusterService,
+            final ThreadPool threadPool,
+            final ResourceWatcherService resourceWatcherService,
+            final ScriptService scriptService,
+            final NamedXContentRegistry xContentRegistry,
+            final Environment environment,
+            final NodeEnvironment nodeEnvironment,
+            final NamedWriteableRegistry namedWriteableRegistry) {
+
+        this.threadPool.set(threadPool);
+        if (enabled == false || isCacheEnabled() == false) {
+            return List.of();
+        }
+
+        final CacheService cacheService = new CacheService(settings);
+        this.cacheService.set(cacheService);
+        return List.of(cacheService);
+    }
+
+    @Override
+    public void onRepositoriesModule(RepositoriesModule repositoriesModule) {  // should we use some SPI mechanism?
+        if (enabled) {
+            repositoriesService.set(repositoriesModule.getRepositoryService());
+        }
+    }
+
+    @Override
+    public Map<String, DirectoryFactory> getDirectoryFactories() {
+        if (enabled) {
+            RepositoriesService repositories = this.repositoriesService.get();
+            assert repositories != null : "repositories service should be set";
+
+            ThreadPool threadPool = this.threadPool.get();
+            assert threadPool != null : "thread pool service should be set";
+
+            CacheService cacheService = this.cacheService.get();
+            assert cacheService != null || isCacheEnabled() == false : "cache service should be set";
+
+            return Map.of("ephemeral", newDirectoryFactory(repositories, threadPool, cacheService));
+        }
+        return Map.of();
+    }
+
+    public static DirectoryFactory newDirectoryFactory(final RepositoriesService repositories,
+                                                       final ThreadPool threadPool,
+                                                       @Nullable final CacheService cache) {
+        return (indexSettings, shardPath) -> {
+            if (repositories == null) {
+                throw new IllegalArgumentException("An instance of RepositoriesService is required to build a SearchableSnapshotDirectory");
+            }
+            if (threadPool == null) {
+                throw new IllegalArgumentException("An instance of ThreadPool is required to build a SearchableSnapshotDirectory");
+            }
+
+            SearchableSnapshotContext context = new SearchableSnapshotContext(
+                EPHEMERAL_INDEX_REPOSITORY_SETTING.get(indexSettings.getSettings()),
+                EPHEMERAL_INDEX_SNAPSHOT_SETTING.get(indexSettings.getSettings()),
+                shardPath.getShardId().getIndex().getUUID(), // assuming it is initialized as the snapshot's index id
+                shardPath.getShardId().getId());
+
+            SearchableSnapshotShard searchableSnapshotShard = new BlobStoreSearchableSnapshotShard(context, repositories, threadPool);
+            if (cache != null) {
+                searchableSnapshotShard = new CachedSearchableSnapshotShard(searchableSnapshotShard, cache);
+            }
+
+            int bufferSize = Math.toIntExact(EPHEMERAL_INDEX_BUFFER_SIZE_SETTING.get(indexSettings.getSettings()).getBytes());
+            return new SearchableSnapshotDirectory(searchableSnapshotShard, bufferSize);
+        };
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots.cache;
+
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotContext;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A simple in-memory LRU cache used to cache segments of Lucene files.
+ */
+public class CacheService extends AbstractLifecycleComponent {
+
+    public static final Setting<Boolean> CACHE_ENABLED_SETTING =
+        Setting.boolSetting("xpack.searchablesnapshots.cache.enabled", true, Setting.Property.NodeScope);
+
+    public static final Setting<ByteSizeValue> CACHE_SIZE_SETTING =
+        Setting.memorySizeSetting("xpack.searchablesnapshots.cache.size", "10%", Setting.Property.NodeScope);
+
+    public static final Setting<ByteSizeValue> CACHE_SEGMENT_SIZE_SETTING =
+        Setting.byteSizeSetting("xpack.searchablesnapshots.cache.segment_size", new ByteSizeValue(8, ByteSizeUnit.KB),
+            new ByteSizeValue(1, ByteSizeUnit.KB), new ByteSizeValue(1, ByteSizeUnit.GB), Setting.Property.NodeScope);
+
+    private final Cache<CacheKey, CacheValue> cache;
+    private final int segmentSize;
+
+    public CacheService(final Settings settings) {
+        assert CACHE_ENABLED_SETTING.get(settings);
+        this.cache = CacheBuilder.<CacheKey, CacheValue>builder()
+            .setMaximumWeight(CACHE_SIZE_SETTING.get(settings).getBytes())
+            .weigher((cacheKey, cacheValue) -> cacheValue.ramBytesUsed())
+            .build();
+        this.segmentSize = Math.toIntExact(CACHE_SEGMENT_SIZE_SETTING.get(settings).getBytes());
+    }
+
+    public int getSegmentSize() {
+        return segmentSize;
+    }
+
+    @Override
+    protected void doStart() {
+    }
+
+    @Override
+    protected void doStop() {
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        cache.invalidateAll();
+    }
+
+    public CacheValue computeIfAbsent(final CacheKey cacheKey, CheckedFunction<CacheKey, CacheValue, IOException> fn) throws Exception {
+        return cache.computeIfAbsent(cacheKey, fn::apply);
+    }
+
+    /**
+     * A {@link CacheKey} is an object that is used as a key in cache in order to
+     * refer to a specific segment of a given file from a snapshot.
+     */
+    static final class CacheKey {
+
+        /** The snapshot the file is stored into **/
+        private final SearchableSnapshotContext context;
+        /** The name of the physical Lucene file **/
+        private final String name;
+        /** The segment (ie, the part) of the file the key refers to **/
+        private final long segment;
+
+        CacheKey(final SearchableSnapshotContext context, final String name, final long segment) {
+            this.context = Objects.requireNonNull(context);
+            this.name = Objects.requireNonNull(name);
+            this.segment = segment;
+        }
+
+        public long segment() {
+            return segment;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CacheKey cacheKey = (CacheKey) o;
+            return segment == cacheKey.segment &&
+                Objects.equals(context, cacheKey.context) &&
+                Objects.equals(name, cacheKey.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(context, name, segment);
+        }
+
+        @Override
+        public String toString() {
+            return "CacheKey{" +
+                "context=" + context +
+                ", name='" + name + '\'' +
+                ", segment=" + segment +
+                '}';
+        }
+    }
+
+    /**
+     * Abstract class for all cached objects.
+     */
+    abstract static class CacheValue {
+
+        abstract long ramBytesUsed();
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CachedSearchableSnapshotShard.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CachedSearchableSnapshotShard.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots.cache;
+
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.xpack.searchablesnapshots.FilterSearchableSnapshotShard;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotShard;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.CacheKey;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService.CacheValue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+
+public class CachedSearchableSnapshotShard extends FilterSearchableSnapshotShard {
+
+    private final CacheService cacheService;
+    private final int segmentSize;
+
+    public CachedSearchableSnapshotShard(final SearchableSnapshotShard in, final CacheService cacheService) {
+        super(in);
+        this.cacheService = Objects.requireNonNull(cacheService);
+        this.segmentSize = cacheService.getSegmentSize();
+    }
+
+    private CacheKey computeCacheKey(final String name, final long position) {
+        return new CacheKey(getContext(), name, position / segmentSize);
+    }
+
+    @Override
+    public Map<String, FileInfo> listSnapshotFiles() throws IOException {
+        final CacheKey cacheKey = computeCacheKey("listSnapshotFiles(" + getContext() + ")", 0L);
+        try {
+            ListOfFilesCacheValue cachedListOfFiles = (ListOfFilesCacheValue) cacheService.computeIfAbsent(cacheKey, key ->
+                new ListOfFilesCacheValue(super.listSnapshotFiles()));
+            return Map.copyOf(cachedListOfFiles.files);
+        } catch (Exception e) {
+            throw new IOException("Failed to list searchable snapshot shard files from cache", e);
+        }
+    }
+
+    @Override
+    public ByteBuffer readSnapshotFile(final String name, long position, int length) throws IOException {
+        final int segmentSize = cacheService.getSegmentSize();
+
+        //
+        //    .-------------------------.
+        //    |    PARENTAL ADVISORY    |
+        //    |                         |
+        //    |     over-simplistic     |
+        //    |     implementation      |
+        //    |                         |
+        //    '-------------------------'
+        //
+        try {
+            final ByteBuffer buffer = ByteBuffer.allocate(length);
+
+            int read = 0;
+            while (length > 0) {
+                final CacheKey cacheKey = computeCacheKey(name, position);
+
+                FileSegmentCacheValue cachedFileSegment = (FileSegmentCacheValue) cacheService.computeIfAbsent(cacheKey, key ->
+                    new FileSegmentCacheValue(super.readSnapshotFile(name, key.segment() * segmentSize, segmentSize)));
+
+                // always duplicate ByteBuffer as it may come from cache
+                final ByteBuffer segmentBuffer = cachedFileSegment.buffer.duplicate();
+
+                // adjust reading position within the segment file
+                final int segmentPosition = (int) (position % segmentSize);
+                segmentBuffer.position(segmentPosition);
+
+                // adjust length of bytes to read from the segment file
+                final int limit = Math.min(length, segmentBuffer.limit() - segmentPosition);
+                segmentBuffer.limit(segmentPosition + limit);
+                buffer.put(segmentBuffer);
+
+                position += limit;
+                length -= limit;
+                read += limit;
+            }
+            return buffer.limit(read).position(0);
+        } catch (Exception e) {
+            throw new IOException("Failed to retrieve the list of snapshot files", e);
+        }
+    }
+
+    /**
+     * Cached value for the list of files
+     */
+    private class ListOfFilesCacheValue extends CacheValue {
+
+        private final Map<String, FileInfo> files;
+
+        ListOfFilesCacheValue(final Map<String, FileInfo> files) {
+            this.files = Objects.requireNonNull(files);
+        }
+
+        @Override
+        long ramBytesUsed() {
+            return 0L;
+        }
+    }
+
+    /**
+     * Cached value for a segment of a file
+     */
+    private class FileSegmentCacheValue extends CacheValue {
+        private final ByteBuffer buffer;
+
+
+        FileSegmentCacheValue(final ByteBuffer buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        long ramBytesUsed() {
+            return this.buffer.capacity();
+        }
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryTests.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.index.store;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.search.CheckHits;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.core.internal.io.IOUtils;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardPath;
+import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
+import org.elasticsearch.plugins.IndexStorePlugin;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.test.DummyShardLock;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
+import org.elasticsearch.xpack.searchablesnapshots.cache.CacheService;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchableSnapshotDirectoryTests extends ESTestCase {
+
+    public void testListAll() throws Exception {
+        testDirectories((directory, searchableDirectory) ->
+            assertThat(searchableDirectory.listAll(), equalTo(Arrays.stream(directory.listAll())
+                .filter(file -> "write.lock".equals(file) == false)
+                .filter(file -> file.startsWith("extra") == false)
+                .toArray(String[]::new))));
+    }
+
+    public void testFileLength() throws Exception {
+        testDirectories((directory, searchableDirectory) ->
+            Arrays.stream(directory.listAll())
+                .filter(file -> "write.lock".equals(file) == false)
+                .filter(file -> file.startsWith("extra") == false)
+                .forEach(file -> {
+                    try {
+                        assertThat(searchableDirectory.fileLength(file), equalTo(directory.fileLength(file)));
+                    } catch (IOException e) {
+                        throw new AssertionError(e);
+                    }
+                }));
+    }
+
+    public void testIndexSearcher() throws Exception {
+        testDirectories((directory, searchableDirectory) -> {
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                final IndexSearcher searcher = newSearcher(reader);
+
+                try (DirectoryReader searchableReader = DirectoryReader.open(searchableDirectory)) {
+                    final IndexSearcher searchableSearcher = newSearcher(searchableReader);
+                    {
+                        Query query = new MatchAllDocsQuery();
+                        assertThat(searchableSearcher.count(query), equalTo(searcher.count(query)));
+                        CheckHits.checkEqual(query,
+                            searchableSearcher.search(query, 10).scoreDocs,
+                            searcher.search(query, 10).scoreDocs);
+                    }
+                    {
+                        Query query = new TermQuery(new Term("text", "fox"));
+                        assertThat(searchableSearcher.count(query), equalTo(searcher.count(query)));
+                        CheckHits.checkEqual(query,
+                            searchableSearcher.search(query, 10).scoreDocs,
+                            searcher.search(query, 10).scoreDocs);
+                    }
+                    {
+                        Query query = new TermInSetQuery("text", List.of(new BytesRef("quick"), new BytesRef("lazy")));
+                        assertThat(searchableSearcher.count(query), equalTo(searcher.count(query)));
+                        CheckHits.checkEqual(query,
+                            searchableSearcher.search(query, 10).scoreDocs,
+                            searcher.search(query, 10).scoreDocs);
+                    }
+                    {
+                        Query query = new TermRangeQuery("rank",
+                            BytesRefs.toBytesRef(randomLongBetween(0L, 500L)),
+                            BytesRefs.toBytesRef(randomLongBetween(501L, 1000L)),
+                            randomBoolean(), randomBoolean());
+                        assertThat(searchableSearcher.count(query), equalTo(searcher.count(query)));
+                        CheckHits.checkEqual(query,
+                            searchableSearcher.search(query, 10).scoreDocs,
+                            searcher.search(query, 10).scoreDocs);
+                    }
+                }
+            }
+        });
+    }
+
+    public void testDirectoryReader() throws Exception {
+        testDirectories((directory, searchableDirectory) -> {
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                try (DirectoryReader searchableReader = DirectoryReader.open(searchableDirectory)) {
+                    assertThat(searchableReader.leaves(), hasSize(reader.leaves().size()));
+                    assertThat(searchableReader.maxDoc(), equalTo(reader.maxDoc()));
+                    assertThat(searchableReader.getVersion(), equalTo(reader.getVersion()));
+                    assertThat(searchableReader.getIndexCommit().getGeneration(), equalTo(reader.getIndexCommit().getGeneration()));
+
+                    String field = randomFrom("id", "text");
+                    Terms terms = reader.leaves().get(0).reader().terms(field);
+                    Terms searchableTerms = searchableReader.leaves().get(0).reader().terms(field);
+                    assertThat(searchableTerms.size(), equalTo(terms.size()));
+                    assertThat(searchableTerms.getDocCount(), equalTo(terms.getDocCount()));
+                    assertThat(searchableTerms.getMin(), equalTo(terms.getMin()));
+                    assertThat(searchableTerms.getMax(), equalTo(terms.getMax()));
+                }
+            }
+        });
+    }
+
+    public void testReadByte() throws Exception {
+        testIndexInputs((indexInput, searchableIndexInput) -> {
+            try {
+                for (int i = 0; i < 10; i++) {
+                    if (randomBoolean()) {
+                        long position = randomLongBetween(0L, indexInput.length());
+                        indexInput.seek(position);
+                        searchableIndexInput.seek(position);
+                    }
+                    assertThat("File pointers values should be the same before reading a byte",
+                        searchableIndexInput.getFilePointer(), equalTo(indexInput.getFilePointer()));
+
+                    if (indexInput.getFilePointer() < indexInput.length()) {
+                        assertThat(searchableIndexInput.readByte(), equalTo(indexInput.readByte()));
+                    } else {
+                        expectThrows(EOFException.class, searchableIndexInput::readByte);
+                    }
+                    assertThat("File pointers values should be the same after reading a byte",
+                        searchableIndexInput.getFilePointer(), equalTo(indexInput.getFilePointer()));
+                }
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        });
+    }
+
+    public void testReadBytes() throws Exception {
+        final byte[] buffer = new byte[8192];
+        final byte[] searchableBuffer = new byte[buffer.length];
+
+        testIndexInputs((indexInput, searchableIndexInput) -> {
+            try {
+                if (randomBoolean()) {
+                    long position = randomLongBetween(0L, indexInput.length());
+                    indexInput.seek(position);
+                    searchableIndexInput.seek(position);
+                }
+                assertThat("File pointers values should be the same before reading a byte",
+                    searchableIndexInput.getFilePointer(), equalTo(indexInput.getFilePointer()));
+
+                int available = Math.toIntExact(indexInput.length() - indexInput.getFilePointer());
+                if (available == 0) {
+                    expectThrows(EOFException.class, () -> searchableIndexInput.readBytes(searchableBuffer, 0, searchableBuffer.length));
+                    return;
+                }
+
+                int length = randomIntBetween(1, Math.min(available, buffer.length));
+
+                Arrays.fill(buffer, (byte) 0);
+                indexInput.readBytes(buffer, 0, length);
+
+                Arrays.fill(searchableBuffer, (byte) 0);
+                searchableIndexInput.readBytes(searchableBuffer, 0, length);
+
+                assertThat("File pointers values should be the same after reading a byte",
+                    searchableIndexInput.getFilePointer(), equalTo(indexInput.getFilePointer()));
+                assertArrayEquals(searchableBuffer, buffer);
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        });
+    }
+
+    /**
+     * This method :
+     * - sets up a default {@link Directory} and index random documents
+     * - snapshots the directory using a FS repository
+     * - creates a {@link SearchableSnapshotDirectory} instance based on the snapshot files
+     * - consumes the default and the searchable snapshot directories using the {@link CheckedBiConsumer}.
+     */
+    private void testDirectories(final CheckedBiConsumer<Directory, Directory, Exception> consumer) throws Exception {
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("_index", Settings.builder()
+            .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID(random()))
+            .put(IndexMetaData.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT)
+            .build());
+        final ShardId shardId = new ShardId(indexSettings.getIndex(), randomIntBetween(0, 10));
+        final List<Releasable> releasables = new ArrayList<>();
+
+        try (Directory directory = newDirectory()) {
+            final IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+            try (IndexWriter writer = new IndexWriter(directory, indexWriterConfig)) {
+                final int nbDocs = scaledRandomIntBetween(0, 1_000);
+                final List<String> words = List.of("the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog");
+                for (int i = 0; i < nbDocs; i++) {
+                    final Document doc = new Document();
+                    doc.add(new StringField("id", "" + i, Field.Store.YES));
+                    String text = String.join(" ", randomSubsetOf(randomIntBetween(1, words.size()), words));
+                    doc.add(new TextField("text", text, Field.Store.YES));
+                    doc.add(new NumericDocValuesField("rank", i));
+                    writer.addDocument(doc);
+                }
+                if (randomBoolean()) {
+                    writer.flush();
+                }
+                if (randomBoolean()) {
+                    writer.forceMerge(1, true);
+                }
+                writer.commit();
+            }
+
+            final ThreadPool threadPool = new TestThreadPool(getClass().getSimpleName());
+            releasables.add(() -> terminate(threadPool));
+
+            final Store store = new Store(shardId, indexSettings, directory, new DummyShardLock(shardId));
+            store.incRef();
+            releasables.add(store::decRef);
+            try {
+                final SegmentInfos segmentInfos = Lucene.readSegmentInfos(store.directory());
+                final IndexCommit indexCommit = Lucene.getIndexCommit(segmentInfos, store.directory());
+
+                Path repositoryPath = createTempDir();
+                Settings.Builder repositorySettings = Settings.builder().put("location", repositoryPath);
+                boolean compress = randomBoolean();
+                if (compress) {
+                    repositorySettings.put("compress", randomBoolean());
+                }
+                if (randomBoolean()) {
+                    repositorySettings.put("base_path", randomAlphaOfLengthBetween(3, 10));
+                }
+                if (randomBoolean()) {
+                    repositorySettings.put("chunk_size", randomIntBetween(100, 1000), ByteSizeUnit.BYTES);
+                }
+                final String repositoryName = randomAlphaOfLength(10);
+                final BlobStoreRepository repository = new FsRepository(
+                    new RepositoryMetaData(repositoryName, FsRepository.TYPE, repositorySettings.build()),
+                    new Environment(Settings.builder()
+                        .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
+                        .put(Environment.PATH_REPO_SETTING.getKey(), repositoryPath.toAbsolutePath())
+                        .putList(Environment.PATH_DATA_SETTING.getKey(), tmpPaths()).build(), null),
+                    NamedXContentRegistry.EMPTY, threadPool);
+                repository.start();
+                releasables.add(repository::stop);
+
+                final SnapshotId snapshotId = new SnapshotId("_snapshot", UUIDs.randomBase64UUID(random()));
+                final IndexId indexId = new IndexId(indexSettings.getIndex().getName(), UUIDs.randomBase64UUID(random()));
+
+                final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+                threadPool.generic().submit(() -> {
+                    IndexShardSnapshotStatus snapshotStatus = IndexShardSnapshotStatus.newInitializing(null);
+                    repository.snapshotShard(store, null, snapshotId, indexId, indexCommit, snapshotStatus, true, future);
+                    future.actionGet();
+                });
+                future.actionGet();
+
+                final RepositoriesService repositories = mock(RepositoriesService.class);
+                when(repositories.repository(eq(repositoryName))).thenReturn(repository);
+
+                final boolean cacheEnabled = randomBoolean();
+                CacheService cacheService = null;
+                if (cacheEnabled) {
+                    cacheService = new CacheService(Settings.builder()
+                        .put(CacheService.CACHE_ENABLED_SETTING.getKey(), cacheEnabled)
+                        .put(CacheService.CACHE_SEGMENT_SIZE_SETTING.getKey(),
+                            new ByteSizeValue(1 << randomIntBetween(1, 10), ByteSizeUnit.KB))
+                        .build());
+                    releasables.add(cacheService);
+                }
+
+                final IndexSettings searchableIndexSettings = IndexSettingsModule.newIndexSettings("_searchable_snapshot_index",
+                    Settings.builder()
+                        .put(indexSettings.getSettings())
+                        .put(SearchableSnapshots.EPHEMERAL_INDEX_REPOSITORY_SETTING.getKey(), repositoryName)
+                        .put(SearchableSnapshots.EPHEMERAL_INDEX_SNAPSHOT_SETTING.getKey(), snapshotId.getUUID())
+                        .build());
+
+                IndexStorePlugin.DirectoryFactory factory = SearchableSnapshots.newDirectoryFactory(repositories, threadPool, cacheService);
+
+                Path tempDir = createTempDir().resolve(indexId.getId()).resolve(Integer.toString(shardId.id()));
+                ShardPath shardPath = new ShardPath(false, tempDir, tempDir, new ShardId(new Index("_na", indexId.getId()), shardId.id()));
+
+                try (Directory searchableDirectory = factory.newDirectory(searchableIndexSettings, shardPath)) {
+                    consumer.accept(directory, searchableDirectory);
+                }
+            } finally {
+                Releasables.close(releasables);
+            }
+        }
+    }
+
+    private void testIndexInputs(final CheckedBiConsumer<IndexInput, IndexInput, Exception> consumer) throws Exception {
+        testDirectories((directory, searchableDirectory) -> {
+            for (String fileName : randomSubsetOf(Arrays.asList(searchableDirectory.listAll()))) {
+                final IOContext context = newIOContext(random());
+                try (IndexInput indexInput = directory.openInput(fileName, context)) {
+                    final List<Closeable> closeables = new ArrayList<>();
+                    try {
+                        IndexInput searchableIndexInput = searchableDirectory.openInput(fileName, context);
+                        closeables.add(searchableIndexInput);
+                        if (randomBoolean()) {
+                            searchableIndexInput = searchableIndexInput.clone();
+                        }
+                        consumer.accept(indexInput, searchableIndexInput);
+                    } finally {
+                        IOUtils.close(closeables);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotIndexInputTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.index.store;
+
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Version;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotShard;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchableSnapshotIndexInputTests extends ESTestCase {
+
+    private IndexInput createIndexInput(final byte[] input) throws IOException {
+        final FileInfo fileInfo = new FileInfo(randomAlphaOfLength(10),
+            new StoreFileMetaData("_file", (long) input.length, "_checksum", Version.LATEST),
+            new ByteSizeValue(randomBoolean() && input.length > 1 ? randomIntBetween(1, input.length): Long.MAX_VALUE, ByteSizeUnit.BYTES));
+
+        final SearchableSnapshotShard searchableSnapshotShard = mock(SearchableSnapshotShard.class);
+        when(searchableSnapshotShard.listSnapshotFiles())
+            .thenReturn(Map.of(fileInfo.physicalName(), fileInfo));
+        when(searchableSnapshotShard.readSnapshotFile(eq(fileInfo.physicalName()), anyLong(), anyInt()))
+            .thenAnswer(invocationOnMock -> {
+                final String name = (String) invocationOnMock.getArguments()[0];
+                if (name.equals(fileInfo.physicalName()) == false) {
+                    throw new IOException("Unexpected part name " + name);
+                }
+                final Long position = (Long) invocationOnMock.getArguments()[1];
+                if (position < 0 || position > fileInfo.length()) {
+                    throw new IOException("Unexpected position " + position);
+                }
+                final Integer length = (Integer) invocationOnMock.getArguments()[2];
+                if (length <= 0 || length > fileInfo.length()) {
+                    throw new IOException("Unexpected length " + length);
+                }
+
+                return ByteBuffer.wrap(input, Math.toIntExact(position), length);
+            });
+
+        final int bufferSize = 1 << randomIntBetween(5, 10);
+        final SearchableSnapshotDirectory directory = new SearchableSnapshotDirectory(searchableSnapshotShard, bufferSize);
+        return directory.openInput(fileInfo.physicalName(), newIOContext(random()));
+    }
+
+    public void testRandomReads() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(StandardCharsets.UTF_8);
+            IndexInput indexInput = createIndexInput(input);
+            assertEquals(input.length, indexInput.length());
+            assertEquals(0, indexInput.getFilePointer());
+            byte[] output = randomReadAndSlice(indexInput, input.length);
+            assertArrayEquals(input, output);
+        }
+    }
+
+    public void testRandomOverflow() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(StandardCharsets.UTF_8);
+            IndexInput indexInput = createIndexInput(input);
+            int firstReadLen = randomIntBetween(0, input.length - 1);
+            randomReadAndSlice(indexInput, firstReadLen);
+            int bytesLeft = input.length - firstReadLen;
+            int secondReadLen = bytesLeft + randomIntBetween(1, 100);
+            expectThrows(EOFException.class, () -> indexInput.readBytes(new byte[secondReadLen], 0, secondReadLen));
+        }
+    }
+
+    public void testSeekOverflow() throws IOException {
+        for (int i = 0; i < 100; i++) {
+            byte[] input = randomUnicodeOfLength(randomIntBetween(1, 1000)).getBytes(StandardCharsets.UTF_8);
+            IndexInput indexInput = createIndexInput(input);
+            int firstReadLen = randomIntBetween(0, input.length - 1);
+            randomReadAndSlice(indexInput, firstReadLen);
+            expectThrows(IOException.class, () -> {
+                switch (randomIntBetween(0, 2)) {
+                    case 0:
+                        indexInput.seek(Integer.MAX_VALUE + 4L);
+                        break;
+                    case 1:
+                        indexInput.seek(-randomIntBetween(1, 10));
+                        break;
+                    default:
+                        int seek = input.length + randomIntBetween(1, 100);
+                        indexInput.seek(seek);
+                        break;
+                }
+            });
+        }
+    }
+
+    private byte[] randomReadAndSlice(IndexInput indexInput, int length) throws IOException {
+        int readPos = (int) indexInput.getFilePointer();
+        byte[] output = new byte[length];
+        while (readPos < length) {
+            switch (randomIntBetween(0, 3)) {
+                case 0:
+                    // Read by one byte at a time
+                    output[readPos++] = indexInput.readByte();
+                    break;
+                case 1:
+                    // Read several bytes into target
+                    int len = randomIntBetween(1, length - readPos);
+                    indexInput.readBytes(output, readPos, len);
+                    readPos += len;
+                    break;
+                case 2:
+                    // Read several bytes into 0-offset target
+                    len = randomIntBetween(1, length - readPos);
+                    byte[] temp = new byte[len];
+                    indexInput.readBytes(temp, 0, len);
+                    System.arraycopy(temp, 0, output, readPos, len);
+                    readPos += len;
+                    break;
+                case 3:
+                    // Read using slice
+                    len = randomIntBetween(1, length - readPos);
+                    IndexInput slice = indexInput.slice("slice (" + readPos + ", " + len + ") of " + indexInput.toString(), readPos, len);
+                    temp = randomReadAndSlice(slice, len);
+                    // assert that position in the original input didn't change
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    System.arraycopy(temp, 0, output, readPos, len);
+                    readPos += len;
+                    indexInput.seek(readPos);
+                    assertEquals(readPos, indexInput.getFilePointer());
+                    break;
+                default:
+                    fail();
+            }
+            assertEquals(readPos, indexInput.getFilePointer());
+        }
+        return output;
+    }
+}


### PR DESCRIPTION
**Note:** this draft pull request targets the `feature/searchable-snapshots` branch

This pull request introduces a simple caching mechanism that operates at the Lucene files level of searchable snapshot directories.

Several new classes are introduced or changed since #49651: the searchable snapshot directory (`SearchableSnapshotDirectory`) now contains a representation of the snapshotted shard files (`SearchableSnapshotShard`) which allows to list the files or read a file from a specific snapshot. 

A basic implementation of a searchable snapshot shard is `BlobStoreSearchableSnapshotShard` which directly accesses a remote blob store repository  to list or to read files. This implementation takes care of converting the names of Lucene files into blob names in the repository and to load the appropriate chunks of blobs (the implementation is still very raw and error prone and must be consolidate).

Another implementation of a searchable snapshot shard is `CachedSearchableSnapshotShard` which 
caches segment (or portion) of file using a `CacheService`. This cache service uses the existing LRU `org.elasticsearch.common.cache.Cache` to cache file segments in memory. This cache is also very raw and should evolve to something more complex that caches segment of files on disk. The `CachedSearchableSnapshotShard` acts as a `FilterSearchableSnapshotShard` so that it delegates the listing or the reading of files to another searchable snapshot shard in case of the segment of file to read is not present in cache (ie, a cache miss). When the segment of file to read requested by the searchable snapshot directory's index input is present in cache it is served directly.

Finally, this pull request reuses the tests added in #49651 to test the searchable snapshot directory implementation by randomly use the cache or not.