### PR TITLE
Make "percolator" and "parent-join" plugins extensible (elastic#50915)

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/ParentJoinPlugin.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/ParentJoinPlugin.java
@@ -28,6 +28,7 @@ import org.elasticsearch.join.mapper.ParentJoinFieldMapper;
 import org.elasticsearch.join.query.HasChildQueryBuilder;
 import org.elasticsearch.join.query.HasParentQueryBuilder;
 import org.elasticsearch.join.query.ParentIdQueryBuilder;
+import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -37,7 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class ParentJoinPlugin extends Plugin implements SearchPlugin, MapperPlugin {
+public class ParentJoinPlugin extends Plugin implements SearchPlugin, MapperPlugin, ExtensiblePlugin {
 
     public ParentJoinPlugin() {
     }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorPlugin.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorPlugin.java
@@ -21,6 +21,7 @@ package org.elasticsearch.percolator;
 
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -33,7 +34,7 @@ import java.util.Map;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
-public class PercolatorPlugin extends Plugin implements MapperPlugin, SearchPlugin {
+public class PercolatorPlugin extends Plugin implements MapperPlugin, SearchPlugin, ExtensiblePlugin {
     @Override
     public List<QuerySpec<?>> getQueries() {
         return singletonList(new QuerySpec<>(PercolateQueryBuilder.NAME, PercolateQueryBuilder::new, PercolateQueryBuilder::fromXContent));

--- a/plugins/examples/custom-querybuilder/build.gradle
+++ b/plugins/examples/custom-querybuilder/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+apply plugin: 'elasticsearch.testclusters'
+apply plugin: 'elasticsearch.esplugin'
+
+esplugin {
+  name 'custom-querybuilder'
+  description 'An example of custom query builder. Uses percolate and has_child queries inside'
+  classname 'org.elasticsearch.example.customquerybuilder.CustomQueryBuilderPlugin'
+  extendedPlugins = ['percolator', 'parent-join']
+  licenseFile rootProject.file('licenses/APACHE-LICENSE-2.0.txt')
+  noticeFile rootProject.file('NOTICE.txt')
+}
+
+dependencies {
+  compileOnly "org.elasticsearch.plugin:percolator-client:${versions.elasticsearch}"
+  compileOnly "org.elasticsearch.plugin:parent-join-client:${versions.elasticsearch}"
+}
+
+testClusters.integTest {
+  testDistribution = 'oss'
+}

--- a/plugins/examples/custom-querybuilder/src/main/java/org/elasticsearch/example/customquerybuilder/CustomQueryBuilder.java
+++ b/plugins/examples/custom-querybuilder/src/main/java/org/elasticsearch/example/customquerybuilder/CustomQueryBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.example.customquerybuilder;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.join.query.HasChildQueryBuilder;
+import org.elasticsearch.percolator.PercolateQueryBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class CustomQueryBuilder extends AbstractQueryBuilder<CustomQueryBuilder> {
+    private static final ParseField PHRASE_FIELD = new ParseField("phrase");
+    private static final String QUERY_FIELD_NAME = "query";
+    private static final String CHILD_SCOPE = "child";
+    private String phrase;
+
+    public static final String NAME = "custom";
+
+    public CustomQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.phrase = in.readString();
+    }
+
+    public CustomQueryBuilder(String phrase) {
+        this.phrase = phrase;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(phrase);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(PHRASE_FIELD.getPreferredName(), phrase);
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        XContentBuilder docBuilder = XContentFactory.jsonBuilder().startObject();
+        docBuilder.field(PHRASE_FIELD.getPreferredName(), phrase);
+        docBuilder.endObject();
+
+        PercolateQueryBuilder percolateQuery =
+            new PercolateQueryBuilder(QUERY_FIELD_NAME, BytesReference.bytes(docBuilder), XContentType.JSON);
+        HasChildQueryBuilder hasChildQueryBuilder = new HasChildQueryBuilder(CHILD_SCOPE, percolateQuery, ScoreMode.Max);
+        return hasChildQueryBuilder.toQuery(context);
+    }
+
+    public static CustomQueryBuilder fromXContent(XContentParser parser) throws IOException, ParsingException {
+        String queryName = null;
+        String phrase = null;
+        float boost = AbstractQueryBuilder.DEFAULT_BOOST;
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                throw new ParsingException(parser.getTokenLocation(),
+                    "[custom] query does not support object in [" + currentFieldName + "] field");
+            } else if (token.isValue()) {
+                if (currentFieldName == null) {
+                    throw new IllegalStateException("Value came before field");
+                }
+                if (PHRASE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    phrase = parser.text();
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    boost = parser.floatValue();
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    queryName = parser.text();
+                } else {
+                    throw new ParsingException(parser.getTokenLocation(), "[custom] query does not support [" + currentFieldName + "]");
+                }
+            }
+        }
+
+        CustomQueryBuilder queryBuilder = new CustomQueryBuilder(phrase);
+        queryBuilder.boost(boost);
+        if (queryName != null) {
+            queryBuilder.queryName(queryName);
+        }
+        return queryBuilder;
+    }
+
+    @Override
+    protected boolean doEquals(CustomQueryBuilder other) {
+        return Objects.equals(phrase, other.phrase);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(phrase);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+}

--- a/plugins/examples/custom-querybuilder/src/main/java/org/elasticsearch/example/customquerybuilder/CustomQueryBuilderPlugin.java
+++ b/plugins/examples/custom-querybuilder/src/main/java/org/elasticsearch/example/customquerybuilder/CustomQueryBuilderPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.example.customquerybuilder;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CustomQueryBuilderPlugin extends Plugin implements SearchPlugin {
+
+    public List<SearchPlugin.QuerySpec<?>> getQueries() {
+        return Collections.singletonList(new SearchPlugin.QuerySpec<>(
+            CustomQueryBuilder.NAME,
+            CustomQueryBuilder::new,
+            CustomQueryBuilder::fromXContent));
+    }
+}

--- a/plugins/examples/custom-querybuilder/src/test/java/com/elasticsearch/example/customquerybuilder/CustomQueryBuilderTests.java
+++ b/plugins/examples/custom-querybuilder/src/test/java/com/elasticsearch/example/customquerybuilder/CustomQueryBuilderTests.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.elasticsearch.example.customquerybuilder;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.example.customquerybuilder.CustomQueryBuilder;
+import org.elasticsearch.example.customquerybuilder.CustomQueryBuilderPlugin;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.join.ParentJoinPlugin;
+import org.elasticsearch.join.query.HasChildQueryBuilder;
+import org.elasticsearch.percolator.PercolatorPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.AbstractQueryTestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.startsWith;
+
+public class CustomQueryBuilderTests extends AbstractQueryTestCase<CustomQueryBuilder> {
+    private static final String TYPE = "_doc";
+    private static final String PARENT_DOC = "parent";
+    private static final String CHILD_DOC = "child";
+    private static final String JOIN_FIELD = "join_field";
+    private static final String QUERY_FIELD = "query";
+    private static final String PHRASE_FIELD = "phrase";
+
+    private String phrase;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Arrays.asList(CustomQueryBuilderPlugin.class, ParentJoinPlugin.class, PercolatorPlugin.class);
+    }
+
+    @Override
+    protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
+        XContentBuilder mapping = jsonBuilder().startObject().startObject(TYPE).startObject("properties")
+            .startObject(JOIN_FIELD)
+            .field("type", "join")
+            .startObject("relations")
+            .field(PARENT_DOC, CHILD_DOC)
+            .endObject()
+            .endObject()
+            .startObject(QUERY_FIELD)
+            .field("type", "percolator")
+            .endObject()
+            .startObject(PHRASE_FIELD)
+            .field("type", "text")
+            .endObject()
+            .endObject().endObject().endObject();
+
+        mapperService.merge(TYPE,
+            new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+    }
+
+    @Override
+    protected CustomQueryBuilder doCreateTestQueryBuilder() {
+        phrase = randomAlphaOfLength(4);
+        return new CustomQueryBuilder(phrase);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(CustomQueryBuilder queryBuilder, Query query, QueryShardContext context) {
+        assertThat(query, instanceOf(HasChildQueryBuilder.LateParsingQuery.class));
+        HasChildQueryBuilder.LateParsingQuery lateParsingQuery = (HasChildQueryBuilder.LateParsingQuery) query;
+        assertEquals(ScoreMode.Max, lateParsingQuery.getScoreMode());
+        assertThat(lateParsingQuery.getInnerQuery(), instanceOf(BooleanQuery.class));
+        BooleanQuery booleanQuery = (BooleanQuery) lateParsingQuery.getInnerQuery();
+        for (BooleanClause booleanClause : booleanQuery.clauses()) {
+            if (BooleanClause.Occur.FILTER.equals(booleanClause.getOccur())) {
+                assertThat(booleanClause.getQuery(), instanceOf(TermQuery.class));
+                assertEquals(new Term(JOIN_FIELD, CHILD_DOC), ((TermQuery) booleanClause.getQuery()).getTerm());
+            } else if (BooleanClause.Occur.MUST.equals(booleanClause.getOccur())) {
+                // unable to check if query is instance of PercolateQuery because this class is not public
+                assertThat(booleanClause.getQuery().toString(), startsWith("PercolateQuery"));
+                assertThat(booleanClause.getQuery().toString(), containsString(phrase));
+            } else {
+                fail("Unexpected clause inside [has_child] query");
+            }
+        }
+    }
+
+    /**
+     * As percolate query is not cacheable, this one is also not
+     */
+    @Override
+    public void testCacheability() throws IOException {
+        CustomQueryBuilder queryBuilder = createTestQueryBuilder();
+        QueryShardContext context = createShardContext();
+        QueryBuilder rewritten = rewriteQuery(queryBuilder, new QueryShardContext(context));
+        assertNotNull(rewritten.toQuery(context));
+        assertFalse("query should not be cacheable: " + queryBuilder.toString(), context.isCacheable());
+    }
+
+    @Override
+    protected boolean builderGeneratesCacheableQueries() {
+        return false;
+    }
+}

--- a/plugins/examples/custom-querybuilder/src/test/java/com/elasticsearch/example/customquerybuilder/CustomQueryBuilderYamlTestSuiteIT.java
+++ b/plugins/examples/custom-querybuilder/src/test/java/com/elasticsearch/example/customquerybuilder/CustomQueryBuilderYamlTestSuiteIT.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.elasticsearch.example.customquerybuilder;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+public class CustomQueryBuilderYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    public CustomQueryBuilderYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+}

--- a/plugins/examples/custom-querybuilder/src/test/resources/rest-api-spec/test/customquerybuilder/10_basic.yml
+++ b/plugins/examples/custom-querybuilder/src/test/resources/rest-api-spec/test/customquerybuilder/10_basic.yml
@@ -1,0 +1,16 @@
+# tests that the custom query builder plugin is installed
+---
+"plugin loaded":
+  - skip:
+      reason: "contains is a newly added assertion"
+      features: contains
+  - do:
+      cluster.state: {}
+
+  # Get master node id
+  - set: { master_node: master }
+
+  - do:
+      nodes.info: {}
+
+  - contains:  { nodes.$master.plugins: { name: custom-querybuilder } }

--- a/plugins/examples/custom-querybuilder/src/test/resources/rest-api-spec/test/customquerybuilder/20_query.yml
+++ b/plugins/examples/custom-querybuilder/src/test/resources/rest-api-spec/test/customquerybuilder/20_query.yml
@@ -1,0 +1,42 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            properties:
+              join_field:
+                type: join
+                relations:
+                  parent: child
+              phrase:
+                type: text
+              query:
+                type: percolator
+
+  - do:
+      index:
+        index: test
+        id:    1
+        body:  { "join_field": "parent" }
+
+  - do:
+      index:
+        index:   test
+        id:      2
+        routing: 1
+        body:    { "query": { "match_phrase" : { "phrase" : "how to" } }, "join_field": { "name": "child", "parent": "1" } }
+
+  - do:
+      indices.refresh: {}
+
+---
+"Parent/child inner hits":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body: { "query" : { "custom" : { "phrase" : "how to train your dragon" } } }
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._index: "test" }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.0._source.join_field: "parent" }


### PR DESCRIPTION
In order to be able to use `PercolateQueryBuilder` or `HasChildQueryBuilder` in a custom query builder it is suggested to make `percolator` and `parent-join` plugins extensible. Otherwise Elasticsearch will not share the classLoader between plugins and custom query builder plugin will fail with `NoClassDefFoundError`. More details in #50915.

Closes #50915 