### PR TITLE
Update discovery-settings.asciidoc

### DIFF
--- a/docs/reference/setup/important-settings/discovery-settings.asciidoc
+++ b/docs/reference/setup/important-settings/discovery-settings.asciidoc
@@ -13,7 +13,7 @@ each other and elect a master node.
 ==== `discovery.seed_hosts`
 
 Out of the box, without any network configuration, Elasticsearch will bind to
-the available loopback addresses and will scan local ports 9300 to 9305 to try
+the available loopback addresses and will scan local ports 9200 to 9205 to try
 to connect to other nodes running on the same server. This provides an auto-
 clustering experience without having to do any configuration.
 


### PR DESCRIPTION
This document currently states:

> Elasticsearch will bind to the available loopback addresses and will scan local ports 9300 to 9305.

The default Elasticsearch port is 9200. If one brings up a 3 node cluster of Elasticsearch, Elasticsearch should scan local ports 9200 to 9205 as the template docker-compose-yml file sets the 3 Elastic nodes to: 9200, 9201, 9203. See `https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-docker.html`

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
