### PR TITLE
[DOCS] Adds PUT inference API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/index.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/index.asciidoc
@@ -17,6 +17,7 @@ You can use the following APIs to perform {ml} {dfanalytics} activities.
 
 You can use the following APIs to perform {infer} operations.
 
+* <<put-inference>>
 * <<get-inference>>
 * <<get-inference-stats>>
 * <<delete-inference>>
@@ -26,6 +27,7 @@ See also <<ml-apis>>.
 
 //CREATE
 include::put-dfanalytics.asciidoc[]
+include::put-inference.asciidoc[]
 //DELETE
 include::delete-dfanalytics.asciidoc[]
 include::delete-inference-trained-model.asciidoc[]

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -32,8 +32,8 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 [[ml-put-inference-desc]]
 ==== {api-description-title}
 
-The create {infer} trained model API enables you to supply a trained model that is 
-not created by {dfanalytics}. 
+The create {infer} trained model API enables you to supply a trained model that 
+is not created by {dfanalytics}. 
 
 
 [[ml-put-inference-path-params]]
@@ -197,7 +197,8 @@ The index of the right child.
 
 `tree_node`.`default_left`:::
 (Optional, boolean) 
-Indicates whether to default to the left when the feature is missing. Defaults to `true`.
+Indicates whether to default to the left when the feature is missing. Defaults 
+to `true`.
 
 `tree_node`.`split_feature`:::
 (Optional, integer) 
@@ -485,10 +486,9 @@ Example of a `weighted_mode` object:
 ----------------------------------
 //NOTCONSOLE
 
-////
+
 [[ml-put-inference-json-schema]]
 ===== {infer-cap} JSON schema
 
 For the full JSON schema of model {infer}, 
-https://github.com/elastic/ml_json_schemas[click here].
-////
+https://github.com/elastic/ml-json-schemas[click here].

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -484,3 +484,10 @@ Example of a `weighted_mode` object:
 }
 ----------------------------------
 //NOTCONSOLE
+
+
+[[ml-put-inference-json-schema]]
+===== {infer-cap} JSON schema
+
+For the full JSON schema of model {infer}, 
+https://github.com/elastic/ml_json_schemas[click here].

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -475,7 +475,7 @@ Example of a `weighted_sum` object:
 
 Example of a `weighted_mode` object:
 
-source,js]
+[source,js]
 ----------------------------------
 "aggregate_output" : {
   "weighted_mode" : {

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -133,7 +133,7 @@ The name of the resulting feature.
 (Required, object map of string:double) 
 Object that maps the field value to the target mean value.
 
-`target_mean_encoding`.`default.value`:::
+`target_mean_encoding`.`default_value`:::
 (Required, double) 
 The feature value if the field value is not in the `target_map`.
 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -447,8 +447,20 @@ The following example shows an `ensemble` model object:
 [[ml-put-inference-aggregated-output-example]]
 ===== Aggregated output example
 
-The examples below show `aggregate_output` objects:
+Example of a `logistic_regression` object:
 
+[source,js]
+----------------------------------
+"aggregate_output" : {
+  "logistic_regression" : {
+    "weights" : [2.0, 1.0, .5, -1.0, 5.0, 1.0, 1.0]
+  }
+}
+----------------------------------
+//NOTCONSOLE
+
+
+Example of a `weighted_sum` object:
 
 [source,js]
 ----------------------------------
@@ -461,6 +473,8 @@ The examples below show `aggregate_output` objects:
 //NOTCONSOLE
 
 
+Example of a `weighted_mode` object:
+
 source,js]
 ----------------------------------
 "aggregate_output" : {
@@ -470,4 +484,3 @@ source,js]
 }
 ----------------------------------
 //NOTCONSOLE
-

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -26,8 +26,6 @@ built-in roles and privileges:
 
 * `machine_learning_admin`
 
-
-  
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
@@ -288,6 +286,8 @@ weights into account) is returned.
 (Required, double) 
 The weights to multiply by the input values (the inference values of the trained 
 models).
+
+See <<ml-put-inference-aggregated-output-example>> for more details.
 
 
 [[ml-put-inference-example]]

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -197,7 +197,7 @@ The index of the right child.
 
 `tree_node`.`default_left`:::
 (Optional, boolean) 
-Should default to the left if the feature is missing. Defaults to `true`.
+Indicates whether to default to the left when the feature is missing. Defaults to `true`.
 
 `tree_node`.`split_feature`:::
 (Optional, integer) 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -27,7 +27,6 @@ built-in roles and privileges:
 * `machine_learning_admin`
 
 
-* source index: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
 * cluster: `monitor_ml`
   

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -251,7 +251,7 @@ See <<ml-put-inference-model-example>> for more details.
 ===== Aggregated output types
 
 `logistic_regression`::
-(Optional, boolean) 
+(Optional, object) 
 This `aggregated_output` type works with binary classification (classification 
 for values [0, 1]). It multiplies the outputs (in the case of the `ensemble` 
 model, the inference model values) by the supplied `weights`. The resulting 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -52,9 +52,15 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 [[ml-put-inference-request-body]]
 ==== {api-request-body-title}
 
+`compressed_definition`::
+(Required, string) 
+The compressed (GZipped and Base64 encoded) {infer} definition of the model. 
+If `compressed_definition` is specified, then `definition` cannot be specified.
+
 `definition`::
 (Required, object) 
