### PR TITLE
[DOCS] Add overview page to analysis topic

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -1,11 +1,11 @@
 [[analysis]]
-= Analysis
+= Text analysis
 
 [partintro]
 --
 
-_Analysis_ is the process of converting text, like the body of any email, into
-_tokens_ or _terms_ which are added to the inverted index for searching.
+_Text analysis_ is the process of converting text, like the body of any email,
+into _tokens_ or _terms_ which are added to the inverted index for searching.
 Analysis is performed by an <<analysis-analyzers,_analyzer_>> which can be
 either a built-in analyzer or a <<analysis-custom-analyzer,`custom`>> analyzer
 defined per index.
@@ -106,6 +106,8 @@ looking for:
 * The `standard` analyzer.
 
 --
+
+include::analysis/overview.asciidoc[]
 
 include::analysis/anatomy.asciidoc[]
 

--- a/docs/reference/analysis/overview.asciidoc
+++ b/docs/reference/analysis/overview.asciidoc
@@ -1,0 +1,75 @@
+
+== Text analysis overview
+++++
+<titleabbrev>Overview</titleabbrev>
+++++
+
+Text analysis enables {es} to perform full-text search, where the search returns
+all _relevant_ results rather than just exact matches.
+
+For example, a full-text search for `Quick fox jumps` should not only return
+documents containing that exact search string but also documents containing
+similar or related words, like  `fast fox` or even `foxes leap`.
+
+[discrete]
+[[tokenization]]
+=== Tokenization
+
+Analysis makes full-text search possible by breaking an text down into smaller
+chunks, called _tokens_. In most cases, these tokens are individual words.
+
+For example, without analysis, the text `Quick brown fox` can only be
+matched by searches for the exact string `Quick brown fox`. With analysis,
+the text is converted to the tokens `[Quick, brown, fox]`, which can
+be matched by searches for `Quick fox`, `fox brown`, or other variations.
+
+While improved, this example search experience still has a few problems:
+
+*  A search for `Quick` would not match `quick`, even though you likely want
+either term to match the other
+
+* `fox` and `foxes` share the same root word. However,
+a search for `foxes` would not match `fox` or vice versa.
+
+* While `jumps` and `leaps` don't share a root word, they are synonyms and have
+a similar meaning. However, a search for one would not match the other.
+
+[discrete]
+[[normalization]]
+=== Normalization
+
+To solve these problems, text analysis can _normalize_ these tokens into a
+standard format. This allows you to match tokens that are not exactly the same
+as the search terms, but similar enough to still be relevant. For example:
+
+* `Quick` can be lowercased: `quick`.
+
+* `foxes` can be _stemmed_, or reduced to its root word: `fox`.
+
+* `jump` and `leap` are synonyms and can be indexed as a single word: `jump`.
+
+To ensure search terms match these words as intended, you can apply the same
+tokenization and normalization rules to the query string. For example, a search
+for `Foxes leap` can be normalized to a search for `fox jump`.
+
+[discrete]
+[[analysis-customization]]
+=== Customize text analysis
+
+Text analysis is performed by an <<analyzer-anatomy,_analyzer_>>, a set of rules
+that govern the entire process.
+
+{es} includes a default analyzer, called the
+<<analysis-standard-analyzer,standard analyzer>>, which works well for most use
+cases right out of the box.
+
+If you want to further tailor your search experience, you can choose a different
+<<analysis-analyzers,built-in analyzer>> or even
+<<analysis-custom-analyzer,configure a custom one>>. A custom analyzer gives you
+control over each step of the analysis process, including:
+
+* Changes to the text _before_ tokenization
+
+* How text is converted to tokens
+
+* Normalization changes made to tokens before indexing or search

--- a/docs/reference/analysis/overview.asciidoc
+++ b/docs/reference/analysis/overview.asciidoc
@@ -15,28 +15,31 @@ documents that contain related words like `fast fox` or `foxes leap`.
 [[tokenization]]
 === Tokenization
 
-Analysis makes full-text search possible by breaking an text down into smaller
-chunks, called _tokens_. In most cases, these tokens are individual words.
+Analysis makes full-text search possible through _tokenization_: breaking a text
+down into smaller chunks, called _tokens_. In most cases, these tokens are
+individual words.
 
-For example, without analysis, the text `Quick brown fox` can only be
-matched by searches for the exact string `Quick brown fox`. With analysis,
-the text is converted to the tokens `[Quick, brown, fox]`, which can
-be matched by searches for `Quick fox`, `fox brown`, or other variations.
-
-While improved, this example search experience still has a few problems:
-
-*  A search for `Quick` would not match `quick`, even though you likely want
-either term to match the other
-
-* `fox` and `foxes` share the same root word. However,
-a search for `foxes` would not match `fox` or vice versa.
-
-* While `jumps` and `leaps` don't share a root word, they are synonyms and have
-a similar meaning. However, a search for one would not match the other.
+If you index the phrase `the quick brown fox jumps` as a single string and the
+user searches for `quick fox`, it isn't considered a match. However, if you
+tokenize the phrase and index each word separately, the terms in the query
+string can be looked up individually. This means they can be matched by searches
+for `quick fox`, `fox brown`, or other variations.
 
 [discrete]
 [[normalization]]
 === Normalization
+
+Tokenization enables matching on individual terms, but each token is still
+matched literally. This means:
+
+*  A search for `Quick` would not match `quick`, even though you likely want
+either term to match the other
+
+* Although `fox` and `foxes` share the same root word, a search for `foxes`
+would not match `fox` or vice versa.
+
+* A search for `jumps` would not match `leaps`. While they don't share a root
+word, they are synonyms and have a similar meaning.
 
 To solve these problems, text analysis can _normalize_ these tokens into a
 standard format. This allows you to match tokens that are not exactly the same

--- a/docs/reference/analysis/overview.asciidoc
+++ b/docs/reference/analysis/overview.asciidoc
@@ -7,9 +7,9 @@
 Text analysis enables {es} to perform full-text search, where the search returns
 all _relevant_ results rather than just exact matches.
 
-For example, a full-text search for `Quick fox jumps` should not only return
-documents containing that exact search string but also documents containing
-similar or related words, like  `fast fox` or even `foxes leap`.
+If you search for `Quick fox jumps`, you probably want the document that
+contains `A quick brown fox jumps over the lazy dog`, and you might also want
+documents that contain related words like `fast fox` or `foxes leap`.
 
 [discrete]
 [[tokenization]]

--- a/docs/reference/analysis/overview.asciidoc
+++ b/docs/reference/analysis/overview.asciidoc
@@ -66,7 +66,7 @@ that govern the entire process.
 <<analysis-standard-analyzer,standard analyzer>>, which works well for most use
 cases right out of the box.
 
-If you want to further tailor your search experience, you can choose a different
+If you want to tailor your search experience, you can choose a different
 <<analysis-analyzers,built-in analyzer>> or even
 <<analysis-custom-analyzer,configure a custom one>>. A custom analyzer gives you
 control over each step of the analysis process, including:


### PR DESCRIPTION
Adds a 'text analysis overview' page to the analysis topic docs.

The goals of this page are:
- Concisely summarize the analysis process while avoiding in-depth concepts, tutorials, or API examples
- Explain why analysis is important, largely through highlighting problems with full-text searches missing analysis
- Highlight how analysis can be used to improve search results

This page is inspired by the machine learning overview pages:
- https://www.elastic.co/guide/en/machine-learning/current/ml-overview.html
- https://www.elastic.co/guide/en/machine-learning/current/ml-dfa-overview.html

