### PR TITLE
[DOCS] Adds ML PRs to release notes

### DIFF
--- a/docs/reference/release-notes/7.5.asciidoc
+++ b/docs/reference/release-notes/7.5.asciidoc
@@ -3,6 +3,14 @@
 
 coming::[7.5.2]
 
+[[bug-7.5.2]]
+[float]
+=== Bug fixes
+
+Machine Learning::
+* Fixes potential memory corruption or inconsistent state when background
+persisting categorizer state. {ml-pull}921[#921]
+
 [[release-notes-7.5.1]]
 == {es} version 7.5.1
 


### PR DESCRIPTION
This PR merges content from https://raw.githubusercontent.com/elastic/ml-cpp/7.5/docs/CHANGELOG.asciidoc into the Elasticsearch Release Notes.

Preview: http://elasticsearch_51234.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/release-notes-7.5.2.html