### PR TITLE
Fix CorruptedBlobStoreRepository Test

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1097,6 +1097,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     listener.onFailure(e);
                 }
                 return;
+            } catch (Exception e) {
+                listener.onFailure(new RepositoryException(metadata.name(), "Unexpected exception when loading repository data", e));
+                return;
             }
         }
     }


### PR DESCRIPTION
The tests, when creating broken serialized blobs could randomly create
a sequence of bytes that is partially readable by the deserializer and then
not throw `IOException` but instead `ElasticsearchParseException`.
We should just handle these unexpected exceptions downstream properly and pass them
wrapped as `RepositoryException` to the listener to fix the test and keep the API consistent.

Example failure: https://gradle-enterprise.elastic.co/s/j5weeo3e5q35w/tests/kyv2y2z3r4v7m-qa4jss45jhhq4