### PR TITLE
[ML] Removed key value from the catch regex test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -272,7 +272,7 @@ setup:
 "Test put config given dest index contains uppercase chars":
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[Foo\] must be lowercase;.*/
+      catch: /.*Validation Failed.* Destination index \[Foo\] must be lowercase;.*/
       ml.put_data_frame_analytics:
         id: "config-given-dest-index-uppercase"
         body: >
@@ -308,7 +308,7 @@ setup:
 "Test put config with missing concrete source index":
 
   - do:
-      catch: /.*reason=Validation Failed.* no such index \[missing\]/
+      catch: /.*Validation Failed.* no such index \[missing\]/
       ml.put_data_frame_analytics:
         id: "config-with-missing-concrete-source-index"
         body: >
@@ -344,7 +344,7 @@ setup:
 "Test put config with dest index same as source index":
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[index-source\] is included in source expression \[index-source\]/
+      catch: /.*Validation Failed.* Destination index \[index-source\] is included in source expression \[index-source\]/
       ml.put_data_frame_analytics:
         id: "config-with-same-source-dest-index"
         body: >
@@ -380,7 +380,7 @@ setup:
         name: multiple-dest-index
 
   - do:
-      catch: /.*reason=Validation Failed.* no write index is defined for alias \[multiple-dest-index\].*/
+      catch: /.*Validation Failed.* no write index is defined for alias \[multiple-dest-index\].*/
       ml.put_data_frame_analytics:
         id: "config-with-dest-index-matching-multiple-indices"
         body: >
@@ -407,7 +407,7 @@ setup:
         name: dest-alias
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[another-source-index\] is included in source expression \[another-source-index\]/
+      catch: /.*Validation Failed.* Destination index \[another-source-index\] is included in source expression \[another-source-index\]/
       ml.put_data_frame_analytics:
         id: "config-with-dest-index-included-in-source-via-alias"
         body: >
@@ -425,7 +425,7 @@ setup:
 "Test put config with remote source index":
 
   - do:
-      catch: /.*reason=Validation Failed.* remote source indices are not supported/
+      catch: /.*Validation Failed.* remote source indices are not supported/
       ml.put_data_frame_analytics:
         id: "config-with-missing-concrete-source-index"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
@@ -31,7 +31,7 @@
         index: missing
 
   - do:
-      catch: /.*reason=Validation Failed.* no such index \[missing\]/
+      catch: /.*Validation Failed.* no such index \[missing\]/
       ml.start_data_frame_analytics:
         id: "missing_index"
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -166,7 +166,7 @@ setup:
 ---
 "Test preview with non-existing source index":
   - do:
-      catch: /.*reason=Validation Failed.* no such index \[does_not_exist\]/
+      catch: /.*Validation Failed.* no such index \[does_not_exist\]/
       transform.preview_transform:
         body: >
           {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -79,7 +79,7 @@ setup:
 ---
 "Test put transform with invalid source index":
   - do:
-      catch: /.*reason=Validation Failed.* no such index \[missing-index\]/
+      catch: /.*Validation Failed.* no such index \[missing-index\]/
       transform.put_transform:
         transform_id: "missing-source-transform"
         body: >
@@ -400,7 +400,7 @@ setup:
         name: source-index
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
+      catch: /.*Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[airline-data,created-destination-index\]/
       transform.put_transform:
         transform_id: "transform-from-aliases-failures"
         body: >
@@ -426,7 +426,7 @@ setup:
         name: dest-index
 
   - do:
-      catch: /.*reason=Validation Failed.* no write index is defined for alias [dest2-index].*/
+      catch: /.*Validation Failed.* no write index is defined for alias [dest2-index].*/
       transform.put_transform:
         transform_id: "airline-transform"
         body: >
@@ -537,7 +537,7 @@ setup:
 ---
 "Test invalid destination index name":
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[DeStInAtIoN\] must be lowercase/
+      catch: /.*Validation Failed.* Destination index \[DeStInAtIoN\] must be lowercase/
       transform.put_transform:
         transform_id: "airline-transform"
         body: >

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/transform/transforms_update.yml
@@ -67,7 +67,7 @@ setup:
 ---
 "Test put transform with invalid source index":
   - do:
-      catch: /.*reason=Validation Failed.* no such index \[missing-index\]/
+      catch: /.*Validation Failed.* no such index \[missing-index\]/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -255,7 +255,7 @@ setup:
         name: source2-index
 
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[created-destination-index\]/
+      catch: /.*Validation Failed.* Destination index \[created-destination-index\] is included in source expression \[created-destination-index\]/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -280,7 +280,7 @@ setup:
         index: created-destination-index
         name: dest2-index
   - do:
-      catch: /.*reason=Validation Failed.* no write index is defined for alias [dest2-index].*/
+      catch: /.*Validation Failed.* no write index is defined for alias [dest2-index].*/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -290,7 +290,7 @@ setup:
 ---
 "Test invalid destination index name":
   - do:
-      catch: /.*reason=Validation Failed.* Destination index \[DeStInAtIoN\] must be lowercase/
+      catch: /.*Validation Failed.* Destination index \[DeStInAtIoN\] must be lowercase/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >
@@ -298,7 +298,7 @@ setup:
             "dest": { "index": "DeStInAtIoN" }
           }
   - do:
-      catch: /.*reason=Validation Failed.* Invalid index name \[destination#dest\], must not contain \'#\'/
+      catch: /.*Validation Failed.* Invalid index name \[destination#dest\], must not contain \'#\'/
       transform.update_transform:
         transform_id: "updating-airline-transform"
         body: >


### PR DESCRIPTION
Hello folks!
In some tests, where we are using a regex to catch an error, we are also checking the key value, but the test assumes that the body is serialized as yaml while other clients test it as json.
This pr removes the `reason=` part fo the regex, as it's not important to verify the key value as well, because this message will be present only in that part of the json.