### PR TITLE
Drop BWC suppressions for composite aggs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -243,7 +243,7 @@ setup:
 ---
 "Composite aggregation with format":
   - skip:
-      version: " - 7.99.99" # after BWC merged revert to 7.1.99
+      version: " - 7.1.99"
       reason:  calendar_interval introduced in 7.2.0
       features: warnings
 
@@ -309,7 +309,7 @@ setup:
 ---
 "Composite aggregation with format and calendar_interval":
   - skip:
-      version: " - 7.99.99"  # after BWC merged revert to 7.1.99
+      version: " - 7.1.99"
       reason:  calendar_interval introduced in 7.2.0
 
   - do:
@@ -370,8 +370,8 @@ setup:
 ---
 "Composite aggregation with date_histogram offset":
   - skip:
-      version: " - 7.99.99" # after BWC merged revert to 7.5.99
-      reason:  offset introduced in 8.0.0
+      version: " - 7.5.99"
+      reason:  offset introduced in 7.6.0
 
   - do:
       search:

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -161,13 +161,6 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
-    // disabled temporarily for backporting serialization change
-    if (bwcVersion.before('8.0.0')) {
-      systemProperty 'tests.rest.blacklist', [
-        'upgraded_cluster/80_transform_jobs_crud/Get start, stop mixed cluster batch transform',
-        'upgraded_cluster/80_transform_jobs_crud/Test GET, mixed continuous transforms',
-      ].join(',')
-    }
   }
 
   tasks.register("${baseName}#bwcTest") {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
@@ -1,9 +1,5 @@
 ---
 "Test put batch transform on mixed cluster":
-  - skip:
-      version: " - 7.99.99" # after BWC merged then remove entirely
-      reason:  disabled temporarily for backporting serialization change
-
   - do:
       cluster.health:
         index: "transform-airline-data"
@@ -110,10 +106,6 @@
 
 ---
 "Test put continuous transform on mixed cluster":
-  - skip:
-      version: " - 7.99.99" # after BWC merged then remove entirely
-      reason:  disabled temporarily for backporting serialization change
-
   - do:
       cluster.health:
         index: "transform-airline-data-cont"


### PR DESCRIPTION
When I implemented #50609 I suppressed a few backwards compatibility
checks until I finished the backport. I've now finished the backport so
this enables the tests.
