### PR TITLE
Introduce since field in the json spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -2,7 +2,8 @@
   "bulk":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html",
-      "description":"Allows to perform multiple index/update/delete operations in a single request."
+      "description":"Allows to perform multiple index/update/delete operations in a single request.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -2,7 +2,8 @@
   "cat.aliases":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-alias.html",
-      "description":"Shows information about currently configured aliases to indices including filter and routing infos."
+      "description":"Shows information about currently configured aliases to indices including filter and routing infos.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -2,7 +2,8 @@
   "cat.allocation":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-allocation.html",
-      "description":"Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using."
+      "description":"Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -2,7 +2,8 @@
   "cat.count":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-count.html",
-      "description":"Provides quick access to the document count of the entire cluster, or individual indices."
+      "description":"Provides quick access to the document count of the entire cluster, or individual indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -2,7 +2,8 @@
   "cat.fielddata":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-fielddata.html",
-      "description":"Shows how much heap memory is currently being used by fielddata on every data node in the cluster."
+      "description":"Shows how much heap memory is currently being used by fielddata on every data node in the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -2,7 +2,8 @@
   "cat.health":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-health.html",
-      "description":"Returns a concise representation of the cluster health."
+      "description":"Returns a concise representation of the cluster health.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
@@ -2,7 +2,8 @@
   "cat.help":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat.html",
-      "description":"Returns help for the Cat APIs."
+      "description":"Returns help for the Cat APIs.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -2,7 +2,8 @@
   "cat.indices":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-indices.html",
-      "description":"Returns information about indices: number of primaries and replicas, document counts, disk size, ..."
+      "description":"Returns information about indices: number of primaries and replicas, document counts, disk size, ...",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -2,7 +2,8 @@
   "cat.master":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-master.html",
-      "description":"Returns information about the master node."
+      "description":"Returns information about the master node.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -2,7 +2,8 @@
   "cat.nodeattrs":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodeattrs.html",
-      "description":"Returns information about custom node attributes."
+      "description":"Returns information about custom node attributes.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -2,7 +2,8 @@
   "cat.nodes":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html",
-      "description":"Returns basic statistics about performance of cluster nodes."
+      "description":"Returns basic statistics about performance of cluster nodes.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -2,7 +2,8 @@
   "cat.pending_tasks":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-pending-tasks.html",
-      "description":"Returns a concise representation of the cluster pending tasks."
+      "description":"Returns a concise representation of the cluster pending tasks.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -2,7 +2,8 @@
   "cat.plugins":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-plugins.html",
-      "description":"Returns information about installed plugins across nodes node."
+      "description":"Returns information about installed plugins across nodes node.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -2,7 +2,8 @@
   "cat.recovery":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-recovery.html",
-      "description":"Returns information about index shard recoveries, both on-going completed."
+      "description":"Returns information about index shard recoveries, both on-going completed.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -2,7 +2,8 @@
   "cat.repositories":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-repositories.html",
-      "description":"Returns information about snapshot repositories registered in the cluster."
+      "description":"Returns information about snapshot repositories registered in the cluster.",
+      "since":"2.1.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -2,7 +2,8 @@
   "cat.segments":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html",
-      "description":"Provides low-level information about the segments in the shards of an index."
+      "description":"Provides low-level information about the segments in the shards of an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -2,7 +2,8 @@
   "cat.shards":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html",
-      "description":"Provides a detailed view of shard allocation on nodes."
+      "description":"Provides a detailed view of shard allocation on nodes.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -2,7 +2,8 @@
   "cat.snapshots":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html",
-      "description":"Returns all snapshots in a specific repository."
+      "description":"Returns all snapshots in a specific repository.",
+      "since":"2.1.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -2,7 +2,8 @@
   "cat.tasks":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
-      "description":"Returns information about the tasks currently executing on one or more nodes in the cluster."
+      "description":"Returns information about the tasks currently executing on one or more nodes in the cluster.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -2,7 +2,8 @@
   "cat.templates":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html",
-      "description":"Returns information about existing templates."
+      "description":"Returns information about existing templates.",
+      "since":"5.2.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -2,7 +2,8 @@
   "cat.thread_pool":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html",
-      "description":"Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."
+      "description":"Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -2,7 +2,8 @@
   "clear_scroll":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#_clear_scroll_api",
-      "description":"Explicitly clears the search context for a scroll."
+      "description":"Explicitly clears the search context for a scroll.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -2,7 +2,8 @@
   "cluster.allocation_explain":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html",
-      "description":"Provides explanations for shard allocations in the cluster."
+      "description":"Provides explanations for shard allocations in the cluster.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
@@ -2,7 +2,8 @@
   "cluster.get_settings":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
-      "description":"Returns cluster settings."
+      "description":"Returns cluster settings.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -2,7 +2,8 @@
   "cluster.health":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-health.html",
-      "description":"Returns basic information about the health of the cluster."
+      "description":"Returns basic information about the health of the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
@@ -2,7 +2,8 @@
   "cluster.pending_tasks":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html",
-      "description":"Returns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed."
+      "description":"Returns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -2,7 +2,8 @@
   "cluster.put_settings":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html",
-      "description":"Updates the cluster settings."
+      "description":"Updates the cluster settings.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
@@ -2,7 +2,8 @@
   "cluster.remote_info":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html",
