### PR TITLE
[DOCS] Update SQL REST API pages for new structure

### DIFF
--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -42,12 +42,15 @@ James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00.000Z
 // TESTRESPONSE[non_json]
 
 [[sql-kibana-console]]
+[TIP]
 .Using Kibana Console
+====
 If you are using {kibana-ref}/console-kibana.html[Kibana Console]
 (which is highly recommended), take advantage of the
 triple quotes `"""` when creating the query. This not only automatically escapes double
 quotes (`"`) inside the query string but also support multi-line as shown below:
 image:images/sql/rest/console-triple-quotes.png[]
+====
 
 [[sql-rest-format]]
 === Response Data Formats
@@ -270,8 +273,8 @@ cursor: "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmB
 [[sql-pagination]]
 === Paginating through a large response
 
-Using the example above, one can continue to the next page by sending back the `cursor` field. In
-case of text format the cursor is returned as `Cursor` http header.
+Using the example from the <<sql-rest-format,previous section>>, one can
+continue to the next page by sending back the cursor field.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -274,7 +274,8 @@ cursor: "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmB
 === Paginating through a large response
 
 Using the example from the <<sql-rest-format,previous section>>, one can
-continue to the next page by sending back the cursor field.
+continue to the next page by sending back the cursor field. In case of text
+format, the cursor is returned as `Cursor` http header.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -11,7 +11,6 @@
 * <<sql-rest-fields>>
 
 [[sql-rest-overview]]
-[float]
 === Overview
 
 The SQL REST API accepts SQL in a JSON document, executes it,
@@ -51,7 +50,6 @@ quotes (`"`) inside the query string but also support multi-line as shown below:
 image:images/sql/rest/console-triple-quotes.png[]
 
 [[sql-rest-format]]
-[float]
 === Response Data Formats
 
 While the textual format is nice for humans, computers prefer something
@@ -106,7 +104,6 @@ s|Description
 
 Here are some examples for the human readable formats:
 
-[discrete]
 ==== CSV
 
 [source,console]
@@ -132,7 +129,6 @@ James S.A. Corey,Leviathan Wakes,561,2011-06-02T00:00:00.000Z
 --------------------------------------------------
 // TESTRESPONSE[non_json]
 
-[discrete]
 ==== JSON
 
 [source,console]
@@ -168,7 +164,6 @@ Which returns:
 --------------------------------------------------
 // TESTRESPONSE[s/sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmBmF1dGhvcgFmBG5hbWUBZgpwYWdlX2NvdW50AWYMcmVsZWFzZV9kYXRl\+v\/\/\/w8=/$body.cursor/]
 
-[discrete]
 ==== TSV
 
 [source,console]
@@ -195,7 +190,6 @@ James S.A. Corey	Leviathan Wakes	561	2011-06-02T00:00:00.000Z
 // TESTRESPONSE[s/\t/ /]
 // TESTRESPONSE[non_json]
 
-[discrete]
 ==== TXT
 
 [source,console]
@@ -223,7 +217,6 @@ James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00.000Z
 // TESTRESPONSE[s/\|/\\|/ s/\+/\\+/]
 // TESTRESPONSE[non_json]
 
-[discrete]
 ==== YAML
 
 [source,console]
@@ -275,7 +268,6 @@ cursor: "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmB
 // TESTRESPONSE[s/sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmBmF1dGhvcgFmBG5hbWUBZgpwYWdlX2NvdW50AWYMcmVsZWFzZV9kYXRl\+v\/\/\/w8=/$body.cursor/]
 
 [[sql-pagination]]
-[float]
 === Paginating through a large response
 
 Using the example above, one can continue to the next page by sending back the `cursor` field. In
@@ -339,7 +331,6 @@ Which will like return the
 
 
 [[sql-rest-filtering]]
-[float]
 === Filtering using {es} query DSL
 
 You can filter the results that SQL will run on using a standard
@@ -376,7 +367,6 @@ Douglas Adams  |The Hitchhiker's Guide to the Galaxy|180            |1979-10-12T
 // TESTRESPONSE[non_json]
 
 [[sql-rest-columnar]]
-[float]
 === Columnar results
 
 The most well known way of displaying the results of an SQL query result in general is the one where each
@@ -449,7 +439,6 @@ Which looks like:
 // TESTRESPONSE[s/46ToAwFzQERYRjFaWEo1UVc1a1JtVjBZMmdCQUFBQUFBQUFBQUVXWjBaNlFXbzNOV0pVY21Wa1NUZDJhV2t3V2xwblp3PT3\/\/\/\/\/DwQBZgZhdXRob3IBBHRleHQAAAFmBG5hbWUBBHRleHQAAAFmCnBhZ2VfY291bnQBBGxvbmcBAAFmDHJlbGVhc2VfZGF0ZQEIZGF0ZXRpbWUBAAEP/$body.cursor/]
 
 [[sql-rest-fields]]
