### PR TITLE
[DOCS] Remove outdated file scripts refererence

### DIFF
--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -545,8 +545,8 @@ The `params` would look like:
 // NOTCONSOLE
 <1> The `line_no`, `start`, and `end` parameters are optional.
 
-
-We could write the query as:
+When written as a query, the template would include invalid JSON, such as
+section markers like `{{#line_no}}`:
 
 [source,js]
 ------------------------------------------
@@ -587,19 +587,14 @@ We could write the query as:
 <6> Include the `lte` clause only if `line_no.end` is specified
 <7> Fill in the value of param `line_no.end`
 
-[NOTE]
-==================================
-As written above, this template is not valid JSON because it includes the
-_section_ markers like `{{#line_no}}`.  For this reason, the template should
-either be stored in a file (see <<pre-registered-templates>>) or, when used
-via the REST API, should be written as a string:
+Because search templates cannot include invalid JSON, you can pass the same
+query as a string instead:
 
 [source,js]
 --------------------
 "source": "{\"query\":{\"bool\":{\"must\":{\"match\":{\"line\":\"{{text}}\"}},\"filter\":{{{#line_no}}\"range\":{\"line_no\":{{{#start}}\"gte\":\"{{start}}\"{{#end}},{{/end}}{{/start}}{{#end}}\"lte\":\"{{end}}\"{{/end}}}}{{/line_no}}}}}}"
 --------------------
 // NOTCONSOLE
-==================================
 
 
 [[search-template-encode-urls]]


### PR DESCRIPTION
File scripts were removed in 6.0 with #24627.

This removes an outdated file scripts reference from the conditional clauses section of the search templates docs.

Closes #50089.