### PR TITLE
[DOCS] Adds missing timing_stats descriptions

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -96,9 +96,12 @@ re-started.
 `timing_stats`::
 (object) An object that provides statistical information about timing aspect of
 this {dfeed}.
-//average_search_time_per_bucket_ms
-//bucket_count
-//exponential_average_search_time_per_hour_ms
+`timing_stats`.`average_search_time_per_bucket_ms`:::
+(double) Average of the {dfeed} search times in milliseconds.
+`timing_stats`.`bucket_count`:::
+(long) The number of buckets processed. 
+`timing_stats`.`exponential_average_search_time_per_hour_ms`:::
+(double) Exponential moving average of the {dfeed} search times in milliseconds.
 `timing_stats`.`job_id`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 `timing_stats`.`search_count`::: Number of searches performed by this {dfeed}.


### PR DESCRIPTION
This PR adds definitions for the following properties, which were missing from the get datafeed statistics API:
* bucket_count
* average_search_time_per_bucket_ms
* exponential_average_search_time_per_hour_ms

The descriptions are derived from similar properties in https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html

Preview: http://elasticsearch_50574.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html