### PR TITLE
[7.x] Fix flakiness in CsvProcessorTests (#50254)

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
@@ -209,6 +209,7 @@ public class CsvProcessorTests extends ESTestCase {
 
     private IngestDocument processDocument(String[] headers, String csv, boolean trim) throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        Arrays.stream(headers).filter(ingestDocument::hasField).forEach(ingestDocument::removeField);
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, csv);
         char quoteChar = quote.isEmpty() ? '"' : quote.charAt(0);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix flakiness in CsvProcessorTests (#50254)