-      "description":"Returns the information about configured remote clusters."
+      "description":"Returns the information about configured remote clusters.",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
@@ -2,7 +2,8 @@
   "cluster.reroute":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-reroute.html",
-      "description":"Allows to manually change the allocation of individual shards in the cluster."
+      "description":"Allows to manually change the allocation of individual shards in the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -2,7 +2,8 @@
   "cluster.state":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-state.html",
-      "description":"Returns a comprehensive information about the state of the cluster."
+      "description":"Returns a comprehensive information about the state of the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
@@ -2,7 +2,8 @@
   "cluster.stats":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html",
-      "description":"Returns high-level overview of cluster statistics."
+      "description":"Returns high-level overview of cluster statistics.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -2,7 +2,8 @@
   "count":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-count.html",
-      "description":"Returns number of documents matching a query."
+      "description":"Returns number of documents matching a query.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -2,7 +2,8 @@
   "create":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
-      "description":"Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."
+      "description":"Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -2,7 +2,8 @@
   "delete":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html",
-      "description":"Removes a document from the index."
+      "description":"Removes a document from the index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -2,7 +2,8 @@
   "delete_by_query":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html",
-      "description":"Deletes documents matching the provided query."
+      "description":"Deletes documents matching the provided query.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
@@ -2,7 +2,8 @@
   "delete_by_query_rethrottle":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html",
-      "description":"Changes the number of requests per second for a particular Delete By Query operation."
+      "description":"Changes the number of requests per second for a particular Delete By Query operation.",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -2,7 +2,8 @@
   "delete_script":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
-      "description":"Deletes a script."
+      "description":"Deletes a script.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -2,7 +2,8 @@
   "exists":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
-      "description":"Returns information about whether a document exists in an index."
+      "description":"Returns information about whether a document exists in an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -2,7 +2,8 @@
   "exists_source":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
-      "description":"Returns information about whether a document source exists in an index."
+      "description":"Returns information about whether a document source exists in an index.",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -2,7 +2,8 @@
   "explain":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html",
-      "description":"Returns information about why a specific matches (or doesn't match) a query."
+      "description":"Returns information about why a specific matches (or doesn't match) a query.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -2,7 +2,8 @@
   "field_caps":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html",
-      "description":"Returns the information about the capabilities of fields among multiple indices."
+      "description":"Returns the information about the capabilities of fields among multiple indices.",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -2,7 +2,8 @@
   "get":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
-      "description":"Returns a document."
+      "description":"Returns a document.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
@@ -2,7 +2,8 @@
   "get_script":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
