### PR TITLE
Deprecate `_upgrade` API (#47678)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
@@ -2,7 +2,7 @@
   "indices.get_upgrade":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
-      "description":"Returns a progress status of current upgrade."
+      "description":"DEPRECATED Returns a progress status of current upgrade."
     },
     "stability":"stable",
     "url":{
@@ -11,7 +11,11 @@
           "path":"/_upgrade",
           "methods":[
             "GET"
-          ]
+          ],
+          "deprecated":{
+            "version":"8.0.0",
+            "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+          }
         },
         {
           "path":"/{index}/_upgrade",
@@ -23,6 +27,10 @@
               "type":"list",
               "description":"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"
             }
+          },
+          "deprecated":{
+            "version":"8.0.0",
+            "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
           }
         }
       ]
@@ -47,10 +55,6 @@
         "default":"open",
         "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
       }
-    },
-    "deprecated":{
-      "version":"8.0.0",
-      "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_upgrade.json
@@ -2,7 +2,7 @@
   "indices.get_upgrade":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
-      "description":"The _upgrade API is no longer useful and will be removed."
+      "description":"Returns a progress status of current upgrade."
     },
     "stability":"stable",
     "url":{
@@ -47,6 +47,10 @@
         "default":"open",
         "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
       }
+    },
+    "deprecated":{
+      "version":"8.0.0",
+      "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -2,7 +2,7 @@
   "indices.upgrade":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
-      "description":"The _upgrade API is no longer useful and will be removed."
+      "description":"Upgrades to the current version of Lucene."
     },
     "stability":"stable",
     "url":{
@@ -55,6 +55,10 @@
         "type":"boolean",
         "description":"If true, only ancient (an older Lucene major release) segments will be upgraded"
       }
+    },
+    "deprecated":{
+      "version":"8.0.0",
+      "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.upgrade.json
@@ -2,7 +2,7 @@
   "indices.upgrade":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-upgrade.html",
-      "description":"Upgrades to the current version of Lucene."
+      "description":"DEPRECATED Upgrades to the current version of Lucene."
     },
     "stability":"stable",
     "url":{
@@ -11,7 +11,11 @@
           "path":"/_upgrade",
           "methods":[
             "POST"
-          ]
+          ],
+          "deprecated":{
+            "version":"8.0.0",
+            "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+          }
         },
         {
           "path":"/{index}/_upgrade",
@@ -23,6 +27,10 @@
               "type":"list",
               "description":"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"
             }
+          },
+          "deprecated":{
+            "version":"8.0.0",
+            "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
           }
         }
       ]
@@ -55,10 +63,6 @@
         "type":"boolean",
         "description":"If true, only ancient (an older Lucene major release) segments will be upgraded"
       }
