### PR TITLE
Docs: Remove broken [float]

### DIFF
--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -18,7 +18,6 @@ The second command selectively retrieves nodes information of only
 
 By default, it just returns all attributes and core settings for a node:
 
-[float]
 [[core-info]]
 
 `build_hash`::

--- a/docs/reference/cluster/remote-info.asciidoc
+++ b/docs/reference/cluster/remote-info.asciidoc
@@ -13,7 +13,6 @@ GET /_remote/info
 This command returns connection and endpoint information keyed by
 the configured remote cluster alias.
 
-[float]
 [[connection-info]]
 
 `seeds`::


### PR DESCRIPTION
This removes a broken [float] tag. In our docbook-based docs build it is
just ignored silently. `--direct_html`, which I'm trying to move all of
the books to ignores it but log a warning which fails the build. I
*could* make it not log the warning, but this error is fairly rare and I
feel like it is worth cleaning up.

NOTE: This is targeting 7.2 because the error has already been fixed in master.