### PR TITLE
Specify the indexname in searches

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
@@ -46,6 +46,7 @@ setup:
       headers:
         Content-Type: application/json
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:
@@ -76,6 +77,7 @@ setup:
       headers:
         Content-Type: application/json
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:
@@ -108,6 +110,7 @@ setup:
       warnings:
         - The vector functions of the form function(query, doc['field']) are deprecated, and the form function(query, 'field') should be used instead. For example, cosineSimilarity(query, doc['field']) is replaced by cosineSimilarity(query, 'field').
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
@@ -47,6 +47,7 @@ setup:
       headers:
         Content-Type: application/json
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:
@@ -77,6 +78,7 @@ setup:
       headers:
         Content-Type: application/json
       search:
+        index: test-index
         rest_total_hits_as_int: true
         body:
           query:


### PR DESCRIPTION
Vector REST tests occasionally fail on 7.x because
we don't receive the expected response headers with deprecation warnings.
This happens as searchers are executed against all indices including
internal indices, whose shards do not produce expected warnings.

This PR ensures that searchers are executed only against expected
indices.

Closes #50716