### PR TITLE
Remove unused IndicesOptions#fromByte method

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestTests.java
@@ -19,21 +19,14 @@
 
 package org.elasticsearch.action.admin.indices.settings.get;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
-import java.util.Base64;
 
 public class GetSettingsRequestTests extends ESTestCase {
-    private static final String TEST_622_REQUEST_BYTES = "ADwDAAEKdGVzdF9pbmRleA4BEHRlc3Rfc2V0dGluZ19rZXkB";
-    private static final GetSettingsRequest TEST_622_REQUEST = new GetSettingsRequest()
-        .indices("test_index")
-        .names("test_setting_key")
-        .humanReadable(true);
     private static final GetSettingsRequest TEST_700_REQUEST = new GetSettingsRequest()
             .includeDefaults(true)
             .humanReadable(true)
@@ -48,21 +41,5 @@ public class GetSettingsRequestTests extends ESTestCase {
         StreamInput si = StreamInput.wrap(responseBytes);
         GetSettingsRequest deserialized = new GetSettingsRequest(si);
         assertEquals(TEST_700_REQUEST, deserialized);
-    }
-
-    public void testSerializeBackwardsCompatibility() throws IOException {
-        BytesStreamOutput bso = new BytesStreamOutput();
-        bso.setVersion(Version.V_6_2_2);
-        TEST_700_REQUEST.writeTo(bso);
-
-        byte[] responseBytes = BytesReference.toBytes(bso.bytes());
-        assertEquals(TEST_622_REQUEST_BYTES, Base64.getEncoder().encodeToString(responseBytes));
-    }
-
-    public void testDeserializeBackwardsCompatibility() throws IOException {
-        StreamInput si = StreamInput.wrap(Base64.getDecoder().decode(TEST_622_REQUEST_BYTES));
-        si.setVersion(Version.V_6_2_2);
-        GetSettingsRequest deserialized = new GetSettingsRequest(si);
-        assertEquals(TEST_622_REQUEST, deserialized);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -79,7 +79,7 @@ public class IndicesOptionsTests extends ESTestCase {
     public void testSerializationPre70() throws Exception {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
-            Version version = randomVersionBetween(random(), null, Version.V_6_6_0);
+            Version version = randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.fromId(6999999));
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
@@ -100,12 +100,7 @@ public class IndicesOptionsTests extends ESTestCase {
             assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
 
             assertEquals(indicesOptions2.ignoreAliases(), indicesOptions.ignoreAliases());
-            if (output.getVersion().onOrAfter(Version.V_6_6_0)) {
-                assertEquals(indicesOptions2.ignoreThrottled(), indicesOptions.ignoreThrottled());
-            } else {
-                assertFalse(indicesOptions2.ignoreThrottled()); // make sure we never write this option to pre 6.6
-            }
-
+            assertEquals(indicesOptions2.ignoreThrottled(), indicesOptions.ignoreThrottled());
         }
     }
 
@@ -191,31 +186,6 @@ public class IndicesOptionsTests extends ESTestCase {
         assertEquals(defaultOptions.allowAliasesToMultipleIndices(), updatedOptions.allowAliasesToMultipleIndices());
         assertEquals(defaultOptions.forbidClosedIndices(), updatedOptions.forbidClosedIndices());
         assertEquals(defaultOptions.ignoreAliases(), updatedOptions.ignoreAliases());
-    }
-
-    public void testSimpleByteBWC() {
-        Map<Byte, IndicesOptions> old = new HashMap<>();
-        // These correspond to each individual option (bit) in the old byte-based IndicesOptions
-        old.put((byte) 0, IndicesOptions.fromOptions(false, false, false, false, true, false, false, false));
-        old.put((byte) 1, IndicesOptions.fromOptions(true, false, false, false, true, false, false, false));
-        old.put((byte) 2, IndicesOptions.fromOptions(false, true, false, false, true, false, false, false));
-        old.put((byte) 4, IndicesOptions.fromOptions(false, false, true, false, true, false, false, false));
-        old.put((byte) 8, IndicesOptions.fromOptions(false, false, false, true, true, false, false, false));
-        old.put((byte) 16, IndicesOptions.fromOptions(false, false, false, false, false, false, false, false));
-        old.put((byte) 32, IndicesOptions.fromOptions(false, false, false, false, true, true, false, false));
-        old.put((byte) 64, IndicesOptions.fromOptions(false, false, false, false, true, false, true, false));
-        // Test a few multi-selected options
-        old.put((byte) 13, IndicesOptions.fromOptions(true, false, true, true, true, false, false, false));
-        old.put((byte) 19, IndicesOptions.fromOptions(true, true, false, false, false, false, false, false));
-        old.put((byte) 24, IndicesOptions.fromOptions(false, false, false, true, false, false, false, false));
-        old.put((byte) 123, IndicesOptions.fromOptions(true, true, false, true, false, true, true, false));
-
-        for (Map.Entry<Byte, IndicesOptions> entry : old.entrySet()) {
-            IndicesOptions indicesOptions2 = IndicesOptions.fromByte(entry.getKey());
-            logger.info("--> 1 {}", entry.getValue().toString());
-            logger.info("--> 2 {}", indicesOptions2.toString());
-            assertThat("IndicesOptions for byte " + entry.getKey() + " differ for conversion",indicesOptions2, equalTo(entry.getValue()));
-        }
     }
 
     public void testEqualityAndHashCode() {

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -42,6 +42,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -78,8 +79,12 @@ public class IndicesOptionsTests extends ESTestCase {
 
     public void testSerializationPre70() throws Exception {
         int iterations = randomIntBetween(5, 20);
+        List<Version> declaredVersions = Version.getDeclaredVersions(Version.class);
+        OptionalInt maxV6Id = declaredVersions.stream().filter(v -> v.major == 6).mapToInt(v -> v.id).max();
+        assertTrue(maxV6Id.isPresent());
+        final Version maxVersion = Version.fromId(maxV6Id.getAsInt());
         for (int i = 0; i < iterations; i++) {
-            Version version = randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.fromId(6999999));
+            Version version = randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), maxVersion);
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
                     randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 


### PR DESCRIPTION
This change removes a no longer used method, `fromByte`, in
IndicesOptions. This method was necessary for backwards compatibility
with versions prior to 6.4.0 and was used when talking to those
versions. However, the minimum wire compatibility version has changed
and we no longer use this code.

Backport of #50665