### PR TITLE
Increase timeout on FollowIndexSecurityIT.testAutoFollowPatterns

### DIFF
--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -169,7 +169,7 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
         assertBusy(() -> {
             ensureYellow(allowedIndex);
             verifyDocuments(allowedIndex, 5, "*:*");
-        });
+        }, 30, TimeUnit.SECONDS);
         assertThat(indexExists(disallowedIndex), is(false));
         assertBusy(() -> {
             verifyCcrMonitoring(allowedIndex, allowedIndex);


### PR DESCRIPTION
Analysis here: https://github.com/elastic/elasticsearch/issues/50279#issuecomment-566627942

Closes #50279