### PR TITLE
[DOCS] Document `indices` cluster stats

### DIFF
--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -9,10 +9,6 @@ specified with _node filters_. For example, the <<tasks,Task Management>>,
 <<cluster-nodes-stats,Nodes Stats>>, and <<cluster-nodes-info,Nodes Info>> APIs
 can all report results from a filtered set of nodes rather than from all nodes.
 
-[float]
-[[node-filter]]
-==== Node filters
-
 _Node filters_ are written as a comma-separated list of individual filters,
 each of which adds or removes nodes from the chosen subset. Each filter can be
 one of the following:

--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -9,6 +9,7 @@ specified with _node filters_. For example, the <<tasks,Task Management>>,
 <<cluster-nodes-stats,Nodes Stats>>, and <<cluster-nodes-info,Nodes Info>> APIs
 can all report results from a filtered set of nodes rather than from all nodes.
 
+[float]
 [[node-filter]]
 ==== Node filters
 

--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -9,6 +9,9 @@ specified with _node filters_. For example, the <<tasks,Task Management>>,
 <<cluster-nodes-stats,Nodes Stats>>, and <<cluster-nodes-info,Nodes Info>> APIs
 can all report results from a filtered set of nodes rather than from all nodes.
 
+[[node-filter]]
+==== Node filters
+
 _Node filters_ are written as a comma-separated list of individual filters,
 each of which adds or removes nodes from the chosen subset. Each filter can be
 one of the following:

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -91,7 +91,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
     (string) The name of the cluster.
 
 `status`::
-    (string) The health status of the cluster.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
 
 `timed_out`::
     (boolean) If `false` the response returned within the period of 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -318,7 +318,7 @@ all selected nodes.
 
 `indices.segments.max_unsafe_auto_id_timestamp`::
 (integer)
-Timestamp of the most recent retry request.
+Timestamp of the most recently retried indexing request.
 
 `indices.segments.file_sizes.size`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -76,7 +76,7 @@ shards. Returned values include:
 
   `yellow`:::
   All primary shards are assigned, but one or more replica shards are
-  unassigned. If a node in the cluster fails, data could be lost.
+  unassigned. If a node in the cluster fails, some data could be unavailable until that node is repaired.
 
   `red`:::
   One or more primary shards are unassigned. This can occur briefly during

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -73,68 +73,68 @@ See <<cluster-health>>.
 
 `indices.count`::
 (integer)
-Total number of indices in the selected nodes.
+Total number of indices with shards assigned to selected nodes.
 
 `indices.shards.total`::
 (integer)
-Total number of shards assigned to the selected nodes.
+Total number of shards assigned to selected nodes.
 
 `indices.shards.primaries`::
 (integer)
-Number of primary shards assigned to the selected nodes.
+Number of primary shards assigned to selected nodes.
 
 `indices.shards.replication`::
 (integer)
-Ratio of replica shards to primary shards across the selected nodes.
+Ratio of replica shards to primary shards across all selected nodes.
 
 `indices.shards.index.shards.min`::
 (integer)
-Minimum number of shards in an index, counting only shards assigned to the
+Minimum number of shards in an index, counting only shards assigned to
 selected nodes.
 
 `indices.shards.index.shards.max`::
 (integer)
-Maximum number of shards in an index, counting only shards assigned to the
+Maximum number of shards in an index, counting only shards assigned to
 selected nodes.
 
 `indices.shards.index.shards.avg`::
 (integer)
-Mean number of shards in an index, counting only the shards assigned to the
+Mean number of shards in an index, counting only shards assigned to
 selected nodes.
 
 `indices.shards.index.primaries.min`::
 (integer)
-Minimum number of primary shards in an index, counting only the shards assigned
-to the selected nodes.
+Minimum number of primary shards in an index, counting only shards assigned
+to selected nodes.
 
 `indices.shards.index.primaries.max`::
 (integer)
-Maximum number of primary shards in an index, counting only the shards assigned
-to the selected nodes.
+Maximum number of primary shards in an index, counting only shards assigned
+to selected nodes.
 
 `indices.shards.index.primaries.avg`::
 (integer)
-Mean number of primary shards in an index, counting only the shards assigned to
-the selected nodes.
+Mean number of primary shards in an index, counting only shards assigned to
+selected nodes.
 
 `indices.shards.index.replication.min`::
 (integer)
-Minimum replication factor in an index, counting only the shards assigned to the
+Minimum replication factor in an index, counting only shards assigned to
 selected nodes.
 
 `indices.shards.index.replication.max`::
 (integer)
-Maximum replication factor in an index, counting only the shards assigned to the
+Maximum replication factor in an index, counting only shards assigned to
 selected nodes.
 
 `indices.shards.index.replication.avg`::
 (integer)
-Mean replication factor in an index, counting only the shards assigned to the
-selected nodes.
+Mean replication factor in an index, counting only shards assigned to selected
+nodes.
 
 `indices.docs.count`::
 (integer)
-Total number of non-deleted documents across all primary shards assigned to the
+Total number of non-deleted documents across all primary shards assigned to
 selected nodes.
 +
 This number is based on documents in Lucene segments and may include documents
@@ -142,7 +142,7 @@ from nested fields.
 
 `indices.docs.deleted`::
 (integer)
-Total number of deleted documents across all primary shards assigned to the
+Total number of deleted documents across all primary shards assigned to
 selected nodes.
 +
 This number is based on documents in Lucene segments. {es} reclaims the disk
@@ -150,30 +150,30 @@ space of deleted Lucene documents when a segment is merged.
 
 `indices.store.size`::
 (<<byte-units, byte units>>)
-Total size of all shards across the selected nodes.
+Total size of all shards across selected nodes.
 
 `indices.store.size_in_bytes`::
 (integer)
-Total size, in bytes, of all shards across the selected nodes.
+Total size, in bytes, of all shards across selected nodes.
 
 `indices.fielddata.memory_size`::
 (<<byte-units, byte units>>)
-Total size of the memory used for field data cache on all shards across the
+Total size of the memory used for field data cache on all shards across
 selected nodes.
 
 `indices.fielddata.memory_size_in_bytes`::
 (integer)
 Total size, in bytes, of the memory used for field data cache on all shards
