### PR TITLE
[7.x] [ML][Inference] updates specs with new params + docs (#50373)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_trained_model.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_trained_model.json
@@ -1,7 +1,7 @@
 {
   "ml.delete_trained_model":{
     "documentation":{
-      "url":"TODO"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-inference.html"
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
@@ -1,7 +1,7 @@
 {
   "ml.get_trained_models":{
     "documentation":{
-      "url":"TODO"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference.html"
     },
     "stability":"experimental",
     "url":{
@@ -36,8 +36,14 @@
       "include_model_definition":{
         "type":"boolean",
         "required":false,
-        "description":"Should the full model definition be included in the results. These definitions can be large",
+        "description":"Should the full model definition be included in the results. These definitions can be large. So be cautious when including them. Defaults to false.",
         "default":false
+      },
+      "decompress_definition": {
+        "type": "boolean",
+        "required": false,
+        "default": true,
+        "description": "Should the model definition be decompressed into valid JSON or returned in a custom compressed format. Defaults to true."
       },
       "from":{
         "type":"int",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models_stats.json
@@ -1,7 +1,7 @@
 {
   "ml.get_trained_models_stats":{
     "documentation":{
-      "url":"TODO"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference-stats.html"
     },
     "stability":"experimental",
     "url":{


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Inference] updates specs with new params + docs  (#50373)