### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/90_error.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/90_error.yml
@@ -1,8 +1,8 @@
 ---
 'Misspelled fields get "did you mean"':
   - skip:
-      version: " - 7.99.99"
-      reason: Implemented in 8.0
+      version: " - 7.5.99"
+      reason: Implemented in 7.6
   - do:
       catch: /\[UpdateRequest\] unknown field \[dac\] did you mean \[doc\]\?/
       update:


### PR DESCRIPTION
Now that we've backported #50938 to 7.x it should be safe to run its
test against BWC clusters that include that branch.
