### PR TITLE
Fix _bulk API path to include type in guide

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -315,7 +315,7 @@ To get some data into {es} that you can start searching and analyzing:
 +
 [source,sh]
 --------------------------------------------------
-curl -H "Content-Type: application/json" -XPOST "localhost:9200/bank/_bulk?pretty&refresh" --data-binary "@accounts.json"
+curl -H "Content-Type: application/json" -XPOST "localhost:9200/bank/account/_bulk?pretty&refresh" --data-binary "@accounts.json"
 curl "localhost:9200/_cat/indices?v"
 --------------------------------------------------
 // NOTCONSOLE


### PR DESCRIPTION
The current guide directs users to use an API path without type which results in an  `action_request_validation_exception`. These changes fix the command.