### PR TITLE
[DOCS] Fixed typos (_op => op)

### DIFF
--- a/docs/painless/painless-contexts/painless-reindex-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-reindex-context.asciidoc
@@ -10,7 +10,7 @@ reindexed into a target index.
 `params` (`Map`, read-only)::
         User-defined parameters passed in as part of the query.
 
-`ctx['_op']` (`String`)::
+`ctx['op']` (`String`)::
         The name of the operation.
 
 {ref}/mapping-routing-field.html[`ctx['_routing']`] (`String`)::
@@ -34,7 +34,7 @@ reindexed into a target index.
 
 *Side Effects*
 
-`ctx['_op']`::
+`ctx['op']`::
         Use the default of `index` to update a document. Set to `none` to
         specify no operation or `delete` to delete the current document from
         the index.

--- a/docs/painless/painless-contexts/painless-update-by-query-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-update-by-query-context.asciidoc
@@ -11,7 +11,7 @@ result of query.
 `params` (`Map`, read-only)::
         User-defined parameters passed in as part of the query.
 
-`ctx['_op']` (`String`)::
+`ctx['op']` (`String`)::
         The name of the operation.
 
 {ref}/mapping-routing-field.html[`ctx['_routing']`] (`String`, read-only)::
@@ -35,7 +35,7 @@ result of query.
 
 *Side Effects*
 
-`ctx['_op']`::
+`ctx['op']`::
         Use the default of `index` to update a document. Set to `none` to
         specify no operation or `delete` to delete the current document from
         the index.

--- a/docs/painless/painless-contexts/painless-update-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-update-context.asciidoc
@@ -9,7 +9,7 @@ add, modify, or delete fields within a single document.
 `params` (`Map`, read-only)::
         User-defined parameters passed in as part of the query.
 
-`ctx['_op']` (`String`)::
+`ctx['op']` (`String`)::
         The name of the operation.
 
 {ref}/mapping-routing-field.html[`ctx['_routing']`] (`String`, read-only)::
@@ -36,7 +36,7 @@ add, modify, or delete fields within a single document.
 
 *Side Effects*
 
-`ctx['_op']`::
+`ctx['op']`::
         Use the default of `index` to update a document. Set to `none` to
         specify no operation or `delete` to delete the current document from
         the index.


### PR DESCRIPTION
The documentation mentions the `ctx.op` parameter [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#update-api-example), [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html) and [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html#reindex-scripts), however the respective Painless context documentation uses `ctx._op` instead.

According to the [source code](https://github.com/elastic/elasticsearch/blob/7.5/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java#L388), it should be `ctx.op`. So this PR aims at fixing those typos in the documentation.