### PR TITLE
Make cluster state writer resilient to disk issues

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -466,8 +466,8 @@ public class GatewayMetaState implements Closeable {
                 } else {
                     if (clusterState.term() != lastAcceptedState.term()) {
                         assert clusterState.term() > lastAcceptedState.term() : clusterState.term() + " vs " + lastAcceptedState.term();
-                        // In a new currentTerm, we cannot compare the persisted metadata's lastAcceptedVersion to those in the new state, so
-                        // it's simplest to write everything again.
+                        // In a new currentTerm, we cannot compare the persisted metadata's lastAcceptedVersion to those in the new state,
+                        // so it's simplest to write everything again.
                         getWriterSafe().writeFullStateAndCommit(currentTerm, clusterState);
                     } else {
                         // Within the same currentTerm, we _can_ use metadata versions to skip unnecessary writing.

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -701,8 +701,8 @@ public class PersistedClusterStateService {
                     close();
                 } catch (Exception e2) {
                     e.addSuppressed(e2);
-                    throw new IOError(e);
                 }
+                throw new IOError(e);
             } finally {
                 closeIfAnyIndexWriterHasTragedyOrIsClosed();
             }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -71,7 +71,6 @@ import org.elasticsearch.index.Index;
 
 import java.io.Closeable;
 import java.io.FilterOutputStream;
-import java.io.IOError;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -41,6 +41,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.Bits;
@@ -80,6 +81,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntPredicate;
 
 /**
@@ -520,6 +522,7 @@ public class PersistedClusterStateService {
         private final BigArrays bigArrays;
 
         boolean fullStateWritten = false;
+        private final AtomicBoolean closed = new AtomicBoolean();
 
         private Writer(List<MetaDataIndexWriter> metaDataIndexWriters, String nodeId, BigArrays bigArrays) {
             this.metaDataIndexWriters = metaDataIndexWriters;
@@ -527,13 +530,39 @@ public class PersistedClusterStateService {
             this.bigArrays = bigArrays;
         }
 
+        private void ensureOpen() {
+            if (closed.get()) {
+                throw new AlreadyClosedException("cluster state writer is closed already");
+            }
+        }
+
+        public boolean isOpen() {
+            return closed.get() == false;
+        }
+
+        private void closeIfAnyIndexWriterHasTragedyOrIsClosed() {
+            if (metaDataIndexWriters.stream().map(writer -> writer.indexWriter)
+                .anyMatch(iw -> iw.getTragicException() != null || iw.isOpen() == false)) {
+                try {
+                    close();
+                } catch (Exception e) {
+                    logger.warn("failed on closing cluster state writer", e);
+                }
+            }
+        }
+
         /**
          * Overrides and commits the given current term and cluster state
          */
         public void writeFullStateAndCommit(long currentTerm, ClusterState clusterState) throws IOException {
-            overwriteMetaData(clusterState.metaData());
-            commit(currentTerm, clusterState.version());
-            fullStateWritten = true;
+            ensureOpen();
+            try {
+                overwriteMetaData(clusterState.metaData());
+                commit(currentTerm, clusterState.version());
+                fullStateWritten = true;
+            } finally {
+                closeIfAnyIndexWriterHasTragedyOrIsClosed();
+            }
         }
 
         /**
@@ -541,9 +570,14 @@ public class PersistedClusterStateService {
          */
         void writeIncrementalStateAndCommit(long currentTerm, ClusterState previousClusterState,
                                             ClusterState clusterState) throws IOException {
+            ensureOpen();
             assert fullStateWritten : "Need to write full state first before doing incremental writes";
-            updateMetaData(previousClusterState.metaData(), clusterState.metaData());
-            commit(currentTerm, clusterState.version());
+            try {
+                updateMetaData(previousClusterState.metaData(), clusterState.metaData());
+                commit(currentTerm, clusterState.version());
+            } finally {
+                closeIfAnyIndexWriterHasTragedyOrIsClosed();
+            }
         }
 
         /**
@@ -634,23 +668,23 @@ public class PersistedClusterStateService {
             }
         }
 
-        public void commit(long currentTerm, long lastAcceptedVersion) {
+        public void commit(long currentTerm, long lastAcceptedVersion) throws IOException {
+            ensureOpen();
             try {
                 for (MetaDataIndexWriter metaDataIndexWriter : metaDataIndexWriters) {
                     metaDataIndexWriter.commit(nodeId, currentTerm, lastAcceptedVersion);
                 }
-            } catch (IOException e) {
-                // The commit() call has similar semantics to a fsync(): although it's atomic, if it fails then we've no idea whether the
-                // data on disk is now the old version or the new version, and this is a disaster. It's safest to fail the whole node and
-                // retry from the beginning.
-                throw new IOError(e);
+            } finally {
+                closeIfAnyIndexWriterHasTragedyOrIsClosed();
             }
         }
 
         @Override
         public void close() throws IOException {
-            logger.trace("closing");
-            IOUtils.close(metaDataIndexWriters);
+            logger.trace("closing PersistedClusterStateService.Writer");
+            if (closed.compareAndSet(false, true)) {
+                IOUtils.close(metaDataIndexWriters);
+            }
         }
 
         private ReleasableDocument makeIndexMetaDataDocument(IndexMetaData indexMetaData) throws IOException {

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -699,7 +699,8 @@ public class PersistedClusterStateService {
                 // retry from the beginning.
                 try {
                     close();
-                } finally {
+                } catch (Exception e2) {
+                    e.addSuppressed(e2);
                     throw new IOError(e);
                 }
             } finally {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -865,8 +865,6 @@ public class Node implements Closeable {
         toClose.add(injector.getInstance(SearchService.class));
         toClose.add(() -> stopWatch.stop().start("transport"));
         toClose.add(injector.getInstance(TransportService.class));
-        toClose.add(() -> stopWatch.stop().start("gateway_meta_state"));
-        toClose.add(injector.getInstance(GatewayMetaState.class));
 
         for (LifecycleComponent plugin : pluginLifecycleComponents) {
             toClose.add(() -> stopWatch.stop().start("plugin(" + plugin.getClass().getName() + ")"));
@@ -882,8 +880,11 @@ public class Node implements Closeable {
         // Don't call shutdownNow here, it might break ongoing operations on Lucene indices.
         // See https://issues.apache.org/jira/browse/LUCENE-7248. We call shutdownNow in
         // awaitClose if the node doesn't finish closing within the specified time.
-        toClose.add(() -> stopWatch.stop().start("node_environment"));
 
+        toClose.add(() -> stopWatch.stop().start("gateway_meta_state"));
+        toClose.add(injector.getInstance(GatewayMetaState.class));
+
+        toClose.add(() -> stopWatch.stop().start("node_environment"));
         toClose.add(injector.getInstance(NodeEnvironment.class));
         toClose.add(stopWatch::stop);
 

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.gateway;
 
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MockDirectoryWrapper;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -48,8 +51,11 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -253,7 +259,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         try {
             gateway = newGatewayPersistedState();
 
-            //generate random coordinationMetaData with different lastAcceptedConfiguration and lastCommittedConfiguration
+            // generate random coordinationMetaData with different lastAcceptedConfiguration and lastCommittedConfiguration
             CoordinationMetaData coordinationMetaData;
             do {
                 coordinationMetaData = createCoordinationMetaData(randomNonNegativeLong());
@@ -293,7 +299,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         final ClusterState state = createClusterState(randomNonNegativeLong(),
             MetaData.builder().clusterUUID(randomAlphaOfLength(10)).build());
         try (GatewayMetaState.LucenePersistedState ignored = new GatewayMetaState.LucenePersistedState(
-            persistedClusterStateService.createWriter(), 42L, state)) {
+            persistedClusterStateService, 42L, state)) {
 
         }
 
@@ -407,6 +413,98 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         }
 
         ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    public void testStatePersistenceWithIOIssues() throws IOException {
+        final AtomicReference<Double> ioExceptionRate = new AtomicReference<>(0.01d);
+        final List<MockDirectoryWrapper> list = new ArrayList<>();
+        final PersistedClusterStateService persistedClusterStateService =
+            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE) {
+                @Override
+                Directory createDirectory(Path path) {
+                    final MockDirectoryWrapper wrapper = newMockFSDirectory(path);
+                    wrapper.setAllowRandomFileNotFoundException(randomBoolean());
+                    wrapper.setRandomIOExceptionRate(ioExceptionRate.get());
+                    wrapper.setRandomIOExceptionRateOnOpen(ioExceptionRate.get());
+                    list.add(wrapper);
+                    return wrapper;
+                }
+            };
+        ClusterState state = createClusterState(randomNonNegativeLong(),
+            MetaData.builder().clusterUUID(randomAlphaOfLength(10)).build());
+        long currentTerm = 42L;
+        try (GatewayMetaState.LucenePersistedState persistedState = new GatewayMetaState.LucenePersistedState(
+            persistedClusterStateService, currentTerm, state)) {
+
+            try {
+                if (randomBoolean()) {
+                    final ClusterState newState = createClusterState(randomNonNegativeLong(),
+                        MetaData.builder().clusterUUID(randomAlphaOfLength(10)).build());
+                    persistedState.setLastAcceptedState(newState);
+                    state = newState;
+                } else {
+                    final long newTerm = currentTerm + 1;
+                    persistedState.setCurrentTerm(newTerm);
+                    currentTerm = newTerm;
+                }
+            } catch (Exception e) {
+                assertNotNull(ExceptionsHelper.unwrap(e, IOException.class));
+            }
+
+            ioExceptionRate.set(0.0d);
+            for (MockDirectoryWrapper wrapper : list) {
+                wrapper.setRandomIOExceptionRate(ioExceptionRate.get());
+                wrapper.setRandomIOExceptionRateOnOpen(ioExceptionRate.get());
+            }
+
+            for (int i = 0; i < randomIntBetween(1, 5); i++) {
+                if (randomBoolean()) {
+                    final long version = randomNonNegativeLong();
+                    final String indexName = randomAlphaOfLength(10);
+                    final IndexMetaData indexMetaData = createIndexMetaData(indexName, randomIntBetween(1, 5), randomNonNegativeLong());
+                    final MetaData metaData = MetaData.builder().
+                        persistentSettings(Settings.builder().put(randomAlphaOfLength(10), randomAlphaOfLength(10)).build()).
+                        coordinationMetaData(createCoordinationMetaData(1L)).
+                        put(indexMetaData, false).
+                        build();
+                    state = createClusterState(version, metaData);
+                    persistedState.setLastAcceptedState(state);
+                } else {
+                    currentTerm += 1;
+                    persistedState.setCurrentTerm(currentTerm);
+                }
+            }
+
+            assertEquals(state, persistedState.getLastAcceptedState());
+            assertEquals(currentTerm, persistedState.getCurrentTerm());
+
+        } catch (Exception e) {
+            if (ioExceptionRate.get() == 0.0d) {
+                throw e;
+            }
+            assertNotNull(ExceptionsHelper.unwrap(e, IOException.class));
+            return;
+        }
+
+        nodeEnvironment.close();
+
+        // verify that the freshest state was rewritten to each data path
+        for (Path path : nodeEnvironment.nodeDataPaths()) {
+            Settings settings = Settings.builder()
+                .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toAbsolutePath())
+                .put(Environment.PATH_DATA_SETTING.getKey(), path.toString()).build();
+            try (NodeEnvironment nodeEnvironment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings))) {
+                final PersistedClusterStateService newPersistedClusterStateService =
+                    new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE);
+                final PersistedClusterStateService.OnDiskState onDiskState = newPersistedClusterStateService.loadBestOnDiskState();
+                assertFalse(onDiskState.empty());
+                assertThat(onDiskState.currentTerm, equalTo(currentTerm));
+                assertClusterStateEqual(state,
+                    ClusterState.builder(ClusterName.DEFAULT)
+                        .version(onDiskState.lastAcceptedVersion)
+                        .metaData(onDiskState.metaData).build());
+            }
+        }
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOError;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -447,7 +448,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                     persistedState.setCurrentTerm(newTerm);
                     currentTerm = newTerm;
                 }
-            } catch (Exception e) {
+            } catch (IOError | Exception e) {
                 assertNotNull(ExceptionsHelper.unwrap(e, IOException.class));
             }
 
@@ -478,7 +479,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             assertEquals(state, persistedState.getLastAcceptedState());
             assertEquals(currentTerm, persistedState.getCurrentTerm());
 
-        } catch (Exception e) {
+        } catch (IOError | Exception e) {
             if (ioExceptionRate.get() == 0.0d) {
                 throw e;
             }


### PR DESCRIPTION
Adds handling to make the cluster state writer resilient to disk issues. Relates to #48701