### PR TITLE
Add notice about official Rust client

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -41,9 +41,9 @@ a number of clients that have been contributed by the community for various lang
 [[clojure]]
 == Clojure
 
-* https://github.com/mpenet/spandex[Spandex]: 
+* https://github.com/mpenet/spandex[Spandex]:
   Clojure client, based on the new official low level rest-client.
-  
+
 * http://github.com/clojurewerkz/elastisch[Elastisch]:
   Clojure client.
 
@@ -75,7 +75,7 @@ Also see the {client}/go-api/current/index.html[official Elasticsearch Go client
 
 * https://github.com/olivere/elastic[elastic]:
   Elasticsearch client for Google Go.
-  
+
 * https://github.com/softctrl/elk[elk]
   Golang lib for Elasticsearch client.
 
@@ -106,8 +106,8 @@ Also see the {client}/javascript-api/current/index.html[official Elasticsearch J
 
 * https://github.com/mbuhot/eskotlin[ES Kotlin]:
   Elasticsearch Query DSL for kotlin based on the {client}/java-api/current/index.html[official Elasticsearch Java client].
-  
-* https://github.com/jillesvangurp/es-kotlin-wrapper-client[ES Kotlin Wrapper Client]: 
+
+* https://github.com/jillesvangurp/es-kotlin-wrapper-client[ES Kotlin Wrapper Client]:
   Kotlin extension functions and abstractions for the {client}/java-api/current/index.html[official Elasticsearch Highlevel Client]. Aims to reduce the amount of boilerplate needed to do searches, bulk indexing and other common things users do with the client.
 
 [[lua]]
@@ -154,7 +154,7 @@ Also see the {client}/python-api/current/index.html[official Elasticsearch Pytho
 
 * https://github.com/ropensci/elasticdsl[elasticdsl]:
   A high-level R DSL for Elasticsearch, wrapping the elastic R client.
-  
+
 * https://github.com/uptake/uptasticsearch[uptasticsearch]:
   An R client tailored to data science workflows.
 
@@ -178,12 +178,14 @@ Also see the {client}/ruby-api/current/index.html[official Elasticsearch Ruby cl
 [[rust]]
 == Rust
 
+Also see the {client}/rust-api/current/index.html[official Elasticsearch Rust client].
+
 * https://github.com/benashford/rs-es[rs-es]:
   A REST API client with a strongly-typed Query DSL.
 
 * https://github.com/elastic-rs/elastic[elastic]:
   A modular REST API client that supports freeform queries.
-  
+
 [[scala]]
 == Scala
 
@@ -192,7 +194,7 @@ Also see the {client}/ruby-api/current/index.html[official Elasticsearch Ruby cl
 
 * https://github.com/gphat/wabisabi[wabisabi]:
   Asynchronous REST API Scala client.
-  
+
 * https://github.com/workday/escalar[escalar]:
   Type-safe Scala wrapper for the REST API.
 


### PR DESCRIPTION
Added the note about the official Rust client in the [community clients list](https://www.elastic.co/guide/en/elasticsearch/client/community/current/index.html).

/cc @russcam  