### PR TITLE
[7.x] [ML][Inference] Simplify inference processor options (#50105)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
@@ -41,7 +41,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
         private final boolean previouslyLicensed;
 
         public Request(String modelId, boolean previouslyLicensed) {
-            this(modelId, Collections.emptyList(), new RegressionConfig(), previouslyLicensed);
+            this(modelId, Collections.emptyList(), RegressionConfig.EMPTY_PARAMS, previouslyLicensed);
         }
 
         public Request(String modelId,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
@@ -7,11 +7,9 @@ package org.elasticsearch.xpack.core.ml.inference.results;
 
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
-import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
-public interface InferenceResults extends NamedXContentObject, NamedWriteable {
+public interface InferenceResults extends NamedWriteable {
 
-    void writeResult(IngestDocument document, String resultField, InferenceConfig config);
+    void writeResult(IngestDocument document, String parentResultField);
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
@@ -7,9 +7,7 @@ package org.elasticsearch.xpack.core.ml.inference.results;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -32,11 +30,6 @@ public class RawInferenceResults extends SingleValueInferenceResults {
     }
 
     @Override
-    XContentBuilder innerToXContent(XContentBuilder builder, Params params) {
-        return builder;
-    }
-
-    @Override
     public boolean equals(Object object) {
         if (object == this) { return true; }
         if (object == null || getClass() != object.getClass()) { return false; }
@@ -50,7 +43,7 @@ public class RawInferenceResults extends SingleValueInferenceResults {
     }
 
     @Override
-    public void writeResult(IngestDocument document, String resultField, InferenceConfig config) {
+    public void writeResult(IngestDocument document, String parentResultField) {
         throw new UnsupportedOperationException("[raw] does not support writing inference results");
     }
 
@@ -59,8 +52,4 @@ public class RawInferenceResults extends SingleValueInferenceResults {
         return NAME;
     }
 
-    @Override
-    public String getName() {
-        return NAME;
-    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/SingleValueInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/SingleValueInferenceResults.java
@@ -5,16 +5,12 @@
  */
 package org.elasticsearch.xpack.core.ml.inference.results;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
 public abstract class SingleValueInferenceResults implements InferenceResults {
-
-    public final ParseField VALUE = new ParseField("value");
 
     private final double value;
 
@@ -39,13 +35,4 @@ public abstract class SingleValueInferenceResults implements InferenceResults {
         out.writeDouble(value);
     }
 
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(VALUE.getPreferredName(), value);
-        innerToXContent(builder, params);
-        builder.endObject();
-        return builder;
-    }
-
-    abstract XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException;
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
@@ -21,38 +21,44 @@ public class ClassificationConfig implements InferenceConfig {
 
     public static final String NAME = "classification";
 
-    public static final String DEFAULT_TOP_CLASSES_RESULT_FIELD = "top_classes";
-    public static final ParseField  NUM_TOP_CLASSES = new ParseField("num_top_classes");
-    public static final ParseField  TOP_CLASSES_RESULT_FIELD = new ParseField("top_classes_result_field");
+    public static final String DEFAULT_TOP_CLASSES_RESULTS_FIELD = "top_classes";
+    private static final String DEFAULT_RESULTS_FIELD = "predicted_value";
+    public static final ParseField RESULTS_FIELD = new ParseField("results_field");
+    public static final ParseField NUM_TOP_CLASSES = new ParseField("num_top_classes");
+    public static final ParseField TOP_CLASSES_RESULTS_FIELD = new ParseField("top_classes_results_field");
     private static final Version MIN_SUPPORTED_VERSION = Version.V_7_6_0;
 
-    public static ClassificationConfig EMPTY_PARAMS = new ClassificationConfig(0, DEFAULT_TOP_CLASSES_RESULT_FIELD);
+    public static ClassificationConfig EMPTY_PARAMS = new ClassificationConfig(0, DEFAULT_RESULTS_FIELD, DEFAULT_TOP_CLASSES_RESULTS_FIELD);
 
     private final int numTopClasses;
     private final String topClassesResultsField;
+    private final String resultsField;
 
     public static ClassificationConfig fromMap(Map<String, Object> map) {
         Map<String, Object> options = new HashMap<>(map);
         Integer numTopClasses = (Integer)options.remove(NUM_TOP_CLASSES.getPreferredName());
-        String topClassesResultsField = (String)options.remove(TOP_CLASSES_RESULT_FIELD.getPreferredName());
+        String topClassesResultsField = (String)options.remove(TOP_CLASSES_RESULTS_FIELD.getPreferredName());
+        String resultsField = (String)options.remove(RESULTS_FIELD.getPreferredName());
         if (options.isEmpty() == false) {
             throw ExceptionsHelper.badRequestException("Unrecognized fields {}.", options.keySet());
         }
-        return new ClassificationConfig(numTopClasses, topClassesResultsField);
+        return new ClassificationConfig(numTopClasses, resultsField, topClassesResultsField);
     }
 
     public ClassificationConfig(Integer numTopClasses) {
-        this(numTopClasses, null);
+        this(numTopClasses, null, null);
     }
 
-    public ClassificationConfig(Integer numTopClasses, String topClassesResultsField) {
+    public ClassificationConfig(Integer numTopClasses, String resultsField, String topClassesResultsField) {
         this.numTopClasses = numTopClasses == null ? 0 : numTopClasses;
-        this.topClassesResultsField = topClassesResultsField == null ? DEFAULT_TOP_CLASSES_RESULT_FIELD : topClassesResultsField;
+        this.topClassesResultsField = topClassesResultsField == null ? DEFAULT_TOP_CLASSES_RESULTS_FIELD : topClassesResultsField;
+        this.resultsField = resultsField == null ? DEFAULT_RESULTS_FIELD : resultsField;
     }
 
     public ClassificationConfig(StreamInput in) throws IOException {
         this.numTopClasses = in.readInt();
         this.topClassesResultsField = in.readString();
+        this.resultsField = in.readString();
     }
 
     public int getNumTopClasses() {
@@ -63,10 +69,15 @@ public class ClassificationConfig implements InferenceConfig {
         return topClassesResultsField;
     }
 
+    public String getResultsField() {
+        return resultsField;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeInt(numTopClasses);
         out.writeString(topClassesResultsField);
+        out.writeString(resultsField);
     }
 
     @Override
@@ -74,12 +85,14 @@ public class ClassificationConfig implements InferenceConfig {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ClassificationConfig that = (ClassificationConfig) o;
-        return Objects.equals(numTopClasses, that.numTopClasses) && Objects.equals(topClassesResultsField, that.topClassesResultsField);
+        return Objects.equals(numTopClasses, that.numTopClasses) &&
+            Objects.equals(topClassesResultsField, that.topClassesResultsField) &&
+            Objects.equals(resultsField, that.resultsField);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(numTopClasses, topClassesResultsField);
+        return Objects.hash(numTopClasses, topClassesResultsField, resultsField);
     }
 
     @Override
@@ -88,7 +101,8 @@ public class ClassificationConfig implements InferenceConfig {
         if (numTopClasses != 0) {
             builder.field(NUM_TOP_CLASSES.getPreferredName(), numTopClasses);
         }
-        builder.field(TOP_CLASSES_RESULT_FIELD.getPreferredName(), topClassesResultsField);
+        builder.field(TOP_CLASSES_RESULTS_FIELD.getPreferredName(), topClassesResultsField);
+        builder.field(RESULTS_FIELD.getPreferredName(), resultsField);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -150,7 +150,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
         }
         switch(targetType) {
             case REGRESSION:
-                return new RegressionInferenceResults(outputAggregator.aggregate(processedInferences));
+                return new RegressionInferenceResults(outputAggregator.aggregate(processedInferences), config);
             case CLASSIFICATION:
                 ClassificationConfig classificationConfig = (ClassificationConfig) config;
                 List<ClassificationInferenceResults.TopClassEntry> topClasses = InferenceHelpers.topClasses(
@@ -160,7 +160,8 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
                 double value = outputAggregator.aggregate(processedInferences);
                 return new ClassificationInferenceResults(outputAggregator.aggregate(processedInferences),
                     classificationLabel(value, classificationLabels),
-                    topClasses);
+                    topClasses,
+                    config);
             default:
                 throw new UnsupportedOperationException("unsupported target_type [" + targetType + "] for inference on ensemble model");
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
@@ -153,9 +153,9 @@ public class Tree implements LenientlyParsedTrainedModel, StrictlyParsedTrainedM
                     classificationProbability(value),
                     classificationLabels,
                     classificationConfig.getNumTopClasses());
-                return new ClassificationInferenceResults(value, classificationLabel(value, classificationLabels), topClasses);
+                return new ClassificationInferenceResults(value, classificationLabel(value, classificationLabels), topClasses, config);
             case REGRESSION:
-                return new RegressionInferenceResults(value);
+                return new RegressionInferenceResults(value, config);
             default:
                 throw new UnsupportedOperationException("unsupported target_type [" + targetType + "] for inference on tree model");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigTests;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,7 +29,8 @@ public class ClassificationInferenceResultsTests extends AbstractWireSerializing
             randomBoolean() ? null :
                 Stream.generate(ClassificationInferenceResultsTests::createRandomClassEntry)
                     .limit(randomIntBetween(0, 10))
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toList()),
+            ClassificationConfigTests.randomClassificationConfig());
     }
 
     private static ClassificationInferenceResults.TopClassEntry createRandomClassEntry() {
@@ -36,19 +38,23 @@ public class ClassificationInferenceResultsTests extends AbstractWireSerializing
     }
 
     public void testWriteResultsWithClassificationLabel() {
-        ClassificationInferenceResults result = new ClassificationInferenceResults(1.0, "foo", Collections.emptyList());
+        ClassificationInferenceResults result =
+            new ClassificationInferenceResults(1.0, "foo", Collections.emptyList(), ClassificationConfig.EMPTY_PARAMS);
         IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
-        result.writeResult(document, "result_field", ClassificationConfig.EMPTY_PARAMS);
+        result.writeResult(document, "result_field");
 
-        assertThat(document.getFieldValue("result_field", String.class), equalTo("foo"));
+        assertThat(document.getFieldValue("result_field.predicted_value", String.class), equalTo("foo"));
     }
 
     public void testWriteResultsWithoutClassificationLabel() {
-        ClassificationInferenceResults result = new ClassificationInferenceResults(1.0, null, Collections.emptyList());
+        ClassificationInferenceResults result = new ClassificationInferenceResults(1.0,
+            null,
+            Collections.emptyList(),
+            ClassificationConfig.EMPTY_PARAMS);
         IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
-        result.writeResult(document, "result_field", ClassificationConfig.EMPTY_PARAMS);
+        result.writeResult(document, "result_field");
 
-        assertThat(document.getFieldValue("result_field", String.class), equalTo("1.0"));
+        assertThat(document.getFieldValue("result_field.predicted_value", String.class), equalTo("1.0"));
     }
 
     @SuppressWarnings("unchecked")
@@ -59,11 +65,12 @@ public class ClassificationInferenceResultsTests extends AbstractWireSerializing
             new ClassificationInferenceResults.TopClassEntry("baz", 0.1));
         ClassificationInferenceResults result = new ClassificationInferenceResults(1.0,
             "foo",
-            entries);
+            entries,
+            new ClassificationConfig(3, "my_results", "bar"));
         IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
-        result.writeResult(document, "result_field", new ClassificationConfig(3, "bar"));
+        result.writeResult(document, "result_field");
 
-        List<?> list = document.getFieldValue("bar", List.class);
+        List<?> list = document.getFieldValue("result_field.bar", List.class);
         assertThat(list.size(), equalTo(3));
 
         for(int i = 0; i < 3; i++) {
@@ -71,7 +78,7 @@ public class ClassificationInferenceResultsTests extends AbstractWireSerializing
             assertThat(map, equalTo(entries.get(i).asValueMap()));
         }
 
-        assertThat(document.getFieldValue("result_field", String.class), equalTo("foo"));
+        assertThat(document.getFieldValue("result_field.my_results", String.class), equalTo("foo"));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
 
 import java.util.HashMap;
 
@@ -19,15 +20,15 @@ import static org.hamcrest.Matchers.equalTo;
 public class RegressionInferenceResultsTests extends AbstractWireSerializingTestCase<RegressionInferenceResults> {
 
     public static RegressionInferenceResults createRandomResults() {
-        return new RegressionInferenceResults(randomDouble());
+        return new RegressionInferenceResults(randomDouble(), RegressionConfigTests.randomRegressionConfig());
     }
 
     public void testWriteResults() {
-        RegressionInferenceResults result = new RegressionInferenceResults(0.3);
+        RegressionInferenceResults result = new RegressionInferenceResults(0.3, RegressionConfig.EMPTY_PARAMS);
         IngestDocument document = new IngestDocument(new HashMap<>(), new HashMap<>());
-        result.writeResult(document, "result_field", new RegressionConfig());
+        result.writeResult(document, "result_field");
 
-        assertThat(document.getFieldValue("result_field", Double.class), equalTo(0.3));
+        assertThat(document.getFieldValue("result_field.predicted_value", Double.class), equalTo(0.3));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigTests.java
@@ -19,17 +19,20 @@ public class ClassificationConfigTests extends AbstractWireSerializingTestCase<C
 
     public static ClassificationConfig randomClassificationConfig() {
         return new ClassificationConfig(randomBoolean() ? null : randomIntBetween(-1, 10),
-            randomBoolean() ? null : randomAlphaOfLength(10));
+            randomBoolean() ? null : randomAlphaOfLength(10),
+            randomBoolean() ? null : randomAlphaOfLength(10)
+            );
     }
 
     public void testFromMap() {
         ClassificationConfig expected = ClassificationConfig.EMPTY_PARAMS;
         assertThat(ClassificationConfig.fromMap(Collections.emptyMap()), equalTo(expected));
 
-        expected = new ClassificationConfig(3, "foo");
+        expected = new ClassificationConfig(3, "foo", "bar");
         Map<String, Object> configMap = new HashMap<>();
         configMap.put(ClassificationConfig.NUM_TOP_CLASSES.getPreferredName(), 3);
-        configMap.put(ClassificationConfig.TOP_CLASSES_RESULT_FIELD.getPreferredName(), "foo");
+        configMap.put(ClassificationConfig.RESULTS_FIELD.getPreferredName(), "foo");
+        configMap.put(ClassificationConfig.TOP_CLASSES_RESULTS_FIELD.getPreferredName(), "bar");
         assertThat(ClassificationConfig.fromMap(configMap), equalTo(expected));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigTests.java
@@ -10,18 +10,23 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class RegressionConfigTests extends AbstractWireSerializingTestCase<RegressionConfig> {
 
     public static RegressionConfig randomRegressionConfig() {
-        return new RegressionConfig();
+        return new RegressionConfig(randomBoolean() ? null : randomAlphaOfLength(10));
     }
 
     public void testFromMap() {
-        RegressionConfig expected = new RegressionConfig();
-        assertThat(RegressionConfig.fromMap(Collections.emptyMap()), equalTo(expected));
+        RegressionConfig expected = new RegressionConfig("foo");
+        Map<String, Object> config = new HashMap<String, Object>(){{
+            put(RegressionConfig.RESULTS_FIELD.getPreferredName(), "foo");
+        }};
+        assertThat(RegressionConfig.fromMap(config), equalTo(expected));
     }
 
     public void testFromMapWithUnknownField() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -413,12 +413,12 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
         List<Double> featureVector = Arrays.asList(0.4, 0.0);
         Map<String, Object> featureMap = zipObjMap(featureNames, featureVector);
         assertThat(0.9,
-            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         featureVector = Arrays.asList(2.0, 0.7);
         featureMap = zipObjMap(featureNames, featureVector);
         assertThat(0.5,
-            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         // Test with NO aggregator supplied, verifies default behavior of non-weighted sum
         ensemble = Ensemble.builder()
@@ -430,19 +430,19 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
         featureVector = Arrays.asList(0.4, 0.0);
         featureMap = zipObjMap(featureNames, featureVector);
         assertThat(1.8,
-            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         featureVector = Arrays.asList(2.0, 0.7);
         featureMap = zipObjMap(featureNames, featureVector);
         assertThat(1.0,
-            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         featureMap = new HashMap<String, Object>(2) {{
             put("foo", 0.3);
             put("bar", null);
         }};
         assertThat(1.8,
-            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
     }
 
     public void testOperationsEstimations() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/TreeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/TreeTests.java
@@ -118,7 +118,7 @@ public class TreeTests extends AbstractSerializingTestCase<Tree> {
         List<Double> featureVector = Arrays.asList(0.6, 0.0);
         Map<String, Object> featureMap = zipObjMap(featureNames, featureVector); // does not really matter as this is a stump
         assertThat(42.0,
-            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
     }
 
     public void testInfer() {
@@ -138,27 +138,27 @@ public class TreeTests extends AbstractSerializingTestCase<Tree> {
         List<Double> featureVector = Arrays.asList(0.6, 0.0);
         Map<String, Object> featureMap = zipObjMap(featureNames, featureVector);
         assertThat(0.3,
-            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         // This should hit the left child of the left child of the root node
         // i.e. it takes the path left, left
         featureVector = Arrays.asList(0.3, 0.7);
         featureMap = zipObjMap(featureNames, featureVector);
         assertThat(0.1,
-            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         // This should hit the right child of the left child of the root node
         // i.e. it takes the path left, right
         featureVector = Arrays.asList(0.3, 0.9);
         featureMap = zipObjMap(featureNames, featureVector);
         assertThat(0.2,
-            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         // This should still work if the internal values are strings
         List<String> featureVectorStrings = Arrays.asList("0.3", "0.9");
         featureMap = zipObjMap(featureNames, featureVectorStrings);
         assertThat(0.2,
-            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
 
         // This should handle missing values and take the default_left path
         featureMap = new HashMap<String, Object>(2) {{
@@ -166,7 +166,7 @@ public class TreeTests extends AbstractSerializingTestCase<Tree> {
             put("bar", null);
         }};
         assertThat(0.1,
-            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, new RegressionConfig())).value(), 0.00001));
+            closeTo(((SingleValueInferenceResults)tree.infer(featureMap, RegressionConfig.EMPTY_PARAMS)).value(), 0.00001));
     }
 
     public void testTreeClassificationProbability() {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -128,7 +128,8 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
                     .size(0)
                     .trackTotalHits(true)
                     .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.existsQuery("regression_value"))))).get().getHits().getTotalHits().value,
+                        .filter(
+                            QueryBuilders.existsQuery("ml.inference.regression.predicted_value"))))).get().getHits().getTotalHits().value,
             equalTo(20L));
 
         assertThat(client().search(new SearchRequest().indices("index_for_inference_test")
@@ -136,7 +137,12 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
                     .size(0)
                     .trackTotalHits(true)
                     .query(QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.existsQuery("result_class"))))).get().getHits().getTotalHits().value,
+                        .filter(
+                            QueryBuilders.existsQuery("ml.inference.classification.predicted_value")))))
+                .get()
+                .getHits()
+                .getTotalHits()
+                .value,
             equalTo(20L));
 
     }
@@ -147,9 +153,9 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
             "    \"processors\": [\n" +
             "      {\n" +
             "        \"inference\": {\n" +
-            "          \"target_field\": \"result_class\",\n" +
+            "          \"target_field\": \"ml.classification\",\n" +
             "          \"inference_config\": {\"classification\": " +
-            "                {\"num_top_classes\":2, \"top_classes_result_field\": \"result_class_prob\"}},\n" +
+            "                {\"num_top_classes\":2, \"top_classes_results_field\": \"result_class_prob\"}},\n" +
             "          \"model_id\": \"test_classification\",\n" +
             "          \"field_mappings\": {\n" +
             "            \"col1\": \"col1\",\n" +
@@ -161,7 +167,7 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
             "      },\n" +
             "      {\n" +
             "        \"inference\": {\n" +
-            "          \"target_field\": \"regression_value\",\n" +
+            "          \"target_field\": \"ml.regression\",\n" +
             "          \"model_id\": \"test_regression\",\n" +
             "          \"inference_config\": {\"regression\":{}},\n" +
             "          \"field_mappings\": {\n" +
@@ -187,16 +193,17 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
             .prepareSimulatePipeline(new BytesArray(source.getBytes(StandardCharsets.UTF_8)),
                 XContentType.JSON).get();
         SimulateDocumentBaseResult baseResult = (SimulateDocumentBaseResult)response.getResults().get(0);
-        assertThat(baseResult.getIngestDocument().getFieldValue("regression_value", Double.class), equalTo(1.0));
-        assertThat(baseResult.getIngestDocument().getFieldValue("result_class", String.class), equalTo("second"));
-        assertThat(baseResult.getIngestDocument().getFieldValue("result_class_prob", List.class).size(), equalTo(2));
+        assertThat(baseResult.getIngestDocument().getFieldValue("ml.regression.predicted_value", Double.class), equalTo(1.0));
+        assertThat(baseResult.getIngestDocument().getFieldValue("ml.classification.predicted_value", String.class),
+            equalTo("second"));
+        assertThat(baseResult.getIngestDocument().getFieldValue("ml.classification.result_class_prob", List.class).size(),
+            equalTo(2));
 
         String sourceWithMissingModel = "{\n" +
             "  \"pipeline\": {\n" +
             "    \"processors\": [\n" +
             "      {\n" +
             "        \"inference\": {\n" +
-            "          \"target_field\": \"result_class\",\n" +
             "          \"model_id\": \"test_classification_missing\",\n" +
             "          \"inference_config\": {\"classification\":{}},\n" +
             "          \"field_mappings\": {\n" +
@@ -527,8 +534,8 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
         "    \"processors\": [\n" +
         "      {\n" +
         "        \"inference\": {\n" +
-        "          \"target_field\": \"result_class\",\n" +
         "          \"model_id\": \"test_classification\",\n" +
+        "          \"tag\": \"classification\",\n" +
         "          \"inference_config\": {\"classification\": {}},\n" +
         "          \"field_mappings\": {\n" +
         "            \"col1\": \"col1\",\n" +
@@ -543,8 +550,8 @@ public class InferenceIngestIT extends MlNativeAutodetectIntegTestCase {
         "    \"processors\": [\n" +
         "      {\n" +
         "        \"inference\": {\n" +
-        "          \"target_field\": \"regression_value\",\n" +
         "          \"model_id\": \"test_regression\",\n" +
+        "          \"tag\": \"regression\",\n" +
         "          \"inference_config\": {\"regression\": {}},\n" +
         "          \"field_mappings\": {\n" +
         "            \"col1\": \"col1\",\n" +

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
@@ -696,7 +696,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
         client().execute(InternalInferModelAction.INSTANCE, new InternalInferModelAction.Request(
             modelId,
             Collections.singletonList(Collections.emptyMap()),
-            new RegressionConfig(),
+            RegressionConfig.EMPTY_PARAMS,
             false
         ), inferModelSuccess);
         InternalInferModelAction.Response response = inferModelSuccess.actionGet();
@@ -713,7 +713,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
             client().execute(InternalInferModelAction.INSTANCE, new InternalInferModelAction.Request(
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
-                new RegressionConfig(),
+                RegressionConfig.EMPTY_PARAMS,
                 false
             )).actionGet();
         });
@@ -726,7 +726,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
         client().execute(InternalInferModelAction.INSTANCE, new InternalInferModelAction.Request(
             modelId,
             Collections.singletonList(Collections.emptyMap()),
-            new RegressionConfig(),
+            RegressionConfig.EMPTY_PARAMS,
             true
         ), inferModelSuccess);
         response = inferModelSuccess.actionGet();
@@ -742,7 +742,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
         client().execute(InternalInferModelAction.INSTANCE, new InternalInferModelAction.Request(
             modelId,
             Collections.singletonList(Collections.emptyMap()),
-            new RegressionConfig(),
+            RegressionConfig.EMPTY_PARAMS,
             false
         ), listener);
         assertThat(listener.actionGet().getInferenceResults(), is(not(empty())));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
@@ -45,43 +45,42 @@ public class InferenceProcessorTests extends ESTestCase {
     }
 
     public void testMutateDocumentWithClassification() {
-        String targetField = "classification_value";
+        String targetField = "ml.my_processor";
         InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
             auditor,
             "my_processor",
             targetField,
             "classification_model",
             ClassificationConfig.EMPTY_PARAMS,
-            Collections.emptyMap(),
-            "ml.my_processor",
-            true);
+            Collections.emptyMap());
 
         Map<String, Object> source = new HashMap<>();
         Map<String, Object> ingestMetadata = new HashMap<>();
         IngestDocument document = new IngestDocument(source, ingestMetadata);
 
         InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new ClassificationInferenceResults(1.0, "foo", null)),
