### PR TITLE
Fix flaky usage tracking test

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/oss/IndexFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/oss/IndexFeatureSetUsage.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.oss;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -110,28 +111,28 @@ public class IndexFeatureSetUsage extends XPackFeatureSet.Usage {
      * Return the set of used built-in char filters in the cluster.
      */
     public Set<String> getUsedBuiltInCharFilters() {
-        return usedCharFilters;
+        return usedBuiltInCharFilters;
     }
 
     /**
      * Return the set of used built-in tokenizers in the cluster.
      */
     public Set<String> getUsedBuiltInTokenizers() {
-        return usedTokenizers;
+        return usedBuiltInTokenizers;
     }
 
     /**
      * Return the set of used built-in token filters in the cluster.
      */
     public Set<String> getUsedBuiltInTokenFilters() {
-        return usedTokenFilters;
+        return usedBuiltInTokenFilters;
     }
 
     /**
      * Return the set of used built-in analyzers in the cluster.
      */
     public Set<String> getUsedBuiltInAnalyzers() {
-        return usedAnalyzers;
+        return usedBuiltInAnalyzers;
     }
 
     @Override
@@ -181,5 +182,10 @@ public class IndexFeatureSetUsage extends XPackFeatureSet.Usage {
         return Objects.hash(available, enabled, usedFieldTypes, usedCharFilters, usedTokenizers, usedTokenFilters,
                 usedAnalyzers, usedBuiltInCharFilters, usedBuiltInTokenizers, usedBuiltInTokenFilters,
                 usedBuiltInAnalyzers);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/oss/IndexFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/oss/IndexFeatureSetUsageTests.java
@@ -116,7 +116,7 @@ public class IndexFeatureSetUsageTests extends AbstractWireSerializingTestCase<I
                     instance.getUsedBuiltInTokenizers(), instance.getUsedBuiltInTokenFilters(),
                     instance.getUsedBuiltInAnalyzers());
         case 4:
-            Set<String> analyzers = new HashSet<>(instance.getUsedAnalyzerTypes());
+           Set<String> analyzers = new HashSet<>(instance.getUsedAnalyzerTypes());
             if (analyzers.add("english") == false) {
                 analyzers.remove("english");
             }
@@ -125,7 +125,7 @@ public class IndexFeatureSetUsageTests extends AbstractWireSerializingTestCase<I
                     instance.getUsedBuiltInCharFilters(), instance.getUsedBuiltInTokenizers(), instance.getUsedBuiltInTokenFilters(),
                     instance.getUsedBuiltInAnalyzers());
         case 5:
-            Set<String> builtInCharFilters = new HashSet<>();
+            Set<String> builtInCharFilters = new HashSet<>(instance.getUsedBuiltInCharFilters());
             if (builtInCharFilters.add("html_strip") == false) {
                 builtInCharFilters.remove("html_strip");
             }
@@ -135,7 +135,7 @@ public class IndexFeatureSetUsageTests extends AbstractWireSerializingTestCase<I
                     instance.getUsedBuiltInTokenizers(), instance.getUsedBuiltInTokenFilters(),
                     instance.getUsedBuiltInAnalyzers());
         case 6:
-            Set<String> builtInTokenizers = new HashSet<>();
+            Set<String> builtInTokenizers = new HashSet<>(instance.getUsedBuiltInTokenizers());
             if (builtInTokenizers.add("keyword") == false) {
                 builtInTokenizers.remove("keyword");
             }
@@ -144,7 +144,7 @@ public class IndexFeatureSetUsageTests extends AbstractWireSerializingTestCase<I
                     instance.getUsedBuiltInCharFilters(), builtInTokenizers, instance.getUsedBuiltInTokenFilters(),
                     instance.getUsedBuiltInAnalyzers());
         case 7:
-            Set<String> builtInTokenFilters = new HashSet<>();
+            Set<String> builtInTokenFilters = new HashSet<>(instance.getUsedBuiltInTokenFilters());
             if (builtInTokenFilters.add("trim") == false) {
                 builtInTokenFilters.remove("trim");
             }
@@ -153,7 +153,7 @@ public class IndexFeatureSetUsageTests extends AbstractWireSerializingTestCase<I
                     instance.getUsedBuiltInCharFilters(), instance.getUsedBuiltInTokenizers(), builtInTokenFilters,
                     instance.getUsedBuiltInAnalyzers());
         case 8:
-            Set<String> builtInAnalyzers = new HashSet<>();
+            Set<String> builtInAnalyzers = new HashSet<>(instance.getUsedBuiltInAnalyzers());
             if (builtInAnalyzers.add("french") == false) {
                 builtInAnalyzers.remove("french");
             }


### PR DESCRIPTION
We added tracking of index feature usage in #51031 but due to some copy
and paste errors the test fails on some seeds. This fixes those errors.
