### PR TITLE
Respect alternate keystore locations

### DIFF
--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -56,7 +56,8 @@ if [[ -f bin/elasticsearch-users ]]; then
   # enabled, but we have no way of knowing which node we are yet. We'll just
   # honor the variable if it's present.
   if [[ -n "$ELASTIC_PASSWORD" ]]; then
-    [[ -f /usr/share/elasticsearch/config/elasticsearch.keystore ]] || (run_as_other_user_if_needed elasticsearch-keystore create)
+    ES_PATH_CONF=${ES_PATH_CONF:-/usr/share/elasticsearch/config}
+    [[ -f $ES_PATH_CONF/elasticsearch.keystore ]] || (run_as_other_user_if_needed elasticsearch-keystore create)
     if ! (run_as_other_user_if_needed elasticsearch-keystore list | grep -q '^bootstrap.password$'); then
       (run_as_other_user_if_needed echo "$ELASTIC_PASSWORD" | elasticsearch-keystore add -x 'bootstrap.password')
     fi


### PR DESCRIPTION
If an operator has ELASTIC_PASSWORD set and is using a non-default path.conf location via ES_PATH_CONF, the application will hang pre-startup when the keystore already exists. I believe this is because the keystore tool uses ES_PATH_CONF (does it?), so it detects the existing keystore file in the alternate directory and requires an interactive confirmation to ignore or overwrite, which causes the entrypoint script to hang.
