### PR TITLE
Restore the unreleased 7.4.3 version in branch 7.4

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,4 +1,4 @@
-elasticsearch     = 7.4.2
+elasticsearch     = 7.4.3
 lucene            = 8.2.0
 
 bundled_jdk_vendor = adoptopenjdk

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -123,7 +123,8 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_4_0 = new Version(7040099, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version V_7_4_1 = new Version(7040199, org.apache.lucene.util.Version.LUCENE_8_2_0);
     public static final Version V_7_4_2 = new Version(7040299, org.apache.lucene.util.Version.LUCENE_8_2_0);
-    public static final Version CURRENT = V_7_4_2;
+    public static final Version V_7_4_3 = new Version(7040399, org.apache.lucene.util.Version.LUCENE_8_2_0);
+    public static final Version CURRENT = V_7_4_3;
 
     private static final ImmutableOpenIntMap<Version> idToVersion;
 


### PR DESCRIPTION
This change restores the unreleased `7.4.3` version in the `7.4` branch. This unreleased version should still be referenced in the `7.4` branch even though we removed it from the other branches. 
