### PR TITLE
Silence eclipse warnings about forbidden refs

### DIFF
--- a/buildSrc/src/main/resources/eclipse.settings/org.eclipse.jdt.core.prefs
+++ b/buildSrc/src/main/resources/eclipse.settings/org.eclipse.jdt.core.prefs
@@ -22,3 +22,9 @@ org.eclipse.jdt.core.formatter.comment.line_length=140
 org.eclipse.jdt.core.formatter.lineSplit=140
 org.eclipse.jdt.core.formatter.tabulation.char=space
 org.eclipse.jdt.core.formatter.tabulation.size=4
+
+# Silence warnings about references to jdk internals. We intentionally use some
+# and have much tighter control of the warnings in the forbidden APIs gradle
+# task which is the definitive list of allowed references.
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=ignore
+org.eclipse.jdt.core.compiler.problem.discouragedReference=ignore


### PR DESCRIPTION
We intentionally have a couple hundred forbidden and discouraged
references to jdk internals in our tests. This silences all of the
warnings Eclipse has about it. Don't worry though, the build still runs
forbidden APIs to make sure we only reference internal stuff that we've
decided is ok.
