### PR TITLE
Fix testAutoExpandIndicesDuringRollingUpgrade

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -795,15 +795,14 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 Settings.builder().put(IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._id", nodes.get(randomInt(2))));
         }
 
-        assertBusy(() -> {
-            final int numberOfReplicas = Integer.parseInt(
-                getIndexSettingsAsMap(indexName).get(IndexMetaData.SETTING_NUMBER_OF_REPLICAS).toString());
-            if (minimumNodeVersion.onOrAfter(Version.V_7_6_0)) {
-                assertEquals(nodes.size() - 2, numberOfReplicas);
-            } else {
-                assertEquals(nodes.size() - 1, numberOfReplicas);
-            }
-        });
+        final int numberOfReplicas = Integer.parseInt(
+            getIndexSettingsAsMap(indexName).get(IndexMetaData.SETTING_NUMBER_OF_REPLICAS).toString());
+        if (minimumNodeVersion.onOrAfter(Version.V_7_6_0)) {
+            assertEquals(nodes.size() - 2, numberOfReplicas);
+            ensureGreen(indexName);
+        } else {
+            assertEquals(nodes.size() - 1, numberOfReplicas);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -775,7 +775,6 @@ public class RecoveryIT extends AbstractRollingTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/50426")
     public void testAutoExpandIndicesDuringRollingUpgrade() throws Exception {
         final String indexName = "test-auto-expand-filtering";
         final Version minimumNodeVersion = minimumNodeVersion();
@@ -796,15 +795,15 @@ public class RecoveryIT extends AbstractRollingTestCase {
                 Settings.builder().put(IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._id", nodes.get(randomInt(2))));
         }
 
-        ensureGreen(indexName);
-
-        final int numberOfReplicas = Integer.parseInt(
-            getIndexSettingsAsMap(indexName).get(IndexMetaData.SETTING_NUMBER_OF_REPLICAS).toString());
-        if (minimumNodeVersion.onOrAfter(Version.V_7_6_0)) {
-            assertEquals(nodes.size() - 2, numberOfReplicas);
-        } else {
-            assertEquals(nodes.size() - 1, numberOfReplicas);
-        }
+        assertBusy(() -> {
+            final int numberOfReplicas = Integer.parseInt(
+                getIndexSettingsAsMap(indexName).get(IndexMetaData.SETTING_NUMBER_OF_REPLICAS).toString());
+            if (minimumNodeVersion.onOrAfter(Version.V_7_6_0)) {
+                assertEquals(nodes.size() - 2, numberOfReplicas);
+            } else {
+                assertEquals(nodes.size() - 1, numberOfReplicas);
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes the muted test "testAutoExpandIndicesDuringRollingUpgrade". We can't wait in the test for the index to be green, as we have put a filter exclusion into place that prevents all shards from being allocated after a node rejoins. Instead we check whether the correct auto-expansion has taken place. We need to do this in an assertBusy, as older versions of ES are not auto-expanding indices while a node is joining, but only doing this as a follow-up step.

Closes #50426