### PR TITLE
Initial autoscaling commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ subprojects {
     // switched to an exclude list, and eventualy removed completely.
     def projectPathsToFormat = [
       ':build-tools',
+      ':x-pack:plugin:autoscaling',
       ':x-pack:plugin:enrich'
     ]
 

--- a/docs/reference/autoscaling/index.asciidoc
+++ b/docs/reference/autoscaling/index.asciidoc
@@ -1,0 +1,18 @@
+[role="xpack"]
+[testenv="platinum"]
+[[xpack-autoscaling]]
+== Autoscaling
+
+experimental[]
+
+The autoscaling feature enables an operator to configure tiers of nodes that
+self-monitor whether or not they need to scale based on an operator-defined
+policy. Then, via the autoscaling API, an Elasticsearch cluster can report
+whether or not it needs additional resources to meet the policy. For example, an
+operator could define a policy that a warm tier should scale on available disk
+space. Elasticsearch would monitor and forecast the available disk space in the
+warm tier, and if the forecast is such that the cluster will soon not be able to
+allocate existing and future shard copies due to disk space, then the
+autoscaling API would report that the cluster needs to scale due to disk space.
+It remains the responsibility of the operator to add the additional resources
+that the cluster signals it requires.

--- a/docs/reference/autoscaling/index.asciidoc
+++ b/docs/reference/autoscaling/index.asciidoc
@@ -1,7 +1,8 @@
 [role="xpack"]
 [testenv="platinum"]
 [[xpack-autoscaling]]
-== Autoscaling
+[chapter]
+= Autoscaling
 
 experimental[]
 

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -38,9 +38,9 @@ include::index-modules.asciidoc[]
 
 include::ingest.asciidoc[]
 
-include::autoscaling/index.asciidoc[]
-
 include::ilm/index.asciidoc[]
+
+include::autoscaling/index.asciidoc[]
 
 include::sql/index.asciidoc[]
 

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -38,6 +38,8 @@ include::index-modules.asciidoc[]
 
 include::ingest.asciidoc[]
 
+include::autoscaling/index.asciidoc[]
+
 include::ilm/index.asciidoc[]
 
 include::sql/index.asciidoc[]

--- a/x-pack/plugin/autoscaling/build.gradle
+++ b/x-pack/plugin/autoscaling/build.gradle
@@ -1,0 +1,20 @@
+evaluationDependsOn(xpackModule('core'))
+
+apply plugin: 'elasticsearch.esplugin'
+
+esplugin {
+  name 'x-pack-autoscaling'
+  description 'Elasticsearch Expanded Pack Plugin - Autoscaling'
+  classname 'org.elasticsearch.xpack.autoscaling.Autoscaling'
+  extendedPlugins = ['x-pack-core']
+  hasNativeController false
+  requiresKeystore true
+}
+archivesBaseName = 'x-pack-autoscaling'
+
+integTest.enabled = false
+
+dependencies {
+  compileOnly project(path: xpackModule('core'), configuration: 'default')
+  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+}

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.List;
+
+/**
+ * Container class for autoscaling functionality.
+ */
+public class Autoscaling extends Plugin {
+
+    public static final Setting<Boolean> AUTOSCALING_ENABLED_SETTING = Setting.boolSetting(
+        "xpack.autoscaling.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * The settings defined by autoscaling.
+     *
+     * @return the settings
+     */
+    @Override
+    public List<Setting<?>> getSettings() {
+        if (isSnapshot()) {
+            return List.of(AUTOSCALING_ENABLED_SETTING);
+        } else {
+            return List.of();
+        }
+    }
+
+    boolean isSnapshot() {
+        return Build.CURRENT.isSnapshot();
+    }
+
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.autoscaling;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+public class AutoscalingTests extends ESTestCase {
+
+    public void testEnabledSettingRegisteredInSnapshotBuilds() {
+        final Autoscaling plugin = new Autoscaling() {
+
+            @Override
+            protected boolean isSnapshot() {
+                return true;
+            }
+
+        };
+        assertThat(plugin.getSettings(), hasItem(Autoscaling.AUTOSCALING_ENABLED_SETTING));
+    }
+
+    public void testEnabledSettingNotRegisteredInNonSnapshotBuilds() {
+        final Autoscaling plugin = new Autoscaling() {
+
+            @Override
+            protected boolean isSnapshot() {
+                return false;
+            }
+
+        };
+        assertThat(plugin.getSettings(), not(hasItem(Autoscaling.AUTOSCALING_ENABLED_SETTING)));
+    }
+
+}


### PR DESCRIPTION
This commit merely adds the skeleton for the autoscaling project, adding the basics to include the autoscaling module in the default distribution, opt-in to code formatting, and a placeholder for the docs.

