### PR TITLE
Fix NPE in PinnedQuery call to DisjunctionMaxScorer.

### DIFF
--- a/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
+++ b/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
@@ -142,7 +142,10 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
     }
 
-    public void testIssue51034() throws Exception {
+    /**
+     * Test scoring the entire set of documents, which uses a slightly different logic when creating scorers.
+     */
+    public void testExhaustiveScoring() throws Exception {
         assertAcked(prepareCreate("test")
                 .setMapping(jsonBuilder().startObject().startObject("_doc").startObject("properties")
                         .startObject("field1").field("analyzer", "whitespace").field("type", "text").endObject()

--- a/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
+++ b/x-pack/plugin/search-business-rules/src/test/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -141,6 +142,28 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
     }
 
+    public void testIssue51034() throws Exception {
+        assertAcked(prepareCreate("test")
+                .setMapping(jsonBuilder().startObject().startObject("_doc").startObject("properties")
+                        .startObject("field1").field("analyzer", "whitespace").field("type", "text").endObject()
+                        .startObject("field2").field("analyzer", "whitespace").field("type", "text").endObject()
+                                .endObject().endObject().endObject())
+                .setSettings(Settings.builder().put(indexSettings()).put("index.number_of_shards", 1)));
+
+        client().prepareIndex("test").setId("1").setSource("field1", "foo").get();
+        client().prepareIndex("test").setId("2").setSource("field1", "foo", "field2", "foo").get();
+
+        refresh();
+
+        QueryStringQueryBuilder organicQuery = QueryBuilders.queryStringQuery("foo");
+        PinnedQueryBuilder pqb = new PinnedQueryBuilder(organicQuery, "2");
+        SearchResponse searchResponse = client().prepareSearch().setQuery(pqb).setTrackTotalHits(true)
+                .setSearchType(DFS_QUERY_THEN_FETCH).get();
+
+        long numHits = searchResponse.getHits().getTotalHits().value;
+        assertThat(numHits, equalTo(2L));
+    }    
+    
     public void testExplain() throws Exception {
         assertAcked(prepareCreate("test").setMapping(
                 jsonBuilder().startObject().startObject("_doc").startObject("properties").startObject("field1")


### PR DESCRIPTION
The DisjunctionMaxScorer will throw a NullPointerException if `advanceShallow` is called and `scoreMode != ScoreMode.TOP_SCORES`.
Added code in the calling CappedScoreQuery to avoid making this call when not in the required score mode and test to reproduce the issue.