### PR TITLE
Correct condition for v7.5

### DIFF
--- a/x-pack/docs/en/watcher/condition/compare.asciidoc
+++ b/x-pack/docs/en/watcher/condition/compare.asciidoc
@@ -44,7 +44,7 @@ condition returns `true` if the number of the total hits in the
 {
   "condition" : {
     "compare" : {
-      "ctx.payload.hits.total.value" : { <1>
+      "ctx.payload.hits.total" : { <1>
         "gte" : 5 <2>
       }
     }


### PR DESCRIPTION
If I am not mistaken, then this change should be correctly reflecting how to compare the number of hits in 7.5.

Note: This is because Watcher defaults to `"rest_total_hits_as_int" : true` in 7.5.