### PR TITLE
Skip enterprise license tests in release build

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -69,8 +69,8 @@ integTest.runner {
   if (!snapshot) {
     // these tests attempt to install basic/internal licenses signed against the dev/public.key
     // Since there is no infrastructure in place (anytime soon) to generate licenses using the production
-    // private key, these tests are whitelisted in non-snapshot test runs
-    blacklist.addAll(['xpack/15_basic/*', 'license/20_put_license/*'])
+    // private key, these tests are blacklisted in non-snapshot test runs
+    blacklist.addAll(['xpack/15_basic/*', 'license/20_put_license/*', 'license/30_enterprise_license/*'])
   }
   systemProperty 'tests.rest.blacklist', blacklist.join(',')
   dependsOn copyKeyCerts


### PR DESCRIPTION
The release builds use a production license key, and our rest test load
licenses that are signed by the dev license key.

This change adds the new enterprise license Rest tests to the
blacklist on release builds.

Relates: #50067
Resolves: #50151
