### PR TITLE
Add note regarding RBAC & TLS feature changes

### DIFF
--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -10,6 +10,12 @@ password-protect your data as well as implement more advanced security measures
 such as encrypting communications, role-based access control, IP filtering, and
 auditing. 
 
+--
+
+NOTE: RBAC and TLS support were made Basic license features in versions 6.8 and 7.1.  If you are on a older version you will need to upgrade to use these features.
+
+--
+
 To use {es} {security-features}:
 
 . Verify that you are using a license that includes the {security-features}.


### PR DESCRIPTION
My team and I were extremely confused when our 6.6.1 deployment required us to start a trial to enable the RBAC and TLS features.  It seems the only place on the site where the features are mentioned are [in the 6.8 release notes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-highlights-6.8.0.html).

Figure this note addition might help out the next folks who come through.  I am not too particular on the exact change there may be a better spot in the documentation, just cost us a few hours- so want to make sure that this gets fixed.