### PR TITLE
make it clear that index swap for an alias is atomic

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -252,7 +252,45 @@ indices that match this pattern are added/removed.
 
 It is an error to index to an alias which points to more than one index.
 
-It is also possible to swap an index with an alias in one operation:
+It is also possible to swap an index with an alias in one, atomic operation:
+
+[source,console]
+--------------------------------------------------
+PUT test     <1>
+PUT test_2   <2>
+POST /_aliases
+{
+    "actions" : [
+        { "add":  { "index": "test_2", "alias": "test" } },
+        { "remove_index": { "index": "test" } }  <3>
+    ]
+}
+--------------------------------------------------
+
+<1> An index we've added by mistake
+<2> The index we should have added
+<3> `remove_index` is just like <<indices-delete-index>>
+
+In case the old index shouldn't be deleted to keep serving the 
+in-flight requests, it is also possible to use `remove` action instead:
+
+[source,console]
+--------------------------------------------------
+PUT test     <1>
+PUT test_2   <2>
+POST /_aliases
+{
+    "actions" : [
+        { "remove": { "index": "test", "alias": "test" } },  <3>
+        { "add":  { "index": "test_2", "alias": "test" } }   <4>
+    ]
+}
+--------------------------------------------------
+
+<1> An index which is currently active
+<2> The index we want to swap with
+<3> `remove` will dissociate `test` index from `test` alias
+<4> `add` will associate `test_2` index with `test` alias
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -292,23 +292,6 @@ POST /_aliases
 <3> `remove` will dissociate `test` index from `test` alias
 <4> `add` will associate `test_2` index with `test` alias
 
-[source,console]
---------------------------------------------------
-PUT test     <1>
-PUT test_2   <2>
-POST /_aliases
-{
-    "actions" : [
-        { "add":  { "index": "test_2", "alias": "test" } },
-        { "remove_index": { "index": "test" } }  <3>
-    ]
-}
---------------------------------------------------
-
-<1> An index we've added by mistake
-<2> The index we should have added
-<3> `remove_index` is just like <<indices-delete-index>>
-
 [[filtered]]
 ===== Filtered aliases
 


### PR DESCRIPTION
I am trying to validate my assumptions on how ES behaves in scenarios where I want to swap the index behind an alias w/o causing a downtime. Therefore, I wanted to change the documents to highlight these. 

Would anyone be able to have a look at this and validate or invalidate these assumptions please?

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
