### PR TITLE
Update quantiles document in the index the document belongs to

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -59,6 +60,7 @@ import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
@@ -525,9 +527,11 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
         DataFrameAnalyticsAuditor dataFrameAnalyticsAuditor = new DataFrameAnalyticsAuditor(client, clusterService.getNodeName());
         InferenceAuditor inferenceAuditor = new InferenceAuditor(client, clusterService.getNodeName());
         this.dataFrameAnalyticsAuditor.set(dataFrameAnalyticsAuditor);
-        ResultsPersisterService resultsPersisterService = new ResultsPersisterService(client, clusterService, settings);
+        OriginSettingClient originSettingClient = new OriginSettingClient(client, ClientHelper.ML_ORIGIN);
+        ResultsPersisterService resultsPersisterService = new ResultsPersisterService(originSettingClient, clusterService, settings);
         JobResultsProvider jobResultsProvider = new JobResultsProvider(client, settings);
-        JobResultsPersister jobResultsPersister = new JobResultsPersister(client, resultsPersisterService, anomalyDetectionAuditor);
+        JobResultsPersister jobResultsPersister =
+            new JobResultsPersister(originSettingClient, resultsPersisterService, anomalyDetectionAuditor);
         JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client,
             resultsPersisterService,
             anomalyDetectionAuditor);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -17,12 +17,16 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.IdsQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
@@ -244,9 +248,9 @@ public class JobResultsPersister {
      * @param category The category to be persisted
      */
     public void persistCategoryDefinition(CategoryDefinition category, Supplier<Boolean> shouldRetry) {
-        Persistable persistable = new Persistable(category.getJobId(), category, category.getId());
-
-        persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(category.getJobId()), shouldRetry);
+        Persistable persistable =
+            new Persistable(AnomalyDetectorsIndex.resultsWriteAlias(category.getJobId()), category.getJobId(), category, category.getId());
+        persistable.persist(shouldRetry);
         // Don't commit as we expect masses of these updates and they're not
         // read again by this process
     }
