### PR TITLE
[DOCS] Skip synced flush doc tests

### DIFF
--- a/docs/reference/indices/synced-flush.asciidoc
+++ b/docs/reference/indices/synced-flush.asciidoc
@@ -10,7 +10,7 @@ Performs a synced flush on one or more indices.
 --------------------------------------------------
 POST /twitter/_flush/synced
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 
 [[synced-flush-api-request]]
@@ -80,7 +80,7 @@ section of the shard stats returned by the <<indices-stats,indices stats>> API:
 --------------------------------------------------
 GET /twitter/_stats?filter_path=**.commit&level=shards <1>
 --------------------------------------------------
-// TEST[s/^/PUT twitter\nPOST twitter\/_flush\/synced\n/]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 <1> `filter_path` is used to reduce the verbosity of the response, but is entirely optional
 
@@ -116,10 +116,7 @@ The API returns the following response:
    }
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"id" : "3M3zkw2GHMo2Y4h4\/KFKCg=="/"id": $body.indices.twitter.shards.0.0.commit.id/]
-// TESTRESPONSE[s/"translog_uuid" : "hnOG3xFcTDeoI_kvvvOdNA"/"translog_uuid": $body.indices.twitter.shards.0.0.commit.user_data.translog_uuid/]
-// TESTRESPONSE[s/"history_uuid" : "XP7KDJGiS1a2fHYiFL5TXQ"/"history_uuid": $body.indices.twitter.shards.0.0.commit.user_data.history_uuid/]
-// TESTRESPONSE[s/"sync_id" : "AVvFY-071siAOuFGEO9P"/"sync_id": $body.indices.twitter.shards.0.0.commit.user_data.sync_id/]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 <1> the `sync id` marker
 
 NOTE: The `sync_id` marker is removed as soon as the shard is flushed again, and
@@ -172,7 +169,7 @@ A replica shard failed to sync-flush.
 ----
 POST /kimchy/_flush/synced
 ----
-// TEST[s/^/PUT kimchy\n/]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 
 [[synced-flush-api-multi-ex]]
@@ -182,8 +179,7 @@ POST /kimchy/_flush/synced
 --------------------------------------------------
 POST /kimchy,elasticsearch/_flush/synced
 --------------------------------------------------
-// TEST[s/^/PUT elasticsearch\n/]
-// TEST[continued]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 
 [[synced-flush-api-all-ex]]
@@ -193,7 +189,7 @@ POST /kimchy,elasticsearch/_flush/synced
 --------------------------------------------------
 POST /_flush/synced
 --------------------------------------------------
-// TEST[setup:twitter]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 The response contains details about how many shards were successfully
 sync-flushed and information about any failure.
@@ -217,12 +213,12 @@ successfully sync-flushed:
    }
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"successful": 2/"successful": 1/]
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 The following response indicates one shard group failed
 due to pending operations:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
    "_shards": {
@@ -243,13 +239,13 @@ due to pending operations:
    }
 }
 --------------------------------------------------
-// NOTCONSOLE
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]
 
 Sometimes the failures are specific to a shard replica. The copies that failed
 will not be eligible for fast recovery but those that succeeded still will be.
 This case is reported as follows:
 
-[source,js]
+[source,console-result]
 --------------------------------------------------
 {
    "_shards": {
@@ -278,4 +274,4 @@ This case is reported as follows:
    }
 }
 --------------------------------------------------
-// NOTCONSOLE
+// TEST[skip: Synced flush can conflict with scheduled flushes in doc tests]


### PR DESCRIPTION
The current snippets in the synced flush docs can cause conflicts with other background syncs, such as the global checkpoint sync or retention lease sync, in the docs tests.

This skips tests for those snippets to avoid conflicts.

Fixes #49623.