### PR TITLE
[DOCS] Fix indent issue in similarity docs snippet

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -22,19 +22,19 @@ settings.
 --------------------------------------------------
 PUT /index
 {
-    "settings" : {
-        "index" : {
-            "similarity" : {
-              "my_similarity" : {
-                "type" : "DFR",
-                "basic_model" : "g",
-                "after_effect" : "l",
-                "normalization" : "h2",
-                "normalization.h2.c" : "3.0"
-              }
-            }
+  "settings": {
+    "index": {
+      "similarity": {
+        "my_similarity": {
+          "type": "DFR",
+          "basic_model": "g",
+          "after_effect": "l",
+          "normalization": "h2",
+          "normalization.h2.c": "3.0"
         }
+      }
     }
+  }
 }
 --------------------------------------------------
 


### PR DESCRIPTION
Updates snippet to consistently use 2-space indentation. The snippet
previously used a mix of tab/5-space and 2-space indents.

Addresses issue raised by @missinglink in #50855