### PR TITLE
[DOCS] Percentile aggs are non-deterministic

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -251,6 +251,13 @@ for large number of values is that the law of large numbers makes the distributi
 values more and more uniform and the t-digest tree can do a better job at summarizing
 it. It would not be the case on more skewed distributions.
 
+[WARNING]
+====
+Percentile aggregations are also
+https://en.wikipedia.org/wiki/Nondeterministic_algorithm[non-deterministic].
+This means you can get slightly different results using the same data.
+====
+
 [[search-aggregations-metrics-percentile-aggregation-compression]]
 ==== Compression
 


### PR DESCRIPTION
Percentile aggregations are non-deterministic. A percentile aggregation can produce different results even when using the same data.

Based on [this discuss post][0], the non-deterministic property stems from processes in Lucene that can affect the order in which docs are provided to the aggregation.

This adds a warning stating that the aggregation is non-deterministic and what that means.

Closes #49505.

[0]: https://discuss.elastic.co/t/different-results-for-same-query/111757