### PR TITLE
[DOCS] Forms role and privilege requirements as bulleted lists in DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -21,7 +21,7 @@ experimental[]
 [[ml-delete-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required build-in roles:
+If the {es} {security-features} are enabled, you must have the following built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 * `kibana_user` (UI only)

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -21,8 +21,12 @@ experimental[]
 [[ml-delete-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `machine_learning_admin` built-in role to use this API. For more
-information, see <<security-privileges>> and <<built-in-roles>>.
+Required build-in roles:
+
+* `machine_learning_admin`
+* `kibana_user` (UI only)
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-delete-dfanalytics-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -22,8 +22,12 @@ experimental[]
 [[ml-delete-inference-prereq]]
 ==== {api-prereq-title}
 
-* You must have `machine_learning_admin` built-in role to use this API. For more 
-information, see <<security-privileges>> and <<built-in-roles>>.
+Required build-in roles:
+
+* `machine_learning_admin`
+* `kibana_user` (UI only)
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-delete-inference-path-params]]

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -22,7 +22,7 @@ experimental[]
 [[ml-delete-inference-prereq]]
 ==== {api-prereq-title}
 
-Required build-in roles:
+If the {es} {security-features} are enabled, you must have the following built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 * `kibana_user` (UI only)
@@ -67,5 +67,4 @@ The API returns the following result:
   "acknowledged" : true
 }
 ----
-
 

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -22,7 +22,7 @@ experimental[]
 [[ml-evaluate-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required privileges which should be added to a custom role:
+If the {es} {security-features} are enabled, you must have the following privileges:
 
 * cluster: `monitor_ml`
   

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -22,8 +22,11 @@ experimental[]
 [[ml-evaluate-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `monitor_ml` privilege to use this API. For more 
-information, see <<security-privileges>> and <<built-in-roles>>.
+Required privileges which should be added to a custom role:
+
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-evaluate-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -28,7 +28,7 @@ experimental[]
 [[ml-explain-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required privileges which should be added to a custom role:
+If the {es} {security-features} are enabled, you must have the following privileges:
 
 * cluster: `monitor_ml`
   

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -28,8 +28,11 @@ experimental[]
 [[ml-explain-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `monitor_ml` privilege to use this API. For more
-information, see <<security-privileges>> and <<built-in-roles>>.
+Required privileges which should be added to a custom role:
+
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-explain-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -28,8 +28,11 @@ experimental[]
 [[ml-get-dfanalytics-stats-prereq]]
 ==== {api-prereq-title}
 
-* You must have `monitor_ml` privilege to use this API. For more 
-information, see <<security-privileges>> and <<built-in-roles>>.
+Required privileges which should be added to a custom role:
+
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-dfanalytics-stats-path-params]]

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -28,7 +28,7 @@ experimental[]
 [[ml-get-dfanalytics-stats-prereq]]
 ==== {api-prereq-title}
 
-Required privileges which should be added to a custom role:
+If the {es} {security-features} are enabled, you must have the following privileges:
 
 * cluster: `monitor_ml`
   

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -27,7 +27,7 @@ experimental[]
 [[ml-get-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required privileges which should be added to a custom role:
+If the {es} {security-features} are enabled, you must have the following privileges:
 
 * cluster: `monitor_ml`
   

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -27,8 +27,11 @@ experimental[]
 [[ml-get-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `monitor_ml` privilege to use this API. For more information, 
-see <<security-privileges>> and <<built-in-roles>>.
+Required privileges which should be added to a custom role:
+
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -29,8 +29,11 @@ experimental[]
 [[ml-get-inference-stats-prereq]]
 ==== {api-prereq-title}
 
-* You must have `monitor_ml` privilege to use this API. For more information, 
-see <<security-privileges>> and <<built-in-roles>>.
+Required privileges which should be added to a custom role:
+
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-inference-stats-desc]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -29,8 +29,11 @@ experimental[]
 [[ml-get-inference-prereq]]
 ==== {api-prereq-title}
 
-* You must have `monitor_ml` privilege to use this API. For more information, 
-see <<security-privileges>> and <<built-in-roles>>.
+Required privileges which should be added to a custom role:
+
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-get-inference-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -20,10 +20,18 @@ experimental[]
 [[ml-put-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `machine_learning_admin` built-in role to use this API. You must 
-also have `read` and `view_index_metadata` privileges on the source index and 
-`read`, `create_index`, and `index` privileges on the destination index. For 
-more information, see <<security-privileges>> and <<built-in-roles>>.
+Required build-in roles:
+
+* `machine_learning_admin`
+* `kibana_user` (UI only)
+
+Required privileges which should be added to a custom role:
+
+* source index: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, `manage` and `index`
+* cluster: `monitor` (UI only)
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[ml-put-dfanalytics-desc]]

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -25,7 +25,6 @@ If the {es} {security-features} are enabled, you must have the following built-i
 * `machine_learning_admin`
 * `kibana_user` (UI only)
 
-Required privileges which should be added to a custom role:
 
 * source index: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -20,7 +20,7 @@ experimental[]
 [[ml-put-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required build-in roles:
+If the {es} {security-features} are enabled, you must have the following built-in roles and privileges:
 
 * `machine_learning_admin`
 * `kibana_user` (UI only)

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -20,10 +20,19 @@ experimental[]
 [[ml-start-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `machine_learning_admin` built-in role to use this API. You must 
-also have `read` and `view_index_metadata` privileges on the source index and 
-`read`, `create_index`, and `index` privileges on the destination index. For 
-more information, see <<security-privileges>> and <<built-in-roles>>.
+Required build-in roles:
+
+* `machine_learning_admin`
+* `kibana_user` (UI only)
+
+Required privileges which should be added to a custom role:
+
+* source index: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, `manage` and `index`
+* cluster: `monitor` (UI only)
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[ml-start-dfanalytics-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -25,7 +25,6 @@ If the {es} {security-features} are enabled, you must have the following built-i
 * `machine_learning_admin`
 * `kibana_user` (UI only)
 
-Required privileges which should be added to a custom role:
 
 * source index: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -20,7 +20,7 @@ experimental[]
 [[ml-start-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required build-in roles:
+If the {es} {security-features} are enabled, you must have the following built-in roles and privileges:
 
 * `machine_learning_admin`
 * `kibana_user` (UI only)

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -24,8 +24,13 @@ experimental[]
 [[ml-stop-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-* You must have `machine_learning_admin` built-in role to use this API. For more 
-information, see <<security-privileges>> and <<built-in-roles>>.
+Required build-in roles:
+
+* `machine_learning_admin`
+* `kibana_user` (UI only)
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[ml-stop-dfanalytics-desc]]
 ==== {api-description-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -24,7 +24,7 @@ experimental[]
 [[ml-stop-dfanalytics-prereq]]
 ==== {api-prereq-title}
 
-Required build-in roles:
+If the {es} {security-features} are enabled, you must have the following built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
 * `kibana_user` (UI only)


### PR DESCRIPTION
Lists built-in roles and privilege requirements of the DFA APIs as bullet points for improved readability. Refines PUT DFA API requirements.

Related issue: https://github.com/elastic/ml-team/issues/274#issuecomment-571679132

Preview: http://elasticsearch_50732.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-df-analytics-apis.html