### PR TITLE
Realms type as part of the setting name

### DIFF
--- a/x-pack/docs/en/security/authentication/realm-chains.asciidoc
+++ b/x-pack/docs/en/security/authentication/realm-chains.asciidoc
@@ -38,30 +38,31 @@ xpack.security.authc:
   realms:
 
     file:
-      type: file
-      order: 0
+      file1:
+        order: 0
 
     native:
-      type: native
-      order: 1
+      native1:
+        order: 1
 
-    ldap1:
-      type: ldap
-      order: 2
-      enabled: false
-      url: 'url_to_ldap1'
-      ...
+    ldap:
+      ldap1:
+        order: 2
+        enabled: false
+        url: 'url_to_ldap1'
+        ...
 
-    ldap2:
-      type: ldap
-      order: 3
-      url: 'url_to_ldap2'
-      ...
+      ldap2:
+        type: ldap
+        order: 3
+        url: 'url_to_ldap2'
+        ...
 
-    ad1:
-      type: active_directory
-      order: 4
-      url: 'url_to_ad'
+    active_directory:
+      ad1:
+        type: active_directory
+        order: 4
+        url: 'url_to_ad'
 ----------------------------------------
 
 As can be seen above, each realm has a unique name that identifies it. Each type


### PR DESCRIPTION
On version 7.X, realms must [include the realm type](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/breaking-changes-7.0.html#include-realm-type-in-setting) as part of the setting name.

Preview: http://elasticsearch_50552.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.5/realm-chains.html