### PR TITLE
Fix flakiness in CsvProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
@@ -209,6 +209,7 @@ public class CsvProcessorTests extends ESTestCase {
 
     private IngestDocument processDocument(String[] headers, String csv, boolean trim) throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        Arrays.stream(headers).filter(ingestDocument::hasField).forEach(ingestDocument::removeField);
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, csv);
         char quoteChar = quote.isEmpty() ? '"' : quote.charAt(0);


### PR DESCRIPTION
There's flakiness in ```CsvProcesorTests```, where  tests fail if random document generator add field that should not be present. This change cleans generated document from these problematic fields.

Closes #50209