### PR TITLE
Fix exception message for boolean BuildParams properties

### DIFF
--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/info/BuildParams.java
@@ -137,7 +137,7 @@ public class BuildParams {
     }
 
     private static String propertyName(String methodName) {
-        String propertyName = methodName.substring("get".length());
+        String propertyName = methodName.startsWith("is") ? methodName.substring("is".length()) : methodName.substring("get".length());
         return propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);
     }
 


### PR DESCRIPTION
This PR fixes an issue where exception messages were being improperly reported on illegal accesses of `BuildParams` properties with `boolean` values. We now properly handle accessor methods with an `is` prefix, in addition to those with `get` prefixes.