### PR TITLE
Encrypt generated key with AES (#51019)

### DIFF
--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateTool.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertificateTool.java
@@ -922,7 +922,7 @@ public class CertificateTool extends LoggingAwareMultiCommand {
     }
 
     static PEMEncryptor getEncrypter(char[] password) {
-        return new JcePEMEncryptorBuilder("DES-EDE3-CBC").setProvider(BC_PROV).build(password);
+        return new JcePEMEncryptorBuilder("AES-128-CBC").setProvider(BC_PROV).build(password);
     }
 
     private static <T, E extends Exception> T withPassword(String description, char[] password, Terminal terminal,

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -383,9 +383,9 @@ public class CertificateToolTests extends ESTestCase {
             Path keyFile = zipRoot.resolve(filename + "/" + filename + ".key");
             assertTrue(Files.exists(keyFile));
             if (keyPassword != null) {
-                assertTrue(Files.readString(keyFile).contains("DEK-Info: AES-128-CBC"));
+                assertTrue(new String(Files.readAllBytes(keyFile), StandardCharsets.US_ASCII).contains("DEK-Info: AES-128-CBC"));
             } else {
-                assertFalse(Files.readString(keyFile).contains("DEK-Info:"));
+                assertFalse(new String(Files.readAllBytes(keyFile), StandardCharsets.US_ASCII).contains("DEK-Info:"));
             }
             final Path p12 = zipRoot.resolve(filename + "/" + filename + ".p12");
             try (InputStream input = Files.newInputStream(cert)) {


### PR DESCRIPTION
Replace DES with AES to align with modern encryption standards
Backport also fixs Files.readString API that is not available in Java 8

Resolves: #50843