### PR TITLE
Begin moving date_histogram to offset rounding

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -172,6 +172,11 @@ public abstract class Rounding implements Writeable {
     @Deprecated
     public abstract long offset();
 
+    /**
+     * Strip the {@code offset} from these bounds.
+     */
+    public abstract Rounding withoutOffset();
+
     @Override
     public abstract boolean equals(Object obj);
 
@@ -434,6 +439,11 @@ public abstract class Rounding implements Writeable {
         }
 
         @Override
+        public Rounding withoutOffset() {
+            return this;
+        }
+
+        @Override
         public int hashCode() {
             return Objects.hash(unit, timeZone);
         }
@@ -565,6 +575,11 @@ public abstract class Rounding implements Writeable {
         }
 
         @Override
+        public Rounding withoutOffset() {
+            return this;
+        }
+
+        @Override
         public int hashCode() {
             return Objects.hash(interval, timeZone);
         }
@@ -631,6 +646,11 @@ public abstract class Rounding implements Writeable {
         @Override
         public long offset() {
             return offset;
+        }
+
+        @Override
+        public Rounding withoutOffset() {
+            return delegate;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -164,6 +164,14 @@ public abstract class Rounding implements Writeable {
      */
     public abstract long nextRoundingValue(long value);
 
+    /**
+     * How "offset" this rounding is from the traditional "start" of the period.
+     * @deprecated We're in the process of abstracting offset *into* Rounding
+     *             so keep any usage to migratory shims
+     */
+    @Deprecated
+    public abstract long offset();
+
     @Override
     public abstract boolean equals(Object obj);
 
@@ -421,6 +429,11 @@ public abstract class Rounding implements Writeable {
         }
 
         @Override
+        public long offset() {
+            return 0;
+        }
+
+        @Override
         public int hashCode() {
             return Objects.hash(unit, timeZone);
         }
@@ -547,6 +560,11 @@ public abstract class Rounding implements Writeable {
         }
 
         @Override
+        public long offset() {
+            return 0;
+        }
+
+        @Override
         public int hashCode() {
             return Objects.hash(interval, timeZone);
         }
@@ -607,8 +625,12 @@ public abstract class Rounding implements Writeable {
 
         @Override
         public long nextRoundingValue(long value) {
-            // This isn't needed by the current users. We'll implement it when we migrate other users to it.
-            throw new UnsupportedOperationException("not yet supported");
+            return delegate.nextRoundingValue(value - offset) + offset;
+        }
+
+        @Override
+        public long offset() {
+            return offset;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -494,13 +494,13 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
                                                                         Builder subFactoriesBuilder) throws IOException {
         final ZoneId tz = timeZone();
         // TODO use offset here rather than explicitly in the aggregation
-        final Rounding rounding = dateHistogramInterval.createRounding(tz, 0);
+        final Rounding rounding = dateHistogramInterval.createRounding(tz, offset);
         final ZoneId rewrittenTimeZone = rewriteTimeZone(queryShardContext);
         final Rounding shardRounding;
         if (tz == rewrittenTimeZone) {
             shardRounding = rounding;
         } else {
-            shardRounding = dateHistogramInterval.createRounding(rewrittenTimeZone, 0);
+            shardRounding = dateHistogramInterval.createRounding(rewrittenTimeZone, offset);
         }
 
         ExtendedBounds roundedBounds = null;
@@ -508,7 +508,7 @@ public class DateHistogramAggregationBuilder extends ValuesSourceAggregationBuil
             // parse any string bounds to longs and round
             roundedBounds = this.extendedBounds.parseAndValidate(name, queryShardContext, config.format()).round(rounding);
         }
-        return new DateHistogramAggregatorFactory(name, config, offset, order, keyed, minDocCount,
+        return new DateHistogramAggregatorFactory(name, config, order, keyed, minDocCount,
                 rounding, shardRounding, roundedBounds, queryShardContext, parent, subFactoriesBuilder, metaData);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -64,10 +64,9 @@ class DateHistogramAggregator extends BucketsAggregator {
     private final ExtendedBounds extendedBounds;
 
     private final LongHash bucketOrds;
-    private long offset;
 
     DateHistogramAggregator(String name, AggregatorFactories factories, Rounding rounding, Rounding shardRounding,
-            long offset, BucketOrder order, boolean keyed,
+            BucketOrder order, boolean keyed,
             long minDocCount, @Nullable ExtendedBounds extendedBounds, @Nullable ValuesSource.Numeric valuesSource,
             DocValueFormat formatter, SearchContext aggregationContext,
             Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
@@ -75,7 +74,6 @@ class DateHistogramAggregator extends BucketsAggregator {
         super(name, factories, aggregationContext, parent, pipelineAggregators, metaData);
         this.rounding = rounding;
         this.shardRounding = shardRounding;
-        this.offset = offset;
         this.order = InternalOrder.validate(order, this);
         this.keyed = keyed;
         this.minDocCount = minDocCount;
@@ -113,7 +111,7 @@ class DateHistogramAggregator extends BucketsAggregator {
                         long value = values.nextValue();
                         // We can use shardRounding here, which is sometimes more efficient
                         // if daylight saving times are involved.
-                        long rounded = shardRounding.round(value - offset) + offset;
+                        long rounded = shardRounding.round(value);
                         assert rounded >= previousRounded;
                         if (rounded == previousRounded) {
                             continue;
@@ -150,7 +148,7 @@ class DateHistogramAggregator extends BucketsAggregator {
         InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0
                 ? new InternalDateHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds)
                 : null;
-        return new InternalDateHistogram(name, buckets, order, minDocCount, offset, emptyBucketInfo, formatter, keyed,
+        return new InternalDateHistogram(name, buckets, order, minDocCount, rounding.offset(), emptyBucketInfo, formatter, keyed,
                 pipelineAggregators(), metaData());
     }
 
@@ -159,8 +157,8 @@ class DateHistogramAggregator extends BucketsAggregator {
         InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0
                 ? new InternalDateHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds)
                 : null;
-        return new InternalDateHistogram(name, Collections.emptyList(), order, minDocCount, offset, emptyBucketInfo, formatter, keyed,
-                pipelineAggregators(), metaData());
+        return new InternalDateHistogram(name, Collections.emptyList(), order, minDocCount, rounding.offset(), emptyBucketInfo, formatter,
+                keyed, pipelineAggregators(), metaData());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
@@ -39,7 +39,6 @@ import java.util.Map;
 public final class DateHistogramAggregatorFactory
         extends ValuesSourceAggregatorFactory<ValuesSource> {
 
-    private final long offset;
     private final BucketOrder order;
     private final boolean keyed;
     private final long minDocCount;
@@ -48,12 +47,11 @@ public final class DateHistogramAggregatorFactory
     private final Rounding shardRounding;
 
     public DateHistogramAggregatorFactory(String name, ValuesSourceConfig<ValuesSource> config,
-            long offset, BucketOrder order, boolean keyed, long minDocCount,
+            BucketOrder order, boolean keyed, long minDocCount,
             Rounding rounding, Rounding shardRounding, ExtendedBounds extendedBounds, QueryShardContext queryShardContext,
             AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder,
             Map<String, Object> metaData) throws IOException {
         super(name, config, queryShardContext, parent, subFactoriesBuilder, metaData);
-        this.offset = offset;
         this.order = order;
         this.keyed = keyed;
         this.minDocCount = minDocCount;
@@ -104,7 +102,7 @@ public final class DateHistogramAggregatorFactory
     private Aggregator createAggregator(ValuesSource.Numeric valuesSource, SearchContext searchContext,
                                         Aggregator parent, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) throws IOException {
-        return new DateHistogramAggregator(name, factories, rounding, shardRounding, offset, order, keyed, minDocCount, extendedBounds,
+        return new DateHistogramAggregator(name, factories, rounding, shardRounding, order, keyed, minDocCount, extendedBounds,
                 valuesSource, config.format(), searchContext, parent, pipelineAggregators, metaData);
     }
 
@@ -113,7 +111,7 @@ public final class DateHistogramAggregatorFactory
                                              Aggregator parent,
                                              List<PipelineAggregator> pipelineAggregators,
                                              Map<String, Object> metaData) throws IOException {
-        return new DateRangeHistogramAggregator(name, factories, rounding, shardRounding, offset, order, keyed, minDocCount, extendedBounds,
+        return new DateRangeHistogramAggregator(name, factories, rounding, shardRounding, order, keyed, minDocCount, extendedBounds,
             valuesSource, config.format(), searchContext, parent, pipelineAggregators, metaData);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -67,10 +67,9 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
     private final ExtendedBounds extendedBounds;
 
     private final LongHash bucketOrds;
-    private long offset;
 
     DateRangeHistogramAggregator(String name, AggregatorFactories factories, Rounding rounding, Rounding shardRounding,
-                                 long offset, BucketOrder order, boolean keyed,
+                                 BucketOrder order, boolean keyed,
                                  long minDocCount, @Nullable ExtendedBounds extendedBounds, @Nullable ValuesSource.Range valuesSource,
                                  DocValueFormat formatter, SearchContext aggregationContext,
                                  Aggregator parent, List<PipelineAggregator> pipelineAggregators,
@@ -79,7 +78,6 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         super(name, factories, aggregationContext, parent, pipelineAggregators, metaData);
         this.rounding = rounding;
         this.shardRounding = shardRounding;
-        this.offset = offset;
         this.order = InternalOrder.validate(order, this);
         this.keyed = keyed;
         this.minDocCount = minDocCount;
@@ -126,8 +124,8 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
                             // The encoding should ensure that this assert is always true.
                             assert from >= previousFrom : "Start of range not >= previous start";
                             final Long to = (Long) range.getTo();
-                            final long startKey = offsetAwareRounding(shardRounding, from, offset);
-                            final long endKey = offsetAwareRounding(shardRounding, to, offset);
+                            final long startKey = shardRounding.round(from);
+                            final long endKey = shardRounding.round(to);
                             for (long  key = startKey > previousKey ? startKey : previousKey; key <= endKey;
                                  key = shardRounding.nextRoundingValue(key)) {
                                 if (key == previousKey) {
@@ -153,10 +151,6 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         };
     }
 
-    private long offsetAwareRounding(Rounding rounding, long value, long offset) {
-        return rounding.round(value - offset) + offset;
-    }
-
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0;
@@ -175,7 +169,7 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0
                 ? new InternalDateHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds)
                 : null;
-        return new InternalDateHistogram(name, buckets, order, minDocCount, offset, emptyBucketInfo, formatter, keyed,
+        return new InternalDateHistogram(name, buckets, order, minDocCount, rounding.offset(), emptyBucketInfo, formatter, keyed,
                 pipelineAggregators(), metaData());
     }
 
@@ -184,8 +178,8 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0
                 ? new InternalDateHistogram.EmptyBucketInfo(rounding, buildEmptySubAggregations(), extendedBounds)
                 : null;
-        return new InternalDateHistogram(name, Collections.emptyList(), order, minDocCount, offset, emptyBucketInfo, formatter, keyed,
-                pipelineAggregators(), metaData());
+        return new InternalDateHistogram(name, Collections.emptyList(), order, minDocCount, rounding.offset(), emptyBucketInfo, formatter,
+                keyed, pipelineAggregators(), metaData());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ExtendedBounds.java
@@ -166,7 +166,11 @@ public class ExtendedBounds implements ToXContentFragment, Writeable {
     }
 
     ExtendedBounds round(Rounding rounding) {
-        return new ExtendedBounds(min != null ? rounding.round(min) : null, max != null ? rounding.round(max) : null);
+        // Extended bounds shouldn't be effected by the offset
+        Rounding effectiveRounding = rounding.withoutOffset();
+        return new ExtendedBounds(
+                min != null ? effectiveRounding.round(min) : null,
+                max != null ? effectiveRounding.round(max) : null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -497,7 +497,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     @Override
     public Number nextKey(Number key) {
-        return emptyBucketInfo.rounding.nextRoundingValue(key.longValue() - offset) + offset;
+        return emptyBucketInfo.rounding.nextRoundingValue(key.longValue());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -203,12 +203,16 @@ public class RoundingTests extends ESTestCase {
         assertThat(rounding.round(twoHours), equalTo(twoHours));
         assertThat(rounding.nextRoundingValue(-oneDay), equalTo(-oneDay + twoHours));
         assertThat(rounding.nextRoundingValue(0), equalTo(twoHours));
+        assertThat(rounding.withoutOffset().round(0), equalTo(0L));
+        assertThat(rounding.withoutOffset().nextRoundingValue(0), equalTo(oneDay));
 
         rounding = Rounding.builder(Rounding.DateTimeUnit.DAY_OF_MONTH).offset(-twoHours).build();
         assertThat(rounding.round(0), equalTo(-twoHours));
         assertThat(rounding.round(oneDay - twoHours), equalTo(oneDay - twoHours));
         assertThat(rounding.nextRoundingValue(-oneDay), equalTo(-twoHours));
         assertThat(rounding.nextRoundingValue(0), equalTo(oneDay - twoHours));
+        assertThat(rounding.withoutOffset().round(0), equalTo(0L));
+        assertThat(rounding.withoutOffset().nextRoundingValue(0), equalTo(oneDay));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/RoundingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/RoundingTests.java
@@ -201,10 +201,14 @@ public class RoundingTests extends ESTestCase {
         Rounding rounding = Rounding.builder(Rounding.DateTimeUnit.DAY_OF_MONTH).offset(twoHours).build();
         assertThat(rounding.round(0), equalTo(-oneDay + twoHours));
         assertThat(rounding.round(twoHours), equalTo(twoHours));
+        assertThat(rounding.nextRoundingValue(-oneDay), equalTo(-oneDay + twoHours));
+        assertThat(rounding.nextRoundingValue(0), equalTo(twoHours));
 
         rounding = Rounding.builder(Rounding.DateTimeUnit.DAY_OF_MONTH).offset(-twoHours).build();
         assertThat(rounding.round(0), equalTo(-twoHours));
         assertThat(rounding.round(oneDay - twoHours), equalTo(oneDay - twoHours));
+        assertThat(rounding.nextRoundingValue(-oneDay), equalTo(-twoHours));
+        assertThat(rounding.nextRoundingValue(0), equalTo(oneDay - twoHours));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregationHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregationHelperTests.java
@@ -164,7 +164,7 @@ public class PipelineAggregationHelperTests extends ESTestCase {
                     new AggregatorFactories.Builder(), Collections.emptyMap());
                 break;
             case 1:
-                factory = new DateHistogramAggregatorFactory("name", mock(ValuesSourceConfig.class), 0L,
+                factory = new DateHistogramAggregatorFactory("name", mock(ValuesSourceConfig.class),
                     mock(InternalOrder.class), false, 0L, mock(Rounding.class), mock(Rounding.class),
                     mock(ExtendedBounds.class), mock(QueryShardContext.class), mock(AggregatorFactory.class),
                     new AggregatorFactories.Builder(), Collections.emptyMap());

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/cumulativecardinality/CumulativeCardinalityAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/cumulativecardinality/CumulativeCardinalityAggregatorTests.java
@@ -131,7 +131,7 @@ public class CumulativeCardinalityAggregatorTests extends AggregatorTestCase {
         // Date Histogram
         aggBuilders.clear();
         aggBuilders.add(new CumulativeCardinalityPipelineAggregationBuilder("cumulative_card", "sum"));
-        parent = new DateHistogramAggregatorFactory("name", valuesSource, 0L,
+        parent = new DateHistogramAggregatorFactory("name", valuesSource,
             mock(InternalOrder.class), false, 0L, mock(Rounding.class), mock(Rounding.class),
             mock(ExtendedBounds.class), mock(QueryShardContext.class), mock(AggregatorFactory.class),
             new AggregatorFactories.Builder(), Collections.emptyMap());


### PR DESCRIPTION
We added a new rounding in #50609 that handles offsets to the start and
end of the rounding so that we could support `offset` in the `composite`
aggregation. This starts moving `date_histogram` to that new offset.
