### PR TITLE
Fixes to task result index mapping

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -67,8 +67,6 @@ public class TaskResultsService {
 
     public static final String TASK_INDEX = ".tasks";
 
-    public static final String TASK_TYPE = "task";
-
     public static final String TASK_RESULT_INDEX_MAPPING_FILE = "task-index-mapping.json";
 
     public static final String TASK_RESULT_MAPPING_VERSION_META_FIELD = "version";
@@ -103,7 +101,7 @@ public class TaskResultsService {
             CreateIndexRequest createIndexRequest = new CreateIndexRequest();
             createIndexRequest.settings(taskResultIndexSettings());
             createIndexRequest.index(TASK_INDEX);
-            createIndexRequest.mapping(TASK_TYPE, taskResultIndexMapping(), XContentType.JSON);
+            createIndexRequest.mapping(taskResultIndexMapping());
             createIndexRequest.cause("auto(task api)");
 
             client.admin().indices().create(createIndexRequest, new ActionListener<CreateIndexResponse>() {

--- a/server/src/main/resources/org/elasticsearch/tasks/task-index-mapping.json
+++ b/server/src/main/resources/org/elasticsearch/tasks/task-index-mapping.json
@@ -1,7 +1,7 @@
 {
-  "task" : {
+  "_doc" : {
     "_meta": {
-      "version": 2
+      "version": 3
     },
     "dynamic" : "strict",
     "properties" : {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -768,6 +768,13 @@ public class TasksIT extends ESIntegTestCase {
         GetTaskResponse getResponse = expectFinishedTask(taskId);
         assertEquals(result, getResponse.getTask().getResponseAsMap());
         assertNull(getResponse.getTask().getError());
+
+        // run it again to check that the tasks index has been successfully created and can be re-used
+        client().execute(TestTaskPlugin.TestTaskAction.INSTANCE, request).get();
+
+        events = findEvents(TestTaskPlugin.TestTaskAction.NAME, Tuple::v1);
+
+        assertEquals(2, events.size());
     }
 
     public void testTaskStoringFailureResult() throws Exception {


### PR DESCRIPTION
The build-in mapping for the tasks result index still has a mapping type defined; while
this does not matter for index creation, as we still have a create method that takes a
top-level type, it does matter for updates.  In combination with a separate bug, that the
built-in mapping has not incremented its meta version, this meant that tasks submitted 
to a cluster with an already existing task index would attempt to update the mappings
on that index, and fail due to the top-level type.

This commit fixes the mapping to have a top-level mapping of `_doc`, and also updates
the meta version so that we do not update mappings on every new task.  It also adds a 
test that explicitly runs two asynchronous tasks to ensure that the mappings do not
cause a failure.

Fixes #50248 