### PR TITLE
[DOCS] Correctly read total hits inside watcher config

### DIFF
--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -69,14 +69,14 @@ PUT _watcher/watch/error_logs_alert
     }
   },
   "condition" : {
-    "compare" : { "ctx.payload.hits.total.value" : { "gt" : 5 }}
+    "compare" : { "ctx.payload.hits.total" : { "gt" : 5 }}
   },
   "actions" : {
     "email_administrator" : {
       "throttle_period": "15m", <1>
       "email" : { <2>
         "to" : "sys.admino@host.domain",
-        "subject" : "Encountered {{ctx.payload.hits.total.value}} errors",
+        "subject" : "Encountered {{ctx.payload.hits.total}} errors",
         "body" : "Too many error in the system, see attached data",
         "attachments" : {
           "attached_data" : {
@@ -119,14 +119,14 @@ PUT _watcher/watch/log_event_watch
     }
   },
   "condition" : {
-    "compare" : { "ctx.payload.hits.total.value" : { "gt" : 5 }}
+    "compare" : { "ctx.payload.hits.total" : { "gt" : 5 }}
   },
   "throttle_period" : "15m", <1>
   "actions" : {
     "email_administrator" : {
       "email" : {
         "to" : "sys.admino@host.domain",
-        "subject" : "Encountered {{ctx.payload.hits.total.value}} errors",
+        "subject" : "Encountered {{ctx.payload.hits.total}} errors",
         "body" : "Too many error in the system, see attached data",
         "attachments" : {
           "attached_data" : {
@@ -144,7 +144,7 @@ PUT _watcher/watch/log_event_watch
         "host" : "pager.service.domain",
         "port" : 1234,
         "path" : "/{{watch_id}}",
-        "body" : "Encountered {{ctx.payload.hits.total.value}} errors"
+        "body" : "Encountered {{ctx.payload.hits.total}} errors"
       }
     }
   }
@@ -265,13 +265,13 @@ PUT _watcher/watch/log_event_watch
     }
   },
   "condition" : {
-    "compare" : { "ctx.payload.hits.total.value" : { "gt" : 0 } }
+    "compare" : { "ctx.payload.hits.total" : { "gt" : 0 } }
   },
   "actions" : {
     "email_administrator" : {
       "email" : {
         "to" : "sys.admino@host.domain",
-        "subject" : "Encountered {{ctx.payload.hits.total.value}} errors",
+        "subject" : "Encountered {{ctx.payload.hits.total}} errors",
         "body" : "Too many error in the system, see attached data",
         "attachments" : {
           "attached_data" : {
@@ -285,14 +285,14 @@ PUT _watcher/watch/log_event_watch
     },
     "notify_pager" : {
       "condition": { <1>
-        "compare" : { "ctx.payload.hits.total.value" : { "gt" : 5 } }
+        "compare" : { "ctx.payload.hits.total" : { "gt" : 5 } }
       },
       "webhook" : {
         "method" : "POST",
         "host" : "pager.service.domain",
         "port" : 1234,
         "path" : "/{{watch_id}}",
-        "body" : "Encountered {{ctx.payload.hits.total.value}} errors"
+        "body" : "Encountered {{ctx.payload.hits.total}} errors"
       }
     }
   }


### PR DESCRIPTION
Also see https://github.com/elastic/elasticsearch/pull/50611
This might need to be changed in other places as well.

Note: This is because Watcher defaults to `"rest_total_hits_as_int" : true` in 7.5.