### PR TITLE
[DOCS] Correct `for in` example in Painless docs

### DIFF
--- a/docs/painless/painless-lang-spec/painless-statements.asciidoc
+++ b/docs/painless/painless-lang-spec/painless-statements.asciidoc
@@ -25,7 +25,7 @@ Painless also supports the `for in` syntax from Groovy:
 
 [source,painless]
 ---------------------------------------------------------
-for (item : list) {
+for (def item : list) {
   ...
 }
 ---------------------------------------------------------


### PR DESCRIPTION
Adds a needed `def` keyword to the `for in` example in the Painless docs.

Closes #42147.