### PR TITLE
Change compatible version from 8.0 to 7.6

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
@@ -99,7 +99,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
 
     public MulticlassConfusionMatrix(StreamInput in) throws IOException {
         this.size = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
             this.aggNamePrefix = in.readString();
         } else {
             this.aggNamePrefix = DEFAULT_AGG_NAME_PREFIX;
@@ -197,7 +197,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(size);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
             out.writeString(aggNamePrefix);
         }
     }


### PR DESCRIPTION
Now, that the PR with `aggName` is backported (https://github.com/elastic/elasticsearch/pull/50433), the version can be changed to 7.6

Closes https://github.com/elastic/elasticsearch/issues/48759