### PR TITLE
[TEST] Exclude name on ScriptContextInfo mutate

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/ScriptContextInfoSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/ScriptContextInfoSerializingTests.java
@@ -56,7 +56,7 @@ public class ScriptContextInfoSerializingTests extends AbstractSerializingTestCa
     }
 
     private static ScriptContextInfo mutate(ScriptContextInfo instance, Set<String> names) {
-        if (names == null) { names = new HashSet<>(); }
+        if (names == null) { names = new HashSet<>(); names.add(instance.name); }
         switch (randomIntBetween(0, 2)) {
             case 0:
                 return new ScriptContextInfo(

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/ScriptContextInfoSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/ScriptContextInfoSerializingTests.java
@@ -56,7 +56,10 @@ public class ScriptContextInfoSerializingTests extends AbstractSerializingTestCa
     }
 
     private static ScriptContextInfo mutate(ScriptContextInfo instance, Set<String> names) {
-        if (names == null) { names = new HashSet<>(); names.add(instance.name); }
+        if (names == null) {
+            names = new HashSet<>();
+            names.add(instance.name);
+        }
         switch (randomIntBetween(0, 2)) {
             case 0:
                 return new ScriptContextInfo(


### PR DESCRIPTION
ScriptContextInfoSerializingTests:testEqualsAndHashcode was failing
because the mutation was generating the same name.

Fixes: #50331