### PR TITLE
[DOCS] Remove custom page_header.html

### DIFF
--- a/docs/reference/page_header.html
+++ b/docs/reference/page_header.html
@@ -1,9 +1,0 @@
-<p>
-  <strong>IMPORTANT</strong>: Version 7.4 of Elasticsearch has passed its 
-  <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
-</p>  
-<p>
-  This documentation is no longer being updated. 
-  For the latest information, see the 
-  <a href="../current/index.html">current release documentation</a>. 
-</p>


### PR DESCRIPTION
Instead of explicitly setting page_header.html for every OOM version, we're updating the default notice so it doesn't have to be set manually every release.

Relates to: elastic/docs#1528