### PR TITLE
Exclude autoscaling docs from release docs

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -40,7 +40,11 @@ include::ingest.asciidoc[]
 
 include::ilm/index.asciidoc[]
 
+ifeval::["{release-state}"=="unreleased"]
+
 include::autoscaling/index.asciidoc[]
+
+endif::[]
 
 include::sql/index.asciidoc[]
 


### PR DESCRIPTION
Since autoscaling is currently only under development, this commit causes the autoscaling docs to be excluded any time that release docs are being built.
