### PR TITLE
[Transform] refactor source and dest validation to support CCS

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RemoteClusterLicenseChecker.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RemoteClusterLicenseChecker.java
@@ -19,6 +19,7 @@ import org.elasticsearch.protocol.xpack.license.LicenseStatus;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xpack.core.action.XPackInfoAction;
 
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -229,7 +230,7 @@ public final class RemoteClusterLicenseChecker {
      * @param indices the collection of index names
      * @return true if the collection of index names contains a name that represents a remote index, otherwise false
      */
-    public static boolean containsRemoteIndex(final List<String> indices) {
+    public static boolean containsRemoteIndex(final Collection<String> indices) {
         return indices.stream().anyMatch(RemoteClusterLicenseChecker::isRemoteIndex);
     }
 
@@ -240,7 +241,7 @@ public final class RemoteClusterLicenseChecker {
      * @param indices the collection of index names
      * @return list of index names that represent remote index names
      */
-    public static List<String> remoteIndices(final List<String> indices) {
+    public static List<String> remoteIndices(final Collection<String> indices) {
         return indices.stream().filter(RemoteClusterLicenseChecker::isRemoteIndex).collect(Collectors.toList());
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -611,6 +611,11 @@ public class XPackLicenseState {
         return status.active;
     }
 
+    public static boolean isTransformAllowedForOperationMode(final OperationMode operationMode) {
+        // any license (basic and upwards)
+        return operationMode != License.OperationMode.MISSING;
+    }
+
     /**
      * Rollup is always available as long as there is a valid license
      *

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -59,8 +59,6 @@ public final class SourceDestValidator {
         + "alias [{0}], at least a [{1}] license is required, found license [{2}]";
     public static final String REMOTE_CLUSTER_LICENSE_INACTIVE = "License check failed for remote cluster "
         + "alias [{0}], license is not active";
-    public static final String TIMEOUT_CHECK_REMOTE_CLUSTER_LICENSE = "Timeout during license check ({0}) for remote cluster "
-        + "alias(es) [{1}]";
 
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final RemoteClusterService remoteClusterService;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -295,7 +295,7 @@ public final class SourceDestValidator {
 
         ActionListener<Context> validationListener = ActionListener.wrap(c -> {
             if (c.getValidationException() != null) {
-                listener.onFailure(context.getValidationException());
+                listener.onFailure(c.getValidationException());
             } else {
                 listener.onResponse(true);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -399,7 +399,8 @@ public final class SourceDestValidator {
             }
 
             List<String> remoteIndices = new ArrayList<>(context.resolveRemoteSource());
-            // we can only check this node at the moment, clusters with mixed CCS enabled/disabled nodes are not supported, see gh#TBD
+            // we can only check this node at the moment, clusters with mixed CCS enabled/disabled nodes are not supported,
+            // see gh#50033
             if (context.isRemoteSearchEnabled() == false) {
                 context.addValidationError(NEEDS_REMOTE_CLUSTER_SEARCH, true, context.resolveRemoteSource(), context.getNodeName());
                 return;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -414,15 +414,19 @@ public final class SourceDestValidator {
         @Override
         public void validate(Context context, ActionListener<Context> listener) {
             final String destIndex = context.getDest();
+            boolean foundSourceInDest = false;
 
             for (String src : context.getSource()) {
                 if (Regex.simpleMatch(src, destIndex)) {
                     context.addValidationError(DEST_IN_SOURCE, destIndex, src);
-
-                    // todo: revisit
-                    listener.onResponse(context);
-                    return;
+                    // do not return immediately but collect all errors and than return
+                    foundSourceInDest = true;
                 }
+            }
+
+            if (foundSourceInDest) {
+                listener.onResponse(context);
+                return;
             }
 
             if (context.resolvedSource.contains(destIndex)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -50,7 +50,7 @@ public final class SourceDestValidator {
     public static final String NEEDS_REMOTE_CLUSTER_SEARCH = "Source index is configured with a remote index pattern(s) [{0}]"
         + " but the current node [{1}] is not allowed to connect to remote clusters."
         + " Please enable cluster.remote.connect for all data nodes.";
-    public static final String ERROR_REMOTE_CLUSTER_SEARCH = "Error during resolving remote source, error: {0}";
+    public static final String ERROR_REMOTE_CLUSTER_SEARCH = "Error resolving remote source: {0}";
     public static final String UNKNOWN_REMOTE_CLUSTER_LICENSE = "Error during license check ({0}) for remote cluster "
         + "alias(es) {1}, error: {2}";
     public static final String FEATURE_NOT_LICENSED_REMOTE_CLUSTER_LICENSE = "License check failed for remote cluster "
@@ -156,11 +156,8 @@ public final class SourceDestValidator {
                         dest,
                         true
                     );
-                    if (singleWriteIndex != null) {
-                        resolvedDest = singleWriteIndex.getName();
-                    } else {
-                        resolvedDest = dest;
-                    }
+
+                    resolvedDest = singleWriteIndex != null ? singleWriteIndex.getName() : dest;
                 } catch (IllegalArgumentException e) {
                     // stop here as we can not return a single dest index
                     addValidationError(e.getMessage(), false);
@@ -371,8 +368,6 @@ public final class SourceDestValidator {
 
         @Override
         public void validate(Context context) {
-            // boolean remoteIndexesEmpty = context.isRemoteSearchEnabled() ? context.resolveRemoteSource().isEmpty() : true;
-
             try {
                 // non-trivia: if source contains a wildcard index, which does not resolve to a concrete index
                 // the resolved indices might be empty, but we can check if source contained something, this works because

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-package org.elasticsearch.xpack.transform.transforms;
+package org.elasticsearch.xpack.core.common.validation;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -21,9 +21,6 @@ public class TransformMessages {
             "Failed to validate configuration";
     public static final String REST_PUT_FAILED_PERSIST_TRANSFORM_CONFIGURATION = "Failed to persist transform configuration";
     public static final String REST_PUT_TRANSFORM_FAILED_TO_DEDUCE_DEST_MAPPINGS = "Failed to deduce dest mappings";
-    public static final String REST_PUT_TRANSFORM_SOURCE_INDEX_MISSING = "Source index [{0}] does not exist";
-    public static final String REST_PUT_TRANSFORM_DEST_IN_SOURCE = "Destination index [{0}] is included in source expression [{1}]";
-    public static final String REST_PUT_TRANSFORM_DEST_SINGLE_INDEX = "Destination index [{0}] should refer to a single index";
     public static final String REST_PUT_TRANSFORM_INCONSISTENT_ID =
             "Inconsistent id; ''{0}'' specified in the body differs from ''{1}'' specified as a URL argument";
     public static final String TRANSFORM_CONFIG_INVALID = "Transform configuration is invalid [{0}]";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.DestConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -66,7 +67,7 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
             Object providedDestination = content.get(TransformField.DESTINATION.getPreferredName());
             if (providedDestination instanceof Map) {
                 @SuppressWarnings("unchecked")
-                Map<String, String> destMap = (Map<String, String>)providedDestination;
+                Map<String, String> destMap = (Map<String, String>) providedDestination;
                 String pipeline = destMap.get(DestConfig.PIPELINE.getPreferredName());
                 if (pipeline != null) {
                     tempDestination.put(DestConfig.PIPELINE.getPreferredName(), pipeline);
@@ -74,12 +75,15 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
             }
             content.put(TransformField.DESTINATION.getPreferredName(), tempDestination);
             content.put(TransformField.ID.getPreferredName(), "transform-preview");
-            try(XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(content);
-                XContentParser newParser = XContentType.JSON
-                    .xContent()
-                    .createParser(parser.getXContentRegistry(),
+            try (
+                XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(content);
+                XContentParser newParser = XContentType.JSON.xContent()
+                    .createParser(
+                        parser.getXContentRegistry(),
                         LoggingDeprecationHandler.INSTANCE,
-                        BytesReference.bytes(xContentBuilder).streamInput())) {
+                        BytesReference.bytes(xContentBuilder).streamInput()
+                    )
+            ) {
                 return new Request(TransformConfig.fromXContent(newParser, "transform-preview", false));
             }
         }
@@ -87,14 +91,19 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
         @Override
         public ActionRequestValidationException validate() {
             ActionRequestValidationException validationException = null;
-            if(config.getPivotConfig() != null) {
-                for(String failure : config.getPivotConfig().aggFieldValidation()) {
+            if (config.getPivotConfig() != null) {
+                for (String failure : config.getPivotConfig().aggFieldValidation()) {
                     validationException = addValidationError(failure, validationException);
                 }
             }
+
+            validationException = SourceDestValidator.validateRequest(
+                validationException,
+                config.getDestination() != null ? config.getDestination().getIndex() : null
+            );
+
             return validationException;
         }
-
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -141,6 +150,7 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
             PARSER.declareObjectArray(Response::setDocs, (p, c) -> p.mapOrdered(), PREVIEW);
             PARSER.declareObject(Response::setMappings, (p, c) -> p.mapOrdered(), MAPPINGS);
         }
+
         public Response() {}
 
         public Response(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_CREATION_DATE;
@@ -738,14 +739,17 @@ public class SourceDestValidatorTests extends ESTestCase {
         throws InterruptedException {
 
         CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
         LatchedActionListener<T> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
+            assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             if (expected == null) {
                 fail("expected an exception but got a response");
             } else {
                 assertThat(r, equalTo(expected));
             }
         }, e -> {
+            assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             if (onException == null) {
                 logger.error("got unexpected exception", e);
                 fail("got unexpected exception: " + e.getMessage());
@@ -767,14 +771,17 @@ public class SourceDestValidatorTests extends ESTestCase {
     ) throws InterruptedException {
 
         CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
         LatchedActionListener<Context> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
+            assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             if (onAnswer == null) {
                 fail("expected an exception but got a response");
             } else {
                 onAnswer.accept(r);
             }
         }, e -> {
+            assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             if (onException == null) {
                 logger.error("got unexpected exception", e);
                 fail("got unexpected exception: " + e.getMessage());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.transform.transforms;
+package org.elasticsearch.xpack.core.common.validation;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -33,8 +33,9 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.transform.transforms.SourceDestValidator.Context;
-import org.elasticsearch.xpack.transform.transforms.SourceDestValidator.RemoteSourceEnabledAndRemoteLicenseValidation;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.Context;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.RemoteSourceEnabledAndRemoteLicenseValidation;
 import org.junit.After;
 import org.junit.Before;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -412,6 +412,30 @@ public class SourceDestValidatorTests extends ESTestCase {
         );
     }
 
+    public void testCheck_GivenDestIndexMatchesMultipleSourceIndices() throws InterruptedException {
+        assertValidation(
+            listener -> simpleNonRemoteValidator.validate(
+                CLUSTER_STATE,
+                new String[] { "source-1", "source-*", "sou*" },
+                SOURCE_2,
+                SourceDestValidator.ALL_VALIDATIONS,
+                listener
+            ),
+            (Boolean) null,
+            e -> {
+                assertEquals(2, e.validationErrors().size());
+                assertThat(
+                    e.validationErrors().get(0),
+                    equalTo("Destination index [" + SOURCE_2 + "] is included in source expression [source-*]")
+                );
+                assertThat(
+                    e.validationErrors().get(1),
+                    equalTo("Destination index [" + SOURCE_2 + "] is included in source expression [sou*]")
+                );
+            }
+        );
+    }
+
     public void testCheck_GivenDestIndexIsAliasThatMatchesMultipleIndices() throws InterruptedException {
         assertValidation(
             listener -> simpleNonRemoteValidator.validate(

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -166,7 +166,7 @@ setup:
 ---
 "Test preview with non-existing source index":
   - do:
-      catch: /Source index \[does_not_exist\] does not exist/
+      catch: /.*reason=Validation Failed.* no such index \[does_not_exist\]/
       transform.preview_transform:
         body: >
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -384,7 +384,7 @@ setup:
         name: source-index
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
+      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[created-destination-index,airline-data\]/
       transform.put_transform:
         transform_id: "transform-from-aliases-failures"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -79,7 +79,7 @@ setup:
 ---
 "Test put transform with invalid source index":
   - do:
-      catch: /Source index \[missing-index\] does not exist/
+      catch: /.*reason=Validation Failed.* no such index \[missing-index\]/
       transform.put_transform:
         transform_id: "missing-source-transform"
         body: >
@@ -384,7 +384,7 @@ setup:
         name: source-index
 
   - do:
-      catch: /Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
+      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
       transform.put_transform:
         transform_id: "transform-from-aliases-failures"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -410,7 +410,7 @@ setup:
         name: dest-index
 
   - do:
-      catch: /Destination index \[dest-index\] should refer to a single index/
+      catch: /.*reason=Validation Failed.* no write index is defined for alias [dest2-index].*/
       transform.put_transform:
         transform_id: "airline-transform"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -521,7 +521,7 @@ setup:
 ---
 "Test invalid destination index name":
   - do:
-      catch: /dest\.index \[DeStInAtIoN\] must be lowercase/
+      catch: /.*reason=Validation Failed.* Destination index \[DeStInAtIoN\] must be lowercase/
       transform.put_transform:
         transform_id: "airline-transform"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -384,7 +384,7 @@ setup:
         name: source-index
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[created-destination-index,airline-data\]/
+      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
       transform.put_transform:
         transform_id: "transform-from-aliases-failures"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
@@ -280,7 +280,7 @@ setup:
         index: created-destination-index
         name: dest2-index
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[dest2-index\] should refer to a single index/
+      catch: /.*reason=Validation Failed.* no write index is defined for alias [dest2-index].*/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
@@ -290,7 +290,7 @@ setup:
 ---
 "Test invalid destination index name":
   - do:
-      catch: /.*reason=Validation Failed.* dest\.index \[DeStInAtIoN\] must be lowercase/
+      catch: /.*reason=Validation Failed.* Destination index \[DeStInAtIoN\] must be lowercase/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
@@ -67,7 +67,7 @@ setup:
 ---
 "Test put transform with invalid source index":
   - do:
-      catch: /Source index \[missing-index\] does not exist/
+      catch: /.*reason=Validation Failed.* no such index \[missing-index\]/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -255,7 +255,7 @@ setup:
         name: source2-index
 
   - do:
-      catch: /Destination index \[created-destination-index\] is included in source expression \[created-destination-index\]/
+      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[created-destination-index\]/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -280,7 +280,7 @@ setup:
         index: created-destination-index
         name: dest2-index
   - do:
-      catch: /Destination index \[dest2-index\] should refer to a single index/
+      catch: /.*reason=Validation Failed.* Destination index \[dest2-index\] should refer to a single index/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -290,7 +290,7 @@ setup:
 ---
 "Test invalid destination index name":
   - do:
-      catch: /dest\.index \[DeStInAtIoN\] must be lowercase/
+      catch: /.*reason=Validation Failed.* dest\.index \[DeStInAtIoN\] must be lowercase/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -298,7 +298,7 @@ setup:
             "dest": { "index": "DeStInAtIoN" }
           }
   - do:
-      catch: /Invalid index name \[destination#dest\], must not contain \'#\'/
+      catch: /.*reason=Validation Failed.* Invalid index name \[destination#dest\], must not contain \'#\'/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
@@ -137,7 +138,7 @@ public class TransportPreviewTransformAction extends
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             clusterService.getNodeName(),
-            "basic"
+            License.OperationMode.BASIC.description()
         );
 
         if (validationResult != null) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -132,7 +133,7 @@ public class TransportPreviewTransformAction extends
             clusterState,
             indexNameExpressionResolver,
             this.transportService.getRemoteClusterService(),
-            isRemoteSearchEnabled ? SourceDestValidator.remoteClusterLicenseCheckerBasicLicense(client) : null,
+            isRemoteSearchEnabled ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode) : null,
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -42,13 +42,13 @@ import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
-import org.elasticsearch.xpack.transform.transforms.SourceDestValidator;
 import org.elasticsearch.xpack.transform.transforms.pivot.AggregationResultUtils;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.rest.RestStatus;
@@ -217,7 +218,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             clusterState,
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
-            isRemoteSearchEnabled ? SourceDestValidator.remoteClusterLicenseCheckerBasicLicense(client) : null,
+            isRemoteSearchEnabled ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode) : null,
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
@@ -211,19 +212,20 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             );
             return;
         }
-        try {
-            SourceDestValidator.validate(
-                clusterState,
-                indexNameExpressionResolver,
-                transportService.getRemoteClusterService(),
-                isRemoteSearchEnabled ? SourceDestValidator.remoteClusterLicenseCheckerBasicLicense(client) : null,
-                config.getSource().getIndex(),
-                config.getDestination().getIndex(),
-                clusterService.getNodeName(),
-                request.isDeferValidation()
-            );
-        } catch (ElasticsearchStatusException ex) {
-            listener.onFailure(ex);
+
+        ValidationException validationResult = SourceDestValidator.validate(
+            clusterState,
+            indexNameExpressionResolver,
+            transportService.getRemoteClusterService(),
+            isRemoteSearchEnabled ? SourceDestValidator.remoteClusterLicenseCheckerBasicLicense(client) : null,
+            config.getSource().getIndex(),
+            config.getDestination().getIndex(),
+            clusterService.getNodeName(),
+            "basic",
+            request.isDeferValidation()
+        );
+        if (validationResult != null) {
+            listener.onFailure(validationResult);
             return;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
@@ -54,7 +55,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
-import org.elasticsearch.xpack.transform.transforms.SourceDestValidator;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 
 import java.io.IOException;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
@@ -222,7 +223,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             clusterService.getNodeName(),
-            "basic",
+            License.OperationMode.BASIC.description(),
             request.isDeferValidation()
         );
         if (validationResult != null) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -229,7 +229,6 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
             request.isDeferValidation() ? SourceDestValidator.NON_DEFERABLE_VALIDATIONS : SourceDestValidator.ALL_VALIDATIONS,
             ActionListener.wrap(
                 validationResponse -> {
-
                     // Early check to verify that the user can create the destination index and can read from the source
                     if (licenseState.isAuthAllowed() && request.isDeferValidation() == false) {
                         final String username = securityContext.getUser().principal();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
@@ -224,7 +225,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 config.getSource().getIndex(),
                 config.getDestination().getIndex(),
                 clusterService.getNodeName(),
-                "basic",
+                License.OperationMode.BASIC.description(),
                 false
             );
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -49,7 +50,6 @@ import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformIndex;
-import org.elasticsearch.xpack.transform.transforms.SourceDestValidator;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 
 import java.io.IOException;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -217,7 +218,9 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 clusterService.state(),
                 indexNameExpressionResolver,
                 transportService.getRemoteClusterService(),
-                isRemoteSearchEnabled ? SourceDestValidator.remoteClusterLicenseCheckerBasicLicense(client) : null,
+                isRemoteSearchEnabled
+                    ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
+                    : null,
                 config.getSource().getIndex(),
                 config.getDestination().getIndex(),
                 clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -175,13 +175,15 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
             TransformConfig updatedConfig = update.apply(config);
             sourceDestValidator.validate(
                 clusterState,
-                config.getSource().getIndex(),
-                config.getDestination().getIndex(),
+                updatedConfig.getSource().getIndex(),
+                updatedConfig.getDestination().getIndex(),
                 request.isDeferValidation() ? SourceDestValidator.NON_DEFERABLE_VALIDATIONS : SourceDestValidator.ALL_VALIDATIONS,
-                ActionListener.wrap(validationResponse -> {
-
-                    checkPriviledgesAndUpdateTransform(request, clusterState, updatedConfig, configAndVersion.v2(), listener);
-                }, listener::onFailure)
+                ActionListener.wrap(
+                    validationResponse -> {
+                        checkPriviledgesAndUpdateTransform(request, clusterState, updatedConfig, configAndVersion.v2(), listener);
+                    },
+                    listener::onFailure
+                )
             );
 
         }, listener::onFailure));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.common.validation.SourceDestValidator;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
@@ -54,7 +55,6 @@ import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.persistence.TransformIndex;
-import org.elasticsearch.xpack.transform.transforms.SourceDestValidator;
 import org.elasticsearch.xpack.transform.transforms.pivot.Pivot;
 
 import java.io.IOException;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
@@ -217,7 +218,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             clusterService.getNodeName(),
-            "basic",
+            License.OperationMode.BASIC.description(),
             request.isDeferValidation()
         );
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.rest.RestStatus;
@@ -212,7 +213,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
             clusterState,
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
-            isRemoteSearchEnabled ? SourceDestValidator.remoteClusterLicenseCheckerBasicLicense(client) : null,
+            isRemoteSearchEnabled ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode) : null,
             config.getSource().getIndex(),
             config.getDestination().getIndex(),
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPreviewTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportPreviewTransformActionDeprecated.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -20,12 +21,27 @@ import org.elasticsearch.xpack.transform.action.TransportPreviewTransformAction;
 public class TransportPreviewTransformActionDeprecated extends TransportPreviewTransformAction {
 
     @Inject
-    public TransportPreviewTransformActionDeprecated(TransportService transportService, ActionFilters actionFilters,
-                                                    Client client, ThreadPool threadPool, XPackLicenseState licenseState,
-                                                    IndexNameExpressionResolver indexNameExpressionResolver,
-                                                    ClusterService clusterService) {
-        super(PreviewTransformActionDeprecated.NAME, transportService, actionFilters, client, threadPool, licenseState,
-              indexNameExpressionResolver, clusterService);
+    public TransportPreviewTransformActionDeprecated(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        ThreadPool threadPool,
+        XPackLicenseState licenseState,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterService clusterService,
+        Settings settings
+    ) {
+        super(
+            PreviewTransformActionDeprecated.NAME,
+            transportService,
+            actionFilters,
+            client,
+            threadPool,
+            licenseState,
+            indexNameExpressionResolver,
+            clusterService,
+            settings
+        );
     }
 
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/compat/TransportStartTransformActionDeprecated.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -31,7 +32,8 @@ public class TransportStartTransformActionDeprecated extends TransportStartTrans
         IndexNameExpressionResolver indexNameExpressionResolver,
         TransformServices transformServices,
         PersistentTasksService persistentTasksService,
-        Client client
+        Client client,
+        Settings settings
     ) {
         super(
             StartTransformActionDeprecated.NAME,
@@ -43,7 +45,8 @@ public class TransportStartTransformActionDeprecated extends TransportStartTrans
             indexNameExpressionResolver,
             transformServices,
             persistentTasksService,
-            client
+            client,
+            settings
         );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
@@ -41,7 +41,7 @@ public final class SourceDestValidator {
     public static final String NEEDS_REMOTE_CLUSTER_SEARCH = "Source index is configured with a remote index pattern(s) [{0}]"
         + " but the current node [{1}] is not allowed to connect to remote clusters."
         + " Please enable cluster.remote.connect for all data nodes.";
-    public static final String ERROR_REMOTE_CLUSTER_SEARCH = "Error during resolving remote source, error: {2}";
+    public static final String ERROR_REMOTE_CLUSTER_SEARCH = "Error during resolving remote source, error: {0}";
     public static final String UNKNOWN_REMOTE_CLUSTER_LICENSE = "Error during license check ({0}) for remote cluster "
         + "alias(es) {1}, error: {2}";
     public static final String FEATURE_NOT_LICENSED_REMOTE_CLUSTER_LICENSE = "License check failed for remote cluster "

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
@@ -57,6 +57,7 @@ public final class SourceDestValidator {
         private final String[] source;
         private final String dest;
         private final String nodeName;
+        private final String license;
 
         private ValidationException validationException = null;
         private Set<String> resolvedSource = null;
@@ -70,7 +71,8 @@ public final class SourceDestValidator {
             final RemoteClusterLicenseChecker remoteClusterLicenseChecker,
             final String[] source,
             final String dest,
-            final String nodeName
+            final String nodeName,
+            final String license
         ) {
             this.state = state;
             this.indexNameExpressionResolver = indexNameExpressionResolver;
@@ -79,6 +81,7 @@ public final class SourceDestValidator {
             this.source = source;
             this.dest = dest;
             this.nodeName = nodeName;
+            this.license = license;
         }
 
         public ClusterState getState() {
@@ -111,6 +114,10 @@ public final class SourceDestValidator {
 
         public String getNodeName() {
             return nodeName;
+        }
+
+        public String getLicense() {
+            return license;
         }
 
         public Set<String> resolveSource() {
@@ -219,6 +226,7 @@ public final class SourceDestValidator {
      * @param source an array of source indices
      * @param dest destination index
      * @param nodeName the name of this node
+     * @param license the license of the feature validated for
      * @return ValidationException instance containing all validation errors or null if validation found no problems.
      */
     public static ValidationException validateForPreview(
@@ -228,7 +236,8 @@ public final class SourceDestValidator {
         RemoteClusterLicenseChecker remoteClusterLicenseChecker,
         String[] source,
         String dest,
-        String nodeName
+        String nodeName,
+        String license
     ) {
         Context context = new Context(
             clusterState,
@@ -237,7 +246,8 @@ public final class SourceDestValidator {
             remoteClusterLicenseChecker,
             source,
             dest,
-            nodeName
+            nodeName,
+            license
         );
 
         // validation exception might gets thrown if validation stops early
@@ -260,6 +270,8 @@ public final class SourceDestValidator {
      * @param remoteClusterLicenseChecker A RemoteClusterLicenseChecker or null if CCS is disabled
      * @param source an array of source indexes
      * @param dest destination index
+     * @param nodeName the name of this node
+     * @param license the license of the feature validated for
      * @param shouldDefer whether to defer certain validations, used for put while source indices are not created yet
      * @return ValidationException instance containing all validation errors or null if validation found no problems.
      */
@@ -272,6 +284,7 @@ public final class SourceDestValidator {
         String[] source,
         String dest,
         String nodeName,
+        String license,
         boolean shouldDefer
     ) {
         Context context = new Context(
@@ -281,7 +294,8 @@ public final class SourceDestValidator {
             remoteClusterLicenseChecker,
             source,
             dest,
-            nodeName
+            nodeName,
+            license
         );
 
         // validation exception might gets thrown if validation stops early

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
@@ -6,59 +6,300 @@
 
 package org.elasticsearch.xpack.transform.transforms;
 
-import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xpack.core.transform.TransformMessages;
-import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.RemoteClusterLicenseChecker;
+import org.elasticsearch.transport.RemoteClusterService;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 /**
- * This class contains more complex validations in regards to how {@link TransformConfig#getSource()} and
- * {@link TransformConfig#getDestination()} relate to each other.
+ * Validation of source indexes and destination index in different situations (preview, put)
  */
 public final class SourceDestValidator {
 
-    interface SourceDestValidation {
-        boolean isDeferrable();
-        void validate(TransformConfig config, ClusterState clusterState, IndexNameExpressionResolver indexNameExpressionResolver);
+    // messages
+    public static final String SOURCE_INDEX_MISSING = "Source index [{0}] does not exist";
+    public static final String DEST_IN_SOURCE = "Destination index [{0}] is included in source expression [{1}]";
+    public static final String NEEDS_REMOTE_CLUSTER_SEARCH = "Source index is configured with a remote index pattern(s) [{0}]"
+        + " but the current node [{1}] is not allowed to connect to remote clusters."
+        + " Please enable cluster.remote.connect for all data nodes.";
+    public static final String UNKNOWN_REMOTE_CLUSTER_LICENSE = "Error during license check ({0}) for remote cluster "
+        + "alias(es) {1}, error: {2}";
+    public static final String FEATURE_NOT_LICENSED_REMOTE_CLUSTER_LICENSE = "License check failed for remote cluster "
+        + "alias {0}, at least a {1} license is required";
+    public static final String TIMEOUT_CHECK_REMOTE_CLUSTER_LICENSE = "Timeout during license check ({0}) for remote cluster "
+        + "alias(es) [{1}]";
+
+    static class Context {
+        private final ClusterState state;
+        private final IndexNameExpressionResolver indexNameExpressionResolver;
+        private final RemoteClusterService remoteClusterService;
+        private final RemoteClusterLicenseChecker remoteClusterLicenseChecker;
+        private final String[] source;
+        private final String dest;
+        private final String nodeName;
+
+        private ValidationException validationException = null;
+        private Set<String> resolvedSource = null;
+        private Set<String> resolvedRemoteSource = null;
+        private String resolvedDest = null;
+
+        Context(
+            final ClusterState state,
+            final IndexNameExpressionResolver indexNameExpressionResolver,
+            final RemoteClusterService remoteClusterService,
+            final RemoteClusterLicenseChecker remoteClusterLicenseChecker,
+            final String[] source,
+            final String dest,
+            final String nodeName
+        ) {
+            this.state = state;
+            this.indexNameExpressionResolver = indexNameExpressionResolver;
+            this.remoteClusterService = remoteClusterService;
+            this.remoteClusterLicenseChecker = remoteClusterLicenseChecker;
+            this.source = source;
+            this.dest = dest;
+            this.nodeName = nodeName;
+        }
+
+        public ClusterState getState() {
+            return state;
+        }
+
+        public RemoteClusterService getRemoteClusterService() {
+            return remoteClusterService;
+        }
+
+        public RemoteClusterLicenseChecker getRemoteClusterLicenseChecker() {
+            return remoteClusterLicenseChecker;
+        }
+
+        public IndexNameExpressionResolver getIndexNameExpressionResolver() {
+            return indexNameExpressionResolver;
+        }
+
+        public boolean isRemoteSearchEnabled() {
+            return remoteClusterLicenseChecker != null;
+        }
+
+        public String[] getSource() {
+            return source;
+        }
+
+        public String getDest() {
+            return dest;
+        }
+
+        public String getNodeName() {
+            return nodeName;
+        }
+
+        public Set<String> resolveSource() {
+            if (resolvedSource == null) {
+                resolveLocalAndRemoteSource();
+            }
+
+            return resolvedSource;
+        }
+
+        public Set<String> resolveRemoteSource() {
+            if (resolvedRemoteSource == null) {
+                resolveLocalAndRemoteSource();
+            }
+
+            return resolvedRemoteSource;
+        }
+
+        public String resolveDest() {
+            if (resolvedDest == null) {
+                try {
+                    Index singleWriteIndex = indexNameExpressionResolver.concreteWriteIndex(
+                        state,
+                        IndicesOptions.lenientExpandOpen(),
+                        dest,
+                        true
+                    );
+                    if (singleWriteIndex != null) {
+                        resolvedDest = singleWriteIndex.getName();
+                    } else {
+                        resolvedDest = dest;
+                    }
+                } catch (IllegalArgumentException e) {
+                    // stop here as we can not return a single dest index
+                    addValidationError(e.getMessage(), false);
+                }
+            }
+
+            return resolvedDest;
+        }
+
+        public ValidationException addValidationError(String error, boolean continueValidation, Object... args) {
+            if (validationException == null) {
+                validationException = new ValidationException();
+            }
+
+            validationException.addValidationError(new MessageFormat(error, Locale.ROOT).format(args));
+            if (continueValidation == false) {
+                throw validationException;
+            }
+
+            return validationException;
+        }
+
+        public ValidationException getValidationException() {
+            return validationException;
+        }
+
+        private void resolveLocalAndRemoteSource() {
+            resolvedSource = new HashSet<>(Arrays.asList(source));
+            resolvedRemoteSource = new HashSet<>(RemoteClusterLicenseChecker.remoteIndices(resolvedSource));
+            resolvedSource.removeAll(resolvedRemoteSource);
+
+            // special case: if indexNameExpressionResolver gets an empty list it treats it as _all
+            if (resolvedSource.isEmpty() == false) {
+                resolvedSource = new HashSet<>(
+                    Arrays.asList(
+                        indexNameExpressionResolver.concreteIndexNames(
+                            state,
+                            DEFAULT_INDICES_OPTIONS_FOR_VALIDATION,
+                            resolvedSource.toArray(new String[0])
+                        )
+                    )
+                );
+            }
+        }
     }
 
-    private static final List<SourceDestValidation> VALIDATIONS = Arrays.asList(new SourceMissingValidation(),
+    interface SourceDestValidation {
+        boolean isDeferrable();
+
+        void validate(Context context);
+    }
+
+    // note: this is equivalent to the default for search requests
+    private static final IndicesOptions DEFAULT_INDICES_OPTIONS_FOR_VALIDATION = IndicesOptions
+        .strictExpandOpenAndForbidClosedIgnoreThrottled();
+
+    private static final SourceDestValidation SOURCE_MISSING_VALIDATION = new SourceMissingValidation();
+
+    private static final List<SourceDestValidation> PREVIEW_VALIDATIONS = Collections.singletonList(SOURCE_MISSING_VALIDATION);
+
+    private static final List<SourceDestValidation> START_AND_PUT_VALIDATIONS = Arrays.asList(
+        SOURCE_MISSING_VALIDATION,
         new DestinationInSourceValidation(),
-        new DestinationSingleIndexValidation());
+        new DestinationSingleIndexValidation()
+    );
 
     /**
-     * Validates the DataFrameTransformConfiguration source and destination indices.
+     * Validates source and dest indices for preview.
      *
-     * A simple name validation is done on {@link TransformConfig#getDestination()} inside
-     * {@link org.elasticsearch.xpack.core.transform.action.PutTransformAction}
-     *
-     * So, no need to do the name checks here.
-     *
-     * @param config DataFrameTransformConfig to validate
      * @param clusterState The current ClusterState
      * @param indexNameExpressionResolver A valid IndexNameExpressionResolver object
-     * @throws ElasticsearchStatusException when a validation fails
+     * @param remoteClusterService A valid RemoteClusterService object
+     * @param remoteClusterLicenseChecker A RemoteClusterLicenseChecker or null if CCS is disabled
+     * @param source an array of source indices
+     * @param dest destination index
+     * @param nodeName the name of this node
+     * @return ValidationException instance containing all validation errors or null if validation found no problems.
      */
-    public static void validate(TransformConfig config,
-                                ClusterState clusterState,
-                                IndexNameExpressionResolver indexNameExpressionResolver,
-                                boolean shouldDefer) {
-        for (SourceDestValidation validation : VALIDATIONS) {
-            if (shouldDefer && validation.isDeferrable()) {
-                continue;
+    public static ValidationException validateForPreview(
+        ClusterState clusterState,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        RemoteClusterService remoteClusterService,
+        RemoteClusterLicenseChecker remoteClusterLicenseChecker,
+        String[] source,
+        String dest,
+        String nodeName
+    ) {
+        Context context = new Context(
+            clusterState,
+            indexNameExpressionResolver,
+            remoteClusterService,
+            remoteClusterLicenseChecker,
+            source,
+            dest,
+            nodeName
+        );
+
+        // validation exception might gets thrown if validation stops early
+        try {
+            for (SourceDestValidation validation : PREVIEW_VALIDATIONS) {
+                validation.validate(context);
             }
-            validation.validate(config, clusterState, indexNameExpressionResolver);
-        }
+        } catch (ValidationException e) {}
+
+        return context.getValidationException();
+    }
+
+    /**
+     * Validates source and destination indices for put, start and update.
+     * Assumes that name checks have been made at the REST layer.
+     *
+     * @param clusterState The current ClusterState
+     * @param indexNameExpressionResolver A valid IndexNameExpressionResolver object
+     * @param remoteClusterService A valid RemoteClusterService object
+     * @param remoteClusterLicenseChecker A RemoteClusterLicenseChecker or null if CCS is disabled
+     * @param source an array of source indexes
+     * @param dest destination index
+     * @param shouldDefer whether to defer certain validations, used for put while source indices are not created yet
+     * @return ValidationException instance containing all validation errors or null if validation found no problems.
+     */
+
+    public static ValidationException validate(
+        ClusterState clusterState,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        RemoteClusterService remoteClusterService,
+        RemoteClusterLicenseChecker remoteClusterLicenseChecker,
+        String[] source,
+        String dest,
+        String nodeName,
+        boolean shouldDefer
+    ) {
+        Context context = new Context(
+            clusterState,
+            indexNameExpressionResolver,
+            remoteClusterService,
+            remoteClusterLicenseChecker,
+            source,
+            dest,
+            nodeName
+        );
+
+        // validation exception might gets thrown if validation stops early
+        try {
+            for (SourceDestValidation validation : START_AND_PUT_VALIDATIONS) {
+                if (shouldDefer && validation.isDeferrable()) {
+                    continue;
+                }
+                validation.validate(context);
+            }
+
+        } catch (ValidationException e) {}
+
+        return context.getValidationException();
+    }
+
+    public static RemoteClusterLicenseChecker remoteClusterLicenseCheckerBasicLicense(Client client) {
+        return new RemoteClusterLicenseChecker(client, (operationMode -> operationMode != License.OperationMode.MISSING));
     }
 
     static class SourceMissingValidation implements SourceDestValidation {
@@ -69,18 +310,76 @@ public final class SourceDestValidator {
         }
 
         @Override
-        public void validate(TransformConfig config,
-                             ClusterState clusterState,
-                             IndexNameExpressionResolver indexNameExpressionResolver) {
-            for(String src : config.getSource().getIndex()) {
-                String[] concreteNames = indexNameExpressionResolver.concreteIndexNames(clusterState,
-                    IndicesOptions.lenientExpandOpen(),
-                    src);
-                if (concreteNames.length == 0) {
-                    throw new ElasticsearchStatusException(
-                        TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_SOURCE_INDEX_MISSING, src),
-                        RestStatus.BAD_REQUEST);
+        public void validate(Context context) {
+            // boolean remoteIndexesEmpty = context.isRemoteSearchEnabled() ? context.resolveRemoteSource().isEmpty() : true;
+
+            try {
+                // non-trivia: if source contains a wildcard index, which does not resolve to a concrete index
+                // the resolved indices might be empty, but we can check if source contained something, this works because
+                // of no wildcard index is involved the resolve would have thrown an exception
+                if (context.resolveSource().isEmpty() && context.resolveRemoteSource().isEmpty() && context.getSource().length == 0) {
+                    context.addValidationError(SOURCE_INDEX_MISSING, true, Strings.arrayToCommaDelimitedString(context.getSource()));
                 }
+            } catch (IndexNotFoundException e) {
+                context.addValidationError(e.getMessage(), true);
+            }
+        }
+    }
+
+    static class RemoteSourceEnabledAndLicenseValidation implements SourceDestValidation {
+        @Override
+        public boolean isDeferrable() {
+            return true;
+        }
+
+        @Override
+        public void validate(Context context) {
+            if (context.resolveRemoteSource().isEmpty()) {
+                return;
+            }
+
+            List<String> remoteIndices = new ArrayList<>(context.resolveRemoteSource());
+            // we can only check this node at the moment, clusters with mixed CCS enabled/disabled nodes are not supported, see gh#TBD
+            if (context.isRemoteSearchEnabled() == false) {
+                context.addValidationError(NEEDS_REMOTE_CLUSTER_SEARCH, true, context.resolveRemoteSource(), context.getNodeName());
+                return;
+            }
+
+            List<String> remoteAliases = RemoteClusterLicenseChecker.remoteClusterAliases(
+                context.getRemoteClusterService().getRegisteredRemoteClusterNames(),
+                remoteIndices
+            );
+
+            CountDownLatch latch = new CountDownLatch(1);
+
+            context.getRemoteClusterLicenseChecker()
+                .checkRemoteClusterLicenses(
+
+                    remoteAliases,
+                    new LatchedActionListener<>(ActionListener.wrap(response -> {
+                        if (response.isSuccess() == false) {
+                            context.addValidationError(
+                                FEATURE_NOT_LICENSED_REMOTE_CLUSTER_LICENSE,
+                                true,
+                                response.remoteClusterLicenseInfo().clusterAlias()
+                            );
+                        }
+                    }, e -> {
+
+                        context.addValidationError(UNKNOWN_REMOTE_CLUSTER_LICENSE, true, "", remoteAliases, e.getMessage());
+
+                        /*    createUnknownLicenseError(
+                                transformConfig.getId(),
+                                RemoteClusterLicenseChecker.remoteIndices(indicesList),
+                                e,
+                                numberOfRemoteClusters));*/
+                    }), latch)
+                );
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                context.addValidationError(TIMEOUT_CHECK_REMOTE_CLUSTER_LICENSE, true, "", remoteAliases);
             }
         }
     }
@@ -93,42 +392,29 @@ public final class SourceDestValidator {
         }
 
         @Override
-        public void validate(TransformConfig config,
-                             ClusterState clusterState,
-                             IndexNameExpressionResolver indexNameExpressionResolver) {
-            final String destIndex = config.getDestination().getIndex();
-            Set<String> concreteSourceIndexNames = new HashSet<>();
-            for(String src : config.getSource().getIndex()) {
-                String[] concreteNames = indexNameExpressionResolver.concreteIndexNames(clusterState,
-                    IndicesOptions.lenientExpandOpen(),
-                    src);
+        public void validate(Context context) {
+            final String destIndex = context.getDest();
+
+            for (String src : context.getSource()) {
                 if (Regex.simpleMatch(src, destIndex)) {
-                    throw new ElasticsearchStatusException(
-                        TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_DEST_IN_SOURCE, destIndex, src),
-                        RestStatus.BAD_REQUEST);
+                    context.addValidationError(DEST_IN_SOURCE, true, destIndex, src);
+                    return;
                 }
-                concreteSourceIndexNames.addAll(Arrays.asList(concreteNames));
             }
 
-            if (concreteSourceIndexNames.contains(destIndex)) {
-                throw new ElasticsearchStatusException(
-                    TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_DEST_IN_SOURCE,
-                        destIndex,
-                        Strings.arrayToCommaDelimitedString(config.getSource().getIndex())),
-                    RestStatus.BAD_REQUEST
-                );
+            if (context.resolvedSource.contains(destIndex)) {
+                context.addValidationError(DEST_IN_SOURCE, true, destIndex, Strings.arrayToCommaDelimitedString(context.getSource()));
+                return;
             }
 
-            final String[] concreteDest = indexNameExpressionResolver.concreteIndexNames(clusterState,
-                IndicesOptions.lenientExpandOpen(),
-                destIndex);
-            if (concreteDest.length > 0 && concreteSourceIndexNames.contains(concreteDest[0])) {
-                throw new ElasticsearchStatusException(
-                    TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_DEST_IN_SOURCE,
-                        concreteDest[0],
-                        Strings.arrayToCommaDelimitedString(concreteSourceIndexNames.toArray(new String[0]))),
-                    RestStatus.BAD_REQUEST
+            if (context.resolvedSource.contains(context.resolveDest())) {
+                context.addValidationError(
+                    DEST_IN_SOURCE,
+                    true,
+                    context.resolveDest(),
+                    Strings.arrayToCommaDelimitedString(context.getSource())
                 );
+                return;
             }
         }
     }
@@ -141,19 +427,8 @@ public final class SourceDestValidator {
         }
 
         @Override
-        public void validate(TransformConfig config,
-                             ClusterState clusterState,
-                             IndexNameExpressionResolver indexNameExpressionResolver) {
-            final String destIndex = config.getDestination().getIndex();
-            final String[] concreteDest =
-                indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpen(), destIndex);
-
-            if (concreteDest.length > 1) {
-                throw new ElasticsearchStatusException(
-                    TransformMessages.getMessage(TransformMessages.REST_PUT_TRANSFORM_DEST_SINGLE_INDEX, destIndex),
-                    RestStatus.BAD_REQUEST
-                );
-            }
+        public void validate(Context context) {
+            context.resolveDest();
         }
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.transport.RemoteClusterService;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -184,13 +184,13 @@ public final class SourceDestValidator {
         }
 
         private void resolveLocalAndRemoteSource() {
-            resolvedSource = new HashSet<>(Arrays.asList(source));
-            resolvedRemoteSource = new HashSet<>(RemoteClusterLicenseChecker.remoteIndices(resolvedSource));
+            resolvedSource = new LinkedHashSet<>(Arrays.asList(source));
+            resolvedRemoteSource = new LinkedHashSet<>(RemoteClusterLicenseChecker.remoteIndices(resolvedSource));
             resolvedSource.removeAll(resolvedRemoteSource);
 
             // special case: if indexNameExpressionResolver gets an empty list it treats it as _all
             if (resolvedSource.isEmpty() == false) {
-                resolvedSource = new HashSet<>(
+                resolvedSource = new LinkedHashSet<>(
                     Arrays.asList(
                         indexNameExpressionResolver.concreteIndexNames(
                             state,
@@ -372,10 +372,10 @@ public final class SourceDestValidator {
             try {
                 remoteAliases = RemoteClusterLicenseChecker.remoteClusterAliases(context.getRegisteredRemoteClusterNames(), remoteIndices);
             } catch (NoSuchRemoteClusterException e) {
-                context.addValidationError(e.getMessage(), false);
+                context.addValidationError(e.getMessage(), true);
                 return;
             } catch (Exception e) {
-                context.addValidationError(ERROR_REMOTE_CLUSTER_SEARCH, false, e.getMessage());
+                context.addValidationError(ERROR_REMOTE_CLUSTER_SEARCH, true, e.getMessage());
                 return;
             }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidatorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/SourceDestValidatorTests.java
@@ -113,6 +113,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             "dest",
             "node_id",
+            "license",
             false
         );
         assertNull(e);
@@ -127,6 +128,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "ccs:" + SOURCE_1 },
             "dest",
             "node_id",
+            "license",
             false
         );
         assertNull(e);
@@ -138,6 +140,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "ccs:" + SOURCE_1 },
             "dest",
             "node_id",
+            "license",
             false
         );
         assertNull(e);
@@ -152,6 +155,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] {},
             "dest",
             "node_id",
+            "license",
             false
         );
 
@@ -169,6 +173,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "missing" },
             "dest",
             "node_id",
+            "license",
             false
         );
 
@@ -183,6 +188,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "missing" },
             "dest",
             "node_id",
+            "license",
             true
         );
         assertNull(e);
@@ -197,6 +203,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1, "missing" },
             "dest",
             "node_id",
+            "license",
             false
         );
 
@@ -211,6 +218,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1, "missing" },
             "dest",
             "node_id",
+            "license",
             true
         );
         assertNull(e);
@@ -225,6 +233,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1, "wildcard*", "missing" },
             "dest",
             "node_id",
+            "license",
             false
         );
 
@@ -239,6 +248,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1, "wildcard*", "missing" },
             "dest",
             "node_id",
+            "license",
             true
         );
         assertNull(e);
@@ -253,6 +263,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "wildcard*" },
             "dest",
             "node_id",
+            "license",
             false
         );
         assertNull(e);
@@ -267,6 +278,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             "source-1",
             "node_id",
+            "license",
             false
         );
 
@@ -281,6 +293,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             "source-1",
             "node_id",
+            "license",
             true
         );
         assertNull(e);
@@ -295,6 +308,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "source-*" },
             SOURCE_2,
             "node_id",
+            "license",
             false
         );
         assertNotNull(e);
@@ -308,6 +322,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "source-*" },
             SOURCE_2,
             "node_id",
+            "license",
             true
         );
         assertNull(e);
@@ -322,6 +337,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "source-1", "source-*" },
             SOURCE_2,
             "node_id",
