### PR TITLE
Bump the scroll keep-alive time in cluster upgrade tests.

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -32,7 +32,7 @@
         rest_total_hits_as_int: true
         index: upgraded_scroll
         size: 1
-        scroll: 8m
+        scroll: 10m
         sort: foo
         body:
           query:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -32,7 +32,7 @@
         rest_total_hits_as_int: true
         index: upgraded_scroll
         size: 1
-        scroll: 5m
+        scroll: 8m
         sort: foo
         body:
           query:


### PR DESCRIPTION
In the yaml cluster upgrade tests, we start a scroll in a mixed-version cluster,
then attempt to continue the scroll after the upgrade is complete. This test
occasionally fails because the scroll can expire before the cluster is done
upgrading.

The current scroll keep-alive time 5m. This PR bumps it to 10m, which gives a
good buffer since in failing tests the time was only exceeded by ~30 seconds.

Addresses #46529.