### PR TITLE
supported_protocols showed as list

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -516,7 +516,7 @@ and `full`. Defaults to `full`.
 See <<ssl-tls-settings,`ssl.verification_mode`>> for an explanation of these values.
 
 `ssl.supported_protocols`::
-Supported protocols for TLS/SSL (with versions). Defaults to `TLSv1.3,TLSv1.2,TLSv1.1`.
+List of supported protocols for TLS/SSL (with versions). Defaults to `TLSv1.3,TLSv1.2,TLSv1.1` (i.e `[ "TLSv1.3", "TLSv1.2", "TLSv1.1" ]`).
 
 `ssl.cipher_suites`:: Specifies the cipher suites that should be supported when 
 communicating with the LDAP server. 
@@ -767,7 +767,7 @@ and `full`. Defaults to `full`.
 See <<ssl-tls-settings,`ssl.verification_mode`>> for an explanation of these values.
 
 `ssl.supported_protocols`::
-Supported protocols for TLS/SSL (with versions). Defaults to `TLSv1.3,TLSv1.2,TLSv1.1`.
+List of supported protocols for TLS/SSL (with versions). Defaults to `TLSv1.3,TLSv1.2,TLSv1.1` (i.e `[ "TLSv1.3", "TLSv1.2", "TLSv1.1" ]`).
 
 `ssl.cipher_suites`:: Specifies the cipher suites that should be supported when 
 communicating with the Active Directory server. 
@@ -1184,7 +1184,7 @@ Defaults to `full`.
 See <<ssl-tls-settings,`ssl.verification_mode`>> for a more detailed explanation of these values.
 
 `ssl.supported_protocols`::
-Specifies the supported protocols for TLS/SSL. Defaults to `TLSv1.3,TLSv1.2,TLSv1.1`.
+Specifies the list of supported protocols for TLS/SSL. Defaults to `TLSv1.3,TLSv1.2,TLSv1.1` (i.e `[ "TLSv1.3", "TLSv1.2", "TLSv1.1" ]`).
 
 `ssl.cipher_suites`::
 Specifies the
@@ -1458,7 +1458,7 @@ Defaults to `full`.
 See <<ssl-tls-settings,`ssl.verification_mode`>> for a more detailed explanation of these values.
 
 `ssl.supported_protocols`::
-Specifies the supported protocols for TLS/SSL. Defaults to `TLSv1.3,TLSv1.2,TLSv1.1` if
+Specifies the list of supported protocols for TLS/SSL. Defaults to `TLSv1.3,TLSv1.2,TLSv1.1` (i.e `[ "TLSv1.3", "TLSv1.2", "TLSv1.1" ]`) if
 the JVM supports TLSv1.3, otherwise `TLSv1.2,TLSv1.1`.
 
 `ssl.cipher_suites`::
@@ -1513,8 +1513,8 @@ For more information, see
 <<encrypting-communications>>.
 
 `*.ssl.supported_protocols`::
-Supported protocols with versions. Valid protocols: `SSLv2Hello`,
-`SSLv3`, `TLSv1`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`. Defaults to `TLSv1.3,TLSv1.2,TLSv1.1`.
+List of supported protocols with versions. Valid protocols: `SSLv2Hello`,
+`SSLv3`, `TLSv1`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`. Defaults to `TLSv1.3,TLSv1.2,TLSv1.1` (i.e `[ "TLSv1.3", "TLSv1.2", "TLSv1.1" ]`).
 +
 --
 NOTE: If `xpack.security.fips_mode.enabled` is `true`, you cannot use `SSLv2Hello` 


### PR DESCRIPTION
There's no mention that the `supported_protocols` setting is actually a list, which creates confusion at configuration time.

I have added the word "list" in every description of the parameter and also included an example with proper syntax.