-      "description":"Returns a script."
+      "description":"Returns a script.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
@@ -1,7 +1,8 @@
 {
   "get_script_context":{
     "documentation":{
-      "description":"Returns all script contexts."
+      "description":"Returns all script contexts.",
+      "since":"7.6.0"
     },
     "stability":"experimental",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
@@ -1,7 +1,8 @@
 {
   "get_script_languages":{
     "documentation":{
-      "description":"Returns available script types, languages and contexts"
+      "description":"Returns available script types, languages and contexts",
+      "since":"7.6.0"
     },
     "stability":"experimental",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -2,7 +2,8 @@
   "get_source":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
-      "description":"Returns the source of a document."
+      "description":"Returns the source of a document.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -2,7 +2,8 @@
   "index":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
-      "description":"Creates or updates a document in an index."
+      "description":"Creates or updates a document in an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -2,7 +2,8 @@
   "indices.analyze":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-analyze.html",
-      "description":"Performs the analysis process on a text and return the tokens breakdown of the text."
+      "description":"Performs the analysis process on a text and return the tokens breakdown of the text.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -2,7 +2,8 @@
   "indices.clear_cache":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html",
-      "description":"Clears all or specific caches for one or more indices."
+      "description":"Clears all or specific caches for one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
@@ -2,7 +2,8 @@
   "indices.clone": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html",
-      "description": "Clones an index"
+      "description":"Clones an index",
+      "since":"7.4.0"
     },
     "stability": "stable",
     "url": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -2,7 +2,8 @@
   "indices.close":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
-      "description":"Closes an index."
+      "description":"Closes an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -2,7 +2,8 @@
   "indices.create":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html",
-      "description":"Creates an index with optional settings and mappings."
+      "description":"Creates an index with optional settings and mappings.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -2,7 +2,8 @@
   "indices.delete":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html",
-      "description":"Deletes an index."
+      "description":"Deletes an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
@@ -2,7 +2,8 @@
   "indices.delete_alias":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
-      "description":"Deletes an alias."
+      "description":"Deletes an alias.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -2,7 +2,8 @@
   "indices.delete_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
-      "description":"Deletes an index template."
+      "description":"Deletes an index template.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -2,7 +2,8 @@
   "indices.exists":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html",
-      "description":"Returns information about whether a particular index exists."
+      "description":"Returns information about whether a particular index exists.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -2,7 +2,8 @@
   "indices.exists_alias":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
-      "description":"Returns information about whether a particular alias exists."
+      "description":"Returns information about whether a particular alias exists.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -2,7 +2,8 @@
   "indices.exists_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
-      "description":"Returns information about whether a particular index template exists."
+      "description":"Returns information about whether a particular index template exists.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
@@ -2,7 +2,8 @@
   "indices.exists_type":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-types-exists.html",
-      "description":"Returns information about whether a particular document type exists. (DEPRECATED)"
+      "description":"Returns information about whether a particular document type exists. (DEPRECATED)",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
@@ -2,7 +2,8 @@
   "indices.flush":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-flush.html",
-      "description":"Performs the flush operation on one or more indices."
+      "description":"Performs the flush operation on one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json
@@ -2,7 +2,8 @@
   "indices.flush_synced":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html",
-      "description":"Performs a synced flush operation on one or more indices."
+      "description":"Performs a synced flush operation on one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -2,7 +2,8 @@
   "indices.forcemerge":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-forcemerge.html",
-      "description":"Performs the force merge operation on one or more indices."
+      "description":"Performs the force merge operation on one or more indices.",
+      "since":"2.1.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -2,7 +2,8 @@
   "indices.get":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html",
-      "description":"Returns information about one or more indices."
+      "description":"Returns information about one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -2,7 +2,8 @@
   "indices.get_alias":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
-      "description":"Returns an alias."
+      "description":"Returns an alias.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -2,7 +2,8 @@
   "indices.get_field_mapping":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html",
-      "description":"Returns mapping for one or more fields."
+      "description":"Returns mapping for one or more fields.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -2,7 +2,8 @@
   "indices.get_mapping":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html",
-      "description":"Returns mappings for one or more indices."
+      "description":"Returns mappings for one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -2,7 +2,8 @@
   "indices.get_settings":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html",
-      "description":"Returns settings for one or more indices."
+      "description":"Returns settings for one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -2,7 +2,8 @@
   "indices.get_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
-      "description":"Returns an index template."
+      "description":"Returns an index template.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
@@ -2,7 +2,8 @@
   "indices.get_upgrade":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
-      "description":"The _upgrade API is no longer useful and will be removed."
+      "description":"The _upgrade API is no longer useful and will be removed.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -2,7 +2,8 @@
   "indices.open":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html",
-      "description":"Opens an index."
+      "description":"Opens an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -2,7 +2,8 @@
   "indices.put_alias":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
-      "description":"Creates or updates an alias."
+      "description":"Creates or updates an alias.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -2,7 +2,8 @@
   "indices.put_mapping":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html",
-      "description":"Updates the index mappings."
+      "description":"Updates the index mappings.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -2,7 +2,8 @@
   "indices.put_settings":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html",
-      "description":"Updates the index settings."
+      "description":"Updates the index settings.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -2,7 +2,8 @@
   "indices.put_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
-      "description":"Creates or updates an index template."
+      "description":"Creates or updates an index template.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -2,7 +2,8 @@
   "indices.recovery":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html",
-      "description":"Returns information about ongoing index shard recoveries."
+      "description":"Returns information about ongoing index shard recoveries.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
@@ -2,7 +2,8 @@
   "indices.refresh":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html",
-      "description":"Performs the refresh operation in one or more indices."
+      "description":"Performs the refresh operation in one or more indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -2,7 +2,8 @@
   "indices.rollover":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-rollover-index.html",
-      "description":"Updates an alias to point to a new index when the existing index\nis considered to be too large or too old."
+      "description":"Updates an alias to point to a new index when the existing index\nis considered to be too large or too old.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -2,7 +2,8 @@
   "indices.segments":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html",
-      "description":"Provides low-level information about segments in a Lucene index."
+      "description":"Provides low-level information about segments in a Lucene index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -2,7 +2,8 @@
   "indices.shard_stores":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html",
-      "description":"Provides store information for shard copies of indices."
+      "description":"Provides store information for shard copies of indices.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -2,7 +2,8 @@
   "indices.shrink":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shrink-index.html",
-      "description":"Allow to shrink an existing index into a new index with fewer primary shards."
+      "description":"Allow to shrink an existing index into a new index with fewer primary shards.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -2,7 +2,8 @@
   "indices.split":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-split-index.html",
-      "description":"Allows you to split an existing index into a new index with more primary shards."
+      "description":"Allows you to split an existing index into a new index with more primary shards.",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -2,7 +2,8 @@
   "indices.stats":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html",
-      "description":"Provides statistics on operations happening in an index."
+      "description":"Provides statistics on operations happening in an index.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
@@ -2,7 +2,8 @@
   "indices.update_aliases":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html",
-      "description":"Updates index aliases."
+      "description":"Updates index aliases.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -2,7 +2,8 @@
   "indices.upgrade":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
-      "description":"The _upgrade API is no longer useful and will be removed."
+      "description":"The _upgrade API is no longer useful and will be removed.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -2,7 +2,8 @@
   "indices.validate_query":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html",
-      "description":"Allows a user to validate a potentially expensive query without executing it."
+      "description":"Allows a user to validate a potentially expensive query without executing it.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/info.json
@@ -2,7 +2,8 @@
   "info":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html",
-      "description":"Returns basic information about the cluster."
+      "description":"Returns basic information about the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -2,7 +2,8 @@
   "ingest.delete_pipeline":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html",
-      "description":"Deletes a pipeline."
+      "description":"Deletes a pipeline.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -2,7 +2,8 @@
   "ingest.get_pipeline":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html",
-      "description":"Returns a pipeline."
+      "description":"Returns a pipeline.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
@@ -2,7 +2,8 @@
   "ingest.processor_grok":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/grok-processor.html#grok-processor-rest-get",
-      "description":"Returns a list of the built-in patterns."
+      "description":"Returns a list of the built-in patterns.",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -2,7 +2,8 @@
   "ingest.put_pipeline":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/put-pipeline-api.html",
-      "description":"Creates or updates a pipeline."
+      "description":"Creates or updates a pipeline.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
@@ -2,7 +2,8 @@
   "ingest.simulate":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html",
-      "description":"Allows to simulate a pipeline with example documents."
+      "description":"Allows to simulate a pipeline with example documents.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -2,7 +2,8 @@
   "mget":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-get.html",
-      "description":"Allows to get multiple documents in one request."
+      "description":"Allows to get multiple documents in one request.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -2,7 +2,8 @@
   "msearch":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-multi-search.html",
-      "description":"Allows to execute several search operations in one request."
+      "description":"Allows to execute several search operations in one request.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -2,7 +2,8 @@
   "msearch_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html",
-      "description":"Allows to execute several search template operations in one request."
+      "description":"Allows to execute several search template operations in one request.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -2,7 +2,8 @@
   "mtermvectors":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html",
-      "description":"Returns multiple termvectors in one request."
+      "description":"Returns multiple termvectors in one request.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -2,7 +2,8 @@
   "nodes.hot_threads":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-hot-threads.html",
-      "description":"Returns information about hot threads on each node in the cluster."
+      "description":"Returns information about hot threads on each node in the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
@@ -2,7 +2,8 @@
   "nodes.info":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-info.html",
-      "description":"Returns information about nodes in the cluster."
+      "description":"Returns information about nodes in the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -2,7 +2,8 @@
   "nodes.reload_secure_settings":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings",
-      "description":"Reloads secure settings."
+      "description":"Reloads secure settings.",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -2,7 +2,8 @@
   "nodes.stats":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-stats.html",
-      "description":"Returns statistical information about nodes in the cluster."
+      "description":"Returns statistical information about nodes in the cluster.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -2,7 +2,8 @@
   "nodes.usage":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-nodes-usage.html",
-      "description":"Returns low-level information about REST actions usage on nodes."
+      "description":"Returns low-level information about REST actions usage on nodes.",
+      "since":"6.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
@@ -2,7 +2,8 @@
   "ping":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html",
-      "description":"Returns whether the cluster is running."
+      "description":"Returns whether the cluster is running.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -2,7 +2,8 @@
   "put_script":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
-      "description":"Creates or updates a script."
+      "description":"Creates or updates a script.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -2,7 +2,8 @@
   "rank_eval":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html",
-      "description":"Allows to evaluate the quality of ranked search results over a set of typical search queries"
+      "description":"Allows to evaluate the quality of ranked search results over a set of typical search queries",
+      "since":"6.2.0"
     },
     "stability":"experimental",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -2,7 +2,8 @@
   "reindex":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html",
-      "description":"Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."
+      "description":"Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster.",
+      "since":"2.3.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -2,7 +2,8 @@
   "reindex_rethrottle":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html",
-      "description":"Changes the number of requests per second for a particular Reindex operation."
+      "description":"Changes the number of requests per second for a particular Reindex operation.",
+      "since":"2.4.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
@@ -2,7 +2,8 @@
   "render_search_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#_validating_templates",
-      "description":"Allows to use the Mustache language to pre-render a search definition."
+      "description":"Allows to use the Mustache language to pre-render a search definition.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
@@ -2,7 +2,8 @@
   "scripts_painless_execute":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html",
-      "description":"Allows an arbitrary script to be executed and a result to be returned"
+      "description":"Allows an arbitrary script to be executed and a result to be returned",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -2,7 +2,8 @@
   "scroll":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#request-body-search-scroll",
-      "description":"Allows to retrieve a large numbers of results from a single search request."
+      "description":"Allows to retrieve a large numbers of results from a single search request.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -2,7 +2,8 @@
   "search":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html",
-      "description":"Returns results matching a query."
+      "description":"Returns results matching a query.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -2,7 +2,8 @@
   "search_shards":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/search-shards.html",
-      "description":"Returns information about the indices and shards that a search request would be executed against."
+      "description":"Returns information about the indices and shards that a search request would be executed against.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -2,7 +2,8 @@
   "search_template":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
-      "description":"Allows to use the Mustache language to pre-render a search definition."
+      "description":"Allows to use the Mustache language to pre-render a search definition.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
@@ -2,7 +2,8 @@
   "snapshot.cleanup_repository": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description": "Removes stale data from repository."
+      "description":"Removes stale data from repository.",
+      "since":"7.4.0"
     },
     "stability": "stable",
     "url": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
@@ -2,7 +2,8 @@
   "snapshot.create":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Creates a snapshot in a repository."
+      "description":"Creates a snapshot in a repository.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
@@ -2,7 +2,8 @@
   "snapshot.create_repository":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Creates a repository."
+      "description":"Creates a repository.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
@@ -2,7 +2,8 @@
   "snapshot.delete":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Deletes a snapshot."
+      "description":"Deletes a snapshot.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -2,7 +2,8 @@
   "snapshot.delete_repository":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Deletes a repository."
+      "description":"Deletes a repository.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -2,7 +2,8 @@
   "snapshot.get":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Returns information about a snapshot."
+      "description":"Returns information about a snapshot.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
@@ -2,7 +2,8 @@
   "snapshot.get_repository":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Returns information about a repository."
+      "description":"Returns information about a repository.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
@@ -2,7 +2,8 @@
   "snapshot.restore":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Restores a snapshot."
+      "description":"Restores a snapshot.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
@@ -2,7 +2,8 @@
   "snapshot.status":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Returns information about the status of a snapshot."
+      "description":"Returns information about the status of a snapshot.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
@@ -2,7 +2,8 @@
   "snapshot.verify_repository":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Verifies a repository."
+      "description":"Verifies a repository.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -2,7 +2,8 @@
   "tasks.cancel":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
-      "description":"Cancels a task, if it can be cancelled through an API."
+      "description":"Cancels a task, if it can be cancelled through an API.",
+      "since":"2.3.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -2,7 +2,8 @@
   "tasks.get":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
-      "description":"Returns information about a task."
+      "description":"Returns information about a task.",
+      "since":"5.0.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -2,7 +2,8 @@
   "tasks.list":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html",
-      "description":"Returns a list of tasks."
+      "description":"Returns a list of tasks.",
+      "since":"2.3.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -2,7 +2,8 @@
   "termvectors":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html",
-      "description":"Returns information and statistics about terms in the fields of a particular document."
+      "description":"Returns information and statistics about terms in the fields of a particular document.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -2,7 +2,8 @@
   "update":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update.html",
-      "description":"Updates a document with a script or partial document."
+      "description":"Updates a document with a script or partial document.",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -2,7 +2,8 @@
   "update_by_query":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html",
-      "description":"Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
+      "description":"Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change.",
+      "since":"2.4.0"
     },
     "stability":"stable",
     "url":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
