### PR TITLE
Omit loading IndexMetaData when inspecting shards

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.health.ClusterShardHealth;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -43,6 +44,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.concurrent.CountDown;
@@ -100,7 +102,7 @@ public class TransportIndicesShardStoresAction
         final RoutingTable routingTables = state.routingTable();
         final RoutingNodes routingNodes = state.getRoutingNodes();
         final String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request);
-        final Set<ShardId> shardIdsToFetch = new HashSet<>();
+        final Set<Tuple<ShardId, String>> shardsToFetch = new HashSet<>();
 
         logger.trace("using cluster state version [{}] to determine shards", state.version());
         // collect relevant shard ids of the requested indices for fetching store infos
@@ -109,11 +111,12 @@ public class TransportIndicesShardStoresAction
             if (indexShardRoutingTables == null) {
                 continue;
             }
+            final String customDataPath = IndexMetaData.INDEX_DATA_PATH_SETTING.get(state.metaData().index(index).getSettings());
             for (IndexShardRoutingTable routing : indexShardRoutingTables) {
                 final int shardId = routing.shardId().id();
                 ClusterShardHealth shardHealth = new ClusterShardHealth(shardId, routing);
                 if (request.shardStatuses().contains(shardHealth.getStatus())) {
-                    shardIdsToFetch.add(routing.shardId());
+                    shardsToFetch.add(Tuple.tuple(routing.shardId(), customDataPath));
                 }
             }
         }
@@ -123,7 +126,7 @@ public class TransportIndicesShardStoresAction
         // we could fetch all shard store info from every node once (nNodes requests)
         // we have to implement a TransportNodesAction instead of using TransportNodesListGatewayStartedShards
         // for fetching shard stores info, that operates on a list of shards instead of a single shard
-        new AsyncShardStoresInfoFetches(state.nodes(), routingNodes, shardIdsToFetch, listener).start();
+        new AsyncShardStoresInfoFetches(state.nodes(), routingNodes, shardsToFetch, listener).start();
     }
 
     @Override
