### PR TITLE
Add --data-dir option to run task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -434,6 +434,14 @@ class Run extends DefaultTask {
   public void setDebug(boolean enabled) {
     project.project(':distribution').run.debug = enabled
   }
+
+  @Option(
+    option = "data-dir",
+    description = "Override the base data directory used by the testcluster"
+  )
+  public void setDataDir(String dataDirStr) {
+    project.project(':distribution').run.dataDir = dataDirStr
+  }
 }
 
 task run(type: Run) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -134,7 +134,6 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     private final Path confPathRepo;
     private final Path configFile;
-    private final Path confPathData;
     private final Path confPathLogs;
     private final Path transportPortFile;
     private final Path httpPortsFile;
@@ -151,6 +150,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private boolean isWorkingDirConfigured = false;
     private String httpPort = "0";
     private String transportPort = "0";
+    private Path confPathData;
 
     ElasticsearchNode(String path, String name, Project project, ReaperService reaper, File workingDirBase) {
         this.path = path;
@@ -1339,6 +1339,10 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     void setTransportPort(String transportPort) {
         this.transportPort = transportPort;
+    }
+
+    void setDataPath(Path dataPath) {
+        this.confPathData = dataPath;
     }
 
     @Internal


### PR DESCRIPTION
This commit adds a special run.datadir system property that may be
passed to `./gradlew run` which sets the root data directory used by the
task. While normally overriding the data path is not allowed for test
clusters, it is useful when experimenting with the run task.

closes #50338