### PR TITLE
[DOCS] Remove out-dated monitoring note

### DIFF
--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -10,10 +10,6 @@ data collection is disabled.
 This method involves sending the metrics to the monitoring cluster by using 
 exporters. For an alternative method, see <<configuring-metricbeat>>.
 
-NOTE: If you want to collect monitoring data from sources such as Beats and {ls}
-and route it to a monitoring cluster, you must follow this method. You cannot
-use {metricbeat} to ship the monitoring data for those products yet.
-
 Advanced monitoring settings enable you to control how frequently data is 
 collected, configure timeouts, and set the retention period for locally-stored 
 monitoring indices. You can also adjust how monitoring data is displayed. 


### PR DESCRIPTION
The "Collecting monitoring data" page (https://www.elastic.co/guide/en/elasticsearch/reference/current/collecting-monitoring-data.html) contains out-dated information about support for monitoring Beats and Logstash:

> If you want to collect monitoring data from sources such as Beats and Logstash and route it to a monitoring cluster, you must follow this method. You cannot use Metricbeat to ship the monitoring data for those products yet.

Per https://www.elastic.co/guide/en/beats/packetbeat/current/monitoring-metricbeat-collection.html and https://www.elastic.co/guide/en/logstash/master/monitoring-with-metricbeat.html that is not true in 7.3 and later releases.

Preview: http://elasticsearch_51129.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/collecting-monitoring-data.html