### PR TITLE
Add Validation for maxQueryTerms to be greater than 0 for MoreLikeThisQuery

### DIFF
--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -90,10 +90,7 @@ sudo zypper modifyrepo --enable elasticsearch && \
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 
-[NOTE]
-==================================================
-
-The configured repository is disabled by default. This eliminates the possibility of accidentally
+NOTE: The configured repository is disabled by default. This eliminates the possibility of accidentally
 upgrading `elasticsearch` when upgrading the rest of the system. Each install or upgrade command
 must explicitly enable the repository as indicated in the sample commands above.
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -90,7 +90,9 @@ sudo zypper modifyrepo --enable elasticsearch && \
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 
-NOTE: The configured repository is disabled by default. This eliminates the possibility of accidentally
+[NOTE]
+==================================================
+The configured repository is disabled by default. This eliminates the possibility of accidentally
 upgrading `elasticsearch` when upgrading the rest of the system. Each install or upgrade command
 must explicitly enable the repository as indicated in the sample commands above.
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -92,6 +92,7 @@ sudo zypper modifyrepo --enable elasticsearch && \
 
 [NOTE]
 ==================================================
+
 The configured repository is disabled by default. This eliminates the possibility of accidentally
 upgrading `elasticsearch` when upgrading the rest of the system. Each install or upgrade command
 must explicitly enable the repository as indicated in the sample commands above.

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/MoreLikeThisQuery.java
@@ -308,6 +308,9 @@ public class MoreLikeThisQuery extends Query {
     }
 
     public void setMaxQueryTerms(int maxQueryTerms) {
+        if (maxQueryTerms <= 0) {
+            throw new IllegalArgumentException("requires 'maxQueryTerms' to be greater than 0");
+        }
         this.maxQueryTerms = maxQueryTerms;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -577,6 +577,9 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
      * Defaults to {@code 25}.
      */
     public MoreLikeThisQueryBuilder maxQueryTerms(int maxQueryTerms) {
+        if (maxQueryTerms <= 0) {
+            throw new IllegalArgumentException("requires 'maxQueryTerms' to be greater than 0");
+        }
         this.maxQueryTerms = maxQueryTerms;
         return this;
     }

--- a/server/src/test/java/org/elasticsearch/common/lucene/search/morelikethis/MoreLikeThisQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/morelikethis/MoreLikeThisQueryTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.MoreLikeThisQuery;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class MoreLikeThisQueryTests extends ESTestCase {
@@ -64,4 +65,15 @@ public class MoreLikeThisQueryTests extends ESTestCase {
         reader.close();
         indexWriter.close();
     }
+
+    public void testValidateMaxQueryTerms() {
+        IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class,
+            () ->  new MoreLikeThisQuery("lucene", new String[]{"text"}, Lucene.STANDARD_ANALYZER).setMaxQueryTerms(0));
+        assertThat(e1.getMessage(), containsString("requires 'maxQueryTerms' to be greater than 0"));
+
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class,
+            () -> new MoreLikeThisQuery("lucene", new String[]{"text"}, Lucene.STANDARD_ANALYZER).setMaxQueryTerms(-3));
+        assertThat(e2.getMessage(), containsString("requires 'maxQueryTerms' to be greater than 0"));
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -163,7 +163,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
             queryBuilder.unlike(randomUnlikeItems);
         }
         if (randomBoolean()) {
-            queryBuilder.maxQueryTerms(randomInt(25));
+            queryBuilder.maxQueryTerms(randomIntBetween(1, 25));
         }
         if (randomBoolean()) {
             queryBuilder.minTermFreq(randomInt(5));
@@ -338,6 +338,16 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
         assertThat(mltQuery.getLikeText(), equalTo("something"));
         assertThat(mltQuery.getMinTermFrequency(), equalTo(1));
         assertThat(mltQuery.getMaxQueryTerms(), equalTo(12));
+    }
+
+    public void testValidateMaxQueryTerms() {
+        IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class,
+            () -> new MoreLikeThisQueryBuilder(new String[]{"name.first", "name.last"}, new String[]{"something"}, null).maxQueryTerms(0));
+        assertThat(e1.getMessage(), containsString("requires 'maxQueryTerms' to be greater than 0"));
+
+        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class,
+            () -> new MoreLikeThisQueryBuilder(new String[]{"name.first", "name.last"}, new String[]{"something"}, null).maxQueryTerms(-3));
+        assertThat(e2.getMessage(), containsString("requires 'maxQueryTerms' to be greater than 0"));
     }
 
     public void testItemSerialization() throws IOException {


### PR DESCRIPTION
This Pull Request resolves the open issue #49927 .

Code Changes:

Add Validation for maxQueryTerms to be greater than 0 for `MoreLikeThisQuery` and `MoreLikeThisQueryBuilder`.