### PR TITLE
[DOCS] Describes the relationship of the time-related settings in anomaly detection docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -64,6 +64,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
 `frequency`::
 (Optional, <<time-units, time units>>)
 include::{docdir}/ml/ml-shared.asciidoc[tag=frequency]
++
+--
+To learn more about the relationship of time related settings, see 
+<<ml-put-datafeed-time-related-settings>>.
+--
 
 `indices`::
 (Required, array)
@@ -84,6 +89,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=query]
 `query_delay`::
 (Optional, <<time-units, time units>>)
 include::{docdir}/ml/ml-shared.asciidoc[tag=query-delay]
++
+--
+To learn more about the relationship of time related settings, see 
+<<ml-put-datafeed-time-related-settings>>.
+--
 
 `script_fields`::
 (Optional, object)
@@ -92,6 +102,19 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=script-fields]
 `scroll_size`::
 (Optional, unsigned integer)
 include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
+
+
+[[ml-put-datafeed-time-related-settings]]
+===== Interaction of time related settings
+
+Time related settings have the following relationships:
+
+* When `query_delay` is present, queries run at `query_delay` after the end of 
+  each `frequency`.
+* When `frequency` is shorter than `bucket_span` of the associated job, interim 
+  results for the last (partial) bucket are written, and then overwritten by the 
+  full bucket results eventually.
+
 
 [[ml-put-datafeed-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -105,7 +105,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 
 [[ml-put-datafeed-time-related-settings]]
-===== Interaction of time-related settings
+===== Interaction between time-related settings
 
 Time-related settings have the following relationships:
 

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -105,9 +105,9 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 
 [[ml-put-datafeed-time-related-settings]]
-===== Interaction of time related settings
+===== Interaction of time-related settings
 
-Time related settings have the following relationships:
+Time-related settings have the following relationships:
 
 * When `query_delay` is present, queries run at `query_delay` after the end of 
   each `frequency`.

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -109,7 +109,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 Time-related settings have the following relationships:
 
-* When `query_delay` is present, queries run at `query_delay` after the end of 
+* When `query_delay` is present, queries run at `query_delay` after the end of 
   each `frequency`.
   
 * When `frequency` is shorter than `bucket_span` of the associated job, interim 

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -109,7 +109,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 Time-related settings have the following relationships:
 
-* When `query_delay` is present, queries run at `query_delay` after the end of 
+* Queries run at `query_delay` after the end of 
   each `frequency`.
   
 * When `frequency` is shorter than `bucket_span` of the associated job, interim 

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -111,6 +111,7 @@ Time-related settings have the following relationships:
 
 * When `query_delay` is present, queries run at `query_delay` after the end of 
   each `frequency`.
+  
 * When `frequency` is shorter than `bucket_span` of the associated job, interim 
   results for the last (partial) bucket are written, and then overwritten by the 
   full bucket results eventually.

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -66,7 +66,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
 include::{docdir}/ml/ml-shared.asciidoc[tag=frequency]
 +
 --
-To learn more about the relationship of time related settings, see 
+To learn more about the relationship between time related settings, see 
 <<ml-put-datafeed-time-related-settings>>.
 --
 

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -91,7 +91,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=query]
 include::{docdir}/ml/ml-shared.asciidoc[tag=query-delay]
 +
 --
-To learn more about the relationship of time related settings, see 
+To learn more about the relationship between time related settings, see 
 <<ml-put-datafeed-time-related-settings>>.
 --
 

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -49,6 +49,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-config]
 `analysis_config`.`bucket_span`:::
 (<<time-units,time units>>)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span]
++
+--
+To learn more about the relationship of time related settings, see 
+<<ml-put-datafeed-time-related-settings>>.
+--
 
 `analysis_config`.`categorization_field_name`:::
 (string)

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -51,7 +51,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-config]
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span]
 +
 --
-To learn more about the relationship of time related settings, see 
+To learn more about the relationship between time related settings, see 
 <<ml-put-datafeed-time-related-settings>>.
 --
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -606,9 +606,7 @@ The interval at which scheduled queries are made while the {dfeed} runs in real
 time. The default value is either the bucket span for short bucket spans, or,
 for longer bucket spans, a sensible fraction of the bucket span. For example:
 `150s`. When `query_delay` is present, queries run at `query_delay` after the 
-end of each `frequency`. When `frequency` is shorter than `bucket_span` of the 
-associated job, interim results for the last (partial) bucket are written, and 
-then overwritten by the full bucket results eventually.
+end of each `frequency`.
 end::frequency[]
 
 tag::from[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -605,7 +605,10 @@ tag::frequency[]
 The interval at which scheduled queries are made while the {dfeed} runs in real
 time. The default value is either the bucket span for short bucket spans, or,
 for longer bucket spans, a sensible fraction of the bucket span. For example:
-`150s`.
+`150s`. When `query_delay` is present, queries run at `query_delay` after the 
+end of each `frequency`. When `frequency` is shorter than `bucket_span` of the 
+associated job, interim results for the last (partial) bucket are written, and 
+then overwritten by the full bucket results eventually.
 end::frequency[]
 
 tag::from[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -605,8 +605,7 @@ tag::frequency[]
 The interval at which scheduled queries are made while the {dfeed} runs in real
 time. The default value is either the bucket span for short bucket spans, or,
 for longer bucket spans, a sensible fraction of the bucket span. For example:
-`150s`. When `query_delay` is present, queries run at `query_delay` after the 
-end of each `frequency`.
+`150s`.
 end::frequency[]
 
 tag::from[]


### PR DESCRIPTION
This PR adds an `Interaction of time-related settings` section to the PUT datafeed API docs that describes the relationship among time-related parameters.

Related issue: https://github.com/elastic/elasticsearch/issues/50389

Available previews:
* http://elasticsearch_50959.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html
* http://elasticsearch_50959.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-job.html