### PR TITLE
Remove types from WatcherSearchTemplateRequest

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateSearchInputMappingsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateSearchInputMappingsTests.java
@@ -36,14 +36,13 @@ public class HistoryTemplateSearchInputMappingsTests extends AbstractWatcherInte
 
     public void testHttpFields() throws Exception {
         String index = "the-index";
-        String type = "the-type";
         createIndex(index);
         indexDoc(index, "{}");
         flush();
         refresh();
 
         WatcherSearchTemplateRequest request = new WatcherSearchTemplateRequest(
-                new String[]{index}, new String[]{type}, SearchType.QUERY_THEN_FETCH,
+                new String[]{index}, SearchType.QUERY_THEN_FETCH,
                 WatcherSearchTemplateRequest.DEFAULT_INDICES_OPTIONS, new BytesArray("{}")
         );
         PutWatchResponse putWatchResponse = new PutWatchRequestBuilder(client(), "_id").setSource(watchBuilder()
@@ -64,7 +63,6 @@ public class HistoryTemplateSearchInputMappingsTests extends AbstractWatcherInte
         SearchResponse response = client().prepareSearch(HistoryStoreField.INDEX_PREFIX_WITH_TEMPLATE + "*").setSource(searchSource()
                 .aggregation(terms("input_search_type").field("result.input.search.request.search_type"))
                 .aggregation(terms("input_indices").field("result.input.search.request.indices"))
-                .aggregation(terms("input_types").field("result.input.search.request.types"))
                 .aggregation(terms("input_body").field("result.input.search.request.body")))
                 .get();
 
@@ -84,12 +82,6 @@ public class HistoryTemplateSearchInputMappingsTests extends AbstractWatcherInte
         assertThat(terms.getBuckets().size(), is(1));
         assertThat(terms.getBucketByKey(index), notNullValue());
         assertThat(terms.getBucketByKey(index).getDocCount(), is(1L));
-
-        terms = aggs.get("input_types");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getBuckets().size(), is(1));
-        assertThat(terms.getBucketByKey(type), notNullValue());
-        assertThat(terms.getBucketByKey(type).getDocCount(), is(1L));
 
         terms = aggs.get("input_body");
         assertThat(terms, notNullValue());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherUtilsTests.java
@@ -90,7 +90,6 @@ public class WatcherUtilsTests extends ESTestCase {
 
     public void testSerializeSearchRequest() throws Exception {
         String[] expectedIndices = generateRandomStringArray(5, 5, true);
-        String[] expectedTypes = generateRandomStringArray(2, 5, true, false);
         IndicesOptions expectedIndicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(),
                 randomBoolean(), WatcherSearchTemplateRequest.DEFAULT_INDICES_OPTIONS);
         SearchType expectedSearchType = getRandomSupportedSearchType();
@@ -111,14 +110,14 @@ public class WatcherUtilsTests extends ESTestCase {
             ScriptType scriptType = randomFrom(ScriptType.values());
             stored = scriptType == ScriptType.STORED;
             expectedTemplate = new Script(scriptType, stored ? null : "mustache", text, params);
-            request = new WatcherSearchTemplateRequest(expectedIndices, expectedTypes, expectedSearchType,
+            request = new WatcherSearchTemplateRequest(expectedIndices, expectedSearchType,
                     expectedIndicesOptions, expectedTemplate);
         } else {
             SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()).size(11);
             XContentBuilder builder = jsonBuilder();
             builder.value(sourceBuilder);
             expectedSource = BytesReference.bytes(builder);
-            request = new WatcherSearchTemplateRequest(expectedIndices, expectedTypes, expectedSearchType,
+            request = new WatcherSearchTemplateRequest(expectedIndices, expectedSearchType,
                     expectedIndicesOptions, expectedSource);
         }
 
@@ -142,12 +141,6 @@ public class WatcherUtilsTests extends ESTestCase {
             assertThat(result.getTemplate().getIdOrCode(), equalTo(expectedSource.utf8ToString()));
             assertThat(result.getTemplate().getType(), equalTo(ScriptType.INLINE));
         }
-        if (expectedTypes == null) {
-            assertNull(result.getTypes());
-        } else {
-            assertThat(result.getTypes(), arrayContainingInAnyOrder(expectedTypes));
-            assertWarnings(WatcherSearchTemplateRequest.TYPES_DEPRECATION_MESSAGE);
-        }
     }
 
     public void testDeserializeSearchRequest() throws Exception {
@@ -161,16 +154,6 @@ public class WatcherUtilsTests extends ESTestCase {
                 builder.array("indices", indices);
             } else {
                 builder.field("indices", Strings.arrayToCommaDelimitedString(indices));
-            }
-        }
-
-        String[] types = Strings.EMPTY_ARRAY;
-        if (randomBoolean()) {
-            types = generateRandomStringArray(2, 5, false, false);
-            if (randomBoolean()) {
-                builder.array("types", types);
-            } else {
-                builder.field("types", Strings.arrayToCommaDelimitedString(types));
             }
         }
 
@@ -239,12 +222,6 @@ public class WatcherUtilsTests extends ESTestCase {
             assertThat(result.getTemplate().getType(), equalTo(template.getType()));
             assertThat(result.getTemplate().getParams(), equalTo(template.getParams()));
             assertThat(result.getTemplate().getLang(), equalTo(stored ? null : "mustache"));
-        }
-        if (types == Strings.EMPTY_ARRAY) {
-            assertNull(result.getTypes());
-        } else {
-            assertThat(result.getTypes(), arrayContainingInAnyOrder(types));
-            assertWarnings(WatcherSearchTemplateRequest.TYPES_DEPRECATION_MESSAGE);
         }
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequestTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateRequestTests.java
@@ -39,24 +39,6 @@ public class WatcherSearchTemplateRequestTests extends ESTestCase {
         assertHitCount(source, hitCountsAsInt);
     }
 
-    public void testDeprecationForSingleType() throws IOException {
-        String source = "{\"types\":\"mytype\"}";
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
-            parser.nextToken();
-            WatcherSearchTemplateRequest.fromXContent(parser, SearchType.QUERY_THEN_FETCH);
-        }
-        assertWarnings(WatcherSearchTemplateRequest.TYPES_DEPRECATION_MESSAGE);
-    }
-
-    public void testDeprecationForMultiType() throws IOException {
-        String source = "{\"types\":[\"mytype1\",\"mytype2\"]}";
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
-            parser.nextToken();
-            WatcherSearchTemplateRequest.fromXContent(parser, SearchType.QUERY_THEN_FETCH);
-        }
-        assertWarnings(WatcherSearchTemplateRequest.TYPES_DEPRECATION_MESSAGE);
-    }
-
     private void assertHitCount(String source, boolean expectedHitCountAsInt) throws IOException {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
             parser.nextToken();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatcherTestUtils.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatcherTestUtils.java
@@ -92,7 +92,7 @@ public final class WatcherTestUtils {
         try {
             XContentBuilder xContentBuilder = jsonBuilder();
             xContentBuilder.value(sourceBuilder);
-            return new WatcherSearchTemplateRequest(indices, null, searchType,
+            return new WatcherSearchTemplateRequest(indices, searchType,
                     WatcherSearchTemplateRequest.DEFAULT_INDICES_OPTIONS, BytesReference.bytes(xContentBuilder));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
@@ -223,7 +223,7 @@ public class BasicWatcherTests extends AbstractWatcherIntegrationTestCase {
                 .get());
 
         Script template = new Script(ScriptType.STORED, null, "my-template", Collections.emptyMap());
-        WatcherSearchTemplateRequest searchRequest = new WatcherSearchTemplateRequest(new String[]{"events"}, new String[0],
+        WatcherSearchTemplateRequest searchRequest = new WatcherSearchTemplateRequest(new String[]{"events"},
                 SearchType.DEFAULT, WatcherSearchTemplateRequest.DEFAULT_INDICES_OPTIONS, template);
         testConditionSearch(searchRequest);
     }


### PR DESCRIPTION
There is no longer any point in restricting the types for a Watcher search template.  The
types parameter was deprecated in 7x, and can be removed from 8x.

Relates to #41059 