### PR TITLE
Remove snapshots left by previous tests failures on Azure

### DIFF
--- a/plugins/repository-azure/qa/microsoft-azure-storage/src/test/resources/rest-api-spec/test/repository_azure/10_repository.yml
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/src/test/resources/rest-api-spec/test/repository_azure/10_repository.yml
@@ -13,6 +13,19 @@ setup:
             client: "integration_test"
             base_path: ${base_path}
 
+  # Remove the snapshots, if a previous test failed to delete them. This is
+  # useful for third party tests that runs the test against a real external service.
+  - do:
+      snapshot.delete:
+        repository: repository
+        snapshot: snapshot-one
+        ignore: 404
+  - do:
+      snapshot.delete:
+        repository: repository
+        snapshot: snapshot-two
+        ignore: 404
+
 ---
 "Snapshot/Restore with repository-azure":
   - skip:


### PR DESCRIPTION
When a third party test failed, it potentially left some snapshots in the repository. In case of tests running against an external service like Azure, the remaining snapshots can fail the future test executions are they are not supposed to exist.

Similarly to what has been done for S3 and GCS, this pull request cleans up remaining snapshots before the test execution.

Closes #50304