### PR TITLE
[DOCS] Add analysis concept docs

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -3,111 +3,164 @@
 
 [partintro]
 --
+_Analysis_ is the process of converting an input text into smaller chunks,
+called _tokens_ or _terms_, that can be searched.
 
-_Analysis_ is the process of converting text, like the body of any email, into
-_tokens_ or _terms_ which are added to the inverted index for searching.
-Analysis is performed by an <<analysis-analyzers,_analyzer_>> which can be
+To understand why analysis is important and how it works, it's helpful to first
+understand how {es} indexes, matches, and retrieves data.
+
+[discrete]
+[[inverted-index]]
+== Inverted index
+
+When you index a document, {es} stores the data for each document field in a
+structure called an _inverted index_. The field's inverted index lists
+every unique token, typically words, and identifies all of the documents
+in which that token occurs.
+
+For example, you can index two documents, each with a field containing the
+following text:
+
+[source,text]
+------
+1. The quick brown fox jumps
+2. Quick foxes leap over lazy dogs
+------
+
+These values can then be split into sets of separate words, or tokens, called
+_token streams_:
+
+[source,text]
+------
+1. [ The, quick, brown, fox, jumps, lazy, dogs ]
+2. [ Quick, foxes, leap, over, lazy, dogs ]
+------
+
+These token streams can then be compiled into an inverted index that lists each
+unique token and the document containing it.
+
+[options="header"]
+|===
+|Word   | Document 1 | Document 2
+|brown  |            | X
+|dogs   | X          | X
+|fox    | X          |
+|foxes  |            | X
+|jumps  | X          |
+|lazy   | X          | X
+|leap   |            | X
+|over   |            | X
+|quick  | X          |
+|Quick  |            | X
+|The    | X          | 
+|===
+
+When you search for `lazy dogs`, {es} can quickly find which documents contain
+your search terms.
+
+[options="header"]
+|===
+|Word   | Document 1 | Document 2
+|lazy   | X          | X
+|dogs   | X          | X
+|===
+
+However, this example inverted index has a few problems:
+
+* `Quick` and `quick` are listed as separate words, even though you likely want
+either term to match a search for `quick`.
+
+* `fox` and `foxes` share the same root word. However,
+a search for `fox` would not match `foxes` or vice versa.
+
+* While `jumps` and `leap` don't share a root word, they are synonyms and have a
+similar meaning. However, a search for one would not match the other.
+
+To solve this, you can _normalize_ these tokens into a standard format. This
+allows you to match tokens that are not exactly the same as the search terms,
+but similar enough to still be relevant. For example:
+
+* `Quick` can be lowercased: `quick`.
+
+* `foxes` can be _stemmed_, or reduced to its root word: `fox`.
+
+* `jumps` and `leap` are synonyms and can be indexed as a single word: `jump`.
+
+After normalization, the inverted index looks like this:
+
+[options="header"]
+|===
+|Word   | Document 1 | Document 2
+|brown  |            | X
+|dog    | X          | X
+|fox    | X          | X
+|jump   | X          | X
+|lazy   | X          | X
+|over   |            | X
+|quick  | X          | X
+|the    | X          | 
+|===
+
+To ensure search terms match these words as intended, you can apply the same
+normalization rules to the query string. For example, a search for
+`Foxes leaped` is normalized to a search for `fox jump`, which is found in
+both documents
+
+[options="header"]
+|===
+|Word   | Document 1 | Document 2
+|fox    | X          | X
+|jump   | X          | X
+|===
+
+[discrete]
+[[analysis-chain]]
+== Analysis chain
+
+As shown in the previous example, analysis can involve several interconnected
+steps, called the _analysis chain_ or _analysis
+pipeline_, that must be performed in order. These steps include:
+
+[[analysis-preprocessing]]
+String preprocessing::
+Directly changing the input string before any conversion. This typically
+involves changing or removing individual charcters.
+
+[[analysis-tokenization]]
+Tokenization::
+Converting an input string into smaller chunks, called _tokens_ 
+or _terms_. For fields containing unstructured text, like a message or a product
+description, these tokens are often words. A specific set of separated tokens
+is called a _token stream_.
+
+[[analysis-token-normalization]]
+Token normalization::
+Changing, removing, or adding tokens in a token stream, typically to make them
+more searchable. Normalization can involve several techniques, such as stemming
+or adding synonyms. See <<normalization>>.
+
+[discrete]
+[[performing-analysis]]
+== Performing analysis
+
+Analysis is performed by an <<analysis-analyzers,_analyzer_>>, which can be
 either a built-in analyzer or a <<analysis-custom-analyzer,`custom`>> analyzer
 defined per index.
 
