### PR TITLE
Fix Source Only Snapshot REST Test Failure

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/snapshot/10_basic.yml
@@ -39,6 +39,8 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot
         wait_for_completion: true
+        body: |
+          { "indices": "test_index" }
 
   - match: { snapshot.snapshot: test_snapshot }
   - match: { snapshot.state : SUCCESS }


### PR DESCRIPTION
We are matching on the exact number of shards in this test, but may run into
snapshotting more than the single index created in it due to auto-created indices like
`.watcher`.
Fixed by making the test only take a snapshot of the single index used by this test.

Closes #50450