@@ -255,17 +259,50 @@ public class JobResultsPersister {
      * Persist the quantiles (blocking)
      */
     public void persistQuantiles(Quantiles quantiles, Supplier<Boolean> shouldRetry) {
-        Persistable persistable = new Persistable(quantiles.getJobId(), quantiles, Quantiles.documentId(quantiles.getJobId()));
-        persistable.persist(AnomalyDetectorsIndex.jobStateIndexWriteAlias(), shouldRetry);
+        String quantilesDocId = Quantiles.documentId(quantiles.getJobId());
+
+        SearchRequest searchRequest =
+            new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
+                .source(new SearchSourceBuilder().size(1).query(new IdsQueryBuilder().addIds(quantilesDocId)));
+        SearchResponse searchResponse = client.search(searchRequest).actionGet();
+        String indexOrAlias = AnomalyDetectorsIndex.jobStateIndexWriteAlias();
+        if (searchResponse.getHits().getHits().length > 0) {
+            indexOrAlias = searchResponse.getHits().getHits()[0].getIndex();
+        }
+
+        Persistable persistable = new Persistable(indexOrAlias, quantiles.getJobId(), quantiles, quantilesDocId);
+        persistable.persist(shouldRetry);
     }
 
     /**
      * Persist the quantiles (async)
      */
     public void persistQuantiles(Quantiles quantiles, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<IndexResponse> listener) {
-        Persistable persistable = new Persistable(quantiles.getJobId(), quantiles, Quantiles.documentId(quantiles.getJobId()));
-        persistable.setRefreshPolicy(refreshPolicy);
-        persistable.persist(AnomalyDetectorsIndex.jobStateIndexWriteAlias(), listener);
+        String quantilesDocId = Quantiles.documentId(quantiles.getJobId());
+
+        // Step 2: Create or update the quantiles document:
+        //   - if the document did not exist, create the new one in the current write index
+        //   - if the document did exist, update it in the index where it resides (not necessarily the current write index)
+        ActionListener<SearchResponse> searchFormerQuantilesDocListener = ActionListener.wrap(
+            searchResponse -> {
+                String indexOrAlias = AnomalyDetectorsIndex.jobStateIndexWriteAlias();
+                if (searchResponse.getHits().getHits().length > 0) {
+                    indexOrAlias = searchResponse.getHits().getHits()[0].getIndex();
+                }
+
+                Persistable persistable = new Persistable(indexOrAlias, quantiles.getJobId(), quantiles, quantilesDocId);
+                persistable.setRefreshPolicy(refreshPolicy);
+                persistable.persist(listener);
+            },
+            listener::onFailure
+        );
+
+        // Step 1: Search for existing quantiles document in .ml-state*
+        SearchRequest searchRequest =
+            new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern())
+                .source(new SearchSourceBuilder().size(1).query(new IdsQueryBuilder().addIds(quantilesDocId)));
+        executeAsyncWithOrigin(
+            client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest, searchFormerQuantilesDocListener, client::search);
     }
 
     /**
@@ -274,9 +311,14 @@ public class JobResultsPersister {
     public BulkResponse persistModelSnapshot(ModelSnapshot modelSnapshot,
                                              WriteRequest.RefreshPolicy refreshPolicy,
                                              Supplier<Boolean> shouldRetry) {
-        Persistable persistable = new Persistable(modelSnapshot.getJobId(), modelSnapshot, ModelSnapshot.documentId(modelSnapshot));
+        Persistable persistable =
+            new Persistable(
+                AnomalyDetectorsIndex.resultsWriteAlias(modelSnapshot.getJobId()),
+                modelSnapshot.getJobId(),
+                modelSnapshot,
+                ModelSnapshot.documentId(modelSnapshot));
         persistable.setRefreshPolicy(refreshPolicy);
-        return persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(modelSnapshot.getJobId()), shouldRetry);
+        return persistable.persist(shouldRetry);
     }
 
     /**
@@ -285,8 +327,9 @@ public class JobResultsPersister {
     public void persistModelSizeStats(ModelSizeStats modelSizeStats, Supplier<Boolean> shouldRetry) {
         String jobId = modelSizeStats.getJobId();
         logger.trace("[{}] Persisting model size stats, for size {}", jobId, modelSizeStats.getModelBytes());
-        Persistable persistable = new Persistable(jobId, modelSizeStats, modelSizeStats.getId());
-        persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(jobId), shouldRetry);
+        Persistable persistable =
+            new Persistable(AnomalyDetectorsIndex.resultsWriteAlias(jobId), jobId, modelSizeStats, modelSizeStats.getId());
+        persistable.persist(shouldRetry);
     }
 
     /**
@@ -296,9 +339,10 @@ public class JobResultsPersister {
                                       ActionListener<IndexResponse> listener) {
         String jobId = modelSizeStats.getJobId();
         logger.trace("[{}] Persisting model size stats, for size {}", jobId, modelSizeStats.getModelBytes());
-        Persistable persistable = new Persistable(jobId, modelSizeStats, modelSizeStats.getId());
+        Persistable persistable =
+            new Persistable(AnomalyDetectorsIndex.resultsWriteAlias(jobId), jobId, modelSizeStats, modelSizeStats.getId());
         persistable.setRefreshPolicy(refreshPolicy);
-        persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(jobId), listener);
+        persistable.persist(listener);
     }
 
     /**
@@ -354,13 +398,15 @@ public class JobResultsPersister {
     public BulkResponse persistDatafeedTimingStats(DatafeedTimingStats timingStats, WriteRequest.RefreshPolicy refreshPolicy) {
         String jobId = timingStats.getJobId();
         logger.trace("[{}] Persisting datafeed timing stats", jobId);
-        Persistable persistable = new Persistable(
-            jobId,
-            timingStats,
-            new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true")),
-            DatafeedTimingStats.documentId(timingStats.getJobId()));
+        Persistable persistable =
+            new Persistable(
+                AnomalyDetectorsIndex.resultsWriteAlias(jobId),
+                jobId,
+                timingStats,
+                new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true")),
+                DatafeedTimingStats.documentId(timingStats.getJobId()));
         persistable.setRefreshPolicy(refreshPolicy);
-        return persistable.persist(AnomalyDetectorsIndex.resultsWriteAlias(jobId), () -> true);
+        return persistable.persist(() -> true);
     }
 
     private static XContentBuilder toXContentBuilder(ToXContent obj, ToXContent.Params params) throws IOException {
@@ -371,17 +417,19 @@ public class JobResultsPersister {
 
     private class Persistable {
 
+        private final String indexName;
         private final String jobId;
         private final ToXContent object;
         private final ToXContent.Params params;
         private final String id;
         private WriteRequest.RefreshPolicy refreshPolicy;
 
-        Persistable(String jobId, ToXContent object, String id) {
-            this(jobId, object, ToXContent.EMPTY_PARAMS, id);
+        Persistable(String indexName, String jobId, ToXContent object, String id) {
+            this(indexName, jobId, object, ToXContent.EMPTY_PARAMS, id);
         }
 
-        Persistable(String jobId, ToXContent object, ToXContent.Params params, String id) {
+        Persistable(String indexName, String jobId, ToXContent object, ToXContent.Params params, String id) {
+            this.indexName = indexName;
             this.jobId = jobId;
             this.object = object;
             this.params = params;
@@ -393,7 +441,7 @@ public class JobResultsPersister {
             this.refreshPolicy = refreshPolicy;
         }
 
-        BulkResponse persist(String indexName, Supplier<Boolean> shouldRetry) {
+        BulkResponse persist(Supplier<Boolean> shouldRetry) {
             logCall(indexName);
             try {
                 return resultsPersisterService.indexWithRetry(jobId,
@@ -414,7 +462,7 @@ public class JobResultsPersister {
             }
         }
 
-        void persist(String indexName, ActionListener<IndexResponse> listener) {
+        void persist(ActionListener<IndexResponse> listener) {
             logCall(indexName);
 
             try (XContentBuilder content = toXContentBuilder(object, params)) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -21,7 +21,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -76,11 +76,11 @@ public class JobResultsPersister {
 
     private static final Logger logger = LogManager.getLogger(JobResultsPersister.class);
 
-    private final Client client;
+    private final OriginSettingClient client;
     private final ResultsPersisterService resultsPersisterService;
     private final AnomalyDetectionAuditor auditor;
 
-    public JobResultsPersister(Client client,
+    public JobResultsPersister(OriginSettingClient client,
                                ResultsPersisterService resultsPersisterService,
                                AnomalyDetectionAuditor auditor) {
         this.client = client;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -13,9 +13,12 @@ import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -48,10 +51,20 @@ public class ResultsPersisterService {
     // Having an exponent higher than this causes integer overflow
     private static final int MAX_RETRY_EXPONENT = 24;
 
+    private final CheckedConsumer<Integer, InterruptedException> sleeper;
     private final OriginSettingClient client;
     private volatile int maxFailureRetries;
 
     public ResultsPersisterService(OriginSettingClient client, ClusterService clusterService, Settings settings) {
+        this(Thread::sleep, client, clusterService, settings);
+    }
+
+    // Visible for testing
+    ResultsPersisterService(CheckedConsumer<Integer, InterruptedException> sleeper,
+                            OriginSettingClient client,
+                            ClusterService clusterService,
+                            Settings settings) {
+        this.sleeper = sleeper;
         this.client = client;
         this.maxFailureRetries = PERSIST_RESULTS_MAX_RETRIES.get(settings);
         clusterService.getClusterSettings()
@@ -81,29 +94,77 @@ public class ResultsPersisterService {
                                            String jobId,
                                            Supplier<Boolean> shouldRetry,
                                            Consumer<String> msgHandler) {
-        int currentMin = MIN_RETRY_SLEEP_MILLIS;
-        int currentMax = MIN_RETRY_SLEEP_MILLIS;
-        int currentAttempt = 0;
-        BulkResponse bulkResponse = null;
-        final Random random = Randomness.get();
-        while(currentAttempt <= maxFailureRetries) {
-            bulkResponse = client.bulk(bulkRequest).actionGet();
+        RetryContext retryContext = new RetryContext(jobId, shouldRetry, msgHandler);
+        while (true) {
+            BulkResponse bulkResponse = client.bulk(bulkRequest).actionGet();
             if (bulkResponse.hasFailures() == false) {
                 return bulkResponse;
             }
-            if (shouldRetry.get() == false) {
-                throw new ElasticsearchException("[{}] failed to index all results. {}", jobId, bulkResponse.buildFailureMessage());
+
+            retryContext.nextIteration("index", bulkResponse.buildFailureMessage());
+
+            // We should only retry the docs that failed.
+            bulkRequest = buildNewRequestFromFailures(bulkRequest, bulkResponse);
+        }
+    }
+
+    public SearchResponse searchWithRetry(SearchRequest searchRequest,
+                                          String jobId,
+                                          Supplier<Boolean> shouldRetry,
+                                          Consumer<String> msgHandler) {
+        RetryContext retryContext = new RetryContext(jobId, shouldRetry, msgHandler);
+        while (true) {
+            SearchResponse searchResponse = client.search(searchRequest).actionGet();
+            if (searchResponse.status().getStatus() == 200) {
+                return searchResponse;
             }
-            if (currentAttempt > maxFailureRetries) {
-                LOGGER.warn("[{}] failed to index after [{}] attempts. Setting [xpack.ml.persist_results_max_retries] was reduced",
-                    jobId,
-                    currentAttempt);
-                throw new ElasticsearchException("[{}] failed to index all results after [{}] attempts. {}",
-                    jobId,
-                    currentAttempt,
-                    bulkResponse.buildFailureMessage());
-            }
+
+            retryContext.nextIteration("search", searchResponse.status().toString());
+        }
+    }
+
+    /**
+     * {@link RetryContext} object handles logic that is executed between consecutive retries of an action.
+     *
+     * Note that it does not execute the action itself.
+     */
+    private class RetryContext {
+
+        final String jobId;
+        final Supplier<Boolean> shouldRetry;
+        final Consumer<String> msgHandler;
+        final Random random = Randomness.get();
+
+        int currentAttempt = 0;
+        int currentMin = MIN_RETRY_SLEEP_MILLIS;
+        int currentMax = MIN_RETRY_SLEEP_MILLIS;
+
+        RetryContext(String jobId, Supplier<Boolean> shouldRetry, Consumer<String> msgHandler) {
+            this.jobId = jobId;
+            this.shouldRetry = shouldRetry;
+            this.msgHandler = msgHandler;
+        }
+
+        void nextIteration(String actionName, String failureMessage) {
             currentAttempt++;
+
+            // If the outside conditions have changed and retries are no longer needed, do not retry.
+            if (shouldRetry.get() == false) {
+                String msg = new ParameterizedMessage(
+                    "[{}] should not retry {} after [{}] attempts. {}", jobId, actionName, currentAttempt, failureMessage)
+                    .getFormattedMessage();
+                LOGGER.info(() -> new ParameterizedMessage("[{}] {}", jobId, msg));
+                throw new ElasticsearchException(msg);
+            }
+
+            // If the configured maximum number of retries has been reached, do not retry.
+            if (currentAttempt > maxFailureRetries) {
+                String msg = new ParameterizedMessage(
+                    "[{}] failed to {} after [{}] attempts. {}", jobId, actionName, currentAttempt, failureMessage).getFormattedMessage();
+                LOGGER.warn(() -> new ParameterizedMessage("[{}] {}", jobId, msg));
+                throw new ElasticsearchException(msg);
+            }
+
             // Since we exponentially increase, we don't want force randomness to have an excessively long sleep
             if (currentMax < MAX_RETRY_SLEEP_MILLIS) {
                 currentMin = currentMax;
@@ -117,32 +178,26 @@ public class ResultsPersisterService {
             int randSleep = currentMin + random.nextInt(randBound);
             {
                 String msg = new ParameterizedMessage(
-                    "failed to index after [{}] attempts. Will attempt again in [{}].",
+                    "failed to {} after [{}] attempts. Will attempt again in [{}].",
+                    actionName,
                     currentAttempt,
                     TimeValue.timeValueMillis(randSleep).getStringRep())
                     .getFormattedMessage();
-                LOGGER.warn(()-> new ParameterizedMessage("[{}] {}", jobId, msg));
+                LOGGER.warn(() -> new ParameterizedMessage("[{}] {}", jobId, msg));
                 msgHandler.accept(msg);
             }
-            // We should only retry the docs that failed.
-            bulkRequest = buildNewRequestFromFailures(bulkRequest, bulkResponse);
             try {
-                Thread.sleep(randSleep);
+                sleeper.accept(randSleep);
             } catch (InterruptedException interruptedException) {
                 LOGGER.warn(
-                    new ParameterizedMessage("[{}] failed to index after [{}] attempts due to interruption",
+                    new ParameterizedMessage("[{}] failed to {} after [{}] attempts due to interruption",
                         jobId,
+                        actionName,
                         currentAttempt),
                     interruptedException);
                 Thread.currentThread().interrupt();
             }
         }
-        String bulkFailureMessage = bulkResponse == null ? "" : bulkResponse.buildFailureMessage();
-        LOGGER.warn("[{}] failed to index after [{}] attempts.", jobId, currentAttempt);
-        throw new ElasticsearchException("[{}] failed to index all results after [{}] attempts. {}",
-            jobId,
-            currentAttempt,
-            bulkFailureMessage);
     }
 
     private BulkRequest buildNewRequestFromFailures(BulkRequest bulkRequest, BulkResponse bulkResponse) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterApplierService;
@@ -19,6 +20,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
@@ -113,13 +115,14 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
                 ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING)));
         ClusterService clusterService = new ClusterService(settings, clusterSettings, tp);
 
