### PR TITLE
Update BWC version for hidden indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -223,7 +223,7 @@ public class IndicesOptions implements ToXContentFragment {
 
     public void writeIndicesOptions(StreamOutput out) throws IOException {
         out.writeEnumSet(options);
-        if (out.getVersion().before(Version.V_8_0_0) && expandWildcards.contains(WildcardStates.HIDDEN)) {
+        if (out.getVersion().before(Version.V_7_7_0) && expandWildcards.contains(WildcardStates.HIDDEN)) {
             final EnumSet<WildcardStates> states = EnumSet.copyOf(expandWildcards);
             states.remove(WildcardStates.HIDDEN);
             out.writeEnumSet(states);
@@ -235,7 +235,7 @@ public class IndicesOptions implements ToXContentFragment {
     public static IndicesOptions readIndicesOptions(StreamInput in) throws IOException {
         EnumSet<Option> options = in.readEnumSet(Option.class);
         EnumSet<WildcardStates> states = in.readEnumSet(WildcardStates.class);
-        if (in.getVersion().before(Version.V_8_0_0)) {
+        if (in.getVersion().before(Version.V_7_7_0)) {
             states.add(WildcardStates.HIDDEN);
         }
         return new IndicesOptions(options, states);

--- a/server/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
@@ -53,8 +53,7 @@ public class OriginalIndicesTests extends ESTestCase {
             // indices options are not equivalent when sent to an older version and re-read due
             // to the addition of hidden indices as expand to hidden indices is always true when
             // read from a prior version
-            // TODO update version on backport!
-            if (out.getVersion().onOrAfter(Version.V_8_0_0) || originalIndices.indicesOptions().expandWildcardsHidden()) {
+            if (out.getVersion().onOrAfter(Version.V_7_7_0) || originalIndices.indicesOptions().expandWildcardsHidden()) {
                 assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));
             } else if (originalIndices.indicesOptions().expandWildcardsHidden()) {
                 assertThat(originalIndices2.indicesOptions(), equalTo(originalIndices.indicesOptions()));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
@@ -65,7 +65,7 @@ public class ClusterSearchShardsRequestTests extends ESTestCase {
                 // indices options are not equivalent when sent to an older version and re-read due
                 // to the addition of hidden indices as expand to hidden indices is always true when
                 // read from a prior version
-                if (version.onOrAfter(Version.V_8_0_0) || request.indicesOptions().expandWildcardsHidden()) { // TODO change on backport!
+                if (version.onOrAfter(Version.V_7_7_0) || request.indicesOptions().expandWildcardsHidden()) {
                     assertEquals(request.indicesOptions(), deserialized.indicesOptions());
                 }
                 assertEquals(request.routing(), deserialized.routing());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestTests.java
@@ -66,7 +66,7 @@ public class CloseIndexRequestTests extends ESTestCase {
                     // to the addition of hidden indices as expand to hidden indices is always true when
                     // read from a prior version
                     // TODO update version on backport!
-                    if (out.getVersion().onOrAfter(Version.V_8_0_0) || request.indicesOptions().expandWildcardsHidden()) {
+                    if (out.getVersion().onOrAfter(Version.V_7_7_0) || request.indicesOptions().expandWildcardsHidden()) {
                         assertEquals(request.indicesOptions(), indicesOptions);
                     }
                     if (in.getVersion().onOrAfter(Version.V_7_2_0)) {
@@ -104,7 +104,7 @@ public class CloseIndexRequestTests extends ESTestCase {
                 // to the addition of hidden indices as expand to hidden indices is always true when
                 // read from a prior version
                 // TODO change version on backport
-                if (out.getVersion().onOrAfter(Version.V_8_0_0) || sample.indicesOptions().expandWildcardsHidden()) {
+                if (out.getVersion().onOrAfter(Version.V_7_7_0) || sample.indicesOptions().expandWildcardsHidden()) {
                     assertEquals(sample.indicesOptions(), deserializedRequest.indicesOptions());
                 }
                 if (out.getVersion().onOrAfter(Version.V_7_2_0)) {

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -70,7 +70,7 @@ public class IndicesOptionsTests extends ESTestCase {
             assertThat(indicesOptions2.allowNoIndices(), equalTo(indicesOptions.allowNoIndices()));
             assertThat(indicesOptions2.expandWildcardsOpen(), equalTo(indicesOptions.expandWildcardsOpen()));
             assertThat(indicesOptions2.expandWildcardsClosed(), equalTo(indicesOptions.expandWildcardsClosed()));
-            if (version.before(Version.V_8_0_0)) {
+            if (version.before(Version.V_7_7_0)) {
                 assertThat(indicesOptions2.expandWildcardsHidden(), is(true));
             } else {
                 assertThat(indicesOptions2.expandWildcardsHidden(), equalTo(indicesOptions.expandWildcardsHidden()));


### PR DESCRIPTION
This commit updates the BWC version we use in wire serialization for
the hidden indices to V_7_7_0 after the backport of the feature in

Relates #50452