### PR TITLE
[DOCS] Specifies the possible data types of classification dependent_variable

### DIFF
--- a/docs/reference/ml/df-analytics/apis/analysisobjects.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/analysisobjects.asciidoc
@@ -145,8 +145,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
 include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 --
-The data type of the field must be numeric (`integer`, `short`, `byte`) or 
-boolean.
+The data type of the field must be numeric (`integer`, `short`, `long`, `byte`), 
+categorical (`ip`, `keyword`, `text`), or boolean.
 --
   
 `num_top_classes`::

--- a/docs/reference/ml/df-analytics/apis/analysisobjects.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/analysisobjects.asciidoc
@@ -145,7 +145,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
 include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 --
-The data type of the field must be numeric or boolean.
+The data type of the field must be numeric (`integer`, `short`, `byte`) or 
+boolean.
 --
   
 `num_top_classes`::


### PR DESCRIPTION
This PR explicitly names the supported numeric data types of the `dependent_variable` in the case of classification analysis.