### PR TITLE
Write global meta only when changed

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -593,9 +593,11 @@ public class PersistedClusterStateService {
             logger.trace("currentTerm [{}] matches previous currentTerm, writing changes only",
                 metaData.coordinationMetaData().term());
 
-            try (ReleasableDocument globalMetaDataDocument = makeGlobalMetaDataDocument(metaData)) {
-                for (MetaDataIndexWriter metaDataIndexWriter : metaDataIndexWriters) {
-                    metaDataIndexWriter.updateGlobalMetaData(globalMetaDataDocument.getDocument());
+            if (MetaData.isGlobalStateEquals(previouslyWrittenMetaData, metaData) == false) {
+                try (ReleasableDocument globalMetaDataDocument = makeGlobalMetaDataDocument(metaData)) {
+                    for (MetaDataIndexWriter metaDataIndexWriter : metaDataIndexWriters) {
+                        metaDataIndexWriter.updateGlobalMetaData(globalMetaDataDocument.getDocument());
+                    }
                 }
             }
 


### PR DESCRIPTION
Uses the same optimization for the new cluster state storage layer as the old one, writing global metadata only when changed. Avoids writing out the global metadata if none of the persistent fields changed. Speeds up `server:integTest` by ~10%.

Relates #48701