### PR TITLE
Specify name on enrich.get_policy as list type

### DIFF
--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -50,7 +50,7 @@ GET /_enrich/policy/my-policy
 [[get-enrich-policy-api-request]]
 ==== {api-request-title}
 
-`GET /_enrich/policy/<enrich-policy>`
+`GET /_enrich/policy/<name>`
 
 `GET /_enrich/policy`
 
@@ -64,7 +64,7 @@ include::put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
 [[get-enrich-policy-api-path-params]]
 ==== {api-path-parms-title}
 
-`<enrich-policy>`::
+`<name>`::
 +
 --
 (Optional, string)

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
@@ -9,8 +9,8 @@
           "methods": [ "GET" ],
           "parts": {
             "name": {
-              "type" : "string",
-              "description" : "The name of the enrich policy"
+              "type" : "list",
+              "description" : "A comma-separated list of enrich policy names"
             }
           }
         },


### PR DESCRIPTION
This PR updates the enrich.get_policy API to specify name as a list, in line with other URL parts that accept a comma-separated list of values
