### PR TITLE
compress extent depending of how many values are set

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeReader.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeReader.java
@@ -60,13 +60,7 @@ public class TriangleTreeReader {
         if (treeOffset == 0) {
             // TODO: Compress serialization of extent
             input.setPosition(CENTROID_HEADER_SIZE_IN_BYTES);
-            int top = input.readInt();
-            int bottom = Math.toIntExact(top - input.readVLong());
-            int posRight = input.readInt();
-            int posLeft = input.readInt();
-            int negRight = input.readInt();
-            int negLeft = input.readInt();
-            extent.reset(top, bottom, negLeft, negRight, posLeft, posRight);
+            Extent.readFromCompressed(input, extent);
             treeOffset = input.getPosition();
         } else {
             input.setPosition(treeOffset);

--- a/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeWriter.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/TriangleTreeWriter.java
@@ -50,12 +50,7 @@ public class TriangleTreeWriter {
         out.writeInt(coordinateEncoder.encodeX(centroidCalculator.getX()));
         out.writeInt(coordinateEncoder.encodeY(centroidCalculator.getY()));
         centroidCalculator.getDimensionalShapeType().writeTo(out);
-        out.writeInt(extent.top);
-        out.writeVLong((long) extent.top - extent.bottom);
-        out.writeInt(extent.posRight);
-        out.writeInt(extent.posLeft);
-        out.writeInt(extent.negRight);
-        out.writeInt(extent.negLeft);
+        extent.writeCompressed(out);
         node.writeTo(out);
     }
 


### PR DESCRIPTION
This commit adds a basic strategy to compress the extent of geoshape doc values depending on how many values are set.