-[float]
-== Index time analysis
+For a list of built-in analyzers or to learn more about custom analyzers, see <<analysis-analyzers>>.
 
-For instance, at index time the built-in <<english-analyzer,`english`>> _analyzer_ 
-will first convert the sentence:
+To learn about the components of an analyzer, see
+<<analyzer-anatomy>>.
 
-[source,text]
-------
-"The QUICK brown foxes jumped over the lazy dog!"
-------
-
-into distinct tokens. It will then lowercase each token, remove frequent
-stopwords ("the") and reduce the terms to their word stems (foxes -> fox,
-jumped -> jump, lazy -> lazi). In the end, the following terms will be added
-to the inverted index:
-
-[source,text]
-------
-[ quick, brown, fox, jump, over, lazi, dog ]
-------
-
-[float]
-[[specify-index-time-analyzer]]
-=== Specifying an index time analyzer
-
-Each <<text,`text`>> field in a mapping can specify its own
-<<analyzer,`analyzer`>>:
-
-[source,console]
--------------------------
-PUT my_index
-{
-  "mappings": {
-    "properties": {
-      "title": {
-        "type":     "text",
-        "analyzer": "standard"
-      }
-    }
-  }
-}
--------------------------
-
-At index time, if no `analyzer` has been specified, it looks for an analyzer
-in the index settings called `default`.  Failing that, it defaults to using
-the <<analysis-standard-analyzer,`standard` analyzer>>.
-
-
-[float]
-== Search time analysis
-
-This same analysis process is applied to the query string at search time in
-<<full-text-queries,full text queries>> like the
-<<query-dsl-match-query,`match` query>>
-to convert the text in the query string into terms of the same form as those
-that are stored in the inverted index.
-
-For instance, a user might search for:
-
-[source,text]
-------
-"a quick fox"
-------
-
-which would be analysed by the same `english` analyzer into the following terms:
-
-[source,text]
-------
-[ quick, fox ]
-------
-
-Even though the exact words used in the query string don't appear in the
-original text (`quick` vs `QUICK`, `fox` vs `foxes`), because we have applied
-the same analyzer to both the text and the query string, the terms from the
-query string exactly match the terms from the text in the inverted index,
-which means that this query would match our example document.
-
-[float]
-=== Specifying a search time analyzer
-
-Usually the same analyzer should be used both at
-index time and at search time, and <<full-text-queries,full text queries>>
-like the  <<query-dsl-match-query,`match` query>> will use the mapping to look
-up the analyzer to use for each field.
-
-The analyzer to use to search a particular field is determined by
-looking for:
-
-* An `analyzer` specified in the query itself.
-* The <<search-analyzer,`search_analyzer`>> mapping parameter.
-* The <<analyzer,`analyzer`>> mapping parameter.
-* An analyzer in the index settings called `default_search`.
-* An analyzer in the index settings called `default`.
-* The `standard` analyzer.
-
+After choosing an analyzer, you can apply it to an index, individual
+<<text,`text`>> fields, or full-text queries. See <<specify-analyzer>>.
 --
 
 include::analysis/anatomy.asciidoc[]
+
+include::analysis/normalizing-tokens.asciidoc[]
+
+include::analysis/specify-analyzer.asciidoc[]
 
 include::analysis/testing.asciidoc[]
 
@@ -120,4 +173,3 @@ include::analysis/tokenizers.asciidoc[]
 include::analysis/tokenfilters.asciidoc[]
 
 include::analysis/charfilters.asciidoc[]
-

--- a/docs/reference/analysis/anatomy.asciidoc
+++ b/docs/reference/analysis/anatomy.asciidoc
@@ -3,21 +3,23 @@
 
 An _analyzer_  -- whether built-in or custom -- is just a package which
 contains three lower-level building blocks: _character filters_,
