### PR TITLE
[DOCS] Fine-tunes training_percent definition

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1064,8 +1064,8 @@ end::tokenizer[]
 tag::training-percent[]
 Defines what percentage of the eligible documents that will 
 be used for training. Documents that are ignored by the analysis (for example 
-those that contain arrays) won’t be included in the calculation for used 
-percentage. Defaults to `100`.
+those that contain arrays with more than one value) won’t be included in the 
+calculation for used percentage. Defaults to `100`.
 end::training-percent[]
 
 tag::use-null[]


### PR DESCRIPTION
This PR makes the definition of `training_percent` more exact.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-570507304