### PR TITLE
Emit warnings when index templates have multiple mappings

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -20,6 +20,7 @@ package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
@@ -32,6 +33,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -50,6 +52,8 @@ import java.util.Objects;
 import java.util.Set;
 
 public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaData> {
+
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(IndexTemplateMetaData.class));
 
     private final String name;
 
@@ -97,6 +101,11 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
         this.patterns = patterns;
         this.settings = settings;
         this.mappings = mappings;
+        if (this.mappings.size() > 1) {
+            deprecationLogger.deprecatedAndMaybeLog("index-templates",
+                "Index template {} contains multiple typed mappings; templates in 8x will only support a single mapping",
+                name);
+        }
         this.aliases = aliases;
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -167,5 +168,16 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
             IndexTemplateMetaData parsed = IndexTemplateMetaData.Builder.fromXContent(parser, templateName);
             assertThat(parsed, equalTo(template));
         }
+    }
+
+    public void testDeprecationWarningsOnMultipleMappings() throws IOException {
+        IndexTemplateMetaData.Builder builder = IndexTemplateMetaData.builder("my-template");
+        builder.patterns(Arrays.asList("a", "b"));
+        builder.putMapping("type1", "{\"type1\":{}}");
+        builder.putMapping("type2", "{\"type2\":{}}");
+        builder.build();
+
+        assertWarnings("Index template my-template contains multiple typed mappings; " +
+            "templates in 8x will only support a single mapping");
     }
 }


### PR DESCRIPTION
Index templates created in the 5x line can still be present in the cluster state
through multiple upgrades, and may have more than one mapping defined.  8x
will stop supporting templates with multiple mappings, and we should emit
deprecation warnings in 7x clusters to give users a chance to update their
templates before upgrading.