@@ -2,7 +2,8 @@
   "update_by_query_rethrottle":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html",
-      "description":"Changes the number of requests per second for a particular Update By Query operation."
+      "description":"Changes the number of requests per second for a particular Update By Query operation.",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
@@ -1,7 +1,8 @@
 {
   "ccr.delete_auto_follow_pattern":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-delete-auto-follow-pattern.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow.json
@@ -1,7 +1,8 @@
 {
   "ccr.follow":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-follow.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_info.json
@@ -1,7 +1,8 @@
 {
   "ccr.follow_info":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-info.html",
+      "since":"6.7.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_stats.json
@@ -1,7 +1,8 @@
 {
   "ccr.follow_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-follow-stats.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.forget_follower.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.forget_follower.json
@@ -1,7 +1,8 @@
 {
   "ccr.forget_follower":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current",
+      "since":"6.7.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
@@ -1,7 +1,8 @@
 {
   "ccr.get_auto_follow_pattern":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-auto-follow-pattern.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_auto_follow_pattern.json
@@ -1,7 +1,8 @@
 {
   "ccr.pause_auto_follow_pattern":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-pause-auto-follow-pattern.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-pause-auto-follow-pattern.html",
+      "since":"7.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_follow.json
@@ -1,7 +1,8 @@
 {
   "ccr.pause_follow":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-pause-follow.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
@@ -1,7 +1,8 @@
 {
   "ccr.put_auto_follow_pattern":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-put-auto-follow-pattern.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_auto_follow_pattern.json
@@ -1,7 +1,8 @@
 {
   "ccr.resume_auto_follow_pattern":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-resume-auto-follow-pattern.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-resume-auto-follow-pattern.html",
+      "since":"7.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_follow.json
@@ -1,7 +1,8 @@
 {
   "ccr.resume_follow":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-post-resume-follow.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
@@ -1,7 +1,8 @@
 {
   "ccr.stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-get-stats.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow.json
@@ -1,7 +1,8 @@
 {
   "ccr.unfollow":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.delete_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.delete_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.delete_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.get_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform_stats.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.get_transform_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.preview_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.preview_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.preview_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.put_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.put_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.put_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.start_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.start_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.start_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.stop_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.stop_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.stop_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.update_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.update_transform.json
@@ -1,7 +1,8 @@
 {
   "data_frame_transform_deprecated.update_transform": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html",
+      "since":"7.5.0"
     },
     "stability": "beta",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.delete_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.delete_policy.json
@@ -1,6 +1,9 @@
 {
   "enrich.delete_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-delete-policy.html",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-delete-policy.html",
+      "since": "7.5.0"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
@@ -1,6 +1,9 @@
 {
   "enrich.execute_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-execute-policy.html",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-execute-policy.html",
+      "since": "7.5.0"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
@@ -1,6 +1,9 @@
 {
   "enrich.get_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-get-policy.html",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-get-policy.html",
+      "since": "7.5.0"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.put_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.put_policy.json
@@ -1,6 +1,9 @@
 {
   "enrich.put_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-put-policy.html",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-put-policy.html",
+      "since": "7.5.0"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.stats.json
@@ -1,6 +1,9 @@
 {
   "enrich.stats": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats.html",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats.html",
+      "since": "7.5.0"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/graph.explore.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/graph.explore.json
@@ -1,7 +1,8 @@
 {
   "graph.explore":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "ilm.delete_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "ilm.explain_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "ilm.get_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_status.json
@@ -1,7 +1,8 @@
 {
   "ilm.get_status":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-status.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.move_to_step.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.move_to_step.json
@@ -1,7 +1,8 @@
 {
   "ilm.move_to_step":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "ilm.put_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
@@ -1,7 +1,8 @@
 {
   "ilm.remove_policy":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-remove-policy.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.retry.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.retry.json
@@ -1,7 +1,8 @@
 {
   "ilm.retry":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-retry-policy.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.start.json
@@ -1,7 +1,8 @@
 {
   "ilm.start":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-start.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.stop.json
@@ -1,7 +1,8 @@
 {
   "ilm.stop":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-stop.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
@@ -1,7 +1,8 @@
 {
   "indices.freeze":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
@@ -1,7 +1,8 @@
 {
   "indices.reload_search_analyzers":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
@@ -1,7 +1,8 @@
 {
   "indices.unfreeze":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen.html",
+      "since":"6.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.delete.json
@@ -1,7 +1,8 @@
 {
   "license.delete":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-license.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
@@ -1,7 +1,8 @@
 {
   "license.get":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_basic_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_basic_status.json
@@ -1,7 +1,8 @@
 {
   "license.get_basic_status":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-basic-status.html",
+      "since":"6.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_trial_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_trial_status.json
@@ -1,7 +1,8 @@
 {
   "license.get_trial_status":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/get-trial-status.html",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post.json
@@ -1,7 +1,8 @@
 {
   "license.post":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/update-license.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_basic.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_basic.json
@@ -1,7 +1,8 @@
 {
   "license.post_start_basic":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html",
+      "since":"6.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_trial.json
@@ -1,7 +1,8 @@
 {
   "license.post_start_trial":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/migration.deprecations.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/migration.deprecations.json
@@ -1,7 +1,8 @@
 {
   "migration.deprecations":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/migration-api-deprecation.html",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
@@ -1,7 +1,8 @@
 {
   "ml.close_job":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_calendar":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_event.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_event.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_calendar_event":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_job.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_calendar_job":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_data_frame_analytics.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_data_frame_analytics":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_datafeed.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_datafeed":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_expired_data":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_filter.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_filter":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_forecast.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_forecast.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_forecast":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_job.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_job":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_model_snapshot.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_model_snapshot":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_trained_model.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_trained_model.json
@@ -1,7 +1,8 @@
 {
   "ml.delete_trained_model":{
     "documentation":{
-      "url":"TODO"
+      "url":"TODO",
+      "since":"7.6.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.evaluate_data_frame.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.evaluate_data_frame.json
@@ -1,7 +1,8 @@
 {
   "ml.evaluate_data_frame":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.explain_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.explain_data_frame_analytics.json
@@ -1,7 +1,8 @@
 {
   "ml.explain_data_frame_analytics": {
     "documentation": {
-      "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html",
+      "since":"7.6.0"
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.find_file_structure.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.find_file_structure.json
@@ -1,7 +1,8 @@
 {
   "ml.find_file_structure":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-find-file-structure.html",
+      "since":"6.5.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.flush_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.flush_job.json
@@ -1,7 +1,8 @@
 {
   "ml.flush_job":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.forecast.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.forecast.json
@@ -1,7 +1,8 @@
 {
   "ml.forecast":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_buckets.json
@@ -1,7 +1,8 @@
 {
   "ml.get_buckets":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendar_events.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendar_events.json
@@ -1,7 +1,8 @@
 {
   "ml.get_calendar_events":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
@@ -1,7 +1,8 @@
 {
   "ml.get_calendars":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_categories.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_categories.json
@@ -1,7 +1,8 @@
 {
   "ml.get_categories":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
@@ -1,7 +1,8 @@
 {
   "ml.get_data_frame_analytics":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics_stats.json
@@ -1,7 +1,8 @@
 {
   "ml.get_data_frame_analytics_stats":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -1,7 +1,8 @@
 {
   "ml.get_datafeed_stats":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -1,7 +1,8 @@
 {
   "ml.get_datafeeds":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_filters.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_filters.json
@@ -1,7 +1,8 @@
 {
   "ml.get_filters":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_influencers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_influencers.json
@@ -1,7 +1,8 @@
 {
   "ml.get_influencers":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -1,7 +1,8 @@
 {
   "ml.get_job_stats":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -1,7 +1,8 @@
 {
   "ml.get_jobs":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_model_snapshots.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_model_snapshots.json
@@ -1,7 +1,8 @@
 {
   "ml.get_model_snapshots":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -1,7 +1,8 @@
 {
   "ml.get_overall_buckets":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html",
+      "since":"6.1.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_records.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_records.json
@@ -1,7 +1,8 @@
 {
   "ml.get_records":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
@@ -1,7 +1,8 @@
 {
   "ml.get_trained_models":{
     "documentation":{
-      "url":"TODO"
+      "url":"TODO",
+      "since":"7.6.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models_stats.json
@@ -1,7 +1,8 @@
 {
   "ml.get_trained_models_stats":{
     "documentation":{
-      "url":"TODO"
+      "url":"TODO",
+      "since":"7.6.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.info.json
@@ -1,7 +1,8 @@
 {
   "ml.info":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.open_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.open_job.json
@@ -1,7 +1,8 @@
 {
   "ml.open_job":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_calendar_events.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_calendar_events.json
@@ -1,7 +1,8 @@
 {
   "ml.post_calendar_events":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_data.json
@@ -1,7 +1,8 @@
 {
   "ml.post_data":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -1,7 +1,8 @@
 {
   "ml.preview_datafeed":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar.json
@@ -1,7 +1,8 @@
 {
   "ml.put_calendar":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar_job.json
@@ -1,7 +1,8 @@
 {
   "ml.put_calendar_job":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_data_frame_analytics.json
@@ -1,7 +1,8 @@
 {
   "ml.put_data_frame_analytics":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -1,7 +1,8 @@
 {
   "ml.put_datafeed":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_filter.json
@@ -1,7 +1,8 @@
 {
   "ml.put_filter":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_job.json
@@ -1,7 +1,8 @@
 {
   "ml.put_job":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.revert_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.revert_model_snapshot.json
@@ -1,7 +1,8 @@
 {
   "ml.revert_model_snapshot":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.set_upgrade_mode.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.set_upgrade_mode.json
@@ -1,7 +1,8 @@
 {
   "ml.set_upgrade_mode":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html",
+      "since":"6.7.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
@@ -1,7 +1,8 @@
 {
   "ml.start_data_frame_analytics":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -1,7 +1,8 @@
 {
   "ml.start_datafeed":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
@@ -1,7 +1,8 @@
 {
   "ml.stop_data_frame_analytics":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html",
+      "since":"7.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -1,7 +1,8 @@
 {
   "ml.stop_datafeed":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -1,7 +1,8 @@
 {
   "ml.update_datafeed":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_filter.json
@@ -1,7 +1,8 @@
 {
   "ml.update_filter":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"6.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_job.json
@@ -1,7 +1,8 @@
 {
   "ml.update_job":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_model_snapshot.json
@@ -1,7 +1,8 @@
 {
   "ml.update_model_snapshot":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html",
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
@@ -1,7 +1,8 @@
 {
   "ml.validate":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
@@ -1,7 +1,8 @@
 {
   "ml.validate_detector":{
     "documentation":{
-      "url":null
+      "url":null,
+      "since":"5.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
@@ -1,7 +1,8 @@
 {
   "monitoring.bulk":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html",
+      "since":null
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.delete_job.json
@@ -1,7 +1,8 @@
 {
   "rollup.delete_job":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_jobs.json
@@ -1,7 +1,8 @@
 {
   "rollup.get_jobs":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_caps.json
@@ -1,7 +1,8 @@
 {
   "rollup.get_rollup_caps":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
@@ -1,7 +1,8 @@
 {
   "rollup.get_rollup_index_caps":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.4.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.put_job.json
@@ -1,7 +1,8 @@
 {
   "rollup.put_job":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -1,7 +1,8 @@
 {
   "rollup.rollup_search":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.start_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.start_job.json
@@ -1,7 +1,8 @@
 {
   "rollup.start_job":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.stop_job.json
@@ -1,7 +1,8 @@
 {
   "rollup.stop_job":{
     "documentation":{
-      "url":""
+      "url":"",
+      "since":"6.3.0"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.authenticate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.authenticate.json
@@ -1,7 +1,8 @@
 {
   "security.authenticate":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.change_password.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.change_password.json
@@ -1,7 +1,8 @@
 {
   "security.change_password":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-change-password.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
@@ -1,7 +1,8 @@
 {
   "security.clear_cached_realms":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-cache.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
@@ -1,7 +1,8 @@
 {
   "security.clear_cached_roles":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-role-cache.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.create_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.create_api_key.json
@@ -1,7 +1,8 @@
 {
   "security.create_api_key":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html",
+      "since":"6.7.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_privileges.json
@@ -1,7 +1,8 @@
 {
   "security.delete_privileges":{
     "documentation":{
-      "url":"TODO"
+      "url":"TODO",
+      "since":"6.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role.json
@@ -1,7 +1,8 @@
 {
   "security.delete_role":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role_mapping.json
@@ -1,7 +1,8 @@
 {
   "security.delete_role_mapping":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role-mapping.html",
+      "since":"5.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_user.json
@@ -1,7 +1,8 @@
 {
   "security.delete_user":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-user.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
@@ -1,7 +1,8 @@
 {
   "security.disable_user":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-disable-user.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
@@ -1,7 +1,8 @@
 {
   "security.enable_user":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-enable-user.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
@@ -1,7 +1,8 @@
 {
   "security.get_api_key":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html",
+      "since":"6.7.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_builtin_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_builtin_privileges.json
@@ -1,7 +1,8 @@
 {
   "security.get_builtin_privileges":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html",
+      "since":"7.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
@@ -1,7 +1,8 @@
 {
   "security.get_privileges":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html",
+      "since":"6.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
@@ -1,7 +1,8 @@
 {
   "security.get_role":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
@@ -1,7 +1,8 @@
 {
   "security.get_role_mapping":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html",
+      "since":"5.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_token.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_token.json
@@ -1,7 +1,8 @@
 {
   "security.get_token":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html",
+      "since":"5.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user.json
@@ -1,7 +1,8 @@
 {
   "security.get_user":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user_privileges.json
@@ -1,7 +1,8 @@
 {
   "security.get_user_privileges":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-privileges.html",
+      "since":"6.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.has_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.has_privileges.json
@@ -1,7 +1,8 @@
 {
   "security.has_privileges":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html",
+      "since":"6.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_api_key.json
@@ -1,7 +1,8 @@
 {
   "security.invalidate_api_key":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html",
+      "since":"6.7.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_token.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_token.json
@@ -1,7 +1,8 @@
 {
   "security.invalidate_token":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-token.html",
+      "since":"5.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_privileges.json
@@ -1,7 +1,8 @@
 {
   "security.put_privileges":{
     "documentation":{
-      "url":"TODO"
+      "url":"TODO",
+      "since":"6.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role.json
@@ -1,7 +1,8 @@
 {
   "security.put_role":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role_mapping.json
@@ -1,7 +1,8 @@
 {
   "security.put_role_mapping":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html",
+      "since":"5.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_user.json
@@ -1,7 +1,8 @@
 {
   "security.put_user":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.delete_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.delete_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "slm.delete_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-delete.html",
+      "since":"7.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "slm.execute_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html",
+      "since":"7.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_retention.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_retention.json
@@ -1,7 +1,8 @@
 {
   "slm.execute_retention":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-retention.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-retention.html",
+      "since":"7.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "slm.get_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html",
+      "since":"7.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
@@ -1,7 +1,8 @@
 {
   "slm.get_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/slm-get-stats.html",
+      "since":"7.5.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
@@ -1,7 +1,8 @@
 {
   "slm.get_status":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html",
+      "since":"7.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -1,7 +1,8 @@
 {
   "slm.put_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-put.html",
+      "since":"7.4.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
@@ -1,7 +1,8 @@
 {
   "slm.start":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html",
+      "since":"7.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
@@ -1,7 +1,8 @@
 {
   "slm.stop":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html",
+      "since":"7.6.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.clear_cursor.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.clear_cursor.json
@@ -1,7 +1,8 @@
 {
   "sql.clear_cursor":{
     "documentation":{
-      "url":"Clear SQL cursor"
+      "url":"Clear SQL cursor",
+      "since":"6.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.query.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.query.json
@@ -1,7 +1,8 @@
 {
   "sql.query":{
     "documentation":{
-      "url":"Execute SQL"
+      "url":"Execute SQL",
+      "since":"6.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
@@ -1,7 +1,8 @@
 {
   "sql.translate":{
     "documentation":{
-      "url":"Translate SQL into Elasticsearch queries"
+      "url":"Translate SQL into Elasticsearch queries",
+      "since":"6.3.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ssl.certificates.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ssl.certificates.json
@@ -1,7 +1,8 @@
 {
   "ssl.certificates":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-ssl.html",
+      "since":"6.2.0"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.delete_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.delete_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.delete_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.get_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -1,7 +1,8 @@
 {
   "transform.get_transform_stats":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.preview_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.preview_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.preview_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.put_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.put_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.put_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.start_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.start_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.start_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.stop_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.stop_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.stop_transform":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-transform.html",
+      "since":"7.5.0"
     },
     "stability":"beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.update_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.update_transform.json
@@ -1,7 +1,8 @@
 {
   "transform.update_transform": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html",
+      "since":"7.5.0"
     },
     "stability": "beta",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.ack_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.ack_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.ack_watch":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-ack-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.activate_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.activate_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.activate_watch":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-activate-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.deactivate_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.deactivate_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.deactivate_watch":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-deactivate-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.delete_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.delete_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.delete_watch":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-delete-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.execute_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.execute_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.execute_watch":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.get_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.get_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.get_watch":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-get-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.put_watch.json
@@ -1,7 +1,8 @@
 {
   "watcher.put_watch":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-put-watch.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.start.json
@@ -1,7 +1,8 @@
 {
   "watcher.start":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-start.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
@@ -1,7 +1,8 @@
 {
   "watcher.stats":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stats.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stop.json
@@ -1,7 +1,8 @@
 {
   "watcher.stop":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-stop.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
@@ -1,7 +1,8 @@
 {
   "xpack.info":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html",
+      "since":null
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.usage.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.usage.json
@@ -1,7 +1,8 @@
 {
   "xpack.usage":{
     "documentation":{
-      "url":"Retrieve information about xpack features usage"
+      "url":"Retrieve information about xpack features usage",
+      "since":null
     },
     "stability":"stable",
     "url":{


### PR DESCRIPTION
Hello team!
This pr introduces a new field in the JSON spec, the field name is `since`. As you can imagine, the field will show in which version of Elasticsearch an API has been added.
Our customers would benefit immensely from this addition as we could include this information in client documentation and the method's docblock's.

For now, there are a few caveats. For the OSS APIs the lowest version you can find is `v2.1.0`, because the JSON spec has been introduced in `v2.0.0` and we can't be sure when an API has been introduced before that version *(without manually checking the source code)*.
The same applies to the xPack APIs, which are tracked from `v5.4.0` and above. Where we can't define when an API has been introduced, you will find `null` instead of the version number.

Example:
```json
{
  "indices.clone": {
    "documentation": {
      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html",
      "description": "Clones an index",
      "since": "7.4.0"
    },
...
```
```json
{
  "bulk": {
    "documentation": {
      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html",
      "description": "Allows to perform multiple index/update/delete operations in a single request.",
      "since": null
    },
...
```

We know that supporting this additional field could be uncomfortable when writing the JSON spec, but we think that it's very useful, and the resulting documentation quality will improve.

cc @elastic/es-clients 