### PR TITLE
Respect ES_PATH_CONF on package install

### DIFF
--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -8,6 +8,13 @@
 #       $1=0         : indicates a removal
 #       $1=1         : indicates an upgrade
 
+# source the default env file
+if [ -f "${path.env}" ]; then
+    . "${path.env}"
+else
+  ES_PATH_CONF="${path.conf}"
+fi
+
 IS_UPGRADE=false
 
 case "$1" in
@@ -95,11 +102,11 @@ fi
 
 # the equivalent code for rpm is in posttrans
 if [ "$PACKAGE" = "deb" ]; then
-    if [ ! -f /etc/elasticsearch/elasticsearch.keystore ]; then
+    if [ ! -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
         /usr/share/elasticsearch/bin/elasticsearch-keystore create
-        chown root:elasticsearch /etc/elasticsearch/elasticsearch.keystore
-        chmod 660 /etc/elasticsearch/elasticsearch.keystore
-        md5sum /etc/elasticsearch/elasticsearch.keystore > /etc/elasticsearch/.elasticsearch.keystore.initial_md5sum
+        chown root:elasticsearch "${ES_PATH_CONF}"/elasticsearch.keystore
+        chmod 660 "${ES_PATH_CONF}"/elasticsearch.keystore
+        md5sum "${ES_PATH_CONF}"/elasticsearch.keystore > "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
     else
         /usr/share/elasticsearch/bin/elasticsearch-keystore upgrade
     fi

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -8,6 +8,14 @@
 #   On RedHat,
 #       $1=0         : indicates a removal
 #       $1=1         : indicates an upgrade
+
+# source the default env file
+if [ -f "${path.env}" ]; then
+    . "${path.env}"
+else
+  ES_PATH_CONF="${path.conf}"
+fi
+
 REMOVE_DIRS=false
 REMOVE_USER_AND_GROUP=false
 
@@ -73,8 +81,8 @@ if [ "$REMOVE_DIRS" = "true" ]; then
     fi
 
     # delete the conf directory if and only if empty
-    if [ -d /etc/elasticsearch ]; then
-        rmdir --ignore-fail-on-non-empty /etc/elasticsearch
+    if [ -d "${ES_PATH_CONF}" ]; then
+        rmdir --ignore-fail-on-non-empty "${ES_PATH_CONF}"
     fi
 
 fi

--- a/distribution/packages/src/common/scripts/prerm
+++ b/distribution/packages/src/common/scripts/prerm
@@ -9,6 +9,13 @@
 #       $1=0         : indicates a removal
 #       $1=1         : indicates an upgrade
 
+# source the default env file
+if [ -f "${path.env}" ]; then
+    . "${path.env}"
+else
+  ES_PATH_CONF="${path.conf}"
+fi
+
 STOP_REQUIRED=false
 REMOVE_SERVICE=false
 
@@ -65,9 +72,9 @@ if [ "$STOP_REQUIRED" = "true" ]; then
     echo " OK"
 fi
 
-if [ -f /etc/elasticsearch/elasticsearch.keystore ]; then
-  if md5sum --status -c /etc/elasticsearch/.elasticsearch.keystore.initial_md5sum; then
-    rm /etc/elasticsearch/elasticsearch.keystore /etc/elasticsearch/.elasticsearch.keystore.initial_md5sum
+if [ -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
+  if md5sum --status -c "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum; then
+    rm "${ES_PATH_CONF}"/elasticsearch.keystore "${ES_PATH_CONF}"/.elasticsearch.keystore.initial_md5sum
   fi
 fi
 


### PR DESCRIPTION
We respect ES_PATH_CONF everywhere except package install. This commit addresses this by respecting ES_PATH_CONF when installing the RPM/Debian packages.