-across the selected nodes.
+across selected nodes.
 
 `indices.fielddata.evictions`::
 (integer)
-Total number of evictions from the field data cache on all shards across the
+Total number of evictions from the field data cache on all shards across
 selected nodes.
 
 `indices.query_cache.memory_size`::
 (<<byte-units, byte units>>)
-Total memory used for the query cache on all shards across all selected nodes.
+Total memory used for the query cache on all shards across selected nodes.
 
 `indices.query_cache.memory_size_in_bytes`::
 (integer)
@@ -195,12 +195,12 @@ Total count of query cache misses on all shards across all selected nodes.
 
 `indices.query_cache.cache_size`::
 (integer)
-Total number of entries _currently_ in the query cache on all shards across all
+Total number of entries currently in the query cache on all shards across all
 selected nodes.
 
 `indices.query_cache.cache_count`::
 (integer)
-Total number of entries _ever_ added to the query cache on all shards across all
+Total number of entries ever added to the query cache on all shards across all
 selected nodes.
 
 `indices.query_cache.evictions`::

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -133,15 +133,15 @@ selected nodes.
 
 `indices.docs.count`::
 (integer)
-Number of non-deleted documents in total across all primary shards assigned to
-the selected nodes.
+Total number of non-deleted documents across all primary shards assigned to the
+selected nodes.
 +
 This number is based on documents in Lucene segments and may include documents
 from nested fields.
 
 `indices.docs.deleted`::
 (integer)
-Number of deleted documents in total across all primary shards assigned to the
+Total number of deleted documents across all primary shards assigned to the
 selected nodes.
 +
 This number is based on documents in Lucene segments. {es} reclaims the disk

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -186,11 +186,11 @@ selected nodes.
 
 `indices.query_cache.hit_count`::
 (integer)
-Total count of of query cache hits on all shards across all selected nodes.
+Total count of query cache hits on all shards across all selected nodes.
 
 `indices.query_cache.miss_count`::
 (integer)
-Total count of of query cache misses on all shards across all selected nodes.
+Total count of query cache misses on all shards across all selected nodes.
 
 `indices.query_cache.cache_size`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -258,11 +258,13 @@ all selected nodes.
 
 `indices.segments.norms_memory`::
 (<<byte-units, byte units>>)
-Size of normalization factors in segments.
+Total amount of memory used for normalization factors on all shards across all
+selected nodes.
 
 `indices.segments.norms_memory_in_bytes`::
 (integer)
-Size, in bytes, of normalization factors in segments.
+Total amount, in bytes, of memory used for normalization factors on all shards
+across all selected nodes.
 
 `indices.segments.points_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -133,7 +133,8 @@ selected nodes.
 
 `indices.docs.count`::
 (integer)
-Number of non-deleted documents in the cluster.
+Number of non-deleted documents in total across all primary shards assigned to
+the selected nodes.
 +
 This number is based on documents in Lucene segments and may include documents
 from nested fields.

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -307,12 +307,14 @@ all selected nodes.
 
 `indices.segments.fixed_bit_set_memory`::
 (<<byte-units, byte units>>)
-Memory used by fixed bit sets for nested object field types and type
-filters for <<parent-join,join>> fields.
+Total amount of memory used by fixed bit sets for nested object field types and
+type filters for <<parent-join,join>> fields on all shards across all selected
+nodes.
 
 `indices.segments.fixed_bit_set_memory_in_bytes`::
 (integer)
-Memory, in bytes, used by fixed bit sets.
+Total amount of memory, in bytes, used by fixed bit sets  on all shards across
+all selected nodes.
 
 `indices.segments.max_unsafe_auto_id_timestamp`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -66,22 +66,9 @@ Unique identifier for the cluster.
 Last time the cluster statistics were refreshed.
 
 `status`::
-(string)
-Health status of the cluster based on the state of its primary and replica
-shards. Returned values include:
-
-  `green`:::
-  All primary shard and replica shards are assigned. There are at least two
-  copies of all shards.
-
-  `yellow`:::
-  All primary shards are assigned, but one or more replica shards are
-  unassigned. If a node in the cluster fails, some data could be unavailable until that node is repaired.
-
-  `red`:::
-  One or more primary shards are unassigned. This can occur briefly during
-  cluster startup as primary shards are assigned during cluster startup. At
-  other times, this status may indicate data loss.
+include::{docdir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
++
+See <<cluster-health>>.
 
 `indices.count`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -204,35 +204,37 @@ selected nodes.
 
 `indices.query_cache.evictions`::
 (integer)
-Number of query cache evictions.
+Total number of query cache evictions on all shards across all selected nodes.
 
 `indices.completion.size_in_bytes`::
 (<<byte-units, byte units>>)
-Memory used for completion.
+Total memory used for completion on all shards across all selected nodes.
 
 `indices.completion.size_in_bytes`::
 (integer)
-Memory, in bytes, used for completion.
+Total memory, in bytes, used for completion on all shards across all selected
+nodes.
 
 `indices.segments.count`::
 (integer)
-Number of segments.
+Total number of segments on all shards across all selected nodes.
 
 `indices.segments.memory`::
 (<<byte-units, byte units>>)
-Size of segments.
+Total size of segments on all shards across all selected nodes.
 
 `indices.segments.memory_in_bytes`::
 (integer)
-Size, in bytes, of segments.
+Total size, in bytes, of segments on all shards across all selected nodes.
 
 `indices.segments.terms_memory`::
 (<<byte-units, byte units>>)
-Size of terms in segments.
+Total amount of segment memory used  on all shards across all selected nodes.
 
 `indices.segments.terms_memory_in_bytes`::
 (integer)
-Size, in bytes, of terms in segments.
+Total amount, in bytes, of segment memory used  on all shards across all
+selected nodes.
 
 `indices.segments.stored_fields_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -320,17 +320,11 @@ all selected nodes.
 (integer)
 Timestamp of the most recently retried indexing request.
 
