### PR TITLE
[DOCS] Fix missing start quote

### DIFF
--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -281,7 +281,7 @@ as described in <<random-score-function, random score function>>.
 --------------------------------------------------
 "script" : {
     "source" : "Math.log10(doc['field'].value * params.factor)",
-    params" : {
+    "params" : {
         "factor" : 5
     }
 }
@@ -297,7 +297,7 @@ a value `1` if a document doesn't have a field `field`:
 --------------------------------------------------
 "script" : {
     "source" : "Math.log10((doc['field'].size() == 0 ? 1 : doc['field'].value()) * params.factor)",
-    params" : {
+    "params" : {
         "factor" : 5
     }
 }


### PR DESCRIPTION
On [this page](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-score-query.html#field-value-factor) I noticed that `params"` was missing a start quote:

<img width="770" alt="Screenshot 2020-01-03 at 11 21 04" src="https://user-images.githubusercontent.com/809707/71718360-45e74300-2e1b-11ea-8266-9ff711d31e61.png">
