### PR TITLE
Add release highlights for 7.6

### DIFF
--- a/docs/reference/release-notes/highlights-7.6.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.6.0.asciidoc
@@ -1,0 +1,32 @@
+[[release-highlights-7.6.0]]
+== 7.6.0 release highlights
+++++
+<titleabbrev>7.6.0</titleabbrev>
+++++
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+[float]
+==== Histogram field type
+
+A new {ref}/histogram.html[histogram field type] has been added.  The new `histogram` field accepts
+pre-aggregated histograms which can later be used directly in the
+{ref}/search-aggregations-metrics-percentile-aggregation.html[percentiles] and
+{ref}/search-aggregations-metrics-percentile-rank-aggregation.html[percentile_ranks] aggregations.
+This allows users to pre-aggregate histogram data locally to the client and only send the final
+datastructure, saving storage and network transfer, but still retaining the ability to
+aggregate it like any other data.
+
+// end::notable-highlights[]
+
+// tag::notable-highlights[]
+[float]
+==== Optimize sorting on long field types
+
+Sorting on a `long` field now internally rewrites into a Lucene `DistanceFeatureQuery`.
+This allows skipping non-competitive hits which leads to increased query performance.
+In benchmarks this has sped up sorts on `long` fields by 10x.
+
+// end::notable-highlights[]

--- a/docs/reference/release-notes/highlights-7.6.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.6.0.asciidoc
@@ -11,22 +11,22 @@
 [float]
 ==== New histogram field type
 
-A new {ref}/histogram.html[histogram field type] has been added.  The new `histogram` field accepts
+A new {ref}/histogram.html[histogram field type] has been added. The new `histogram` field accepts
 pre-aggregated histograms which can later be used directly in the
 {ref}/search-aggregations-metrics-percentile-aggregation.html[percentiles] and
 {ref}/search-aggregations-metrics-percentile-rank-aggregation.html[percentile_ranks] aggregations.
-This allows users to pre-aggregate histogram data locally to the client and only send the final
-datastructure, saving storage and network transfer, but still retaining the ability to
+This allows users to pre-aggregate histogram data locally and only send the final
+data structure, saving storage and network bandwidth while retaining the ability to
 aggregate it like any other data.
 
 // end::notable-highlights[]
 
 // tag::notable-highlights[]
 [float]
-==== Optimize sorting on long field types
+==== Optimized sorting on long field types
 
-Sorting on a `long` field now internally rewrites into a Lucene `DistanceFeatureQuery`.
-This allows skipping non-competitive hits which leads to increased query performance.
-In benchmarks this has sped up sorts on `long` fields by 10x.
+Sorting on a {ref}/number.html[`long`] field now internally rewrites into a Lucene `DistanceFeatureQuery`.
+This lets {es} skip non-competitive hits, which often improves query speed.
+In benchmarking tests, this sped up sorts on `long` fields by 10x.
 
 // end::notable-highlights[]

--- a/docs/reference/release-notes/highlights-7.6.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.6.0.asciidoc
@@ -9,7 +9,7 @@
 
 // tag::notable-highlights[]
 [float]
-==== Histogram field type
+==== New histogram field type
 
 A new {ref}/histogram.html[histogram field type] has been added.  The new `histogram` field accepts
 pre-aggregated histograms which can later be used directly in the

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -6,6 +6,7 @@
 This section summarizes the most important changes in each release. For the
 full list, see <<es-release-notes>> and <<breaking-changes>>.
 
+* <<release-highlights-7.6.0>>
 * <<release-highlights-7.5.0>>
 * <<release-highlights-7.4.0>>
 * <<release-highlights-7.3.0>>
@@ -15,6 +16,7 @@ full list, see <<es-release-notes>> and <<breaking-changes>>.
 
 --
 
+include::highlights-7.6.0.asciidoc[]
 include::highlights-7.5.0.asciidoc[]
 include::highlights-7.4.0.asciidoc[]
 include::highlights-7.3.0.asciidoc[]


### PR DESCRIPTION
@mayya-sharipova @iverase Your PRs (optimize sorts on longs, histograms) were marked as `release-highlight` so I put together a little summary for each.  Let me know if I described it incorrectly or missed something important.