-_tokenizers_, and _token filters_.
+_tokenizers_, and _token filters_. Each of these building blocks correspond
+to a step in the <<analysis-chain,analysis chain>>.
 
 The built-in <<analysis-analyzers,analyzers>> pre-package these building
 blocks into analyzers suitable for different languages and types of text.
-Elasticsearch also exposes the individual building blocks so that they can be
+{es} also exposes the individual building blocks so that they can be
 combined to define new <<analysis-custom-analyzer,`custom`>> analyzers.
 
 [float]
 === Character filters
 
-A _character filter_ receives the original text as a stream of characters and
-can transform the stream by adding, removing, or changing characters.  For
-instance, a character filter could be used to convert Hindu-Arabic numerals
-(٠‎١٢٣٤٥٦٧٨‎٩‎) into their Arabic-Latin equivalents (0123456789), or to strip HTML
-elements like `<b>` from the stream.
+A _character filter_ performs <<analysis-preprocessing,string preprocessing>>.
+It receives the original text as a stream of characters and can transform the
+stream by adding, removing, or changing characters.  For instance, a character
+filter could be used to convert Hindu-Arabic numerals (٠‎١٢٣٤٥٦٧٨‎٩‎) into their
+Arabic-Latin equivalents (0123456789), or to strip HTML elements like `<b>` from
+the stream.
 
 An analyzer may have *zero or more* <<analysis-charfilters,character filters>>,
 which are applied in order.
@@ -25,11 +27,12 @@ which are applied in order.
 [float]
 === Tokenizer
 
-A _tokenizer_  receives a stream of characters, breaks it up into individual
-_tokens_ (usually individual words), and outputs a stream of _tokens_. For
-instance, a <<analysis-whitespace-tokenizer,`whitespace`>> tokenizer breaks
-text into tokens whenever it sees any whitespace.  It would convert the text
-`"Quick brown fox!"` into the terms `[Quick, brown, fox!]`.
+A _tokenizer_  performs <<analysis-tokenization,tokenization>>. It receives a
+stream of characters, breaks it up into individual _tokens_ (usually individual
+words), and outputs a stream of _tokens_. For instance, a
+<<analysis-whitespace-tokenizer,`whitespace`>> tokenizer breaks text into tokens
+whenever it sees any whitespace.  It would convert the text `"Quick brown fox!"`
+into the terms `[Quick, brown, fox!]`.
 
 The tokenizer is also responsible for recording the order or _position_ of
 each term and the start and end _character offsets_ of the original word which
@@ -41,13 +44,13 @@ An analyzer must have *exactly one* <<analysis-tokenizers,tokenizer>>.
 [float]
 === Token filters
 
-A _token filter_ receives the token stream and may add, remove, or change
-tokens.  For example, a <<analysis-lowercase-tokenfilter,`lowercase`>> token
-filter converts all tokens to lowercase, a
-<<analysis-stop-tokenfilter,`stop`>> token filter removes common words
-(_stop words_) like `the` from the token stream, and a
-<<analysis-synonym-tokenfilter,`synonym`>> token filter introduces synonyms
-into the token stream.
+A _token filter_ performs <<analysis-token-normalization,token normalization>>.
+It receives the token stream and may add, remove, or change tokens.  For
+example, a <<analysis-lowercase-tokenfilter,`lowercase`>> token filter converts
+all tokens to lowercase, a <<analysis-stop-tokenfilter,`stop`>> token filter
+removes common words (_stop words_) like `the` from the token stream, and a
+<<analysis-synonym-tokenfilter,`synonym`>> token filter introduces synonyms into
+the token stream.
 
 Token filters are not allowed to change the position or character offsets of
 each token.

