### PR TITLE
Move scripted metric to ObjectParser

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -50,8 +50,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
-import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
-
 /**
  * {@link Script} represents used-defined input that can be used to
  * compile and execute a script from the {@link ScriptService}
@@ -274,13 +272,24 @@ public final class Script implements ToXContentObject, Writeable {
     }
 
     /**
-     * Declare a script field on an {@link ObjectParser}.
+     * Declare a script field on an {@link ObjectParser} with the standard name ({@code script}).
      * @param <T> Whatever type the {@linkplain ObjectParser} is parsing.
      * @param parser the parser itself
      * @param consumer the consumer for the script
      */
     public static <T> void declareScript(AbstractObjectParser<T, ?> parser, BiConsumer<T, Script> consumer) {
-        parser.declareField(constructorArg(), (p, c) -> Script.parse(p), Script.SCRIPT_PARSE_FIELD, ValueType.OBJECT_OR_STRING);
+        parser.declareField(consumer, (p, c) -> Script.parse(p), Script.SCRIPT_PARSE_FIELD, ValueType.OBJECT_OR_STRING);
+    }
+
+    /**
+     * Declare a script field on an {@link ObjectParser}.
+     * @param <T> Whatever type the {@linkplain ObjectParser} is parsing.
+     * @param parser the parser itself
+     * @param consumer the consumer for the script
+     * @param parseField the field name
+     */
+    public static <T> void declareScript(AbstractObjectParser<T, ?> parser, BiConsumer<T, Script> consumer, ParseField parseField) {
+        parser.declareField(consumer, (p, c) -> Script.parse(p), parseField, ValueType.OBJECT_OR_STRING);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -278,7 +278,7 @@ public final class Script implements ToXContentObject, Writeable {
      * @param consumer the consumer for the script
      */
     public static <T> void declareScript(AbstractObjectParser<T, ?> parser, BiConsumer<T, Script> consumer) {
-        parser.declareField(consumer, (p, c) -> Script.parse(p), Script.SCRIPT_PARSE_FIELD, ValueType.OBJECT_OR_STRING);
+        declareScript(parser, consumer, Script.SCRIPT_PARSE_FIELD);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -422,7 +422,7 @@ public class SearchModule {
         registerAggregation(new AggregationSpec(GeoCentroidAggregationBuilder.NAME, GeoCentroidAggregationBuilder::new,
                 GeoCentroidAggregationBuilder::parse).addResultReader(InternalGeoCentroid::new));
         registerAggregation(new AggregationSpec(ScriptedMetricAggregationBuilder.NAME, ScriptedMetricAggregationBuilder::new,
-                ScriptedMetricAggregationBuilder::parse).addResultReader(InternalScriptedMetric::new));
+                (name, p) -> ScriptedMetricAggregationBuilder.PARSER.parse(p, name)).addResultReader(InternalScriptedMetric::new));
         registerAggregation((new AggregationSpec(CompositeAggregationBuilder.NAME, CompositeAggregationBuilder::new,
             CompositeAggregationBuilder::parse).addResultReader(InternalComposite::new)));
         registerFromPlugin(plugins, SearchPlugin::getAggregations, this::registerAggregation);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -20,14 +20,13 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
@@ -38,6 +37,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
 public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder<ScriptedMetricAggregationBuilder> {
     public static final String NAME = "scripted_metric";
 
@@ -46,6 +47,20 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
     private static final ParseField COMBINE_SCRIPT_FIELD = new ParseField("combine_script");
     private static final ParseField REDUCE_SCRIPT_FIELD = new ParseField("reduce_script");
     private static final ParseField PARAMS_FIELD = new ParseField("params");
+
+    public static final ConstructingObjectParser<ScriptedMetricAggregationBuilder, String> PARSER =
+            new ConstructingObjectParser<>(NAME, false, (args, name) -> {
+                ScriptedMetricAggregationBuilder builder = new ScriptedMetricAggregationBuilder(name);
+                builder.mapScript((Script) args[0]);
+                return builder;
+            });
+    static {
+        Script.declareScript(PARSER, ScriptedMetricAggregationBuilder::initScript, INIT_SCRIPT_FIELD);
+        Script.declareScript(PARSER, constructorArg(), MAP_SCRIPT_FIELD);
+        Script.declareScript(PARSER, ScriptedMetricAggregationBuilder::combineScript, COMBINE_SCRIPT_FIELD);
+        Script.declareScript(PARSER, ScriptedMetricAggregationBuilder::reduceScript, REDUCE_SCRIPT_FIELD);
+        PARSER.declareObject(ScriptedMetricAggregationBuilder::params, (p, name) -> p.map(), PARAMS_FIELD);
+    }
 
     private Script initScript;
     private Script mapScript;
@@ -258,62 +273,6 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
         }
         builder.endObject();
         return builder;
-    }
-
-    public static ScriptedMetricAggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {
-        Script initScript = null;
-        Script mapScript = null;
-        Script combineScript = null;
-        Script reduceScript = null;
-        Map<String, Object> params = null;
-        XContentParser.Token token;
-        String currentFieldName = null;
-
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token == XContentParser.Token.START_OBJECT || token == XContentParser.Token.VALUE_STRING) {
-                if (INIT_SCRIPT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    initScript = Script.parse(parser);
-                } else if (MAP_SCRIPT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    mapScript = Script.parse(parser);
-                } else if (COMBINE_SCRIPT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    combineScript = Script.parse(parser);
-                } else if (REDUCE_SCRIPT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    reduceScript = Script.parse(parser);
-                } else if (token == XContentParser.Token.START_OBJECT &&
-                        PARAMS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    params = parser.map();
-                } else {
-                    throw new ParsingException(parser.getTokenLocation(),
-                            "Unknown key for a " + token + " in [" + aggregationName + "]: [" + currentFieldName + "].");
-                }
-            } else {
-                throw new ParsingException(parser.getTokenLocation(), "Unexpected token " + token + " in [" + aggregationName + "].");
-            }
-        }
-
-        if (mapScript == null) {
-            throw new ParsingException(parser.getTokenLocation(), "map_script field is required in [" + aggregationName + "].");
-        }
-
-        ScriptedMetricAggregationBuilder factory = new ScriptedMetricAggregationBuilder(aggregationName);
-        if (initScript != null) {
-            factory.initScript(initScript);
-        }
-        if (mapScript != null) {
-            factory.mapScript(mapScript);
-        }
-        if (combineScript != null) {
-            factory.combineScript(combineScript);
-        }
-        if (reduceScript != null) {
-            factory.reduceScript(reduceScript);
-        }
-        if (params != null) {
-            factory.params(params);
-        }
-        return factory;
     }
 
     @Override


### PR DESCRIPTION
This replaces the hand rolled parsing code for scripted metric with
`ObjectParser` which is simpler to work with because it is declarative.
