### PR TITLE
Remove included docs

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -290,7 +290,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
 from the local cluster state. Defaults to `false`, which means the list of
 selected nodes is computed from the cluster state on the master node. In either
 case the coordinating node sends a request for further information to each
-selected node. deprecated::[7.6,This parameter does not cause this API to act
+selected node. deprecated:[7.6,This parameter does not cause this API to act
 locally. It will be removed in version 8.0.]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -290,7 +290,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
 from the local cluster state. Defaults to `false`, which means the list of
 selected nodes is computed from the cluster state on the master node. In either
 case the coordinating node sends a request for further information to each
-selected node. deprecated:[7.6,This parameter does not cause this API to act
+selected node. deprecated:[7.6.0,This parameter does not cause this API to act
 locally. It will be removed in version 8.0.]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -286,12 +286,13 @@ Number of suggest operations, such as `0`.
 include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
 
 `local`::
-(Optional, boolean) If `true`, the request computes the list of selected nodes
-from the local cluster state. Defaults to `false`, which means the list of
-selected nodes is computed from the cluster state on the master node. In either
-case the coordinating node sends a request for further information to each
-selected node. deprecated:[7.6.0,This parameter does not cause this API to act
-locally. It will be removed in version 8.0.]
+(Optional, boolean) 
+deprecated:[7.6.0,This parameter does not cause this API to act locally. It will be removed in version 8.0.]
+If `true`, the request computes the list of selected nodes from the local
+cluster state. Defaults to `false`, which means the list of selected nodes is
+computed from the cluster state on the master node. In either case the
+coordinating node sends a request for further information to each selected
+node.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -285,9 +285,6 @@ Number of suggest operations, such as `0`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
-+
---
 `local`::
 (Optional, boolean) If `true`, the request computes the list of selected nodes
 from the local cluster state. Defaults to `false`, which means the list of
@@ -295,7 +292,6 @@ selected nodes is computed from the cluster state on the master node. In either
 case the coordinating node sends a request for further information to each
 selected node. deprecated::[7.6,This parameter does not cause this API to act
 locally. It will be removed in version 8.0.]
---
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 


### PR DESCRIPTION
In #50499 we accidentally duplicated the docs for the `?local` parameter to the
`GET _cat/nodes` API. This commit removes the duplicate docs.