### PR TITLE
Correctly retrieve number of hits in 7.5

### DIFF
--- a/x-pack/docs/en/watcher/actions/email.asciidoc
+++ b/x-pack/docs/en/watcher/actions/email.asciidoc
@@ -31,7 +31,7 @@ the watch payload in the email body:
     "email" : { <2>
       "to" : "username@example.org", <3>
       "subject" : "Watcher Notification", <4>
-      "body" : "{{ctx.payload.hits.total.value}} error logs found" <5>
+      "body" : "{{ctx.payload.hits.total}} error logs found" <5>
     }
   }
 }


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/50611

Note: This is because Watcher defaults to `"rest_total_hits_as_int" : true` in 7.5.