-`indices.segments.file_sizes.size`::
-(<<byte-units, byte units>>)
-Size of the segment file.
-
-`indices.segments.file_sizes.size_in_bytes`::
-(integer)
-Size, in bytes, of the segment file.
-
-`indices.segments.file_sizes.description`::
-(string)
-Description of the segment file.
+`indices.segments.file_sizes`::
+(object)
+This object is not populated by the cluster stats API.
++
+To populate this object, use the <<cluster-nodes-stats,node stats API>>.
 
 
 [[cluster-stats-api-example]]

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -36,7 +36,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=node-filter]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
 
 [[cluster-stats-api-response-body]]
 ==== {api-response-body-title}

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -186,11 +186,11 @@ selected nodes.
 
 `indices.query_cache.hit_count`::
 (integer)
-Number of query cache hits.
+Total count of of query cache hits on all shards across all selected nodes.
 
 `indices.query_cache.miss_count`::
 (integer)
-Number of query cache misses.
+Total count of of query cache misses on all shards across all selected nodes.
 
 `indices.query_cache.cache_size`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -84,6 +84,8 @@ Number of primary shards assigned to the selected nodes.
 
 `indices.shards.replication`::
 (integer)
+Ratio of replica shards to primary shards in the selected nodes.
+
 Number of replica shards.
 
 `indices.shards.index.shards.min`::

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -172,11 +172,12 @@ selected nodes.
 
 `indices.query_cache.memory_size`::
 (<<byte-units, byte units>>)
-Memory used for query cache.
+Total memory used for the query cache on all shards across all selected nodes.
 
 `indices.query_cache.memory_size_in_bytes`::
 (integer)
-Memory, in bytes, used for query cache.
+Total memory, in bytes, used for the query cache on all shards across all
+selected nodes.
 
 `indices.query_cache.total_count`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -118,7 +118,8 @@ the selected nodes.
 
 `indices.shards.index.replication.min`::
 (integer)
-Lowest historic number of replica shards for the cluster.
+Minimum replication factor in an index, counting only the shards assigned to the
+selected nodes.
 
 `indices.shards.index.replication.max`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -55,7 +55,7 @@ Number of nodes that failed to start.
 
 `cluster_name`::
 (string)
-Name of the cluster.
+Name of the cluster. See <<cluster.name>>.
 
 `cluster_uuid`::
 (string)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -194,11 +194,13 @@ Total count of of query cache misses on all shards across all selected nodes.
 
 `indices.query_cache.cache_size`::
 (integer)
-Size, in bytes, of the query cache.
+Total number of entries _currently_ in the query cache on all shards across all
+selected nodes.
 
 `indices.query_cache.cache_count`::
 (integer)
-Count of queries in the query cache.
+Total number of entries _ever_ added to the query cache on all shards across all
+selected nodes.
 
 `indices.query_cache.evictions`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -287,11 +287,13 @@ selected nodes.
 
 `indices.segments.index_writer_memory_in_bytes`::
 (<<byte-units, byte units>>)
-Memory used by the index writer.
+Total amount of memory used by all index writers on all shards across all
+selected nodes.
 
 `indices.segments.index_writer_memory_in_bytes`::
 (integer)
-Memory, in bytes, used by the index writer.
+Total amount, in bytes, of memory used by all index writers on all shards across
+all selected nodes.
 
 `indices.segments.version_map_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -123,7 +123,8 @@ selected nodes.
 
 `indices.shards.index.replication.max`::
 (integer)
-Highest historic number of replica shards for the cluster.
+Maximum replication factor in an index, counting only the shards assigned to the
+selected nodes.
 
 `indices.shards.index.replication.avg`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -167,7 +167,8 @@ across the selected nodes.
 
 `indices.fielddata.evictions`::
 (integer)
-Number of fielddata evictions.
+Total number of evictions from the field data cache on all shards across the
+selected nodes.
 
 `indices.query_cache.memory_size`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -108,7 +108,8 @@ to the selected nodes.
 
 `indices.shards.index.primaries.max`::
 (integer)
-Highest historic number of primary shards for the cluster.
+Maximum number of primary shards in an index, counting only the shards assigned
+to the selected nodes.
 
 `indices.shards.index.primaries.avg`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -52,7 +52,7 @@ Number of nodes that responded successfully to the request.
 `_nodes.failed`::
 (integer)
 Number of nodes that rejected the request or failed to respond. If this value
-is not `0`, a reason for the rejection or failure is included in this response.
+is not `0`, a reason for the rejection or failure is included in the response.
 
 `cluster_name`::
 (string)
@@ -203,7 +203,7 @@ to selected nodes.
 `indices.query_cache.cache_count`::
 (integer)
 Total number of entries added to the query cache across all shards assigned
-to selected nodes. This includes current and removed query cache entries.
+to selected nodes. This number includes current and evicted entries.
 
 `indices.query_cache.evictions`::
 (integer)
@@ -256,12 +256,12 @@ assigned to selected nodes.
 
 `indices.segments.term_vectors_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used for terms vectors across all shards assigned to
