### PR TITLE
Fix NPE when `./gradlew run` without `--data-dir`

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -3,6 +3,7 @@ package org.elasticsearch.gradle.testclusters;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -49,7 +50,9 @@ public class RunTask extends DefaultTestClustersTask {
     }
 
     @Input
+    @Optional
     public String getDataDir() {
+        if (dataDir == null) { return null;}
         return dataDir.toString();
     }
 


### PR DESCRIPTION
Relates to  #50342

Reviewers, please merge and back-port if you find this ok. 