### PR TITLE
[DOCS] Fix time_zone example in range query docs

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -214,19 +214,20 @@ UTC offset. For example:
 ----
 GET _search
 {
-    "query": {
-        "range" : {
-            "timestamp" : {
-                "time_zone": "+01:00", <1>
-                "gte": "2015-01-01 00:00:00", <2>
-                "lte": "now" <3>
-            }
-        }
+  "query": {
+    "range": {
+      "timestamp": {
+        "time_zone": "+01:00",        <1>
+        "gte": "2020-01-01T00:00:00", <2>
+        "lte": "now"                  <3>
+      }
     }
+  }
 }
 ----
+// TEST[continued]
 
 <1> Indicates that `date` values use a UTC offset of `+01:00`.
 <2> With a UTC offset of `+01:00`, {es} converts this date to
-`2014-12-31T23:00:00 UTC`.
+`2019-12-31T23:00:00 UTC`.
 <3> The `time_zone` parameter does not affect the `now` value.


### PR DESCRIPTION
One of the example snippets in the range query docs was missing a required 'T' in the `date` format.
This adds the required 'T'.

Thanks to @bmorelli25 for pointing this out!