### PR TITLE
Fix MultiVersionRepository BwC Tests

### DIFF
--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -274,7 +274,6 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
             XContentParser parser = JsonXContent.jsonXContent.createParser(
             xContentRegistry(), DeprecationHandler.THROW_UNSUPPORTED_OPERATION, entity)) {
             final Map<String, Object> raw = parser.map();
-            logger.error(raw);
             final Map<String, Object> snapshot = (Map<String, Object>) raw.get("snapshot");
             final Map<String, Object> shardStats = (Map<String, Object>) snapshot.get("shards");
             assertThat(shardStats.get("successful"), is(shards));


### PR DESCRIPTION
The HLRC doesn't like what its getting back from some older 6.x versions for the restore status
so I moved that request to the low level client.
Closes #50819

I manually confirmed that this runs fine for all BwC test versions:

```

BUILD SUCCESSFUL in 51m 1s
414 actionable tasks: 322 executed, 92 up-to-date

```