### PR TITLE
Docs: Add an example to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,10 @@ For IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij]
 
     ./gradlew :run
 
+You can access Elasticsearch with
+
+    curl elastic:password@localhost:9200
+
 ### Configuring IDEs And Running Tests
 
 Eclipse users can automatically configure their IDE: `./gradlew eclipse`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,9 @@ For IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij]
 
     ./gradlew :run
 
-You can access Elasticsearch with
+You can access Elasticsearch with:
 
-    curl elastic:password@localhost:9200
+    curl -u elastic:password localhost:9200
 
 ### Configuring IDEs And Running Tests
 


### PR DESCRIPTION
Adds an example of accessing Elasticsearch after building it from source
for the first time to CONTRIBUTING.md. I'm sure how to do it is
intuitive to some folks but I had to read three two build.gradle file to
find the password and I'd like to save other new folks the trouble.