--- a/docs/reference/analysis/normalizing-tokens.asciidoc
+++ b/docs/reference/analysis/normalizing-tokens.asciidoc
@@ -1,0 +1,77 @@
+[[normalization]]
+== Normalizing tokens
+
+_Token normalization_ is the process of changing, removing, or adding tokens in 
+a token stream, typically to make them more searchable. Normalization is handled
+by the <<analysis-tokenfilters,token filters>> of an <<analysis-analyzers,analyzer>>.
+
+The changes made by these filters can vary widely. Some filters remove insignificant differences between otherwise identical
+tokens, such as using the <<analysis-lowercase-tokenfilter,`lowercase`>> filter
+to change uppercase to lowercase.
+
+Other filters might make more significant or complex changes, including:
+
+* <<stemming,Stemming>> tokens to their root word
+* Removing stop words, commonly used words which are rarely relevant to searches
+* Adding synonyms so that searches for a term also match related terms
+
+[[stemming]]
+=== Stemming
+
+Most languages of the world are inflected, meaning that words can change their
+form to express differences in the following:
+
+* _Number_:      fox, foxes
+* _Tense_:       pay, paid, paying
+* _Person_:      hear, hears
+
+_Stemming_ removes these inflections to reduce words to a root form. This lets
+you match the various inflected forms of a word during a search. For example, if
+`foxes` is stemmed to `fox`, searches for the term `fox` match documents that
+contain either `fox` or `foxes`.
+
+[[stemming-token-filters]]
+==== Stemming token filters
+
+{es} offers a number of built-in and configurable <<analysis-tokenfilters,token
+filters>> for stemming.
+
+If you're unsure where to start, use the
+<<analysis-stemmer-tokenfilter,`stemmer`>> filter, which supports multiple
+languages and stemmer types. The <<analysis-stemmer-tokenfilter,`stemmer`
+filter page>> highlights the recommended stemmer for each language in bold,
+based on a reasonable compromise between performance and quality.
+
+Aside from the `stemmer` filter, other stemming token filters include:
+
+* <<analysis-hunspell-tokenfilter,`hunspell`>>
+* <<analysis-kstem-tokenfilter,`kstem`>>
+* <<analysis-porterstem-tokenfilter,`porter_stem`>>
+* <<analysis-snowball-tokenfilter,`snowball`>>
+
+[float]
+[[overriding-stemmers]]
+==== Overriding stemmers
+
+[[stemmer-keyword]]
+You can use a _keyword_ token filter to exclude tokens such as proper nouns or
+brand names from stemming. Tokens that you designate as keywords are not
+stemmed.
+
+Keyword token filters include:
+
+<<analysis-keyword-repeat-tokenfilter,`keyword_marker`>>::
+Designates specific tokens as keywords.
+
+<<analysis-keyword-repeat-tokenfilter,`keyword_repeat`>>::
+Outputs both the stemmed and unstemmed (keyword) version of each token.
+
+<<analysis-stemmer-override-tokenfilter,`stemmer_override`>>::
+Uses a custom mapping to stem certain tokens as specified. These tokens are then
+marked as keywords and excluded from further stemming.
+
+[IMPORTANT]
+====
+To work, keyword token filters must be included in your analyzer configuration
+_before_ any stemming token filters.
+====

--- a/docs/reference/analysis/specify-analyzer.asciidoc
+++ b/docs/reference/analysis/specify-analyzer.asciidoc
@@ -1,0 +1,55 @@
+[[specify-analyzer]]
+== Specify an analyzer
+
+After choosing an <<analysis-analyzers,analyzer>>, you can apply it to an index,
+individual <<text,`text`>> fields, or <<full-text-queries,full text queries>>.
+
+[[specify-index-time-analyzer]]
+=== Specifying an index time analyzer
+
+Each <<text,`text`>> field in a mapping can specify its own
+<<analyzer,`analyzer`>>:
+
+[source,console]
+-------------------------
+PUT my_index
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type":     "text",
+        "analyzer": "standard"
+      }
+    }
+  }
+}
+-------------------------
+
+At index time, if no `analyzer` has been specified, it looks for an analyzer
+in the index settings called `default`.  Failing that, it defaults to using
+the <<analysis-standard-analyzer,`standard` analyzer>>.
+
+
+[specify-search-time-analyzer]
+=== Specifying a search time analyzer
+
+This same analysis process is applied to the query string at search time in
+<<full-text-queries,full text queries>> like the
+<<query-dsl-match-query,`match` query>>
+to convert the text in the query string into terms of the same form as those
+that are stored in the inverted index.
+
+Usually the same analyzer should be used both at
+index time and at search time, and <<full-text-queries,full text queries>>
+like the  <<query-dsl-match-query,`match` query>> will use the mapping to look
+up the analyzer to use for each field.
+
+The analyzer to use to search a particular field is determined by
+looking for:
+
+* An `analyzer` specified in the query itself.
+* The <<search-analyzer,`search_analyzer`>> mapping parameter.
+* The <<analyzer,`analyzer`>> mapping parameter.
+* An analyzer in the index settings called `default_search`.
+* An analyzer in the index settings called `default`.
+* The `standard` analyzer.

