### PR TITLE
Fix hardcoded version replacement in put-dfanalytics.asciidoc 

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -407,7 +407,7 @@ The API returns the following result:
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "8.0.0"/"version": $body.version/]
+// TESTRESPONSE[s/"version" : "8.0.0"/"version" : $body.version/]
 
 
 [[ml-put-dfanalytics-example-r]]


### PR DESCRIPTION
The substitution must match the whitespace in the console result.

Inspired by #51053 this is the same fix on master for the inevitable failure when 8.0 is released.  