+            Collections.singletonList(new ClassificationInferenceResults(1.0,
+                "foo",
+                null,
+                ClassificationConfig.EMPTY_PARAMS)),
             true);
         inferenceProcessor.mutateDocument(response, document);
 
-        assertThat(document.getFieldValue(targetField, String.class), equalTo("foo"));
-        assertThat(document.getFieldValue("ml", Map.class),
-            equalTo(Collections.singletonMap("my_processor", Collections.singletonMap("model_id", "classification_model"))));
+        assertThat(document.getFieldValue(targetField + "." + ClassificationConfig.EMPTY_PARAMS.getResultsField(), String.class),
+            equalTo("foo"));
+        assertThat(document.getFieldValue("ml.my_processor.model_id", String.class), equalTo("classification_model"));
     }
 
     @SuppressWarnings("unchecked")
     public void testMutateDocumentClassificationTopNClasses() {
-        String targetField = "classification_value_probabilities";
+        ClassificationConfig classificationConfig = new ClassificationConfig(2, null, null);
         InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
             auditor,
             "my_processor",
-            targetField,
-            "classification_model",
-            new ClassificationConfig(2, null),
-            Collections.emptyMap(),
             "ml.my_processor",
-            true);
+            "classification_model",
+            classificationConfig,
+            Collections.emptyMap());
 
         Map<String, Object> source = new HashMap<>();
         Map<String, Object> ingestMetadata = new HashMap<>();
