### PR TITLE
Skip test suite entirely for non-applicable distribution types

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
@@ -23,7 +23,7 @@ import junit.framework.TestCase;
 import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Shell;
-import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.util.regex.Pattern;
 
@@ -32,8 +32,8 @@ import static org.junit.Assume.assumeTrue;
 
 public class DebMetadataTests extends PackagingTestCase {
 
-    @Before
-    public void filterDistros() {
+    @BeforeClass
+    public static void filterDistros() {
         assumeTrue("only deb", distribution.packaging == Distribution.Packaging.DEB);
     }
 


### PR DESCRIPTION
We are getting loads of [Windows packaging test failures](https://gradle-enterprise.elastic.co/scans/tests?failures.failureClassification=non_verification&list.offset=0&list.size=50&list.sortColumn=startTime&list.sortOrder=desc&search.buildToolType=gradle&search.buildToolType=maven&search.startTimeMax=1578610235297&search.startTimeMin=1576137600000&search.tags=ci&search.tags=windows&tests.container=org.elasticsearch.packaging.test.DebMetadataTests&tests.sortField=FAILED&tests.test=classMethod&tests.unstableOnly&trends.section=overview&trends.timeResolution=day&viewer.tzOffset=-480) while attempting to do cleanup for a test suite that shouldn't even run at all on Windows. This is due to the incorrect usage of the junit `@Before` instead of `@BeforeClass` annotation. So instead of skipping the suite entirely, we are skipping all individual tests but still trying to do post-test cleanup, which is entirely unnecessary in this case. This PR simply changes the annotation on the test predicate assertion method.