### PR TITLE
Fix and Reenable SnapshotTool Minio Tests

### DIFF
--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -141,7 +141,7 @@ task thirdPartyTest(type: Test) {
 }
 
 if (useFixture) {
-  testFixtures.useFixture(':test:fixtures:minio-fixture')
+  testFixtures.useFixture(':test:fixtures:minio-fixture', 'minio-fixture')
 
   def minioAddress = {
     int minioPort = project(':test:fixtures:minio-fixture').postProcessFixture.ext."test.fixtures.minio-fixture.tcp.9000"

--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -11,3 +11,15 @@ services:
     ports:
       - "9000"
     command: ["server", "/minio/data"]
+
+  minio-fixture-for-snapshot-tool:
+      build:
+        context: .
+        args:
+          bucket: "bucket"
+          accessKey: "sn_tool_access_key"
+          secretKey: "sn_tool_secret_key"
+        dockerfile: Dockerfile
+      ports:
+        - "9000"
+      command: ["server", "/minio/data"]

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -4,6 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
   compile project(":plugins:repository-s3")
@@ -26,9 +27,9 @@ String s3PermanentBucket = System.getenv("amazon_s3_bucket")
 String s3PermanentBasePath = System.getenv("amazon_s3_base_path")
 
 if (!s3PermanentAccessKey && !s3PermanentSecretKey && !s3PermanentBucket && !s3PermanentBasePath) {
-  s3PermanentAccessKey = 's3_integration_test_permanent_access_key'
-  s3PermanentSecretKey = 's3_integration_test_permanent_secret_key'
-  s3PermanentBucket = 'permanent-bucket-test'
+  s3PermanentAccessKey = 'sn_tool_access_key'
+  s3PermanentSecretKey = 'sn_tool_secret_key'
+  s3PermanentBucket = 'bucket'
   s3PermanentBasePath = 'integration_test'
 
   useS3Fixture = true
@@ -48,41 +49,17 @@ task thirdPartyTest(type: Test) {
 }
 
 if (useS3Fixture) {
-  thirdPartyTest.enabled = false;
   testingConventions.enabled = false;
-  /*
-
-  See: https://github.com/elastic/elasticsearch/issues/46813 Fails with --parallel
-
-  apply plugin: 'elasticsearch.test.fixtures'
-
-  testFixtures.useFixture()
-
-  task writeDockerFile {
-    File minioDockerfile = new File("${project.buildDir}/minio-docker/Dockerfile")
-    outputs.file(minioDockerfile)
-    doLast {
-      minioDockerfile.parentFile.mkdirs()
-      minioDockerfile.text =
-        "FROM minio/minio:RELEASE.2019-01-23T23-18-58Z\n" +
-          "RUN mkdir -p /minio/data/${s3PermanentBucket}\n" +
-          "ENV MINIO_ACCESS_KEY ${s3PermanentAccessKey}\n" +
-          "ENV MINIO_SECRET_KEY ${s3PermanentSecretKey}"
-    }
-  }
-
-  preProcessFixture {
-    dependsOn(writeDockerFile)
-  }
+  testFixtures.useFixture(':test:fixtures:minio-fixture', "minio-fixture-for-snapshot-tool")
 
   def minioAddress = {
-    int minioPort = postProcessFixture.ext."test.fixtures.minio-fixture.tcp.9000"
+    int minioPort = project(':test:fixtures:minio-fixture').postProcessFixture.ext."test.fixtures.minio-fixture-for-snapshot-tool.tcp.9000"
     assert minioPort > 0
     'http://127.0.0.1:' + minioPort
   }
 
   thirdPartyTest {
-    dependsOn tasks.postProcessFixture
+    dependsOn project(':test:fixtures:minio-fixture').postProcessFixture
     nonInputProperties.systemProperty 'test.s3.endpoint', "${-> minioAddress.call()}"
   }
 
@@ -91,7 +68,7 @@ if (useS3Fixture) {
       throw new IllegalStateException("Tried to run third party tests but not all of the necessary environment variables 'amazon_s3_access_key', " +
         "'amazon_s3_secret_key', 'amazon_s3_bucket', and 'amazon_s3_base_path' are set.");
     }
-  }*/
+  }
 }
 
 check.dependsOn(thirdPartyTest)

--- a/x-pack/snapshot-tool/qa/s3/docker-compose.yml
+++ b/x-pack/snapshot-tool/qa/s3/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '3'
-services:
-  minio-fixture:
-    build:
-      context: ./build/minio-docker
-      dockerfile: Dockerfile
-    ports:
-      - "9000"
-    command: ["server", "/minio/data"]


### PR DESCRIPTION
This solves half of the problem in #46813 by moving the S3
tests to using the shared minio fixture so we at least have
some non-3rd-party, constantly running coverage on these tests.

Sorry for not handling GCS right away as well but it was a little trickier for GCS and I just wanted to reenable these tests as quickly as possible because I'd like to make changes to the underlying test codebase they use.