### PR TITLE
Wait for green after opening job in NetworkDisruptionIT

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -48,11 +48,11 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
         Job.Builder job = createJob("relocation-job", new ByteSizeValue(2, ByteSizeUnit.MB));
         PutJobAction.Request putJobRequest = new PutJobAction.Request(job);
         client().execute(PutJobAction.INSTANCE, putJobRequest).actionGet();
-        ensureGreen();
 
         OpenJobAction.Request openJobRequest = new OpenJobAction.Request(job.getId());
         AcknowledgedResponse openJobResponse = client().execute(OpenJobAction.INSTANCE, openJobRequest).actionGet();
         assertTrue(openJobResponse.isAcknowledged());
+        ensureGreen();
 
         // Record which node the job starts off on
         String origJobNode = awaitJobOpenedAndAssigned(job.getId(), null);


### PR DESCRIPTION
The test was failing to relocate a job to a new node after a network disruption because the `.ml-state` index did not have active shards:

```
[o.e.p.PersistentTasksClusterService] ignoring task job-relocation-job because assignment is the same node: [null], explanation: [Not opening job [relocation-job], because not all primary shards are active for the following indices [.ml-state]]
```

`.ml-state`  is created when the first job is opened then the node was removed from the cluster before the index had time to replicate. Waiting for a green cluster state before triggering the disruption should ensure the replicas are present and fix the test. 

I hope this closes #49908 but I'll leave the issue open and trace logging enabled for a week in case it reoccurs. 