--- a/docs/reference/analysis/specify-analyzer.asciidoc
+++ b/docs/reference/analysis/specify-analyzer.asciidoc
@@ -1,55 +1,205 @@
 [[specify-analyzer]]
 == Specify an analyzer
 
-After choosing an <<analysis-analyzers,analyzer>>, you can apply it to an index,
-individual <<text,`text`>> fields, or <<full-text-queries,full text queries>>.
+<<analysis,Analysis>> occurs in two contexts:
 
+Index time::
+When a <<text,`text`>> field value is converted to tokens and added to the
+field's <<inverted-index,inverted index>>.
+
+Search time::
+When using a <<full-text-queries,full text query>>, such as the
+<<query-dsl-match-query,`match`>> query, to search a `text` field. Usually, this
+converts the query string into the same type of tokens stored in the field's
+inverted index. Search time is also called _query time_.
+
+The <<analysis-analyzers,analyzers>> used are called
+<<specify-index-time-analyzer,_index-time analyzers_>> and
+<<specify-search-time-analyzer,_search-time analyzers_>> respectively.
+
+[discrete]
 [[specify-index-time-analyzer]]
-=== Specifying an index time analyzer
+=== Index-time analyzer
 
-Each <<text,`text`>> field in a mapping can specify its own
-<<analyzer,`analyzer`>>:
+You can specify index-time analyzers for
+<<specify-index-time-field-analyzer,individual fields>>, an
+<<specify-index-time-default-analyzer,index>>, or both.
+
+When indexing a `text` field value, {es} determines which analyzer to use by
+checking the following parameters in this order:
+
+. The <<analyzer,`analyzer`>> mapping parameter of the field
+. The `default` analyzer in the index settings
+
+If none of these parameters are specified, the
+<<analysis-standard-analyzer,`standard` analyzer>> is used.
+
+[discrete]
+[[specify-index-time-field-analyzer]]
+==== Specify an index-time analyzer for a field
+
+You can use the <<analyzer,`analyzer`>> mapping parameter to specify the
+index-time analyzer for an individual `text` field.
+
+For example, the following <<indices-create-index,create index>> API request
+specifies the <<analysis-simple-analyzer,`simple`>> analyzer as the index-time
+analyzer for the `title` field.
 
 [source,console]
 -------------------------
-PUT my_index
+PUT books
 {
   "mappings": {
     "properties": {
       "title": {
         "type":     "text",
-        "analyzer": "standard"
+        "analyzer": "simple"
       }
     }
   }
 }
 -------------------------
 
-At index time, if no `analyzer` has been specified, it looks for an analyzer
-in the index settings called `default`.  Failing that, it defaults to using
-the <<analysis-standard-analyzer,`standard` analyzer>>.
+[discrete]
+[[specify-index-time-default-analyzer]]
+==== Specify a default index-time analyzer
 
+When creating an index, you can set a default index-time analyzer using the
+index's `default` setting.
 
-[specify-search-time-analyzer]
-=== Specifying a search time analyzer
+For example, the following <<indices-create-index,create index>> API request
+specifies the <<analysis-whitespace-analyzer,`whitespace`>> analyzer as the
+default index-time analyzer for the `books` index.
 
-This same analysis process is applied to the query string at search time in
-<<full-text-queries,full text queries>> like the
-<<query-dsl-match-query,`match` query>>
-to convert the text in the query string into terms of the same form as those
-that are stored in the inverted index.
+[source,console]
+----
+PUT books
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "default": {
+          "type": "whitespace"
+        }
+      }
+    }
+  }
+}
+----
 
-Usually the same analyzer should be used both at
-index time and at search time, and <<full-text-queries,full text queries>>
-like the  <<query-dsl-match-query,`match` query>> will use the mapping to look
-up the analyzer to use for each field.
+A default index-time analyzer can be useful when mapping multiple `text` fields
+that use the same analyzer. This analyzer also works as a general fallback if no
+other analyzer is specified for a field or query.
 
-The analyzer to use to search a particular field is determined by
-looking for:
+[discrete]
+[[specify-search-time-analyzer]]
+=== Search-time analyzer
 
