### PR TITLE
[DOCS] Updates ML links

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Detector.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Detector.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * <code>by_field_name</code> and <code>over_field_name</code> can be used depending on the specific
  * function chosen. For more information see the
  * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html">create anomaly detection
- * jobs API</a> and <a href="https://www.elastic.co/guide/en/elastic-stack-overview/current/ml-functions.html">detector functions</a>.
+ * jobs API</a> and <a href="https://www.elastic.co/guide/en/machine-learning/current/ml-functions.html">detector functions</a>.
  */
 public class Detector implements ToXContentObject {
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Detector.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Detector.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * <code>by_field_name</code> and <code>over_field_name</code> can be used depending on the specific
  * function chosen. For more information see the
  * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html">create anomaly detection
- * jobs API</a> and <a href="https://www.elastic.co/guide/en/machine-learning/current/ml-functions.html">detector functions</a>.
+ * jobs API</a> and <a href="https://www.elastic.co/guide/en/elastic-stack-overview/current/ml-functions.html">detector functions</a>.
  */
 public class Detector implements ToXContentObject {
 

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -168,7 +168,7 @@ embroidery_ needles.
 ==== But wait, there’s more
 
 Want to automate the analysis of your time-series data? You can use
-{stack-ov}/ml-overview.html[machine learning] features to create accurate
+{ml-docs}/ml-overview.html[machine learning] features to create accurate
 baselines of normal behavior in your data and identify anomalous patterns. With
 machine learning, you can detect:
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -23,7 +23,7 @@ Deletes a filter.
 [[ml-delete-filter-desc]]
 ==== {api-description-title}
 
-This API deletes a {stack-ov}/ml-rules.html[filter]. 
+This API deletes a {ml-docs}/ml-rules.html[filter]. 
 If a {ml} job references the filter, you cannot delete the filter. You must 
 update or delete the job before you can delete the filter.
 

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -35,7 +35,7 @@ one or more forecasts before they expire.
 NOTE: When you delete a job, its associated forecasts are deleted. 
 
 For more information, see
-{stack-ov}/ml-overview.html#ml-forecasting[Forecasting the future].
+{ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future].
 
 [[ml-delete-forecast-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/eventresource.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/eventresource.asciidoc
@@ -24,4 +24,4 @@ An events resource has the following properties:
  in milliseconds since the epoch or ISO 8601 format.
 
 For more information, see
-{stack-ov}/ml-calendars.html[Calendars and Scheduled Events].
+{ml-docs}/ml-calendars.html[Calendars and scheduled events].

--- a/docs/reference/ml/anomaly-detection/apis/filterresource.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/filterresource.asciidoc
@@ -14,4 +14,4 @@ A filter resource has the following properties:
 `items`::
   (array of strings) An array of strings which is the filter item list.
   
-For more information, see {stack-ov}/ml-rules.html[Machine learning custom rules].
+For more information, see {ml-docs}/ml-rules.html[Machine learning custom rules].

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -23,7 +23,7 @@ Predicts the future behavior of a time series by using its historical behavior.
 [[ml-forecast-desc]]
 ==== {api-description-title}
 
-See {stack-ov}/ml-overview.html#ml-forecasting[Forecasting the future].
+See {ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future].
 
 [NOTE]
 ===============================

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -29,7 +29,7 @@ You can get scheduled event information for a single calendar or for all
 calendars by using `_all`.
 
 For more information, see
-{stack-ov}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
 [[ml-get-calendar-event-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -29,7 +29,7 @@ You can get information for a single calendar or for all calendars by using
 `_all`.
 
 For more information, see 
-{stack-ov}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
 [[ml-get-calendar-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -37,7 +37,7 @@ The anomaly results from a categorization analysis are available as bucket,
 influencer, and record results. For example, the results might indicate that
 at 16:45 there was an unusual count of log message category 11. You can then
 examine the description and examples of that category. For more information, see
-{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
+{ml-docs}/ml-configuring-categories.html[Categorizing log messages].
 
 [[ml-get-category-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -26,7 +26,7 @@ Retrieves filters.
 ==== {api-description-title}
 
 You can get a single filter or all filters. For more information, see 
-{stack-ov}/ml-rules.html[Machine learning custom rules].
+{ml-docs}/ml-rules.html[Machine learning custom rules].
 
 [[ml-get-filter-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -36,7 +36,7 @@ by specifying `*` as the `<job_id>`.
 By default, an overall bucket has a span equal to the largest bucket span of the
 specified {anomaly-jobs}. To override that behavior, use the optional
 `bucket_span` parameter. To learn more about the concept of buckets, see
-{stack-ov}/ml-buckets.html[Buckets].
+{ml-docs}/ml-buckets.html[Buckets].
 
 The `overall_score` is calculated by combining the scores of all the buckets
 within the overall bucket span. First, the maximum `anomaly_score` per

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -23,7 +23,7 @@ Posts scheduled events in a calendar.
 [[ml-post-calendar-event-desc]]
 ==== {api-description-title}
 
-This API accepts a list of {stack-ov}/ml-calendars.html[scheduled events], each
+This API accepts a list of {ml-docs}/ml-calendars.html[scheduled events], each
 of which must have a start time, end time, and description.
 
 [[ml-post-calendar-event-path-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -24,7 +24,7 @@ Instantiates a calendar.
 ==== {api-description-title}
 
 For more information, see
-{stack-ov}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
 [[ml-put-calendar-path-parms]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -23,7 +23,7 @@ Instantiates a filter.
 [[ml-put-filter-desc]]
 ==== {api-description-title}
 
-A {stack-ov}/ml-rules.html[filter] contains a list of strings. 
+A {ml-docs}/ml-rules.html[filter] contains a list of strings. 
 It can be used by one or more jobs. Specifically, filters are referenced in 
 the `custom_rules` property of detector configuration objects. 
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -2,7 +2,7 @@ tag::aggregations[]
 If set, the {dfeed} performs aggregation searches. Support for aggregations is
 limited and should only be used with low cardinality data. For more information,
 see
-{stack-ov}/ml-configuring-aggregation.html[Aggregating data for faster performance].
+{ml-docs}/ml-configuring-aggregation.html[Aggregating data for faster performance].
 end::aggregations[]
 
 tag::allow-lazy-open[]
@@ -203,7 +203,7 @@ at the same time as `categorization_filters`. The categorization analyzer
 specifies how the `categorization_field` is interpreted by the categorization
 process. The syntax is very similar to that used to define the `analyzer` in the
 <<indices-analyze,Analyze endpoint>>. For more information, see
-{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
+{ml-docs}/ml-configuring-categories.html[Categorizing log messages].
 +
 --
 The `categorization_analyzer` field can be specified either as a string or as an
@@ -234,7 +234,7 @@ set this value to `0`, no examples are stored.
 --
 NOTE: The `categorization_examples_limit` only applies to analysis that uses
 categorization. For more information, see
-{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
+{ml-docs}/ml-configuring-categories.html[Categorizing log messages].
 
 --
 end::categorization-examples-limit[]
@@ -244,7 +244,7 @@ If this property is specified, the values of the specified field will be
 categorized. The resulting categories must be used in a detector by setting
 `by_field_name`, `over_field_name`, or `partition_field_name` to the keyword
 `mlcategory`. For more information, see
-{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
+{ml-docs}/ml-configuring-categories.html[Categorizing log messages].
 end::categorization-field-name[]
 
 tag::categorization-filters[]
@@ -254,7 +254,7 @@ are used to filter out matching sequences from the categorization field values.
 You can use this functionality to fine tune the categorization by excluding 
 sequences from consideration when categories are defined. For example, you can 
 exclude SQL statements that appear in your log files. For more information, see 
-{stack-ov}/ml-configuring-categories.html[Categorizing log messages]. This
+{ml-docs}/ml-configuring-categories.html[Categorizing log messages]. This
 property cannot be used at the same time as `categorization_analyzer`. If you
 only want to define simple regular expression filters that are applied prior to 
 tokenization, setting this property is the easiest method. If you also want to 
@@ -299,7 +299,7 @@ tag::custom-rules[]
 An array of custom rule objects, which enable you to customize the way detectors
 operate. For example, a rule may dictate to the detector conditions under which
 results should be skipped. For more examples, see 
-{stack-ov}/ml-configuring-detector-custom-rules.html[Configuring detector custom rules].
+{ml-docs}/ml-configuring-detector-custom-rules.html[Customizing detectors with custom rules].
 A custom rule has the following properties:
 +
 --
@@ -363,7 +363,7 @@ end::custom-rules[]
 tag::custom-settings[]
 Advanced configuration option. Contains custom meta data about the job. For
 example, it can contain custom URL information as shown in
-{stack-ov}/ml-configuring-url.html[Adding custom URLs to {ml} results].
+{ml-docs}/ml-configuring-url.html[Adding custom URLs to {ml} results].
 end::custom-settings[]
 
 tag::data-description[]
@@ -503,7 +503,7 @@ an effort to determine whether any data has subsequently been added to the index
 If missing data is found, it is a good indication that the `query_delay` option
 is set too low and the data is being indexed after the {dfeed} has passed that
 moment in time. See 
-{stack-ov}/ml-delayed-data-detection.html[Working with delayed data].
+{ml-docs}/ml-delayed-data-detection.html[Working with delayed data].
 
 This check runs only on real-time {dfeeds}.
 
@@ -692,7 +692,7 @@ end::from[]
 tag::function[]
 The analysis function that is used. For example, `count`, `rare`, `mean`, `min`, 
 `max`, and `sum`. For more information, see
-{stack-ov}/ml-functions.html[Function reference].
+{ml-docs}/ml-functions.html[Function reference].
 end::function[]
 
 tag::gamma[]
@@ -979,7 +979,7 @@ tag::over-field-name[]
 The field used to split the data. In particular, this property is used for 
 analyzing the splits with respect to the history of all splits. It is used for 
 finding unusual values in the population of all splits. For more information,
-see {stack-ov}/ml-configuring-pop.html[Performing population analysis].
+see {ml-docs}/ml-configuring-pop.html[Performing population analysis].
 end::over-field-name[]
 
 tag::outlier-fraction[]
@@ -1049,7 +1049,7 @@ tag::script-fields[]
 Specifies scripts that evaluate custom expressions and returns script fields to
 the {dfeed}. The detector configuration objects in a job can contain functions
 that use these script fields. For more information, see
-{stack-ov}/ml-configuring-transform.html[Transforming data with script fields]
+{ml-docs}/ml-configuring-transform.html[Transforming data with script fields]
 and <<request-body-search-script-fields,Script fields>>.
 end::script-fields[]
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -46,7 +46,7 @@ A node that has `xpack.ml.enabled` and `node.ml` set to `true`, which is the
 default behavior in the {es} {default-dist}. If you want to use {ml-features},
 there must be at least one {ml} node in your cluster. For more information about
 {ml-features}, see
-{stack-ov}/xpack-ml.html[Machine learning in the {stack}].
+{ml-docs}/xpack-ml.html[Machine learning in the {stack}].
 +
 IMPORTANT: If you use the {oss-dist}, do not set `node.ml`. Otherwise, the node
 fails to start.

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -631,19 +631,19 @@ more details.
 === Calendar resources
 
 See <<ml-get-calendar>> and
-{stack-ov}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
 [role="exclude",id="ml-filter-resource"]
 === Filter resources
 
 See <<ml-get-filter>> and
-{stack-ov}/ml-rules.html[Machine learning custom rules].
+{ml-docs}/ml-rules.html[Machine learning custom rules].
 
 [role="exclude",id="ml-event-resource"]
 === Scheduled event resources
 
 See <<ml-get-calendar-event>> and
-{stack-ov}/ml-calendars.html[Calendars and scheduled events].
+{ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
 [role="exclude",id="index-apis"]
 === Index APIs

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -55,7 +55,7 @@ was automatically saved. This option avoids the overhead of managing active jobs
 during the shutdown and is faster than explicitly stopping {dfeeds} and closing 
 jobs.
 
-* {stack-ov}/stopping-ml.html[Stop all {dfeeds} and close all jobs]. This option
+* {ml-docs}/stopping-ml.html[Stop all {dfeeds} and close all jobs]. This option
 saves the model state at the time of closure. When you reopen the jobs after the
 cluster restart, they use the exact same model. However, saving the latest model 
 state takes longer than using upgrade mode, especially if you have a lot of jobs 

--- a/docs/reference/upgrade/close-ml.asciidoc
+++ b/docs/reference/upgrade/close-ml.asciidoc
@@ -34,7 +34,7 @@ state that was automatically saved. This option avoids the overhead of managing
 active jobs during the upgrade and is faster than explicitly stopping {dfeeds}
 and closing jobs.
 
-* {stack-ov}/stopping-ml.html[Stop all {dfeeds} and close all jobs]. This option
+* {ml-docs}/stopping-ml.html[Stop all {dfeeds} and close all jobs]. This option
 saves the model state at the time of closure. When you reopen the jobs after the
 upgrade, they use the exact same model. However, saving the latest model state
 takes longer than using upgrade mode, especially if you have a lot of jobs or

--- a/docs/reference/upgrade/reindex_upgrade.asciidoc
+++ b/docs/reference/upgrade/reindex_upgrade.asciidoc
@@ -62,7 +62,7 @@ If you use {ml-features} and your {ml} indices were created before
 {prev-major-version}, you must temporarily halt the tasks associated with your
 {ml} jobs and {dfeeds} and prevent new jobs from opening during the reindex. Use
 the <<ml-set-upgrade-mode,set upgrade mode API>> or
-{stack-ov}/stopping-ml.html[stop all {dfeeds} and close all {ml} jobs].
+{ml-docs}/stopping-ml.html[stop all {dfeeds} and close all {ml} jobs].
 
 If you use {es} {security-features}, before you reindex `.security*` internal
 indices it is a good idea to create a temporary superuser account in the `file`
@@ -121,7 +121,7 @@ from a 6.6 or later cluster, it is a good idea to temporarily halt the tasks
 associated with your {ml} jobs and {dfeeds} to prevent inconsistencies between
 different {ml} indices that are reindexed at slightly different times. Use the
 <<ml-set-upgrade-mode,set upgrade mode API>> or 
-{stack-ov}/stopping-ml.html[stop all {dfeeds} and close all {ml} jobs].
+{ml-docs}/stopping-ml.html[stop all {dfeeds} and close all {ml} jobs].
 endif::include-xpack[]
 
 =============================================


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/777

This PR updates links to machine learning content so that they point to the appropriate book (https://www.elastic.co/guide/en/machine-learning/master/index.html instead of https://www.elastic.co/guide/en/elastic-stack-overview/master/index.html).