### PR TITLE
EQL: Protocol support for async mode

### DIFF
--- a/x-pack/plugin/eql/qa/rest/src/test/resources/rest-api-spec/test/eql/10_basic.yml
+++ b/x-pack/plugin/eql/qa/rest/src/test/resources/rest-api-spec/test/eql/10_basic.yml
@@ -25,3 +25,18 @@ setup:
   - match: {took: 0}
   - match: {hits.total.value: 0}
 
+---
+# Testing async execution
+"Execute some EQL async":
+  - do:
+      eql.search:
+        index: eql_test
+        wait_for_completion: false
+        body:
+          rule: "process where user = 'SYSTEM'"
+
+  - match: {task: '/.+:\d+/'}
+  - set: {task: task}
+
+
+# TODO: Add get task when task result is stored

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -41,6 +41,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
     private int fetchSize = 50;
     private SearchAfterBuilder searchAfterBuilder;
     private String rule;
+    private boolean waitForCompletion;
 
     static final String KEY_QUERY = "query";
     static final String KEY_TIMESTAMP_FIELD = "timestamp_field";
@@ -75,6 +76,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         fetchSize = in.readVInt();
         searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
         rule = in.readString();
+        waitForCompletion = in.readBoolean();
     }
 
     @Override
@@ -224,6 +226,15 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         return this;
     }
 
+    public boolean waitForCompletion() {
+        return this.waitForCompletion;
+    }
+
+    public EqlSearchRequest waitForCompletion(boolean waitForCompletion) {
+        this.waitForCompletion = waitForCompletion;
+        return this;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -236,6 +247,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         out.writeVInt(fetchSize);
         out.writeOptionalWriteable(searchAfterBuilder);
         out.writeString(rule);
+        out.writeBoolean(waitForCompletion);
     }
 
     @Override
@@ -256,7 +268,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             Objects.equals(eventTypeField, that.eventTypeField) &&
             Objects.equals(implicitJoinKeyField, that.implicitJoinKeyField) &&
             Objects.equals(searchAfterBuilder, that.searchAfterBuilder) &&
-            Objects.equals(rule, that.rule);
+            Objects.equals(rule, that.rule) &&
+            Objects.equals(waitForCompletion, that.waitForCompletion);
     }
 
     @Override
@@ -270,7 +283,8 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             eventTypeField,
             implicitJoinKeyField,
             searchAfterBuilder,
-            rule);
+            rule,
+            waitForCompletion);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -99,24 +99,26 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
     private static final ParseField TASK = new ParseField(Fields.TASK);
 
     private static final ConstructingObjectParser<EqlSearchResponse, Void> PARSER =
-        new ConstructingObjectParser<>("eql/search_response", false,
+        new ConstructingObjectParser<>("eql/search_response", true,
             args -> {
-                if (args[0] != null) {
-                    if (args[1] != null || args[2] != null || args[3] != null) {
-                        throw new IllegalArgumentException("Unexpected elements in async response");
-                    }
-                    return new EqlSearchResponse(new TaskId((String)args[0]));
+                int i = 0;
+                String taskId = (String) args[i++];
+                Hits hits = (Hits) args[i++];
+                Long took = (Long) args[i++];
+                Boolean timeout = (Boolean) args[i];
+                if (taskId != null) {
+                    return new EqlSearchResponse(new TaskId(taskId));
                 } else {
-                    if (args[1] == null) {
+                    if (hits == null) {
                         throw new IllegalArgumentException("Missing hits");
                     }
-                    if (args[2] == null) {
+                    if (took == null) {
                         throw new IllegalArgumentException("Missing took time");
                     }
-                    if (args[3] == null) {
+                    if (timeout == null) {
                         throw new IllegalArgumentException("Missing timeout");
                     }
-                    return new EqlSearchResponse((Hits)args[1], (long)args[2], (boolean)args[3]);
+                    return new EqlSearchResponse(hits, took, timeout);
                 }
             });
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -38,10 +38,13 @@ public class EqlSearchRequestTests extends AbstractSerializingTestCase<EqlSearch
         "   }" +
         "}";
 
-    static String defaultTestIndex = "endgame-*";
+    private String[] defaultTestIndex;
+    private boolean waitForCompletion;
 
     @Before
     public void setup() {
+        defaultTestIndex = generateRandomStringArray(10, 10, false);
+        waitForCompletion = randomBoolean();
     }
 
     @Override
@@ -61,7 +64,7 @@ public class EqlSearchRequestTests extends AbstractSerializingTestCase<EqlSearch
         try {
             QueryBuilder query = parseQuery(defaultTestQuery);
             EqlSearchRequest request = new EqlSearchRequest()
-                .indices(new String[]{defaultTestIndex})
+                .indices(defaultTestIndex)
                 .query(query)
                 .timestampField(randomAlphaOfLength(10))
                 .eventTypeField(randomAlphaOfLength(10))
@@ -71,6 +74,9 @@ public class EqlSearchRequestTests extends AbstractSerializingTestCase<EqlSearch
 
             if (randomBoolean()) {
                 request.searchAfter(randomJsonSearchFromBuilder());
+            }
+            if (waitForCompletion || randomBoolean()) {
+                request.waitForCompletion(waitForCompletion);
             }
             return request;
         } catch (IOException ex) {
@@ -130,7 +136,7 @@ public class EqlSearchRequestTests extends AbstractSerializingTestCase<EqlSearch
 
     @Override
     protected EqlSearchRequest doParseInstance(XContentParser parser) {
-        return EqlSearchRequest.fromXContent(parser).indices(new String[]{defaultTestIndex});
+        return EqlSearchRequest.fromXContent(parser).indices(defaultTestIndex).waitForCompletion(waitForCompletion);
     }
 
     public void testSizeException() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -123,4 +123,5 @@ public class EqlSearchResponseTests extends AbstractSerializingTestCase<EqlSearc
     protected EqlSearchResponse doParseInstance(XContentParser parser) {
         return EqlSearchResponse.fromXContent(parser);
     }
+
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -9,6 +9,7 @@ import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.util.HashMap;
@@ -32,11 +33,15 @@ public class EqlSearchResponseTests extends AbstractSerializingTestCase<EqlSearc
 
     @Override
     protected EqlSearchResponse createTestInstance() {
-        TotalHits totalHits = null;
         if (randomBoolean()) {
-            totalHits = new TotalHits(randomIntBetween(100, 1000), TotalHits.Relation.EQUAL_TO);
+            return new EqlSearchResponse(new TaskId(randomAlphaOfLength(5), randomLong()));
+        } else {
+            TotalHits totalHits = null;
+            if (randomBoolean()) {
+                totalHits = new TotalHits(randomIntBetween(100, 1000), TotalHits.Relation.EQUAL_TO);
+            }
+            return createRandomInstance(totalHits);
         }
-        return createRandomInstance(totalHits);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
@@ -21,7 +21,13 @@
         }
       ]
     },
-    "params":{},
+    "params":{
+      "wait_for_completion":{
+        "type":"boolean",
+        "default":true,
+        "description":"Should the request should block until the operation is complete."
+      }
+    },
     "body":{
       "description":"Eql request body. Use the `query` to limit the query scope.",
       "required":true


### PR DESCRIPTION
Adds a protocol support for async mode. The actual implementation
will be added when more details of query handling are clear.

Relates to #49581
