### PR TITLE
Guard against null geoBoundingBox (#50506)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedGeoBounds.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -30,14 +31,17 @@ import org.elasticsearch.search.aggregations.ParsedAggregation;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.geo.GeoBoundingBox.BOTTOM_RIGHT_FIELD;
 import static org.elasticsearch.common.geo.GeoBoundingBox.BOUNDS_FIELD;
 import static org.elasticsearch.common.geo.GeoBoundingBox.LAT_FIELD;
 import static org.elasticsearch.common.geo.GeoBoundingBox.LON_FIELD;
 import static org.elasticsearch.common.geo.GeoBoundingBox.TOP_LEFT_FIELD;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 
 public class ParsedGeoBounds extends ParsedAggregation implements GeoBounds {
+
+    // A top of Double.NEGATIVE_INFINITY yields an empty xContent, so the bounding box is null
+    @Nullable
     private GeoBoundingBox geoBoundingBox;
 
     @Override
@@ -54,13 +58,15 @@ public class ParsedGeoBounds extends ParsedAggregation implements GeoBounds {
     }
 
     @Override
+    @Nullable
     public GeoPoint topLeft() {
-        return geoBoundingBox.topLeft();
+        return geoBoundingBox != null ? geoBoundingBox.topLeft() : null;
     }
 
     @Override
+    @Nullable
     public GeoPoint bottomRight() {
-        return geoBoundingBox.bottomRight();
+        return geoBoundingBox != null ? geoBoundingBox.bottomRight() : null;
     }
 
     private static final ObjectParser<ParsedGeoBounds, Void> PARSER = new ObjectParser<>(ParsedGeoBounds.class.getSimpleName(), true,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.metrics.InternalGeoBounds;
-import org.elasticsearch.search.aggregations.metrics.ParsedGeoBounds;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 


### PR DESCRIPTION
A geo box with a top value of Double.NEGATIVE_INFINITY will yield an empty
xContent which translates to a null `geoBoundingBox`. This commit marks the
field as `Nullable` and guards against null when retrieving the `topLeft`
and `bottomRight` fields.

Fixes https://github.com/elastic/elasticsearch/issues/50505

(cherry picked from commit 051718f9b1e1ca957229b01e80d7b79d7e727e14)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of https://github.com/elastic/elasticsearch/pull/50506