### PR TITLE
[DOCS] Fuzzy wildcard not supported in `query_string`

### DIFF
--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -44,6 +44,7 @@ You can specify fields to search in the query syntax:
 
     _exists_:title
 
+[[query-string-wildcard]]
 ====== Wildcards
 
 Wildcard searches can be run on individual terms, using `?` to replace
@@ -112,6 +113,7 @@ Elasticsearch to visit every term in the index:
 Use with caution!
 =======
 
+[[query-string-fuzziness]]
 ====== Fuzziness
 
 We can search for terms that are
@@ -131,6 +133,16 @@ The default _edit distance_ is `2`, but an edit distance of `1` should be
 sufficient to catch 80% of all human misspellings. It can be specified as:
 
     quikc~1
+
+[[avoid-widlcards-fuzzy-searches]]
+[WARNING]
+.Avoid mixing fuzziness with wildcards
+====
+Mixing <<fuzziness,fuzzy>> and <<query-string-wildcard,wildcard>> operators is
+_not_ supported. When mixed, one of the operators is not applied. For example,
+you can search for `app~1` (fuzzy) or `app*` (wildcard), but searches for
+`app*~1` do not apply the fuzzy operator (`~1`).
+====
 
 ====== Proximity searches
 


### PR DESCRIPTION
The `query_string` does not support mixing wildcards with fuzziness.
This adds a related warning to the `query_string`syntax docs.

Closes #50045. Relates to #29019.