### PR TITLE
[DOCS] Add tutorials section to analysis topic

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -146,7 +146,7 @@ include::analysis/overview.asciidoc[]
 
 include::analysis/anatomy.asciidoc[]
 
-include::analysis/testing.asciidoc[]
+include::analysis/configure-text-analysis.asciidoc[]
 
 include::analysis/analyzers.asciidoc[]
 

--- a/docs/reference/analysis/analyzers.asciidoc
+++ b/docs/reference/analysis/analyzers.asciidoc
@@ -54,8 +54,6 @@ If you do not find an analyzer suitable for your needs, you can create a
 <<analysis-tokenizers,tokenizer>>, and <<analysis-tokenfilters,token filters>>.
 
 
-include::analyzers/configuring.asciidoc[]
-
 include::analyzers/fingerprint-analyzer.asciidoc[]
 
 include::analyzers/keyword-analyzer.asciidoc[]
@@ -71,5 +69,3 @@ include::analyzers/standard-analyzer.asciidoc[]
 include::analyzers/stop-analyzer.asciidoc[]
 
 include::analyzers/whitespace-analyzer.asciidoc[]
-
-include::analyzers/custom-analyzer.asciidoc[]

--- a/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/custom-analyzer.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-custom-analyzer]]
-=== Custom Analyzer
+=== Create a custom analyzer
 
 When the built-in analyzers do not fulfill your needs, you can create a
 `custom` analyzer which uses the appropriate combination of:

--- a/docs/reference/analysis/configure-text-analysis.asciidoc
+++ b/docs/reference/analysis/configure-text-analysis.asciidoc
@@ -1,0 +1,29 @@
+[[configure-text-analysis]]
+== Configure text analysis
+
+By default, {es} uses the <<analysis-standard-analyzer,`standard` analyzer>> for
+all text analysis. The `standard` analyzer gives you out-of-the-box support for
+most natural languages and use cases. If you chose to use the `standard`
+analyzer as-is, no further configuration is needed.
+
+If the standard analyzer does not fit your needs, review and test {es}'s other
+built-in <<analysis-analyzers,built-in analyzers>>. Built-in analyzers don't
+require configuration, but some support options that can be used to adjust their
+behavior. For example, you can configure the `standard` analyzer with a list of
+custom stop words to remove.
+
+If no built-in analyzer fits your needs, you can test and create a custom
+analyzer. Custom analyzers involve selecting and combining different
+<<analyzer-anatomy,analyzer components>>, giving you greater control over
+the process.
+
+* <<test-analyzer>>
+* <<configuring-analyzers>>
+* <<analysis-custom-analyzer>>
+
+
+include::testing.asciidoc[]
+
+include::analyzers/configuring.asciidoc[]
+
+include::analyzers/custom-analyzer.asciidoc[]

--- a/docs/reference/analysis/testing.asciidoc
+++ b/docs/reference/analysis/testing.asciidoc
@@ -1,4 +1,5 @@
-== Testing analyzers
+[[test-analyzer]]
+=== Test an analyzer
 
 The <<indices-analyze,`analyze` API>> is an invaluable tool for viewing the
 terms produced by an analyzer. A built-in analyzer (or combination of built-in


### PR DESCRIPTION
Adds a 'Configure text analysis' page to house tutorial content for the
analysis topic.

Also relocates the following pages as children as this new page:

* 'Test an analyzer'
* 'Configuring built-in analyzers'
* 'Create a custom analyzer'

I plan to add a tutorial for specifying index-time and search-time
analyzers to this section as part of a future PR.