### PR TITLE
[TEST] Unknown scripting annotations raise error

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhitelistLoaderTests.java
@@ -31,6 +31,26 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class WhitelistLoaderTests extends ScriptTestCase {
+    public void testUnknownAnnotations() {
+        Map<String, WhitelistAnnotationParser> parsers = new HashMap<>(WhitelistAnnotationParser.BASE_ANNOTATION_PARSERS);
+
+        RuntimeException expected = expectThrows(RuntimeException.class, () -> {
+            WhitelistLoader.loadFromResourceFiles(Whitelist.class, parsers, "org.elasticsearch.painless.annotation.unknown");
+        });
+        assertEquals(
+            "invalid annotation: parser not found for [unknownAnnotation] [@unknownAnnotation]", expected.getCause().getMessage()
+        );
+        assertEquals(IllegalArgumentException.class, expected.getCause().getClass());
+
+        expected = expectThrows(RuntimeException.class, () -> {
+            WhitelistLoader.loadFromResourceFiles(Whitelist.class, parsers, "org.elasticsearch.painless.annotation.unknown_with_options");
+        });
+        assertEquals(
+            "invalid annotation: parser not found for [unknownAnootationWithMessage] [@unknownAnootationWithMessage[arg=\"arg value\"]]",
+            expected.getCause().getMessage()
+        );
+        assertEquals(IllegalArgumentException.class, expected.getCause().getClass());
+    }
 
     public void testAnnotations() {
         Map<String, WhitelistAnnotationParser> parsers = new HashMap<>(WhitelistAnnotationParser.BASE_ANNOTATION_PARSERS);

--- a/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.annotation.unknown
+++ b/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.annotation.unknown
@@ -1,0 +1,6 @@
+# whitelist for annotation tests with unknown annotation
+
+class org.elasticsearch.painless.AnnotationTestObject @no_import {
+  void unknownAnnotationMethod() @unknownAnnotation
+  void unknownAnnotationMethod() @unknownAnootationWithMessage[message="use another method"]
+}

--- a/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.annotation.unknown_with_options
+++ b/modules/lang-painless/src/test/resources/org/elasticsearch/painless/spi/org.elasticsearch.painless.annotation.unknown_with_options
@@ -1,0 +1,5 @@
+# whitelist for annotation tests with unknown annotation containing options
+
+class org.elasticsearch.painless.AnnotationTestObject @no_import {
+  void unknownAnnotationMethod() @unknownAnootationWithMessage[arg="arg value"]
+}


### PR DESCRIPTION
Ensure that unknown annotations, such as typo'd `@nondeterministic`, will raise an exception.