### PR TITLE
Prototype: Product quantization for nn search

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/Vectors.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/Vectors.java
@@ -13,11 +13,13 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
+import org.elasticsearch.xpack.vectors.query.AnnPQQueryBuilder;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,9 +27,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 
-public class Vectors extends Plugin implements MapperPlugin, ActionPlugin {
+public class Vectors extends Plugin implements MapperPlugin, ActionPlugin, SearchPlugin {
 
     protected final boolean enabled;
 
@@ -51,5 +55,13 @@ public class Vectors extends Plugin implements MapperPlugin, ActionPlugin {
         mappers.put(DenseVectorFieldMapper.CONTENT_TYPE, new DenseVectorFieldMapper.TypeParser());
         mappers.put(SparseVectorFieldMapper.CONTENT_TYPE, new SparseVectorFieldMapper.TypeParser());
         return Collections.unmodifiableMap(mappers);
+    }
+
+    @Override
+    public List<QuerySpec<?>> getQueries() {
+        if (enabled == false) {
+            return emptyList();
+        }
+        return singletonList(new QuerySpec<>(AnnPQQueryBuilder.NAME, AnnPQQueryBuilder::new, AnnPQQueryBuilder::fromXContent));
     }
 }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/KMeansClustering.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/KMeansClustering.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.InPlaceMergeSorter;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.DoubleArray;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+public class KMeansClustering {
+    private static final Random random = new Random(42L);
+    private static final BigArrays bigArrays = BigArrays.NON_RECYCLING_INSTANCE;
+
+    public static void runPQKMeansClustering(
+            int algorithm,
+            DocValuesProducer valuesProducer,
+            FieldInfo field,
+            float[][][] pcentroids,
+            ByteArray[] docCentroids,
+            DoubleArray[] docCentroidDists,
+            int pcentroidsCount,
+            int pqCount,
+            int pdims,
+            int numIters,
+            float sampleFraction) throws IOException {
+
+        // initialize centroids
+        int numDocs = 0;
+        BinaryDocValues values = valuesProducer.getBinary(field);
+        while (values.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+            BytesRef bytes = values.binaryValue();
+            if (numDocs < pcentroidsCount) {
+                float[][] pvectors = decodeVector(bytes, pqCount, pdims);
+                for (int pq = 0; pq < pqCount; pq++) {
+                    pcentroids[pq][numDocs] = pvectors[pq];
+                }
+            } else if (random.nextDouble() < pcentroidsCount * (1.0 / numDocs)) {
+                int c = random.nextInt(pcentroidsCount);
+                float[][] pvectors = decodeVector(bytes, pqCount, pdims);
+                for (int pq = 0; pq < pqCount; pq++) {
+                    pcentroids[pq][c] = pvectors[pq];
+                }
+            }
+            numDocs++;
+        }
+
+        //System.out.println("Running k-means with on [" + numDocs + "] docs...");
+        if (algorithm == 1) { // Lloyds algorithm
+            for (int pq = 0; pq < pqCount; pq++) {
+                docCentroids[pq] = bigArrays.newByteArray(numDocs);
+            }
+            for (int itr = 0; itr < numIters; itr++) {
+                float fraction = (itr < numIters - 1) && numDocs > 100_000 ? sampleFraction : 1.0f;
+                pcentroids = runKMeansStepLloyds(itr, fraction, valuesProducer, field, pcentroids, docCentroids);
+            }
+        } else { // KMeans sort algorithm
+            double[][][] cdists = new double[pqCount][pcentroidsCount][pcentroidsCount]; // inter-centroid distances
+            int[][][] cdistIndexes = new int[pqCount][pcentroidsCount][pcentroidsCount]; // indexes of other centroids sorted by distances
+            for (int pq = 0; pq < pqCount; pq++) {
+                docCentroids[pq] = bigArrays.newByteArray(numDocs);
+                docCentroidDists[pq] = bigArrays.newDoubleArray(numDocs);
+            }
+            for (int itr = 0; itr < numIters; itr++) {
+                float fraction = (itr < numIters - 1) && numDocs > 100_000 ? sampleFraction : 1.0f;
+                pcentroids = runKMeansStepSort(itr, fraction, valuesProducer, field,
+                    pcentroids, docCentroids, docCentroidDists, cdists, cdistIndexes) ;
+            }
+        }
+    }
+
+    /**
+     * Runs one iteration of k-means Lloyds. For each document vector, we first find the
+     * nearest centroid, then update the location of the new centroid.
+     */
+    private static float[][][] runKMeansStepLloyds(int iter,
+            float sampleFraction,
+            DocValuesProducer valuesProducer,
+            FieldInfo field,
+            float[][][] centroids,
+            ByteArray[] docCentroids) throws IOException {
+
+        int pqCount = centroids.length; // number of quantizers
+        int cCount = centroids[0].length; // number of product centroids in each quantizer
+        int pdims = centroids[0][0].length; // number of dims in each product centroid
+        float[][][] newCentroids = new float[pqCount][cCount][pdims];
+        int[][] newCentroidSize = new int[pqCount][cCount];
+
+        double distToCentroid = 0.0;
+        double distToOtherCentroids = 0.0;
+        int doc;
+        int numDocs = 0;
+        BinaryDocValues values = valuesProducer.getBinary(field);
+        while ((doc = values.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            if (random.nextFloat() > sampleFraction) {
+                continue;
+            }
+            numDocs++;
+            BytesRef bytes = values.binaryValue();
+            float[][] vector = decodeVector(bytes, pqCount, pdims);
+            // find best centroid for each vector part
+            for (int pq = 0; pq < pqCount; pq++) {
+                short bestCentroid = -1;
+                double bestDist = Double.MAX_VALUE;
+                for (short c = 0; c < cCount; c++) {
+                    double dist = l2Squared(centroids[pq][c], vector[pq]);
+                    distToOtherCentroids += dist;
+                    if (dist < bestDist) {
+                        bestCentroid = c;
+                        bestDist = dist;
+                    }
+                }
+                newCentroidSize[pq][bestCentroid]++;
+                for (int dim = 0; dim < pdims; dim++) {
+                    newCentroids[pq][bestCentroid][dim] += vector[pq][dim];
+                }
+                distToCentroid += bestDist;
+                distToOtherCentroids -= bestDist;
+                docCentroids[pq].set(doc, (byte) bestCentroid);
+            }
+        }
+        for (int pq = 0; pq < pqCount; pq++) {
+            for (int c = 0; c < cCount; c++) {
+                if (newCentroidSize[pq][c] > 0) {
+                    for (int dim = 0; dim < pdims; dim++) {
+                        newCentroids[pq][c][dim] /= newCentroidSize[pq][c];
+                    }
+                } else {
+                    newCentroids[pq][c] = centroids[pq][c]; // keep old centroid
+                }
+            }
+        }
+        distToCentroid /= numDocs;
+        distToOtherCentroids /= numDocs * (centroids.length - 1);
+
+//        System.out.println("Finished iteration [" + iter + "]. Squared dist to centroid [" + distToCentroid +
+//            "], squared dist to other centroids [" + distToOtherCentroids + "].");
+        return newCentroids;
+    }
+
+
+
+    /**
+     * Based on the paper:
+     * Phillips, Steven J. "Acceleration of k-means and related clustering algorithms."
+     * Workshop on Algorithm Engineering and Experimentation. Springer, Berlin, Heidelberg, 2002.
+     */
+    private static float[][][] runKMeansStepSort(int itr,
+           float sampleFraction,
+           DocValuesProducer valuesProducer,
+           FieldInfo field,
+           float[][][] centroids,
+           ByteArray[] docCentroids,
+           DoubleArray[] docCentroidDists,
+           double[][][] cdists,
+           int[][][] cdistIndexes) throws IOException {
+
+        int pqCount = centroids.length; // number of quantizers
+        int cCount = centroids[0].length; // number of product centroids in each quantizer
+        int pdims = centroids[0][0].length; // number of dims in each product centroid
+        float[][][] newCentroids = new float[pqCount][cCount][pdims];
+        int[][] newCentroidSize = new int[pqCount][cCount];
+
+        double distToCentroid = 0.0;
+        double distToOtherCentroids = 0.0;
+        int doc;
+        int numDocs = 0;
+        BinaryDocValues values = valuesProducer.getBinary(field);
+        while ((doc = values.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            if (random.nextFloat() > sampleFraction) {
+                continue;
+            }
+            numDocs++;
+            BytesRef bytes = values.binaryValue();
+            float[][] vector = decodeVector(bytes, pqCount, pdims);
+
+            // find best centroid for each vector part
+            for (int pq = 0; pq < pqCount; pq++) {
+                int bestCentroid = itr == 0 ? -1 : docCentroids[pq].get(doc) & 0xFF; // centroids are stored as unsigned bytes
+                double bestDist = itr == 0 ? Double.MAX_VALUE: docCentroidDists[pq].get(doc);
+                double prevBestDist = bestDist;
+                for (int c = 0; c < cCount; c++) {
+                    int cIndex;
+                    if (itr == 0) {
+                        cIndex = c;
+                    } else {
+                        cIndex = cdistIndexes[pq][bestCentroid][c]; // consider next closest centroid to bestCentroid
+                        if (cdists[pq][bestCentroid][cIndex] >= (4 * prevBestDist)) {
+                            // we stop considering all other centroids, as squared distances to them exceed 4 * prevBestDist
+                            break;
+                        }
+                    }
+                    double dist = l2Squared(centroids[pq][cIndex], vector[pq]);
+                    distToOtherCentroids += dist;
+                    if (dist < bestDist) {
+                        bestCentroid = cIndex;
+                        bestDist = dist;
+                    }
+                }
+                newCentroidSize[pq][bestCentroid]++;
+                for (int dim = 0; dim < pdims; dim++) {
+                    newCentroids[pq][bestCentroid][dim] += vector[pq][dim];
+                }
+                distToCentroid += bestDist;
+                distToOtherCentroids -= bestDist;
+                docCentroids[pq].set(values.docID(), (byte) bestCentroid);
+                docCentroidDists[pq].set(values.docID(), bestDist);
+            }
+        }
+        for (int pq = 0; pq < pqCount; pq++) {
+            for (int c = 0; c < cCount; c++) {
+                if (newCentroidSize[pq][c] > 0) {
+                    for (int dim = 0; dim < pdims; dim++) {
+                        newCentroids[pq][c][dim] /= newCentroidSize[pq][c];
+                    }
+                } else {
+                    newCentroids[pq][c] = centroids[pq][c]; // keep old centroid
+                }
+            }
+            for (int i = 0; i < cCount; i++) {
+                for (int j = 0; j < i; j++) {
+                    cdists[pq][i][j] = cdists[pq][j][i];
+                }
+                for (int j = i+1; j < cCount; j++) {
+                    cdists[pq][i][j] = l2Squared(newCentroids[pq][i], newCentroids[pq][j]);
+                }
+                sortDistIndexes(cdists[pq][i], cdistIndexes[pq][i], cCount);
+            }
+        }
+        distToCentroid /= numDocs;
+        distToOtherCentroids /= numDocs * (cCount - 1);
+
+
+//        System.out.println("Finished iteration [" + itr + "]. Dist to centroid [" + distToCentroid +
+//            "], dist to other centroids [" + distToOtherCentroids + "].");
+        return newCentroids;
+    }
+
+    public static void sortDistIndexes(double[] srcDists, int[] indexes, int n) {
+        double[] dists = new double[srcDists.length];
+        System.arraycopy(srcDists, 0, dists, 0, dists.length);
+        for (int i = 0 ; i < indexes.length; i++) {
+            indexes[i] = i;
+        }
+
+        new InPlaceMergeSorter() {
+            @Override
+            public int compare(int i, int j) {
+                return Double.compare(dists[i], dists[j]);
+            }
+
+            @Override
+            public void swap(int i, int j) {
+                double tempDist = dists[i];
+                dists[i] = dists[j];
+                dists[j] = tempDist;
+
+                int tempIndex = indexes[i];
+                indexes[i] = indexes[j];
+                indexes[j] = tempIndex;
+            }
+        }.sort(0, n);
+    }
+
+
+    // break vector into <pqCount> parts
+    private static float[][] decodeVector(BytesRef bytes, int pqCount, int pdims) {
+        float[][] vector = new float[pqCount][pdims];
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes.bytes, bytes.offset, bytes.length);
+        for (int pq = 0; pq < pqCount; pq ++) {
+            for (int dim = 0; dim < pdims; dim++) {
+                vector[pq][dim] = byteBuffer.getFloat();
+            }
+        }
+        return vector;
+    }
+
+    private static double l2Squared(float[] v1, float[] v2) {
+        double dist = 0;
+        for (int dim = 0; dim < v1.length; dim++) {
+            float dif = v1[dim] - v2[dim];
+            dist += dif * dif;
+        }
+        return dist;
+    }
+
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQCodec.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQCodec.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.codecs.LiveDocsFormat;
+import org.apache.lucene.codecs.NormsFormat;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.SegmentInfoFormat;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.TermVectorsFormat;
+
+public final class PQCodec extends Codec {
+
+    private static final String CODEC_NAME = "ProductQuantizationCodec";
+
+    public PQCodec() {
+        super(CODEC_NAME);
+    }
+
+    private Codec delegate() {
+        return Codec.getDefault();
+    }
+
+    @Override
+    public PostingsFormat postingsFormat() {
+        return delegate().postingsFormat();
+    }
+
+    @Override
+    public DocValuesFormat docValuesFormat() {
+        DocValuesFormat docValuesFormat = delegate().docValuesFormat();
+        return new PQDocValuesFormat(CODEC_NAME, docValuesFormat);
+    }
+
+    @Override
+    public StoredFieldsFormat storedFieldsFormat() {
+        return delegate().storedFieldsFormat();
+    }
+
+    @Override
+    public TermVectorsFormat termVectorsFormat() {
+        return delegate().termVectorsFormat();
+    }
+
+    @Override
+    public FieldInfosFormat fieldInfosFormat() {
+        return delegate().fieldInfosFormat();
+    }
+
+    @Override
+    public SegmentInfoFormat segmentInfoFormat() {
+        return delegate().segmentInfoFormat();
+    }
+
+    @Override
+    public NormsFormat normsFormat() {
+        return delegate().normsFormat();
+    }
+
+    @Override
+    public LiveDocsFormat liveDocsFormat() {
+        return delegate().liveDocsFormat();
+    }
+
+    @Override
+    public CompoundFormat compoundFormat() {
+        return delegate().compoundFormat();
+    }
+
+    @Override
+    public PointsFormat pointsFormat() {
+        return delegate().pointsFormat();
+    }
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQDocValuesFormat.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQDocValuesFormat.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.codec;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+import java.io.IOException;
+
+public class PQDocValuesFormat extends DocValuesFormat {
+    private final DocValuesFormat delegate;
+
+    protected PQDocValuesFormat(String name, DocValuesFormat delegate) {
+        super(name);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        DocValuesConsumer consumer = delegate.fieldsConsumer(state);
+        return new PQDocValuesWriter(state, consumer, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION);
+    }
+
+    @Override
+    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+        DocValuesProducer producer = delegate.fieldsProducer(state);
+        return new PQDocValuesReader(state, producer, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION);
+    }
+
+    static final int VERSION_START = 0;
+    static final int VERSION_CURRENT = VERSION_START;
+
+    // stores 1) original vectors 2) product centroids with product centroids square magnitudes
+    // 3) docCentroids -- what product centroids this document vector belongs to
+    static final String DATA_CODEC = "LucenePQData";
+    static final String DATA_EXTENSION = "pq";
+    static final String META_CODEC = "LucenePQMetadata";
+    static final String META_EXTENSION = "pqm";
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQDocValuesReader.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQDocValuesReader.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.codec;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.internal.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.INT_BYTES;
+
+public class PQDocValuesReader extends DocValuesProducer implements Closeable {
+
+    private final SegmentReadState state;
+    private final DocValuesProducer delegate;
+    private final IndexInput data;
+    private final int maxDoc;
+    private final Map<String, VectorBinaryEntry> vectorBinaries = new HashMap<>();
+
+    public PQDocValuesReader(SegmentReadState state, DocValuesProducer delegate, String dataCodec, String dataExtension,
+            String metaCodec, String metaExtension) throws IOException {
+        this.state = state;
+        this.delegate = delegate;
+        this.maxDoc = state.segmentInfo.maxDoc();
+
+        int version = -1;
+        String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
+        try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, state.context)) {
+            Throwable exc = null;
+            try {
+                version = CodecUtil.checkIndexHeader(in, metaCodec, PQDocValuesFormat.VERSION_START, PQDocValuesFormat.VERSION_CURRENT,
+                    state.segmentInfo.getId(), state.segmentSuffix);
+                readFields(in, state.fieldInfos);
+            } catch (Throwable exception) {
+                exc = exception;
+            } finally {
+                CodecUtil.checkFooter(in, exc);
+            }
+        }
+        String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
+        this.data = state.directory.openInput(dataName, state.context);
+        boolean success = false;
+        try {
+            int version2 = CodecUtil.checkIndexHeader(data, dataCodec, PQDocValuesFormat.VERSION_START, PQDocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(), state.segmentSuffix);
+            if (version != version2) {
+                throw new CorruptIndexException("Format versions mismatch: meta=" + version + ", data=" + version2, data);
+            }
+            CodecUtil.retrieveChecksum(data);
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this.data);
+            }
+        }
+    }
+
+    private void readFields(ChecksumIndexInput meta, FieldInfos finfos) throws IOException {
+        for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
+            FieldInfo finfo = finfos.fieldInfo(fieldNumber);
+            if (finfo == null) {
+                throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
+            }
+            vectorBinaries.put(finfo.name, readVectorBinary(meta));
+        }
+    }
+
+    private VectorBinaryEntry readVectorBinary(ChecksumIndexInput meta) throws IOException {
+        VectorBinaryEntry entry = new VectorBinaryEntry();
+        entry.dims = meta.readInt();
+        entry.pqCount = meta.readInt();
+        entry.pcentroidsCount = meta.readInt();
+        entry.vectorsOffset = meta.readLong();
+        entry.vectorsLength = meta.readLong();
+        entry.centroidsOffset = meta.readLong();
+        entry.centroidsLength = meta.readInt();
+        entry.centroidsSquaredMagnitudeOffset = meta.readLong();
+        entry.centroidsSquaredMagnitudeLength = meta.readInt();
+        entry.docCentroidsOffset = meta.readLong();
+        entry.docCentroidsLength = meta.readLong();
+        return entry;
+    }
+
+    @Override
+    public NumericDocValues getNumeric(FieldInfo field) throws IOException {
+        return delegate.getNumeric(field);
+    }
+
+    @Override
+    public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+        String ann = field.attributes().get("ann");
+        if ((ann == null) || (ann.equals("pq") == false)) {
+            return delegate.getBinary(field);
+        }
+
+        VectorBinaryEntry entry = vectorBinaries.get(field.name);
+        int pdims = entry.dims / entry.pqCount;
+
+        final IndexInput vectorsSlice = data.slice("vectors", entry.vectorsOffset, entry.vectorsLength);
+        final int vectorLength = entry.dims * INT_BYTES + INT_BYTES;  // vectors are encoded with their length
+
+        final IndexInput docCentroidsSlice = data.slice("docCentroids", entry.docCentroidsOffset, entry.docCentroidsLength);
+        final int centroidsLength = entry.pqCount;
+
+        return new VectorDocValues(maxDoc) {
+            final BytesRef vectorBytes = new BytesRef(new byte[vectorLength], 0, vectorLength);
+            final BytesRef docCentroidsBytes = new BytesRef(new byte[centroidsLength], 0, centroidsLength);
+            @Override
+            public BytesRef binaryValue() throws IOException {
+                vectorsSlice.seek((long) doc * vectorLength);
+                vectorsSlice.readBytes(vectorBytes.bytes, 0, vectorLength);
+                return vectorBytes;
+            }
+
+            @Override
+            public BytesRef docCentroids() throws IOException {
+                docCentroidsSlice.seek((long) doc * centroidsLength);
+                docCentroidsSlice.readBytes(docCentroidsBytes.bytes, 0, centroidsLength);
+                return docCentroidsBytes;
+            }
+
+            @Override
+            public float[][][] pcentroids() throws IOException {
+                byte[] pcentroidBytes = new byte[entry.centroidsLength];
+                data.seek(entry.centroidsOffset);
+                data.readBytes(pcentroidBytes, 0, entry.centroidsLength);
+
+                ByteBuffer byteBuffer = ByteBuffer.wrap(pcentroidBytes, 0, entry.centroidsLength);
+                float[][][] pcentroids = new float[entry.pqCount][entry.pcentroidsCount][pdims];
+                for (int pq = 0; pq < entry.pqCount; pq++) {
+                    for (int c = 0; c < entry.pcentroidsCount; c++) {
+                        for (int dim = 0; dim < pdims; dim++) {
+                            pcentroids[pq][c][dim] = byteBuffer.getFloat();
+                        }
+                    }
+                }
+                return pcentroids;
+            }
+
+            @Override
+            public float[][] pCentroidsSquaredMagnitudes() throws IOException {
+                byte[] pcSMdBytes = new byte[entry.centroidsSquaredMagnitudeLength];
+                data.seek(entry.centroidsSquaredMagnitudeOffset);
+                data.readBytes(pcSMdBytes, 0, entry.centroidsSquaredMagnitudeLength);
+
+                ByteBuffer byteBuffer = ByteBuffer.wrap(pcSMdBytes, 0, entry.centroidsSquaredMagnitudeLength);
+                float[][] pcSquaredMagnitudes = new float[entry.pqCount][entry.pcentroidsCount];
+                for (int pq = 0; pq < entry.pqCount; pq++) {
+                    for (int c = 0; c < entry.pcentroidsCount; c++) {
+                        pcSquaredMagnitudes[pq][c] = byteBuffer.getFloat();
+                    }
+                }
+                return pcSquaredMagnitudes;
+            }
+
+            @Override
+            public int pcentroidsCount() {
+                return entry.pcentroidsCount;
+            }
+
+        };
+    }
+
+    @Override
+    public SortedDocValues getSorted(FieldInfo field) throws IOException {
+        return delegate.getSorted(field);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+        return delegate.getSortedNumeric(field);
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+        return delegate.getSortedSet(field);
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        delegate.checkIntegrity();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+        data.close();
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return delegate.ramBytesUsed();
+    }
+
+
+    private static class VectorBinaryEntry {
+        int dims;
+        int pqCount;
+        int pcentroidsCount;
+        long vectorsOffset;
+        long vectorsLength;
+        long centroidsOffset;
+        int centroidsLength;
+        long centroidsSquaredMagnitudeOffset;
+        int centroidsSquaredMagnitudeLength;
+        long docCentroidsOffset;
+        long docCentroidsLength;
+    }
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQDocValuesWriter.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/PQDocValuesWriter.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.codec;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.core.internal.io.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.MAX_PCENTROIDS_COUNT;
+import static org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.INT_BYTES;
+import static org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.KMEANS_ALGORITHM_LLOYDS;
+
+public class PQDocValuesWriter extends DocValuesConsumer implements Closeable {
+    private final SegmentWriteState state;
+    private final DocValuesConsumer delegate;
+    private final Random random;
+    private final BigArrays bigArrays;
+    private final int maxDoc;
+    private IndexOutput data, meta;
+
+    public PQDocValuesWriter(SegmentWriteState state, DocValuesConsumer delegate,
+            String dataCodec, String dataExtension, String metaCodec, String metaExtension) throws IOException {
+        this.state = state;
+        this.delegate = delegate;
+
+        this.random = new Random(42L);
+        this.bigArrays = BigArrays.NON_RECYCLING_INSTANCE;
+        this.maxDoc = state.segmentInfo.maxDoc();
+
+        boolean success = false;
+        try {
+            String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
+            data = state.directory.createOutput(dataName, state.context);
+            CodecUtil.writeIndexHeader(data, dataCodec, PQDocValuesFormat.VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+            String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
+            meta = state.directory.createOutput(metaName, state.context);
+            CodecUtil.writeIndexHeader(meta, metaCodec, PQDocValuesFormat.VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+        boolean success = false;
+        try {
+            if (meta != null) {
+                meta.writeInt(-1); // write EOF marker
+                CodecUtil.writeFooter(meta); // write checksum
+            }
+            if (data != null) {
+                CodecUtil.writeFooter(data); // write checksum
+            }
+            success = true;
+        } finally {
+            if (success) {
+                IOUtils.close(data, meta);
+            } else {
+                IOUtils.closeWhileHandlingException(data, meta);
+            }
+            meta = data = null;
+        }
+    }
+
+
+    // TODO: redesign for cases where NOT all docs have vector values
+    // TODO: handle deleted docs (don't write deleted docs)
+    @Override
+    public void addBinaryField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        String ann = field.attributes().get("ann");
+        if ((ann == null) || (ann.equals("pq") == false)) {
+            delegate.addBinaryField(field, valuesProducer);
+            return;
+        }
+
+        int dims = Integer.parseInt(field.attributes().get("dims"));
+        int pqCount = Integer.parseInt(field.attributes().get("pqCount")); // number of product quantizers
+        int kmeansAlgorithm = field.attributes().get("kmeansAlgorithm").equals(KMEANS_ALGORITHM_LLOYDS)? 1 : 2;
+        int numIters = Integer.parseInt(field.attributes().get("kmeansIters"));
+        float sampleFraction = Float.parseFloat(field.attributes().get("kmeansSampleFraction"));
+        int pcentroidsCount = (int) Math.sqrt(maxDoc); // number of product centroids in each product quantizer
+        if (pcentroidsCount > MAX_PCENTROIDS_COUNT) {
+            pcentroidsCount = MAX_PCENTROIDS_COUNT;
+        }
+
+        int pdims = dims/pqCount;
+        float[][][] pcentroids = new float[pqCount][pcentroidsCount][pdims];
+        ByteArray[] docCentroids = new ByteArray[pqCount];
+        DoubleArray[] docCentroidDists;
+        if (kmeansAlgorithm == 1) {
+            docCentroidDists = null;
+        } else {
+            docCentroidDists = new DoubleArray[pqCount];
+        }
+        KMeansClustering.runPQKMeansClustering(kmeansAlgorithm, valuesProducer, field, pcentroids, docCentroids,
+            docCentroidDists, pcentroidsCount, pqCount, pdims, numIters, sampleFraction);
+
+        meta.writeInt(field.number);
+        meta.writeInt(dims); // number of vector dims
+        meta.writeInt(pqCount); // number of product quantizers
+        meta.writeInt(pcentroidsCount); // number of product centroids in each product quantizer
+
+        // write original vectors
+        long start = data.getFilePointer();
+        meta.writeLong(start); // start of vectors
+        BinaryDocValues values = valuesProducer.getBinary(field);
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            BytesRef v = values.binaryValue();
+            data.writeBytes(v.bytes, v.offset, v.length);
+        }
+        meta.writeLong(data.getFilePointer() - start); // dataLength of vectors
+
+        // write centroids
+        start = data.getFilePointer();
+        meta.writeLong(start); // start of centroids
+        byte[] pcentroidBytes = new byte[pqCount * pcentroidsCount * pdims * INT_BYTES];
+        ByteBuffer pcentroidByteBuffer = ByteBuffer.wrap(pcentroidBytes);
+        float[][] pcSquaredMagnitudes = new float[pqCount][pcentroidsCount];
+        for (int pq = 0; pq < pqCount; pq++) {
+            for (int c = 0; c < pcentroidsCount; c++) {
+                for (int dim = 0; dim < pdims; dim++) {
+                    pcentroidByteBuffer.putFloat(pcentroids[pq][c][dim]);
+                    pcSquaredMagnitudes[pq][c] += pcentroids[pq][c][dim] * pcentroids[pq][c][dim];
+                }
+            }
+        }
+        data.writeBytes(pcentroidBytes, pcentroidBytes.length);
+        meta.writeInt((int) (data.getFilePointer() - start)); // dataLength of centroids
+
+        // write centroids' squared magnitudes
+        start = data.getFilePointer();
+        meta.writeLong(start); // start of centroids' squared magnitudes
+        byte[] pcSMdBytes = new byte[pqCount * pcentroidsCount * INT_BYTES];
+        ByteBuffer pcSMByteBuffer = ByteBuffer.wrap(pcSMdBytes);
+        for (int pq = 0; pq < pqCount; pq++) {
+            for (int c = 0; c < pcentroidsCount; c++) {
+                pcSMByteBuffer.putFloat(pcSquaredMagnitudes[pq][c]);
+            }
+        }
+        data.writeBytes(pcSMdBytes, pcSMdBytes.length);
+        meta.writeInt((int) (data.getFilePointer() - start)); // dataLength of centroids' squared magnitudes
+
+        // write docCentroids -- which centroid each document belongs to
+        start = data.getFilePointer();
+        meta.writeLong(start); // start of centroids
+        long numDocs = docCentroids[0].size();
+        for (int i = 0; i < numDocs; i++) {
+            for (int pq = 0; pq < pqCount; pq++) {
+                data.writeByte(docCentroids[pq].get(i));
+            }
+        }
+        meta.writeLong(data.getFilePointer() - start); // dataLength of docCentroids
+    }
+
+    @Override
+    public void addNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        delegate.addNumericField(field, valuesProducer);
+    }
+
+    @Override
+    public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        delegate.addSortedField(field, valuesProducer);
+    }
+
+    @Override
+    public void addSortedNumericField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        delegate.addSortedNumericField(field, valuesProducer);
+    }
+
+    @Override
+    public void addSortedSetField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
+        delegate.addSortedSetField(field, valuesProducer);
+    }
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/VectorDocValues.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/codec/VectorDocValues.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
+public abstract class VectorDocValues extends BinaryDocValues {
+    final int maxDoc;
+    int doc = -1;
+
+    VectorDocValues(int maxDoc) {
+        this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public long cost() {
+        return maxDoc;
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        if (target >= maxDoc) {
+            return doc = NO_MORE_DOCS;
+        }
+        return doc = target;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        doc = target;
+        return true;
+    }
+
+    /*
+     * get product centroids computed for all documents in this segment
+     */
+    public abstract float[][][] pcentroids () throws IOException;
+
+    /*
+     * get squared magnitudes of the product centroids computed for all documents in this segment
+     */
+    public abstract float[][] pCentroidsSquaredMagnitudes() throws IOException;
+
+    /*
+     * get number of product centroids in each product quantizer for this segment
+     */
+    public abstract int pcentroidsCount();
+
+
+    /*
+     * get a binary value of the product centroids that the current document belongs to
+     */
+    public abstract BytesRef docCentroids() throws IOException;
+
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/AnnPQQuery.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/AnnPQQuery.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.vectors.codec.VectorDocValues;
+import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.DenseVectorFieldType;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+
+public class AnnPQQuery extends Query {
+    final DenseVectorFieldType fieldType;
+    final float[] queryVector;
+    final int pqCount;
+    final int pdims;
+    final float[] qSquareMagnitudes;
+
+    public AnnPQQuery(DenseVectorFieldType fieldType, float[] queryVector) {
+        this.fieldType = fieldType;
+        this.queryVector = queryVector;
+        this.pqCount = fieldType.pqCount();
+        this.pdims = fieldType.dims()/pqCount; // number of dimensions in each product centroid
+
+        // calculate query square magnitudes broken by quantizers
+        this.qSquareMagnitudes = new float[pqCount];
+        for (int pq = 0; pq < pqCount; pq++) {
+            for (int dim = pq * pdims; dim < (pq * pdims + pdims); dim++) {
+                qSquareMagnitudes[pq] += queryVector[dim] * queryVector[dim];
+            }
+        }
+    }
+
+    //TODO: handle deleted docs, intersect live docs with vectordocValues
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new Weight(this) {
+            @Override
+            public void extractTerms(Set<Term> terms) {}
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                final VectorDocValues values = (VectorDocValues) context.reader().getBinaryDocValues(fieldType.name());
+                return new ANNPQScorer(this, values);
+            }
+
+            @Override
+            public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                return null;
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return true;
+            }
+        };
+    }
+
+    private class ANNPQScorer extends Scorer {
+        private final VectorDocValues values;
+        private final float[][] cqDistances; // squared distances between queryVector and all product centroids
+
+        private ANNPQScorer(Weight w, VectorDocValues values) throws IOException {
+            super(w);
+            this.values = values;
+
+            // precalculate squared distances between queryVector and all product centroids
+            // we use euclidean distance for this
+            // ((c1-q1)^2 + (c2-q2)^2 ...) can be converted to (||c||^2 + ||q||^2 - 2*c*q)
+            // where ||c||^2 -- squared magnitude of product centroid
+            // where ||q||^2 -- squared magnitude of query vector
+            float[][][] pCentroids = values.pcentroids();
+            float[][] pcSquaredMagnitudes = values.pCentroidsSquaredMagnitudes();
+            int pcentroidsCount = values.pcentroidsCount();
+
+            this.cqDistances = new float[pqCount][pcentroidsCount];
+            for (int pq = 0; pq < pqCount; pq++) {
+                for (int c = 0; c < pcentroidsCount; c++) {
+                    float dotProduct = 0;
+                    for (int dim = 0; dim < pdims; dim++) {
+                        dotProduct += queryVector[pq * pdims + dim] * pCentroids[pq][c][dim];
+                    }
+                    cqDistances[pq][c] = pcSquaredMagnitudes[pq][c] + qSquareMagnitudes[pq] - 2 * dotProduct;
+                }
+            }
+        }
+
+        @Override
+        public final int docID() {
+            return values.docID();
+        }
+
+        @Override
+        public float score() throws IOException {
+            BytesRef valueBR = values.docCentroids();
+            int offset = valueBR.offset;
+            float score = 0;
+            for (int i = 0; i < pqCount; i++) {
+                int docCentroid = valueBR.bytes[offset++] & 0xFF; // centroids are stored as unsigned bytes
+                score += cqDistances[i][docCentroid];
+            }
+            score = 1/score; // as we want to get closest vectors fist, score is inversely proportional to distance
+            return score;
+        }
+
+        @Override
+        public final DocIdSetIterator iterator() {
+            return values;
+        }
+
+        @Override
+        public float getMaxScore(int upTo) {
+            return Float.MAX_VALUE;
+        }
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        AnnPQQuery other = (AnnPQQuery) obj;
+        return Objects.equals(fieldType, other.fieldType)
+            && Arrays.equals(queryVector, other.queryVector);
+    }
+
+    @Override
+    public String toString(String field) {
+        String s = "annpq  (field:" + fieldType.name() + ")";
+        return s;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldType.hashCode(), Arrays.hashCode(queryVector));
+    }
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/AnnPQQueryBuilder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/AnnPQQueryBuilder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.query;
+
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
+import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.DenseVectorFieldType;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * A query that finds approximate nearest neighbours based on product quantization and kmeans clustering
+ */
+public class AnnPQQueryBuilder extends AbstractQueryBuilder<AnnPQQueryBuilder> {
+
+    public static final String NAME = "ann_pq";
+    public static final ParseField FIELD_FIELD = new ParseField("field");
+    public static final ParseField QUERY_VECTOR_FIELD = new ParseField("query_vector");
+
+
+    private static ConstructingObjectParser<AnnPQQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME, false,
+        args -> {
+            @SuppressWarnings("unchecked") List<Float> qvList = (List<Float>) args[1];
+            float[] qv = new float[qvList.size()];
+            int i = 0;
+            for (Float f : qvList) {
+                qv[i++] = f;
+            };
+            AnnPQQueryBuilder AnnQueryBuilder = new AnnPQQueryBuilder((String) args[0], qv);
+            return AnnQueryBuilder;
+        });
+
+    static {
+        PARSER.declareString(constructorArg(), FIELD_FIELD);
+        PARSER.declareFloatArray(constructorArg(), QUERY_VECTOR_FIELD);
+    }
+
+    public static AnnPQQueryBuilder fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final String field;
+    private final float[] queryVector;
+
+    public AnnPQQueryBuilder(String field, float[] queryVector) {
+        this.field = field;
+        this.queryVector = queryVector;
+    }
+
+    public AnnPQQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        field = in.readString();
+        queryVector = in.readFloatArray();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(field);
+        out.writeFloatArray(queryVector);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(FIELD_FIELD.getPreferredName(), field);
+        builder.field(QUERY_VECTOR_FIELD.getPreferredName(), queryVector);
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected boolean doEquals(AnnPQQueryBuilder other) {
+        return this.field.equals(other.field) &&
+            Arrays.equals(this.queryVector, other.queryVector);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.field, this.queryVector);
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        MappedFieldType fieldType = context.getMapperService().fullName(field);
+        if ((fieldType instanceof DenseVectorFieldType) == false ){
+            throw new IllegalArgumentException("Field [" + field +
+                "] is not of the expected type of [" + DenseVectorFieldMapper.CONTENT_TYPE + "]");
+        }
+        DenseVectorFieldType dfieldType = (DenseVectorFieldType) fieldType;
+        if (dfieldType.ann().equals("pq") == false) {
+            throw new IllegalArgumentException("Field [" + field + "] is not indexed with product quantization!");
+        }
+        return new AnnPQQuery(dfieldType,queryVector);
+    }
+
+}

