### PR TITLE
upgrade jts to 1.16.1

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -6,7 +6,7 @@ bundled_jdk = 13.0.1+9
 
 # optional dependencies
 spatial4j         = 0.7
-jts               = 1.15.0
+jts               = 1.16.1
 # note that ingest-geoip has a hard-coded version; if you modify this version,
 # you should also inspect that version to see if it can be advanced along with
 # the com.maxmind.geoip2:geoip2 dependency


### PR DESCRIPTION
Upgrades jts to 1.16.1. Includes some bug fixes/improvements. Release notes at: https://github.com/locationtech/jts/releases