### PR TITLE
Remove _reload_search_analyzer experimental status

### DIFF
--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Reload search analyzers</titleabbrev>
 ++++
 
-experimental::[]
-
 Reloads an index's <<search-analyzer,search analyzers>> and their resources.
 
 [source,console]

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
@@ -3,7 +3,7 @@
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-reload-analyzers.html"
     },
-    "stability":"experimental",
+    "stability" : "stable",
     "url":{
       "paths":[
         {


### PR DESCRIPTION
Removing the experimental status in the docs and the rest specs.