### PR TITLE
[DOCS] Fix rpm ifevals

### DIFF
--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -96,7 +96,7 @@ ifeval::["{release-state}"=="unreleased"]
 [NOTE]
 ==================================================
 
-The configured repository is diabled by default. This eliminates the possibility of accidentally
+The configured repository is disabled by default. This eliminates the possibility of accidentally
 upgrading `elasticsearch` when upgrading the rest of the system. Each install or upgrade command
 must explicitly enable the repository as indicated in the sample commands above.
 ==================================================

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -90,13 +90,16 @@ sudo zypper modifyrepo --enable elasticsearch && \
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 
+endif::[]
+
+ifeval::["{release-state}"=="unreleased"]
 [NOTE]
 ==================================================
 
-The configured repository is disabled by default. This eliminates the possibility of accidentally
+The configured repository is diabled by default. This eliminates the possibility of accidentally
 upgrading `elasticsearch` when upgrading the rest of the system. Each install or upgrade command
 must explicitly enable the repository as indicated in the sample commands above.
-
+==================================================
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/49893

The mismatched ifeval and endifs seemed to be cause the 7.5 Elasticsearch Reference to fail with messages like this:

> 17:06:33 INFO:build_docs:asciidoctor: ERROR: sql/security.asciidoc: line 39: include file not found: /tmp/docsbuild/CXIiGEotjw/elasticsearch/docs/reference/sql/{sql-tests}/security/roles.yml