@@ -92,29 +91,26 @@ public class InferenceProcessorTests extends ESTestCase {
         classes.add(new ClassificationInferenceResults.TopClassEntry("bar", 0.4));
 
         InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new ClassificationInferenceResults(1.0, "foo", classes)),
+            Collections.singletonList(new ClassificationInferenceResults(1.0, "foo", classes, classificationConfig)),
             true);
         inferenceProcessor.mutateDocument(response, document);
 
-        assertThat((List<Map<?,?>>)document.getFieldValue(ClassificationConfig.DEFAULT_TOP_CLASSES_RESULT_FIELD, List.class),
+        assertThat((List<Map<?,?>>)document.getFieldValue("ml.my_processor.top_classes", List.class),
             contains(classes.stream().map(ClassificationInferenceResults.TopClassEntry::asValueMap).toArray(Map[]::new)));
-        assertThat(document.getFieldValue("ml", Map.class),
-            equalTo(Collections.singletonMap("my_processor", Collections.singletonMap("model_id", "classification_model"))));
-        assertThat(document.getFieldValue(targetField, String.class), equalTo("foo"));
+        assertThat(document.getFieldValue("ml.my_processor.model_id", String.class), equalTo("classification_model"));
+        assertThat(document.getFieldValue("ml.my_processor.predicted_value", String.class), equalTo("foo"));
     }
 
     @SuppressWarnings("unchecked")
     public void testMutateDocumentClassificationTopNClassesWithSpecificField() {
-        String targetField = "classification_value_probabilities";
+        ClassificationConfig classificationConfig = new ClassificationConfig(2, "result", "tops");
         InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
             auditor,
             "my_processor",
-            targetField,
-            "classification_model",
-            new ClassificationConfig(2, "my_top_classes"),
-            Collections.emptyMap(),
             "ml.my_processor",
-            true);
+            "classification_model",
+            classificationConfig,
+            Collections.emptyMap());
 
         Map<String, Object> source = new HashMap<>();
         Map<String, Object> ingestMetadata = new HashMap<>();
