### PR TITLE
Unmute 'Test url escaping with url mustache function' webhook watcher test

### DIFF
--- a/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/mustache/50_webhook_url_escaping.yml
+++ b/x-pack/qa/smoke-test-watcher/src/test/resources/rest-api-spec/test/mustache/50_webhook_url_escaping.yml
@@ -1,8 +1,5 @@
 ---
 "Test url escaping with url mustache function":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/41172"
   - do:
       cluster.health:
           wait_for_status: yellow
@@ -10,7 +7,6 @@
   - do:
       index:
         index:   <date-index-{now/d}>
-        type:    log
         id:      1
         refresh: true
         body:    { foo: bar }
@@ -36,9 +32,14 @@
           pipeline:
             description: _description
             processors: [ grok: { field: host, patterns : ["%{IPORHOST:hostname}:%{NUMBER:port:int}"] } ]
-          docs: [ { _index: index, _type: type, _id: id, _source: { host: $host } } ]
+          docs: [ { _index: index, _id: id, _source: { host: $host } } ]
   - set: { docs.0.doc._source.hostname: hostname }
   - set: { docs.0.doc._source.port: port }
+
+  - do:
+      count:
+        index: <date-index-{now/d}>
+  - match: {count: 1}
 
   - do:
       watcher.put_watch:
@@ -67,7 +68,7 @@
                   method: PUT
                   host: $hostname
                   port: $port
-                  path: "/{{#url}}{{ctx.metadata.index}}{{/url}}/log/2"
+                  path: "/{{#url}}{{ctx.metadata.index}}{{/url}}/_doc/2"
                   params:
                     refresh: "true"
                   body: "{ \"foo\": \"bar\" }"
@@ -78,6 +79,8 @@
   - do:
       watcher.execute_watch:
           id: "test_watch"
+  - match: {watch_record.result.condition.met: true}
+  - match: {watch_record.result.actions.0.status: 'success'}
 
   - do:
       count:


### PR DESCRIPTION
Some changes had to be made in order to make the test pass due to the removal or types.
Added some more assertions. The failure description in this comment [0] indicates that the rest handler couldn't be found. The test passes now.
I plan to merge this into master and see how CI reacts, if it handles this change well then I will also unmute this test in 7 dot x branch.

Relates to #41172

0: https://github.com/elastic/elasticsearch/issues/41172#issuecomment-496993976