### PR TITLE
Scripting: ScriptFactory not required by compile (#50344)

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/AnalysisPredicateScript.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/AnalysisPredicateScript.java
@@ -27,7 +27,6 @@ import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.util.AttributeSource;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 
 /**
  * A predicate based on the current token in a TokenStream
@@ -108,7 +107,7 @@ public abstract class AnalysisPredicateScript {
      */
     public abstract boolean execute(Token token);
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         AnalysisPredicateScript newInstance();
     }
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PredicateTokenScriptFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PredicateTokenScriptFilterTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTokenStreamTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -64,7 +63,7 @@ public class PredicateTokenScriptFilterTests extends ESTokenStreamTestCase {
         @SuppressWarnings("unchecked")
         ScriptService scriptService = new ScriptService(indexSettings, Collections.emptyMap(), Collections.emptyMap()){
             @Override
-            public <FactoryType extends ScriptFactory> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+            public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
                 assertEquals(context, AnalysisPredicateScript.CONTEXT);
                 assertEquals(new Script("my_script"), script);
                 return (FactoryType) factory;

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTokenStreamTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -64,7 +63,7 @@ public class ScriptedConditionTokenFilterTests extends ESTokenStreamTestCase {
         @SuppressWarnings("unchecked")
         ScriptService scriptService = new ScriptService(indexSettings, Collections.emptyMap(), Collections.emptyMap()){
             @Override
-            public <FactoryType extends ScriptFactory> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+            public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
                 assertEquals(context, AnalysisPredicateScript.CONTEXT);
                 assertEquals(new Script("token.getPosition() > 1"), script);
                 return (FactoryType) factory;

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -44,7 +44,6 @@ import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.TermsSetQueryScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -88,25 +87,75 @@ public class ExpressionScriptEngine implements ScriptEngine {
                 return wrappedFactory; });
 
         contexts.put(FilterScript.CONTEXT,
-            (Expression expr) -> (FilterScript.Factory) (p, lookup) -> newFilterScript(expr, lookup, p));
+            (Expression expr) -> new FilterScript.Factory() {
+                @Override
+                public boolean isResultDeterministic() {
+                    return true;
+                }
+
+                @Override
+                public FilterScript.LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup) {
+                    return newFilterScript(expr, lookup, params);
+                }
+            });
 
         contexts.put(ScoreScript.CONTEXT,
-            (Expression expr) -> (ScoreScript.Factory) (p, lookup) -> newScoreScript(expr, lookup, p));
+            (Expression expr) -> new ScoreScript.Factory() {
+                @Override
+                public ScoreScript.LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup) {
+                    return newScoreScript(expr, lookup, params);
+                }
+
+                @Override
+                public boolean isResultDeterministic() {
+                    return true;
+                }
+            });
 
         contexts.put(TermsSetQueryScript.CONTEXT,
             (Expression expr) -> (TermsSetQueryScript.Factory) (p, lookup) -> newTermsSetQueryScript(expr, lookup, p));
 
         contexts.put(AggregationScript.CONTEXT,
-            (Expression expr) -> (AggregationScript.Factory) (p, lookup) -> newAggregationScript(expr, lookup, p));
+            (Expression expr) -> new AggregationScript.Factory() {
+                @Override
+                public AggregationScript.LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup) {
+                    return newAggregationScript(expr, lookup, params);
+                }
+
+                @Override
+                public boolean isResultDeterministic() {
+                    return true;
+                }
+            });
 
         contexts.put(NumberSortScript.CONTEXT,
-            (Expression expr) -> (NumberSortScript.Factory) (p, lookup) -> newSortScript(expr, lookup, p));
+            (Expression expr) -> new NumberSortScript.Factory() {
+                @Override
+                public NumberSortScript.LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup) {
+                    return newSortScript(expr, lookup, params);
+                }
+
+                @Override
+                public boolean isResultDeterministic() {
+                    return true;
+                }
+            });
 
         contexts.put(FieldScript.CONTEXT,
-            (Expression expr) -> (FieldScript.Factory) (p, lookup) -> newFieldScript(expr, lookup, p));
+            (Expression expr) -> new FieldScript.Factory() {
+                @Override
+                public FieldScript.LeafFactory newFactory(Map<String, Object> params, SearchLookup lookup) {
+                    return newFieldScript(expr, lookup, params);
+                }
 
-        ExpressionScriptEngine.contexts = Collections.unmodifiableMap(contexts);
-    }
+                @Override
+                public boolean isResultDeterministic() {
+                    return true;
+                }
+            });
+
+            ExpressionScriptEngine.contexts = Collections.unmodifiableMap(contexts);
+        }
 
     @Override
     public String getType() {
@@ -114,7 +163,7 @@ public class ExpressionScriptEngine implements ScriptEngine {
     }
 
     @Override
-    public <T extends ScriptFactory> T compile(
+    public <T> T compile(
         String scriptName,
         String scriptSource,
         ScriptContext<T> context,

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -21,9 +21,8 @@ package org.elasticsearch.script.mustache;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheFactory;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.SpecialPermission;
@@ -32,7 +31,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.TemplateScript;
 
 import java.io.Reader;
@@ -65,7 +63,7 @@ public final class MustacheScriptEngine implements ScriptEngine {
      * @return a compiled template object for later execution.
      * */
     @Override
-    public <T extends ScriptFactory> T compile(
+    public <T> T compile(
         String templateName,
         String templateSource,
         ScriptContext<T> context,

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -28,7 +28,6 @@ import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
-import org.elasticsearch.script.ScriptFactory;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -123,7 +122,7 @@ public final class PainlessScriptEngine implements ScriptEngine {
     }
 
     @Override
-    public <T extends ScriptFactory> T compile(
+    public <T> T compile(
         String scriptName,
         String scriptSource,
         ScriptContext<T> context,
@@ -169,7 +168,7 @@ public final class PainlessScriptEngine implements ScriptEngine {
      * @param <T> The factory class.
      * @return A factory class that will return script instances.
      */
-    private <T extends ScriptFactory> Type generateStatefulFactory(
+    private <T> Type generateStatefulFactory(
         Loader loader,
         ScriptContext<T> context,
         Set<String> extractedVariables
@@ -275,7 +274,7 @@ public final class PainlessScriptEngine implements ScriptEngine {
      * @param <T> The factory class.
      * @return A factory class that will return script instances.
      */
-    private <T extends ScriptFactory> T generateFactory(
+    private <T> T generateFactory(
         Loader loader,
         ScriptContext<T> context,
         Set<String> extractedVariables,

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -76,7 +76,6 @@ import org.elasticsearch.script.FilterScript;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -435,7 +434,7 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
 
         public abstract Object execute();
 
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
 
             PainlessTestScript newInstance(Map<String, Object> params);
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BaseClassTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BaseClassTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless;
 
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +65,7 @@ public class BaseClassTests extends ScriptTestCase {
 
     public abstract static class Gets {
 
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             Gets newInstance(String testString, int testInt, Map<String, Object> params);
         }
 
@@ -112,7 +111,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class NoArgs {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             NoArgs newInstance();
         }
 
@@ -138,7 +137,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class OneArg {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             OneArg newInstance();
         }
 
@@ -155,7 +154,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class ArrayArg {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             ArrayArg newInstance();
         }
 
@@ -172,7 +171,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class PrimitiveArrayArg {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             PrimitiveArrayArg newInstance();
         }
 
@@ -189,7 +188,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class DefArrayArg {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             DefArrayArg newInstance();
         }
 
@@ -213,7 +212,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class ManyArgs {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             ManyArgs newInstance();
         }
 
@@ -252,7 +251,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class VarArgs {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             VarArgs newInstance();
         }
 
@@ -268,7 +267,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class DefaultMethods {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             DefaultMethods newInstance();
         }
 
@@ -302,7 +301,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class ReturnsVoid {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             ReturnsVoid newInstance();
         }
 
@@ -326,7 +325,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class ReturnsPrimitiveBoolean {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             ReturnsPrimitiveBoolean newInstance();
         }
 
@@ -392,7 +391,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class ReturnsPrimitiveInt {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             ReturnsPrimitiveInt newInstance();
         }
 
@@ -456,7 +455,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class ReturnsPrimitiveFloat {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             ReturnsPrimitiveFloat newInstance();
         }
 
@@ -505,7 +504,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
    public abstract static class ReturnsPrimitiveDouble {
-       public interface Factory extends ScriptFactory {
+       public interface Factory {
            ReturnsPrimitiveDouble newInstance();
        }
 
@@ -568,7 +567,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class NoArgsConstant {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             NoArgsConstant newInstance();
         }
 
@@ -585,7 +584,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class WrongArgsConstant {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             WrongArgsConstant newInstance();
         }
 
@@ -603,7 +602,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class WrongLengthOfArgConstant {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             WrongLengthOfArgConstant newInstance();
         }
 
@@ -620,7 +619,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class UnknownArgType {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             UnknownArgType newInstance();
         }
 
@@ -637,7 +636,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class UnknownReturnType {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             UnknownReturnType newInstance();
         }
 
@@ -654,7 +653,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class UnknownArgTypeInArray {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             UnknownArgTypeInArray newInstance();
         }
 
@@ -671,7 +670,7 @@ public class BaseClassTests extends ScriptTestCase {
     }
 
     public abstract static class TwoExecuteMethods {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             TwoExecuteMethods newInstance();
         }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicStatementTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicStatementTests.java
@@ -2,7 +2,6 @@ package org.elasticsearch.painless;
 
 import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -261,7 +260,7 @@ public class BasicStatementTests extends ScriptTestCase {
     }
 
     public abstract static class OneArg {
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             OneArg newInstance();
         }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BindingsTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.painless.spi.WhitelistInstanceBinding;
 import org.elasticsearch.painless.spi.WhitelistLoader;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -90,7 +89,7 @@ public class BindingsTests extends ScriptTestCase {
         public static final String[] PARAMETERS = { "test", "bound" };
         public int getTestValue() {return 7;}
         public abstract int execute(int test, int bound);
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             BindingsTestScript newInstance();
         }
         public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("bindings_test", Factory.class);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FactoryTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FactoryTests.java
@@ -35,6 +35,7 @@ public class FactoryTests extends ScriptTestCase {
         Map<ScriptContext<?>, List<Whitelist>> contexts = super.scriptContexts();
         contexts.put(StatefulFactoryTestScript.CONTEXT, Whitelist.BASE_WHITELISTS);
         contexts.put(FactoryTestScript.CONTEXT, Whitelist.BASE_WHITELISTS);
+        contexts.put(DeterministicFactoryTestScript.CONTEXT, Whitelist.BASE_WHITELISTS);
         contexts.put(EmptyTestScript.CONTEXT, Whitelist.BASE_WHITELISTS);
         contexts.put(TemplateScript.CONTEXT, Whitelist.BASE_WHITELISTS);
 
@@ -85,7 +86,7 @@ public class FactoryTests extends ScriptTestCase {
             boolean needsD();
         }
 
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             StatefulFactory newFactory(int x, int y);
 
             boolean needsTest();
@@ -138,7 +139,7 @@ public class FactoryTests extends ScriptTestCase {
         public static final String[] PARAMETERS = new String[] {"test"};
         public abstract Object execute(int test);
 
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             FactoryTestScript newInstance(Map<String, Object> params);
 
             boolean needsTest();
@@ -147,6 +148,31 @@ public class FactoryTests extends ScriptTestCase {
 
         public static final ScriptContext<FactoryTestScript.Factory> CONTEXT =
             new ScriptContext<>("test", FactoryTestScript.Factory.class);
+    }
+
+    public abstract static class DeterministicFactoryTestScript {
+        private final Map<String, Object> params;
+
+        public DeterministicFactoryTestScript(Map<String, Object> params) {
+            this.params = params;
+        }
+
+        public Map<String, Object> getParams() {
+            return params;
+        }
+
+        public static final String[] PARAMETERS = new String[] {"test"};
+        public abstract Object execute(int test);
+
+        public interface Factory extends ScriptFactory{
+            FactoryTestScript newInstance(Map<String, Object> params);
+
+            boolean needsTest();
+            boolean needsNothing();
+        }
+
+        public static final ScriptContext<DeterministicFactoryTestScript.Factory> CONTEXT =
+            new ScriptContext<>("test", DeterministicFactoryTestScript.Factory.class);
     }
 
     public void testFactory() {
@@ -163,26 +189,26 @@ public class FactoryTests extends ScriptTestCase {
     }
 
     public void testDeterministic() {
-        FactoryTestScript.Factory factory =
+        DeterministicFactoryTestScript.Factory factory =
             scriptEngine.compile("deterministic_test", "Integer.parseInt('123')",
-                FactoryTestScript.CONTEXT, Collections.emptyMap());
+                DeterministicFactoryTestScript.CONTEXT, Collections.emptyMap());
         assertTrue(factory.isResultDeterministic());
         assertEquals(123, factory.newInstance(Collections.emptyMap()).execute(0));
     }
 
     public void testNotDeterministic() {
-        FactoryTestScript.Factory factory =
+        DeterministicFactoryTestScript.Factory factory =
             scriptEngine.compile("not_deterministic_test", "Math.random()",
-                FactoryTestScript.CONTEXT, Collections.emptyMap());
+                DeterministicFactoryTestScript.CONTEXT, Collections.emptyMap());
         assertFalse(factory.isResultDeterministic());
         Double d = (Double)factory.newInstance(Collections.emptyMap()).execute(0);
         assertTrue(d >= 0.0 && d <= 1.0);
     }
 
     public void testMixedDeterministicIsNotDeterministic() {
-        FactoryTestScript.Factory factory =
+        DeterministicFactoryTestScript.Factory factory =
             scriptEngine.compile("not_deterministic_test", "Integer.parseInt('123') + Math.random()",
-                FactoryTestScript.CONTEXT, Collections.emptyMap());
+                DeterministicFactoryTestScript.CONTEXT, Collections.emptyMap());
         assertFalse(factory.isResultDeterministic());
         Double d = (Double)factory.newInstance(Collections.emptyMap()).execute(0);
         assertTrue(d >= 123.0 && d <= 124.0);
@@ -192,7 +218,7 @@ public class FactoryTests extends ScriptTestCase {
         public static final String[] PARAMETERS = {};
         public abstract Object execute();
 
-        public interface Factory extends ScriptFactory {
+        public interface Factory {
             EmptyTestScript newInstance();
         }
 

--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -63,7 +63,7 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
         }
 
         @Override
-        public <T extends ScriptFactory> T compile(
+        public <T> T compile(
             String scriptName,
             String scriptSource,
             ScriptContext<T> context,
@@ -93,7 +93,8 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
             return Collections.singleton(ScoreScript.CONTEXT);
         }
 
-        private static class PureDfFactory implements ScoreScript.Factory {
+        private static class PureDfFactory implements ScoreScript.Factory,
+                                                      ScriptFactory {
             @Override
             public boolean isResultDeterministic() {
                 // PureDfLeafFactory only uses deterministic APIs, this

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -358,11 +358,9 @@ public class QueryShardContext extends QueryRewriteContext {
     }
 
     /** Compile script using script service */
-    public <FactoryType extends ScriptFactory> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+    public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
         FactoryType factory = scriptService.compile(script, context);
-        // TODO(stu): can check `factory instanceof ScriptFactory && ((ScriptFactory) factory).isResultDeterministic() == false`
-        // to avoid being so intrusive
-        if (factory.isResultDeterministic() == false) {
+        if (factory instanceof ScriptFactory && ((ScriptFactory) factory).isResultDeterministic() == false) {
             failIfFrozen();
         }
         return factory;

--- a/server/src/main/java/org/elasticsearch/script/BucketAggregationSelectorScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BucketAggregationSelectorScript.java
@@ -48,7 +48,7 @@ public abstract class BucketAggregationSelectorScript {
 
     public abstract boolean execute();
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         BucketAggregationSelectorScript newInstance(Map<String, Object> params);
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/IngestConditionalScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestConditionalScript.java
@@ -45,7 +45,7 @@ public abstract class IngestConditionalScript {
 
     public abstract boolean execute(Map<String, Object> ctx);
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         IngestConditionalScript newInstance(Map<String, Object> params);
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/IngestScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestScript.java
@@ -46,7 +46,7 @@ public abstract class IngestScript {
 
     public abstract void execute(Map<String, Object> ctx);
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         IngestScript newInstance(Map<String, Object> params);
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ScriptContext.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContext.java
@@ -54,7 +54,7 @@ import java.lang.reflect.Method;
  * If the variable name starts with an underscore, for example, {@code _score}, the needs method would
  * be {@code boolean needs_score()}.
  */
-public final class ScriptContext<FactoryType extends ScriptFactory> {
+public final class ScriptContext<FactoryType> {
 
     /** A unique identifier for this context. */
     public final String name;

--- a/server/src/main/java/org/elasticsearch/script/ScriptEngine.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptEngine.java
@@ -42,7 +42,7 @@ public interface ScriptEngine extends Closeable {
      * @param params compile-time parameters (such as flags to the compiler)
      * @return A compiled script of the FactoryType from {@link ScriptContext}
      */
-    <FactoryType extends ScriptFactory> FactoryType compile(
+    <FactoryType> FactoryType compile(
         String name,
         String code,
         ScriptContext<FactoryType> context,

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -284,7 +284,7 @@ public class ScriptService implements Closeable, ClusterStateApplier {
      *
      * @return a compiled script which may be used to construct instances of a script for the given context
      */
-    public <FactoryType extends ScriptFactory> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+    public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
         Objects.requireNonNull(script);
         Objects.requireNonNull(context);
 

--- a/server/src/main/java/org/elasticsearch/script/TemplateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/TemplateScript.java
@@ -41,7 +41,7 @@ public abstract class TemplateScript {
     /** Run a template and return the resulting string, encoded in utf8 bytes. */
     public abstract String execute();
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         TemplateScript newInstance(Map<String, Object> params);
     }
 

--- a/server/src/main/java/org/elasticsearch/script/UpdateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateScript.java
@@ -67,7 +67,7 @@ public abstract class UpdateScript {
 
     public abstract void execute();
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         UpdateScript newInstance(Map<String, Object> params, Map<String, Object> ctx);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -397,7 +396,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
         ScriptService scriptService = new ScriptService(Settings.EMPTY, Collections.emptyMap(), Collections.emptyMap()){
             @Override
             @SuppressWarnings("unchecked")
-            public <FactoryType extends ScriptFactory> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+            public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
                 assertEquals(IntervalFilterScript.CONTEXT, context);
                 assertEquals(new Script("interval.start > 3"), script);
                 return (FactoryType) factory;

--- a/server/src/test/java/org/elasticsearch/script/ScriptContextTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptContextTests.java
@@ -23,28 +23,28 @@ import org.elasticsearch.test.ESTestCase;
 
 public class ScriptContextTests extends ESTestCase {
 
-    public interface TwoNewInstance extends ScriptFactory {
+    public interface TwoNewInstance {
         String newInstance(int foo, int bar);
         String newInstance(int foo);
 
-        interface StatefulFactory extends ScriptFactory {
+        interface StatefulFactory {
             TwoNewInstance newFactory();
         }
     }
 
-    public interface TwoNewFactory extends ScriptFactory {
+    public interface TwoNewFactory {
         String newFactory(int foo, int bar);
         String newFactory(int foo);
     }
 
-    public interface MissingNewInstance extends ScriptFactory {
+    public interface MissingNewInstance {
         String typoNewInstanceMethod(int foo);
     }
 
     public interface DummyScript {
         int execute(int foo);
 
-        interface Factory extends ScriptFactory {
+        interface Factory {
             DummyScript newInstance();
         }
     }
@@ -54,7 +54,7 @@ public class ScriptContextTests extends ESTestCase {
         interface StatefulFactory {
             DummyStatefulScript newInstance();
         }
-        interface Factory extends ScriptFactory {
+        interface Factory {
             StatefulFactory newFactory();
         }
     }

--- a/server/src/test/java/org/elasticsearch/script/ScriptLanguagesInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptLanguagesInfoTests.java
@@ -75,7 +75,7 @@ public class ScriptLanguagesInfoTests extends ESTestCase {
     }
 
 
-    public interface MiscContext extends ScriptFactory {
+    public interface MiscContext {
         void execute();
         Object newInstance();
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -1037,7 +1037,6 @@ public class ScriptedMetricIT extends ESIntegTestCase {
      * Make sure that a request using a deterministic script gets cached and nondeterministic scripts do not get cached.
      */
     public void testScriptCaching() throws Exception {
-        // TODO(stu): add non-determinism in init, agg, combine and reduce, ensure not cached
         Script mapScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "state['count'] = 1", Collections.emptyMap());
         Script combineScript =
             new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op aggregation", Collections.emptyMap());

--- a/server/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/server/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -34,7 +34,6 @@ import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -76,7 +75,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public <T extends ScriptFactory> T compile(
+                public <T> T compile(
                     String scriptName,
                     String scriptSource,
                     ScriptContext<T> context,

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -34,7 +34,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.suggest.phrase.DirectCandidateGeneratorBuilder;
 import org.elasticsearch.search.suggest.phrase.Laplace;
@@ -1138,7 +1137,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        public <T extends ScriptFactory> T compile(
+        public <T> T compile(
             String scriptName,
             String scriptSource,
             ScriptContext<T> context,

--- a/test/framework/src/main/java/org/elasticsearch/ingest/TestTemplateService.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/TestTemplateService.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.TemplateScript;
 
@@ -49,7 +48,7 @@ public class TestTemplateService extends ScriptService {
     }
 
     @Override
-    public <FactoryType extends ScriptFactory> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
+    public <FactoryType> FactoryType compile(Script script, ScriptContext<FactoryType> context) {
         if (this.compilationException) {
             throw new RuntimeException("could not compile script");
         } else {

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -95,7 +95,7 @@ public class MockScriptEngine implements ScriptEngine {
     }
 
     @Override
-    public <T extends ScriptFactory> T compile(String name, String source, ScriptContext<T> context, Map<String, String> params) {
+    public <T> T compile(String name, String source, ScriptContext<T> context, Map<String, String> params) {
         // Scripts are always resolved using the script's source. For inline scripts, it's easy because they don't have names and the
         // source is always provided. For stored and file scripts, the source of the script must match the key of a predefined script.
         MockDeterministicScript script = scripts.get(source);
@@ -254,7 +254,6 @@ public class MockScriptEngine implements ScriptEngine {
 
     @Override
     public Set<ScriptContext<?>> getSupportedContexts() {
-        // TODO(stu): make part of `compile()`
         return Stream.of(
             FieldScript.CONTEXT,
             TermsSetQueryScript.CONTEXT,
@@ -397,7 +396,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    public static class MockMetricAggInitScriptFactory implements ScriptedMetricAggContexts.InitScript.Factory, ScriptFactory {
+    public static class MockMetricAggInitScriptFactory implements ScriptedMetricAggContexts.InitScript.Factory {
         private final MockDeterministicScript script;
         MockMetricAggInitScriptFactory(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -430,7 +429,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    public static class MockMetricAggMapScriptFactory implements  ScriptedMetricAggContexts.MapScript.Factory, ScriptFactory {
+    public static class MockMetricAggMapScriptFactory implements  ScriptedMetricAggContexts.MapScript.Factory {
         private final MockDeterministicScript script;
         MockMetricAggMapScriptFactory(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -478,7 +477,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    public static class MockMetricAggCombineScriptFactory implements ScriptedMetricAggContexts.CombineScript.Factory, ScriptFactory {
+    public static class MockMetricAggCombineScriptFactory implements ScriptedMetricAggContexts.CombineScript.Factory {
         private final MockDeterministicScript script;
         MockMetricAggCombineScriptFactory(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -510,7 +509,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    public static class MockMetricAggReduceScriptFactory implements ScriptedMetricAggContexts.ReduceScript.Factory, ScriptFactory {
+    public static class MockMetricAggReduceScriptFactory implements ScriptedMetricAggContexts.ReduceScript.Factory {
         private final MockDeterministicScript script;
         MockMetricAggReduceScriptFactory(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -586,7 +585,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    class MockAggregationScript implements AggregationScript.Factory, ScriptFactory {
+    class MockAggregationScript implements AggregationScript.Factory {
         private final MockDeterministicScript script;
         MockAggregationScript(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -617,7 +616,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    class MockSignificantTermsHeuristicScoreScript implements SignificantTermsHeuristicScoreScript.Factory, ScriptFactory {
+    class MockSignificantTermsHeuristicScoreScript implements SignificantTermsHeuristicScoreScript.Factory {
         private final MockDeterministicScript script;
         MockSignificantTermsHeuristicScoreScript(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -633,7 +632,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    class MockFieldScriptFactory implements FieldScript.Factory, ScriptFactory {
+    class MockFieldScriptFactory implements FieldScript.Factory {
         private final MockDeterministicScript script;
         MockFieldScriptFactory(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }
@@ -652,7 +651,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
     }
 
-    class MockStringSortScriptFactory implements StringSortScript.Factory, ScriptFactory {
+    class MockStringSortScriptFactory implements StringSortScript.Factory {
         private final MockDeterministicScript script;
         MockStringSortScriptFactory(MockDeterministicScript script) { this.script = script; }
         @Override public boolean isResultDeterministic() { return script.isResultDeterministic(); }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/script/MockMustacheScriptEngine.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/script/MockMustacheScriptEngine.java
@@ -39,7 +39,7 @@ public class MockMustacheScriptEngine extends MockScriptEngine {
     }
 
     @Override
-    public <T extends ScriptFactory> T compile(String name, String script, ScriptContext<T> context, Map<String, String> params) {
+    public <T> T compile(String name, String script, ScriptContext<T> context, Map<String, String> params) {
         if (script.contains("{{") && script.contains("}}")) {
             throw new IllegalArgumentException("Fix your test to not rely on mustache");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/monitoring/test/MockPainlessScriptEngine.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/monitoring/test/MockPainlessScriptEngine.java
@@ -11,7 +11,6 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.ScoreScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
-import org.elasticsearch.script.ScriptFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -43,7 +42,7 @@ public class MockPainlessScriptEngine extends MockScriptEngine {
     }
 
     @Override
-    public <T extends ScriptFactory> T compile(String name, String script, ScriptContext<T> context, Map<String, String> options) {
+    public <T> T compile(String name, String script, ScriptContext<T> context, Map<String, String> options) {
         if (context.instanceClazz.equals(ScoreScript.class)) {
             return context.factoryClazz.cast(new MockScoreScript(p -> 0.0));
         }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/WatcherConditionScript.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.watcher.condition;
 
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.watcher.support.Variables;
 
@@ -38,7 +37,7 @@ public abstract class WatcherConditionScript {
         return ctx;
     }
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         WatcherConditionScript newInstance(Map<String, Object> params, WatchExecutionContext watcherContext);
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/script/WatcherTransformScript.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.watcher.transform.script;
 
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptFactory;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.watcher.support.Variables;
@@ -39,7 +38,7 @@ public abstract class WatcherTransformScript {
         return ctx;
     }
 
-    public interface Factory extends ScriptFactory {
+    public interface Factory {
         WatcherTransformScript newInstance(Map<String, Object> params, WatchExecutionContext watcherContext, Payload payload);
     }
 


### PR DESCRIPTION
Avoid backwards incompatible changes for 8.x and 7.6 by removing type
restriction on compile and Factory.  Factories may optionally implement
ScriptFactory.  If so, then they can indicate determinism and thus
cacheability.

**Backport**

Relates: #49466