### PR TITLE
Fix GCS Mock Broken Handling of some Blobs (#50666)

### DIFF
--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -271,6 +271,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                     return buf;
                 }
             };
+            boolean skippedEmptyLine = false;
             while ((read = in.read()) != -1) {
                 out.reset();
                 boolean markAndContinue = false;
@@ -290,7 +291,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                 } while ((read = in.read()) != -1);
                 final String bucketPrefix = "{\"bucket\":";
                 final String start = new String(out.toByteArray(), 0, Math.min(out.size(), bucketPrefix.length()), UTF_8);
-                if (start.length() == 0 || start.equals("\r\n") || start.startsWith("--")
+                if ((skippedEmptyLine == false && start.length() == 0) || start.startsWith("--")
                     || start.toLowerCase(Locale.ROOT).startsWith("content")) {
                     markAndContinue = true;
                 } else if (start.startsWith(bucketPrefix)) {
@@ -302,6 +303,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
                     }
                 }
                 if (markAndContinue) {
+                    skippedEmptyLine = start.length() == 0;
                     in.mark(Integer.MAX_VALUE);
                     continue;
                 }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -132,7 +132,11 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
                     byte[] buffer = new byte[scaledRandomIntBetween(1, data.length - target.length())];
                     int offset = scaledRandomIntBetween(0, buffer.length - 1);
                     int read = stream.read(buffer, offset, buffer.length - offset);
-                    target.append(new BytesRef(buffer, offset, read));
+                    if (read >= 0) {
+                        target.append(new BytesRef(buffer, offset, read));
+                    } else {
+                        fail("Expected [" + (data.length - target.length()) + "] more bytes to be readable but reached EOF");
+                    }
                 }
                 assertEquals(data.length, target.length());
                 assertArrayEquals(data, Arrays.copyOfRange(target.bytes(), 0, target.length()));


### PR DESCRIPTION
* Fix GCS Mock Broken Handling of some Blobs

We were incorrectly handling blobs starting in `\r\n` which broke
tests randomly when blobs started on these.

Relates #49429


backport of #50666 