### PR TITLE
Fix meta version of task index mapping

### DIFF
--- a/server/src/main/resources/org/elasticsearch/tasks/task-index-mapping.json
+++ b/server/src/main/resources/org/elasticsearch/tasks/task-index-mapping.json
@@ -1,7 +1,7 @@
 {
   "task" : {
     "_meta": {
-      "version": 2
+      "version": 3
     },
     "dynamic" : "strict",
     "properties" : {


### PR DESCRIPTION
The built-in task index mapping has a `version` field in its metadata, so that
the `TaskResultsService` can check to see if it needs to update mappings when
a new task result is stored.  #48393 updated this version in `TaskResultsService`
but omitted to change the version in the mapping itself, so a mapping update
is applied every time a new task result is stored.

This commit updates the mapping version so that it corresponds to the version
in `TaskResultsService`.