### PR TITLE
[DOCS] Retitle analysis reference pages

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -150,11 +150,11 @@ include::analysis/testing.asciidoc[]
 
 include::analysis/analyzers.asciidoc[]
 
-include::analysis/normalizers.asciidoc[]
-
 include::analysis/tokenizers.asciidoc[]
 
 include::analysis/tokenfilters.asciidoc[]
 
 include::analysis/charfilters.asciidoc[]
+
+include::analysis/normalizers.asciidoc[]
 

--- a/docs/reference/analysis/analyzers.asciidoc
+++ b/docs/reference/analysis/analyzers.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-analyzers]]
-== Analyzers
+== Built-in analyzer reference
 
 Elasticsearch ships with a wide range of built-in analyzers, which can be used
 in any index without further configuration:

--- a/docs/reference/analysis/charfilters.asciidoc
+++ b/docs/reference/analysis/charfilters.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-charfilters]]
-== Character Filters
+== Character filters reference
 
 _Character filters_ are used to preprocess the stream of characters before it
 is passed to the <<analysis-tokenizers,tokenizer>>.

--- a/docs/reference/analysis/tokenfilters.asciidoc
+++ b/docs/reference/analysis/tokenfilters.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-tokenfilters]]
-== Token Filters
+== Token filter reference
 
 Token filters accept a stream of tokens from a
 <<analysis-tokenizers,tokenizer>> and can modify tokens

--- a/docs/reference/analysis/tokenizers.asciidoc
+++ b/docs/reference/analysis/tokenizers.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-tokenizers]]
-== Tokenizers
+== Tokenizer reference
 
 A _tokenizer_  receives a stream of characters, breaks it up into individual
 _tokens_ (usually individual words), and outputs a stream of _tokens_. For


### PR DESCRIPTION
The explicitly labels several pages for the Analysis topic as reference pages. The goal is to avoid confusing users who may be expecting conceptual or task-related docs.

### Supporting changes

* Changes titles to sentence case.

* Appends pages with 'reference' to differentiate their content from
  conceptual overviews.

* Moves the 'Normalizers' page to end of the Analysis topic pages.
