### PR TITLE
Fix testSkipRefreshIfShardIsRefreshingAlready

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -432,20 +432,20 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             }
         };
         int iterations = randomIntBetween(10, 100);
+        ThreadPoolStats.Stats beforeStats = getRefreshThreadPoolStats();
         for (int i = 0; i < iterations; i++) {
             controller.forceCheck();
         }
         assertBusy(() -> {
             ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
-            assertThat(stats.getQueue(), equalTo(0));
-            assertThat(stats.getActive(), equalTo(1));
+            assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations - 1));
         });
         refreshLatch.get().countDown(); // allow refresh
         assertBusy(() -> {
             ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
-            assertThat(stats.getQueue(), equalTo(0));
-            assertThat(stats.getActive(), equalTo(0));
+            assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations));
         });
+        System.out.println(shard.refreshStats().getTotal());
         assertThat(shard.refreshStats().getTotal(), equalTo(refreshStats.getTotal() + 1));
         closeShards(shard);
     }

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -445,7 +445,6 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
             assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations));
         });
-        System.out.println(shard.refreshStats().getTotal());
         assertThat(shard.refreshStats().getTotal(), equalTo(refreshStats.getTotal() + 1));
         closeShards(shard);
     }


### PR DESCRIPTION
The test checked queue size and active count, however,
ThreadPoolExecutor pulls out the request from the queue before marking
the worker active, risking that we think all tasks are done when they
are not. Now check on completed-tasks metric instead, which is
guaranteed to be monotonic.

Relates #50769

Given that the original issue has not yet been backported, this should likely be backported together with that.