@@ -135,46 +138,46 @@ public class TransportIndicesShardStoresAction
     private class AsyncShardStoresInfoFetches {
         private final DiscoveryNodes nodes;
         private final RoutingNodes routingNodes;
-        private final Set<ShardId> shardIds;
+        private final Set<Tuple<ShardId, String>> shards;
         private final ActionListener<IndicesShardStoresResponse> listener;
         private CountDown expectedOps;
         private final Queue<InternalAsyncFetch.Response> fetchResponses;
 
-        AsyncShardStoresInfoFetches(DiscoveryNodes nodes, RoutingNodes routingNodes, Set<ShardId> shardIds,
+        AsyncShardStoresInfoFetches(DiscoveryNodes nodes, RoutingNodes routingNodes, Set<Tuple<ShardId, String>> shards,
                                     ActionListener<IndicesShardStoresResponse> listener) {
             this.nodes = nodes;
             this.routingNodes = routingNodes;
-            this.shardIds = shardIds;
+            this.shards = shards;
             this.listener = listener;
             this.fetchResponses = new ConcurrentLinkedQueue<>();
-            this.expectedOps = new CountDown(shardIds.size());
+            this.expectedOps = new CountDown(shards.size());
         }
 
         void start() {
-            if (shardIds.isEmpty()) {
+            if (shards.isEmpty()) {
                 listener.onResponse(new IndicesShardStoresResponse());
             } else {
                 // explicitely type lister, some IDEs (Eclipse) are not able to correctly infer the function type
                 Lister<BaseNodesResponse<NodeGatewayStartedShards>, NodeGatewayStartedShards> lister = this::listStartedShards;
-                for (ShardId shardId : shardIds) {
-                    InternalAsyncFetch fetch = new InternalAsyncFetch(logger, "shard_stores", shardId, lister);
+                for (Tuple<ShardId, String> shard : shards) {
+                    InternalAsyncFetch fetch = new InternalAsyncFetch(logger, "shard_stores", shard.v1(), shard.v2(), lister);
                     fetch.fetchData(nodes, Collections.<String>emptySet());
                 }
             }
         }
 
-        private void listStartedShards(ShardId shardId, DiscoveryNode[] nodes,
+        private void listStartedShards(ShardId shardId, String customDataPath, DiscoveryNode[] nodes,
                                        ActionListener<BaseNodesResponse<NodeGatewayStartedShards>> listener) {
-            var request = new TransportNodesListGatewayStartedShards.Request(shardId, nodes);
+            var request = new TransportNodesListGatewayStartedShards.Request(shardId, customDataPath, nodes);
             client.executeLocally(TransportNodesListGatewayStartedShards.TYPE, request,
                 ActionListener.wrap(listener::onResponse, listener::onFailure));
         }
 
         private class InternalAsyncFetch extends AsyncShardFetch<NodeGatewayStartedShards> {
 
-            InternalAsyncFetch(Logger logger, String type, ShardId shardId,
+            InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath,
                                Lister<? extends BaseNodesResponse<NodeGatewayStartedShards>, NodeGatewayStartedShards> action) {
-                super(logger, type, shardId, action);
+                super(logger, type, shardId, customDataPath, action);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -61,22 +62,25 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
      * An action that lists the relevant shard data that needs to be fetched.
      */
     public interface Lister<NodesResponse extends BaseNodesResponse<NodeResponse>, NodeResponse extends BaseNodeResponse> {
-        void list(ShardId shardId, DiscoveryNode[] nodes, ActionListener<NodesResponse> listener);
+        void list(ShardId shardId, @Nullable String customDataPath, DiscoveryNode[] nodes, ActionListener<NodesResponse> listener);
     }
 
     protected final Logger logger;
     protected final String type;
     protected final ShardId shardId;
+    protected final String customDataPath;
     private final Lister<BaseNodesResponse<T>, T> action;
     private final Map<String, NodeEntry<T>> cache = new HashMap<>();
     private final Set<String> nodesToIgnore = new HashSet<>();
     private final AtomicLong round = new AtomicLong();
     private boolean closed;
 
-    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, Lister<? extends BaseNodesResponse<T>, T> action) {
+    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, String customDataPath,
+                              Lister<? extends BaseNodesResponse<T>, T> action) {
         this.logger = logger;
         this.type = type;
-        this.shardId = shardId;
+        this.shardId = Objects.requireNonNull(shardId);
+        this.customDataPath = Objects.requireNonNull(customDataPath);
         this.action = (Lister<BaseNodesResponse<T>, T>) action;
     }
 
@@ -285,7 +289,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     // visible for testing
     void asyncFetch(final DiscoveryNode[] nodes, long fetchingRound) {
         logger.trace("{} fetching [{}] from {}", shardId, type, nodes);
-        action.list(shardId, nodes, new ActionListener<BaseNodesResponse<T>>() {
+        action.list(shardId, customDataPath, nodes, new ActionListener<BaseNodesResponse<T>>() {
             @Override
             public void onResponse(BaseNodesResponse<T> response) {
                 processAsyncFetch(response.getNodes(), response.failures(), fetchingRound);

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -187,7 +187,9 @@ public class TransportNodesListGatewayStartedShards extends
         }
 
         /**
-         * Returns null if custom data path information is not available (due to BWC)
+         * Returns the custom data path that is used to look up information for this shard.
+         * Returns an empty string if no custom data path is used for this index.
+         * Returns null if custom data path information is not available (due to BWC).
          */
         @Nullable
         public String getCustomDataPath() {
@@ -263,7 +265,9 @@ public class TransportNodesListGatewayStartedShards extends
         }
 
         /**
-         * Returns null if custom data path information is not available (due to BWC)
+         * Returns the custom data path that is used to look up information for this shard.
+         * Returns an empty string if no custom data path is used for this index.
+         * Returns null if custom data path information is not available (due to BWC).
          */
         @Nullable
         public String getCustomDataPath() {

--- a/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
+++ b/server/src/main/java/org/elasticsearch/gateway/TransportNodesListGatewayStartedShards.java
@@ -21,6 +21,7 @@ package org.elasticsearch.gateway;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -33,6 +34,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -109,26 +111,24 @@ public class TransportNodesListGatewayStartedShards extends
             ShardStateMetaData shardStateMetaData = ShardStateMetaData.FORMAT.loadLatestState(logger, namedXContentRegistry,
                 nodeEnv.availableShardPaths(request.shardId));
             if (shardStateMetaData != null) {
-                IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndex());
-                if (metaData == null) {
-                    // we may send this requests while processing the cluster state that recovered the index
-                    // sometimes the request comes in before the local node processed that cluster state
-                    // in such cases we can load it from disk
-                    metaData = IndexMetaData.FORMAT.loadLatestState(logger, namedXContentRegistry,
-                        nodeEnv.indexPaths(shardId.getIndex()));
-                }
-                if (metaData == null) {
-                    ElasticsearchException e = new ElasticsearchException("failed to find local IndexMetaData");
-                    e.setShard(request.shardId);
-                    throw e;
-                }
-
                 if (indicesService.getShardOrNull(shardId) == null) {
+                    final String customDataPath;
+                    if (request.getCustomDataPath() != null) {
+                        customDataPath = request.getCustomDataPath();
+                    } else {
+                        // TODO: Fallback for BWC with older ES versions. Remove once request.getCustomDataPath() always returns non-null
+                        final IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndex());
+                        if (metaData != null) {
+                            customDataPath = new IndexSettings(metaData, settings).customDataPath();
+                        } else {
+                            logger.trace("{} node doesn't have meta data for the requests index", shardId);
+                            throw new ElasticsearchException("node doesn't have meta data for index " + shardId.getIndex());
+                        }
+                    }
                     // we don't have an open shard on the store, validate the files on disk are openable
                     ShardPath shardPath = null;
                     try {
-                        IndexSettings indexSettings = new IndexSettings(metaData, settings);
-                        shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, indexSettings);
+                        shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, customDataPath);
                         if (shardPath == null) {
                             throw new IllegalStateException(shardId + " no shard path found");
                         }
@@ -162,27 +162,45 @@ public class TransportNodesListGatewayStartedShards extends
 
     public static class Request extends BaseNodesRequest<Request> {
 
-        private ShardId shardId;
+        private final ShardId shardId;
+        @Nullable
+        private final String customDataPath;
 
         public Request(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                customDataPath = in.readString();
+            } else {
+                customDataPath = null;
+            }
         }
 
-        public Request(ShardId shardId, DiscoveryNode[] nodes) {
+        public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
             super(nodes);
-            this.shardId = shardId;
+            this.shardId = Objects.requireNonNull(shardId);
+            this.customDataPath = Objects.requireNonNull(customDataPath);
         }
-
 
         public ShardId shardId() {
-            return this.shardId;
+            return shardId;
+        }
+
+        /**
+         * Returns null if custom data path information is not available (due to BWC)
+         */
+        @Nullable
+        public String getCustomDataPath() {
+            return customDataPath;
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeString(customDataPath);
+            }
         }
     }
 
@@ -211,33 +229,53 @@ public class TransportNodesListGatewayStartedShards extends
 
     public static class NodeRequest extends BaseNodeRequest {
 
-        private ShardId shardId;
+        private final ShardId shardId;
+        @Nullable
+        private final String customDataPath;
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                customDataPath = in.readString();
+            } else {
+                customDataPath = null;
+            }
         }
 
         public NodeRequest(Request request) {
-            this.shardId = request.shardId();
+            this.shardId = Objects.requireNonNull(request.shardId());
+            this.customDataPath = Objects.requireNonNull(request.getCustomDataPath());
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                assert customDataPath != null;
+                out.writeString(customDataPath);
+            }
         }
 
         public ShardId getShardId() {
             return shardId;
         }
+
+        /**
+         * Returns null if custom data path information is not available (due to BWC)
+         */
+        @Nullable
+        public String getCustomDataPath() {
+            return customDataPath;
+        }
     }
 
     public static class NodeGatewayStartedShards extends BaseNodeResponse {
 
-        private String allocationId = null;
-        private boolean primary = false;
-        private Exception storeException = null;
+        private final String allocationId;
+        private final boolean primary;
+        private final Exception storeException;
 
         public NodeGatewayStartedShards(StreamInput in) throws IOException {
             super(in);
@@ -245,6 +283,8 @@ public class TransportNodesListGatewayStartedShards extends
             primary = in.readBoolean();
             if (in.readBoolean()) {
                 storeException = in.readException();
+            } else {
+                storeException = null;
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -368,12 +368,12 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             eventListener.beforeIndexShardCreated(shardId, indexSettings);
             ShardPath path;
             try {
-                path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings);
+                path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings.customDataPath());
             } catch (IllegalStateException ex) {
                 logger.warn("{} failed to load shard path, trying to remove leftover", shardId);
                 try {
                     ShardPath.deleteLeftoverShardDirectory(logger, nodeEnv, lock, this.indexSettings);
-                    path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings);
+                    path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings.customDataPath());
                 } catch (Exception inner) {
                     ex.addSuppressed(inner);
                     throw ex;

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.index.MergePolicy;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -631,14 +632,14 @@ public final class IndexSettings {
      * Returns <code>true</code> if the index has a custom data path
      */
     public boolean hasCustomDataPath() {
-        return customDataPath() != null;
+        return Strings.isNotEmpty(customDataPath());
     }
 
     /**
-     * Returns the customDataPath for this index, if configured. <code>null</code> o.w.
+     * Returns the customDataPath for this index, if configured. <code>""</code> o.w.
      */
     public String customDataPath() {
-        return settings.get(IndexMetaData.SETTING_DATA_PATH);
+        return IndexMetaData.INDEX_DATA_PATH_SETTING.get(settings);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommand.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommand.java
@@ -192,7 +192,7 @@ public class RemoveCorruptedShardDataCommand extends EnvironmentAwareCommand {
                             if (Files.exists(shardPathLocation) == false) {
                                 continue;
                             }
-                            final ShardPath shardPath = ShardPath.loadShardPath(logger, shId, indexSettings,
+                            final ShardPath shardPath = ShardPath.loadShardPath(logger, shId, indexSettings.customDataPath(),
                                 new Path[]{shardPathLocation}, nodePath.path);
                             if (shardPath != null) {
                                 consumer.accept(shardPath);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.index.shard;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -114,13 +115,13 @@ public final class ShardPath {
     /**
      * This method walks through the nodes shard paths to find the data and state path for the given shard. If multiple
      * directories with a valid shard state exist the one with the highest version will be used.
-     * <b>Note:</b> this method resolves custom data locations for the shard.
+     * <b>Note:</b> this method resolves custom data locations for the shard if such a custom data path is provided.
      */
     public static ShardPath loadShardPath(Logger logger, NodeEnvironment env,
-                                                ShardId shardId, IndexSettings indexSettings) throws IOException {
+                                          ShardId shardId, String customDataPath) throws IOException {
         final Path[] paths = env.availableShardPaths(shardId);
         final Path sharedDataPath = env.sharedDataPath();
-        return loadShardPath(logger, shardId, indexSettings, paths, sharedDataPath);
+        return loadShardPath(logger, shardId, customDataPath, paths, sharedDataPath);
     }
 
     /**
@@ -128,9 +129,9 @@ public final class ShardPath {
      * directories with a valid shard state exist the one with the highest version will be used.
      * <b>Note:</b> this method resolves custom data locations for the shard.
      */
-    public static ShardPath loadShardPath(Logger logger, ShardId shardId, IndexSettings indexSettings, Path[] availableShardPaths,
+    public static ShardPath loadShardPath(Logger logger, ShardId shardId, String customDataPath, Path[] availableShardPaths,
                                           Path sharedDataPath) throws IOException {
-        final String indexUUID = indexSettings.getUUID();
+        final String indexUUID = shardId.getIndex().getUUID();
         Path loadedPath = null;
         for (Path path : availableShardPaths) {
             // EMPTY is safe here because we never call namedObject
@@ -156,13 +157,14 @@ public final class ShardPath {
         } else {
             final Path dataPath;
             final Path statePath = loadedPath;
-            if (indexSettings.hasCustomDataPath()) {
-                dataPath = NodeEnvironment.resolveCustomLocation(indexSettings, shardId, sharedDataPath);
+            final boolean hasCustomDataPath = Strings.isNotEmpty(customDataPath);
+            if (hasCustomDataPath) {
+                dataPath = NodeEnvironment.resolveCustomLocation(customDataPath, shardId, sharedDataPath);
             } else {
                 dataPath = statePath;
             }
             logger.debug("{} loaded data path [{}], state path [{}]", shardId, dataPath, statePath);
-            return new ShardPath(indexSettings.hasCustomDataPath(), dataPath, statePath, shardId);
+            return new ShardPath(hasCustomDataPath, dataPath, statePath, shardId);
         }
     }
 
@@ -195,7 +197,7 @@ public final class ShardPath {
         final Path statePath;
 
         if (indexSettings.hasCustomDataPath()) {
-            dataPath = env.resolveCustomLocation(indexSettings, shardId);
+            dataPath = env.resolveCustomLocation(indexSettings.customDataPath(), shardId);
             statePath = env.nodePaths()[0].resolve(shardId);
         } else {
             BigInteger totFreeSpace = BigInteger.ZERO;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -971,7 +971,7 @@ public class IndicesService extends AbstractLifecycleComponent
             } else if (indexSettings.hasCustomDataPath()) {
                 // lets see if it's on a custom path (return false if the shared doesn't exist)
                 // we don't need to delete anything that is not there
-                return Files.exists(nodeEnv.resolveCustomLocation(indexSettings, shardId)) ?
+                return Files.exists(nodeEnv.resolveCustomLocation(indexSettings.customDataPath(), shardId)) ?
                         ShardDeletionCheckResult.FOLDER_FOUND_CAN_DELETE :
                         ShardDeletionCheckResult.NO_FOLDER_FOUND;
             } else {

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -34,13 +34,13 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 public class TransportNodesListShardStoreMetaData extends TransportNodesAction<TransportNodesListShardStoreMetaData.Request,
@@ -73,19 +74,17 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     private final Settings settings;
     private final IndicesService indicesService;
     private final NodeEnvironment nodeEnv;
-    private final NamedXContentRegistry namedXContentRegistry;
 
     @Inject
     public TransportNodesListShardStoreMetaData(Settings settings, ThreadPool threadPool,
                                                 ClusterService clusterService, TransportService transportService,
                                                 IndicesService indicesService, NodeEnvironment nodeEnv,
-                                                ActionFilters actionFilters, NamedXContentRegistry namedXContentRegistry) {
+                                                ActionFilters actionFilters) {
         super(ACTION_NAME, threadPool, clusterService, transportService, actionFilters,
             Request::new, NodeRequest::new, ThreadPool.Names.FETCH_SHARD_STORE, NodeStoreFilesMetaData.class);
         this.settings = settings;
         this.indicesService = indicesService;
         this.nodeEnv = nodeEnv;
-        this.namedXContentRegistry = namedXContentRegistry;
     }
 
     @Override
@@ -107,18 +106,20 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
     @Override
     protected NodeStoreFilesMetaData nodeOperation(NodeRequest request, Task task) {
         try {
-            return new NodeStoreFilesMetaData(clusterService.localNode(), listStoreMetaData(request.shardId));
+            return new NodeStoreFilesMetaData(clusterService.localNode(), listStoreMetaData(request));
         } catch (IOException e) {
             throw new ElasticsearchException("Failed to list store metadata for shard [" + request.shardId + "]", e);
         }
     }
 
-    private StoreFilesMetaData listStoreMetaData(ShardId shardId) throws IOException {
+    private StoreFilesMetaData listStoreMetaData(NodeRequest request) throws IOException {
+        final ShardId shardId = request.getShardId();
         logger.trace("listing store meta data for {}", shardId);
         long startTimeNS = System.nanoTime();
         boolean exists = false;
         try {
             IndexService indexService = indicesService.indexService(shardId.getIndex());
+            final String customDataPath;
             if (indexService != null) {
                 IndexShard indexShard = indexService.getShardOrNull(shardId.id());
                 if (indexShard != null) {
@@ -135,23 +136,27 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
                         return new StoreFilesMetaData(shardId, Store.MetadataSnapshot.EMPTY, Collections.emptyList());
                     }
                 }
+                if (request.getCustomDataPath() != null) {
+                    customDataPath = request.getCustomDataPath();
+                } else {
+                    // TODO: Fallback for BWC with older ES versions. Remove this once request.getCustomDataPath() always returns non-null
+                    customDataPath = indexService.getIndexSettings().customDataPath();
+                }
+            } else {
+                if (request.getCustomDataPath() != null) {
+                    customDataPath = request.getCustomDataPath();
+                } else {
+                    // TODO: Fallback for BWC with older ES versions. Remove this once request.getCustomDataPath() always returns non-null
+                    IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndex());
+                    if (metaData != null) {
+                        customDataPath = new IndexSettings(metaData, settings).customDataPath();
+                    } else {
+                        logger.trace("{} node doesn't have meta data for the requests index", shardId);
+                        throw new ElasticsearchException("node doesn't have meta data for index " + shardId.getIndex());
+                    }
+                }
             }
-            // try and see if we an list unallocated
-            IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndex());
-            if (metaData == null) {
-                // we may send this requests while processing the cluster state that recovered the index
-                // sometimes the request comes in before the local node processed that cluster state
-                // in such cases we can load it from disk
-                metaData = IndexMetaData.FORMAT.loadLatestState(logger, namedXContentRegistry,
-                    nodeEnv.indexPaths(shardId.getIndex()));
-            }
-            if (metaData == null) {
-                logger.trace("{} node doesn't have meta data for the requests index, responding with empty", shardId);
-                return new StoreFilesMetaData(shardId, Store.MetadataSnapshot.EMPTY, Collections.emptyList());
-            }
-            final IndexSettings indexSettings = indexService != null ? indexService.getIndexSettings() :
-                new IndexSettings(metaData, settings);
-            final ShardPath shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, indexSettings);
+            final ShardPath shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, customDataPath);
             if (shardPath == null) {
                 return new StoreFilesMetaData(shardId, Store.MetadataSnapshot.EMPTY, Collections.emptyList());
             }
@@ -259,22 +264,45 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
     public static class Request extends BaseNodesRequest<Request> {
 
-        private ShardId shardId;
+        private final ShardId shardId;
+        @Nullable
+        private final String customDataPath;
 
         public Request(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                customDataPath = in.readString();
+            } else {
+                customDataPath = null;
+            }
         }
 
-        public Request(ShardId shardId, DiscoveryNode[] nodes) {
+        public Request(ShardId shardId, String customDataPath, DiscoveryNode[] nodes) {
             super(nodes);
-            this.shardId = shardId;
+            this.shardId = Objects.requireNonNull(shardId);
+            this.customDataPath = Objects.requireNonNull(customDataPath);
+        }
+
+        public ShardId shardId() {
+            return shardId;
+        }
+
+        /**
+         * Returns null if custom data path information is not available (due to BWC)
+         */
+        @Nullable
+        public String getCustomDataPath() {
+            return customDataPath;
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeString(customDataPath);
+            }
         }
     }
 
@@ -302,21 +330,45 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
 
     public static class NodeRequest extends BaseNodeRequest {
 
-        private ShardId shardId;
+        private final ShardId shardId;
+        @Nullable
+        private final String customDataPath;
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);
             shardId = new ShardId(in);
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                customDataPath = in.readString();
+            } else {
+                customDataPath = null;
+            }
         }
 
-        NodeRequest(TransportNodesListShardStoreMetaData.Request request) {
-            this.shardId = request.shardId;
+        public NodeRequest(Request request) {
+            this.shardId = Objects.requireNonNull(request.shardId());
+            this.customDataPath = Objects.requireNonNull(request.getCustomDataPath());
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             shardId.writeTo(out);
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                assert customDataPath != null;
+                out.writeString(customDataPath);
+            }
+        }
+
+        public ShardId getShardId() {
+            return shardId;
+        }
+
+        /**
+         * Returns null if custom data path information is not available (due to BWC)
+         */
+        @Nullable
+        public String getCustomDataPath() {
+            return customDataPath;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetaData.java
@@ -119,7 +119,6 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         boolean exists = false;
         try {
             IndexService indexService = indicesService.indexService(shardId.getIndex());
-            final String customDataPath;
             if (indexService != null) {
                 IndexShard indexShard = indexService.getShardOrNull(shardId.id());
                 if (indexShard != null) {
@@ -136,17 +135,15 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
                         return new StoreFilesMetaData(shardId, Store.MetadataSnapshot.EMPTY, Collections.emptyList());
                     }
                 }
-                if (request.getCustomDataPath() != null) {
-                    customDataPath = request.getCustomDataPath();
-                } else {
-                    // TODO: Fallback for BWC with older ES versions. Remove this once request.getCustomDataPath() always returns non-null
-                    customDataPath = indexService.getIndexSettings().customDataPath();
-                }
+            }
+            final String customDataPath;
+            if (request.getCustomDataPath() != null) {
+                customDataPath = request.getCustomDataPath();
             } else {
-                if (request.getCustomDataPath() != null) {
-                    customDataPath = request.getCustomDataPath();
+                // TODO: Fallback for BWC with older ES versions. Remove this once request.getCustomDataPath() always returns non-null
+                if (indexService != null) {
+                    customDataPath = indexService.getIndexSettings().customDataPath();
                 } else {
-                    // TODO: Fallback for BWC with older ES versions. Remove this once request.getCustomDataPath() always returns non-null
                     IndexMetaData metaData = clusterService.state().metaData().index(shardId.getIndex());
                     if (metaData != null) {
                         customDataPath = new IndexSettings(metaData, settings).customDataPath();
@@ -289,7 +286,9 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         }
 
         /**
-         * Returns null if custom data path information is not available (due to BWC)
+         * Returns the custom data path that is used to look up information for this shard.
+         * Returns an empty string if no custom data path is used for this index.
+         * Returns null if custom data path information is not available (due to BWC).
          */
         @Nullable
         public String getCustomDataPath() {
@@ -364,7 +363,9 @@ public class TransportNodesListShardStoreMetaData extends TransportNodesAction<T
         }
 
         /**
-         * Returns null if custom data path information is not available (due to BWC)
+         * Returns the custom data path that is used to look up information for this shard.
+         * Returns an empty string if no custom data path is used for this index.
+         * Returns null if custom data path information is not available (due to BWC).
          */
         @Nullable
         public String getCustomDataPath() {

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -19,14 +19,13 @@
 package org.elasticsearch.env;
 
 import org.apache.lucene.index.SegmentInfos;
-import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.core.internal.io.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.gateway.MetaDataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
@@ -357,19 +356,11 @@ public class NodeEnvironmentTests extends ESTestCase {
         String[] dataPaths = tmpPaths();
         NodeEnvironment env = newNodeEnvironment(dataPaths, "/tmp", Settings.EMPTY);
 
-        final Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, "myindexUUID").build();
-        IndexSettings s1 = IndexSettingsModule.newIndexSettings("myindex", indexSettings);
-        IndexSettings s2 = IndexSettingsModule.newIndexSettings("myindex", Settings.builder()
-                .put(indexSettings)
-                .put(IndexMetaData.SETTING_DATA_PATH, "/tmp/foo").build());
         Index index = new Index("myindex", "myindexUUID");
         ShardId sid = new ShardId(index, 0);
 
-        assertFalse("no settings should mean no custom data path", s1.hasCustomDataPath());
-        assertTrue("settings with path_data should have a custom data path", s2.hasCustomDataPath());
-
         assertThat(env.availableShardPaths(sid), equalTo(env.availableShardPaths(sid)));
-        assertThat(env.resolveCustomLocation(s2, sid).toAbsolutePath(),
+        assertThat(env.resolveCustomLocation("/tmp/foo", sid).toAbsolutePath(),
             equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0").toAbsolutePath()));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",
@@ -379,10 +370,8 @@ public class NodeEnvironmentTests extends ESTestCase {
         assertThat("index paths uses the regular template",
                 env.indexPaths(index), equalTo(stringsToPaths(dataPaths, "indices/" + index.getUUID())));
 
-        IndexSettings s3 = new IndexSettings(s2.getIndexMetaData(), Settings.builder().build());
-
         assertThat(env.availableShardPaths(sid), equalTo(env.availableShardPaths(sid)));
-        assertThat(env.resolveCustomLocation(s3, sid).toAbsolutePath(),
+        assertThat(env.resolveCustomLocation("/tmp/foo", sid).toAbsolutePath(),
             equalTo(PathUtils.get("/tmp/foo/0/" + index.getUUID() + "/0").toAbsolutePath()));
 
         assertThat("shard paths with a custom data_path should contain only regular paths",

--- a/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -373,7 +373,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         private AtomicInteger reroute = new AtomicInteger();
 
         TestFetch(ThreadPool threadPool) {
-            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), null);
+            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "", null);
             this.threadPool = threadPool;
         }
 

--- a/server/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -542,7 +542,9 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
     public void testStartedShardFoundIfStateNotYetProcessed() throws Exception {
         // nodes may need to report the shards they processed the initial recovered cluster state from the master
         final String nodeName = internalCluster().startNode();
-        assertAcked(prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1)));
+        createIndex("test", Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).build());
+        final String customDataPath = IndexMetaData.INDEX_DATA_PATH_SETTING.get(
+            client().admin().indices().prepareGetSettings("test").get().getIndexToSettings().get("test"));
         final Index index = resolveIndex("test");
         final ShardId shardId = new ShardId(index, 0);
         indexDoc("test", "1");
@@ -579,7 +581,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
 
         TransportNodesListGatewayStartedShards.NodesGatewayStartedShards response;
         response = ActionTestUtils.executeBlocking(internalCluster().getInstance(TransportNodesListGatewayStartedShards.class),
-            new TransportNodesListGatewayStartedShards.Request(shardId, new DiscoveryNode[]{node}));
+            new TransportNodesListGatewayStartedShards.Request(shardId, customDataPath, new DiscoveryNode[]{node}));
 
         assertThat(response.getNodes(), hasSize(1));
         assertThat(response.getNodes().get(0).allocationId(), notNullValue());

--- a/server/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/ShardPathTests.java
@@ -18,15 +18,12 @@
  */
 package org.elasticsearch.index.shard;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.IndexSettingsModule;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -37,16 +34,12 @@ import static org.hamcrest.Matchers.is;
 public class ShardPathTests extends ESTestCase {
     public void testLoadShardPath() throws IOException {
         try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
-            Settings.Builder builder = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, "0xDEADBEEF")
-                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
-            Settings settings = builder.build();
             ShardId shardId = new ShardId("foo", "0xDEADBEEF", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             ShardStateMetaData.FORMAT.writeAndCleanup(
                     new ShardStateMetaData(true, "0xDEADBEEF", AllocationId.newInitializing()), path);
-            ShardPath shardPath =
-                    ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings));
+            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, "");
             assertEquals(path, shardPath.getDataPath());
             assertEquals("0xDEADBEEF", shardPath.getShardId().getIndex().getUUID());
             assertEquals("foo", shardPath.getShardId().getIndexName());
@@ -58,32 +51,24 @@ public class ShardPathTests extends ESTestCase {
     public void testFailLoadShardPathOnMultiState() throws IOException {
         try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
             final String indexUUID = "0xDEADBEEF";
-            Settings.Builder builder = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, indexUUID)
-                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
-            Settings settings = builder.build();
             ShardId shardId = new ShardId("foo", indexUUID, 0);
             Path[] paths = env.availableShardPaths(shardId);
             assumeTrue("This test tests multi data.path but we only got one", paths.length > 1);
             ShardStateMetaData.FORMAT.writeAndCleanup(
                     new ShardStateMetaData(true, indexUUID, AllocationId.newInitializing()), paths);
-            Exception e = expectThrows(IllegalStateException.class, () ->
-                ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings)));
+            Exception e = expectThrows(IllegalStateException.class, () -> ShardPath.loadShardPath(logger, env, shardId, ""));
             assertThat(e.getMessage(), containsString("more than one shard state found"));
         }
     }
 
     public void testFailLoadShardPathIndexUUIDMissmatch() throws IOException {
         try (NodeEnvironment env = newNodeEnvironment(Settings.builder().build())) {
-            Settings.Builder builder = Settings.builder().put(IndexMetaData.SETTING_INDEX_UUID, "foobar")
-                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
-            Settings settings = builder.build();
             ShardId shardId = new ShardId("foo", "foobar", 0);
             Path[] paths = env.availableShardPaths(shardId);
             Path path = randomFrom(paths);
             ShardStateMetaData.FORMAT.writeAndCleanup(
                     new ShardStateMetaData(true, "0xDEADBEEF", AllocationId.newInitializing()), path);
-            Exception e = expectThrows(IllegalStateException.class, () ->
-                ShardPath.loadShardPath(logger, env, shardId, IndexSettingsModule.newIndexSettings(shardId.getIndex(), settings)));
+            Exception e = expectThrows(IllegalStateException.class, () -> ShardPath.loadShardPath(logger, env, shardId, ""));
             assertThat(e.getMessage(), containsString("expected: foobar on shard path"));
         }
     }
@@ -107,22 +92,19 @@ public class ShardPathTests extends ESTestCase {
 
     public void testGetRootPaths() throws IOException {
         boolean useCustomDataPath = randomBoolean();
-        final Settings indexSettings;
         final Settings nodeSettings;
         final String indexUUID = "0xDEADBEEF";
-        Settings.Builder indexSettingsBuilder = Settings.builder()
-                .put(IndexMetaData.SETTING_INDEX_UUID, indexUUID)
-                .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT);
         final Path customPath;
+        final String customDataPath;
         if (useCustomDataPath) {
             final Path path = createTempDir();
-            indexSettings = indexSettingsBuilder.put(IndexMetaData.SETTING_DATA_PATH, "custom").build();
+            customDataPath = "custom";
             nodeSettings = Settings.builder().put(Environment.PATH_SHARED_DATA_SETTING.getKey(), path.toAbsolutePath().toAbsolutePath())
                     .build();
             customPath = path.resolve("custom").resolve("0");
         } else {
             customPath = null;
-            indexSettings = indexSettingsBuilder.build();
+            customDataPath = "";
             nodeSettings = Settings.EMPTY;
         }
         try (NodeEnvironment env = newNodeEnvironment(nodeSettings)) {
@@ -131,8 +113,7 @@ public class ShardPathTests extends ESTestCase {
             Path path = randomFrom(paths);
             ShardStateMetaData.FORMAT.writeAndCleanup(
                     new ShardStateMetaData(true, indexUUID, AllocationId.newInitializing()), path);
-            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId,
-                IndexSettingsModule.newIndexSettings(shardId.getIndex(), indexSettings, nodeSettings));
+            ShardPath shardPath = ShardPath.loadShardPath(logger, env, shardId, customDataPath);
             boolean found = false;
             for (Path p : env.nodeDataPaths()) {
                 if (p.equals(shardPath.getRootStatePath())) {

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -248,7 +248,8 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         assertHitCount(client().prepareSearch("test").get(), 1);
         IndexMetaData secondMetaData = clusterService.state().metaData().index("test");
         assertAcked(client().admin().indices().prepareClose("test"));
-        ShardPath path = ShardPath.loadShardPath(logger, getNodeEnvironment(), new ShardId(test.index(), 0), test.getIndexSettings());
+        ShardPath path = ShardPath.loadShardPath(logger, getNodeEnvironment(), new ShardId(test.index(), 0),
+            test.getIndexSettings().customDataPath());
         assertTrue(path.exists());
 
         try {
@@ -281,7 +282,8 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         assertTrue(indexShard.routingEntry().started());
 
         final ShardPath shardPath = indexShard.shardPath();
-        assertEquals(ShardPath.loadShardPath(logger, getNodeEnvironment(), indexShard.shardId(), indexSettings), shardPath);
+        assertEquals(ShardPath.loadShardPath(logger, getNodeEnvironment(), indexShard.shardId(), indexSettings.customDataPath()),
+            shardPath);
 
         final IndicesService indicesService = getIndicesService();
         expectThrows(ShardLockObtainFailedException.class, () ->


### PR DESCRIPTION
Loading shard state information during shard allocation sometimes runs into a situation where a data node does not know yet how to look up the shard on disk if custom data paths are used. The current implementation loads the index metadata from disk to determine what the custom data path looks like. This PR removes this dependency, simplifying the lookup.

Relates #48701 but this PR is against master, as it has direct benefits even without the changes in #48701.