-[float]
 === Supported REST parameters
 
 In addition to the `query` and `fetch_size`, a request a number of user-defined fields for specifying

--- a/docs/reference/sql/endpoints/rest.asciidoc
+++ b/docs/reference/sql/endpoints/rest.asciidoc
@@ -11,6 +11,7 @@
 * <<sql-rest-fields>>
 
 [[sql-rest-overview]]
+[float]
 === Overview
 
 The SQL REST API accepts SQL in a JSON document, executes it,
@@ -50,6 +51,7 @@ quotes (`"`) inside the query string but also support multi-line as shown below:
 image:images/sql/rest/console-triple-quotes.png[]
 
 [[sql-rest-format]]
+[float]
 === Response Data Formats
 
 While the textual format is nice for humans, computers prefer something
@@ -104,6 +106,7 @@ s|Description
 
 Here are some examples for the human readable formats:
 
+[discrete]
 ==== CSV
 
 [source,console]
@@ -129,6 +132,7 @@ James S.A. Corey,Leviathan Wakes,561,2011-06-02T00:00:00.000Z
 --------------------------------------------------
 // TESTRESPONSE[non_json]
 
+[discrete]
 ==== JSON
 
 [source,console]
@@ -164,6 +168,7 @@ Which returns:
 --------------------------------------------------
 // TESTRESPONSE[s/sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmBmF1dGhvcgFmBG5hbWUBZgpwYWdlX2NvdW50AWYMcmVsZWFzZV9kYXRl\+v\/\/\/w8=/$body.cursor/]
 
+[discrete]
 ==== TSV
 
 [source,console]
@@ -190,6 +195,7 @@ James S.A. Corey	Leviathan Wakes	561	2011-06-02T00:00:00.000Z
 // TESTRESPONSE[s/\t/ /]
 // TESTRESPONSE[non_json]
 
+[discrete]
 ==== TXT
 
 [source,console]
@@ -217,6 +223,7 @@ James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00.000Z
 // TESTRESPONSE[s/\|/\\|/ s/\+/\\+/]
 // TESTRESPONSE[non_json]
 
+[discrete]
 ==== YAML
 
 [source,console]
@@ -268,6 +275,7 @@ cursor: "sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmB
 // TESTRESPONSE[s/sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmBmF1dGhvcgFmBG5hbWUBZgpwYWdlX2NvdW50AWYMcmVsZWFzZV9kYXRl\+v\/\/\/w8=/$body.cursor/]
 
 [[sql-pagination]]
+[float]
 === Paginating through a large response
 
 Using the example above, one can continue to the next page by sending back the `cursor` field. In
@@ -331,6 +339,7 @@ Which will like return the
 
 
 [[sql-rest-filtering]]
+[float]
 === Filtering using {es} query DSL
 
 You can filter the results that SQL will run on using a standard
@@ -367,6 +376,7 @@ Douglas Adams  |The Hitchhiker's Guide to the Galaxy|180            |1979-10-12T
 // TESTRESPONSE[non_json]
 
 [[sql-rest-columnar]]
+[float]
 === Columnar results
 
 The most well known way of displaying the results of an SQL query result in general is the one where each
@@ -439,6 +449,7 @@ Which looks like:
 // TESTRESPONSE[s/46ToAwFzQERYRjFaWEo1UVc1a1JtVjBZMmdCQUFBQUFBQUFBQUVXWjBaNlFXbzNOV0pVY21Wa1NUZDJhV2t3V2xwblp3PT3\/\/\/\/\/DwQBZgZhdXRob3IBBHRleHQAAAFmBG5hbWUBBHRleHQAAAFmCnBhZ2VfY291bnQBBGxvbmcBAAFmDHJlbGVhc2VfZGF0ZQEIZGF0ZXRpbWUBAAEP/$body.cursor/]
 
 [[sql-rest-fields]]
+[float]
 === Supported REST parameters
 
 In addition to the `query` and `fetch_size`, a request a number of user-defined fields for specifying


### PR DESCRIPTION
#43007 restructured the SQL REST API docs so they display across several pages.

This updates up a reference that assumes a single page in the "Paginating through a large response" section. It also reformats a tip for the Kibana console.

Closes #50688

### Preview of changes
http://elasticsearch_50690.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/sql-rest.html