### PR TITLE
Fix name for eclipse formatter in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ Please follow these formatting guidelines:
 
 #### Editor / IDE Support
 
-Eclipse IDEs can import the file [elasticsearch.eclipseformat.xml]
+Eclipse IDEs can import the file [.eclipseformat.xml]
 directly.
 
 IntelliJ IDEs can


### PR DESCRIPTION
The CONTRIBUTING.md file calls the Eclipse formatter
`elasticsearch.eclipseformat.xml` but it looks like we call it
`.eclipseformat.xml`.
