### PR TITLE
In sparse vector REST tests, specify the index name in searches.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/30_sparse_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/30_sparse_vector_basic.yml
@@ -49,6 +49,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -81,6 +82,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -114,6 +116,7 @@ setup:
         - The [sparse_vector] field type is deprecated and will be removed in 8.0.
         - The vector functions of the form function(query, doc['field']) are deprecated, and the form function(query, 'field') should be used instead. For example, cosineSimilarity(query, doc['field']) is replaced by cosineSimilarity(query, 'field').
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/35_sparse_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/35_sparse_vector_l1l2.yml
@@ -49,6 +49,7 @@ setup:
       warnings:
         - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:
@@ -82,6 +83,7 @@ setup:
       warnings:
         - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/40_sparse_vector_special_cases.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/40_sparse_vector_special_cases.yml
@@ -55,6 +55,7 @@ setup:
       warnings:
         - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:
@@ -77,6 +78,7 @@ setup:
       warnings:
         - The [sparse_vector] field type is deprecated and will be removed in 8.0.
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:
@@ -121,6 +123,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -139,6 +142,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -188,6 +192,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -224,6 +229,7 @@ setup:
     headers:
       Content-Type: application/json
     search:
+      index: test-index
       body:
         query:
           script_score:
@@ -266,6 +272,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -297,6 +304,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -327,6 +335,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:
@@ -354,6 +363,7 @@ setup:
     warnings:
       - The [sparse_vector] field type is deprecated and will be removed in 8.0.
     search:
+      index: test-index
       rest_total_hits_as_int: true
       body:
         query:


### PR DESCRIPTION
The `sparse_vector` REST tests occasionally fail on 7.x because we don't receive the expected response headers with deprecation warnings.

One theory as to what is happening is that there is an extra empty index present in addition to the test index. Since the search doesn't specify an index name, it hits both the test index and this extra empty index and shard responses from the extra index don't produce deprecation warnings. If not all shard responses contain the warning headers, then certain deprecation warnings can be lost (due to the bug described in #33936).

This PR tries to harden the `sparse_vector` tests by always specifying the index name during a search. This doesn't fix the root causes of the issue, but is good practice and can help avoid intermittent failures.

Addresses #49383.