### PR TITLE
Rename the remote cluster sniff proxy setting

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -929,7 +929,7 @@ buildRestTests.setups['farequote_index'] = '''
                   airline:
                      type: keyword
                   doc_count:
-                     type: integer       
+                     type: integer
 '''
 buildRestTests.setups['farequote_data'] = buildRestTests.setups['farequote_index'] + '''
   - do:
@@ -941,7 +941,7 @@ buildRestTests.setups['farequote_data'] = buildRestTests.setups['farequote_index
             {"airline":"JZA","responsetime":990.4628,"time":"2016-02-07T00:00:00+0000", "doc_count": 5}
             {"index": {"_id":"2"}}
             {"airline":"JBU","responsetime":877.5927,"time":"2016-02-07T00:00:00+0000", "doc_count": 23}
-            {"index": {"_id":"3"}}            
+            {"index": {"_id":"3"}}
             {"airline":"KLM","responsetime":1355.4812,"time":"2016-02-07T00:00:00+0000", "doc_count": 42}
 '''
 buildRestTests.setups['farequote_job'] = buildRestTests.setups['farequote_data'] + '''
@@ -1100,7 +1100,7 @@ buildRestTests.setups['server_metrics_openjob'] = buildRestTests.setups['server_
 buildRestTests.setups['server_metrics_openjob-raw'] = buildRestTests.setups['server_metrics_datafeed-raw'] + '''
   - do:
       raw:
-        method: POST 
+        method: POST
         path: _ml/anomaly_detectors/total-requests/_open
 '''
 buildRestTests.setups['server_metrics_startdf'] = buildRestTests.setups['server_metrics_openjob'] + '''
