### PR TITLE
re-enable bwc tests and update geo-grid bounds version guard to 7.6 after #50996

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,8 +205,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/50996" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilder.java
@@ -67,7 +67,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     GeoTileGridValuesSourceBuilder(StreamInput in) throws IOException {
         super(in);
         this.precision = in.readInt();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
             this.geoBoundingBox = new GeoBoundingBox(in);
         }
     }
@@ -90,7 +90,7 @@ public class GeoTileGridValuesSourceBuilder extends CompositeValuesSourceBuilder
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeInt(precision);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
             geoBoundingBox.writeTo(out);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -98,7 +98,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
         precision = in.readVInt();
         requiredSize = in.readVInt();
         shardSize = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_6_0)) {
             geoBoundingBox = new GeoBoundingBox(in);
         }
     }
@@ -108,7 +108,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
         out.writeVInt(precision);
         out.writeVInt(requiredSize);
         out.writeVInt(shardSize);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_6_0)) {
             geoBoundingBox.writeTo(out);
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -59,7 +59,7 @@ public class GeoHashGridTests extends BaseAggregationTestCase<GeoGridAggregation
     }
 
     public void testSerializationPreBounds() throws Exception {
-        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_7_6_0);
+        Version noBoundsSupportVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_5_0);
         GeoHashGridAggregationBuilder builder = createTestAggregatorBuilder();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setVersion(Version.V_7_6_0);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -59,10 +59,10 @@ public class GeoHashGridTests extends BaseAggregationTestCase<GeoGridAggregation
     }
 
     public void testSerializationPreBounds() throws Exception {
-        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
+        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_7_6_0);
         GeoHashGridAggregationBuilder builder = createTestAggregatorBuilder();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setVersion(Version.V_8_0_0);
+            output.setVersion(Version.V_7_6_0);
             builder.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(),
                 new NamedWriteableRegistry(Collections.emptyList()))) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoTileGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoTileGridTests.java
@@ -59,7 +59,7 @@ public class GeoTileGridTests extends BaseAggregationTestCase<GeoGridAggregation
     }
 
     public void testSerializationPreBounds() throws Exception {
-        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_7_6_0);
+        Version noBoundsSupportVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_5_0);
         GeoTileGridAggregationBuilder builder = createTestAggregatorBuilder();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setVersion(Version.V_7_6_0);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoTileGridTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoTileGridTests.java
@@ -59,10 +59,10 @@ public class GeoTileGridTests extends BaseAggregationTestCase<GeoGridAggregation
     }
 
     public void testSerializationPreBounds() throws Exception {
-        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
+        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_7_6_0);
         GeoTileGridAggregationBuilder builder = createTestAggregatorBuilder();
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setVersion(Version.V_8_0_0);
+            output.setVersion(Version.V_7_6_0);
             builder.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(),
                 new NamedWriteableRegistry(Collections.emptyList()))) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilderTests.java
@@ -43,7 +43,7 @@ public class GeoTileGridValuesSourceBuilderTests extends ESTestCase {
     }
 
     public void testBWCBounds() throws IOException {
-        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_7_6_0);
+        Version noBoundsSupportVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_5_0);
         GeoTileGridValuesSourceBuilder builder = new GeoTileGridValuesSourceBuilder("name");
         if (randomBoolean()) {
             builder.geoBoundingBox(GeoBoundingBoxTests.randomBBox());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/GeoTileGridValuesSourceBuilderTests.java
@@ -43,13 +43,13 @@ public class GeoTileGridValuesSourceBuilderTests extends ESTestCase {
     }
 
     public void testBWCBounds() throws IOException {
-        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
+        Version noBoundsSupportVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_7_6_0);
         GeoTileGridValuesSourceBuilder builder = new GeoTileGridValuesSourceBuilder("name");
         if (randomBoolean()) {
             builder.geoBoundingBox(GeoBoundingBoxTests.randomBBox());
         }
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setVersion(Version.V_8_0_0);
+            output.setVersion(Version.V_7_6_0);
             builder.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(),
                 new NamedWriteableRegistry(Collections.emptyList()))) {


### PR DESCRIPTION
after #50996 (backport of #50002) merged, the version guard 
on geo-grid `bounds` parameter can be updated to 7.6

re-enables bwc tests