### PR TITLE
[7.5][DOCS] Specifies the possible data types of classification dependent_variable

### DIFF
--- a/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/dfanalyticsresources.asciidoc
@@ -225,7 +225,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
 include::{docdir}/ml/ml-shared.asciidoc[tag=dependent_variable]
 +
 --
-The data type of the field must be numeric or boolean.
+The data type of the field must be numeric (`integer`, `short`, `long`, `byte`), 
+categorical (`ip`, `keyword`, `text`), or boolean.
 --
   
 `num_top_classes`::


### PR DESCRIPTION
This PR backports the following commit to 7.5:
[DOCS] Specifies the possible data types of classification dependent_variable #50582