### PR TITLE
Ensure we emit a warning when using the deprecated 'template' field.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -92,6 +92,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -1576,6 +1577,32 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertThat(extractValue("my-template.mappings.properties.host_name.type", templates), equalTo("keyword"));
         assertThat((Map<String, String>) extractValue("my-template.aliases.alias-1", templates), hasEntry("index_routing", "abc"));
         assertThat((Map<String, String>) extractValue("my-template.aliases.{index}-write", templates), hasEntry("search_routing", "xyz"));
+    }
+
+    public void testPutTemplateWithDeprecatedTemplateField() throws Exception {
+        PutIndexTemplateRequest putTemplateRequest = new PutIndexTemplateRequest("my-template")
+            .source(XContentFactory.jsonBuilder()
+                .startObject()
+                    .field("template", "name-*")
+                    .field("order", 10)
+                    .startObject("settings")
+                        .field("number_of_shards", 3)
+                        .field("number_of_replicas", 0)
+                    .endObject()
+                .endObject());
+
+        AcknowledgedResponse putTemplateResponse = execute(putTemplateRequest,
+            highLevelClient().indices()::putTemplate,
+            highLevelClient().indices()::putTemplateAsync,
+            expectWarnings("Deprecated field [template] used, replaced by [index_patterns]"));
+        assertThat(putTemplateResponse.isAcknowledged(), equalTo(true));
+
+        Map<String, Object> templates = getAsMap("/_template/my-template");
+        assertThat(templates.keySet(), hasSize(1));
+        assertThat(extractValue("my-template.order", templates), equalTo(10));
+        assertThat(extractRawValues("my-template.index_patterns", templates), contains("name-*"));
+        assertThat(extractValue("my-template.settings.index.number_of_shards", templates), equalTo("3"));
+        assertThat(extractValue("my-template.settings.index.number_of_replicas", templates), equalTo("0"));
     }
 
     public void testPutTemplateWithTypesUsingUntypedAPI() throws Exception {


### PR DESCRIPTION
Since 6.0, the 'template' field has been deprecated in put template requests in
favour of index_patterns. Previously, the PutIndexTemplateRequest would accept
the 'template' field in its 'source' methods and silently convert it to
'index_patterns'. This meant that users specifying 'template' in the source
would not receive a deprecation warning from the server.

This PR makes a small change to no longer silently convert 'template' to
'index_patterns', which ensures that users receive a deprecation warning.

Follow-up to #49460.