-    },
-    "deprecated":{
-      "version":"8.0.0",
-      "description":"The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/10_basic.yml
@@ -1,5 +1,9 @@
 ---
 "Basic test for upgrade indices":
+  - skip:
+      version: " - 7.99.99"
+      reason: "_upgrade api is deprecated since 8.0.0"
+      features: ["warnings", "node_selector"]
 
   - do:
       indices.create:
@@ -12,12 +16,21 @@
   - do:
       indices.upgrade:
         index: test_index
+      warnings:
+        - "The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+      node_selector:
+        version: "8.0.0 - "
 
   - match: {upgraded_indices.test_index.oldest_lucene_segment_version: '/(\d\.)+\d/'}
   - is_true: upgraded_indices.test_index.upgrade_version
 
 ---
 "Upgrade indices ignore unavailable":
+  - skip:
+      version: " - 7.99.99"
+      reason: "_upgrade api is deprecated since 8.0.0"
+      features: ["warnings", "node_selector"]
+
   - do:
       indices.create:
         index: test_index
@@ -31,6 +44,10 @@
       indices.upgrade:
         index: ["does_not_exist", "test_index"]
         ignore_unavailable: true
+      warnings:
+        - "The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+      node_selector:
+        version: "8.0.0 - "
 
   - match: {_shards.total: 1}
   - is_true: upgraded_indices.test_index.upgrade_version
@@ -38,17 +55,29 @@
 
 ---
 "Upgrade indices allow no indices":
+  - skip:
+      version: " - 7.99.99"
+      reason: "_upgrade api is deprecated since 8.0.0"
+      features: ["warnings", "node_selector"]
 
   - do:
       indices.upgrade:
         index: test_index
         ignore_unavailable: true
         allow_no_indices: true
+      warnings:
+        - "The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+      node_selector:
+        version: "8.0.0 - "
 
   - match: {_shards.total: 0}
 
 ---
 "Upgrade indices disallow no indices":
+  - skip:
+      version: " - 7.99.99"
+      reason: "_upgrade api is deprecated since 8.0.0"
+      features: ["warnings", "node_selector"]
 
   - do:
       catch: missing
@@ -56,9 +85,17 @@
         index: test_index
         ignore_unavailable: true
         allow_no_indices: false
+      warnings:
+        - "The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+      node_selector:
+        version: "8.0.0 - "
 
 ---
 "Upgrade indices disallow unavailable":
+  - skip:
+      version: " - 7.99.99"
+      reason: "_upgrade api is deprecated since 8.0.0"
+      features: ["warnings", "node_selector"]
 
   - do:
       indices.create:
@@ -69,4 +106,7 @@
       indices.upgrade:
         index: ["test_index", "does_not_exist"]
         ignore_unavailable: false
-
+      warnings:
+        - "The _upgrade API is no longer useful and will be removed. Instead, see _reindex API."
+      node_selector:
+        version: "8.0.0 - "

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/20_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.upgrade/20_deprecated.yml
@@ -1,0 +1,102 @@
+---
+"Basic test for upgrade indices < 8.0.0":
+  - skip:
+      version: "8.0.0 - "
+      reason: "_upgrade api has deprecation header since 8.0.0"
+      features: "node_selector"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      indices.upgrade:
+        index: test_index
+      node_selector:
+        version: " - 7.99.99"
+
+  - match: {upgraded_indices.test_index.oldest_lucene_segment_version: '/(\d\.)+\d/'}
+  - is_true: upgraded_indices.test_index.upgrade_version
+
+---
+"Upgrade indices ignore unavailable < 8.0.0":
+  - skip:
+      version: "8.0.0 - "
+      reason: "_upgrade api has deprecation header since 8.0.0"
+      features: "node_selector"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      indices.upgrade:
+        index: ["does_not_exist", "test_index"]
+        ignore_unavailable: true
+      node_selector:
+        version: " - 7.99.99"
+
+  - match: {_shards.total: 1}
+  - is_true: upgraded_indices.test_index.upgrade_version
+  - is_false: upgraded_indices.does_not_exist
+
+---
+"Upgrade indices allow no indices < 8.0.0":
+  - skip:
+      version: "8.0.0 - "
+      reason: "_upgrade api has deprecation header since 8.0.0"
+      features: "node_selector"
+
+  - do:
+      indices.upgrade:
+        index: test_index
+        ignore_unavailable: true
+        allow_no_indices: true
+      node_selector:
+        version: " - 7.99.99"
+
+  - match: {_shards.total: 0}
+
+---
+"Upgrade indices disallow no indices < 8.0.0":
+  - skip:
+      version: "8.0.0 - "
+      reason: "_upgrade api has deprecation header since 8.0.0"
+      features: "node_selector"
+
+  - do:
+      catch: missing
+      indices.upgrade:
+        index: test_index
+        ignore_unavailable: true
+        allow_no_indices: false
+      node_selector:
+        version: " - 7.99.99"
+
+---
+"Upgrade indices disallow unavailable < 8.0.0":
+  - skip:
+      version: "8.0.0 - "
+      reason: "_upgrade api has deprecation header since 8.0.0"
+      features: "node_selector"
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      catch: missing
+      indices.upgrade:
+        index: ["test_index", "does_not_exist"]
+        ignore_unavailable: false
+      node_selector:
+        version: " - 7.99.99"

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -297,8 +297,8 @@ import org.elasticsearch.rest.action.admin.indices.RestResizeHandler;
 import org.elasticsearch.rest.action.admin.indices.RestRolloverIndexAction;
 import org.elasticsearch.rest.action.admin.indices.RestSyncedFlushAction;
 import org.elasticsearch.rest.action.admin.indices.RestUpdateSettingsAction;
-import org.elasticsearch.rest.action.admin.indices.RestUpgradeAction;
-import org.elasticsearch.rest.action.admin.indices.RestUpgradeStatusAction;
+import org.elasticsearch.rest.action.admin.indices.RestUpgradeActionDeprecated;
+import org.elasticsearch.rest.action.admin.indices.RestUpgradeStatusActionDeprecated;
 import org.elasticsearch.rest.action.admin.indices.RestValidateQueryAction;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
 import org.elasticsearch.rest.action.cat.RestAliasAction;
@@ -633,8 +633,8 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestFlushAction(restController));
         registerHandler.accept(new RestSyncedFlushAction(restController));
         registerHandler.accept(new RestForceMergeAction(restController));