@@ -1178,7 +1178,7 @@ buildRestTests.setups['remote_cluster'] = buildRestTests.setups['host'] + '''
       cluster.put_settings:
         body:
           persistent:
-            cluster.remote.remote_cluster.seeds: $transport_host
+            cluster.remote.remote_cluster.sniff.seeds: $transport_host
 '''
 
 buildRestTests.setups['remote_cluster_and_leader_index'] = buildRestTests.setups['remote_cluster'] + '''
@@ -1309,7 +1309,7 @@ buildRestTests.setups['logdata_job'] = buildRestTests.setups['setup_logdata'] + 
         id: "loganalytics"
         body:  >
           {
-            "source": { 
+            "source": {
               "index": "logdata"
               },
             "dest": {

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -98,7 +98,7 @@ PUT /_cluster/settings
     "cluster" : {
       "remote" : {
         "leader" : {
-          "seeds" : [
+          "sniff.seeds" : [
             "127.0.0.1:9300" <1>
           ]
         }

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -29,17 +29,17 @@ PUT _cluster/settings
     "cluster": {
       "remote": {
         "cluster_one": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9300"
           ]
         },
         "cluster_two": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9301"
           ]
         },
         "cluster_three": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9302"
           ]
         }

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -81,10 +81,10 @@ nodes. For example:
 cluster:
     remote:
         cluster_one: <1>
-            seeds: 127.0.0.1:9300 <2>
+            sniff.seeds: 127.0.0.1:9300 <2>
             transport.ping_schedule: 30s <3>
-        cluster_two: 
-            seeds: 127.0.0.1:9301
+        cluster_two:
+            sniff.seeds: 127.0.0.1:9301
             transport.compress: true <4>
             skip_unavailable: true <5>
 
@@ -99,7 +99,7 @@ seed node in the remote cluster.
 <5> Disconnected remote clusters are optional for `cluster_two`.
 
 For more information about the optional transport settings, see
-<<modules-transport>>. 
+<<modules-transport>>.
 
 
 If you use <<cluster-update-settings,cluster settings>>, the remote clusters
@@ -113,20 +113,20 @@ PUT _cluster/settings
     "cluster": {
       "remote": {
         "cluster_one": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9300"
           ],
           "transport.ping_schedule": "30s"
         },
         "cluster_two": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9301"
           ],
           "transport.compress": true,
           "skip_unavailable": true
         },
         "cluster_three": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9302"
           ]
         }
@@ -149,13 +149,13 @@ PUT _cluster/settings
     "cluster": {
       "remote": {
         "cluster_one": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9300"
           ],
           "transport.ping_schedule": "60s"
         },
         "cluster_two": {
-          "seeds": [
+          "sniff.seeds": [
             "127.0.0.1:9301"
           ],
           "transport.compress": false
@@ -181,7 +181,7 @@ PUT _cluster/settings
     "cluster": {
       "remote": {
         "cluster_two": { <1>
-          "seeds": null,
+          "sniff.seeds": null,
           "skip_unavailable": null,
           "transport": {
             "compress": null

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.java
@@ -85,7 +85,6 @@ public class FullClusterRestartSettingsUpgradeIT extends AbstractFullClusterRest
                 final ClusterGetSettingsResponse clusterGetSettingsResponse = ClusterGetSettingsResponse.fromXContent(parser);
                 final Settings settings = clusterGetSettingsResponse.getPersistentSettings();
 
-                logger.error(settings);
                 assertFalse(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS_OLD.getConcreteSettingForNamespace("foo").exists(settings));
 
                 assertTrue(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.getConcreteSettingForNamespace("foo")

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartSettingsUpgradeIT.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.transport.SniffConnectionStrategy;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FullClusterRestartSettingsUpgradeIT extends AbstractFullClusterRestartTestCase {
+
+    public void testRemoteClusterSettingsUpgraded() throws IOException {
+        // TODO: Change to 7.6 on backport
+        assumeTrue("settings automatically upgraded since 8.0.0", getOldClusterVersion().before(Version.V_8_0_0));
+        if (isRunningAgainstOldCluster()) {
+            final Request putSettingsRequest = new Request("PUT", "/_cluster/settings");
+            try (XContentBuilder builder = jsonBuilder()) {
+                builder.startObject();
+                {
+                    builder.startObject("persistent");
+                    {
+                        builder.field("search.remote.foo.proxy", "localhost:9201");
+                        builder.field("search.remote.foo.seeds", Collections.singletonList("localhost:9200"));
+                    }
+                    builder.endObject();
+                }
+                builder.endObject();
+                putSettingsRequest.setJsonEntity(Strings.toString(builder));
+            }
+            client().performRequest(putSettingsRequest);
+
+            final Request getSettingsRequest = new Request("GET", "/_cluster/settings");
+            final Response response = client().performRequest(getSettingsRequest);
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, response.getEntity().getContent())) {
+                final ClusterGetSettingsResponse clusterGetSettingsResponse = ClusterGetSettingsResponse.fromXContent(parser);
+                final Settings settings = clusterGetSettingsResponse.getPersistentSettings();
+
+                assertTrue(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS_OLD.getConcreteSettingForNamespace("foo").exists(settings));
+                assertTrue(SniffConnectionStrategy.REMOTE_CLUSTERS_PROXY_OLD.getConcreteSettingForNamespace("foo").exists(settings));
+                assertThat(
+                    SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS_OLD.getConcreteSettingForNamespace("foo").get(settings),
+                    equalTo(Collections.singletonList("localhost:9200")));
+                assertThat(
+                    SniffConnectionStrategy.REMOTE_CLUSTERS_PROXY_OLD.getConcreteSettingForNamespace("foo").get(settings),
+                    equalTo("localhost:9201"));
+            }
+
+            assertSettingDeprecationsAndWarnings(new Setting<?>[]{
+                SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS_OLD.getConcreteSettingForNamespace("foo"),
+            });
+        } else {
+            final Request getSettingsRequest = new Request("GET", "/_cluster/settings");
+            final Response getSettingsResponse = client().performRequest(getSettingsRequest);
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, getSettingsResponse.getEntity().getContent())) {
+                final ClusterGetSettingsResponse clusterGetSettingsResponse = ClusterGetSettingsResponse.fromXContent(parser);
+                final Settings settings = clusterGetSettingsResponse.getPersistentSettings();
+
+                logger.error(settings);
+                assertFalse(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS_OLD.getConcreteSettingForNamespace("foo").exists(settings));
+
+                assertTrue(SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.getConcreteSettingForNamespace("foo")
+                    .exists(settings));
+                assertTrue(SniffConnectionStrategy.REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo")
+                    .exists(settings));
+                assertThat(
+                    SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS.getConcreteSettingForNamespace("foo").get(settings),
+                    equalTo(Collections.singletonList("localhost:9200")));
+                assertThat(
+                    SniffConnectionStrategy.REMOTE_CLUSTERS_PROXY.getConcreteSettingForNamespace("foo").get(settings),
+                    equalTo("localhost:9201"));
+            }
+        }
+    }
+
+}

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -47,7 +47,7 @@ task mixedClusterTest(type: RestIntegTestTask) {
 }
 
 testClusters.mixedClusterTest {
-  setting 'cluster.remote.my_remote_cluster.seeds',
+  setting 'cluster.remote.my_remote_cluster.sniff.seeds',
     { "\"${testClusters.'remote-cluster'.getAllTransportPortURI().get(0)}\"" }
   setting 'cluster.remote.connections_per_cluster', '1'
   setting 'cluster.remote.connect', 'true'

--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
@@ -121,16 +121,16 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
         flat_settings: true
         body:
           transient:
-            cluster.remote.test_remote_cluster.seeds: $remote_ip
+            cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip
 
-  - match: {transient: {cluster.remote.test_remote_cluster.seeds: $remote_ip}}
+  - match: {transient: {cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip}}
 
   - do:
       search:
@@ -151,16 +151,16 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
         flat_settings: true
         body:
           transient:
-            cluster.remote.test_remote_cluster.seeds: $remote_ip
+            cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip
 
-  - match: {transient: {cluster.remote.test_remote_cluster.seeds: $remote_ip}}
+  - match: {transient: {cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip}}
 
   - do:
       search:

--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/15_connection_mode_configuration.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/15_connection_mode_configuration.yml
@@ -4,7 +4,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       catch: bad_request
@@ -42,7 +42,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       catch: bad_request
@@ -78,7 +78,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
@@ -112,7 +112,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
@@ -146,7 +146,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:

--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
@@ -15,7 +15,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
@@ -100,16 +100,16 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
         flat_settings: true
         body:
           transient:
-            cluster.remote.remote1.seeds: $remote_ip
+            cluster.remote.remote1.sniff.seeds: $remote_ip
 
-  - match: {transient: {cluster.remote.remote1.seeds: $remote_ip}}
+  - match: {transient: {cluster.remote.remote1.sniff.seeds: $remote_ip}}
 
   - do:
       cluster.remote_info: {}
@@ -158,5 +158,5 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.remote1.seeds: null
+            cluster.remote.remote1.sniff.seeds: null
             cluster.remote.remote1.skip_unavailable: null

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -84,6 +84,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'old_cluster'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty 'tests.old_cluster_version', bwcVersion.toString().minus("-SNAPSHOT")
   }
 
   tasks.register("${baseName}#oneThirdUpgradedTest", RestTestRunnerTask) {
@@ -96,6 +97,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.first_round', 'true'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty 'tests.old_cluster_version', bwcVersion.toString().minus("-SNAPSHOT")
   }
 
   tasks.register("${baseName}#twoThirdsUpgradedTest", RestTestRunnerTask) {
@@ -108,6 +110,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.first_round', 'false'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty 'tests.old_cluster_version', bwcVersion.toString().minus("-SNAPSHOT")
   }
 
   tasks.register("${baseName}#upgradedClusterTest", RestTestRunnerTask) {
@@ -119,6 +122,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty 'tests.old_cluster_version', bwcVersion.toString().minus("-SNAPSHOT")
   }
 
   if (project.bwc_tests_enabled) {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.upgrades;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
@@ -44,6 +45,12 @@ public abstract class AbstractRollingTestCase extends ESRestTestCase {
     protected static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.suite"));
     protected static final boolean firstMixedRound = Boolean.parseBoolean(System.getProperty("tests.first_round", "false"));
 
+    private final Version oldClusterVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
+
+    public final Version getOldClusterVersion() {
+        return oldClusterVersion;
+    }
+
     @Override
     protected final boolean preserveIndicesUponCompletion() {
         return true;
@@ -51,6 +58,11 @@ public abstract class AbstractRollingTestCase extends ESRestTestCase {
 
     @Override
     protected final boolean preserveReposUponCompletion() {
+        return true;
+    }
+
+    @Override
+    protected boolean preserveClusterSettings() {
         return true;
     }
 

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
@@ -40,6 +40,11 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
         return true;
     }
 
+    @Override
+    protected boolean preserveClusterSettings() {
+        return true;
+    }
+
     public UpgradeClusterClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -839,7 +839,6 @@ public abstract class AbstractScopedSettings {
         final Settings.Builder builder = Settings.builder();
         boolean changed = false; // track if any settings were upgraded
         for (final String key : settings.keySet()) {
-//            final Setting<?> setting = getRaw(key);
            boolean settingUpgraded = false;
             for (Map.Entry<Setting<?>, SettingUpgrader<?>> entry : settingUpgraders.entrySet()) {
                 Setting<?> setting = entry.getKey();
@@ -868,26 +867,6 @@ public abstract class AbstractScopedSettings {
                 // the setting does not have an upgrader, copy the setting
                 builder.copy(key, settings);
             }
-//            final SettingUpgrader<?> upgrader = settingUpgraders.get(setting);
-//            if (upgrader == null) {
-//                // the setting does not have an upgrader, copy the setting
-//                builder.copy(key, settings);
-//            } else {
-//                // the setting has an upgrader, so mark that we have changed a setting and apply the upgrade logic
-//                changed = true;
-//                // noinspection ConstantConditions
-//                if (setting.getConcreteSetting(key).isListSetting()) {
-//                    final List<String> value = settings.getAsList(key);
-//                    final String upgradedKey = upgrader.getKey(key);
-//                    final List<String> upgradedValue = upgrader.getListValue(value);
-//                    builder.putList(upgradedKey, upgradedValue);
-//                } else {
-//                    final String value = settings.get(key);
-//                    final String upgradedKey = upgrader.getKey(key);
-//                    final String upgradedValue = upgrader.getValue(value);
-//                    builder.put(upgradedKey, upgradedValue);
-//                }
-//            }
         }
         // we only return a new instance if there was an upgrade
         return changed ? builder.build() : settings;

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -839,27 +839,55 @@ public abstract class AbstractScopedSettings {
         final Settings.Builder builder = Settings.builder();
         boolean changed = false; // track if any settings were upgraded
         for (final String key : settings.keySet()) {
-            final Setting<?> setting = getRaw(key);
-            final SettingUpgrader<?> upgrader = settingUpgraders.get(setting);
-            if (upgrader == null) {
-                // the setting does not have an upgrader, copy the setting
-                builder.copy(key, settings);
-            } else {
-                // the setting has an upgrader, so mark that we have changed a setting and apply the upgrade logic
-                changed = true;
-                // noinspection ConstantConditions
-                if (setting.getConcreteSetting(key).isListSetting()) {
-                    final List<String> value = settings.getAsList(key);
-                    final String upgradedKey = upgrader.getKey(key);
-                    final List<String> upgradedValue = upgrader.getListValue(value);
-                    builder.putList(upgradedKey, upgradedValue);
-                } else {
-                    final String value = settings.get(key);
-                    final String upgradedKey = upgrader.getKey(key);
-                    final String upgradedValue = upgrader.getValue(value);
-                    builder.put(upgradedKey, upgradedValue);
+//            final Setting<?> setting = getRaw(key);
+           boolean settingUpgraded = false;
+            for (Map.Entry<Setting<?>, SettingUpgrader<?>> entry : settingUpgraders.entrySet()) {
+                Setting<?> setting = entry.getKey();
+                if (setting.match(key)) {
+                    SettingUpgrader<?> upgrader = entry.getValue();
+                    // the setting has an upgrader, so mark that we have changed a setting and apply the upgrade logic
+                    changed = true;
+                    // noinspection ConstantConditions
+                    if (setting.getConcreteSetting(key).isListSetting()) {
+                        final List<String> value = settings.getAsList(key);
+                        final String upgradedKey = upgrader.getKey(key);
+                        final List<String> upgradedValue = upgrader.getListValue(value);
+                        builder.putList(upgradedKey, upgradedValue);
+                    } else {
+                        final String value = settings.get(key);
+                        final String upgradedKey = upgrader.getKey(key);
+                        final String upgradedValue = upgrader.getValue(value);
+                        builder.put(upgradedKey, upgradedValue);
+                    }
+                    settingUpgraded = true;
+                    break;
                 }
             }
+
+            if (settingUpgraded == false) {
+                // the setting does not have an upgrader, copy the setting
+                builder.copy(key, settings);
+            }
+//            final SettingUpgrader<?> upgrader = settingUpgraders.get(setting);
+//            if (upgrader == null) {
+//                // the setting does not have an upgrader, copy the setting
+//                builder.copy(key, settings);
+//            } else {
+//                // the setting has an upgrader, so mark that we have changed a setting and apply the upgrade logic
+//                changed = true;
+//                // noinspection ConstantConditions
+//                if (setting.getConcreteSetting(key).isListSetting()) {
+//                    final List<String> value = settings.getAsList(key);
+//                    final String upgradedKey = upgrader.getKey(key);
+//                    final List<String> upgradedValue = upgrader.getListValue(value);
+//                    builder.putList(upgradedKey, upgradedValue);
+//                } else {
+//                    final String value = settings.get(key);
+//                    final String upgradedKey = upgrader.getKey(key);
+//                    final String upgradedValue = upgrader.getValue(value);
+//                    builder.put(upgradedKey, upgradedValue);
+//                }
+//            }
         }
         // we only return a new instance if there was an upgrade
         return changed ? builder.build() : settings;

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -109,6 +109,7 @@ import org.elasticsearch.transport.SniffConnectionStrategy;
 import org.elasticsearch.transport.TransportSettings;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -467,6 +468,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
             ClusterBootstrapService.UNCONFIGURED_BOOTSTRAP_TIMEOUT_SETTING,
             LagDetector.CLUSTER_FOLLOWER_LAG_TIMEOUT_SETTING);
 
-    static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.emptyList();
+    static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.unmodifiableList(Arrays.asList(
+        SniffConnectionStrategy.PROXY_SETTING_UPGRADER,
+        SniffConnectionStrategy.SEEDS_SETTING_UPGRADER));
 
 }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -105,6 +105,12 @@ public class RemoteClusterConnectionTests extends ESTestCase {
         return startTransport(id, knownNodes, version, threadPool, Settings.EMPTY);
     }
 
+    @Override
+    protected boolean enableWarningsCheck() {
+        // We currently test with the deprecated seeds setting.
+        return false;
+    }
+
     public static MockTransportService startTransport(
         final String id,
         final List<DiscoveryNode> knownNodes,

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -680,6 +680,12 @@ public class SniffConnectionStrategyTests extends ESTestCase {
         }
     }
 
+    @Override
+    protected boolean enableWarningsCheck() {
+        // We currently test with deprecated seed setting
+        return false;
+    }
+
     private static List<String> seedNodes(final DiscoveryNode... seedNodes) {
         return Arrays.stream(seedNodes).map(s -> s.getAddress().toString()).collect(Collectors.toList());
     }

--- a/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
@@ -58,10 +58,10 @@ PUT _cluster/settings
     "cluster": {
       "remote": {
         "one": {
-          "seeds": [ "10.0.1.1:9300" ]
+          "sniff.seeds": [ "10.0.1.1:9300" ]
         },
         "two": {
-          "seeds": [ "10.0.2.1:9300" ]
+          "sniff.seeds": [ "10.0.2.1:9300" ]
         }
       }
     }
@@ -86,7 +86,7 @@ First, enable cluster `one` to perform cross cluster search on remote cluster
 PUT _cluster/settings
 {
   "persistent": {
-    "cluster.remote.two.seeds": [ "10.0.2.1:9300" ]
+    "cluster.remote.two.sniff.seeds": [ "10.0.2.1:9300" ]
   }
 }
 -----------------------------------------------------------

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -51,7 +51,7 @@ testClusters."follow-cluster" {
   testDistribution = 'DEFAULT'
   setting 'xpack.monitoring.collection.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds', { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
+  setting 'cluster.remote.leader_cluster.sniff.seeds', { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
 }
 
 

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -34,7 +34,7 @@ task "middle-cluster"(type: RestIntegTestTask) {
 testClusters."middle-cluster" {
   testDistribution = 'DEFAULT'
   setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
+  setting 'cluster.remote.leader_cluster.sniff.seeds',
     { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
 }
 
@@ -55,9 +55,9 @@ testClusters."follow-cluster" {
   testDistribution = 'DEFAULT'
   setting 'xpack.monitoring.collection.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
+  setting 'cluster.remote.leader_cluster.sniff.seeds',
     { "\"${testClusters."leader-cluster".getAllTransportPortURI().join(",")}\"" }
-  setting 'cluster.remote.middle_cluster.seeds',
+  setting 'cluster.remote.middle_cluster.sniff.seeds',
     { "\"${testClusters."middle-cluster".getAllTransportPortURI().join(",")}\"" }
 }
 

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -31,7 +31,7 @@ task 'follow-cluster'(type: RestIntegTestTask) {
 testClusters.'follow-cluster' {
   testDistribution = 'DEFAULT'
   setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
+  setting 'cluster.remote.leader_cluster.sniff.seeds',
     { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().join(",")}\"" }
 }
 

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/auto_follow.yml
@@ -14,10 +14,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.local.seeds: $local_ip
+            cluster.remote.local.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.local.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.local.sniff.seeds: $local_ip}}
 
   - do:
       ccr.put_auto_follow_pattern:
@@ -73,10 +73,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.local.seeds: $local_ip
+            cluster.remote.local.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.local.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.local.sniff.seeds: $local_ip}}
 
   - do:
       ccr.put_auto_follow_pattern:

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
@@ -14,10 +14,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.local.seeds: $local_ip
+            cluster.remote.local.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.local.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.local.sniff.seeds: $local_ip}}
 
   - do:
       indices.create:

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/follow_info.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/follow_info.yml
@@ -14,10 +14,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.local.seeds: $local_ip
+            cluster.remote.local.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.local.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.local.sniff.seeds: $local_ip}}
 
   - do:
       indices.create:

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/follow_stats.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/follow_stats.yml
@@ -14,10 +14,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.local.seeds: $local_ip
+            cluster.remote.local.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.local.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.local.sniff.seeds: $local_ip}}
 
   - do:
       indices.create:

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/forget_follower.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/forget_follower.yml
@@ -14,10 +14,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.remote_cluster.seeds: $local_ip
+            cluster.remote.remote_cluster.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.remote_cluster.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.remote_cluster.sniff.seeds: $local_ip}}
 
   - do:
       indices.create:

--- a/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/index_directly_into_follower_index.yml
+++ b/x-pack/plugin/ccr/qa/rest/src/test/resources/rest-api-spec/test/ccr/index_directly_into_follower_index.yml
@@ -14,10 +14,10 @@
       cluster.put_settings:
         body:
           transient:
-            cluster.remote.local.seeds: $local_ip
+            cluster.remote.local.sniff.seeds: $local_ip
         flat_settings: true
 
-  - match: {transient: {cluster.remote.local.seeds: $local_ip}}
+  - match: {transient: {cluster.remote.local.sniff.seeds: $local_ip}}
 
   - do:
       indices.create:

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -32,7 +32,7 @@ testClusters.'follow-cluster' {
   testDistribution = 'DEFAULT'
   setting 'xpack.monitoring.collection.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.leader_cluster.seeds',
+  setting 'cluster.remote.leader_cluster.sniff.seeds',
     { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}\"" }
   nameCustomization = { 'follow' }
 }

--- a/x-pack/plugin/ccr/qa/security/build.gradle
+++ b/x-pack/plugin/ccr/qa/security/build.gradle
@@ -37,7 +37,7 @@ task 'follow-cluster'(type: RestIntegTestTask) {
 
 testClusters.'follow-cluster' {
   testDistribution = 'DEFAULT'
-  setting 'cluster.remote.leader_cluster.seeds', {
+  setting 'cluster.remote.leader_cluster.sniff.seeds', {
     "\"${testClusters.'leader-cluster'.getAllTransportPortURI().join(",")}\""
   }
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -235,7 +235,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
             builder.put(followerClusterSettings());
         }
         if (configureRemoteClusterViaNodeSettings() && leaderSeedAddress != null) {
-            builder.put("cluster.remote.leader_cluster.seeds", leaderSeedAddress);
+            builder.put("cluster.remote.leader_cluster.sniff.seeds", leaderSeedAddress);
         }
         return new NodeConfigurationSource() {
             @Override

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrSingleNodeTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrSingleNodeTestCase.java
@@ -64,7 +64,7 @@ public abstract class CcrSingleNodeTestCase extends ESSingleNodeTestCase {
     public void setupLocalRemote() throws Exception {
         ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
         String address = getInstanceFromNode(TransportService.class).boundAddress().publishAddress().toString();
-        updateSettingsRequest.transientSettings(Settings.builder().put("cluster.remote.local.seeds", address));
+        updateSettingsRequest.transientSettings(Settings.builder().put("cluster.remote.local.sniff.seeds", address));
         assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
 
         List<RemoteConnectionInfo> infos = client().execute(RemoteInfoAction.INSTANCE, new RemoteInfoRequest()).get().getInfos();
@@ -86,7 +86,7 @@ public abstract class CcrSingleNodeTestCase extends ESSingleNodeTestCase {
     @After
     public void removeLocalRemote() throws Exception {
         ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();
-        updateSettingsRequest.transientSettings(Settings.builder().put("cluster.remote.local.seeds", (String) null));
+        updateSettingsRequest.transientSettings(Settings.builder().put("cluster.remote.local.sniff.seeds", (String) null));
         assertAcked(client().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
 
         assertBusy(() -> {

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -58,7 +58,7 @@ testClusters.'follow-cluster' {
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setting 'indices.lifecycle.poll_interval', '1000ms'
-  setting 'cluster.remote.leader_cluster.seeds',
+  setting 'cluster.remote.leader_cluster.sniff.seeds',
     { "\"${testClusters.'leader-cluster'.getAllTransportPortURI().get(0)}\"" }
 }
 

--- a/x-pack/qa/multi-cluster-search-security/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/build.gradle
@@ -43,7 +43,7 @@ testClusters.'mixed-cluster' {
   setting 'xpack.monitoring.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
-  setting 'cluster.remote.my_remote_cluster.seeds', {
+  setting 'cluster.remote.my_remote_cluster.sniff.seeds', {
     testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
   }
   setting 'cluster.remote.connections_per_cluster', "1"

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
@@ -175,16 +175,16 @@ teardown:
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
         flat_settings: true
         body:
           transient:
-            cluster.remote.test_remote_cluster.seeds: $remote_ip
+            cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip
 
-  - match: {transient: {cluster.remote.test_remote_cluster.seeds: $remote_ip}}
+  - match: {transient: {cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip}}
 
   - do:
       headers: { Authorization: "Basic am9lOnMza3JpdA==" }

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/20_info.yml
@@ -48,16 +48,16 @@ teardown:
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
         flat_settings: true
         body:
           transient:
-            cluster.remote.test_remote_cluster.seeds: $remote_ip
+            cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip
 
-  - match: {transient: {cluster.remote.test_remote_cluster.seeds: $remote_ip}}
+  - match: {transient: {cluster.remote.test_remote_cluster.sniff.seeds: $remote_ip}}
 
   # we do another search here since this will enforce the connection to be established
   # otherwise the cluster might not have been connected yet.

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/70_connection_mode_configuration.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/70_connection_mode_configuration.yml
@@ -4,7 +4,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       catch: bad_request
@@ -42,7 +42,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       catch: bad_request
@@ -78,7 +78,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
@@ -112,7 +112,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:
@@ -146,7 +146,7 @@
       cluster.get_settings:
         include_defaults: true
 
-  - set: { defaults.cluster.remote.my_remote_cluster.seeds.0: remote_ip }
+  - set: { defaults.cluster.remote.my_remote_cluster.sniff.seeds.0: remote_ip }
 
   - do:
       cluster.put_settings:

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/AbstractMultiClusterUpgradeTestCase.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/AbstractMultiClusterUpgradeTestCase.java
@@ -118,7 +118,7 @@ public abstract class AbstractMultiClusterUpgradeTestCase extends ESRestTestCase
         if (leaderRemoteClusterSeed != null) {
             logger.info("Configuring leader remote cluster [{}]", leaderRemoteClusterSeed);
             Request request = new Request("PUT", "/_cluster/settings");
-            request.setJsonEntity("{\"persistent\": {\"cluster.remote.leader.seeds\": \"" + leaderRemoteClusterSeed + "\"}}");
+            request.setJsonEntity("{\"persistent\": {\"cluster.remote.leader.sniff.seeds\": \"" + leaderRemoteClusterSeed + "\"}}");
             assertThat(leaderClient.performRequest(request).getStatusLine().getStatusCode(), equalTo(200));
             if (followerClient != null) {
                 assertThat(followerClient.performRequest(request).getStatusLine().getStatusCode(), equalTo(200));
@@ -133,7 +133,7 @@ public abstract class AbstractMultiClusterUpgradeTestCase extends ESRestTestCase
         if (followerRemoteClusterSeed != null) {
             logger.info("Configuring follower remote cluster [{}]", followerRemoteClusterSeed);
             Request request = new Request("PUT", "/_cluster/settings");
-            request.setJsonEntity("{\"persistent\": {\"cluster.remote.follower.seeds\": \"" + followerRemoteClusterSeed + "\"}}");
+            request.setJsonEntity("{\"persistent\": {\"cluster.remote.follower.sniff.seeds\": \"" + followerRemoteClusterSeed + "\"}}");
             assertThat(leaderClient.performRequest(request).getStatusLine().getStatusCode(), equalTo(200));
             assertThat(followerClient.performRequest(request).getStatusLine().getStatusCode(), equalTo(200));
         } else {


### PR DESCRIPTION
In order to use the "proxy" name for the new connection mode, the 
existing `cluster.remote.cluster_name.proxy` setting must be renamed
to `cluster.remote.cluster_name.sniff.proxy`. This commit implements
this change and adds a setting upgrader. Since the setting is not 
documented, the old setting is immediately removed. Finally, the
settings upgrader infrastructure is modified so that settings that are
not registered with the cluster can be upgraded.