### PR TITLE
[7.x] Synchronize processInStream.close() call

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -183,7 +183,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             "Finished analysis");
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/49680")
     public void testStopAndRestart() throws Exception {
         initialize("regression_stop_and_restart");
         indexData(sourceIndex, 350, 0);


### PR DESCRIPTION
Due to https://bugs.openjdk.java.net/browse/JDK-8054565 the `FilterOutputStream` cannot be closed twice in Java 8.
This PR is a workaround for this issue. It needs to be merged only to 7.x branch as in master we use Java 9 which contains the proper fix.
It also unmutes `testStopAndRestart` test case that was suffering from the underlying issue.

Relates https://github.com/elastic/elasticsearch/issues/49680