### PR TITLE
[DOCS] Remove shadow replica reference

### DIFF
--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -257,7 +257,7 @@ Reason the shard is unassigned. Returned values are:
 * `NEW_INDEX_RESTORED`: Unassigned as a result of restoring into a new index.
 * `NODE_LEFT`: Unassigned as a result of the node hosting it leaving the cluster.
 * `REALLOCATED_REPLICA`: A better replica location is identified and causes the existing replica allocation to be cancelled.
-* `REINITIALIZED`: When a shard moves from started back to initializing, for example, with shadow replicas.
+* `REINITIALIZED`: When a shard moves from started back to initializing.
 * `REPLICA_ADDED`: Unassigned as a result of explicit addition of a replica.
 * `REROUTE_CANCELLED`: Unassigned as a result of explicit cancel reroute command.
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -104,7 +104,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
          */
         REROUTE_CANCELLED,
         /**
-         * When a shard moves from started back to initializing, for example, during shadow replica
+         * When a shard moves from started back to initializing.
          */
         REINITIALIZED,
         /**


### PR DESCRIPTION
Removes references to shadow replicas from the cat shards API docs
and from a comment in cluster/routing/UnassignedInfo.java.

Shadow replicas were removed with #23906.