@@ -125,98 +121,36 @@ public class InferenceProcessorTests extends ESTestCase {
         classes.add(new ClassificationInferenceResults.TopClassEntry("bar", 0.4));
 
         InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new ClassificationInferenceResults(1.0, "foo", classes)),
+            Collections.singletonList(new ClassificationInferenceResults(1.0, "foo", classes, classificationConfig)),
             true);
         inferenceProcessor.mutateDocument(response, document);
 
-        assertThat((List<Map<?,?>>)document.getFieldValue("my_top_classes", List.class),
+        assertThat((List<Map<?,?>>)document.getFieldValue("ml.my_processor.tops", List.class),
             contains(classes.stream().map(ClassificationInferenceResults.TopClassEntry::asValueMap).toArray(Map[]::new)));
-        assertThat(document.getFieldValue("ml", Map.class),
-            equalTo(Collections.singletonMap("my_processor", Collections.singletonMap("model_id", "classification_model"))));
-        assertThat(document.getFieldValue(targetField, String.class), equalTo("foo"));
+        assertThat(document.getFieldValue("ml.my_processor.model_id", String.class), equalTo("classification_model"));
+        assertThat(document.getFieldValue("ml.my_processor.result", String.class), equalTo("foo"));
     }
 
     public void testMutateDocumentRegression() {
-        String targetField = "regression_value";
+        RegressionConfig regressionConfig = new RegressionConfig("foo");
         InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
             auditor,
             "my_processor",
-            targetField,
-            "regression_model",
-            new RegressionConfig(),
-            Collections.emptyMap(),
             "ml.my_processor",
-            true);
+            "regression_model",
+            regressionConfig,
+            Collections.emptyMap());
 
         Map<String, Object> source = new HashMap<>();
         Map<String, Object> ingestMetadata = new HashMap<>();
         IngestDocument document = new IngestDocument(source, ingestMetadata);
 
         InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new RegressionInferenceResults(0.7)), true);
