### PR TITLE
Adding clarification for using wait_if_ongoing

### DIFF
--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -100,6 +100,8 @@ If `false`,
 {es} returns an error
 if you request a flush
 when another flush operation is running.
+Because of this, you cannot set
+`force=true` at the same time.
 
 Defaults to `true`.
 --


### PR DESCRIPTION
If you check the [Elasticsearch version 7.2.0 release notes](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/release-notes-7.2.0.html), there was a change in 7.2 that prevents you from executing the flush API with both of these parameters set, `force=true&wait_if_ongoing=false`. Elasticsearch does include an error message with the following response.
>Validation Failed: 1: wait_if_ongoing must be true for a force flush

However, this still added some confusion for my customer as it previously didn't get presented as a problem in earlier versions. So I added some clarification to the doc. Although it may be debatable as to whether or not this can be considered a Breaking Change. I'll let you decide on that.