### PR TITLE
Disable LongGCDisruptionTests on JDK11+12

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test.disruption;
 
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.test.ESTestCase;
 
@@ -114,6 +115,8 @@ public class LongGCDisruptionTests extends ESTestCase {
      * but does keep retrying until all threads can be safely paused
      */
     public void testNotBlockingUnsafeStackTraces() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/50047",
+            JavaVersion.current().equals(JavaVersion.parse("11")) || JavaVersion.current().equals(JavaVersion.parse("12")));
         final String nodeName = "test_node";
         LongGCDisruption disruption = new LongGCDisruption(random(), nodeName) {
             @Override


### PR DESCRIPTION
See discussion in https://github.com/elastic/elasticsearch/issues/50047#issuecomment-564543192.
There are reproducible issues with `Thread#suspend` in `Jdk11` and `Jdk12` for me locally
and we have one failure for each on CI.
`Jdk8` and `Jdk13` are stable though on CI and in my testing so I'd selectively disable
this test here to keep the coverage. We aren't using `suspend` in production code so the
JDK bug behind this does not affect us.

Closes #50047 