### PR TITLE
[docs] clarify which fields 'index_options' setting applies to

### DIFF
--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -28,6 +28,8 @@ following settings:
     offsets (which map the term back to the original string) are indexed.
     Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
+NOTE: This setting only applies to `text` fields.
+
 NOTE: <<number,Numeric fields>> don't support the `index_options` parameter any longer.
 
 <<mapping-index,Analyzed>> string fields use `positions` as the default, and


### PR DESCRIPTION
Heya,

I spent some time today down a rabbit hole that is `index_options`, not understanding why I was able to set them on a `keyword` field, but when I do a `GET mapping` call the property is unset for the field.

It seems to me (and I could very well be wrong about this) that the `index_options` property only really applies to `text` fields?
If you set it to a value such as `"index_options": "doc"` for `keyword` fields and then retrieve the mapping it seems that the value wasn't actually set:

```bash
curl -s -XDELETE "http://localhost:9200/foo?pretty=true"
curl -s -XPUT "http://localhost:9200/foo"

curl -s -XPUT "http://localhost:9200/foo/_mapping/_doc?pretty=true" \
  -H 'Content-Type: application/json' \
  -d '{
      "properties": {
        "bar": {
          "type": "keyword",
          "index_options": "docs"
        }
      }
    }'

curl -s -XGET "http://localhost:9200/foo/_mapping?pretty=true"
```

```js
{
  "foo" : {
    "mappings" : {
      "_doc" : {
        "properties" : {
          "bar" : {
            "type" : "keyword"
          }
        }
      }
    }
  }
}
```

However, this works as expected for `text` fields:

```bash
curl -s -XDELETE "http://localhost:9200/foo?pretty=true"
curl -s -XPUT "http://localhost:9200/foo"

curl -s -XPUT "http://localhost:9200/foo/_mapping/_doc?pretty=true" \
  -H 'Content-Type: application/json' \
  -d '{
      "properties": {
        "bar": {
          "type": "text",
          "index_options": "docs"
        }
      }
    }'

curl -s -XGET "http://localhost:9200/foo/_mapping?pretty=true"
```

```js
{
  "foo" : {
    "mappings" : {
      "_doc" : {
        "properties" : {
          "bar" : {
            "type" : "text",
            "index_options" : "docs"
          }
        }
      }
    }
  }
}
```

It seems that `keyword` fields have `freqs`, `positions` and `offsets` disabled by default, which is great and what I was trying to achieve :+1:

I opened this issue to highlight that it's not clear from the documentation which field types this setting applies to, and if it's only applicable to `text` fields then it might be nice to mention that explicitly in the docs?