### PR TITLE
Log attachment generation failures

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/email/ExecutableEmailAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/email/ExecutableEmailAction.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.watcher.actions.email;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.ExecutableAction;
@@ -24,7 +25,6 @@ import org.elasticsearch.xpack.watcher.support.Variables;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 public class ExecutableEmailAction extends ExecutableAction<EmailAction> {
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/email/ExecutableEmailAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/email/ExecutableEmailAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.watcher.actions.email;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.ExecutableAction;
@@ -23,6 +24,7 @@ import org.elasticsearch.xpack.watcher.support.Variables;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class ExecutableEmailAction extends ExecutableAction<EmailAction> {
 
@@ -57,6 +59,8 @@ public class ExecutableEmailAction extends ExecutableAction<EmailAction> {
                     Attachment attachment = parser.toAttachment(ctx, payload, emailAttachment);
                     attachments.put(attachment.id(), attachment);
                 } catch (ElasticsearchException | IOException e) {
+                    logger().error(
+                        (Supplier<?>) () -> new ParameterizedMessage("failed to execute action [{}/{}]", ctx.watch().id(), actionId), e);
                     return new EmailAction.Result.FailureWithException(action.type(), e);
                 }
             }


### PR DESCRIPTION
Watcher logs when actions fail in `ActionWrapper`, but failures to
generate an email attachment are not logged and we thus only know the
type of the exception and not where/how it occurred.
