### PR TITLE
[7.x] [ML][Inference] minor fixes for created_by, and action permission (#50890)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAction.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 public class PutTrainedModelAction extends ActionType<PutTrainedModelAction.Response> {
 
     public static final PutTrainedModelAction INSTANCE = new PutTrainedModelAction();
-    public static final String NAME = "cluster:monitor/xpack/ml/inference/put";
+    public static final String NAME = "cluster:admin/xpack/ml/inference/put";
     private PutTrainedModelAction() {
         super(NAME, Response::new);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask.ProgressTracker;
 import org.elasticsearch.xpack.ml.dataframe.process.results.AnalyticsResult;
 import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
@@ -173,7 +174,7 @@ public class AnalyticsResultProcessor {
             .collect(toList());
         return TrainedModelConfig.builder()
             .setModelId(modelId)
-            .setCreatedBy("data-frame-analytics")
+            .setCreatedBy(XPackUser.NAME)
             .setVersion(Version.CURRENT)
             .setCreateTime(createTime)
             .setTags(Collections.singletonList(analytics.getId()))

--- a/x-pack/plugin/ml/src/main/resources/org/elasticsearch/xpack/ml/inference/persistence/lang_ident_model_1.json
+++ b/x-pack/plugin/ml/src/main/resources/org/elasticsearch/xpack/ml/inference/persistence/lang_ident_model_1.json
@@ -1,6 +1,6 @@
 {
   "model_id" : "lang_ident_model_1",
-  "created_by" : "ml_admin",
+  "created_by" : "_xpack",
   "version" : "7.6.0",
   "description" : "Model used for identifying language from arbitrary input text.",
   "create_time" : 1575548914594,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinitionTests;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask.ProgressTracker;
 import org.elasticsearch.xpack.ml.dataframe.process.results.AnalyticsResult;
 import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
@@ -167,7 +168,7 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
         assertThat(storedModel.getLicenseLevel(), equalTo(License.OperationMode.PLATINUM));
         assertThat(storedModel.getModelId(), containsString(JOB_ID));
         assertThat(storedModel.getVersion(), equalTo(Version.CURRENT));
-        assertThat(storedModel.getCreatedBy(), equalTo("data-frame-analytics"));
+        assertThat(storedModel.getCreatedBy(), equalTo(XPackUser.NAME));
         assertThat(storedModel.getTags(), contains(JOB_ID));
         assertThat(storedModel.getDescription(), equalTo(JOB_DESCRIPTION));
         assertThat(storedModel.getModelDefinition(), equalTo(inferenceModel.build()));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML][Inference] minor fixes for created_by, and action permission  (#50890)