+            "license",
             false
         );
         assertNotNull(e);
@@ -335,6 +351,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { "source-1", "source-*" },
             SOURCE_2,
             "node_id",
+            "license",
             true
         );
         assertNull(e);
@@ -349,6 +366,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             DEST_ALIAS,
             "node_id",
+            "license",
             false
         );
         assertNotNull(e);
@@ -368,6 +386,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             DEST_ALIAS,
             "node_id",
+            "license",
             true
         );
         assertNotNull(e);
@@ -389,6 +408,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             ALIAS_READ_WRITE_DEST,
             "node_id",
+            "license",
             false
         );
         assertNotNull(e);
@@ -403,6 +423,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             SOURCE_1_ALIAS,
             "node_id",
+            "license",
             false
         );
         assertNotNull(e);
@@ -417,6 +438,7 @@ public class SourceDestValidatorTests extends ESTestCase {
             new String[] { SOURCE_1 },
             SOURCE_1_ALIAS,
             "node_id",
+            "license",
             true
         );
         assertNull(e);


### PR DESCRIPTION
refactors source and dest validation, adds support for CCS, makes resolve work like reindex/search, allow aliased dest index with a single write index.

fixes #49988 
fixes #49851
relates #43201

Notes: `SourceDestValidator` is now de-coupled from transform, I moved it into x-pack core for re-usage (e.g. df analytics)