### PR TITLE
Make testclusters registry extension name unique

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -38,6 +38,7 @@ public class TestClustersPlugin implements Plugin<Project> {
 
     private static final String LIST_TASK_NAME = "listTestClusters";
     public static final String EXTENSION_NAME = "testClusters";
+    private static final String REGISTRY_EXTENSION_NAME = "testClustersRegistry";
 
     private static final Logger logger =  Logging.getLogger(TestClustersPlugin.class);
 
@@ -56,9 +57,9 @@ public class TestClustersPlugin implements Plugin<Project> {
         // provide a task to be able to list defined clusters.
         createListClustersTask(project, container);
 
-        if (project.getRootProject().getExtensions().findByName("testClusters") == null) {
+        if (project.getRootProject().getExtensions().findByName(REGISTRY_EXTENSION_NAME) == null) {
             TestClustersRegistry registry = project.getRootProject().getExtensions()
-                .create("testClusters", TestClustersRegistry.class);
+                .create(REGISTRY_EXTENSION_NAME, TestClustersRegistry.class);
 
             // When we know what tasks will run, we claim the clusters of those task to differentiate between clusters
             // that are defined in the build script and the ones that will actually be used in this invocation of gradle


### PR DESCRIPTION
The testclusters registory is a singleton extension element added to the
root project which tracks which test clusters are used throughout the
multi project. But having the same name as the extension used to
configure test clusters within each subprojects breaks using a single
project for an external plugin. This commit renames the registry
extension to make it unique.

closes #49787