### PR TITLE
Enforce Logging of Errors in GCS Rest RetriesTests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -232,7 +232,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
     /**
      * Wrap a {@link HttpHandler} to log any thrown exception using the given {@link Logger}.
      */
-    private static HttpHandler wrap(final HttpHandler handler, final Logger logger) {
+    public static HttpHandler wrap(final HttpHandler handler, final Logger logger) {
         return exchange -> {
             try {
                 handler.handle(exchange);


### PR DESCRIPTION
It's impossible to tell why #50754 fails without this change.
We're failing to close the `exchange` somewhere and there is no
write timeout in the GCS SDK (something to look into separately)
only a read timeout on the socket so if we're failing on an assertion without
reading the full request body (at least into the read-buffer ... this test works
in some other spots that intentionally don't fully drain the `requestBody` because the body is small enough to fit into the read-buffer I think ... that's why it's only failing for the large write ... I left the small write spots as is for that reason for now) we're locking up waiting forever on `write0`.

This change ensure the `exchange` is closed in the tests where we could lock up
on a write and logs the failure so we can find out what broke #50754.

