### PR TITLE
Fix delete- and update-by-query on indices without sequence numbers

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -472,6 +472,62 @@ public class RecoveryIT extends AbstractRollingTestCase {
         }
     }
 
+    /** Ensure that we can always execute delete-by-query regardless of the version of cluster */
+    public void testDeleteByQuery() throws Exception {
+        final String index = "test_delete_by_query";
+        if (CLUSTER_TYPE == ClusterType.OLD) {
+            Settings.Builder settings = Settings.builder()
+                .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 2);
+            createIndex(index, settings.build());
+        }
+        for (int i = 0; i < 100; i++) {
+            Request indexDoc = new Request("POST", index + "/test");
+            indexDoc.setJsonEntity("{\"test\": \"test_" + randomInt(5) + "\"}");
+            client().performRequest(indexDoc);
+        }
+        client().performRequest(new Request("POST", index + "/_refresh"));
+        if (randomBoolean()) {
+            ensureGreen(index);
+        }
+        Request update = new Request("POST", index + "/_delete_by_query");
+        update.setJsonEntity("{\"query\": {\"term\": { \"test\": \"test_" + CLUSTER_TYPE.ordinal() + "\" }}}");
+        Map<String, Object> doc = entityAsMap(client().performRequest(update));
+        logger.info(doc);
+
+        if (randomBoolean()) {
+            syncedFlush(index);
+        }
+    }
+
+    /** Ensure that we can always execute delete-by-query regardless of the version of cluster */
+    public void testUpdateByQuery() throws Exception {
+        final String index = "test_update_by_query";
+        if (CLUSTER_TYPE == ClusterType.OLD) {
+            Settings.Builder settings = Settings.builder()
+                .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 2);
+            createIndex(index, settings.build());
+        }
+        for (int i = 0; i < 100; i++) {
+            Request indexDoc = new Request("POST", index + "/test");
+            indexDoc.setJsonEntity("{\"test\": \"test_" + randomInt(5) + "\"}");
+            client().performRequest(indexDoc);
+        }
+        client().performRequest(new Request("POST", index + "/_refresh"));
+        if (randomBoolean()) {
+            ensureGreen(index);
+        }
+        Request update = new Request("POST", index + "/_update_by_query");
+        update.setJsonEntity("{\"query\": {\"term\": { \"test\": \"test_" + CLUSTER_TYPE.ordinal() + "\" }}}");
+        Map<String, Object> doc = entityAsMap(client().performRequest(update));
+        logger.info(doc);
+
+        if (randomBoolean()) {
+            syncedFlush(index);
+        }
+    }
+
     private void syncedFlush(String index) throws Exception {
         // We have to spin synced-flush requests here because we fire the global checkpoint sync for the last write operation.
         // A synced-flush request considers the global checkpoint sync as an going operation because it acquires a shard permit.

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -490,9 +490,9 @@ public class RecoveryIT extends AbstractRollingTestCase {
         if (randomBoolean()) {
             ensureGreen(index);
         }
-        Request update = new Request("POST", index + "/_delete_by_query");
-        update.setJsonEntity("{\"query\": {\"term\": { \"test\": \"test_" + CLUSTER_TYPE.ordinal() + "\" }}}");
-        Map<String, Object> doc = entityAsMap(client().performRequest(update));
+        Request deleteByQuery = new Request("POST", index + "/_delete_by_query");
+        deleteByQuery.setJsonEntity("{\"query\": {\"term\": { \"test\": \"test_" + CLUSTER_TYPE.ordinal() + "\" }}}");
+        Map<String, Object> doc = entityAsMap(client().performRequest(deleteByQuery));
         logger.info(doc);
 
         if (randomBoolean()) {
@@ -518,9 +518,9 @@ public class RecoveryIT extends AbstractRollingTestCase {
         if (randomBoolean()) {
             ensureGreen(index);
         }
-        Request update = new Request("POST", index + "/_update_by_query");
-        update.setJsonEntity("{\"query\": {\"term\": { \"test\": \"test_" + CLUSTER_TYPE.ordinal() + "\" }}}");
-        Map<String, Object> doc = entityAsMap(client().performRequest(update));
+        Request updateByQuery = new Request("POST", index + "/_update_by_query");
+        updateByQuery.setJsonEntity("{\"query\": {\"term\": { \"test\": \"test_" + CLUSTER_TYPE.ordinal() + "\" }}}");
+        Map<String, Object> doc = entityAsMap(client().performRequest(updateByQuery));
         logger.info(doc);
 
         if (randomBoolean()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
@@ -109,7 +110,8 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
                                     UpdateFilterAction.Request request,
                                     ActionListener<PutFilterAction.Response> listener) {
         IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
-        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0)) {
+        if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0) &&
+            seqNo != SequenceNumbers.UNASSIGNED_SEQ_NO) {
             indexRequest.setIfSeqNo(seqNo);
             indexRequest.setIfPrimaryTerm(primaryTerm);
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -884,7 +884,8 @@ public final class TokenService extends AbstractComponent {
                                     client.prepareUpdate(SecurityIndexManager.SECURITY_INDEX_NAME, TYPE, tokenDocId)
                                         .setDoc("refresh_token", Collections.singletonMap("refreshed", true))
                                         .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
-                                if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0)) {
+                                if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0) &&
+                                    response.getSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) {
                                     assert response.getSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
                                         : "reading a token [" + tokenDocId + "] with no sequence number";
                                     assert response.getPrimaryTerm() != SequenceNumbers.UNASSIGNED_PRIMARY_TERM :

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapper;
 import org.elasticsearch.xpack.core.watcher.actions.ActionWrapperResult;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
@@ -363,7 +364,8 @@ public class ExecutionService extends AbstractComponent {
 
         UpdateRequest updateRequest = new UpdateRequest(Watch.INDEX, Watch.DOC_TYPE, watch.id());
         updateRequest.doc(source);
-        boolean useSeqNoForCAS = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0);
+        boolean useSeqNoForCAS = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0)
+            && watch.getSourceSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO;
         if (useSeqNoForCAS) {
             updateRequest.setIfSeqNo(watch.getSourceSeqNo());
             updateRequest.setIfPrimaryTerm(watch.getSourcePrimaryTerm());

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -109,7 +110,8 @@ public class TransportAckWatchAction extends WatcherTransportAction<AckWatchRequ
 
                             UpdateRequest updateRequest = new UpdateRequest(Watch.INDEX, Watch.DOC_TYPE, request.getWatchId());
                             // this may reject this action, but prevents concurrent updates from a watch execution
-                            if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0)) {
+                            if (clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_6_7_0) &&
+                                getResponse.getSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) {
                                 updateRequest.setIfSeqNo(getResponse.getSeqNo());
                                 updateRequest.setIfPrimaryTerm(getResponse.getPrimaryTerm());
                             } else {


### PR DESCRIPTION
This fixes a bug where delete-by-query and update-by-query were not working on an older index that did not have sequence numbers yet. The reason is that in a mixed-version 6.x/5.x cluster, documents can have a primary term but miss a sequence number.

After upgrade, this resulted in exceptions of the form:

```
{
    "error": {
        "root_cause": [
            {
                "type": "action_request_validation_exception",
                "reason": "Validation Failed: 1: ifSeqNo is unassigned, but primary term is [1];"
            }
        ],
        "type": "action_request_validation_exception",
        "reason": "Validation Failed: 1: ifSeqNo is unassigned, but primary term is [1];"
    },
    "status": 400
}
```