### PR TITLE
[DOCS] Add note to community clients page

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -4,6 +4,15 @@
 == Preface
 :client: https://www.elastic.co/guide/en/elasticsearch/client
 
+[NOTE]
+====
+This is a list of clients submitted by members of the Elastic community.
+Elastic does not support or endorse these clients.
+
+If you'd like to add a new client to this list, please
+https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-code-and-documentation-changes[open a pull request].
+====
+
 Besides the link:/guide[officially supported Elasticsearch clients], there are
 a number of clients that have been contributed by the community for various languages:
 


### PR DESCRIPTION
Adds a note to the 'Community Contributed Clients' page explicitly
stating that Elastic does not support or endorse the clients.