--- a/x-pack/plugin/vectors/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/x-pack/plugin/vectors/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,0 +1,1 @@
+org.elasticsearch.xpack.vectors.codec.PQCodec

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/PQCodecTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/mapper/PQCodecTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+
+package org.elasticsearch.xpack.vectors.mapper;
+
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.vectors.Vectors;
+import org.elasticsearch.xpack.vectors.query.AnnPQQueryBuilder;
+
+import java.util.Collection;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+
+public class PQCodecTests extends ESSingleNodeTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(Vectors.class, LocalStateCompositeXPackPlugin.class);
+    }
+
+    public void testPQKMeans() throws Exception {
+        Settings indexSettings = Settings.builder()
+            .put("number_of_shards", 1)
+            .put("number_of_replicas", 0)
+            .put("index.codec", "ProductQuantizationCodec")
+            .build();
+
+        createIndex("index", indexSettings);
+        client().admin().indices().preparePutMapping("index")
+            .setSource(XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("_doc")
+                .startObject("properties")
+                .startObject("my_vector")
+                .field("type", "dense_vector")
+                .field("dims", 4)
+                .field("ann", "pq")
+                .field("product_quantizers_count", 2)
+                .field("kmeans_algorithm", "lloyds")
+                .field("kmeans_iters", 5)
+                .field("kmeans_sample_fraction", 1.0)
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject())
+            .get();
+
+        BulkRequestBuilder requestBuilder =  client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        float[] vector = new float[4];
+        for (int i = 1; i <= 1024; i++) {
+            for (int dim = 0; dim < 4; dim++) {
+                vector[dim] = randomIntBetween(0, 100);
+            }
+            requestBuilder.add(client().prepareIndex("index").setId(Integer.toString(i)).setSource("my_vector", vector));
+        }
+        requestBuilder.get();
+
+        GetResponse response = client().prepareGet("index", "1").get();
+        assertTrue(response.isExists());
+
+        float[] queryVector = new float[4];
+        for (int dim = 0; dim < 4; dim++) {
+            queryVector[dim] = randomIntBetween(0, 100);
+        }
+        SearchResponse searchResponse = client().prepareSearch("index")
+            .setQuery(new AnnPQQueryBuilder("my_vector", queryVector)).setSize(5).get();
+        assertNoFailures(searchResponse);
+    }
+}


