### PR TITLE
Drop references to deprecated logger (backport of #50474)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/ApiKeyBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/ApiKeyBaseRestHandler.java
@@ -6,6 +6,8 @@
 
 package org.elasticsearch.xpack.security.rest.action.apikey;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -16,6 +18,8 @@ import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
  * A base rest handler that handles licensing for ApiKey actions
  */
 abstract class ApiKeyBaseRestHandler extends SecurityBaseRestHandler {
+    private static final Logger logger = LogManager.getLogger();
+
     ApiKeyBaseRestHandler(Settings settings, XPackLicenseState licenseState) {
         super(settings, licenseState);
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/OpenIdConnectBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/OpenIdConnectBaseRestHandler.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.rest.action.oidc;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -14,6 +16,7 @@ import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 public abstract class OpenIdConnectBaseRestHandler extends SecurityBaseRestHandler {
+    private static final Logger logger = LogManager.getLogger();
 
     private static final String OIDC_REALM_TYPE = OpenIdConnectRealmSettings.TYPE;
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/RestOpenIdConnectAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/RestOpenIdConnectAuthenticateAction.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.rest.action.oidc;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.settings.Settings;
@@ -30,6 +32,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
  * Rest handler that authenticates the user based on the information provided as parameters of the redirect_uri
  */
 public class RestOpenIdConnectAuthenticateAction extends OpenIdConnectBaseRestHandler {
+    private static final Logger logger = LogManager.getLogger();
 
     static final ObjectParser<OpenIdConnectAuthenticateRequest, Void> PARSER = new ObjectParser<>("oidc_authn",
         OpenIdConnectAuthenticateRequest::new);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/RestOpenIdConnectPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/RestOpenIdConnectPrepareAuthenticationAction.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.rest.action.oidc;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.settings.Settings;
@@ -30,6 +32,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
  * Generates an oAuth 2.0 authentication request as a URL string and returns it to the REST client.
  */
 public class RestOpenIdConnectPrepareAuthenticationAction extends OpenIdConnectBaseRestHandler {
+    private static final Logger logger = LogManager.getLogger();
 
     static final ObjectParser<OpenIdConnectPrepareAuthenticationRequest, Void> PARSER = new ObjectParser<>("oidc_prepare_authentication",
         OpenIdConnectPrepareAuthenticationRequest::new);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/RestSamlAuthenticateAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.security.rest.action.saml;
 
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -36,9 +37,9 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
  * A REST handler that attempts to authenticate a user based on the provided SAML response/assertion.
  */
 public class RestSamlAuthenticateAction extends SamlBaseRestHandler implements RestHandler {
+    private static final Logger logger = LogManager.getLogger();
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
 
-    private static final DeprecationLogger deprecationLogger =
-        new DeprecationLogger(LogManager.getLogger(RestSamlAuthenticateAction.class));
     static class Input {
         String content;
         List<String> ids;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/SamlBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/SamlBaseRestHandler.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.security.rest.action.saml;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -17,6 +19,7 @@ import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
  * An abstract implementation of {@link SecurityBaseRestHandler} that performs a license check for the SAML realm type
  */
 public abstract class SamlBaseRestHandler extends SecurityBaseRestHandler {
+    private static final Logger logger = LogManager.getLogger();
 
     private static final String SAML_REALM_TYPE = SamlRealmSettings.TYPE;
 


### PR DESCRIPTION
This drops all remaining references to `BaseRestHandler.logger` which
has been deprecated for something like a year now. I replaced all of the
references with locally declared loggers which is so much less spooky
action at a distance to me.
