### PR TITLE
[DOCS] Deterministic scripted queries are cached (#50408)

### DIFF
--- a/docs/reference/modules/indices/request_cache.asciidoc
+++ b/docs/reference/modules/indices/request_cache.asciidoc
@@ -21,6 +21,9 @@ but it will cache `hits.total`,  <<search-aggregations,aggregations>>, and
 <<search-suggesters,suggestions>>.
 
 Most queries that use `now` (see <<date-math>>) cannot be cached.
+
+Scripted queries that use the API calls which are non-deterministic, such as
+`Math.random()` or `new Date()` are not cached.
 ===================================
 
 [float]
@@ -94,10 +97,6 @@ GET /my_index/_search?request_cache=true
 }
 -----------------------------
 // TEST[continued]
-
-IMPORTANT: If your query uses a script whose result is not deterministic (e.g.
-it uses a random function or references the current time) you should set the
-`request_cache` flag to `false` to disable caching for that request.
 
 Requests where `size` is greater than 0 will not be cached even if the request cache is
 enabled in the index settings. To cache these requests you will need to use the


### PR DESCRIPTION
**Backport**

Refs: #49321
