### PR TITLE
[7.x] [ML] construct new random generator on each persistence call (#50657)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -52,7 +52,6 @@ public class ResultsPersisterService {
     // Having an exponent higher than this causes integer overflow
     private static final int MAX_RETRY_EXPONENT = 24;
 
-    private final Random random = Randomness.get();
     private final Client client;
     private volatile int maxFailureRetries;
 
@@ -90,6 +89,7 @@ public class ResultsPersisterService {
         int currentMax = MIN_RETRY_SLEEP_MILLIS;
         int currentAttempt = 0;
         BulkResponse bulkResponse = null;
+        final Random random = Randomness.get();
         while(currentAttempt <= maxFailureRetries) {
             bulkResponse = bulkIndex(bulkRequest);
             if (bulkResponse.hasFailures() == false) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] construct new random generator on each persistence call  (#50657)