### PR TITLE
Remove ingest-geoip build legacy

### DIFF
--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -32,16 +32,8 @@ dependencies {
   compile("com.fasterxml.jackson.core:jackson-databind:${versions.jacksondatabind}")
   compile('com.maxmind.db:maxmind-db:1.2.2')
 
-  testCompile 'org.elasticsearch:geolite2-databases:20191119'
+  compile('org.elasticsearch:geolite2-databases:20191119')
 }
-
-task copyDefaultGeoIp2DatabaseFiles(type: Copy) {
-  from { zipTree(configurations.testCompile.files.find { it.name.contains('geolite2-databases') }) }
-  into "${project.buildDir}/ingest-geoip"
-  include "*.mmdb"
-}
-
-project.bundlePlugin.dependsOn(copyDefaultGeoIp2DatabaseFiles)
 
 bundlePlugin {
   from("${project.buildDir}/ingest-geoip") {


### PR DESCRIPTION
We declared the geolite2-databases dependency as a test compile dependency for legacy reasons, when ingest-geoip was bundled as a plugin (related to the fact that these databases where handled in the Elasticsearch config instead of the module directory, and testing concerns). When we switched to bundling ingest-geoip by default, that legacy could have been removed. This commit removes that unneeded legacy.

