### PR TITLE
Fix non-corruption in testCurrentHeaderVersion

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogHeaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogHeaderTests.java
@@ -52,14 +52,11 @@ public class TranslogHeaderTests extends ESTestCase {
         }
         final TranslogCorruptedException mismatchUUID = expectThrows(TranslogCorruptedException.class, () -> {
             try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.READ)) {
-                TranslogHeader.read(UUIDs.randomBase64UUID(), translogFile, channel);
+                TranslogHeader.read(randomValueOtherThan(translogUUID, UUIDs::randomBase64UUID), translogFile, channel);
             }
         });
         assertThat(mismatchUUID.getMessage(), containsString("this translog file belongs to a different translog"));
-        int corruptions = between(1, 10);
-        for (int i = 0; i < corruptions && Files.size(translogFile) > 0; i++) {
-            TestTranslog.corruptFile(logger, random(), translogFile, false);
-        }
+        TestTranslog.corruptFile(logger, random(), translogFile, false);
         final TranslogCorruptedException corruption = expectThrows(TranslogCorruptedException.class, () -> {
             try (FileChannel channel = FileChannel.open(translogFile, StandardOpenOption.READ)) {
                 TranslogHeader.read(randomBoolean() ? outHeader.getTranslogUUID() : UUIDs.randomBase64UUID(), translogFile, channel);


### PR DESCRIPTION
Today we make multiple attempts to corrupt the translog header in
`TranslogHeaderTests#testCurrentHeaderVersion`, but if we are extraordinarily
unlucky then this sequence of corruptions may restore the file to its original
state. An example of such an extraordinarily unlucky run is as follows.

    ./gradlew ':server:test' --tests "org.elasticsearch.index.translog.TranslogHeaderTests.testCurrentHeaderVersion"
        -Dtests.seed=FA72F7F56C4B3643 -Dtests.security.manager=true -Dtests.jvms=4
        -Dtests.locale=es-GT -Dtests.timezone=Europe/Budapest -Dcompiler.java=13

Log output:

    1> [2020-01-11T00:58:32,320][INFO ][o.e.i.t.TranslogHeaderTests] [testCurrentHeaderVersion] before test
    1> [2020-01-11T00:58:32,322][INFO ][o.e.i.t.TranslogHeaderTests] [testCurrentHeaderVersion] corruptFile: corrupting file /home/davidturner/elasticsearch/server/build/testrun/test/temp/org.elasticsearch.index.translog.TranslogHeaderTests_FA72F7F56C4B3643-001/tempDir-002/translog-6712189936700025777.tlog at position 6 turning 0x72 into 0x63
    1> [2020-01-11T00:58:32,323][INFO ][o.e.i.t.TranslogHeaderTests] [testCurrentHeaderVersion] corruptFile: corrupting file /home/davidturner/elasticsearch/server/build/testrun/test/temp/org.elasticsearch.index.translog.TranslogHeaderTests_FA72F7F56C4B3643-001/tempDir-002/translog-6712189936700025777.tlog at position 6 turning 0x63 into 0x72
    1> [2020-01-11T00:58:32,324][INFO ][o.e.i.t.TranslogHeaderTests] [testCurrentHeaderVersion] after test

This change adjusts the test to only corrupt the file once, which is certain
not to leave the file in its original state.