### PR TITLE
JDBC driver  compatible with Elasticsearch version in spring-boot

### DIFF
--- a/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/Version.java
+++ b/x-pack/plugin/sql/sql-client/src/main/java/org/elasticsearch/xpack/sql/client/Version.java
@@ -92,7 +92,7 @@ public class Version {
         String ver = "Unknown";
         String hash = ver;
 
-        if (urlStr.endsWith(".jar")) {
+        if (urlStr.endsWith(".jar") || urlStr.endsWith(".jar!/")) {
             try (JarInputStream jar = new JarInputStream(url.openStream())) {
                 Manifest manifest = jar.getManifest();
                 hash = manifest.getMainAttributes().getValue("Change");


### PR DESCRIPTION
just like say
#50201

https://discuss.elastic.co/t/this-version-of-the-jdbc-driver-is-only-compatible-with-elasticsearch-version-vunknown-unknown/211894


We use spring-boot project and  "spring-boot-maven-plugin" to package a .jar file with all dependency jar like "x-pack-sql-jdbc";

It takes jdbc-driver version as follow 
    URL url = Version.class.getProtectionDomain().getCodeSource().getLocation();

in org.elasticsearch.xpack.sql.client.Version source file;

in spring boot jar class loader, ".jar" file likes ".jar!/"

thus,  variable url can not take right version;


   this pr will fix this bug