+Total amount of memory used for term vectors across all shards assigned to
 selected nodes.
 
 `indices.segments.term_vectors_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used for terms vectors across all shards
+Total amount, in bytes, of memory used for term vectors across all shards
 assigned to selected nodes.
 
 `indices.segments.norms_memory`::

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -76,7 +76,7 @@ Total number of indices in the selected nodes.
 
 `indices.shards.total`::
 (integer)
-Total number of shards for all indices.
+Total number of shards assigned to the selected nodes.
 
 `indices.shards.primaries`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -47,11 +47,12 @@ Total number of nodes selected by the request's node filters.
 
 `_nodes.successful`::
 (integer)
-Number of nodes that responded succesfully to the request.
+Number of nodes that responded successfully to the request.
 
 `_nodes.failed`::
 (integer)
-Number of nodes that failed to start.
+Number of nodes that rejected or timed out the request. If this value is not `0`,
+the failure reasonis included in the response.
 
 `cluster_name`::
 (string)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -72,7 +72,7 @@ See <<cluster-health>>.
 
 `indices.count`::
 (integer)
-Total number of indices in the cluster.
+Total number of indices in the selected nodes.
 
 `indices.shards.total`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -153,7 +153,7 @@ Total size of all shards across the selected nodes.
 
 `indices.store.size_in_bytes`::
 (integer)
-Size, in bytes, of the store.
+Total size, in bytes, of all shards across the selected nodes.
 
 `indices.fielddata.memory_size`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -113,7 +113,8 @@ to the selected nodes.
 
 `indices.shards.index.primaries.avg`::
 (integer)
-Average number of primary shards for the cluster.
+Mean number of primary shards in an index, counting only the shards assigned to
+the selected nodes.
 
 `indices.shards.index.replication.min`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -238,11 +238,13 @@ selected nodes.
 
 `indices.segments.stored_fields_memory`::
 (<<byte-units, byte units>>)
-Size of stored fields in segments.
+Total amount of memory used for stored fields on all shards across all
+selected nodes.
 
 `indices.segments.stored_fields_memory_in_bytes`::
 (integer)
-Size, in bytes, of stored fields in segments.
+Total amount, in bytes, of memory used for stored fields on all shards across
+all selected nodes.
 
 `indices.segments.term_vectors_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -12,7 +12,7 @@ Returns cluster statistics.
 
 `GET /_cluster/stats` +
 
-`GET /_cluster/stats/nodes/<node_id>`
+`GET /_cluster/stats/nodes/<node_filter>`
 
 
 [[cluster-stats-api-desc]]
@@ -28,7 +28,7 @@ memory usage) and information about the current nodes that form the cluster
 ==== {api-path-parms-title}
 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{docdir}/rest-api/common-parms.asciidoc[tag=node-filter]
 
 
 [[cluster-stats-api-query-params]]
@@ -43,7 +43,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `_nodes.total`::
 (integer)
-Total number of nodes in the cluster.
+Total number of nodes selected by the request's node filters.
 
 `_nodes.successful`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -206,7 +206,7 @@ selected nodes.
 (integer)
 Total number of query cache evictions on all shards across all selected nodes.
 
-`indices.completion.size_in_bytes`::
+`indices.completion.size`::
 (<<byte-units, byte units>>)
 Total memory used for completion on all shards across all selected nodes.
 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -51,8 +51,8 @@ Number of nodes that responded successfully to the request.
 
 `_nodes.failed`::
 (integer)
-Number of nodes that rejected or timed out the request. If this value is not `0`,
-the failure reasonis included in the response.
+Number of nodes that rejected or timed out the request. If this value is not
+`0`, the failure reason is included in the response.
 
 `cluster_name`::
 (string)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -38,6 +38,278 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
