### PR TITLE
Improve SearchHit "equals" implementation for null fields cases (#50327)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -906,7 +906,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
                 && Objects.equals(seqNo, other.seqNo)
                 && Objects.equals(primaryTerm, other.primaryTerm)
                 && Objects.equals(source, other.source)
-                && Objects.equals(fields, other.fields)
+                && Objects.equals(getFields(), other.getFields())
                 && Objects.equals(getHighlightFields(), other.getHighlightFields())
                 && Arrays.equals(matchedQueries, other.matchedQueries)
                 && Objects.equals(explanation, other.explanation)

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -73,9 +73,12 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         if (randomBoolean()) {
             nestedIdentity = NestedIdentityTests.createTestItem(randomIntBetween(0, 2));
         }
-        Map<String, DocumentField> fields = new HashMap<>();
-        if (randomBoolean()) {
-            fields = GetResultTests.randomDocumentFields(xContentType).v2();
+        Map<String, DocumentField> fields = null;
+        if (frequently()) {
+            fields = new HashMap<>();
+            if (randomBoolean()) {
+                fields = GetResultTests.randomDocumentFields(xContentType).v2();
+            }
         }
         SearchHit hit = new SearchHit(internalId, uid, type, nestedIdentity, fields);
         if (frequently()) {


### PR DESCRIPTION
Backport of #50327