-        registerHandler.accept(new RestUpgradeAction(restController));
-        registerHandler.accept(new RestUpgradeStatusAction(restController));
+        registerHandler.accept(new RestUpgradeActionDeprecated(restController));
+        registerHandler.accept(new RestUpgradeStatusActionDeprecated(restController));
         registerHandler.accept(new RestClearIndicesCacheAction(restController));
 
         registerHandler.accept(new RestIndexAction(restController, clusterService));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeActionDeprecated.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeActionDeprecated.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.admin.indices.upgrade.post.UpgradeRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -32,11 +34,19 @@ import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-public class RestUpgradeAction extends BaseRestHandler {
+public class RestUpgradeActionDeprecated extends BaseRestHandler {
 
-    public RestUpgradeAction(RestController controller) {
-        controller.registerHandler(POST, "/_upgrade", this);
-        controller.registerHandler(POST, "/{index}/_upgrade", this);
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+        LogManager.getLogger(RestUpgradeActionDeprecated.class));
+
+    public static final String UPGRADE_API_DEPRECATION_MESSAGE =
+        "The _upgrade API is no longer useful and will be removed. Instead, see _reindex API.";
+
+    public RestUpgradeActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(POST, "/_upgrade", this,
+            UPGRADE_API_DEPRECATION_MESSAGE, deprecationLogger);
+        controller.registerAsDeprecatedHandler(POST, "/{index}/_upgrade", this,
+            UPGRADE_API_DEPRECATION_MESSAGE, deprecationLogger);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeStatusActionDeprecated.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeStatusActionDeprecated.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -31,12 +33,18 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import java.io.IOException;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.action.admin.indices.RestUpgradeActionDeprecated.UPGRADE_API_DEPRECATION_MESSAGE;
 
-public class RestUpgradeStatusAction extends BaseRestHandler {
+public class RestUpgradeStatusActionDeprecated extends BaseRestHandler {
 
-    public RestUpgradeStatusAction(RestController controller) {
-        controller.registerHandler(GET, "/_upgrade", this);
-        controller.registerHandler(GET, "/{index}/_upgrade", this);
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
+        LogManager.getLogger(RestUpgradeStatusActionDeprecated.class));
+
+    public RestUpgradeStatusActionDeprecated(RestController controller) {
+        controller.registerAsDeprecatedHandler(GET, "/_upgrade", this,
+            UPGRADE_API_DEPRECATION_MESSAGE, deprecationLogger);
+        controller.registerAsDeprecatedHandler(GET, "/{index}/_upgrade", this,
+            UPGRADE_API_DEPRECATION_MESSAGE, deprecationLogger);
     }
 
     @Override


### PR DESCRIPTION
Issue comment [#47678](https://github.com/elastic/elasticsearch/issues/47678#issuecomment-568743376)

Suggest deprecate Upgrade API instead of implementing high-level API for it.