### PR TITLE
[DOCS] Update license expiry links

### DIFF
--- a/docs/reference/licensing/delete-license.asciidoc
+++ b/docs/reference/licensing/delete-license.asciidoc
@@ -17,7 +17,8 @@ This API enables you to delete licensing information.
 ==== Description
 
 When your license expires, {xpack} operates in a degraded mode.  For more
-information, see {stack-ov}/license-expiration.html[License Expiration].
+information, see
+{kibana-ref}/managing-licenses.html#license-expiration[License expiration].
 
 [float]
 ==== Authorization

--- a/docs/reference/licensing/update-license.asciidoc
+++ b/docs/reference/licensing/update-license.asciidoc
@@ -161,5 +161,6 @@ curl -XPUT -u elastic 'http://<host>:<port>/_license?acknowledge=true' -H "Conte
 ------------------------------------------------------------
 // NOTCONSOLE
 
-For more information about the features that are disabled when you downgrade
-your license, see {stack-ov}/license-expiration.html[License Expiration].
+For more information about the features that are disabled when your license
+expires, see
+{kibana-ref}/managing-licenses.html#license-expiration[License expiration].


### PR DESCRIPTION
Related to elastic/kibana#54081

This PR updates links to license expiration details, now that the content has moved to the Kibana Guide.

Preview:
* http://elasticsearch_50812.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-license.html
* http://elasticsearch_50812.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-license.html