### PR TITLE
Add test for IntervalsSourceProvider.Prefix

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -87,7 +87,7 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
                 return Wildcard.fromXContent(parser);
         }
         throw new ParsingException(parser.getTokenLocation(),
-            "Unknown interval type [" + parser.currentName() + "], expecting one of [match, any_of, all_of, prefix]");
+            "Unknown interval type [" + parser.currentName() + "], expecting one of [match, any_of, all_of, prefix, wildcard]");
     }
 
     private static IntervalsSourceProvider parseInnerIntervals(XContentParser parser) throws IOException {
@@ -548,6 +548,18 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public static Prefix fromXContent(XContentParser parser) throws IOException {
             return PARSER.parse(parser, null);
         }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public String getAnalyzer() {
+            return analyzer;
+        }
+
+        public String getUseField() {
+            return useField;
+        }
     }
 
     public static class Wildcard extends IntervalsSourceProvider {
@@ -613,10 +625,10 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            Prefix prefix = (Prefix) o;
-            return Objects.equals(pattern, prefix.prefix) &&
-                Objects.equals(analyzer, prefix.analyzer) &&
-                Objects.equals(useField, prefix.useField);
+            Wildcard wildcard = (Wildcard) o;
+            return Objects.equals(pattern, wildcard.pattern) &&
+                Objects.equals(analyzer, wildcard.analyzer) &&
+                Objects.equals(useField, wildcard.useField);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IntervalsSourceProvider.java
@@ -549,15 +549,15 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
             return PARSER.parse(parser, null);
         }
 
-        public String getPrefix() {
+        String getPrefix() {
             return prefix;
         }
 
-        public String getAnalyzer() {
+        String getAnalyzer() {
             return analyzer;
         }
 
-        public String getUseField() {
+        String getUseField() {
             return useField;
         }
     }
@@ -625,10 +625,10 @@ public abstract class IntervalsSourceProvider implements NamedWriteable, ToXCont
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            Wildcard wildcard = (Wildcard) o;
-            return Objects.equals(pattern, wildcard.pattern) &&
-                Objects.equals(analyzer, wildcard.analyzer) &&
-                Objects.equals(useField, wildcard.useField);
+            Prefix prefix = (Prefix) o;
+            return Objects.equals(pattern, prefix.prefix) &&
+                Objects.equals(analyzer, prefix.analyzer) &&
+                Objects.equals(useField, prefix.useField);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/query/PrefixIntervalsSourceProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/PrefixIntervalsSourceProviderTests.java
@@ -1,0 +1,57 @@
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.index.query.IntervalsSourceProvider.Prefix;
+
+public class PrefixIntervalsSourceProviderTests extends AbstractSerializingTestCase<Prefix> {
+
+    @Override
+    protected Prefix createTestInstance() {
+        return new Prefix(
+            randomAlphaOfLength(10),
+            randomBoolean() ? randomAlphaOfLength(10) : null,
+            randomBoolean() ? randomAlphaOfLength(10) : null
+        );
+    }
+
+    @Override
+    protected Prefix mutateInstance(Prefix instance) throws IOException {
+        String prefix = instance.getPrefix();
+        String analyzer = instance.getAnalyzer();
+        String useField = instance.getUseField();
+        switch (between(0, 2)) {
+            case 0:
+                prefix += "a";
+                break;
+            case 1:
+                analyzer = randomAlphaOfLength(5);
+                break;
+            case 2:
+                useField = useField == null ? randomAlphaOfLength(5) : null;
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
+        }
+        return new Prefix(prefix, analyzer, useField);
+    }
+
+    @Override
+    protected Writeable.Reader<Prefix> instanceReader() {
+        return Prefix::new;
+    }
+
+    @Override
+    protected Prefix doParseInstance(XContentParser parser) throws IOException {
+        if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
+            parser.nextToken();
+        }
+        Prefix prefix = (Prefix) IntervalsSourceProvider.fromXContent(parser);
+        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+        return prefix;
+    }
+}


### PR DESCRIPTION
This PR adds unit test for wire and xContent serialization of `IntervalsSourceProvider.Prefix`.

Relates https://github.com/elastic/elasticsearch/issues/50150