### PR TITLE
Fix bare warnings on RollupJobTests (backport of #50633)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/RollupJobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/RollupJobTests.java
@@ -6,9 +6,7 @@
 package org.elasticsearch.xpack.core.rollup.job;
 
 import org.elasticsearch.cluster.Diff;
-import org.elasticsearch.cluster.Diffable;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractDiffableSerializationTestCase;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
@@ -18,24 +16,24 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class RollupJobTests extends AbstractDiffableSerializationTestCase {
+public class RollupJobTests extends AbstractDiffableSerializationTestCase<RollupJob> {
     @Override
-    protected Writeable.Reader<Diff> diffReader() {
+    protected Writeable.Reader<Diff<RollupJob>> diffReader() {
         return RollupJob::readJobDiffFrom;
     }
 
     @Override
-    protected ToXContent doParseInstance(XContentParser parser) throws IOException {
+    protected RollupJob doParseInstance(XContentParser parser) throws IOException {
         return RollupJob.fromXContent(parser);
     }
 
     @Override
-    protected Writeable.Reader instanceReader() {
+    protected Writeable.Reader<RollupJob> instanceReader() {
         return RollupJob::new;
     }
 
     @Override
-    protected Writeable createTestInstance() {
+    protected RollupJob createTestInstance() {
         if (randomBoolean()) {
             return new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), null);
         }
@@ -49,8 +47,7 @@ public class RollupJobTests extends AbstractDiffableSerializationTestCase {
     }
 
     @Override
-    protected Diffable makeTestChanges(Diffable testInstance) {
-        RollupJob other = (RollupJob) testInstance;
+    protected RollupJob makeTestChanges(RollupJob other) {
         if (randomBoolean()) {
             if (other.getHeaders().isEmpty()) {
                 Map<String, String> headers = new HashMap<>(1);


### PR DESCRIPTION
Silences some ugly warnings.
