### PR TITLE
[7.x] Add generated benchmark files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.ipr
 *.iws
 build-idea/
+# These files are generated in the main tree by IntelliJ
+benchmarks/src/main/generated/*
 
 # eclipse files
 .project
@@ -42,7 +44,7 @@ html_docs
 /tmp/
 eclipse-build
 
-# projects using testfixtures 
+# projects using testfixtures
 testfixtures_shared/
 
 # These are generated from .ci/jobs.t


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add generated benchmark files to gitignore (#51000)