-The {infer} definition for the model.
+The {infer} definition for the model. If `definition` is specified, then 
+`compressed_definition` cannot be specified.
 
 `definition`.`preprocessors`:::
 (Optional, object)

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -68,11 +68,6 @@ details.
 (Optional, string) 
 A human-readable description of the {infer} trained model.
 
-`ensamble`::
-(Optional, object)
-The definition for an ensamble model. See <<ml-put-inference-ensamble-model>> 
-for details.
-
 `input`::
 (Required, object) 
 The input field names for the model definition.
@@ -105,25 +100,6 @@ The name of the resulting feature.
 (Object map of string:double) 
 Object that maps the field value to the frequency encoded value.
 
-[source,js]
-----------------------------------
-{
-	"frequency_encoding": {
-		"field": "FlightDelayType",
-		"feature_name": "FlightDelayType_frequency",
-		"frequency_map": {
-			"Carrier Delay": 0.6007414737092798,
-			"NAS Delay": 0.6007414737092798,
-			"Weather Delay": 0.024573576178086153,
-			"Security Delay": 0.02476631010889467,
-			"No Delay": 0.6007414737092798,
-			"Late Aircraft Delay": 0.6007414737092798
-		}
-	}
-}
-----------------------------------
-//NOTCONSOLE
-
 `one_hot_encoding`::
 (Object) 
 Defines a one hot encoding map for a field.
@@ -135,23 +111,6 @@ The field name to encode.
 `one_hot_encoding`.`hot_map`:::
 (Object map of strings) 
 String map of "field_value: one_hot_column_name".
-
-[source,js]
-----------------------------------
-{
-	"one_hot_encoding": {
-		"field": "FlightDelayType",
-		"hot_map": {
-			"Carrier Delay": "FlightDelayType_Carrier Delay",
-			"NAS Delay": "FlightDelayType_NAS Delay",
-			"No Delay": "FlightDelayType_No Delay",
-			"Late Aircraft Delay": "FlightDelayType_Late Aircraft Delay"
-		}
-	}
-}
-----------------------------------
-//NOTCONSOLE
-
 
 `target_mean_encoding`::
 (Object) 
@@ -173,25 +132,7 @@ Object that maps the field value to the target mean value.
 (Double) 
 The feature value if the field value is not in the `target_map`.
 
-[source,js]
-----------------------------------
-{
-	"target_mean_encoding": {
-		"field": "FlightDelayType",
-		"feature_name": "FlightDelayType_targetmean",
-		"target_map": {
-			"Carrier Delay": 39.97465788139886,
-			"NAS Delay": 39.97465788139886,
-			"Security Delay": 203.171206225681,
-			"Weather Delay": 187.64705882352948,
-			"No Delay": 39.97465788139886,
-			"Late Aircraft Delay": 39.97465788139886
-		},
-		"default_value": 158.17995752420433
-	}
-}
-----------------------------------
-//NOTCONSOLE
+See <<ml-put-inference-preprocessor-example>> for more details.
 
 
 [[ml-put-inference-trained-model]]
@@ -218,7 +159,15 @@ An array of `tree_node` objects. The nodes must be in ordinal order by their
 (String) 
 String indicating the model target type; `regression` or `classification`.
 
+There are two major types of nodes: leaf nodes and not-leaf nodes.
+
+* Leaf nodes only need `node_index` and `leaf_value` defined.
+* All other nodes need `split_feature`, `left_child`, `right_child`, 
+  `threshold`, `decision_type`, and `default_left` defined.
+
 `tree_node`::
+(Object)
+
 
 `tree_node`.`decision_type`:::
 (Optional, string) 
@@ -257,11 +206,147 @@ The index of the current node.
 The leaf value of the of the node, if the value is a leaf (in other words, no 
 children).
 
-There are two major types of nodes: leaf nodes and not-leaf nodes.
+`ensemble`::
+(Optional, object)
+The definition for an ensemble model.
 
