### PR TITLE
Close engine before reset log appender

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2369,7 +2369,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.index(indexForDoc(doc));
             engine.flush();
             assertTrue(mockAppender.sawIndexWriterMessage);
-
+            engine.close();
         } finally {
             Loggers.removeAppender(rootLogger, mockAppender);
             mockAppender.stop();


### PR DESCRIPTION
>   1> [2019-12-18T08:55:30,347][TRACE][o.e.i.e.E.MS             ] [[index] [index][0] elasticsearch[[index][0]: Lucene Merge Thread #0] MS:   merge thread: start
  1> 2019-12-18 08:55:30,375 elasticsearch[[index][0]: Lucene Merge Thread #0] ERROR Attempted to append to non-started appender testIndexWriterInfoStream

Merge threads can run and access the mock appender after we have stopped it.

Closes #50315