### PR TITLE
[DOCS] an array of index patterns is also valid for source indices with transform

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -764,8 +764,9 @@ end::source-transforms[]
 
 tag::source-index-transforms[]
 The _source indices_ for the {transform}. It can be a single index, an index
-pattern (for example, `"myindex*"`), or an array of indices (for example,
-`["index1", "index2"]`).
+pattern (for example, `"myindex*"`), an array of indices (for example,
+`["index1", "index2"]`), or an array of index patterns (for example,
+`["myindex1-*", "myindex2-*"]`.
 end::source-index-transforms[]
 
 tag::source-query-transforms[]


### PR DESCRIPTION
Note that it's also possible to use an array of index patterns for source indices with transform, as this wasn't explicitly mentioned.

Preview:
* http://elasticsearch_50777.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html
* http://elasticsearch_50777.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html
* http://elasticsearch_50777.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-transform.html