### PR TITLE
Disable auto refresh in testSegmentsStats

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -41,6 +41,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
@@ -594,7 +595,8 @@ public class IndexStatsIT extends ESIntegTestCase {
 
     public void testSegmentsStats() {
         assertAcked(prepareCreate("test_index")
-                .setSettings(Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))));
+            .setSettings(Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, between(0, 1))
+                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE)));
         ensureGreen();
 
         NumShards test1 = getNumShards("test_index");


### PR DESCRIPTION
If an auto-refresh happens, then `version_map_memory` is reset to 0. By default, the auto-refresh occurs for every second in the first 30 seconds until search becomes idle. 

I still do not understand why this test always failed at [version_map_memory](https://github.com/elastic/elasticsearch/blob/62c31011240b9a4e3ddeeccc6f4b5540b4f74af2/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java#L609) although, it could fail at [index_writer_memory](https://github.com/elastic/elasticsearch/blob/62c31011240b9a4e3ddeeccc6f4b5540b4f74af2/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java#L610).

Closes #50362