### PR TITLE
Improve Snapshot Finalization Ex. Handling

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress.ShardSnapshotStatus;
 import org.elasticsearch.cluster.SnapshotsInProgress.ShardState;
 import org.elasticsearch.cluster.SnapshotsInProgress.State;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -1053,7 +1054,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             public void onFailure(final Exception e) {
                 Snapshot snapshot = entry.snapshot();
                 logger.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
-                if (ExceptionsHelper.unwrap(e, NotMasterException.class) != null) {
+                if (ExceptionsHelper.unwrap(e, NotMasterException.class, FailedToCommitClusterStateException.class) != null) {
                     // Failure due to not being master any more, don't try to remove snapshot from cluster state the next master
                     // will try ending this snapshot again
                     endingSnapshots.remove(snapshot);

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1053,12 +1053,14 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public void onFailure(final Exception e) {
                 Snapshot snapshot = entry.snapshot();
-                logger.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
                 if (ExceptionsHelper.unwrap(e, NotMasterException.class, FailedToCommitClusterStateException.class) != null) {
                     // Failure due to not being master any more, don't try to remove snapshot from cluster state the next master
                     // will try ending this snapshot again
+                    logger.debug(() -> new ParameterizedMessage(
+                        "[{}] failed to update cluster state during snapshot finalization", snapshot), e);
                     endingSnapshots.remove(snapshot);
                 } else {
+                    logger.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
                     removeSnapshotFromClusterState(snapshot, null, e);
                 }
             }


### PR DESCRIPTION
Like in #49989 we can get into a situation where the setting of
the repository generation (during snapshot finalization) in the cluster
state fails due to master failing over.
In this case we should not try to execute the next cluster state update
that will remove the snapshot from the cluster state. 
Otherwise we may needlessly drop an otherwise fine snapshot from the repository
completely on a master failover via the rare case of the removing of the snapshot from the CS working out because the node that failed the generation update from the blob store repository becoming master just in time to remove the snapshot from the repository.

Note: this won't corrupt the repository, it simply needlessly fails snapshots that should just work out fine on a master failover like the case in #49989

Closes #49989
