### PR TITLE
ElasticSearchExceptionTests guessRootCauses fix

### DIFF
--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -805,9 +805,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                 failure = new BroadcastShardOperationFailedException(new ShardId("_index", "_uuid", 5), "F", failureCause);
 
                 expected = new ElasticsearchException("Elasticsearch exception [type=file_already_exists_exception, reason=File exists]");
-                // strangely, the wrapped exception appears as the root cause...
-                suppressed = new ElasticsearchException("Elasticsearch exception [type=broadcast_shard_operation_failed_exception, " +
-                        "reason=F]");
+                suppressed = new ElasticsearchException("Elasticsearch exception [type=file_already_exists_exception, reason=File exists]");
                 expected.addSuppressed(suppressed);
                 break;
 


### PR DESCRIPTION
testFailureToAndFromXContentWithDetails had incorporated that
guessRootCauses returned the wrapper when the underlying exception
was not an ElasticsearchException, fixed.

Relates #50525

Discovered while backporting #50525, so the fix for this will be incorporated into
the [backport of that](#50742).