### PR TITLE
[ML] Fix DFA explain API timeout when source index is missing

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
@@ -171,9 +171,10 @@ public class ExtractedFieldsDetectorFactory {
                 docValueFieldsLimitListener.onResponse(minDocValueFieldsLimit);
             },
             e -> {
-                if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+                Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (cause instanceof IndexNotFoundException) {
                     docValueFieldsLimitListener.onFailure(new ResourceNotFoundException("cannot retrieve data because index "
-                        + ((IndexNotFoundException) e).getIndex() + " does not exist"));
+                        + ((IndexNotFoundException) cause).getIndex() + " does not exist"));
                 } else {
                     docValueFieldsLimitListener.onFailure(e);
                 }


### PR DESCRIPTION
This commit fixes a bug that caused the data frame analytics
_explain API to time out in a multi-node setup when the source
index was missing. When we try to create the extracted fields detector,
we check the index settings. If the index is missing that responds
with a failure that could be wrapped as a remote exception.
While we unwrapped correctly to check if the cause was an
`IndexNotFoundException`, we then proceeded to cast the original
exception instead of the cause.
