### PR TITLE
[DOCS] Correct cat snapshots API request example

### DIFF
--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -13,8 +13,6 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 
 `GET /_cat/snapshots/<repository>`
 
-`GET /_cat/snapshots`
-
 
 [[cat-snapshots-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -20,10 +20,9 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 `<repository>`::
 +
 --
-(Required, string) Comma-separated list of snapshot repositories used to limit
-the request. Accepts wildcard expressions.
+(Required, string) Snapshot repository used to limit the request.
 
-If any repository fails during the request, {es} returns an error.
+If the repository fails during the request, {es} returns an error.
 --
 
 

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -20,7 +20,7 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 `<repository>`::
 +
 --
-(Optional, string) Comma-separated list of snapshot repositories used to limit
+(Required, string) Comma-separated list of snapshot repositories used to limit
 the request. Accepts wildcard expressions.
 
 If any repository fails during the request, {es} returns an error.

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -21,7 +21,7 @@ more repositories. A snapshot is a backup of an index or running {es} cluster.
 +
 --
 (Optional, string) Comma-separated list of snapshot repositories used to limit
-the request. Accepts wildcard expressions. `_all` returns all repositories.
+the request. Accepts wildcard expressions.
 
 If any repository fails during the request, {es} returns an error.
 --


### PR DESCRIPTION
For 7.x and earlier branches, `_cat/repositories` API requests require a
repository name.

This removes an erroneous request example without a repository name
added with a8e0275.

Fixes #50181.