### PR TITLE
Fix upgrade of custom similarity

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.Similarity;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.TriFunction;
@@ -145,7 +146,7 @@ public class MetaDataIndexUpgradeService {
                 @Override
                 public TriFunction<Settings, Version, ScriptService, Similarity> get(Object key) {
                     assert key instanceof String : "key must be a string but was: " + key.getClass();
-                    return SimilarityService.BUILT_IN.get(SimilarityService.DEFAULT_SIMILARITY);
+                    return (settings, version, scriptService) -> new BM25Similarity();
                 }
 
                 // this entrySet impl isn't fully correct but necessary as SimilarityService will iterate

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeServiceTests.java
@@ -82,6 +82,18 @@ public class MetaDataIndexUpgradeServiceTests extends ESTestCase {
         assertSame(src, service.upgradeIndexMetaData(src, Version.CURRENT.minimumIndexCompatibilityVersion())); // no double upgrade
     }
 
+    public void testUpgradeCustomSimilarity() {
+        MetaDataIndexUpgradeService service = getMetaDataIndexUpgradeService();
+        IndexMetaData src = newIndexMeta("foo",
+            Settings.builder()
+                .put("index.similarity.my_similarity.type", "DFR")
+                .put("index.similarity.my_similarity.after_effect", "l")
+                .build());
+        assertFalse(service.isUpgraded(src));
+        src = service.upgradeIndexMetaData(src, Version.CURRENT.minimumIndexCompatibilityVersion());
+        assertTrue(service.isUpgraded(src));
+    }
+
     public void testIsUpgraded() {
         MetaDataIndexUpgradeService service = getMetaDataIndexUpgradeService();
         IndexMetaData src = newIndexMeta("foo", Settings.builder().put("index.refresh_interval", "-200").build());


### PR DESCRIPTION
This change fixes the upgrade of index metadata that contain a custom similarity with options that are not compatible with BM25.
The upgrade doesn't need a real similarity service so we fake one that resolves all custom similarity to BM25 but this logic fails because the BM25 provider checks that all options are compatible. This commit removes the verification step as it is not needed during the upgrade (the verification is done when the index is restored/opened).

Closes #50763