### PR TITLE
Fix an example output of edge n-gram token filter.

### DIFF
--- a/docs/reference/analysis/tokenfilters/edgengram-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/edgengram-tokenfilter.asciidoc
@@ -49,7 +49,7 @@ The filter produces the following tokens:
 
 [source,text]
 --------------------------------------------------
-[ t, th, q, ui, b, br, f, fo, j, ju ]
+[ t, th, q, qu, b, br, f, fo, j, ju ]
 --------------------------------------------------
 
 /////////////////////


### PR DESCRIPTION
Given a token `quick`, the default edge n-gram token filter returns `[q, qu]`, not `[q, ui]`.