### PR TITLE
Fix incorrect use of multiline NOTE in rpm docs

### DIFF
--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -90,10 +90,7 @@ sudo zypper modifyrepo --enable elasticsearch && \
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 
-[NOTE]
-==================================================
-
-The configured repository is disabled by default. This eliminates the possibility of accidentally
+NOTE: The configured repository is disabled by default. This eliminates the possibility of accidentally
 upgrading `elasticsearch` when upgrading the rest of the system. Each install or upgrade command
 must explicitly enable the repository as indicated in the sample commands above.
 


### PR DESCRIPTION
This was a copy/paste error from #49893. This commit converts the NOTE
to use inline style instead of one needing closing linebreak.