### PR TITLE
Add Searchable Snapshots plugin project

### DIFF
--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -1,0 +1,22 @@
+evaluationDependsOn(xpackModule('core'))
+
+apply plugin: 'elasticsearch.esplugin'
+esplugin {
+  name 'searchable-snapshots'
+  description 'A plugin for the searchable snapshots functionality'
+  classname 'org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots'
+  extendedPlugins = ['x-pack-core']
+}
+archivesBaseName = 'x-pack-searchable-snapshots'
+
+dependencies {
+  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+}
+
+// xpack modules are installed in real clusters as the meta plugin, so
+// installing them as individual plugins for integ tests doesn't make sense,
+// so we disable integ tests
+integTest.enabled = false
+
+test.enabled = false

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.plugins.Plugin;
+
+/**
+ * Plugin for Searchable Snapshots feature
+ */
+public class SearchableSnapshots extends Plugin {
+
+}


### PR DESCRIPTION
**Note:** this change targets the `feature/searchable-snapshots` branch

This pull request adds a new (almost empty) Gradle project for the _Searchable Snapshots_ plugin in x-pack. Better names suggestions are welcome.