+[[cluster-stats-api-response-body]]
+==== {api-response-body-title}
+
+`_nodes.total`::
+(integer)
+Total number of nodes in the cluster.
+
+`_nodes.successful`::
+(integer)
+Number of nodes that started succesfully.
+
+`_nodes.failed`::
+(integer)
+Number of nodes that failed to start.
+
+`cluster_name`::
+(string)
+Name of the cluster.
+
+`cluster_uuid`::
+(string)
+Unique identifier for the cluster.
+
+`timestamp`::
+(https://en.wikipedia.org/wiki/Unix_time[Unix timestamp])
+Last time the cluster statistics were refreshed.
+
+`status`::
+(string)
+Health status of the cluster based on the state of its primary and replica
+shards. Returned values include:
+
+  `green`:::
+  All primary shard and replica shards are assigned. There are at least two
+  copies of all shards.
+
+  `yellow`:::
+  All primary shards are assigned, but one or more replica shards are
+  unassigned. If a node in the cluster fails, data could be lost.
+
+  `red`:::
+  One or more primary shards are unassigned. This can occur briefly during
+  cluster startup as primary shards are assigned during cluster startup. At
+  other times, this status may indicate data loss.
+
+`indices.count`::
+(integer)
+Total number of indices in the cluster.
+
+`indices.shards.total`::
+(integer)
+Total number of shards for all indices.
+
+`indices.shards.primaries`::
+(integer)
+Number of primary shards.
+
+`indices.shards.replication`::
+(integer)
+Number of replica shards.
+
+`indices.shards.index.shards.min`::
+(integer)
+Lowest historic number of shards for the cluster.
+
+`indices.shards.index.shards.max`::
+(integer)
+Highest historic number of shards for the cluster.
+
+`indices.shards.index.shards.avg`::
+(integer)
+Average number of shards for the cluster.
+
+`indices.shards.index.primaries.min`::
+(integer)
+Lowest historic number of primary shards for the cluster.
+
+`indices.shards.index.primaries.max`::
+(integer)
+Highest historic number of primary shards for the cluster.
+
+`indices.shards.index.primaries.avg`::
+(integer)
+Average number of primary shards for the cluster.
+
+`indices.shards.index.replication.min`::
+(integer)
+Lowest historic number of replica shards for the cluster.
+
+`indices.shards.index.replication.max`::
+(integer)
+Highest historic number of replica shards for the cluster.
+
+`indices.shards.index.replication.avg`::
+(integer)
+Average number of replica shards for the cluster.
+
+`indices.docs.count`::
+(integer)
+Number of non-deleted documents in the cluster.
++
+This number is based on documents in Lucene segments and may include documents
+from nested fields.
+
+`indices.docs.deleted`::
+(integer)
+Number of deleted documents in the cluster.
++
+This number is based on documents in Lucene segments. {es} reclaims the disk
+space of deleted Lucene documents when a segment is merged.
+
+`indices.store.size`::
+(<<byte-units, byte units>>)
+Size of the indices store.
+
+`indices.store.size_in_bytes`::
+(integer)
+Size, in bytes, of the store.
+
+`indices.fielddata.memory_size`::
+(<<byte-units, byte units>>)
+Memory used for fielddata cache.
+
+`indices.fielddata.memory_size_in_bytes`::
+(integer)
+Memory, in bytes, used for fielddata cache.
+
+`indices.fielddata.evictions`::
+(integer)
+Number of fielddata evictions.
+
+`indices.query_cache.memory_size`::
+(<<byte-units, byte units>>)
+Memory used for query cache.
+
+`indices.query_cache.memory_size_in_bytes`::
+(integer)
+Memory, in bytes, used for query cache.
+
+`indices.query_cache.total_count`::
+(integer)
+Total count of hits, misses, and cached queries in the query cache.
+
+`indices.query_cache.hit_count`::
+(integer)
+Number of query cache hits.
+
+`indices.query_cache.miss_count`::
+(integer)
+Number of query cache misses.
+
+`indices.query_cache.cache_size`::
+(integer)
+Size, in bytes, of the query cache.
+
+`indices.query_cache.cache_count`::
+(integer)
+Count of queries in the query cache.
+
+`indices.query_cache.evictions`::
+(integer)
+Number of query cache evictions.
+
+`indices.completion.size_in_bytes`::
+(<<byte-units, byte units>>)
+Memory used for completion.
+
+`indices.completion.size_in_bytes`::
+(integer)
+Memory, in bytes, used for completion.
+
+`indices.segments.count`::
+(integer)
+Number of segments.
+
+`indices.segments.memory`::
+(<<byte-units, byte units>>)
+Size of segments.
+
+`indices.segments.memory_in_bytes`::
+(integer)
+Size, in bytes, of segments.
+
+`indices.segments.terms_memory`::
+(<<byte-units, byte units>>)
+Size of terms in segments.
+
+`indices.segments.terms_memory_in_bytes`::
+(integer)
+Size, in bytes, of terms in segments.
+
+`indices.segments.stored_fields_memory`::
+(<<byte-units, byte units>>)
+Size of stored fields in segments.
+
+`indices.segments.stored_fields_memory_in_bytes`::
+(integer)
+Size, in bytes, of stored fields in segments.
+
+`indices.segments.term_vectors_memory`::
+(<<byte-units, byte units>>)
+Size of term vectors in segments.
+
+`indices.segments.term_vectors_memory_in_bytes`::
+(integer)
+Size, in bytes, of term vectors in segments.
+
+`indices.segments.norms_memory`::
+(<<byte-units, byte units>>)
+Size of normalization factors in segments.
+
+`indices.segments.norms_memory_in_bytes`::
+(integer)
+Size, in bytes, of normalization factors in segments.
+
+`indices.segments.points_memory`::
+(<<byte-units, byte units>>)
+Size of points in segments.
+
+`indices.segments.points_memory_in_bytes`::
+(integer)
+Size, in bytes, of points in segments.
+
+`indices.segments.doc_values_memory`::
+(<<byte-units, byte units>>)
+Size of doc values in segments.
+
+`indices.segments.doc_values_memory_in_bytes`::
+(integer)
+Size, in bytes, of doc values in segments.
+
+`indices.segments.index_writer_memory_in_bytes`::
+(<<byte-units, byte units>>)
+Memory used by the index writer.
+
+`indices.segments.index_writer_memory_in_bytes`::
+(integer)
+Memory, in bytes, used by the index writer.
+
+`indices.segments.version_map_memory`::
+(<<byte-units, byte units>>)
+Memory used by the version map.
+
+`indices.segments.version_map_memory_in_bytes`::
+(integer)
+Memory, in bytes, used by the version map.
+
+`indices.segments.fixed_bit_set_memory`::
+(<<byte-units, byte units>>)
+Memory used by fixed bit sets for nested object field types and type
+filters for <<parent-join,join>> fields.
+
+`indices.segments.fixed_bit_set_memory_in_bytes`::
+(integer)
+Memory, in bytes, used by fixed bit sets.
+
+`indices.segments.max_unsafe_auto_id_timestamp`::
+(integer)
+Timestamp of the most recent retry request.
+
+`indices.segments.file_sizes.size`::
+(<<byte-units, byte units>>)
+Size of the segment file.
+
+`indices.segments.file_sizes.size_in_bytes`::
+(integer)
+Size, in bytes, of the segment file.
+
+`indices.segments.file_sizes.description`::
+(string)
+Description of the segment file.
+
 
 [[cluster-stats-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -80,7 +80,7 @@ Total number of shards assigned to the selected nodes.
 
 `indices.shards.primaries`::
 (integer)
-Number of primary shards.
+Number of primary shards assigned to the selected nodes.
 
 `indices.shards.replication`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -229,11 +229,11 @@ Total size, in bytes, of segments on all shards across all selected nodes.
 
 `indices.segments.terms_memory`::
 (<<byte-units, byte units>>)
-Total amount of segment memory used  on all shards across all selected nodes.
+Total amount of segment memory used on all shards across all selected nodes.
 
 `indices.segments.terms_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of segment memory used  on all shards across all
+Total amount, in bytes, of segment memory used on all shards across all
 selected nodes.
 
 `indices.segments.stored_fields_memory`::

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -62,7 +62,7 @@ Name of the cluster. See <<cluster.name>>.
 Unique identifier for the cluster.
 
 `timestamp`::
-(https://en.wikipedia.org/wiki/Unix_time[Unix timestamp])
+(https://en.wikipedia.org/wiki/Unix_time[Unix timestamp] in milliseconds)
 Last time the cluster statistics were refreshed.
 
 `status`::

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -181,7 +181,8 @@ selected nodes.
 
 `indices.query_cache.total_count`::
 (integer)
-Total count of hits, misses, and cached queries in the query cache.
+Total count of hits and misses in the query cache on all shards across all
+selected nodes.
 
 `indices.query_cache.hit_count`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -248,11 +248,13 @@ all selected nodes.
 
 `indices.segments.term_vectors_memory`::
 (<<byte-units, byte units>>)
-Size of term vectors in segments.
+Total amount of memory used for terms vectors on all shards across
+all selected nodes.
 
 `indices.segments.term_vectors_memory_in_bytes`::
 (integer)
-Size, in bytes, of term vectors in segments.
+Total amount, in bytes, of memory used for terms vectors on all shards across
+all selected nodes.
 
 `indices.segments.norms_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -157,11 +157,13 @@ Total size, in bytes, of all shards across the selected nodes.
 
 `indices.fielddata.memory_size`::
 (<<byte-units, byte units>>)
-Memory used for fielddata cache.
+Total size of the memory used for field data cache on all shards across the
+selected nodes.
 
 `indices.fielddata.memory_size_in_bytes`::
 (integer)
-Memory, in bytes, used for fielddata cache.
+Total size, in bytes, of the memory used for field data cache on all shards
+across the selected nodes.
 
 `indices.fielddata.evictions`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -128,7 +128,8 @@ selected nodes.
 
 `indices.shards.index.replication.avg`::
 (integer)
-Average number of replica shards for the cluster.
+Mean replication factor in an index, counting only the shards assigned to the
+selected nodes.
 
 `indices.docs.count`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -47,7 +47,7 @@ Total number of nodes in the cluster.
 
 `_nodes.successful`::
 (integer)
-Number of nodes that started succesfully.
+Number of nodes that responded succesfully to the request.
 
 `_nodes.failed`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -268,11 +268,12 @@ across all selected nodes.
 
 `indices.segments.points_memory`::
 (<<byte-units, byte units>>)
-Size of points in segments.
+Total amount of memory used for points on all shards across all selected nodes.
 
 `indices.segments.points_memory_in_bytes`::
 (integer)
-Size, in bytes, of points in segments.
+Total amount, in bytes, of memory used for points on all shards across all
+selected nodes.
 
 `indices.segments.doc_values_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -51,8 +51,8 @@ Number of nodes that responded successfully to the request.
 
 `_nodes.failed`::
 (integer)
-Number of nodes that rejected or timed out the request. If this value is not
-`0`, the failure reason is included in the response.
+Number of nodes that rejected the request or failed to respond. If this value
+is not `0`, a reason for the rejection or failure is included in this response.
 
 `cluster_name`::
 (string)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -277,11 +277,13 @@ selected nodes.
 
 `indices.segments.doc_values_memory`::
 (<<byte-units, byte units>>)
-Size of doc values in segments.
+Total amount of doc values used for points on all shards across all selected
+nodes.
 
 `indices.segments.doc_values_memory_in_bytes`::
 (integer)
-Size, in bytes, of doc values in segments.
+Total amount, in bytes, of doc values used for points on all shards across all
+selected nodes.
 
 `indices.segments.index_writer_memory_in_bytes`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -297,11 +297,13 @@ all selected nodes.
 
 `indices.segments.version_map_memory`::
 (<<byte-units, byte units>>)
-Memory used by the version map.
+Total amount of memory used by all version maps on all shards across all
+selected nodes.
 
 `indices.segments.version_map_memory_in_bytes`::
 (integer)
-Memory, in bytes, used by the version map.
+Total amount, in bytes, of memory used by all version maps on all shards across
+all selected nodes.
 
 `indices.segments.fixed_bit_set_memory`::
 (<<byte-units, byte units>>)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -149,7 +149,7 @@ space of deleted Lucene documents when a segment is merged.
 
 `indices.store.size`::
 (<<byte-units, byte units>>)
-Size of the indices store.
+Total size of all shards across the selected nodes.
 
 `indices.store.size_in_bytes`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -141,7 +141,8 @@ from nested fields.
 
 `indices.docs.deleted`::
 (integer)
-Number of deleted documents in the cluster.
+Number of deleted documents in total across all primary shards assigned to the
+selected nodes.
 +
 This number is based on documents in Lucene segments. {es} reclaims the disk
 space of deleted Lucene documents when a segment is merged.

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -63,8 +63,9 @@ Name of the cluster, based on the <<cluster.name>> setting.
 Unique identifier for the cluster.
 
 `timestamp`::
-(https://en.wikipedia.org/wiki/Unix_time[Unix timestamp] in milliseconds)
-Last time the cluster statistics were refreshed.
+(integer)
+https://en.wikipedia.org/wiki/Unix_time[Unix timestamp], in milliseconds, of
+the last time the cluster statistics were refreshed.
 
 `status`::
 include::{docdir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
@@ -150,182 +151,193 @@ space of deleted Lucene documents when a segment is merged.
 
 `indices.store.size`::
 (<<byte-units, byte units>>)
-Total size of all shards across selected nodes.
+Total size of all shards assigned to selected nodes.
 
 `indices.store.size_in_bytes`::
 (integer)
-Total size, in bytes, of all shards across selected nodes.
+Total size, in bytes, of all shards assigned to selected nodes.
 
 `indices.fielddata.memory_size`::
 (<<byte-units, byte units>>)
-Total size of the memory used for field data cache on all shards across
-selected nodes.
+Total amount of memory used for the field data cache across all shards
+assigned to selected nodes.
 
 `indices.fielddata.memory_size_in_bytes`::
 (integer)
-Total size, in bytes, of the memory used for field data cache on all shards
-across selected nodes.
+Total amount, in bytes, of memory used for the field data cache across all
+shards assigned to selected nodes.
 
 `indices.fielddata.evictions`::
 (integer)
-Total number of evictions from the field data cache on all shards across
-selected nodes.
+Total number of evictions from the field data cache across all shards assigned
+to selected nodes.
 
 `indices.query_cache.memory_size`::
 (<<byte-units, byte units>>)
-Total memory used for the query cache on all shards across selected nodes.
+Total amount of memory used for the query cache across all shards assigned to
+selected nodes.
 
 `indices.query_cache.memory_size_in_bytes`::
 (integer)
-Total memory, in bytes, used for the query cache on all shards across all
-selected nodes.
+Total amount, in bytes, of memory used for the query cache across all shards
+assigned to selected nodes.
 
 `indices.query_cache.total_count`::
 (integer)
-Total count of hits and misses in the query cache on all shards across all
+Total count of hits and misses in the query cache across all shards assigned to
 selected nodes.
 
 `indices.query_cache.hit_count`::
 (integer)
-Total count of query cache hits on all shards across all selected nodes.
+Total count of query cache hits across all shards assigned to selected nodes.
 
 `indices.query_cache.miss_count`::
 (integer)
-Total count of query cache misses on all shards across all selected nodes.
+Total count of query cache misses across all shards assigned to selected nodes.
 
 `indices.query_cache.cache_size`::
 (integer)
-Total number of entries currently in the query cache on all shards across all
-selected nodes.
+Total number of entries currently in the query cache across all shards assigned
+to selected nodes.
 
 `indices.query_cache.cache_count`::
 (integer)
-Total number of entries ever added to the query cache on all shards across all
-selected nodes.
+Total number of entries added to the query cache across all shards assigned
+to selected nodes. This includes current and removed query cache entries.
 
 `indices.query_cache.evictions`::
 (integer)
-Total number of query cache evictions on all shards across all selected nodes.
+Total number of query cache evictions across all shards assigned to selected
+nodes.
 
 `indices.completion.size`::
 (<<byte-units, byte units>>)
-Total memory used for completion on all shards across all selected nodes.
+Total amount of memory used for completion across all shards assigned to
+selected nodes.
 
 `indices.completion.size_in_bytes`::
 (integer)
-Total memory, in bytes, used for completion on all shards across all selected
-nodes.
+Total amount, in bytes, of memory used for completion across all shards assigned
+to selected nodes.
 
 `indices.segments.count`::
 (integer)
-Total number of segments on all shards across all selected nodes.
+Total number of segments across all shards assigned to selected nodes.
 
 `indices.segments.memory`::
 (<<byte-units, byte units>>)
-Total size of segments on all shards across all selected nodes.
+Total amount of memory used for segments across all shards assigned to selected
+nodes.
 
 `indices.segments.memory_in_bytes`::
 (integer)
-Total size, in bytes, of segments on all shards across all selected nodes.
+Total amount, in bytes, of memory used for segments across all shards assigned to
+selected nodes.
 
 `indices.segments.terms_memory`::
 (<<byte-units, byte units>>)
-Total amount of segment memory used on all shards across all selected nodes.
+Total amount of memory used for terms across all shards assigned to selected
+nodes.
 
 `indices.segments.terms_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of segment memory used on all shards across all
+Total amount, in bytes, of memory used for terms across all shards assigned to
 selected nodes.
 
 `indices.segments.stored_fields_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used for stored fields on all shards across all
+Total amount of memory used for stored fields across all shards assigned to
 selected nodes.
 
 `indices.segments.stored_fields_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used for stored fields on all shards across
-all selected nodes.
+Total amount, in bytes, of memory used for stored fields across all shards
+assigned to selected nodes.
 
 `indices.segments.term_vectors_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used for terms vectors on all shards across
-all selected nodes.
+Total amount of memory used for terms vectors across all shards assigned to
+selected nodes.
 
 `indices.segments.term_vectors_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used for terms vectors on all shards across
-all selected nodes.
+Total amount, in bytes, of memory used for terms vectors across all shards
+assigned to selected nodes.
 
 `indices.segments.norms_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used for normalization factors on all shards across all
-selected nodes.
+Total amount of memory used for normalization factors across all shards assigned
+to selected nodes.
 
 `indices.segments.norms_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used for normalization factors on all shards
-across all selected nodes.
+Total amount, in bytes, of memory used for normalization factors across all
+shards assigned to selected nodes.
 
 `indices.segments.points_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used for points on all shards across all selected nodes.
+Total amount of memory used for points across all shards assigned to selected
+nodes.
 
 `indices.segments.points_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used for points on all shards across all
+Total amount, in bytes, of memory used for points across all shards assigned to
 selected nodes.
 
 `indices.segments.doc_values_memory`::
 (<<byte-units, byte units>>)
-Total amount of doc values used for points on all shards across all selected
-nodes.
+Total amount of memory used for doc values across all shards assigned to
+selected nodes.
 
 `indices.segments.doc_values_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of doc values used for points on all shards across all
-selected nodes.
+Total amount, in bytes, of memory used for doc values across all shards assigned
+to selected nodes.
 
-`indices.segments.index_writer_memory_in_bytes`::
+`indices.segments.index_writer_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used by all index writers on all shards across all
+Total amount of memory used by all index writers across all shards assigned to
 selected nodes.
 
 `indices.segments.index_writer_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used by all index writers on all shards across
-all selected nodes.
+Total amount, in bytes, of memory used by all index writers across all shards
+assigned to selected nodes.
 
 `indices.segments.version_map_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used by all version maps on all shards across all
+Total amount of memory used by all version maps across all shards assigned to
 selected nodes.
 
 `indices.segments.version_map_memory_in_bytes`::
 (integer)
-Total amount, in bytes, of memory used by all version maps on all shards across
-all selected nodes.
+Total amount, in bytes, of memory used by all version maps across all shards
+assigned to selected nodes.
 
 `indices.segments.fixed_bit_set_memory`::
 (<<byte-units, byte units>>)
-Total amount of memory used by fixed bit sets for nested object field types and
-type filters for <<parent-join,join>> fields on all shards across all selected
-nodes.
+Total amount of memory used by fixed bit sets across all shards assigned to
+selected nodes.
++
+Fixed bit sets are used for nested object field types and
+type filters for <<parent-join,join>> fields.
 
 `indices.segments.fixed_bit_set_memory_in_bytes`::
 (integer)
-Total amount of memory, in bytes, used by fixed bit sets  on all shards across
-all selected nodes.
+Total amount of memory, in bytes, used by fixed bit sets across all shards
+assigned to selected nodes.
 
 `indices.segments.max_unsafe_auto_id_timestamp`::
 (integer)
-Timestamp of the most recently retried indexing request.
+https://en.wikipedia.org/wiki/Unix_time[Unix timestamp], in milliseconds, of
+the most recently retried indexing request.
 
 `indices.segments.file_sizes`::
 (object)
 This object is not populated by the cluster stats API.
 +
-To populate this object, use the <<cluster-nodes-stats,node stats API>>.
+To get information on segment files, use the <<cluster-nodes-stats,node stats
+API>>.
 
 
 [[cluster-stats-api-example]]

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -84,25 +84,27 @@ Number of primary shards assigned to the selected nodes.
 
 `indices.shards.replication`::
 (integer)
-Ratio of replica shards to primary shards in the selected nodes.
-
-Number of replica shards.
+Ratio of replica shards to primary shards across the selected nodes.
 
 `indices.shards.index.shards.min`::
 (integer)
-Lowest historic number of shards for the cluster.
+Minimum number of shards in an index, counting only shards assigned to the
+selected nodes.
 
 `indices.shards.index.shards.max`::
 (integer)
-Highest historic number of shards for the cluster.
+Maximum number of shards in an index, counting only shards assigned to the
+selected nodes.
 
 `indices.shards.index.shards.avg`::
 (integer)
-Average number of shards for the cluster.
+Mean number of shards in an index, counting only the shards assigned to the
+selected nodes.
 
 `indices.shards.index.primaries.min`::
 (integer)
-Lowest historic number of primary shards for the cluster.
+Minimum number of primary shards in an index, counting only the shards assigned
+to the selected nodes.
 
 `indices.shards.index.primaries.max`::
 (integer)

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -43,7 +43,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
 
 `_nodes.total`::
 (integer)
-Total number of nodes selected by the request's node filters.
+Total number of nodes selected by the request's <<cluster-nodes,node filters>>.
 
 `_nodes.successful`::
 (integer)
@@ -56,7 +56,7 @@ Number of nodes that rejected or timed out the request. If this value is not
 
 `cluster_name`::
 (string)
-Name of the cluster. See <<cluster.name>>.
+Name of the cluster, based on the <<cluster.name>> setting.
 
 `cluster_uuid`::
 (string)

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -521,6 +521,13 @@ such as `1264`.
 A value of `-1` indicates {es} was unable to compute this number.
 end::memory[]
 
+tag::node-filter[]
+`<node_filter>`::
+(Optional, string)
+Comma-separated list of <<node-filter,node filters>> used to limit returned
+information. Defaults to all nodes in the cluster.
+end::node-filter[]
+
 tag::node-id[]
 `<node_id>`::
 (Optional, string) Comma-separated list of node IDs or names used to limit

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -523,7 +523,7 @@ end::memory[]
 tag::node-filter[]
 `<node_filter>`::
 (Optional, string)
-Comma-separated list of <<node-filter,node filters>> used to limit returned
+Comma-separated list of <<cluster-nodes,node filters>> used to limit returned
 information. Defaults to all nodes in the cluster.
 end::node-filter[]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -105,7 +105,7 @@ Health status of the cluster based on the state of its
 primary and replica shards. Statuses are:
 
   `green`:::
-  All primary shard and replica shards are assigned.
+  All shards are assigned.
 
   `yellow`:::
   All primary shards are assigned, but one or more replica shards are

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -109,8 +109,8 @@ primary and replica shards. Statuses are:
 
   `yellow`:::
   All primary shards are assigned, but one or more replica shards are
-  unassigned. If a node in the cluster fails, some data could be unavailable
-  until that node is repaired.
+  unassigned, so some data is unavailable. If a node in the cluster fails, some
+  data could be unavailable until that node is repaired.
 
   `red`:::
   One or more primary shards are unassigned. This can occur briefly during

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -114,8 +114,7 @@ primary and replica shards. Statuses are:
 
   `red`:::
   One or more primary shards are unassigned. This can occur briefly during
-  cluster startup as primary shards are assigned during cluster startup. At
-  other times, this status may indicate data loss.
+  cluster startup as primary shards are assigned during cluster startup.
 end::cluster-health-status[]
 
 tag::committed[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -99,6 +99,26 @@ tag::bytes[]
 (Optional, <<byte-units,byte size units>>) Unit used to display byte values.
 end::bytes[]
 
+tag::cluster-health-status[]
+(string)
+Health status of the cluster based on the state of its
+primary and replica shards. Statuses are:
+
+  `green`:::
+  All primary shard and replica shards are assigned. There are at least two
+  copies of all shards.
+
+  `yellow`:::
+  All primary shards are assigned, but one or more replica shards are
+  unassigned. If a node in the cluster fails, some data could be unavailable
+  until that node is repaired.
+
+  `red`:::
+  One or more primary shards are unassigned. This can occur briefly during
+  cluster startup as primary shards are assigned during cluster startup. At
+  other times, this status may indicate data loss.
+end::cluster-health-status[]
+
 tag::committed[]
 If `true`,
 the segments is synced to disk. Segments that are synced can survive a hard reboot.

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -105,8 +105,7 @@ Health status of the cluster based on the state of its
 primary and replica shards. Statuses are:
 
   `green`:::
-  All primary shard and replica shards are assigned. There are at least two
-  copies of all shards.
+  All primary shard and replica shards are assigned.
 
   `yellow`:::
   All primary shards are assigned, but one or more replica shards are

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -101,8 +101,8 @@ end::bytes[]
 
 tag::cluster-health-status[]
 (string)
-Health status of the cluster based on the state of its
-primary and replica shards. Statuses are:
+Health status of the cluster, based on the state of its primary and replica
+shards. Statuses are:
 
   `green`:::
   All shards are assigned.

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -114,8 +114,7 @@ primary and replica shards. Statuses are:
 
   `red`:::
   One or more primary shards are unassigned, so some data is unavailable. This
-  can occur briefly during cluster startup as primary shards are assigned during
-  cluster startup.
+  can occur briefly during cluster startup as primary shards are assigned.
 end::cluster-health-status[]
 
 tag::committed[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -109,12 +109,13 @@ primary and replica shards. Statuses are:
 
   `yellow`:::
   All primary shards are assigned, but one or more replica shards are
-  unassigned, so some data is unavailable. If a node in the cluster fails, some
+  unassigned. If a node in the cluster fails, some
   data could be unavailable until that node is repaired.
 
   `red`:::
-  One or more primary shards are unassigned. This can occur briefly during
-  cluster startup as primary shards are assigned during cluster startup.
+  One or more primary shards are unassigned, so some data is unavailable. This
+  can occur briefly during cluster startup as primary shards are assigned during
+  cluster startup.
 end::cluster-health-status[]
 
 tag::committed[]


### PR DESCRIPTION
Documents the header and `indices` response parameters returned by the `_cluster/stats` API.

The remaining `nodes` parameters will be documented in a forthcoming PR.