### PR TITLE
Track max shard size for all copies

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -29,19 +30,26 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.stream.StreamSupport;
+
 /**
  * ClusterInfo is an object representing a map of nodes to {@link DiskUsage}
- * and a map of shard ids to shard sizes, see
- * <code>InternalClusterInfoService.shardIdentifierFromRouting(String)</code>
- * for the key used in the shardSizes map
+ * and a map of shard ids to shard sizes.
  */
 public class ClusterInfo implements ToXContentFragment, Writeable {
+
+    /**
+     * Only needed to support shard sizes keyed by String as in {@link Version#V_7_0_0} - TODO remove this in v9.
+     */
+    private static final String BWC_SHARD_ID_UUID = "_bwc_shard_id_uuid_";
+
     private final ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage;
     private final ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage;
-    final ImmutableOpenMap<String, Long> shardSizes;
+    final ImmutableOpenMap<ShardId, Long> shardSizes;
     public static final ClusterInfo EMPTY = new ClusterInfo();
     final ImmutableOpenMap<ShardRouting, String> routingToDataPath;
 
@@ -56,10 +64,9 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * @param mostAvailableSpaceUsage  a node id to disk usage mapping for the path that has the most available space on the node.
      * @param shardSizes a shardkey to size in bytes mapping per shard.
      * @param routingToDataPath the shard routing to datapath mapping
-     * @see #shardIdentifierFromRouting
      */
     public ClusterInfo(ImmutableOpenMap<String, DiskUsage> leastAvailableSpaceUsage,
-            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage, ImmutableOpenMap<String, Long> shardSizes,
+            ImmutableOpenMap<String, DiskUsage> mostAvailableSpaceUsage, ImmutableOpenMap<ShardId, Long> shardSizes,
             ImmutableOpenMap<ShardRouting, String> routingToDataPath) {
         this.leastAvailableSpaceUsage = leastAvailableSpaceUsage;
         this.shardSizes = shardSizes;
@@ -67,17 +74,29 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         this.routingToDataPath = routingToDataPath;
     }
 
+    private static ShardId readShardId(StreamInput in) throws IOException {
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            return new ShardId(in);
+        } else {
+            // earlier versions used a string of the form "[indexname][0][p]" or "[indexname][0][r]" to distinguish primaries from replicas
+            // but the only time we use a serialized ClusterInfo is for allocation explanation, not for allocation calculations, so we can
+            // use a placeholder with a fake UUID and shard number and use the index name field for the original string:
+            final String shardKey = in.readString();
+            return new ShardId(shardKey, BWC_SHARD_ID_UUID, 0);
+        }
+    }
+
     public ClusterInfo(StreamInput in) throws IOException {
         Map<String, DiskUsage> leastMap = in.readMap(StreamInput::readString, DiskUsage::new);
         Map<String, DiskUsage> mostMap = in.readMap(StreamInput::readString, DiskUsage::new);
-        Map<String, Long> sizeMap = in.readMap(StreamInput::readString, StreamInput::readLong);
+        Map<ShardId, Long> sizeMap = in.readMap(ClusterInfo::readShardId, StreamInput::readLong);
         Map<ShardRouting, String> routingMap = in.readMap(ShardRouting::new, StreamInput::readString);
 
         ImmutableOpenMap.Builder<String, DiskUsage> leastBuilder = ImmutableOpenMap.builder();
         this.leastAvailableSpaceUsage = leastBuilder.putAll(leastMap).build();
         ImmutableOpenMap.Builder<String, DiskUsage> mostBuilder = ImmutableOpenMap.builder();
         this.mostAvailableSpaceUsage = mostBuilder.putAll(mostMap).build();
-        ImmutableOpenMap.Builder<String, Long> sizeBuilder = ImmutableOpenMap.builder();
+        ImmutableOpenMap.Builder<ShardId, Long> sizeBuilder = ImmutableOpenMap.builder();
         this.shardSizes = sizeBuilder.putAll(sizeMap).build();
         ImmutableOpenMap.Builder<ShardRouting, String> routingBuilder = ImmutableOpenMap.builder();
         this.routingToDataPath = routingBuilder.putAll(routingMap).build();
@@ -96,8 +115,12 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
             c.value.writeTo(out);
         }
         out.writeVInt(this.shardSizes.size());
