### PR TITLE
Replace AggParseContext with a String (backport of #50625)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -101,7 +101,6 @@ import org.elasticsearch.plugins.SearchPlugin.SearchExtensionSpec;
 import org.elasticsearch.plugins.SearchPlugin.SignificanceHeuristicSpec;
 import org.elasticsearch.plugins.SearchPlugin.SuggesterSpec;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.BaseAggregationBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
@@ -462,8 +461,8 @@ public class SearchModule {
     private void registerAggregation(AggregationSpec spec) {
         if (false == transportClient) {
             namedXContents.add(new NamedXContentRegistry.Entry(BaseAggregationBuilder.class, spec.getName(), (p, c) -> {
-                AggregatorFactories.AggParseContext context = (AggregatorFactories.AggParseContext) c;
-                return spec.getParser().parse(context.name, p);
+                String name = (String) c;
+                return spec.getParser().parse(name, p);
             }));
         }
         namedWriteables.add(
@@ -569,8 +568,8 @@ public class SearchModule {
     private void registerPipelineAggregation(PipelineAggregationSpec spec) {
         if (false == transportClient) {
             namedXContents.add(new NamedXContentRegistry.Entry(BaseAggregationBuilder.class, spec.getName(), (p, c) -> {
-                AggregatorFactories.AggParseContext context = (AggregatorFactories.AggParseContext) c;
-                return spec.getParser().parse(context.name, p);
+                String name = (String) c;
+                return spec.getParser().parse(name, p);
             }));
         }
         namedWriteables.add(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -119,8 +119,7 @@ public class AggregatorFactories {
                                     + aggregationName + "]: [" + aggBuilder.getType() + "] and [" + fieldName + "]");
                         }
 
-                        aggBuilder = parser.namedObject(BaseAggregationBuilder.class, fieldName,
-                                new AggParseContext(aggregationName));
+                        aggBuilder = parser.namedObject(BaseAggregationBuilder.class, fieldName, aggregationName);
                     }
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Expected [" + XContentParser.Token.START_OBJECT + "] under ["
@@ -149,17 +148,6 @@ public class AggregatorFactories {
         }
 
         return factories;
-    }
-
-    /**
-     * Context to parse and aggregation. This should eventually be removed and replaced with a String.
-     */
-    public static final class AggParseContext {
-        public final String name;
-
-        public AggParseContext(String name) {
-            this.name = name;
-        }
     }
 
     public static final AggregatorFactories EMPTY = new AggregatorFactories(new AggregatorFactory[0], new ArrayList<>());


### PR DESCRIPTION
We used to have a *ton* off stuff in the `AggParseContext` but now we
parse aggs entirely with named xcontent. So we don't need the context
any more.
