### PR TITLE
EQL: Make EqlSearchResponse immutable

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -22,6 +22,8 @@ import org.elasticsearch.xpack.eql.action.EqlSearchAction;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse;
 
+import java.util.Collections;
+
 public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRequest, EqlSearchResponse> {
     private final SecurityContext securityContext;
     private final ClusterService clusterService;
@@ -54,8 +56,8 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
             new SearchHit(2, "222", null),
         });
         EqlSearchResponse.Hits hits = new EqlSearchResponse.Hits(new EqlSearchResponse.Sequences(new EqlSearchResponse.Sequence[]{
-            new EqlSearchResponse.Sequence(new String[]{"4021"}, events),
-            new EqlSearchResponse.Sequence(new String[]{"2343"}, events)
+            new EqlSearchResponse.Sequence(Collections.singletonList("4021"), events),
+            new EqlSearchResponse.Sequence(Collections.singletonList("2343"), events)
         }), new TotalHits(0,  TotalHits.Relation.EQUAL_TO));
         return new EqlSearchResponse(hits, 0, false);
     }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -11,7 +11,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 public class EqlSearchResponseTests extends AbstractSerializingTestCase<EqlSearchResponse> {
 
@@ -58,9 +60,9 @@ public class EqlSearchResponseTests extends AbstractSerializingTestCase<EqlSearc
         if (randomBoolean()) {
             seq = new EqlSearchResponse.Sequence[size];
             for (int i = 0; i < size; i++) {
-                String[] joins = null;
+                List<String> joins = null;
                 if (randomBoolean()) {
-                    joins = generateRandomStringArray(6, 11, false);
+                    joins = Arrays.asList(generateRandomStringArray(6, 11, false));
                 }
                 seq[i] = new EqlSearchResponse.Sequence(joins, randomEvents());
             }
@@ -82,9 +84,9 @@ public class EqlSearchResponseTests extends AbstractSerializingTestCase<EqlSearc
         if (randomBoolean()) {
             cn = new EqlSearchResponse.Count[size];
             for (int i = 0; i < size; i++) {
-                String[] keys = null;
+                List<String> keys = null;
                 if (randomBoolean()) {
-                    keys = generateRandomStringArray(6, 11, false);
+                    keys = Arrays.asList(generateRandomStringArray(6, 11, false));
                 }
                 cn[i] = new EqlSearchResponse.Count(randomIntBetween(0, 41), keys, randomFloat());
             }


### PR DESCRIPTION
Refactors EqlSearchResponse to make it immutable

Relates to #49581
