### PR TITLE
Make EC2 Discovery Cache Empty Seed Hosts List

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2SeedHostsProvider.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2SeedHostsProvider.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.discovery.ec2.AwsEc2Service.HostType.PUBLIC_IP;
 import static org.elasticsearch.discovery.ec2.AwsEc2Service.HostType.TAG_PREFIX;
 
 class AwsEc2SeedHostsProvider implements SeedHostsProvider {
-    
+
     private static final Logger logger = LogManager.getLogger(AwsEc2SeedHostsProvider.class);
 
     private final TransportService transportService;
@@ -221,22 +221,13 @@ class AwsEc2SeedHostsProvider implements SeedHostsProvider {
 
     private final class TransportAddressesCache extends SingleObjectCache<List<TransportAddress>> {
 
-        private boolean empty = true;
-
         protected TransportAddressesCache(TimeValue refreshInterval) {
             super(refreshInterval,  new ArrayList<>());
         }
 
         @Override
-        protected boolean needsRefresh() {
-            return (empty || super.needsRefresh());
-        }
-
-        @Override
         protected List<TransportAddress> refresh() {
-            final List<TransportAddress> nodes = fetchDynamicNodes();
-            empty = nodes.isEmpty();
-            return nodes;
+            return fetchDynamicNodes();
         }
     }
 }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryTests.java
@@ -306,10 +306,10 @@ public class Ec2DiscoveryTests extends ESTestCase {
                 return new ArrayList<>();
             }
         };
-        for (int i=0; i<3; i++) {
+        for (int i = 0; i < 3; i++) {
             provider.getSeedAddresses(null);
         }
-        assertThat(provider.fetchCount, is(3));
+        assertThat(provider.fetchCount, is(1));
     }
 
     public void testGetNodeListCached() throws Exception {


### PR DESCRIPTION
Follow up to #50550. Cache empty nodes lists (`fetchDynamicNodes` will return an empty list in case of failure) now that the plugin properly retries requests to AWS EC2 APIs.

Note: I'd suggest adding tests for the exception handling once https://github.com/elastic/elasticsearch/pull/50605 is in and we can add them cleanly by using a mocked REST APi instead of adding more actual mocking of AWS SDK classes for this.