### PR TITLE
[DOCS] Add `index-extra-title-page.html` for direct HTML migration

### DIFF
--- a/docs/reference/index-extra-title-page.html
+++ b/docs/reference/index-extra-title-page.html
@@ -1,0 +1,20 @@
+<div class="legalnotice">
+  <p>
+    Welcome to the official documentation for Elasticsearch:
+    the search and analytics engine that powers the Elastic Stack.
+    If you want to learn how to use Elasticsearch to search and analyze your
+    data, you've come to the right place. This guide shows you how to:
+  </p>
+  <div class="itemizedlist">
+    <ul class="itemizedlist" type="disc">
+      <li class="listitem">Install, configure, and administer an Elasticsearch
+      cluster.</li>
+      <li class="listitem">Index your data, optimize your indices, and search
+      with the Elasticsearch query language.
+      </li>
+      <li class="listitem">Discover trends, patterns, and anomalies with
+      aggregations and the machine learning APIs.
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
Adds the `index-extra-title-page.html` file, which will replace `index-docinfo.xml` and `index.x-docinfo.xml` once we migrate our docs build to direct HTML.

This file contains the following introductory text for the [ES Reference index][0]:
<img width="730" alt="Screen Shot 2019-12-13 at 10 25 11 AM" src="https://user-images.githubusercontent.com/40268737/70811066-e5706300-1d92-11ea-9833-e92042361de6.png">

The file is inert until the direct HTML migration happens. Even then, this change is no-op.

[0]: https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html