### PR TITLE
Fix CorruptedBlobStoreRepository Test (#51128)

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1110,6 +1110,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     listener.onFailure(e);
                 }
                 return;
+            } catch (Exception e) {
+                listener.onFailure(new RepositoryException(metadata.name(), "Unexpected exception when loading repository data", e));
+                return;
             }
         }
     }


### PR DESCRIPTION
The tests, when creating broken serialized blobs could randomly create
a sequence of bytes that is partially readable by the deserializer and then
not throw `IOException` but instead `ElasticsearchParseException`.
We should just handle these unexpected exceptions downstream properly and pass them
wrapped as `RepositoryException` to the listener to fix the test and keep the API consistent.

backport of #51128 