### PR TITLE
[DOCS] Fixes "enables you to"

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -14,7 +14,7 @@ Updates a document using the specified script.
 [[update-api-desc]]
 ==== {api-description-title}
 
-Enables you script document updates. The script can update, delete, or skip
+Enables you to script document updates. The script can update, delete, or skip
 modifying the document. The update API also supports passing a partial document,
 which is merged into the existing document. To fully replace an existing
 document, use the <<docs-index_,`index` API>>.

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -23,7 +23,7 @@ Validates detector configuration information.
 [[ml-valid-detector-desc]]
 ==== {api-description-title}
 
-This API enables you validate the detector configuration
+This API enables you to validate the detector configuration
 before you create an {anomaly-job}.
 
 [[ml-valid-detector-request-body]]

--- a/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-job.asciidoc
@@ -23,7 +23,7 @@ Validates {anomaly-job} configuration information.
 [[ml-valid-job-desc]]
 ==== {api-description-title}
 
-This API enables you validate the {anomaly-job} configuration before you
+This API enables you to validate the {anomaly-job} configuration before you
 create the job.
 
 [[ml-valid-job-request-body]]

--- a/docs/reference/upgrade/reindex_upgrade.asciidoc
+++ b/docs/reference/upgrade/reindex_upgrade.asciidoc
@@ -102,8 +102,8 @@ endif::include-xpack[]
 === Reindex from a remote cluster
 
 You can use <<reindex-from-remote,reindex from remote>> to migrate indices from
-your old cluster to a new {version} cluster. This enables you move to {version}
-from a pre-6.8 cluster without interrupting service.
+your old cluster to a new {version} cluster. This enables you to move to
+{version} from a pre-6.8 cluster without interrupting service.
 
 [WARNING]
 =============================================

--- a/x-pack/docs/en/watcher/input/chain.asciidoc
+++ b/x-pack/docs/en/watcher/input/chain.asciidoc
@@ -7,7 +7,7 @@ execution context when the watch is triggered. The inputs in a chain
 are processed in order and the data loaded by an input can be accessed by the
 subsequent inputs in the chain. 
 
-The `chain` input enables you perform actions based on data from multiple 
+The `chain` input enables you to perform actions based on data from multiple
 sources. You can also use the data collected by one input to load data
 from another source.
 


### PR DESCRIPTION
Noticed this in the [Update API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html) and found similar instances in the rest of the docs.
Note: I'm not a native English speaker but it sounds wrong if "enables you" isn't followed by "to". I could be wrong about this though so feel free to disregard this PR.