### PR TITLE
[DOCS] Correct typo in `ignore_malformed` mapping parm docs

### DIFF
--- a/docs/reference/mapping/params/ignore-malformed.asciidoc
+++ b/docs/reference/mapping/params/ignore-malformed.asciidoc
@@ -95,7 +95,7 @@ Malformed fields are silently ignored at indexing time when `ignore_malformed`
 is turned on. Whenever possible it is recommended to keep the number of
 documents that have a malformed field contained, or queries on this field will
 become meaningless. Elasticsearch makes it easy to check how many documents
-have malformed fields by using `exist` or `term` queries on the special
+have malformed fields by using `exists`,`term` or `terms` queries on the special
 <<mapping-ignored-field,`_ignored`>> field.
 
 [[json-object-limits]]


### PR DESCRIPTION
It should be exists query.


- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