+            Collections.singletonList(new RegressionInferenceResults(0.7, regressionConfig)), true);
         inferenceProcessor.mutateDocument(response, document);
 
-        assertThat(document.getFieldValue(targetField, Double.class), equalTo(0.7));
-        assertThat(document.getFieldValue("ml", Map.class),
-            equalTo(Collections.singletonMap("my_processor", Collections.singletonMap("model_id", "regression_model"))));
-    }
-
-    public void testMutateDocumentNoModelMetaData() {
-        String targetField = "regression_value";
-        InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
-            auditor,
-            "my_processor",
-            targetField,
-            "regression_model",
-            new RegressionConfig(),
-            Collections.emptyMap(),
-            "ml.my_processor",
-            false);
-
-        Map<String, Object> source = new HashMap<>();
-        Map<String, Object> ingestMetadata = new HashMap<>();
-        IngestDocument document = new IngestDocument(source, ingestMetadata);
-
-        InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new RegressionInferenceResults(0.7)), true);
-        inferenceProcessor.mutateDocument(response, document);
-
-        assertThat(document.getFieldValue(targetField, Double.class), equalTo(0.7));
-        assertThat(document.hasField("ml"), is(false));
-    }
-
-    public void testMutateDocumentModelMetaDataExistingField() {
-        String targetField = "regression_value";
-        InferenceProcessor inferenceProcessor = new InferenceProcessor(client,
-            auditor,
-            "my_processor",
-            targetField,
-            "regression_model",
-            new RegressionConfig(),
-            Collections.emptyMap(),
-            "ml.my_processor",
-            true);
-
-        //cannot use singleton map as attempting to mutate later
-        Map<String, Object> ml = new HashMap<String, Object>(){{
-            put("regression_prediction", 0.55);
-        }};
-        Map<String, Object> source = new HashMap<String, Object>(){{
-            put("ml", ml);
-        }};
-        Map<String, Object> ingestMetadata = new HashMap<>();
-        IngestDocument document = new IngestDocument(source, ingestMetadata);
-
-        InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new RegressionInferenceResults(0.7)), true);
-        inferenceProcessor.mutateDocument(response, document);
-
-        assertThat(document.getFieldValue(targetField, Double.class), equalTo(0.7));
-        assertThat(document.getFieldValue("ml", Map.class),
-            equalTo(new HashMap<String, Object>(){{
-                put("my_processor", Collections.singletonMap("model_id", "regression_model"));
-                put("regression_prediction", 0.55);
-            }}));
+        assertThat(document.getFieldValue("ml.my_processor.foo", Double.class), equalTo(0.7));
+        assertThat(document.getFieldValue("ml.my_processor.model_id", String.class), equalTo("regression_model"));
     }
 
     public void testGenerateRequestWithEmptyMapping() {
@@ -228,10 +162,8 @@ public class InferenceProcessorTests extends ESTestCase {
             "my_processor",
             "my_field",
             modelId,
-            new ClassificationConfig(topNClasses, null),
-            Collections.emptyMap(),
-            "ml.my_processor",
-            false);
+            new ClassificationConfig(topNClasses, null, null),
+            Collections.emptyMap());
 
         Map<String, Object> source = new HashMap<String, Object>(){{
             put("value1", 1);
@@ -259,10 +191,8 @@ public class InferenceProcessorTests extends ESTestCase {
             "my_processor",
             "my_field",
             modelId,
-            new ClassificationConfig(topNClasses, null),
-            fieldMapping,
-            "ml.my_processor",
-            false);
+            new ClassificationConfig(topNClasses, null, null),
+            fieldMapping);
 
         Map<String, Object> source = new HashMap<String, Object>(3){{
             put("value1", 1);
@@ -287,10 +217,8 @@ public class InferenceProcessorTests extends ESTestCase {
             "my_processor",
             targetField,
             "regression_model",
-            new RegressionConfig(),
-            Collections.emptyMap(),
-            "ml.my_processor",
-            true);
+            RegressionConfig.EMPTY_PARAMS,
+            Collections.emptyMap());
 
         Map<String, Object> source = new HashMap<>();
         Map<String, Object> ingestMetadata = new HashMap<>();
@@ -299,7 +227,7 @@ public class InferenceProcessorTests extends ESTestCase {
         assertThat(inferenceProcessor.buildRequest(document).isPreviouslyLicensed(), is(false));
 
         InternalInferModelAction.Response response = new InternalInferModelAction.Response(
-            Collections.singletonList(new RegressionInferenceResults(0.7)), true);
+            Collections.singletonList(new RegressionInferenceResults(0.7, RegressionConfig.EMPTY_PARAMS)), true);
         inferenceProcessor.handleResponse(response, document, (doc, ex) -> {
             assertThat(doc, is(not(nullValue())));
             assertThat(ex, is(nullValue()));
@@ -308,7 +236,7 @@ public class InferenceProcessorTests extends ESTestCase {
         assertThat(inferenceProcessor.buildRequest(document).isPreviouslyLicensed(), is(true));
 
         response = new InternalInferModelAction.Response(
-            Collections.singletonList(new RegressionInferenceResults(0.7)), false);
+            Collections.singletonList(new RegressionInferenceResults(0.7, RegressionConfig.EMPTY_PARAMS)), false);
 
         inferenceProcessor.handleResponse(response, document, (doc, ex) -> {
             assertThat(doc, is(not(nullValue())));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -93,7 +93,7 @@ public class LocalModelTests extends ESTestCase {
             put("categorical", "dog");
         }};
 
-        SingleValueInferenceResults results = getSingleValue(model, fields, new RegressionConfig());
+        SingleValueInferenceResults results = getSingleValue(model, fields, RegressionConfig.EMPTY_PARAMS);
         assertThat(results.value(), equalTo(1.3));
 
         PlainActionFuture<InferenceResults> failedFuture = new PlainActionFuture<>();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
@@ -119,12 +119,15 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         }});
 
         // Test regression
-        InternalInferModelAction.Request request = new InternalInferModelAction.Request(modelId1, toInfer, new RegressionConfig(), true);
+        InternalInferModelAction.Request request = new InternalInferModelAction.Request(modelId1,
+            toInfer,
+            RegressionConfig.EMPTY_PARAMS,
+            true);
         InternalInferModelAction.Response response = client().execute(InternalInferModelAction.INSTANCE, request).actionGet();
         assertThat(response.getInferenceResults().stream().map(i -> ((SingleValueInferenceResults)i).value()).collect(Collectors.toList()),
             contains(1.3, 1.25));
 
-        request = new InternalInferModelAction.Request(modelId1, toInfer2, new RegressionConfig(), true);
+        request = new InternalInferModelAction.Request(modelId1, toInfer2, RegressionConfig.EMPTY_PARAMS, true);
         response = client().execute(InternalInferModelAction.INSTANCE, request).actionGet();
         assertThat(response.getInferenceResults().stream().map(i -> ((SingleValueInferenceResults)i).value()).collect(Collectors.toList()),
             contains(1.65, 1.55));
@@ -140,7 +143,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             contains("not_to_be", "to_be"));
 
         // Get top classes
-        request = new InternalInferModelAction.Request(modelId2, toInfer, new ClassificationConfig(2, null), true);
+        request = new InternalInferModelAction.Request(modelId2, toInfer, new ClassificationConfig(2, null, null), true);
         response = client().execute(InternalInferModelAction.INSTANCE, request).actionGet();
 
         ClassificationInferenceResults classificationInferenceResults =
@@ -159,7 +162,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             greaterThan(classificationInferenceResults.getTopClasses().get(1).getProbability()));
 
         // Test that top classes restrict the number returned
-        request = new InternalInferModelAction.Request(modelId2, toInfer2, new ClassificationConfig(1, null), true);
+        request = new InternalInferModelAction.Request(modelId2, toInfer2, new ClassificationConfig(1, null, null), true);
         response = client().execute(InternalInferModelAction.INSTANCE, request).actionGet();
 
         classificationInferenceResults = (ClassificationInferenceResults)response.getInferenceResults().get(0);
@@ -172,7 +175,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         InternalInferModelAction.Request request = new InternalInferModelAction.Request(
             model,
             Collections.emptyList(),
-            new RegressionConfig(),
+            RegressionConfig.EMPTY_PARAMS,
             true);
         try {
             client().execute(InternalInferModelAction.INSTANCE, request).actionGet();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Inference] Simplify inference processor options  (#50105)