-        resultsPersisterService = new ResultsPersisterService(client(), clusterService, settings);
+        OriginSettingClient originSettingClient = new OriginSettingClient(client(), ClientHelper.ML_ORIGIN);
+        resultsPersisterService = new ResultsPersisterService(originSettingClient, clusterService, settings);
         resultProcessor = new AutodetectResultProcessor(
                 client(),
                 auditor,
                 JOB_ID,
                 renormalizer,
-                new JobResultsPersister(client(), resultsPersisterService, new AnomalyDetectionAuditor(client(), "test_node")),
+                new JobResultsPersister(originSettingClient, resultsPersisterService, new AnomalyDetectionAuditor(client(), "test_node")),
                 process,
                 new ModelSizeStats.Builder(JOB_ID).build(),
                 new TimingStats(JOB_ID)) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/EstablishedMemUsageIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/EstablishedMemUsageIT.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -12,6 +13,7 @@ import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
@@ -54,11 +56,11 @@ public class EstablishedMemUsageIT extends BaseMlIntegTestCase {
                 ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING)));
         ClusterService clusterService = new ClusterService(settings, clusterSettings, tp);
 
-        ResultsPersisterService resultsPersisterService = new ResultsPersisterService(client(), clusterService, settings);
+        OriginSettingClient originSettingClient = new OriginSettingClient(client(), ClientHelper.ML_ORIGIN);
+        ResultsPersisterService resultsPersisterService = new ResultsPersisterService(originSettingClient, clusterService, settings);
         jobResultsProvider = new JobResultsProvider(client(), settings);