### PR DESCRIPTION
Based on paper:
Jegou, Herve, Matthijs Douze, and Cordelia Schmid.
"Product quantization for nearest neighbor search." 2010

## Indexing
```js
PUT /my_index
{
  "settings": {
    "index": {
      "codec": "ProductQuantizationCodec"
    }
  },
  "mappings": {
    "properties": {
      "my_vector": {
        "type": "dense_vector",
        "dims": 512,
        "ann": "pq",
        "product_quantizers_count": 64,
        "kmeans_algorithm": "lloyds",
        "kmeans_iters": 5,
        "kmeans_sample_fraction": 0.5
      }
    }
  }
}

POST /my_index/_forcemerge?max_num_segments=1

```
## Querying
```js
GET /my_index/_search
{
  "size": 10,
  "_source": false,
  "query": {
    "ann_pq": {
      "field": "my_vector",
      "query_vector": [0.1,0.234,..]
    }
  }
}
```
##  Querying with rescroring
```js
GET /my_index/_search
{
  "size": 10,
  "_source": false,
  "query": {
    "ann_pq": {
      "field": "my_vector",
      "query_vector": [0.1, 0.234,...]
    }
  },
  "rescore": {
    "window_size": 100,
    "query": {
      "rescore_query": {
        "script_score": {
          "query": {
            "match_all": {}
          },
          "script": {
            "source": "1/(1 + l2norm(params.query_vector, 'my_vector'))",
            "params": {
              "query_vector":[0.1, 0.234, ...]
            }
          }
        }
      },
      "query_weight": 0,
      "rescore_query_weight": 1
    }
  }
}

```
Relates to #42326