### PR TITLE
Support "accept_enterprise" param in get license

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -292,7 +292,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     private static boolean licenseIsCompatible(License license, Version version) {
         if (License.LicenseType.ENTERPRISE.getTypeName().equalsIgnoreCase(license.type())) {
-            return version.onOrAfter(Version.V_8_0_0);
+            return version.onOrAfter(Version.V_7_6_0);
         } else {
             return true;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/RestGetLicenseAction.java
@@ -6,7 +6,9 @@
 
 package org.elasticsearch.license;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.protocol.xpack.license.GetLicenseRequest;
@@ -26,6 +28,8 @@ import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestGetLicenseAction extends BaseRestHandler {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(RestGetLicenseAction.class));
 
     RestGetLicenseAction(RestController controller) {
         controller.registerHandler(GET, "/_license", this);
@@ -47,6 +51,18 @@ public class RestGetLicenseAction extends BaseRestHandler {
         final Map<String, String> overrideParams = new HashMap<>(2);
         overrideParams.put(License.REST_VIEW_MODE, "true");
         overrideParams.put(License.LICENSE_VERSION_MODE, String.valueOf(License.VERSION_CURRENT));
+
+        // In 7.x, there was an opt-in flag to show "enterprise" licenses. In 8.0 the flag is deprecated and can only be true
+        // TODO Remove this from 9.0
+        if (request.hasParam("accept_enterprise")) {
+            deprecationLogger.deprecatedAndMaybeLog("get_license_accept_enterprise",
+                "Including [accept_enterprise] in get license requests is deprecated." +
+                    " The parameter will be removed in the next major version");
+            if (request.paramAsBoolean("accept_enterprise", true) == false) {
+                throw new IllegalArgumentException("The [accept_enterprise] parameters may not be false");
+            }
+        }
+
         final ToXContent.Params params = new ToXContent.DelegatingMapParams(overrideParams, request);
         GetLicenseRequest getLicenseRequest = new GetLicenseRequest();
         getLicenseRequest.local(request.paramAsBoolean("local", getLicenseRequest.local()));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
@@ -18,6 +18,11 @@
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"
+      },
+      "accept_enterprise":{
+        "type":"boolean",
+        "deprecated":true,
+        "description":"Supported for backwards compatibility with 7.x. If this param is used it must be set to true"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/license/30_enterprise_license.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/license/30_enterprise_license.yml
@@ -1,0 +1,50 @@
+---
+teardown:
+  - do:
+      license.post:
+        acknowledge: true
+        body: |
+          {"licenses":[{"uid":"3aa62ffe-36e1-4fad-bfdc-9dff8301eb22","type":"trial","issue_date_in_millis":1523456691721,"expiry_date_in_millis":1838816691721,"max_nodes":5,"issued_to":"customer","issuer":"elasticsearch","signature":"AAAABAAAAA2kWNcuc+DT0lrlmYZKAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAEn6fG9y2VxKBu2T3D5hffh56kzOQODCOdhr0y2d17ZSIJMZRqO7ZywPCWNS1aR33GhfIHkTER0ysML0xMH/gXavhyRvMBndJj0UBKzuwpTawSlnxYtcqN8mSBIvJC7Ki+uJ1SpAILC2ZP9fnkRlqwXqBlTwfYn7xnZgu9DKrOWru/ipTPObo7jcePl8VTK6nWFen7/hCFDQTUFZ0jQvd+nq7A1PAcHGNxGfdbMVmAXCXgGWkRfT3clo9/vadgo+isNyh1sPq9mN7gwsvBAKtA1FrpH2EXYYbfOsSpBvUmhYMgErLg1k3/CbS0pCWLKOaX1xTMayosdZOjagU3auZXY=","start_date_in_millis":-1}]}
+---
+"Installing enterprise license":
+  - skip:
+      features: warnings
+
+  ## current license version
+  - do:
+      license.post:
+        acknowledge: true
+        body: |
+          {"license":{"uid":"6e57906b-a8d1-4c1f-acb7-73a16edc3934","type":"enterprise","issue_date_in_millis":1523456691721,"expiry_date_in_millis":1838816691721,"max_nodes":50,"issued_to":"rest-test","issuer":"elasticsearch","signature":"AAAABAAAAA03e8BZRVXaCV4CpPGRAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAAZNhjABV6PRfa7P7sJgn70XCGoKtAVT75yU13JvKBd/UjD4TPhuZcztqZ/tcLEPxm/TSvGlogWmnw/Rw8xs8jMpBpKsJ+LOXjHhDdvXb2y7JJhCH8nlSEblMDRXysNvWpKe60Z/hb7hS4JynEUt0EBb6ji7BL42O07PNll1EGmkfsHazfs46iV91BG1VxXksI78XgWSaA0F/h7tvrNW9PTgsUaLo06InlQ8jA1dal90AoXp+MVDOHWQjVFZzUnO87/7lEb+VXt0IwchaW17ahihJqkCtGvKpWFwpuhx9xiFvkySN/g5LIVjYCvgBkiWExQ9p0Zzg3VoSlMBnVy0BWo=","start_date_in_millis":-1}}
+
+  - match: { license_status:  "valid" }
+
+  - do:
+      license.get: {}
+
+  ## a license object has 11 attributes
+  - length: { license: 11 }
+
+  ## In 8.0, the enterprise license is always reports truthfully
+  - match: { license.type: "enterprise" }
+
+  - do:
+      warnings:
+        - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
+      license.get:
+        accept_enterprise: "true"
+
+  ## a license object has 11 attributes
+  - length: { license: 11 }
+
+  ## Always returns real type
+  - match: { license.type: "enterprise" }
+
+  ## "false" is rejected
+  - do:
+      catch: bad_request
+      warnings:
+        - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
+      license.get:
+        accept_enterprise: "false"
+


### PR DESCRIPTION
In 7.6 (#49474) we added an "accept_enterprise" parameter to the
GET _license endpoint.

This commit adds the same parameter to 8.0, except that
(a) it is deprecated
(b) the only acceptable value is "true"

This change also updates the license service to recognise 7.6 as a
supported cluster version for the enterprise license type.
