### PR TITLE
[DOCS] Improves description for forecast_stats

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -168,7 +168,7 @@ related to this job. If there are no forecasts, this property is omitted.
 
 `forecasts_stats`.`records`:::
 (object) The `avg`, `min`, `max` and `total` number of model_forecast documents 
-written for forecasts related to this job. Omitted if forecasts do not exist.
+written for forecasts related to this job. If there are no forecasts, this property is omitted.
 
 `forecasts_stats`.`processing_time_ms`:::
 (object) The `avg`, `min`, `max` and `total` runtime in milliseconds for 

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -164,7 +164,7 @@ value of `1` indicates that at least one forecast exists.
 
 `forecasts_stats`.`memory_bytes`:::
 (object) The `avg`, `min`, `max` and `total` memory usage in bytes for forecasts 
-related to this job. Omitted if forecasts do not exist.
+related to this job. If there are no forecasts, this property is omitted.
 
 `forecasts_stats`.`records`:::
 (object) The `avg`, `min`, `max` and `total` number of model_forecast documents 

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -172,7 +172,7 @@ written for forecasts related to this job. If there are no forecasts, this prope
 
 `forecasts_stats`.`processing_time_ms`:::
 (object) The `avg`, `min`, `max` and `total` runtime in milliseconds for 
-forecasts related to this job. Omitted if forecasts do not exist.
+forecasts related to this job. If there are no forecasts, this property is omitted.
 
 `forecasts_stats`.`status`:::
 (object) The count of forecasts by their status. For example: 

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -176,7 +176,7 @@ forecasts related to this job. If there are no forecasts, this property is omitt
 
 `forecasts_stats`.`status`:::
 (object) The count of forecasts by their status. For example: 
-{"finished" : 2, "started" : 1}. Omitted if forecasts do not exist.
+{"finished" : 2, "started" : 1}. If there are no forecasts, this property is omitted.
 
 `forecasts_stats`.`total`:::
 (long) The number of individual forecasts currently available for this job. A 

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -148,8 +148,9 @@ expected number of data points. If your data contains many sparse buckets,
 consider using a longer `bucket_span`.
 
 [[forecastsstats]]`forecasts_stats`::
-(object) An object that provides statistical information about forecasts
-of this job. It has the following properties:
+(object) An object that provides statistical information about forecasts 
+belonging to this job. Some statistics are omitted if no forecasts have been 
+made. It has the following properties:
 +
 --
 NOTE: Unless there is at least one forecast, `memory_bytes`, `records`,
@@ -158,24 +159,28 @@ NOTE: Unless there is at least one forecast, `memory_bytes`, `records`,
 --
 
 `forecasts_stats`.`forecasted_jobs`:::
-(long) The number of jobs that have at least one forecast.
+(long) A value of `0` indicates that forecasts do not exist for this job. A 
+value of `1` indicates that at least one forecast exists.
 
 `forecasts_stats`.`memory_bytes`:::
-(object) Statistics about the memory usage: minimum, maximum, average and total.
+(object) The `avg`, `min`, `max` and `total` memory usage in bytes for forecasts 
+related to this job. Omitted if forecasts do not exist.
 
 `forecasts_stats`.`records`:::
-(object) Statistics about the number of forecast records: minimum, maximum,
-average and total.
+(object) The `avg`, `min`, `max` and `total` number of model_forecast documents 
+written for forecasts related to this job. Omitted if forecasts do not exist.
 
 `forecasts_stats`.`processing_time_ms`:::
-(object) Statistics about the forecast runtime in milliseconds: minimum, maximum,
-average and total.
+(object) The `avg`, `min`, `max` and `total` runtime in milliseconds for 
+forecasts related to this job. Omitted if forecasts do not exist.
 
 `forecasts_stats`.`status`:::
-(object) Counts per forecast status. For example: `{"finished" : 2}`. 
+(object) The count of forecasts by their status. For example: 
+{"finished" : 2, "started" : 1}. Omitted if forecasts do not exist.
 
 `forecasts_stats`.`total`:::
-(long) The number of forecasts currently available for this model.
+(long) The number of individual forecasts currently available for this job. A 
+value of `1` or more indicates that forecasts exist.
 
 `job_id`::
 (string)


### PR DESCRIPTION
Improves the description of the `forecast_stats` objects of the GET job stats API docs.

Related issue: https://github.com/elastic/ml-team/issues/274#issuecomment-571714977

Preview: http://elasticsearch_50729.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html