### PR TITLE
Replace synced-flush with flush in rolling upgrade to 8.0

### DIFF
--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -36,15 +36,17 @@ To perform a rolling upgrade to {version}:
 include::disable-shard-alloc.asciidoc[]
 --
 
-. *Stop non-essential indexing and perform a synced flush.* (Optional)
+. *Stop non-essential indexing and perform a flush.* (Optional)
 +
 --
 While you can continue indexing during the upgrade, shard recovery
 is much faster if you temporarily stop non-essential indexing and perform a
-<<indices-synced-flush-api, synced-flush>>.
+<<indices-flush, flush>>.
 
-include::synced-flush.asciidoc[]
-
+[source,console]
+--------------------------------------------------
+POST /_flush
+--------------------------------------------------
 --
 
 . *Temporarily stop the tasks associated with active {ml} jobs and {dfeeds}.* (Optional)
@@ -148,7 +150,7 @@ As soon as another node is upgraded, the replicas can be assigned and the
 status will change to `green`.
 ====================================================
 
-Shards that were not <<indices-synced-flush-api,sync-flushed>> might take longer to
+Shards that were not <<indices-flush,flushed>> might take longer to
 recover.  You can monitor the recovery status of individual shards by
 submitting a <<cat-recovery,`_cat/recovery`>> request:
 


### PR DESCRIPTION
This change recommends using a regular flush instead of synced-flush in a rolling upgrade from 7.x to 8.0. We can perform noop recoveries with a regular flush.
