### PR TITLE
[ML] Disable invalid assertion

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -592,7 +592,9 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         // Assert that all the class probabilities lie within [0, 1] interval.
         classProbabilities.forEach(p -> assertThat(p, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0))));
         // Assert that the top classes are listed in the order of decreasing probabilities.
-        assertThat(Ordering.natural().reverse().isOrdered(classProbabilities), is(true));
+        // This is not true after https://github.com/elastic/ml-cpp/pull/926. I'll fix and re-enable
+        // once that change is merged.
+        //assertThat(Ordering.natural().reverse().isOrdered(classProbabilities), is(true));
     }
 
     private <T> void assertEvaluation(String dependentVariable, List<T> dependentVariableValues, String predictedClassField) {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -5,7 +5,8 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import com.google.common.collect.Ordering;
+// Pending fix
+//import com.google.common.collect.Ordering;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.get.GetIndexAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;


### PR DESCRIPTION
The assertion is no longer valid after elastic/ml-cpp#926 is merged. I'll update and re-enable once that change is merged. (I've commented out the assert rather than disabled the failing unit tests because it might fail on in any calling code depending on the seed used.)