### PR TITLE
Remove type metadata from ingest documents

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
@@ -126,7 +126,7 @@ public class AppendProcessorTests extends ESTestCase {
     public void testAppendMetadataExceptVersion() throws Exception {
         // here any metadata field value becomes a list, which won't make sense in most of the cases,
         // but support for append is streamlined like for set so we test it
-        MetaData randomMetaData = randomFrom(MetaData.INDEX, MetaData.TYPE, MetaData.ID, MetaData.ROUTING);
+        MetaData randomMetaData = randomFrom(MetaData.INDEX, MetaData.ID, MetaData.ROUTING);
         List<String> values = new ArrayList<>();
         Processor appendProcessor;
         if (randomBoolean()) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
@@ -101,7 +101,7 @@ public class SetProcessorTests extends ESTestCase {
     }
 
     public void testSetMetadataExceptVersion() throws Exception {
-        MetaData randomMetaData = randomFrom(MetaData.INDEX, MetaData.TYPE, MetaData.ID, MetaData.ROUTING);
+        MetaData randomMetaData = randomFrom(MetaData.INDEX, MetaData.ID, MetaData.ROUTING);
         Processor processor = createSetProcessor(randomMetaData.getFieldName(), "_value", true);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         processor.execute(ingestDocument);

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -179,10 +179,6 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
                 dataMap, Fields.SOURCE);
             String index = ConfigurationUtils.readStringOrIntProperty(null, null,
                 dataMap, MetaData.INDEX.getFieldName(), "_index");
-            if (dataMap.containsKey(MetaData.TYPE.getFieldName())) {
-                deprecationLogger.deprecatedAndMaybeLog("simulate_pipeline_with_types",
-                    "[types removal] specifying _type in pipeline simulation requests is deprecated");
-            }
             String id = ConfigurationUtils.readStringOrIntProperty(null, null,
                 dataMap, MetaData.ID.getFieldName(), "_id");
             String routing = ConfigurationUtils.readOptionalStringOrIntProperty(null, null,

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -25,7 +25,6 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IndexFieldMapper;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
-import org.elasticsearch.index.mapper.TypeFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.script.TemplateScript;
 
@@ -692,7 +691,6 @@ public final class IngestDocument {
 
     public enum MetaData {
         INDEX(IndexFieldMapper.NAME),
-        TYPE(TypeFieldMapper.NAME),
         ID(IdFieldMapper.NAME),
         ROUTING(RoutingFieldMapper.NAME),
         VERSION(VersionFieldMapper.NAME),

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -43,7 +43,6 @@ import static org.elasticsearch.action.ingest.SimulatePipelineRequest.SIMULATED_
 import static org.elasticsearch.ingest.IngestDocument.MetaData.ID;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.INDEX;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.ROUTING;
-import static org.elasticsearch.ingest.IngestDocument.MetaData.TYPE;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.VERSION;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.VERSION_TYPE;
 import static org.hamcrest.Matchers.equalTo;
@@ -127,7 +126,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         for (int i = 0; i < numDocs; i++) {
             Map<String, Object> doc = new HashMap<>();
             Map<String, Object> expectedDoc = new HashMap<>();
-            List<IngestDocument.MetaData> fields = Arrays.asList(INDEX, TYPE, ID, ROUTING, VERSION, VERSION_TYPE);
+            List<IngestDocument.MetaData> fields = Arrays.asList(INDEX, ID, ROUTING, VERSION, VERSION_TYPE);
             for(IngestDocument.MetaData field : fields) {
                 if (field == VERSION) {
                     Long value = randomLong();
@@ -139,14 +138,6 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
                     );
                     doc.put(field.getFieldName(), value);
                     expectedDoc.put(field.getFieldName(), value);
-                } else if (field == TYPE) {
-                    if (useExplicitType) {
-                        String value = randomAlphaOfLengthBetween(1, 10);
-                        doc.put(field.getFieldName(), value);
-                        expectedDoc.put(field.getFieldName(), value);
-                    } else {
-                        expectedDoc.put(field.getFieldName(), "_doc");
-                    }
                 } else {
                     if (randomBoolean()) {
                         String value = randomAlphaOfLengthBetween(1, 10);

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -108,15 +108,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         assertThat(actualRequest.getPipeline().getProcessors().size(), equalTo(1));
     }
 
-    public void testParseWithProvidedPipelineNoType() throws Exception {
-        innerTestParseWithProvidedPipeline(false);
-    }
-
-    public void testParseWithProvidedPipelineWithType() throws Exception {
-        innerTestParseWithProvidedPipeline(true);
-    }
-
-    private void innerTestParseWithProvidedPipeline(boolean useExplicitType) throws Exception {
+    public void innerTestParseWithProvidedPipeline() throws Exception {
         int numDocs = randomIntBetween(1, 10);
 
         Map<String, Object> requestContent = new HashMap<>();
@@ -204,9 +196,6 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         assertThat(actualRequest.getPipeline().getId(), equalTo(SIMULATED_PIPELINE_ID));
         assertThat(actualRequest.getPipeline().getDescription(), nullValue());
         assertThat(actualRequest.getPipeline().getProcessors().size(), equalTo(numProcessors));
-        if (useExplicitType) {
-            assertWarnings("[types removal] specifying _type in pipeline simulation requests is deprecated");
-        }
     }
 
     public void testNullPipelineId() {


### PR DESCRIPTION
Referring to the `_type` field in an Ingest document has been deprecated and effectively
a no-op since 7.x, and we can remove support for it entirely in 8.0

Relates to #41059 