### PR TITLE
[7.x][Transform] implement a workaround for remote cluster validation

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/NoSuchRemoteClusterException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NoSuchRemoteClusterException.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  */
 public final class NoSuchRemoteClusterException extends ResourceNotFoundException {
 
-    NoSuchRemoteClusterException(String clusterName) {
+    public NoSuchRemoteClusterException(String clusterName) {
         //No node available for cluster
         super("no such remote cluster: [" + clusterName + "]");
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -706,7 +706,6 @@ public class SourceDestValidatorTests extends ESTestCase {
         }, null);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/50420")
     public void testRemoteSourceDoesNotExist() throws InterruptedException {
         Context context = spy(
             new SourceDestValidator.Context(


### PR DESCRIPTION
In 7.x an internal API used for validating remote cluster does not throw, see #50420 for the details.
This change implements a workaround for remote cluster validation, only for 7.x branches.

fixes #50420