### PR TITLE
[DOCS] Update several search request body links

### DIFF
--- a/docs/reference/query-dsl/has-parent-query.asciidoc
+++ b/docs/reference/query-dsl/has-parent-query.asciidoc
@@ -112,7 +112,7 @@ You can use this parameter to query multiple indices that may not contain the
 [[has-parent-query-performance]]
 ===== Sorting
 You cannot sort the results of a `has_parent` query using standard
-<<search-request-sort,sort options>>.
+<<request-body-search-sort,sort options>>.
 
 If you need to sort returned documents by a field in their parent documents, use
 a `function_score` query and sort by `_score`. For example, the following query

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -58,7 +58,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 `ccs_minimize_roundtrips`::
   (Optional, boolean) If `true`, the network round-trips between the 
   coordinating node and the remote clusters ewill be minimized when executing 
-  {ccs} requests. See <<ccs-reduction>> for more. Defaults to `true`. 
+  {ccs} requests. See <<ccs-network-delays>>. Defaults to `true`. 
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
 

--- a/x-pack/docs/en/watcher/input/search.asciidoc
+++ b/x-pack/docs/en/watcher/input/search.asciidoc
@@ -163,7 +163,7 @@ accurately.
 |======
 | Name                                          |Required   | Default             | Description
 
-| `request.search_type`                         | no        | `query_then_fetch`  | The <<search-request-search-type,type>>
+| `request.search_type`                         | no        | `query_then_fetch`  | The <<request-body-search-search-type,type>>
                                                                                     of search request to perform. Valid values are: `dfs_query_and_fetch`,
                                                                                     `dfs_query_then_fetch`, `query_and_fetch`, and `query_then_fetch`. The
                                                                                     Elasticsearch default is `query_then_fetch`.


### PR DESCRIPTION
#44238 changed several links related to the Elasticsearch search request body API. This updates several places still using outdated links or anchors.

This will ultimately let us remove some redirects related to those link changes.