### PR TITLE
[ML] Fix exception when field is not included and excluded at the sam…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -235,13 +235,13 @@ public class ExtractedFieldsDetector {
                 if (IGNORE_FIELDS.contains(field)) {
                     throw ExceptionsHelper.badRequestException("field [{}] cannot be analyzed", field);
                 }
+                if (excludes.contains(field)) {
+                    fieldsIterator.remove();
+                    addExcludedField(field, "field in excludes list", fieldSelection);
+                }
             } else {
                 fieldsIterator.remove();
                 addExcludedField(field, "field not in includes list", fieldSelection);
-            }
-            if (excludes.contains(field)) {
-                fieldsIterator.remove();
-                addExcludedField(field, "field in excludes list", fieldSelection);
             }
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -233,6 +233,27 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         );
     }
 
+    public void testDetect_GivenFieldIsNotIncludedAndIsExcluded() {
+        FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder()
+            .addAggregatableField("foo", "float")
+            .addAggregatableField("bar", "float")
+            .build();
+        analyzedFields = new FetchSourceContext(true, new String[]  {"foo"}, new String[] {"bar"});
+
+        ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
+            SOURCE_INDEX, buildOutlierDetectionConfig(), false, 100, fieldCapabilities, Collections.emptyMap());
+        Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
+
+        List<ExtractedField> allFields = fieldExtraction.v1().getAllFields();
+        assertThat(allFields, hasSize(1));
+        assertThat(allFields.stream().map(ExtractedField::getName).collect(Collectors.toList()), contains("foo"));
+
+        assertFieldSelectionContains(fieldExtraction.v2(),
+            FieldSelection.excluded("bar", Collections.singleton("float"), "field not in includes list"),
+            FieldSelection.included("foo", Collections.singleton("float"), false, FieldSelection.FeatureType.NUMERICAL)
+        );
+    }
+
     public void testDetect_GivenRegressionAndRequiredFieldHasInvalidType() {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder()
             .addAggregatableField("some_float", "float")


### PR DESCRIPTION
…e time

Executing the data frame analytics _explain API with a config that contains
a field that is not in the includes list but at the same time is the excludes
list results to trying to remove the field twice from the iterator. That causes
an `IllegalStateException`. This commit fixes this issue and adds a test that
captures the scenario.
