### PR TITLE
[DOCS] Removes CCS limitation item from Transforms limitations

### DIFF
--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -52,13 +52,6 @@ table.
 
 
 [float]
-[[transform-ccs-limitations]]
-==== {ccs-cap} is not supported
-
-{ccs-cap} is not supported for {transforms}.
-
-
-[float]
 [[transform-kibana-limitations]]
 ==== Up to 1,000 {transforms} are supported
 


### PR DESCRIPTION
This PR removes the limitation item referring to unsupported cross-cluster search from the list of transforms limitations.