-        for (ObjectObjectCursor<String, Long> c : this.shardSizes) {
-            out.writeString(c.key);
+        for (ObjectObjectCursor<ShardId, Long> c : this.shardSizes) {
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                c.key.writeTo(out);
+            } else {
+                out.writeString(c.key.toString());
+            }
             if (c.value == null) {
                 out.writeLong(-1);
             } else {
@@ -133,8 +156,14 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         }
         builder.endObject(); // end "nodes"
         builder.startObject("shard_sizes"); {
-            for (ObjectObjectCursor<String, Long> c : this.shardSizes) {
-                builder.humanReadableField(c.key + "_bytes", c.key, new ByteSizeValue(c.value));
+            for (ObjectObjectCursor<ShardId, Long> c : this.shardSizes) {
+                final String shardKey;
+                if (BWC_SHARD_ID_UUID.equals(c.key.getIndex().getUUID())) {
+                    shardKey = c.key.getIndexName();
+                } else {
+                    shardKey = c.key.toString();
+                }
+                builder.humanReadableField(shardKey + "_bytes", shardKey, new ByteSizeValue(c.value));
             }
         }
         builder.endObject(); // end "shard_sizes"
@@ -165,7 +194,10 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * Returns the shard size for the given shard routing or <code>null</code> it that metric is not available.
      */
     public Long getShardSize(ShardRouting shardRouting) {
-        return shardSizes.get(shardIdentifierFromRouting(shardRouting));
+        // this ClusterInfo instance was never serialized and sent over the wire, so it does not have any fake shard IDs.
+        assert StreamSupport.stream(shardSizes.keys().spliterator(), false)
+            .noneMatch(c -> BWC_SHARD_ID_UUID.equals(c.value.getIndex().getUUID())) : shardSizes;
+        return shardSizes.get(shardRouting.shardId());
     }
 
     /**
@@ -183,11 +215,4 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         return shardSize == null ? defaultValue : shardSize;
     }
 
-    /**
-     * Method that incorporates the ShardId for the shard into a string that
-     * includes a 'p' or 'r' depending on whether the shard is a primary.
-     */
-    static String shardIdentifierFromRouting(ShardRouting shardRouting) {
-        return shardRouting.shardId().toString() + "[" + (shardRouting.primary() ? "p" : "r") + "]";
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.plugins.ActionPlugin;
@@ -130,7 +131,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         assertNotNull("info should not be null", info);
         ImmutableOpenMap<String, DiskUsage> leastUsages = info.getNodeLeastAvailableDiskUsages();
         ImmutableOpenMap<String, DiskUsage> mostUsages = info.getNodeMostAvailableDiskUsages();
-        ImmutableOpenMap<String, Long> shardSizes = info.shardSizes;
+        ImmutableOpenMap<ShardId, Long> shardSizes = info.shardSizes;
         assertNotNull(leastUsages);
         assertNotNull(shardSizes);
         assertThat("some usages are populated", leastUsages.values().size(), Matchers.equalTo(2));
@@ -209,7 +210,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         assertThat(info.getNodeLeastAvailableDiskUsages().size(), greaterThanOrEqualTo(1));
         assertThat(info.getNodeMostAvailableDiskUsages().size(), greaterThanOrEqualTo(1));
         // indices is guaranteed to time out on the latch, not updating anything.
-        assertThat(info.shardSizes.size(), greaterThan(1));
+        assertThat(info.shardSizes.size(), greaterThan(0));
 
         // now we cause an exception
         timeout.set(false);

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -56,13 +57,12 @@ public class ClusterInfoTests extends ESTestCase {
         return builder.build();
     }
 
-    private static ImmutableOpenMap<String, Long> randomShardSizes() {
+    private static ImmutableOpenMap<ShardId, Long> randomShardSizes() {
         int numEntries = randomIntBetween(0, 128);
-        ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.builder(numEntries);
+        ImmutableOpenMap.Builder<ShardId, Long> builder = ImmutableOpenMap.builder(numEntries);
         for (int i = 0; i < numEntries; i++) {
-            String key = randomAlphaOfLength(32);
             long shardSize = randomIntBetween(0, Integer.MAX_VALUE);
-            builder.put(key, shardSize);
+            builder.put(new ShardId(randomAlphaOfLength(10), UUIDs.randomBase64UUID(random()), between(0, 100)), shardSize);
         }
         return builder.build();
     }

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -116,15 +116,15 @@ public class DiskUsageTests extends ESTestCase {
                 new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0 , null, null, null),
                 new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1 , null, null, null)
         };
-        ImmutableOpenMap.Builder<String, Long> shardSizes = ImmutableOpenMap.builder();
+        ImmutableOpenMap.Builder<ShardId, Long> shardSizes = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<ShardRouting, String> routingToPath = ImmutableOpenMap.builder();
         ClusterState state = ClusterState.builder(new ClusterName("blarg")).version(0).build();
         InternalClusterInfoService.buildShardLevelInfo(logger, stats, shardSizes, routingToPath);
         assertEquals(2, shardSizes.size());
-        assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_0)));
-        assertTrue(shardSizes.containsKey(ClusterInfo.shardIdentifierFromRouting(test_1)));
-        assertEquals(100L, shardSizes.get(ClusterInfo.shardIdentifierFromRouting(test_0)).longValue());
-        assertEquals(1000L, shardSizes.get(ClusterInfo.shardIdentifierFromRouting(test_1)).longValue());
+        assertTrue(shardSizes.containsKey(test_0.shardId()));
+        assertTrue(shardSizes.containsKey(test_1.shardId()));
+        assertEquals(100L, shardSizes.get(test_0.shardId()).longValue());
+        assertEquals(1000L, shardSizes.get(test_1.shardId()).longValue());
 
         assertEquals(2, routingToPath.size());
         assertTrue(routingToPath.containsKey(test_0));


### PR DESCRIPTION
Today we distinguish the sizes of primary and replica shards when contemplating
disk-based shard allocation, using a map of shard sizes keyed by strings of the
form `[index][0][p]`. There is no need to distinguish primaries and replicas
like this. Moreover in the case where a replica is not yet allocated the size
of the primary is a good estimate for the size of the replica. Finally, in the
case where there are multiple replicas we took the size of _one_ of them, which
may not have been the largest.

This commit addresses these issues by keying the map of shard sizes by
`ShardId`, collapsing primaries and replicas into a single entry, and taking
the maximum size across all copies of each shard.