### PR TITLE
Declare remaining parsers `final` (backport of #50571)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SyncedFlushResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SyncedFlushResponse.java
@@ -282,7 +282,7 @@ public class SyncedFlushResponse implements ToXContentObject {
         private Map<String, Object> routing;
 
         @SuppressWarnings("unchecked")
-        static ConstructingObjectParser<ShardFailure, Void> PARSER = new ConstructingObjectParser<>(
+        static final ConstructingObjectParser<ShardFailure, Void> PARSER = new ConstructingObjectParser<>(
             "shardfailure",
             a -> new ShardFailure((Integer)a[0], (String)a[1], (Map<String, Object>)a[2])
         );

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
@@ -99,8 +99,7 @@ public class MainResponse {
     }
 
     public static class Version {
-        @SuppressWarnings("unchecked")
-        private static ConstructingObjectParser<Version, Void> PARSER =
+        private static final ConstructingObjectParser<Version, Void> PARSER =
             new ConstructingObjectParser<>(Version.class.getName(), true,
                 args -> {
                     return new Version((String) args[0], (String) args[1], (String) args[2], (String) args[3], (String) args[4],

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MultiTermVectorsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MultiTermVectorsResponse.java
@@ -36,7 +36,7 @@ public class MultiTermVectorsResponse {
         this.responses = responses;
     }
 
-    private static ConstructingObjectParser<MultiTermVectorsResponse, Void> PARSER =
+    private static final ConstructingObjectParser<MultiTermVectorsResponse, Void> PARSER =
         new ConstructingObjectParser<>("multi_term_vectors", true,
         args -> {
             // as the response comes from server, we are sure that args[0] will be a list of TermVectorsResponse

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsResponse.java
@@ -51,7 +51,7 @@ public class TermVectorsResponse {
         this.termVectorList = termVectorList;
     }
 
-    private static ConstructingObjectParser<TermVectorsResponse, Void> PARSER = new ConstructingObjectParser<>("term_vectors", true,
+    private static final ConstructingObjectParser<TermVectorsResponse, Void> PARSER = new ConstructingObjectParser<>("term_vectors", true,
         args -> {
             // as the response comes from server, we are sure that args[6] will be a list of TermVector
             @SuppressWarnings("unchecked") List<TermVector> termVectorList = (List<TermVector>) args[6];
@@ -161,7 +161,7 @@ public class TermVectorsResponse {
 
     public static final class TermVector {
 
-        private static ConstructingObjectParser<TermVector, String> PARSER = new ConstructingObjectParser<>("term_vector", true,
+        private static final ConstructingObjectParser<TermVector, String> PARSER = new ConstructingObjectParser<>("term_vector", true,
             (args, ctxFieldName)  -> {
                 // as the response comes from server, we are sure that args[1] will be a list of Term
                 @SuppressWarnings("unchecked") List<Term> terms = (List<Term>) args[1];
@@ -234,7 +234,7 @@ public class TermVectorsResponse {
         // Class containing a general field statistics for the field
         public static final class FieldStatistics {
 
-            private static ConstructingObjectParser<FieldStatistics, Void> PARSER = new ConstructingObjectParser<>(
+            private static final ConstructingObjectParser<FieldStatistics, Void> PARSER = new ConstructingObjectParser<>(
                 "field_statistics", true,
                 args  -> {
                     return new FieldStatistics((long) args[0], (int) args[1], (long) args[2]);
@@ -298,7 +298,7 @@ public class TermVectorsResponse {
 
 
         public static final class Term {
-            private static ConstructingObjectParser<Term, String> PARSER = new ConstructingObjectParser<>("token", true,
+            private static final ConstructingObjectParser<Term, String> PARSER = new ConstructingObjectParser<>("token", true,
                 (args, ctxTerm)  -> {
                     // as the response comes from server, we are sure that args[4] will be a list of Token
                     @SuppressWarnings("unchecked") List<Token> tokens = (List<Token>) args[4];
@@ -409,7 +409,7 @@ public class TermVectorsResponse {
 
         public static final class Token {
 
-            private static ConstructingObjectParser<Token, Void> PARSER = new ConstructingObjectParser<>("token", true,
+            private static final ConstructingObjectParser<Token, Void> PARSER = new ConstructingObjectParser<>("token", true,
                 args  -> {
                     return new Token((Integer) args[0], (Integer) args[1], (Integer) args[2], (String) args[3]);
                 });

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedRequest.java
@@ -39,7 +39,7 @@ public class StartDatafeedRequest extends ActionRequest implements ToXContentObj
     public static final ParseField END = new ParseField("end");
     public static final ParseField TIMEOUT = new ParseField("timeout");
 
-    public static ConstructingObjectParser<StartDatafeedRequest, Void> PARSER =
+    public static final ConstructingObjectParser<StartDatafeedRequest, Void> PARSER =
         new ConstructingObjectParser<>("start_datafeed_request", a -> new StartDatafeedRequest((String)a[0]));
 
     static {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -58,7 +58,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject {
     private static final ParseField VERSION = new ParseField("version");
     private static final ParseField ALLOW_LAZY_START = new ParseField("allow_lazy_start");
 
-    private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>("data_frame_analytics_config", true, Builder::new);
+    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("data_frame_analytics_config", true, Builder::new);
 
     static {
         PARSER.declareString(Builder::setId, ID);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsDest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsDest.java
@@ -45,7 +45,7 @@ public class DataFrameAnalyticsDest implements ToXContentObject {
     private static final ParseField INDEX = new ParseField("index");
     private static final ParseField RESULTS_FIELD = new ParseField("results_field");
 
-    private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>("data_frame_analytics_dest", true, Builder::new);
+    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("data_frame_analytics_dest", true, Builder::new);
 
     static {
         PARSER.declareString(Builder::setIndex, INDEX);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsSource.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/DataFrameAnalyticsSource.java
@@ -47,7 +47,7 @@ public class DataFrameAnalyticsSource implements ToXContentObject {
     private static final ParseField QUERY = new ParseField("query");
     public static final ParseField _SOURCE = new ParseField("_source");
 
-    private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>("data_frame_analytics_source", true, Builder::new);
+    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("data_frame_analytics_source", true, Builder::new);
 
     static {
         PARSER.declareStringArray(Builder::setIndex, INDEX);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/OutlierDetection.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/OutlierDetection.java
@@ -51,7 +51,7 @@ public class OutlierDetection implements DataFrameAnalysis {
     static final ParseField OUTLIER_FRACTION = new ParseField("outlier_fraction");
     static final ParseField STANDARDIZATION_ENABLED = new ParseField("standardization_enabled");
 
-    private static ObjectParser<Builder, Void> PARSER = new ObjectParser<>(NAME.getPreferredName(), true, Builder::new);
+    private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>(NAME.getPreferredName(), true, Builder::new);
 
     static {
         PARSER.declareInt(Builder::setNNeighbors, N_NEIGHBORS);

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/AckWatchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/AckWatchResponse.java
@@ -45,7 +45,7 @@ public class AckWatchResponse {
     }
 
     private static final ParseField STATUS_FIELD = new ParseField("status");
-    private static ConstructingObjectParser<AckWatchResponse, Void> PARSER =
+    private static final ConstructingObjectParser<AckWatchResponse, Void> PARSER =
         new ConstructingObjectParser<>("ack_watch_response", true,
             a -> new AckWatchResponse((WatchStatus) a[0]));
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/ActivateWatchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/ActivateWatchResponse.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public final class ActivateWatchResponse {
 
     private static final ParseField STATUS_FIELD = new ParseField("status");
-    private static ConstructingObjectParser<ActivateWatchResponse, Void> PARSER =
+    private static final ConstructingObjectParser<ActivateWatchResponse, Void> PARSER =
         new ConstructingObjectParser<>("activate_watch_response", true,
             a -> new ActivateWatchResponse((WatchStatus) a[0]));
 

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/GetWatchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/GetWatchResponse.java
@@ -132,7 +132,7 @@ public class GetWatchResponse {
     private static final ParseField STATUS_FIELD = new ParseField("status");
     private static final ParseField WATCH_FIELD = new ParseField("watch");
 
-    private static ConstructingObjectParser<GetWatchResponse, Void> PARSER =
+    private static final ConstructingObjectParser<GetWatchResponse, Void> PARSER =
         new ConstructingObjectParser<>("get_watch_response", true,
             a -> {
                 boolean isFound = (boolean) a[1];

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/WatcherStatsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/watcher/WatcherStatsResponse.java
@@ -82,7 +82,7 @@ public class WatcherStatsResponse {
     }
 
     @SuppressWarnings("unchecked")
-    private static ConstructingObjectParser<WatcherStatsResponse, Void> PARSER =
+    private static final ConstructingObjectParser<WatcherStatsResponse, Void> PARSER =
         new ConstructingObjectParser<>("watcher_stats_response", true,
             a -> new WatcherStatsResponse((NodesResponseHeader) a[0], (String) a[1], new WatcherMetaData((boolean) a[2]),
                 (List<Node>) a[3]));

--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -125,7 +125,7 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
      * small number of tokens.
      */
     private static class CompareAnalyzers implements ExecutableSection {
-        private static ConstructingObjectParser<CompareAnalyzers, XContentLocation> PARSER =
+        private static final ConstructingObjectParser<CompareAnalyzers, XContentLocation> PARSER =
             new ConstructingObjectParser<>("test_analyzer", false, (a, location) -> {
                 String index = (String) a[0];
                 String first = (String) a[1];

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/ParsedMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/ParsedMatrixStats.java
@@ -187,7 +187,7 @@ public class ParsedMatrixStats extends ParsedAggregation implements MatrixStats 
         Map<String, Double> covariances;
         Map<String, Double> correlations;
 
-        private static ObjectParser<ParsedMatrixStatsResult, Void> RESULT_PARSER =
+        private static final ObjectParser<ParsedMatrixStatsResult, Void> RESULT_PARSER =
                 new ObjectParser<>(ParsedMatrixStatsResult.class.getSimpleName(), true, ParsedMatrixStatsResult::new);
         static {
             RESULT_PARSER.declareString((result, name) -> result.name = name,

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/query/RankFeatureQueryBuilder.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/query/RankFeatureQueryBuilder.java
@@ -260,7 +260,7 @@ public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeat
         }
     }
 
-    public static ConstructingObjectParser<RankFeatureQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(
+    public static final ConstructingObjectParser<RankFeatureQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(
             "feature", args -> {
                 final String field = (String) args[0];
                 final float boost = args[1] == null ? DEFAULT_BOOST : (Float) args[1];

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainRequest.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class ClusterAllocationExplainRequest extends MasterNodeRequest<ClusterAllocationExplainRequest> {
 
-    private static ObjectParser<ClusterAllocationExplainRequest, Void> PARSER = new ObjectParser<>("cluster/allocation/explain");
+    private static final ObjectParser<ClusterAllocationExplainRequest, Void> PARSER = new ObjectParser<>("cluster/allocation/explain");
     static {
         PARSER.declareString(ClusterAllocationExplainRequest::setIndex, new ParseField("index"));
         PARSER.declareInt(ClusterAllocationExplainRequest::setShard, new ParseField("shard"));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverInfo.java
@@ -44,7 +44,7 @@ public class RolloverInfo extends AbstractDiffable<RolloverInfo> implements Writ
     public static final ParseField TIME_FIELD = new ParseField("time");
 
     @SuppressWarnings("unchecked")
-    public static ConstructingObjectParser<RolloverInfo, String> PARSER = new ConstructingObjectParser<>("rollover_info", false,
+    public static final ConstructingObjectParser<RolloverInfo, String> PARSER = new ConstructingObjectParser<>("rollover_info", false,
         (a, alias) -> new RolloverInfo(alias, (List<Condition<?>>) a[0], (Long) a[1]));
     static {
         PARSER.declareNamedObjects(ConstructingObjectParser.constructorArg(),

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java
@@ -45,7 +45,7 @@ public class QueryExplanation implements Writeable, ToXContentFragment {
 
     public static final int RANDOM_SHARD = -1;
 
-    static ConstructingObjectParser<QueryExplanation, Void> PARSER = new ConstructingObjectParser<>(
+    static final ConstructingObjectParser<QueryExplanation, Void> PARSER = new ConstructingObjectParser<>(
         "query_explanation",
         true,
         a -> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
@@ -48,7 +48,7 @@ public class ValidateQueryResponse extends BroadcastResponse {
     public static final String EXPLANATIONS_FIELD = "explanations";
 
     @SuppressWarnings("unchecked")
-    static ConstructingObjectParser<ValidateQueryResponse, Void> PARSER = new ConstructingObjectParser<>(
+    static final ConstructingObjectParser<ValidateQueryResponse, Void> PARSER = new ConstructingObjectParser<>(
         "validate_query",
         true,
         arg -> {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -179,7 +179,7 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
         private final long term;
         private final boolean aborted;
 
-        public static ConstructingObjectParser<Failure, Void> PARSER =
+        public static final ConstructingObjectParser<Failure, Void> PARSER =
             new ConstructingObjectParser<>(
                 "bulk_failures",
                 true,

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -141,7 +141,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
     }
 
     @SuppressWarnings("unchecked")
-    private static ConstructingObjectParser<FieldCapabilities, String> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<FieldCapabilities, String> PARSER = new ConstructingObjectParser<>(
         "field_capabilities",
         true,
         (a, name) -> new FieldCapabilities(name,

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -49,7 +49,7 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
     // pkg private API mainly for cross cluster search to signal that we do multiple reductions ie. the results should not be merged
     private boolean mergeResults = true;
 
-    private static ObjectParser<FieldCapabilitiesRequest, Void> PARSER =
+    private static final ObjectParser<FieldCapabilitiesRequest, Void> PARSER =
         new ObjectParser<>(NAME, FieldCapabilitiesRequest::new);
 
     static {

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoJson.java
@@ -206,7 +206,7 @@ public final class GeoJson {
         return builder.endObject();
     }
 
-    private static ConstructingObjectParser<Geometry, GeoJson> PARSER =
+    private static final ConstructingObjectParser<Geometry, GeoJson> PARSER =
         new ConstructingObjectParser<>("geojson", true, (a, c) -> {
             String type = (String) a[0];
             CoordinateNode coordinates = (CoordinateNode) a[1];

--- a/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -143,8 +143,7 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
         builder.endObject();
     }
 
-    private static ObjectParser<IdsQueryBuilder, Void> PARSER = new ObjectParser<>(NAME,
-            () -> new IdsQueryBuilder());
+    private static final ObjectParser<IdsQueryBuilder, Void> PARSER = new ObjectParser<>(NAME, IdsQueryBuilder::new);
 
     static {
         PARSER.declareStringArray(fromList(String.class, IdsQueryBuilder::types), IdsQueryBuilder.TYPE_FIELD);

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/ScriptScoreQueryBuilder.java
@@ -53,7 +53,7 @@ public class ScriptScoreQueryBuilder extends AbstractQueryBuilder<ScriptScoreQue
     public static final ParseField SCRIPT_FIELD = new ParseField("script");
     public static final ParseField MIN_SCORE_FIELD = new ParseField("min_score");
 
-    private static ConstructingObjectParser<ScriptScoreQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME, false,
+    private static final ConstructingObjectParser<ScriptScoreQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME, false,
         args -> {
             ScriptScoreQueryBuilder ssQueryBuilder = new ScriptScoreQueryBuilder((QueryBuilder) args[0], (Script) args[1]);
             if (args[2] != null) ssQueryBuilder.setMinScore((Float) args[2]);

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -383,7 +383,7 @@ public class BulkByScrollTask extends CancellableTask {
         }
 
         @SuppressWarnings("unchecked")
-        static ConstructingObjectParser<Tuple<Long, Long>, Void> RETRIES_PARSER = new ConstructingObjectParser<>(
+        static final ConstructingObjectParser<Tuple<Long, Long>, Void> RETRIES_PARSER = new ConstructingObjectParser<>(
             "bulk_by_scroll_task_status_retries",
             true,
             a -> new Tuple(a[0], a[1])

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
@@ -145,7 +145,7 @@ public final class RetentionLease implements ToXContentObject, Writeable {
     private static final ParseField TIMESTAMP_FIELD = new ParseField("timestamp");
     private static final ParseField SOURCE_FIELD = new ParseField("source");
 
-    private static ConstructingObjectParser<RetentionLease, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<RetentionLease, Void> PARSER = new ConstructingObjectParser<>(
             "retention_leases",
             (a) -> new RetentionLease((String) a[0], (Long) a[1], (Long) a[2], (String) a[3]));
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeases.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeases.java
@@ -182,7 +182,7 @@ public class RetentionLeases implements ToXContentFragment, Writeable {
     private static final ParseField LEASES_FIELD = new ParseField("leases");
 
     @SuppressWarnings("unchecked")
-    private static ConstructingObjectParser<RetentionLeases, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<RetentionLeases, Void> PARSER = new ConstructingObjectParser<>(
             "retention_leases",
             (a) -> new RetentionLeases((Long) a[0], (Long) a[1], (Collection<RetentionLease>) a[2]));
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptContextInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContextInfo.java
@@ -135,7 +135,7 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
     }
 
     @SuppressWarnings("unchecked")
-    public static ConstructingObjectParser<ScriptContextInfo,Void> PARSER =
+    public static final ConstructingObjectParser<ScriptContextInfo,Void> PARSER =
         new ConstructingObjectParser<>("script_context_info", true,
             (m, name) -> new ScriptContextInfo((String) m[0], (List<ScriptMethodInfo>) m[1])
         );
@@ -210,7 +210,7 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
         }
 
         @SuppressWarnings("unchecked")
-        private static ConstructingObjectParser<ScriptMethodInfo,Void> PARSER =
+        private static final ConstructingObjectParser<ScriptMethodInfo,Void> PARSER =
             new ConstructingObjectParser<>("method", true,
                 (m, name) -> new ScriptMethodInfo((String) m[0], (String) m[1], (List<ParameterInfo>) m[2])
             );
@@ -271,7 +271,7 @@ public class ScriptContextInfo implements ToXContentObject, Writeable {
                 out.writeString(name);
             }
 
-            private static ConstructingObjectParser<ParameterInfo,Void> PARSER =
+            private static final ConstructingObjectParser<ParameterInfo, Void> PARSER =
                 new ConstructingObjectParser<>("parameters", true,
                     (p) -> new ParameterInfo((String)p[0], (String)p[1])
             );

--- a/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
@@ -98,7 +98,7 @@ public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
     }
 
     @SuppressWarnings("unchecked")
-    public static ConstructingObjectParser<ScriptLanguagesInfo,Void> PARSER =
+    public static final ConstructingObjectParser<ScriptLanguagesInfo,Void> PARSER =
         new ConstructingObjectParser<>("script_languages_info", true,
             (a) -> new ScriptLanguagesInfo(
                 new HashSet<>((List<String>)a[0]),
@@ -107,7 +107,7 @@ public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
         );
 
     @SuppressWarnings("unchecked")
-    private static ConstructingObjectParser<Tuple<String,Set<String>>,Void> LANGUAGE_CONTEXT_PARSER =
+    private static final ConstructingObjectParser<Tuple<String,Set<String>>,Void> LANGUAGE_CONTEXT_PARSER =
         new ConstructingObjectParser<>("language_contexts", true,
             (m, name) -> new Tuple<>((String)m[0], Collections.unmodifiableSet(new HashSet<>((List<String>)m[1])))
         );

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -676,7 +676,7 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
      * of the included search hit. The output of the map is used to create the
      * actual SearchHit instance via {@link #createFromMap(Map)}
      */
-    private static ObjectParser<Map<String, Object>, Void> MAP_PARSER = new ObjectParser<>("innerHitParser", true, HashMap::new);
+    private static final ObjectParser<Map<String, Object>, Void> MAP_PARSER = new ObjectParser<>("innerHitParser", true, HashMap::new);
 
     static {
         declareInnerHitsParseFields(MAP_PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
@@ -53,7 +53,7 @@ public class ParsedAdjacencyMatrix extends ParsedMultiBucketAggregation<ParsedAd
         return bucketMap.get(key);
     }
 
-    private static ObjectParser<ParsedAdjacencyMatrix, Void> PARSER =
+    private static final ObjectParser<ParsedAdjacencyMatrix, Void> PARSER =
             new ObjectParser<>(ParsedAdjacencyMatrix.class.getSimpleName(), true, ParsedAdjacencyMatrix::new);
     static {
         declareMultiBucketAggregationFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/ParsedComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/ParsedComposite.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ParsedComposite extends ParsedMultiBucketAggregation<ParsedComposite.ParsedBucket> implements CompositeAggregation {
-    private static ObjectParser<ParsedComposite, Void> PARSER =
+    private static final ObjectParser<ParsedComposite, Void> PARSER =
         new ObjectParser<>(ParsedComposite.class.getSimpleName(), true, ParsedComposite::new);
 
     static {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/ParsedFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/ParsedFilters.java
@@ -60,7 +60,7 @@ public class ParsedFilters extends ParsedMultiBucketAggregation<ParsedFilters.Pa
         return bucketMap.get(key);
     }
 
-    private static ObjectParser<ParsedFilters, Void> PARSER =
+    private static final ObjectParser<ParsedFilters, Void> PARSER =
             new ObjectParser<>(ParsedFilters.class.getSimpleName(), true, ParsedFilters::new);
     static {
         declareMultiBucketAggregationFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/ParsedGeoHashGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/ParsedGeoHashGrid.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 public class ParsedGeoHashGrid extends ParsedGeoGrid {
 
-    private static ObjectParser<ParsedGeoGrid, Void> PARSER = createParser(ParsedGeoHashGrid::new,
+    private static final ObjectParser<ParsedGeoGrid, Void> PARSER = createParser(ParsedGeoHashGrid::new,
         ParsedGeoHashGridBucket::fromXContent, ParsedGeoHashGridBucket::fromXContent);
 
     public static ParsedGeoGrid fromXContent(XContentParser parser, String name) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/ParsedGeoTileGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/ParsedGeoTileGrid.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 public class ParsedGeoTileGrid extends ParsedGeoGrid {
 
-    private static ObjectParser<ParsedGeoGrid, Void> PARSER = createParser(ParsedGeoTileGrid::new,
+    private static final ObjectParser<ParsedGeoGrid, Void> PARSER = createParser(ParsedGeoTileGrid::new,
         ParsedGeoTileGridBucket::fromXContent, ParsedGeoTileGridBucket::fromXContent);
 
     public static ParsedGeoGrid fromXContent(XContentParser parser, String name) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -73,7 +73,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
         implements MultiBucketAggregationBuilder, DateIntervalConsumer {
 
     public static final String NAME = "date_histogram";
-    private static DateMathParser EPOCH_MILLIS_PARSER = DateFormatter.forPattern("epoch_millis").toDateMathParser();
+    private static final DateMathParser EPOCH_MILLIS_PARSER = DateFormatter.forPattern("epoch_millis").toDateMathParser();
 
     public static final Map<String, Rounding.DateTimeUnit> DATE_FIELD_UNITS;
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedAutoDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedAutoDateHistogram.java
@@ -52,7 +52,7 @@ public class ParsedAutoDateHistogram extends ParsedMultiBucketAggregation<Parsed
         return buckets;
     }
 
-    private static ObjectParser<ParsedAutoDateHistogram, Void> PARSER =
+    private static final ObjectParser<ParsedAutoDateHistogram, Void> PARSER =
             new ObjectParser<>(ParsedAutoDateHistogram.class.getSimpleName(), true, ParsedAutoDateHistogram::new);
     static {
         declareMultiBucketAggregationFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -41,7 +41,7 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation<ParsedDate
         return buckets;
     }
 
-    private static ObjectParser<ParsedDateHistogram, Void> PARSER =
+    private static final ObjectParser<ParsedDateHistogram, Void> PARSER =
             new ObjectParser<>(ParsedDateHistogram.class.getSimpleName(), true, ParsedDateHistogram::new);
     static {
         declareMultiBucketAggregationFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
@@ -38,7 +38,7 @@ public class ParsedHistogram extends ParsedMultiBucketAggregation<ParsedHistogra
         return buckets;
     }
 
-    private static ObjectParser<ParsedHistogram, Void> PARSER =
+    private static final ObjectParser<ParsedHistogram, Void> PARSER =
             new ObjectParser<>(ParsedHistogram.class.getSimpleName(), true, ParsedHistogram::new);
     static {
         declareMultiBucketAggregationFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
@@ -45,7 +45,7 @@ public class ParsedBinaryRange extends ParsedMultiBucketAggregation<ParsedBinary
         return buckets;
     }
 
-    private static ObjectParser<ParsedBinaryRange, Void> PARSER =
+    private static final ObjectParser<ParsedBinaryRange, Void> PARSER =
             new ObjectParser<>(ParsedBinaryRange.class.getSimpleName(), true, ParsedBinaryRange::new);
     static {
         declareMultiBucketAggregationFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedDateRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedDateRange.java
@@ -34,7 +34,7 @@ public class ParsedDateRange extends ParsedRange {
         return DateRangeAggregationBuilder.NAME;
     }
 
-    private static ObjectParser<ParsedDateRange, Void> PARSER =
+    private static final ObjectParser<ParsedDateRange, Void> PARSER =
             new ObjectParser<>(ParsedDateRange.class.getSimpleName(), true, ParsedDateRange::new);
     static {
         declareParsedRangeFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedGeoDistance.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedGeoDistance.java
@@ -31,7 +31,7 @@ public class ParsedGeoDistance extends ParsedRange {
         return GeoDistanceAggregationBuilder.NAME;
     }
 
-    private static ObjectParser<ParsedGeoDistance, Void> PARSER =
+    private static final ObjectParser<ParsedGeoDistance, Void> PARSER =
             new ObjectParser<>(ParsedGeoDistance.class.getSimpleName(), true, ParsedGeoDistance::new);
     static {
         declareParsedRangeFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
@@ -53,7 +53,7 @@ public class ParsedRange extends ParsedMultiBucketAggregation<ParsedRange.Parsed
         declareMultiBucketAggregationFields(objectParser, bucketParser::apply, keyedBucketParser::apply);
     }
 
-    private static ObjectParser<ParsedRange, Void> PARSER =
+    private static final ObjectParser<ParsedRange, Void> PARSER =
             new ObjectParser<>(ParsedRange.class.getSimpleName(), true, ParsedRange::new);
     static {
         declareParsedRangeFields(PARSER,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantLongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantLongTerms.java
@@ -32,7 +32,7 @@ public class ParsedSignificantLongTerms extends ParsedSignificantTerms {
         return SignificantLongTerms.NAME;
     }
 
-    private static ObjectParser<ParsedSignificantLongTerms, Void> PARSER =
+    private static final ObjectParser<ParsedSignificantLongTerms, Void> PARSER =
             new ObjectParser<>(ParsedSignificantLongTerms.class.getSimpleName(), true, ParsedSignificantLongTerms::new);
     static {
         declareParsedSignificantTermsFields(PARSER, ParsedBucket::fromXContent);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantStringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantStringTerms.java
@@ -34,7 +34,7 @@ public class ParsedSignificantStringTerms extends ParsedSignificantTerms {
         return SignificantStringTerms.NAME;
     }
 
-    private static ObjectParser<ParsedSignificantStringTerms, Void> PARSER =
+    private static final ObjectParser<ParsedSignificantStringTerms, Void> PARSER =
             new ObjectParser<>(ParsedSignificantStringTerms.class.getSimpleName(), true, ParsedSignificantStringTerms::new);
     static {
         declareParsedSignificantTermsFields(PARSER, ParsedBucket::fromXContent);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
@@ -32,7 +32,7 @@ public class ParsedDoubleTerms extends ParsedTerms {
         return DoubleTerms.NAME;
     }
 
-    private static ObjectParser<ParsedDoubleTerms, Void> PARSER =
+    private static final ObjectParser<ParsedDoubleTerms, Void> PARSER =
             new ObjectParser<>(ParsedDoubleTerms.class.getSimpleName(), true, ParsedDoubleTerms::new);
     static {
         declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedLongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedLongTerms.java
@@ -32,7 +32,7 @@ public class ParsedLongTerms extends ParsedTerms {
         return LongTerms.NAME;
     }
 
-    private static ObjectParser<ParsedLongTerms, Void> PARSER =
+    private static final ObjectParser<ParsedLongTerms, Void> PARSER =
             new ObjectParser<>(ParsedLongTerms.class.getSimpleName(), true, ParsedLongTerms::new);
     static {
         declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedStringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedStringTerms.java
@@ -34,7 +34,7 @@ public class ParsedStringTerms extends ParsedTerms {
         return StringTerms.NAME;
     }
 
-    private static ObjectParser<ParsedStringTerms, Void> PARSER =
+    private static final ObjectParser<ParsedStringTerms, Void> PARSER =
             new ObjectParser<>(ParsedStringTerms.class.getSimpleName(), true, ParsedStringTerms::new);
     static {
         declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentileRanks.java
@@ -49,7 +49,7 @@ public class ParsedHDRPercentileRanks extends ParsedPercentileRanks {
         };
     }
 
-    private static ObjectParser<ParsedHDRPercentileRanks, Void> PARSER =
+    private static final ObjectParser<ParsedHDRPercentileRanks, Void> PARSER =
             new ObjectParser<>(ParsedHDRPercentileRanks.class.getSimpleName(), true, ParsedHDRPercentileRanks::new);
     static {
         ParsedPercentiles.declarePercentilesFields(PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
@@ -41,7 +41,7 @@ public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentil
         return getPercentileAsString(percent);
     }
 
-    private static ObjectParser<ParsedHDRPercentiles, Void> PARSER =
+    private static final ObjectParser<ParsedHDRPercentiles, Void> PARSER =
             new ObjectParser<>(ParsedHDRPercentiles.class.getSimpleName(), true, ParsedHDRPercentiles::new);
     static {
         ParsedPercentiles.declarePercentilesFields(PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentileRanks.java
@@ -49,7 +49,7 @@ public class ParsedTDigestPercentileRanks extends ParsedPercentileRanks {
         };
     }
 
-    private static ObjectParser<ParsedTDigestPercentileRanks, Void> PARSER =
+    private static final ObjectParser<ParsedTDigestPercentileRanks, Void> PARSER =
             new ObjectParser<>(ParsedTDigestPercentileRanks.class.getSimpleName(), true, ParsedTDigestPercentileRanks::new);
     static {
         ParsedPercentiles.declarePercentilesFields(PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
@@ -41,7 +41,7 @@ public class ParsedTDigestPercentiles extends ParsedPercentiles implements Perce
         return getPercentileAsString(percent);
     }
 
-    private static ObjectParser<ParsedTDigestPercentiles, Void> PARSER =
+    private static final ObjectParser<ParsedTDigestPercentiles, Void> PARSER =
             new ObjectParser<>(ParsedTDigestPercentiles.class.getSimpleName(), true, ParsedTDigestPercentiles::new);
     static {
         ParsedPercentiles.declarePercentilesFields(PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTopHits.java
@@ -47,7 +47,7 @@ public class ParsedTopHits extends ParsedAggregation implements TopHits {
         return searchHits.toXContent(builder, params);
     }
 
-    private static ObjectParser<ParsedTopHits, Void> PARSER =
+    private static final ObjectParser<ParsedTopHits, Void> PARSER =
             new ObjectParser<>(ParsedTopHits.class.getSimpleName(), true, ParsedTopHits::new);
     static {
         declareAggregationFields(PARSER);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
@@ -73,7 +73,7 @@ public class ParsedPercentilesBucket extends ParsedPercentiles implements Percen
         return builder;
     }
 
-    private static ObjectParser<ParsedPercentilesBucket, Void> PARSER =
+    private static final ObjectParser<ParsedPercentilesBucket, Void> PARSER =
             new ObjectParser<>(ParsedPercentilesBucket.class.getSimpleName(), true, ParsedPercentilesBucket::new);
 
     static {

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -616,7 +616,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         return PARSER.parse(parser, new FieldSortBuilder(fieldName), null);
     }
 
-    private static ObjectParser<FieldSortBuilder, Void> PARSER = new ObjectParser<>(NAME);
+    private static final ObjectParser<FieldSortBuilder, Void> PARSER = new ObjectParser<>(NAME);
 
     static {
         PARSER.declareField(FieldSortBuilder::missing, p -> p.objectText(),  MISSING, ValueType.VALUE);

--- a/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
@@ -86,7 +86,7 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
         return PARSER.apply(parser, null);
     }
 
-    private static ObjectParser<ScoreSortBuilder, Void> PARSER = new ObjectParser<>(NAME, ScoreSortBuilder::new);
+    private static final ObjectParser<ScoreSortBuilder, Void> PARSER = new ObjectParser<>(NAME, ScoreSortBuilder::new);
 
     static {
         PARSER.declareString((builder, order) -> builder.order(SortOrder.fromString(order)), ORDER_FIELD);

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -270,7 +270,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         return builder;
     }
 
-    private static ConstructingObjectParser<ScriptSortBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME,
+    private static final ConstructingObjectParser<ScriptSortBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME,
             a -> new ScriptSortBuilder((Script) a[0], (ScriptSortType) a[1]));
 
     static {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
@@ -265,9 +265,8 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
             return new Option(in);
         }
 
-        private static ObjectParser<Entry, Void> PARSER = new ObjectParser<>("CompletionSuggestionEntryParser", true,
+        private static final ObjectParser<Entry, Void> PARSER = new ObjectParser<>("CompletionSuggestionEntryParser", true,
                 Entry::new);
-
         static {
             declareCommonFields(PARSER);
             PARSER.declareObjectArray(Entry::addOptions, (p,c) -> Option.fromXContent(p), new ParseField(OPTIONS));
@@ -358,7 +357,7 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
                 return builder;
             }
 
-            private static ObjectParser<Map<String, Object>, Void> PARSER = new ObjectParser<>("CompletionOptionParser",
+            private static final ObjectParser<Map<String, Object>, Void> PARSER = new ObjectParser<>("CompletionOptionParser",
                     true, HashMap::new);
 
             static {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -95,7 +95,7 @@ public final class CategoryQueryContext implements ToXContentObject {
         return result;
     }
 
-    private static ObjectParser<Builder, Void> CATEGORY_PARSER = new ObjectParser<>(NAME, null);
+    private static final ObjectParser<Builder, Void> CATEGORY_PARSER = new ObjectParser<>(NAME, null);
     static {
         CATEGORY_PARSER.declareField(Builder::setCategory, XContentParser::text, new ParseField(CONTEXT_VALUE),
                 ObjectParser.ValueType.VALUE);

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoQueryContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoQueryContext.java
@@ -112,7 +112,7 @@ public final class GeoQueryContext implements ToXContentObject {
         return new Builder();
     }
 
-    private static ObjectParser<GeoQueryContext.Builder, Void> GEO_CONTEXT_PARSER = new ObjectParser<>(NAME, null);
+    private static final ObjectParser<GeoQueryContext.Builder, Void> GEO_CONTEXT_PARSER = new ObjectParser<>(NAME, null);
     static {
         GEO_CONTEXT_PARSER.declareField((parser, geoQueryContext,
                 geoContextMapping) -> geoQueryContext.setGeoPoint(GeoUtils.parseGeoPoint(parser)),

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestion.java
@@ -120,8 +120,7 @@ public class PhraseSuggestion extends Suggest.Suggestion<PhraseSuggestion.Entry>
             }
         }
 
-        private static ObjectParser<Entry, Void> PARSER = new ObjectParser<>("PhraseSuggestionEntryParser", true, Entry::new);
-
+        private static final ObjectParser<Entry, Void> PARSER = new ObjectParser<>("PhraseSuggestionEntryParser", true, Entry::new);
         static {
             declareCommonFields(PARSER);
             PARSER.declareObjectArray(Entry::addOptions, (p, c) -> Option.fromXContent(p), new ParseField(OPTIONS));

--- a/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestion.java
@@ -185,8 +185,7 @@ public class TermSuggestion extends Suggestion<TermSuggestion.Entry> {
             return new Option(in);
         }
 
-        private static ObjectParser<Entry, Void> PARSER = new ObjectParser<>("TermSuggestionEntryParser", true, Entry::new);
-
+        private static final ObjectParser<Entry, Void> PARSER = new ObjectParser<>("TermSuggestionEntryParser", true, Entry::new);
         static {
             declareCommonFields(PARSER);
             PARSER.declareObjectArray(Entry::addOptions, (p,c) -> Option.fromXContent(p), new ParseField(OPTIONS));

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonSerializationTests.java
@@ -47,7 +47,7 @@ public class GeoJsonSerializationTests extends ESTestCase {
     private static class GeometryWrapper implements ToXContentObject {
 
         private Geometry geometry;
-        private static GeoJson PARSER = new GeoJson(true, false, new GeographyValidator(true));
+        private static final GeoJson PARSER = new GeoJson(true, false, new GeographyValidator(true));
 
         GeometryWrapper(Geometry geometry) {
             this.geometry = geometry;


### PR DESCRIPTION
We have about 800 `ObjectParsers` in Elasticsearch, about 700 of which
are final. This is *probably* the right way to declare them because in
practice we never mutate them after they are built. And we certainly
don't change the static reference. Anyway, this adds `final` to these
parsers.

I found the non-final parsers with this:
```
diff \
  <(find . -type f -name '*.java' -exec grep -iHe 'static.*PARSER\s*=' {} \+ | sort) \
  <(find . -type f -name '*.java' -exec grep -iHe 'static.*final.*PARSER\s*=' {} \+ | sort) \
  2>&1 | grep '^<'
```