-        jobResultsPersister = new JobResultsPersister(client(),
-            resultsPersisterService,
-            new AnomalyDetectionAuditor(client(), "test_node"));
+        jobResultsPersister = new JobResultsPersister(
+            originSettingClient, resultsPersisterService, new AnomalyDetectionAuditor(client(), "test_node"));
     }
 
     public void testEstablishedMem_givenNoResults() throws Exception {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
@@ -303,6 +304,7 @@ public class JobResultsPersisterTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     private void testPersistQuantilesSync(SearchHits searchHits, String expectedIndexOrAlias) {
         SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.status()).thenReturn(RestStatus.OK);
         when(searchResponse.getHits()).thenReturn(searchHits);
         doAnswer(withResponse(searchResponse)).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -5,27 +5,29 @@
  */
 package org.elasticsearch.xpack.ml.job.persistence;
 
-import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
@@ -37,7 +39,9 @@ import org.elasticsearch.xpack.core.ml.job.results.ModelPlot;
 import org.elasticsearch.xpack.core.ml.utils.ExponentialAverageCalculationContext;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.test.MockOriginSettingClient;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
+import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.stubbing.Answer;
@@ -53,9 +57,9 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -68,9 +72,21 @@ public class JobResultsPersisterTests extends ESTestCase {
 
     private static final String JOB_ID = "foo";
 
+    private Client client;
+    private OriginSettingClient originSettingClient;
+    private ArgumentCaptor<BulkRequest> bulkRequestCaptor;
+    private JobResultsPersister persister;
+
+    @Before
+    public void setUpTests() {
+        bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+        client = mock(Client.class);
+        doAnswer(withResponse(mock(BulkResponse.class))).when(client).execute(eq(BulkAction.INSTANCE), any(), any());
+        originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
+        persister = new JobResultsPersister(originSettingClient, buildResultsPersisterService(originSettingClient), makeAuditor());
+    }
+
     public void testPersistBucket_OneRecord() {
-        ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(captor);
         Bucket bucket = new Bucket("foo", new Date(), 123456);
         bucket.setAnomalyScore(99.9);
         bucket.setEventCount(57);
@@ -89,9 +105,11 @@ public class JobResultsPersisterTests extends ESTestCase {
         AnomalyRecord record = new AnomalyRecord(JOB_ID, new Date(), 600);
         bucket.setRecords(Collections.singletonList(record));
 
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
         persister.bulkPersisterBuilder(JOB_ID, () -> true).persistBucket(bucket).executeRequest();
-        BulkRequest bulkRequest = captor.getValue();
+
+        verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
+
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(2, bulkRequest.numberOfActions());
 
         String s = ((IndexRequest)bulkRequest.requests().get(0)).source().utf8ToString();
@@ -112,9 +130,6 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testPersistRecords() {
-        ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(captor);
-
         List<AnomalyRecord> records = new ArrayList<>();
         AnomalyRecord r1 = new AnomalyRecord(JOB_ID, new Date(), 42);
         records.add(r1);
@@ -141,9 +156,11 @@ public class JobResultsPersisterTests extends ESTestCase {
         typicals.add(998765.3);
         r1.setTypical(typicals);
 
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
         persister.bulkPersisterBuilder(JOB_ID, () -> true).persistRecords(records).executeRequest();
-        BulkRequest bulkRequest = captor.getValue();
+
+        verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
+
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
 
         String s = ((IndexRequest) bulkRequest.requests().get(0)).source().utf8ToString();
@@ -167,9 +184,6 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testPersistInfluencers() {
-        ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(captor);
-
         List<Influencer> influencers = new ArrayList<>();
         Influencer inf = new Influencer(JOB_ID, "infName1", "infValue1", new Date(), 600);
         inf.setInfluencerScore(16);
@@ -177,9 +191,11 @@ public class JobResultsPersisterTests extends ESTestCase {
         inf.setProbability(0.4);
         influencers.add(inf);
 
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
         persister.bulkPersisterBuilder(JOB_ID, () -> true).persistInfluencers(influencers).executeRequest();
-        BulkRequest bulkRequest = captor.getValue();
+
+        verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
+
+        BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertEquals(1, bulkRequest.numberOfActions());
 
         String s = ((IndexRequest) bulkRequest.requests().get(0)).source().utf8ToString();
@@ -191,10 +207,6 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testExecuteRequest_ClearsBulkRequest() {
-        ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(captor);
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
-
         List<Influencer> influencers = new ArrayList<>();
         Influencer inf = new Influencer(JOB_ID, "infName1", "infValue1", new Date(), 600);
         inf.setInfluencerScore(16);
@@ -208,32 +220,31 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testBulkRequestExecutesWhenReachMaxDocs() {
-        ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(captor);
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
-
         JobResultsPersister.Builder bulkBuilder = persister.bulkPersisterBuilder("foo", () -> true);
         ModelPlot modelPlot = new ModelPlot("foo", new Date(), 123456, 0);
         for (int i=0; i<=JobRenormalizedResultsPersister.BULK_LIMIT; i++) {
             bulkBuilder.persistModelPlot(modelPlot);
         }
 
-        verify(client, times(1)).bulk(any());
-        verify(client, times(1)).threadPool();
+        InOrder inOrder = inOrder(client);
+        inOrder.verify(client).settings();
+        inOrder.verify(client, times(3)).threadPool();
+        inOrder.verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
         verifyNoMoreInteractions(client);
     }
 
     public void testPersistTimingStats() {
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(bulkRequestCaptor);
-
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
         TimingStats timingStats =
             new TimingStats(
                 "foo", 7, 1.0, 2.0, 1.23, 7.89, new ExponentialAverageCalculationContext(600.0, Instant.ofEpochMilli(123456789), 60.0));
         persister.bulkPersisterBuilder(JOB_ID, () -> true).persistTimingStats(timingStats).executeRequest();
 
-        verify(client, times(1)).bulk(bulkRequestCaptor.capture());
+        InOrder inOrder = inOrder(client);
+        inOrder.verify(client).settings();
+        inOrder.verify(client, times(3)).threadPool();
+        inOrder.verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
+        verifyNoMoreInteractions(client);
+
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
         assertThat(bulkRequest.requests().size(), equalTo(1));
         IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
@@ -254,26 +265,24 @@ public class JobResultsPersisterTests extends ESTestCase {
                         "incremental_metric_value_ms", 600.0,
                         "previous_exponential_average_ms", 60.0,
                         "latest_timestamp", 123456789))));
-
-        verify(client, times(1)).threadPool();
-        verifyNoMoreInteractions(client);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings("unchecked")
     public void testPersistDatafeedTimingStats() {
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(bulkRequestCaptor);
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
         DatafeedTimingStats timingStats =
             new DatafeedTimingStats(
                 "foo", 6, 66, 666.0, new ExponentialAverageCalculationContext(600.0, Instant.ofEpochMilli(123456789), 60.0));
         persister.persistDatafeedTimingStats(timingStats, WriteRequest.RefreshPolicy.IMMEDIATE);
 
-        verify(client, times(1)).bulk(bulkRequestCaptor.capture());
+        InOrder inOrder = inOrder(client);
+        inOrder.verify(client).settings();
+        inOrder.verify(client, times(3)).threadPool();
+        inOrder.verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
+        verifyNoMoreInteractions(client);
 
         // Refresh policy is set on the bulk request, not the individual index requests
         assertThat(bulkRequestCaptor.getValue().getRefreshPolicy(), equalTo(WriteRequest.RefreshPolicy.IMMEDIATE));
-        IndexRequest indexRequest = (IndexRequest)bulkRequestCaptor.getValue().requests().get(0);
+        IndexRequest indexRequest = (IndexRequest) bulkRequestCaptor.getValue().requests().get(0);
         assertThat(indexRequest.index(), equalTo(".ml-anomalies-.write-foo"));
         assertThat(indexRequest.id(), equalTo("foo_datafeed_timing_stats"));
         assertThat(
@@ -289,28 +298,20 @@ public class JobResultsPersisterTests extends ESTestCase {
                         "incremental_metric_value_ms", 600.0,
                         "previous_exponential_average_ms", 60.0,
                         "latest_timestamp", 123456789))));
-
-        verify(client, times(1)).threadPool();
-        verifyNoMoreInteractions(client);
     }
 
     @SuppressWarnings("unchecked")
     private void testPersistQuantilesSync(SearchHits searchHits, String expectedIndexOrAlias) {
-        ArgumentCaptor<BulkRequest> bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
-        Client client = mockClient(bulkRequestCaptor);
         SearchResponse searchResponse = mock(SearchResponse.class);
         when(searchResponse.getHits()).thenReturn(searchHits);
-        ActionFuture<SearchResponse> searchActionFuture = mock(ActionFuture.class);
-        when(searchActionFuture.actionGet()).thenReturn(searchResponse);
-        doReturn(searchActionFuture).when(client).search(any());
+        doAnswer(withResponse(searchResponse)).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
 
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
         Quantiles quantiles = new Quantiles("foo", new Date(), "bar");
         persister.persistQuantiles(quantiles, () -> false);
 
         InOrder inOrder = inOrder(client);
-        inOrder.verify(client).search(any());
-        inOrder.verify(client).bulk(bulkRequestCaptor.capture());
+        inOrder.verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
+        inOrder.verify(client).execute(eq(BulkAction.INSTANCE), bulkRequestCaptor.capture(), any());
         inOrder.verifyNoMoreInteractions();
 
         BulkRequest bulkRequest = bulkRequestCaptor.getValue();
@@ -334,21 +335,22 @@ public class JobResultsPersisterTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     private void testPersistQuantilesAsync(SearchHits searchHits, String expectedIndexOrAlias) {
         ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
-        Client client = mockClient(ArgumentCaptor.forClass(BulkRequest.class));
+
         SearchResponse searchResponse = mock(SearchResponse.class);
         when(searchResponse.getHits()).thenReturn(searchHits);
-        doAnswer(withResponse(searchResponse)).when(client).search(any(), any());
-        IndexResponse indexResponse = mock(IndexResponse.class);
-        doAnswer(withResponse(indexResponse)).when(client).index(any(), any());
+        doAnswer(withResponse(searchResponse)).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
 
-        JobResultsPersister persister = new JobResultsPersister(client, buildResultsPersisterService(client), makeAuditor());
+        IndexResponse indexResponse = mock(IndexResponse.class);
+        doAnswer(withResponse(indexResponse)).when(client).execute(eq(IndexAction.INSTANCE), any(), any());
+
         Quantiles quantiles = new Quantiles("foo", new Date(), "bar");
         ActionListener<IndexResponse> indexResponseListener = mock(ActionListener.class);
         persister.persistQuantiles(quantiles, WriteRequest.RefreshPolicy.IMMEDIATE, indexResponseListener);
 
-        InOrder inOrder = inOrder(client);
-        inOrder.verify(client).search(any(), any());
-        inOrder.verify(client).index(indexRequestCaptor.capture(), any());
+        InOrder inOrder = inOrder(client, indexResponseListener);
+        inOrder.verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
+        inOrder.verify(client).execute(eq(IndexAction.INSTANCE), indexRequestCaptor.capture(), any());
+        inOrder.verify(indexResponseListener).onResponse(any());
         inOrder.verifyNoMoreInteractions();
 
         IndexRequest indexRequest = indexRequestCaptor.getValue();
@@ -370,39 +372,13 @@ public class JobResultsPersisterTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     private static <Response> Answer<Response> withResponse(Response response) {
         return invocationOnMock -> {
-            ActionListener<Response> listener = (ActionListener<Response>) invocationOnMock.getArguments()[1];
+            ActionListener<Response> listener = (ActionListener<Response>) invocationOnMock.getArguments()[2];
             listener.onResponse(response);
             return null;
         };
     }
 
-    private Client mockClient(ArgumentCaptor<BulkRequest> captor) {
-        return mockClientWithResponse(captor, new BulkResponse(new BulkItemResponse[0], 0L));
-    }
-
-    @SuppressWarnings("unchecked")
-    private Client mockClientWithResponse(ArgumentCaptor<BulkRequest> captor, BulkResponse... responses) {
-        Client client = mock(Client.class);
-        ThreadPool threadPool = mock(ThreadPool.class);
-        when(client.threadPool()).thenReturn(threadPool);
-        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
-        List<ActionFuture<BulkResponse>> futures = new ArrayList<>(responses.length - 1);
-        ActionFuture<BulkResponse> future1 = makeFuture(responses[0]);
-        for (int i = 1; i < responses.length; i++) {
-            futures.add(makeFuture(responses[i]));
-        }
-        when(client.bulk(captor.capture())).thenReturn(future1, futures.toArray(ActionFuture[]::new));
-        return client;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static ActionFuture<BulkResponse> makeFuture(BulkResponse response) {
-        ActionFuture<BulkResponse> future = mock(ActionFuture.class);
-        when(future.actionGet()).thenReturn(response);
-        return future;
-    }
-
-    private ResultsPersisterService buildResultsPersisterService(Client client) {
+    private ResultsPersisterService buildResultsPersisterService(OriginSettingClient client) {
         ThreadPool tp = mock(ThreadPool.class);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY,
             new HashSet<>(Arrays.asList(InferenceProcessor.MAX_INFERENCE_PROCESSORS,


### PR DESCRIPTION
Currently, the quantiles document is always indexed into the index pointed by an alias ".ml-state-write".
We plan this alias->index mapping to change over time (as we introduce rollover).
Therefore, we need to make sure we don't end up with two copies of the quantiles document.
This PR achieves that by:
  1. searching for the doc
  2. either indexing it into the current write index or updating it in its current index

Relates #29938