-* An `analyzer` specified in the query itself.
-* The <<search-analyzer,`search_analyzer`>> mapping parameter.
-* The <<analyzer,`analyzer`>> mapping parameter.
-* An analyzer in the index settings called `default_search`.
-* An analyzer in the index settings called `default`.
-* The `standard` analyzer.
+[IMPORTANT]
+====
+In most cases, the same analyzer should be used at both index and search time.
+This means specifying a search-time analyzer is usually unnecessary.
+
+By default, full-text queries use a field's index-time analyzer as the
+search-time analyzer. This converts the query string into the same type of
+tokens stored in the field's inverted index, ensuring better search matches.
+
+If you choose to use a separate search-time analyzer, we recommend thoroughly
+testing before going into production.
+====
+
+You can specify search-time analyzers for a
+<<specify-search-time-query-analyzer,full-text query>>, an
+<<specify-search-time-field-analyzer,individual field>>, and an
+<<specify-search-time-default-analyzer,index>>.
+
+Full-text queries determine which search-time analyzer to use during a search by
+checking the following parameters in this order:
+
+. The `analyzer` parameter in the query
+. The <<search-analyzer,`search_analyzer`>> mapping parameter for the field
+. The <<analyzer,`analyzer`>> mapping parameter for the field
+. The `default_search` analyzer in the index settings
+. The `default` analyzer in the index settings
+
+If none of these parameters are specified, the
+<<analysis-standard-analyzer,`standard` analyzer>> is used.
+
+[discrete]
+[[specify-search-time-query-analyzer]]
+==== Specify a search-time analyzer in a query
+
+You can use the `analyzer` parameter in a <<full-text-queries,full-text
+query>> to specify a search-time analyzer for the query.
+
+For example, the following `match` query uses the
+<<analysis-simple-analyzer,`simple`>> analyzer as the query's search-time
+analyzer.
+
+[source,console]
+----
+GET _search
+{
+    "query": {
+        "match" : {
+            "title" : {
+                "query" : "Heart of Darkness",
+                "analyzer" : "simple"
+            }
+        }
+    }
+}
+----
+
+[discrete]
+[[specify-search-time-field-analyzer]]
+==== Specify a search-time analyzer for a field
+
+You can use the <<search-analyzer,`search_analyzer`>> mapping parameter to
+specify the search-time analyzer for an individual `text` field.
+
+For example, the following <<indices-create-index,create index>> API request
+specifies the <<analysis-whitespace-analyzer,`whitespace`>> analyzer as the
+search-time analyzer for the `title` field.
+
+[source,console]
+-------------------------
+PUT books
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type":     "text",
+        "search_analyzer": "whitespace"
+      }
+    }
+  }
+}
+-------------------------
+
+[discrete]
+[[specify-search-time-default-analyzer]]
+==== Specify a default search-time analyzer
+
+When creating an index, you can set a default search-time analyzer using the
+index's `default_search` setting.
+
+For example, the following <<indices-create-index,create index>> API request
+specifies the <<english-analyzer,`english`>> analyzer as the
+default search-time analyzer for the `books` index.
+
+[source,console]
+----
+PUT books
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "default_search": {
+          "type": "english"
+        }
+      }
+    }
+  }
+}
+----

--- a/docs/reference/analysis/specify-analyzer.asciidoc
+++ b/docs/reference/analysis/specify-analyzer.asciidoc
@@ -170,6 +170,7 @@ PUT books
     "properties": {
       "title": {
         "type":     "text",
+        "analyzer": "simple",
         "search_analyzer": "whitespace"
       }
     }


### PR DESCRIPTION
* Adds conceptual docs to the top-level 'Analysis' page. Covered
  concepts include:
    * Inverted index
    * Analysis chain and its steps: preprocessing, tokenization,
      token normalization

* Updates the 'Anatomy of an analyzer' docs to link each analyzer
  component to a step in the analysis chain.

* Relocates information about specifying analyzers from top-level
  'Analysis' page to a separate 'Specify an analyzer' page.

* Adds pages for token normalization techniques, such as stemming,
  synonyms, and stop words. Currently only stemming is documented in
  detail, but I plan to add docs for synonyms and stop words in the
  future.

This splits off conceptual information originally part of #49662.

Closes #50082.