### PR TITLE
SQL: COUNT DISTINCT returns 0 instead of NULL for no matching docs

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
@@ -657,6 +657,29 @@ SELECT COUNT(first_name)=COUNT(DISTINCT first_name) AS areEqual, COUNT(first_nam
 true           |90             |90
 ;
 
+aggCountWithNull
+schema::COUNT(NULL):l|COUNT(*):l|COUNT(DISTINCT languages):l|languages:bt
+SELECT COUNT(NULL), COUNT(*), COUNT(DISTINCT languages), languages FROM test_emp GROUP BY languages ORDER BY languages DESC;
+
+  COUNT(NULL)  |   COUNT(*)    |COUNT(DISTINCT languages)|   languages   
+---------------+---------------+-------------------------+---------------
+null           |21             |1                        |5              
+null           |18             |1                        |4              
+null           |17             |1                        |3              
+null           |19             |1                        |2              
+null           |15             |1                        |1              
+null           |10             |0                        |null          
+;
+
+aggCountZeroDocuments
+schema::COUNT(NULL):l|COUNT(*):l|COUNT(DISTINCT languages):l
+SELECT COUNT(NULL), COUNT(*), COUNT(DISTINCT languages) FROM test_emp WHERE languages > 100;
+
+  COUNT(NULL)  |   COUNT(*)    |COUNT(DISTINCT languages)
+---------------+---------------+-------------------------
+null           |0              |0
+;
+
 aggCountAllEquality
 schema::areEqual:b|afn:l
 SELECT COUNT(first_name)=COUNT(ALL first_name) AS areEqual, COUNT(ALL first_name) afn FROM test_emp;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractor.java
@@ -12,7 +12,6 @@ import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Buck
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
 import org.elasticsearch.search.aggregations.matrix.stats.InternalMatrixStats;
 import org.elasticsearch.search.aggregations.metrics.InternalAvg;
-import org.elasticsearch.search.aggregations.metrics.InternalCardinality;
 import org.elasticsearch.search.aggregations.metrics.InternalMax;
 import org.elasticsearch.search.aggregations.metrics.InternalMin;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
@@ -148,9 +147,6 @@ public class MetricAggExtractor implements BucketExtractor {
         }
         if (agg instanceof InternalAvg) {
             return hasValue((InternalAvg) agg);
-        }
-        if (agg instanceof InternalCardinality) {
-            return hasValue((InternalCardinality) agg);
         }
         if (agg instanceof InternalSum) {
             return hasValue((InternalSum) agg);


### PR DESCRIPTION
This PR reverts a [small change](https://github.com/elastic/elasticsearch/pull/44745) that silently introduced a change in behavior for COUNT DISTINCT that made it return NULL for a query that was not matching any documents, instead of 0.

Fixes https://github.com/elastic/elasticsearch/issues/50013.