### PR TITLE
[Docs] Clarify where `intervals` filter rule is allowed

### DIFF
--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -75,10 +75,6 @@ Valid rules include:
 * <<intervals-wildcard,`wildcard`>>
 * <<intervals-all_of,`all_of`>>
 * <<intervals-any_of,`any_of`>>
-* <<interval_filter,`filter`>>
-
-All rules except the `filter` rule can appear on the top level of the query,
-while the `filter` rule can only be nested inside `match`, `all_of` and `any_of`.
 --
 
 [[intervals-match]]

--- a/docs/reference/query-dsl/intervals-query.asciidoc
+++ b/docs/reference/query-dsl/intervals-query.asciidoc
@@ -76,6 +76,9 @@ Valid rules include:
 * <<intervals-all_of,`all_of`>>
 * <<intervals-any_of,`any_of`>>
 * <<interval_filter,`filter`>>
+
+All rules except the `filter` rule can appear on the top level of the query,
+while the `filter` rule can only be nested inside `match`, `all_of` and `any_of`.
 --
 
 [[intervals-match]]


### PR DESCRIPTION
Add a note to the list of allowed rules that clarifies where the `filter` rule
is allowed.