-* Leaf nodes only need `node_index` and `leaf_value` defined.
-* All other nodes need `split_feature`, `left_child`, `right_child`, `threshold`, 
-`decision_type`, and `default_left` defined.
+`ensemble`.`feature_names`:::
+(String) 
+Features expected by the ensemble, in their expected order.
+
+`ensemble`.`trained_models`:::
+(Object)
+An array of `trained_model` objects. Supported trained models are `tree` and 
+`ensemble`.
+
+`ensemble`.`classification_labels`:::
+(Optional, string) 
+An array of classification labels.
+
+`ensemble`.`target_type`:::
+(String) 
+String indicating the model target type; `regression` or `classification.`
+
+`ensemble`.`aggregate_output`:::
+(Object) 
+An aggregated output object that defines how to aggregate the outputs of the 
+`trained_models`. Supported objects are `weighted_mode`, `weighted_sum`, and 
+`logistic_regression`.
+
+See <<ml-put-inference-model-example>> for more details.
+
+
+[[ml-put-inference-aggreegated-output]]
+===== Aggregated output types
+
+`logistic_regression`::
+This `aggregated_output` type works with binary classification (classification 
+for values [0, 1]). It multiplies the outputs (in the case of the `ensemble` 
+model, the inference model values) by the supplied `weights`. The resulting 
+vector is summed and passed to a `sigmoid` function. The result of the `sigmoid` 
+function is considered the probability of class 1 (`P_1`), consequently, the 
+probability of class 0 is `1 - P_1`. The class with the highest probability 
+(either 0 or 1) is then returned.
+
+`logistic_regression`.`weights`:::
+(Double) 
+The weights to multiply by the input values (the inference values of the trained 
+models).
+
+`weighted_sum`::
+This `aggregated_output` type works with regression. The weighted sum of the 
+input values.
+
+`weighted_sum`.`weights`:::
+(Double) 
+The weights to multiply by the input values (the inference values of the trained 
+models).
+
+`weighted_mode`::
+This `aggregated_output` type works with regression or classification. It takes 
+a weighted vote of the input values. The the most common input value (taking the 
+weights into account) is returned.
+
+`weighted_mode`.`weights`:::
+(Double) 
+The weights to multiply by the input values (the inference values of the trained 
+models).
+
+
+[[ml-put-inference-example]]
+==== {api-examples-title}
+
+[[ml-put-inference-preprocessor-example]]
+===== Preprocessor examples
+
+The example above shows a `frequency_encoding` preprocessor object:
+
+[source,js]
+----------------------------------
+{
+	"frequency_encoding": {
+		"field": "FlightDelayType",
+		"feature_name": "FlightDelayType_frequency",
+		"frequency_map": {
+			"Carrier Delay": 0.6007414737092798,
+			"NAS Delay": 0.6007414737092798,
+			"Weather Delay": 0.024573576178086153,
+			"Security Delay": 0.02476631010889467,
+			"No Delay": 0.6007414737092798,
+			"Late Aircraft Delay": 0.6007414737092798
+		}
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+
+The next example shows a `one_hot_encoding` preprocessor object:
+
+[source,js]
+----------------------------------
+{
+	"one_hot_encoding": {
+		"field": "FlightDelayType",
+		"hot_map": {
+			"Carrier Delay": "FlightDelayType_Carrier Delay",
+			"NAS Delay": "FlightDelayType_NAS Delay",
+			"No Delay": "FlightDelayType_No Delay",
+			"Late Aircraft Delay": "FlightDelayType_Late Aircraft Delay"
+		}
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+
+This example shows a `target_mean_encoding` preprocessor object:
+
+[source,js]
+----------------------------------
+{
+	"target_mean_encoding": {
+		"field": "FlightDelayType",
+		"feature_name": "FlightDelayType_targetmean",
+		"target_map": {
+			"Carrier Delay": 39.97465788139886,
+			"NAS Delay": 39.97465788139886,
+			"Security Delay": 203.171206225681,
+			"Weather Delay": 187.64705882352948,
+			"No Delay": 39.97465788139886,
+			"Late Aircraft Delay": 39.97465788139886
+		},
+		"default_value": 158.17995752420433
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+
+[[ml-put-inference-model-example]]
+===== Model examples
+
+The first example shows a `trained_model` object:
 
 [source,js]
 ----------------------------------
@@ -279,7 +364,8 @@ There are two major types of nodes: leaf nodes and not-leaf nodes.
 			"DistanceMiles",
 			"FlightDelayType_Late Aircraft Delay"
 		],
-		"tree_structure": [{
+		"tree_structure": [
+      {
 				"decision_type": "lt",
 				"threshold": 9069.33437193022,
 				"split_feature": 0,
@@ -303,7 +389,52 @@ There are two major types of nodes: leaf nodes and not-leaf nodes.
 //NOTCONSOLE
 
 
-[[ml-put-inference-ensamble-model]]
-===== {infer-cap} ensemble model definitions
+The following example shows an `ensemble` model object:
+
+[source,js]
+----------------------------------
+"ensemble": {
+	"feature_names": [
+		...
+	],
+	"trained_models": [
+    {
+			"tree": {
+				"feature_names": [],
+				"tree_structure": [
+          {
+					"decision_type": "lte",
+					"node_index": 0,
+					"leaf_value": 47.64069875778043,
+					"default_left": false
+				}
+      ],
+				"target_type": "regression"
+			}
+		},
+		...
+	],
+	"aggregate_output": {
+		"weighted_sum": {
+			"weights": [
+				...
+			]
+		}
+	},
+	"target_type": "regression"
+}
+----------------------------------
+//NOTCONSOLE
 
 
+[[ml-put-inference-aggregated-output-example]]
+===== Aggregated output examples
+
+For the following examples, we use `[1.0, 2.0, 2.0, 3.0, 5.0]` as input. 
+
+If `weighted_mode: { weights: [1.0, -1.0, .5, 1.0, 5.0]}`, then the aggregated 
+output will return `5.0` as that is the most common input value given the 
+weights.
+
+If `weighted_mode: { weights: [1.0, 1.0, 1.0, 1.0, 1.0]}`, then it would return 
+`2.0`, as `2.0` appears the most in the input and the weights are uniform.

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -48,8 +48,8 @@ not created by {dfanalytics}.
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
-[[ml-put-inference-query-params]]
-==== {api-query-parms-title}
+[[ml-put-inference-request-body]]
+==== {api-request-body-title}
 
 `definition`::
 (Required, object) 
@@ -141,7 +141,7 @@ See <<ml-put-inference-preprocessor-example>> for more details.
 
 `tree`::
 (Required, object) 
-The definition for a decision tree.
+The definition for a binary decision tree.
 
 `tree`.`feature_names`:::
 (Required, string) 
@@ -241,7 +241,7 @@ See <<ml-put-inference-model-example>> for more details.
 ===== Aggregated output types
 
 `logistic_regression`::
-(Optional, object) 
+(Optional, boolean) 
 This `aggregated_output` type works with binary classification (classification 
 for values [0, 1]). It multiplies the outputs (in the case of the `ensemble` 
 model, the inference model values) by the supplied `weights`. The resulting 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -292,18 +292,18 @@ The example above shows a `frequency_encoding` preprocessor object:
 [source,js]
 ----------------------------------
 {
-	"frequency_encoding": {
-		"field": "FlightDelayType",
-		"feature_name": "FlightDelayType_frequency",
-		"frequency_map": {
-			"Carrier Delay": 0.6007414737092798,
-			"NAS Delay": 0.6007414737092798,
-			"Weather Delay": 0.024573576178086153,
-			"Security Delay": 0.02476631010889467,
-			"No Delay": 0.6007414737092798,
-			"Late Aircraft Delay": 0.6007414737092798
-		}
-	}
+   "frequency_encoding":{
+      "field":"FlightDelayType",
+      "feature_name":"FlightDelayType_frequency",
+      "frequency_map":{
+         "Carrier Delay":0.6007414737092798,
+         "NAS Delay":0.6007414737092798,
+         "Weather Delay":0.024573576178086153,
+         "Security Delay":0.02476631010889467,
+         "No Delay":0.6007414737092798,
+         "Late Aircraft Delay":0.6007414737092798
+      }
+   }
 }
 ----------------------------------
 //NOTCONSOLE
@@ -313,16 +313,16 @@ The next example shows a `one_hot_encoding` preprocessor object:
 
 [source,js]
 ----------------------------------
-{
-	"one_hot_encoding": {
-		"field": "FlightDelayType",
-		"hot_map": {
-			"Carrier Delay": "FlightDelayType_Carrier Delay",
-			"NAS Delay": "FlightDelayType_NAS Delay",
-			"No Delay": "FlightDelayType_No Delay",
-			"Late Aircraft Delay": "FlightDelayType_Late Aircraft Delay"
-		}
-	}
+{ 
+   "one_hot_encoding":{ 
+      "field":"FlightDelayType",
+      "hot_map":{ 
+         "Carrier Delay":"FlightDelayType_Carrier Delay",
+         "NAS Delay":"FlightDelayType_NAS Delay",
+         "No Delay":"FlightDelayType_No Delay",
+         "Late Aircraft Delay":"FlightDelayType_Late Aircraft Delay"
+      }
+   }
 }
 ----------------------------------
 //NOTCONSOLE
@@ -333,19 +333,19 @@ This example shows a `target_mean_encoding` preprocessor object:
 [source,js]
 ----------------------------------
 {
-	"target_mean_encoding": {
-		"field": "FlightDelayType",
-		"feature_name": "FlightDelayType_targetmean",
-		"target_map": {
-			"Carrier Delay": 39.97465788139886,
-			"NAS Delay": 39.97465788139886,
-			"Security Delay": 203.171206225681,
-			"Weather Delay": 187.64705882352948,
-			"No Delay": 39.97465788139886,
-			"Late Aircraft Delay": 39.97465788139886
-		},
-		"default_value": 158.17995752420433
-	}
+   "target_mean_encoding":{
+      "field":"FlightDelayType",
+      "feature_name":"FlightDelayType_targetmean",
+      "target_map":{
+         "Carrier Delay":39.97465788139886,
+         "NAS Delay":39.97465788139886,
+         "Security Delay":203.171206225681,
+         "Weather Delay":187.64705882352948,
+         "No Delay":39.97465788139886,
+         "Late Aircraft Delay":39.97465788139886
+      },
+      "default_value":158.17995752420433
+   }
 }
 ----------------------------------
 //NOTCONSOLE
@@ -359,39 +359,39 @@ The first example shows a `trained_model` object:
 [source,js]
 ----------------------------------
 {
-	"tree": {
-		"feature_names": [
-			"DistanceKilometers",
-			"FlightTimeMin",
-			"FlightDelayType_NAS Delay",
-			"Origin_targetmean",
-			"DestRegion_targetmean",
-			"DestCityName_targetmean",
-			"OriginAirportID_targetmean",
-			"OriginCityName_frequency",
-			"DistanceMiles",
-			"FlightDelayType_Late Aircraft Delay"
-		],
-		"tree_structure": [
-      {
-				"decision_type": "lt",
-				"threshold": 9069.33437193022,
-				"split_feature": 0,
-				"split_gain": 4112.094574306927,
-				"node_index": 0,
-				"default_left": true,
-				"left_child": 1,
-				"right_child": 2
-			},
-			...
-      {
-				"node_index": 9,
-				"leaf_value": -27.68987349695448
-			},
-			...
-		],
-		"target_type": "regression"
-	}
+   "tree":{
+      "feature_names":[
+         "DistanceKilometers",
+         "FlightTimeMin",
+         "FlightDelayType_NAS Delay",
+         "Origin_targetmean",
+         "DestRegion_targetmean",
+         "DestCityName_targetmean",
+         "OriginAirportID_targetmean",
+         "OriginCityName_frequency",
+         "DistanceMiles",
+         "FlightDelayType_Late Aircraft Delay"
+      ],
+      "tree_structure":[
+         {
+            "decision_type":"lt",
+            "threshold":9069.33437193022,
+            "split_feature":0,
+            "split_gain":4112.094574306927,
+            "node_index":0,
+            "default_left":true,
+            "left_child":1,
+            "right_child":2
+         },
+         ...         
+         {
+            "node_index":9,
+            "leaf_value":-27.68987349695448
+         },
+         ...
+      ],
+      "target_type":"regression"
+   }
 }
 ----------------------------------
 //NOTCONSOLE
@@ -401,35 +401,35 @@ The following example shows an `ensemble` model object:
 
 [source,js]
 ----------------------------------
-"ensemble": {
-	"feature_names": [
-		...
-	],
-	"trained_models": [
-    {
-			"tree": {
-				"feature_names": [],
-				"tree_structure": [
-          {
-					"decision_type": "lte",
-					"node_index": 0,
-					"leaf_value": 47.64069875778043,
-					"default_left": false
-				}
-      ],
-				"target_type": "regression"
-			}
-		},
-		...
-	],
-	"aggregate_output": {
-		"weighted_sum": {
-			"weights": [
-				...
-			]
-		}
-	},
-	"target_type": "regression"
+"ensemble":{
+   "feature_names":[
+      ...
+   ],
+   "trained_models":[
+      {
+         "tree":{
+            "feature_names":[],
+            "tree_structure":[
+               {
+                  "decision_type":"lte",
+                  "node_index":0,
+                  "leaf_value":47.64069875778043,
+                  "default_left":false
+               }
+            ],
+            "target_type":"regression"
+         }
+      },
+      ...
+   ],
+   "aggregate_output":{
+      "weighted_sum":{
+         "weights":[
+            ...
+         ]
+      }
+   },
+   "target_type":"regression"
 }
 ----------------------------------
 //NOTCONSOLE

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -485,9 +485,10 @@ Example of a `weighted_mode` object:
 ----------------------------------
 //NOTCONSOLE
 
-
+////
 [[ml-put-inference-json-schema]]
 ===== {infer-cap} JSON schema
 
 For the full JSON schema of model {infer}, 
 https://github.com/elastic/ml_json_schemas[click here].
+////

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -36,14 +36,15 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 [[ml-put-inference-desc]]
 ==== {api-description-title}
 
-
+Create {infer} trained model API enables you to supply a trained model that is 
+not created by {dfanalytics}. 
 
 
 [[ml-put-inference-path-params]]
 ==== {api-path-parms-title}
 
 `<model_id>`::
-(Optional, string) 
+(Required, string) 
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
@@ -85,51 +86,51 @@ An array of tags to organize the model.
 ===== {infer-cap} preprocessor definitions
 
 `frequency_encoding`::
-(Object) 
+(Required, object) 
 Defines a frequency encoding for a field.
 
 `frequency_encoding`.`field`:::
-(String) 
+(Required, string) 
 The field name to encode.
 
 `frequency_encoding`.`feature_name`:::
-(String) 
+(Required, string) 
 The name of the resulting feature.
 
 `frequency_encoding`.`frequency_map`:::
-(Object map of string:double) 
+(Required, object map of string:double) 
 Object that maps the field value to the frequency encoded value.
 
 `one_hot_encoding`::
-(Object) 
+(Required, object) 
 Defines a one hot encoding map for a field.
 
 `one_hot_encoding`.`field`:::
-(String) 
+(Required, string) 
 The field name to encode.
 
 `one_hot_encoding`.`hot_map`:::
-(Object map of strings) 
+(Required, object map of strings) 
 String map of "field_value: one_hot_column_name".
 
 `target_mean_encoding`::
-(Object) 
+(Required, object) 
 Defines a target mean encoding for a field.
 
 `target_mean_encoding`.`field`:::
-(String)
+(Required, string)
 The field name to encode.
 
 `target_mean_encoding`.`feature_name`:::
-(String) 
+(Required, string) 
 The name of the resulting feature.
 
 `target_mean_encoding`.`target.map`:::
-(Object map of string:double) 
+(Required, object map of string:double) 
 Object that maps the field value to the target mean value.
 
 `target_mean_encoding`.`default.value`:::
-(Double) 
+(Required, double) 
 The feature value if the field value is not in the `target_map`.
 
 See <<ml-put-inference-preprocessor-example>> for more details.
@@ -139,15 +140,15 @@ See <<ml-put-inference-preprocessor-example>> for more details.
 ===== {infer-cap} trained model definitions
 
 `tree`::
-(Object) 
+(Required, object) 
 The definition for a decision tree.
 
 `tree`.`feature_names`:::
-(String) 
+(Required, string) 
 Features expected by the tree, in their expected order.
 
 `tree`.`tree_structure`:::
-(Object) 
+(Required, object) 
 An array of `tree_node` objects. The nodes must be in ordinal order by their 
 `tree_node.node_index` value.
 
@@ -156,7 +157,7 @@ An array of `tree_node` objects. The nodes must be in ordinal order by their
 `classification`).
 
 `tree`.`target_type`:::
-(String) 
+(Required, string) 
 String indicating the model target type; `regression` or `classification`.
 
 There are two major types of nodes: leaf nodes and not-leaf nodes.
@@ -166,8 +167,8 @@ There are two major types of nodes: leaf nodes and not-leaf nodes.
   `threshold`, `decision_type`, and `default_left` defined.
 
 `tree_node`::
-(Object)
-
+(Required, object) 
+The definition of a node in a tree.
 
 `tree_node`.`decision_type`:::
 (Optional, string) 
@@ -211,11 +212,11 @@ children).
 The definition for an ensemble model.
 
 `ensemble`.`feature_names`:::
-(String) 
+(Required, string) 
 Features expected by the ensemble, in their expected order.
 
 `ensemble`.`trained_models`:::
-(Object)
+(Required, object)
 An array of `trained_model` objects. Supported trained models are `tree` and 
 `ensemble`.
 
@@ -224,11 +225,11 @@ An array of `trained_model` objects. Supported trained models are `tree` and
 An array of classification labels.
 
 `ensemble`.`target_type`:::
-(String) 
+(Required, string) 
 String indicating the model target type; `regression` or `classification.`
 
 `ensemble`.`aggregate_output`:::
-(Object) 
+(Required, object) 
 An aggregated output object that defines how to aggregate the outputs of the 
 `trained_models`. Supported objects are `weighted_mode`, `weighted_sum`, and 
 `logistic_regression`.
@@ -236,39 +237,45 @@ An aggregated output object that defines how to aggregate the outputs of the
 See <<ml-put-inference-model-example>> for more details.
 
 
-[[ml-put-inference-aggreegated-output]]
+[[ml-put-inference-aggregated-output]]
 ===== Aggregated output types
 
 `logistic_regression`::
+(Optional, object) 
 This `aggregated_output` type works with binary classification (classification 
 for values [0, 1]). It multiplies the outputs (in the case of the `ensemble` 
 model, the inference model values) by the supplied `weights`. The resulting 
-vector is summed and passed to a `sigmoid` function. The result of the `sigmoid` 
-function is considered the probability of class 1 (`P_1`), consequently, the 
-probability of class 0 is `1 - P_1`. The class with the highest probability 
-(either 0 or 1) is then returned.
+vector is summed and passed to a 
+https://en.wikipedia.org/wiki/Sigmoid_function[`sigmoid` function]. The result 
+of the `sigmoid` function is considered the probability of class 1 (`P_1`), 
+consequently, the probability of class 0 is `1 - P_1`. The class with the 
+highest probability (either 0 or 1) is then returned. For more information about 
+logistic regression, see 
+https://en.wikipedia.org/wiki/Logistic_regression[this wiki article].
 
 `logistic_regression`.`weights`:::
-(Double) 
+(Required, double) 
 The weights to multiply by the input values (the inference values of the trained 
 models).
 
 `weighted_sum`::
+(Optional, object) 
 This `aggregated_output` type works with regression. The weighted sum of the 
 input values.
 
 `weighted_sum`.`weights`:::
-(Double) 
+(Required, double) 
 The weights to multiply by the input values (the inference values of the trained 
 models).
 
 `weighted_mode`::
+(Optional, object) 
 This `aggregated_output` type works with regression or classification. It takes 
 a weighted vote of the input values. The the most common input value (taking the 
 weights into account) is returned.
 
 `weighted_mode`.`weights`:::
-(Double) 
+(Required, double) 
 The weights to multiply by the input values (the inference values of the trained 
 models).
 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -129,7 +129,7 @@ The field name to encode.
 (Required, string) 
 The name of the resulting feature.
 
-`target_mean_encoding`.`target.map`:::
+`target_mean_encoding`.`target_map`:::
 (Required, object map of string:double) 
 Object that maps the field value to the target mean value.
 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -27,7 +27,6 @@ built-in roles and privileges:
 * `machine_learning_admin`
 
 
-* destination index: `read`, `create_index`, `manage` and `index`
 * cluster: `monitor_ml`
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -33,6 +33,7 @@ built-in roles and privileges:
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
+
 [[ml-put-inference-desc]]
 ==== {api-description-title}
 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -167,6 +167,7 @@ There are two major types of nodes: leaf nodes and not-leaf nodes.
 * All other nodes need `split_feature`, `left_child`, `right_child`, 
   `threshold`, `decision_type`, and `default_left` defined.
 
+
 `tree_node`::
 (Required, object) 
 The definition of a node in a tree.

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -1,0 +1,309 @@
+[role="xpack"]
+[testenv="basic"]
+[[put-inference]]
+=== Create {infer} trained model API
+[subs="attributes"]
+++++
+<titleabbrev>Crerate {infer} trained model</titleabbrev>
+++++
+
+Creates an {infer} trained model.
+
+experimental[]
+
+
+[[ml-put-inference-request]]
+==== {api-request-title}
+
+`PUT _ml/inference/<model_id>`
+
+
+[[ml-put-inference-prereq]]
+==== {api-prereq-title}
+
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `machine_learning_admin`
+
+
+* source index: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, `manage` and `index`
+* cluster: `monitor_ml`
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
+[[ml-put-inference-desc]]
+==== {api-description-title}
+
+
+
+
+[[ml-put-inference-path-params]]
+==== {api-path-parms-title}
+
+`<model_id>`::
+(Optional, string) 
+include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
+
+
+[[ml-put-inference-query-params]]
+==== {api-query-parms-title}
+
+`definition`::
+(Required, object) 
+The {infer} definition for the model.
+
+`definition`.`preprocessors`:::
+(Optional, object)
+Collection of preprocessors. See <<ml-put-inference-preprocessors>> for the full 
+list of available preprocessors.
+
+`definition`.`trained_model`:::
+(Required, object) 
+The definition of the trained model. See <<ml-put-inference-trained-model>> for 
+details.
+
+`description`::
+(Optional, string) 
+A human-readable description of the {infer} trained model.
+
+`ensamble`::
+(Optional, object)
+The definition for an ensamble model. See <<ml-put-inference-ensamble-model>> 
+for details.
+
+`input`::
+(Required, object) 
+The input field names for the model definition.
+
+`metadata`::
+(Optional, object) 
+An object map that contains metadata about the model.
+
+`tags`::
+(Optional, string) 
+An array of tags to organize the model.
+
+
+[[ml-put-inference-preprocessors]]
+===== {infer-cap} preprocessor definitions
+
+`frequency_encoding`::
+(Object) 
+Defines a frequency encoding for a field.
+
+`frequency_encoding`.`field`:::
+(String) 
+The field name to encode.
+
+`frequency_encoding`.`feature_name`:::
+(String) 
+The name of the resulting feature.
+
+`frequency_encoding`.`frequency_map`:::
+(Object map of string:double) 
+Object that maps the field value to the frequency encoded value.
+
+[source,js]
+----------------------------------
+{
+	"frequency_encoding": {
+		"field": "FlightDelayType",
+		"feature_name": "FlightDelayType_frequency",
+		"frequency_map": {
+			"Carrier Delay": 0.6007414737092798,
+			"NAS Delay": 0.6007414737092798,
+			"Weather Delay": 0.024573576178086153,
+			"Security Delay": 0.02476631010889467,
+			"No Delay": 0.6007414737092798,
+			"Late Aircraft Delay": 0.6007414737092798
+		}
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+`one_hot_encoding`::
+(Object) 
+Defines a one hot encoding map for a field.
+
+`one_hot_encoding`.`field`:::
+(String) 
+The field name to encode.
+
+`one_hot_encoding`.`hot_map`:::
+(Object map of strings) 
+String map of "field_value: one_hot_column_name".
+
+[source,js]
+----------------------------------
+{
+	"one_hot_encoding": {
+		"field": "FlightDelayType",
+		"hot_map": {
+			"Carrier Delay": "FlightDelayType_Carrier Delay",
+			"NAS Delay": "FlightDelayType_NAS Delay",
+			"No Delay": "FlightDelayType_No Delay",
+			"Late Aircraft Delay": "FlightDelayType_Late Aircraft Delay"
+		}
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+
+`target_mean_encoding`::
+(Object) 
+Defines a target mean encoding for a field.
+
+`target_mean_encoding`.`field`:::
+(String)
+The field name to encode.
+
+`target_mean_encoding`.`feature_name`:::
+(String) 
+The name of the resulting feature.
+
+`target_mean_encoding`.`target.map`:::
+(Object map of string:double) 
+Object that maps the field value to the target mean value.
+
+`target_mean_encoding`.`default.value`:::
+(Double) 
+The feature value if the field value is not in the `target_map`.
+
+[source,js]
+----------------------------------
+{
+	"target_mean_encoding": {
+		"field": "FlightDelayType",
+		"feature_name": "FlightDelayType_targetmean",
+		"target_map": {
+			"Carrier Delay": 39.97465788139886,
+			"NAS Delay": 39.97465788139886,
+			"Security Delay": 203.171206225681,
+			"Weather Delay": 187.64705882352948,
+			"No Delay": 39.97465788139886,
+			"Late Aircraft Delay": 39.97465788139886
+		},
+		"default_value": 158.17995752420433
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+
+[[ml-put-inference-trained-model]]
+===== {infer-cap} trained model definitions
+
+`tree`::
+(Object) 
+The definition for a decision tree.
+
+`tree`.`feature_names`:::
+(String) 
+Features expected by the tree, in their expected order.
+
+`tree`.`tree_structure`:::
+(Object) 
+An array of `tree_node` objects. The nodes must be in ordinal order by their 
+`tree_node.node_index` value.
+
+`tree`.`classification_labels`:::
+(Optional, string) An array of classification labels (used for 
+`classification`).
+
+`tree`.`target_type`:::
+(String) 
+String indicating the model target type; `regression` or `classification`.
+
+`tree_node`::
+
+`tree_node`.`decision_type`:::
+(Optional, string) 
+Indicates the positive value (in other words, when to choose the left node) 
+decision type. Supported `lt`, `lte`, `gt`, `gte`. Defaults to `lte`.
+
+`tree_node`.`threshold`:::
+(Optional, double) 
+The decision threshold with which to compare the feature value.
+
+`tree_node`.`left_child`:::
+(Optional, integer) 
+The index of the left child.
+
+`tree_node`.`right_child`:::
+(Optional, integer) 
+The index of the right child.
+
+`tree_node`.`default_left`:::
+(Optional, boolean) 
+Should default to the left if the feature is missing. Defaults to `true`.
+
+`tree_node`.`split_feature`:::
+(Optional, integer) 
+The index of the feature value in the feature array.
+
+`tree_node`.`node_index`:::
+(Integer) 
+The index of the current node.
+
+`tree_node`.`split_gain`:::
+(Optional, double) The information gain from the split.
+
+`tree_node`.`leaf_value`:::
+(Optional, double) 
+The leaf value of the of the node, if the value is a leaf (in other words, no 
+children).
+
+There are two major types of nodes: leaf nodes and not-leaf nodes.
+
+* Leaf nodes only need `node_index` and `leaf_value` defined.
+* All other nodes need `split_feature`, `left_child`, `right_child`, `threshold`, 
+`decision_type`, and `default_left` defined.
+
+[source,js]
+----------------------------------
+{
+	"tree": {
+		"feature_names": [
+			"DistanceKilometers",
+			"FlightTimeMin",
+			"FlightDelayType_NAS Delay",
+			"Origin_targetmean",
+			"DestRegion_targetmean",
+			"DestCityName_targetmean",
+			"OriginAirportID_targetmean",
+			"OriginCityName_frequency",
+			"DistanceMiles",
+			"FlightDelayType_Late Aircraft Delay"
+		],
+		"tree_structure": [{
+				"decision_type": "lt",
+				"threshold": 9069.33437193022,
+				"split_feature": 0,
+				"split_gain": 4112.094574306927,
+				"node_index": 0,
+				"default_left": true,
+				"left_child": 1,
+				"right_child": 2
+			},
+			...
+      {
+				"node_index": 9,
+				"leaf_value": -27.68987349695448
+			},
+			...
+		],
+		"target_type": "regression"
+	}
+}
+----------------------------------
+//NOTCONSOLE
+
+
+[[ml-put-inference-ensamble-model]]
+===== {infer-cap} ensemble model definitions
+
+

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -279,7 +279,7 @@ models).
 `weighted_mode`::
 (Optional, object) 
 This `aggregated_output` type works with regression or classification. It takes 
-a weighted vote of the input values. The the most common input value (taking the 
+a weighted vote of the input values. The most common input value (taking the 
 weights into account) is returned.
 
 `weighted_mode`.`weights`:::

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -168,6 +168,7 @@ There are two major types of nodes: leaf nodes and not-leaf nodes.
   `threshold`, `decision_type`, and `default_left` defined.
 
 
+
 `tree_node`::
 (Required, object) 
 The definition of a node in a tree.

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -77,6 +77,10 @@ A human-readable description of the {infer} trained model.
 (Required, object) 
 The input field names for the model definition.
 
+`input`.`field_names`:::
+(Required, string) 
+An array of input field names for the model.
+
 `metadata`::
 (Optional, object) 
 An object map that contains metadata about the model.
@@ -292,7 +296,7 @@ models).
 [[ml-put-inference-preprocessor-example]]
 ===== Preprocessor examples
 
-The example above shows a `frequency_encoding` preprocessor object:
+The example below shows a `frequency_encoding` preprocessor object:
 
 [source,js]
 ----------------------------------
@@ -441,13 +445,29 @@ The following example shows an `ensemble` model object:
 
 
 [[ml-put-inference-aggregated-output-example]]
-===== Aggregated output examples
+===== Aggregated output example
 
-For the following examples, we use `[1.0, 2.0, 2.0, 3.0, 5.0]` as input. 
+The examples below show `aggregate_output` objects:
 
-If `weighted_mode: { weights: [1.0, -1.0, .5, 1.0, 5.0]}`, then the aggregated 
-output will return `5.0` as that is the most common input value given the 
-weights.
 
-If `weighted_mode: { weights: [1.0, 1.0, 1.0, 1.0, 1.0]}`, then it would return 
-`2.0`, as `2.0` appears the most in the input and the weights are uniform.
+[source,js]
+----------------------------------
+"aggregate_output" : {
+  "weighted_sum" : {
+    "weights" : [1.0, -1.0, .5, 1.0, 5.0]
+  }
+}
+----------------------------------
+//NOTCONSOLE
+
+
+source,js]
+----------------------------------
+"aggregate_output" : {
+  "weighted_mode" : {
+    "weights" : [1.0, 1.0, 1.0, 1.0, 1.0]
+  }
+}
+----------------------------------
+//NOTCONSOLE
+

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -27,7 +27,6 @@ built-in roles and privileges:
 * `machine_learning_admin`
 
 
-* cluster: `monitor_ml`
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -4,7 +4,7 @@
 === Create {infer} trained model API
 [subs="attributes"]
 ++++
-<titleabbrev>Crerate {infer} trained model</titleabbrev>
+<titleabbrev>Create {infer} trained model</titleabbrev>
 ++++
 
 Creates an {infer} trained model.

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -32,7 +32,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 [[ml-put-inference-desc]]
 ==== {api-description-title}
 
-Create {infer} trained model API enables you to supply a trained model that is 
+The create {infer} trained model API enables you to supply a trained model that is 
 not created by {dfanalytics}. 
 
 


### PR DESCRIPTION
This PR adds the PUT inference API docs to the DFA API docs pool.

Related issue: https://github.com/elastic/ml-team/issues/281

Available preview: http://elasticsearch_51231.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-inference.html