### PR TITLE
Guess root cause support unwrap

### DIFF
--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/210_pipeline_processor.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/210_pipeline_processor.yml
@@ -106,8 +106,8 @@ teardown:
       id: 1
       pipeline: "outer"
       body: {}
-- match: { error.root_cause.0.type: "ingest_processor_exception" }
-- match: { error.root_cause.0.reason: "java.lang.IllegalStateException: Cycle detected for pipeline: outer" }
+- match: { error.root_cause.0.type: "illegal_state_exception" }
+- match: { error.root_cause.0.reason: "Cycle detected for pipeline: outer" }
 
 ---
 "Test Pipeline Processor with templating":
@@ -200,5 +200,5 @@ teardown:
           {
             "org": "legal"
           }
-  - match: { error.root_cause.0.type: "ingest_processor_exception" }
-  - match: { error.root_cause.0.reason: "java.lang.IllegalStateException: Pipeline processor configured for non-existent pipeline [legal-department]" }
+  - match: { error.root_cause.0.type: "illegal_state_exception" }
+  - match: { error.root_cause.0.reason: "Pipeline processor configured for non-existent pipeline [legal-department]" }

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/15_update.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/15_update.yml
@@ -120,6 +120,6 @@
               source: "ctx._source.ctx = ctx"
               params: { bar: 'xxx' }
 
-  - match: { error.root_cause.0.type: "remote_transport_exception" }
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }
   - match: { error.type: "illegal_argument_exception" }
   - match: { error.reason: "Iterable object is self-referencing itself" }

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -641,7 +641,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 }
             }
         }
-        return new ElasticsearchException[]{new ElasticsearchException(t.getMessage(), t) {
+        return new ElasticsearchException[]{new ElasticsearchException(ex.getMessage(), ex) {
             @Override
             protected String getExceptionName() {
                 return getExceptionName(getCause());

--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -164,6 +164,16 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         }
 
         {
+            final ElasticsearchException[] foobars = ElasticsearchException.guessRootCauses(
+                new RemoteTransportException("abc", new IllegalArgumentException("foobar")));
+            assertEquals(foobars.length, 1);
+            assertThat(foobars[0], instanceOf(ElasticsearchException.class));
+            assertEquals("foobar", foobars[0].getMessage());
+            assertEquals(IllegalArgumentException.class, foobars[0].getCause().getClass());
+            assertEquals("illegal_argument_exception", foobars[0].getExceptionName());
+        }
+
+        {
             XContentParseException inner = new XContentParseException(null, "inner");
             XContentParseException outer = new XContentParseException(null, "outer", inner);
             final ElasticsearchException[] causes = ElasticsearchException.guessRootCauses(outer);


### PR DESCRIPTION
ElasticsearchException.guessRootCauses would return wrapper exception if
inner exception was not an ElasticsearchException. Fixed to never return
wrapper exceptions.

At least following APIs change `root_cause.0.type` as a result:

`_update` with bad script
`_index` with bad pipeline

Relates #50417

Specifically, the need to unwrap here:

https://github.com/elastic/elasticsearch/pull/50417/commits/2d16e552f6aa5ab36da57db404a8706cd4fad680#diff-13682f098a7ed5c260bb21049e9efd55R88

is that we do not guess root cause correctly for wrapped exceptions.

Marking this as bugfix since it fixes the root_cause of a few APIs.