### PR TITLE
Remove races in ProxyConnectionStrategyTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -44,7 +43,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ProxyConnectionStrategyTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ProxyConnectionStrategyTests extends ESTestCase {
 
@@ -122,9 +124,11 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
                 ConnectionManager connectionManager = new ConnectionManager(profile, localService.transport);
                 int numOfConnections = randomIntBetween(4, 8);
 
+                AtomicBoolean useAddress1 = new AtomicBoolean(true);
+
                 try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
                      ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
-                         numOfConnections, address1.toString(), alternatingResolver(address1, address2), false)) {
+                         numOfConnections, address1.toString(), alternatingResolver(address1, address2, useAddress1), false)) {
                     assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
                     assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address2)));
 
@@ -139,6 +143,7 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
                     assertEquals(0, initialConnectionsToTransport2);
                     assertEquals(numOfConnections, connectionManager.size());
                     assertTrue(strategy.assertNoRunningConnections());
+                    useAddress1.set(false);
 
                     transport1.close();
 
@@ -199,10 +204,11 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
                 ConnectionManager connectionManager = new ConnectionManager(profile, localService.transport);
                 int numOfConnections = randomIntBetween(4, 8);
 
-                Supplier<TransportAddress> resolver = alternatingResolver(address1, address2);
+                AtomicBoolean useAddress1 = new AtomicBoolean(true);
+
                 try (RemoteConnectionManager remoteConnectionManager = new RemoteConnectionManager(clusterAlias, connectionManager);
                      ProxyConnectionStrategy strategy = new ProxyConnectionStrategy(clusterAlias, localService, remoteConnectionManager,
-                         numOfConnections, address1.toString(), resolver, false)) {
+                         numOfConnections, address1.toString(), alternatingResolver(address1, address2, useAddress1), false)) {
                     assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
                     assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address2)));
 
@@ -212,6 +218,7 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
 
                     assertTrue(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
                     assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address2)));
+                    useAddress1.set(false);
 
                     transport1.close();
 
@@ -375,16 +382,12 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
         }
     }
 
-    private Supplier<TransportAddress> alternatingResolver(TransportAddress address1, TransportAddress address2) {
-        // On the first connection round, the connections will be routed to transport1. On the second
-        //connection round, the connections will be routed to transport2
-        AtomicBoolean transportSwitch = new AtomicBoolean(true);
+    private Supplier<TransportAddress> alternatingResolver(TransportAddress address1, TransportAddress address2,
+                                                           AtomicBoolean useAddress1) {
         return () -> {
-            if (transportSwitch.get()) {
-                transportSwitch.set(false);
+            if (useAddress1.get()) {
                 return address1;
             } else {
-                transportSwitch.set(true);
                 return address2;
             }
         };


### PR DESCRIPTION
Currently, we use delayed address resolution in the proxy strategy tests
to allow tests to connect to different addresses. Unfortunately, this
has the potential to introduce races as the address is resolved each
connection attempt. The number of connection attempts can vary based on
when connections are opening and closing. This commit modifies the test
be allowing them to specifically control which address is used.

Related to #50618