### PR TITLE
Add min_doc_count option to geo grid bucket aggregations

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
@@ -44,16 +44,18 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid> extends Bucke
 
     protected final int requiredSize;
     protected final int shardSize;
+    protected final long minDocCount;
     protected final CellIdSource valuesSource;
     protected final LongHash bucketOrds;
 
     GeoGridAggregator(String name, AggregatorFactories factories, CellIdSource valuesSource,
-                      int requiredSize, int shardSize, SearchContext aggregationContext, Aggregator parent,
+                      int requiredSize, int shardSize, long minDocCount, SearchContext aggregationContext, Aggregator parent,
                       List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, factories, aggregationContext, parent, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
+        this.minDocCount = minDocCount;
         bucketOrds = new LongHash(1, aggregationContext.bigArrays());
     }
 
@@ -95,7 +97,7 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid> extends Bucke
         };
     }
 
-    abstract T buildAggregation(String name, int requiredSize, List<InternalGeoGridBucket> buckets,
+    abstract T buildAggregation(String name, int requiredSize, long minDocCount, List<InternalGeoGridBucket> buckets,
                                               List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData);
 
     /**
@@ -132,12 +134,12 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid> extends Bucke
             bucket.aggregations = bucketAggregations(bucket.bucketOrd);
             list[i] = bucket;
         }
-        return buildAggregation(name, requiredSize, Arrays.asList(list), pipelineAggregators(), metaData());
+        return buildAggregation(name, requiredSize, minDocCount, Arrays.asList(list), pipelineAggregators(), metaData());
     }
 
     @Override
     public InternalGeoGrid buildEmptyAggregation() {
-        return buildAggregation(name, requiredSize, Collections.emptyList(), pipelineAggregators(), metaData());
+        return buildAggregation(name, requiredSize, minDocCount, Collections.emptyList(), pipelineAggregators(), metaData());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
@@ -38,6 +38,7 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
     public static final String NAME = "geohash_grid";
     public static final int DEFAULT_PRECISION = 5;
     public static final int DEFAULT_MAX_NUM_CELLS = 10000;
+    public static final long DEFAULT_MIN_DOC_COUNT = 1;
 
     private static final ObjectParser<GeoGridAggregationBuilder, Void> PARSER = createParser(NAME, GeoUtils::parsePrecision);
 
@@ -46,6 +47,7 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
         precision(DEFAULT_PRECISION);
         size(DEFAULT_MAX_NUM_CELLS);
         shardSize = -1;
+        minDocCount(DEFAULT_MIN_DOC_COUNT);
     }
 
     public GeoHashGridAggregationBuilder(StreamInput in) throws IOException {
@@ -60,10 +62,10 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
 
     @Override
     protected ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> createFactory(
-        String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, int precision, int requiredSize, int shardSize,
+        String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, int precision, int requiredSize, int shardSize, long minDocCount,
         QueryShardContext queryShardContext, AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
         Map<String, Object> metaData) throws IOException {
-        return new GeoHashGridAggregatorFactory(name, config, precision, requiredSize, shardSize, queryShardContext, parent,
+        return new GeoHashGridAggregatorFactory(name, config, precision, requiredSize, shardSize, minDocCount, queryShardContext, parent,
             subFactoriesBuilder, metaData);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -34,20 +34,21 @@ import java.util.Map;
 public class GeoHashGridAggregator extends GeoGridAggregator<InternalGeoHashGrid> {
 
     GeoHashGridAggregator(String name, AggregatorFactories factories, CellIdSource valuesSource,
-                          int requiredSize, int shardSize, SearchContext aggregationContext, Aggregator parent,
+                          int requiredSize, int shardSize, long minDocCount, SearchContext aggregationContext, Aggregator parent,
                           List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
-        super(name, factories, valuesSource, requiredSize, shardSize, aggregationContext, parent, pipelineAggregators, metaData);
+        super(name, factories, valuesSource, requiredSize, shardSize, minDocCount,
+              aggregationContext, parent, pipelineAggregators, metaData);
     }
 
     @Override
-    InternalGeoHashGrid buildAggregation(String name, int requiredSize, List<InternalGeoGridBucket> buckets,
+    InternalGeoHashGrid buildAggregation(String name, int requiredSize, long minDocCount, List<InternalGeoGridBucket> buckets,
                                          List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        return new InternalGeoHashGrid(name, requiredSize, buckets, pipelineAggregators, metaData);
+        return new InternalGeoHashGrid(name, requiredSize, minDocCount, buckets, pipelineAggregators, metaData);
     }
 
     @Override
     public InternalGeoHashGrid buildEmptyAggregation() {
-        return new InternalGeoHashGrid(name, requiredSize, Collections.emptyList(), pipelineAggregators(), metaData());
+        return new InternalGeoHashGrid(name, requiredSize, minDocCount, Collections.emptyList(), pipelineAggregators(), metaData());
     }
 
     InternalGeoGridBucket newEmptyBucket() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregatorFactory.java
@@ -43,14 +43,16 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory<
     private final int precision;
     private final int requiredSize;
     private final int shardSize;
+    private final long minDocCount;
 
     GeoHashGridAggregatorFactory(String name, ValuesSourceConfig<GeoPoint> config, int precision, int requiredSize,
-                                 int shardSize, QueryShardContext queryShardContext, AggregatorFactory parent,
+                                 int shardSize, long minDocCount, QueryShardContext queryShardContext, AggregatorFactory parent,
                                  AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metaData) throws IOException {
         super(name, config, queryShardContext, parent, subFactoriesBuilder, metaData);
         this.precision = precision;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
+        this.minDocCount = minDocCount;
     }
 
     @Override
@@ -58,7 +60,7 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory<
                                             Aggregator parent,
                                             List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metaData) throws IOException {
-        final InternalAggregation aggregation = new InternalGeoHashGrid(name, requiredSize,
+        final InternalAggregation aggregation = new InternalGeoHashGrid(name, requiredSize, minDocCount,
                 Collections.emptyList(), pipelineAggregators, metaData);
         return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metaData) {
             @Override
@@ -79,7 +81,7 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory<
             return asMultiBucketAggregator(this, searchContext, parent);
         }
         CellIdSource cellIdSource = new CellIdSource(valuesSource, precision, Geohash::longEncode);
-        return new GeoHashGridAggregator(name, factories, cellIdSource, requiredSize, shardSize, searchContext, parent,
+        return new GeoHashGridAggregator(name, factories, cellIdSource, requiredSize, shardSize, minDocCount, searchContext, parent,
                 pipelineAggregators, metaData);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
@@ -37,6 +37,7 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
     public static final String NAME = "geotile_grid";
     public static final int DEFAULT_PRECISION = 7;
     private static final int DEFAULT_MAX_NUM_CELLS = 10000;
+    private static final long DEFAULT_MIN_DOC_COUNT = 1;
 
     private static final ObjectParser<GeoGridAggregationBuilder, Void> PARSER = createParser(NAME, GeoTileUtils::parsePrecision);
 
@@ -45,6 +46,7 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
         precision(DEFAULT_PRECISION);
         size(DEFAULT_MAX_NUM_CELLS);
         shardSize = -1;
+        minDocCount(DEFAULT_MIN_DOC_COUNT);
     }
 
     public GeoTileGridAggregationBuilder(StreamInput in) throws IOException {
@@ -59,11 +61,11 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
 
     @Override
     protected ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> createFactory(
-        String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, int precision, int requiredSize, int shardSize,
+        String name, ValuesSourceConfig<ValuesSource.GeoPoint> config, int precision, int requiredSize, int shardSize, long minDocCount,
         QueryShardContext queryShardContext, AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
         Map<String, Object> metaData
     ) throws IOException {
-        return new GeoTileGridAggregatorFactory(name, config, precision, requiredSize, shardSize, queryShardContext, parent,
+        return new GeoTileGridAggregatorFactory(name, config, precision, requiredSize, shardSize, minDocCount, queryShardContext, parent,
             subFactoriesBuilder, metaData);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregator.java
@@ -35,20 +35,21 @@ import java.util.Map;
 public class GeoTileGridAggregator extends GeoGridAggregator<InternalGeoTileGrid> {
 
     GeoTileGridAggregator(String name, AggregatorFactories factories, CellIdSource valuesSource,
-                          int requiredSize, int shardSize, SearchContext aggregationContext, Aggregator parent,
+                          int requiredSize, int shardSize, long minDocCount, SearchContext aggregationContext, Aggregator parent,
                           List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
-        super(name, factories, valuesSource, requiredSize, shardSize, aggregationContext, parent, pipelineAggregators, metaData);
+        super(name, factories, valuesSource, requiredSize, shardSize,
+              minDocCount, aggregationContext, parent, pipelineAggregators, metaData);
     }
 
     @Override
-    InternalGeoTileGrid buildAggregation(String name, int requiredSize, List<InternalGeoGridBucket> buckets,
+    InternalGeoTileGrid buildAggregation(String name, int requiredSize, long minDocCount, List<InternalGeoGridBucket> buckets,
                                          List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        return new InternalGeoTileGrid(name, requiredSize, buckets, pipelineAggregators, metaData);
+        return new InternalGeoTileGrid(name, requiredSize, minDocCount, buckets, pipelineAggregators, metaData);
     }
 
     @Override
     public InternalGeoTileGrid buildEmptyAggregation() {
-        return new InternalGeoTileGrid(name, requiredSize, Collections.emptyList(), pipelineAggregators(), metaData());
+        return new InternalGeoTileGrid(name, requiredSize, minDocCount, Collections.emptyList(), pipelineAggregators(), metaData());
     }
 
     InternalGeoGridBucket newEmptyBucket() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregatorFactory.java
@@ -42,14 +42,16 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory<
     private final int precision;
     private final int requiredSize;
     private final int shardSize;
+    private final long minDocCount;
 
     GeoTileGridAggregatorFactory(String name, ValuesSourceConfig<GeoPoint> config, int precision, int requiredSize,
-                                 int shardSize, QueryShardContext queryShardContext, AggregatorFactory parent,
+                                 int shardSize, long minDocCount, QueryShardContext queryShardContext, AggregatorFactory parent,
                                  AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metaData) throws IOException {
         super(name, config, queryShardContext, parent, subFactoriesBuilder, metaData);
         this.precision = precision;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
+        this.minDocCount = minDocCount;
     }
 
     @Override
@@ -57,7 +59,7 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory<
                                             Aggregator parent,
                                             List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metaData) throws IOException {
-        final InternalAggregation aggregation = new InternalGeoTileGrid(name, requiredSize,
+        final InternalAggregation aggregation = new InternalGeoTileGrid(name, requiredSize, minDocCount,
                 Collections.emptyList(), pipelineAggregators, metaData);
         return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metaData) {
             @Override
@@ -78,7 +80,7 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory<
             return asMultiBucketAggregator(this, searchContext, parent);
         }
         CellIdSource cellIdSource = new CellIdSource(valuesSource, precision, GeoTileUtils::longEncode);
-        return new GeoTileGridAggregator(name, factories, cellIdSource, requiredSize, shardSize, searchContext, parent,
+        return new GeoTileGridAggregator(name, factories, cellIdSource, requiredSize, shardSize, minDocCount, searchContext, parent,
                 pipelineAggregators, metaData);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -33,9 +33,9 @@ import java.util.Map;
  */
 public class InternalGeoHashGrid extends InternalGeoGrid<InternalGeoHashGridBucket> {
 
-    InternalGeoHashGrid(String name, int requiredSize, List<InternalGeoGridBucket> buckets,
+    InternalGeoHashGrid(String name, int requiredSize, long minDocCount, List<InternalGeoGridBucket> buckets,
                         List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, requiredSize, buckets, pipelineAggregators, metaData);
+        super(name, requiredSize, minDocCount, buckets, pipelineAggregators, metaData);
     }
 
     public InternalGeoHashGrid(StreamInput in) throws IOException {
@@ -44,7 +44,7 @@ public class InternalGeoHashGrid extends InternalGeoGrid<InternalGeoHashGridBuck
 
     @Override
     public InternalGeoGrid create(List<InternalGeoGridBucket> buckets) {
-        return new InternalGeoHashGrid(name, requiredSize, buckets, pipelineAggregators(), metaData);
+        return new InternalGeoHashGrid(name, requiredSize, minDocCount, buckets, pipelineAggregators(), metaData);
     }
 
     @Override
@@ -53,8 +53,8 @@ public class InternalGeoHashGrid extends InternalGeoGrid<InternalGeoHashGridBuck
     }
 
     @Override
-    InternalGeoGrid create(String name, int requiredSize, List buckets, List list, Map metaData) {
-        return new InternalGeoHashGrid(name, requiredSize, buckets, list, metaData);
+    InternalGeoGrid create(String name, int requiredSize, long minDocCount, List buckets, List list, Map metaData) {
+        return new InternalGeoHashGrid(name, requiredSize, minDocCount, buckets, list, metaData);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoTileGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoTileGrid.java
@@ -33,9 +33,9 @@ import java.util.Map;
  */
 public class InternalGeoTileGrid extends InternalGeoGrid<InternalGeoTileGridBucket> {
 
-    InternalGeoTileGrid(String name, int requiredSize, List<InternalGeoGridBucket> buckets,
+    InternalGeoTileGrid(String name, int requiredSize, long minDocCount, List<InternalGeoGridBucket> buckets,
                         List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, requiredSize, buckets, pipelineAggregators, metaData);
+        super(name, requiredSize, minDocCount, buckets, pipelineAggregators, metaData);
     }
 
     public InternalGeoTileGrid(StreamInput in) throws IOException {
@@ -44,7 +44,7 @@ public class InternalGeoTileGrid extends InternalGeoGrid<InternalGeoTileGridBuck
 
     @Override
     public InternalGeoGrid create(List<InternalGeoGridBucket> buckets) {
-        return new InternalGeoTileGrid(name, requiredSize, buckets, pipelineAggregators(), metaData);
+        return new InternalGeoTileGrid(name, requiredSize, minDocCount, buckets, pipelineAggregators(), metaData);
     }
 
     @Override
@@ -53,8 +53,8 @@ public class InternalGeoTileGrid extends InternalGeoGrid<InternalGeoTileGridBuck
     }
 
     @Override
-    InternalGeoGrid create(String name, int requiredSize, List buckets, List list, Map metaData) {
-        return new InternalGeoTileGrid(name, requiredSize, buckets, list, metaData);
+    InternalGeoGrid create(String name, int requiredSize, long minDocCount, List buckets, List list, Map metaData) {
+        return new InternalGeoTileGrid(name, requiredSize, minDocCount, buckets, list, metaData);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -39,6 +39,21 @@ public class GeoHashGridTests extends BaseAggregationTestCase<GeoGridAggregation
         if (randomBoolean()) {
             factory.shardSize(randomIntBetween(1, Integer.MAX_VALUE));
         }
+        if (randomBoolean()) {
+            int minDocCount = randomIntBetween(1, 4);
+            switch (minDocCount) {
+            case 1:
+                break;
+            case 2:
+            case 3:
+            case 4:
+                minDocCount = randomIntBetween(1, Integer.MAX_VALUE);
+                break;
+            default:
+                fail();
+            }
+            factory.minDocCount(minDocCount);
+        }
         return factory;
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
@@ -41,6 +41,12 @@ public abstract class GeoGridTestCase<B extends InternalGeoGridBucket, T extends
                                                List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData);
 
     /**
+     * Instantiate a {@link InternalGeoGrid}-derived class using the same parameters as constructor.
+     */
+    protected abstract T createInternalGeoGrid(String name, int size, long minDocCount, List<InternalGeoGridBucket> buckets,
+                                               List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData);
+
+    /**
      * Instantiate a {@link InternalGeoGridBucket}-derived class using the same parameters as constructor.
      */
     protected abstract B createInternalGeoGridBucket(Long key, long docCount, InternalAggregations aggregations);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridTests.java
@@ -29,9 +29,15 @@ import java.util.Map;
 public class GeoHashGridTests extends GeoGridTestCase<InternalGeoHashGridBucket, InternalGeoHashGrid> {
 
     @Override
+    protected InternalGeoHashGrid createInternalGeoGrid(String name, int size, long minDocCount, List<InternalGeoGridBucket> buckets,
+                                                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalGeoHashGrid(name, size, minDocCount, buckets, pipelineAggregators, metaData);
+    }
+
+    @Override
     protected InternalGeoHashGrid createInternalGeoGrid(String name, int size, List<InternalGeoGridBucket> buckets,
                                                         List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        return new InternalGeoHashGrid(name, size, buckets, pipelineAggregators, metaData);
+        return createInternalGeoGrid(name, size, 1, buckets, pipelineAggregators, metaData);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridTests.java
@@ -28,9 +28,15 @@ import java.util.Map;
 public class GeoTileGridTests extends GeoGridTestCase<InternalGeoTileGridBucket, InternalGeoTileGrid> {
 
     @Override
+    protected InternalGeoTileGrid createInternalGeoGrid(String name, int size, long minDocCount, List<InternalGeoGridBucket> buckets,
+                                                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalGeoTileGrid(name, size, minDocCount, buckets, pipelineAggregators, metaData);
+    }
+
+    @Override
     protected InternalGeoTileGrid createInternalGeoGrid(String name, int size, List<InternalGeoGridBucket> buckets,
                                                         List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        return new InternalGeoTileGrid(name, size, buckets, pipelineAggregators, metaData);
+        return createInternalGeoGrid(name, size, 1, buckets, pipelineAggregators, metaData);
     }
 
     @Override


### PR DESCRIPTION
This PR introduces `min_doc_count` option to geo grid aggregations.  
`min_doc_count` will help us to mask privacy and to exclude outliers.

Relates to: #50481