### PR TITLE
[Backport 7.x] Populate OpenIDConnect metadata collections

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -49,6 +49,7 @@ import org.elasticsearch.xpack.security.authc.support.UserRoleMapper;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -218,7 +219,7 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
              */
             Set<Map.Entry> allowedEntries = claimsMap.entrySet().stream().filter(entry -> {
                 Object v = entry.getValue();
-                return (v instanceof String || v instanceof Boolean || v instanceof Number || v instanceof Collections);
+                return (v instanceof String || v instanceof Boolean || v instanceof Number || v instanceof Collection);
             }).collect(Collectors.toSet());
             for (Map.Entry entry : allowedEntries) {
                 userMetadata.put("oidc(" + entry.getKey() + ")", entry.getValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.XPackLicenseState;
-
 import org.elasticsearch.xpack.core.security.action.oidc.OpenIdConnectLogoutResponse;
 import org.elasticsearch.xpack.core.security.action.oidc.OpenIdConnectPrepareAuthenticationResponse;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -31,6 +30,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -43,6 +43,7 @@ import static java.time.Instant.now;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectRealm.CONTEXT_TOKEN_DATA;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -91,6 +92,10 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
         } else {
             assertThat(result.getUser().metadata().get("oidc(iss)"), equalTo("https://op.company.org"));
             assertThat(result.getUser().metadata().get("oidc(name)"), equalTo("Clinton Barton"));
+            final Object groups = result.getUser().metadata().get("oidc(groups)");
+            assertThat(groups, notNullValue());
+            assertThat(groups, instanceOf(Collection.class));
+            assertThat((Collection<?>) groups, contains("group1", "group2", "groups3"));
         }
     }
 


### PR DESCRIPTION
The OpenIdConnectRealm had a bug which would cause it not to populate
User metadata for collections contained in the user JWT claims.

This commit fixes that bug.

Backport of: #50521