### PR TITLE
Improve build scan tags and values for Jenkins matrix jobs

### DIFF
--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -3,8 +3,7 @@ import org.gradle.initialization.BuildRequestMetaData
 
 import java.util.concurrent.TimeUnit
 
-
-long startTime = project.gradle.services.get(BuildRequestMetaData.class).getStartTime()
+long startTime = project.gradle.services.get(BuildRequestMetaData).getStartTime()
 
 buildScan {
   URL jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
@@ -14,18 +13,14 @@ buildScan {
   String nodeName = System.getenv('NODE_NAME')
 
   tag OS.current().name()
-  if (jobName) {
-    value 'Job name', jobName
-  }
-  if (buildNumber) {
-    value 'Job number', buildNumber
-  }
 
+  // Automatically publish scans from Elasticsearch CI
   if (jenkinsUrl?.host?.endsWith('elastic.co')) {
     publishAlways()
     buildScan.server = 'https://gradle-enterprise.elastic.co'
   }
 
+  // Link to Jenkins worker logs and system metrics
   if (nodeName) {
     link 'System logs', "https://infra-stats.elastic.co/app/infra#/logs?" +
       "&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
@@ -39,10 +34,26 @@ buildScan {
 
   // Jenkins-specific build scan metadata
   if (jenkinsUrl) {
+    // Parse job name in the case of matrix builds
+    // Matrix job names come in the form of "base-job-name/matrix_param1=value1,matrix_param2=value2"
+    def splitJobName = jobName.split('/')
+    if (splitJobName.length == 2) {
+      tag splitJobName[0]
+      tag splitJobName[1]
+      value 'Job Name', splitJobName[0]
+      def matrixParams = splitJobName[1].split(',')
+      matrixParams.collect { it.split('=') }.each { param ->
+        value "MATRIX_${param[0].toUpperCase()}", param[1]
+      }
+    } else {
+      tag jobName
+      value 'Job Name', jobName
+    }
+
     tag 'CI'
-    tag jobName
     link 'Jenkins Build', buildUrl
     link 'GCP Upload', "https://console.cloud.google.com/storage/elasticsearch-ci-artifacts/jobs/${jobName}/build/${buildNumber}.tar.bz2"
+    value 'Job Number', buildNumber
 
     System.getenv().getOrDefault('NODE_LABELS', '').split(' ').each {
       value 'Jenkins Worker Label', it


### PR DESCRIPTION
This PR introduces some improvements to how we add tags and custom values to build scans for Jenkins matrix jobs. Matrix job names are an amalgamation of base job name and the axis parameter permutation. This makes it really difficult to do searches and analysis on the base matrix job, or to find all jobs for an individual axis in the case of multi-axis matrix jobs.

In practical terms, the old behavior meant we would tag scans with a job name resembling something like `elastic+elasticsearch+master+matrix-java-periodic/ES_BUILD_JAVA=openjdk13,ES_RUNTIME_JAVA=openjdk13,nodes=general-purpose`. We now split this into two tags, one for the base job name (`elastic+elasticsearch+master+matrix-java-periodic`) and the second for the matrix parameters (`ES_BUILD_JAVA=openjdk13,ES_RUNTIME_JAVA=openjdk13,nodes=general-purpose`). Additionally, each parameter name and value gets added as a custom value with the prefix `MATRIX_` allow us to filter searches on individual axis values (ex: "show me all the openjdk13 builds").