### PR TITLE
Handle renaming the README

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -77,7 +77,7 @@ CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String pla
         }
       }
       from(rootProject.projectDir) {
-        include 'README.textile'
+        include 'README.asciidoc'
       }
       from(rootProject.file('licenses')) {
         include oss ? 'APACHE-LICENSE-2.0.txt' : 'ELASTIC-LICENSE.txt'

--- a/qa/os/bats/utils/packages.bash
+++ b/qa/os/bats/utils/packages.bash
@@ -136,7 +136,7 @@ verify_package_installation() {
     assert_file "$ESPLUGINS" d root root 755
     assert_file "$ESMODULES" d root root 755
     assert_file "$ESHOME/NOTICE.txt" f root root 644
-    assert_file "$ESHOME/README.textile" f root root 644
+    assert_file "$ESHOME/README.asciidoc" f root root 644
 
     if is_dpkg; then
         # Env file

--- a/qa/os/bats/utils/tar.bash
+++ b/qa/os/bats/utils/tar.bash
@@ -105,6 +105,6 @@ verify_archive_installation() {
     assert_file "$ESHOME/logs" d elasticsearch elasticsearch 755
     assert_file "$ESHOME/NOTICE.txt" f elasticsearch elasticsearch 644
     assert_file "$ESHOME/LICENSE.txt" f elasticsearch elasticsearch 644
-    assert_file "$ESHOME/README.textile" f elasticsearch elasticsearch 644
+    assert_file "$ESHOME/README.asciidoc" f elasticsearch elasticsearch 644
     assert_file_not_exist "$ESCONFIG/elasticsearch.keystore"
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -204,7 +204,7 @@ public class Archives {
         Stream.of(
             "NOTICE.txt",
             "LICENSE.txt",
-            "README.textile"
+            "README.asciidoc"
         ).forEach(doc -> assertThat(es.home.resolve(doc), file(File, owner, owner, p644)));
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -445,7 +445,7 @@ public class Docker {
             "elasticsearch-shard"
         ).forEach(executable -> assertPermissionsAndOwnership(es.bin(executable), p755));
 
-        Stream.of("LICENSE.txt", "NOTICE.txt", "README.textile").forEach(doc -> assertPermissionsAndOwnership(es.home.resolve(doc), p644));
+        Stream.of("LICENSE.txt", "NOTICE.txt", "README.asciidoc").forEach(doc -> assertPermissionsAndOwnership(es.home.resolve(doc), p644));
 
         // These are installed to help users who are working with certificates.
         Stream.of("zip", "unzip").forEach(cliPackage -> {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -207,7 +207,7 @@ public class Packages {
 
         Stream.of(
             "NOTICE.txt",
-            "README.textile"
+            "README.asciidoc"
         ).forEach(doc -> assertThat(es.home.resolve(doc), file(File, "root", "root", p644)));
 
         assertThat(es.envFile, file(File, "root", "elasticsearch", p660));


### PR DESCRIPTION
We renamed README.textile to README.asciidoc but a bunch of tests and
the package build itself still pointed at the old name. This switches
them the new name.
