### PR TITLE
[DOCS] Fixes indentation in inference processor code snippet

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -24,12 +24,12 @@ include::common-options.asciidoc[]
 --------------------------------------------------
 {
   "inference": {
-      "model_id": "flight_delay_regression-1571767128603",
-      "target_field": "FlightDelayMin_prediction_infer",
-      "field_mappings": {},
-      "inference_config": {"regression": {}},
-      "model_info_field": "ml"
-    }
+    "model_id": "flight_delay_regression-1571767128603",
+    "target_field": "FlightDelayMin_prediction_infer",
+    "field_mappings": {},
+    "inference_config": { "regression": {} },
+    "model_info_field": "ml"
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE
@@ -67,16 +67,16 @@ Specifies the field to which the top classes are written. Defaults to
 
 [discrete]
 [[inference-processor-config-example]]
-==== `inference_config` examples
+==== `inference` examples
 
 [source,js]
 --------------------------------------------------
 {
-  "inference_config": {
-    “regression”: {
-    “results_field”: “my_regression”
+  "inference": {
+    "regression": {
+      "results_field": "my_regression"
     }
-  },
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE
@@ -89,13 +89,13 @@ object.
 [source,js]
 --------------------------------------------------
 {
-  "inference_config": {
-    “classification”: {
-      “num_top_classes”: 2, 
-      “results_field”: “prediction”, 
-      “top_classes_results_field”: “probabilities”
-      }
+  "inference": {
+    "classification": {
+      "num_top_classes": 2,
+      "results_field": "prediction",
+      "top_classes_results_field": "probabilities"
     }
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -67,12 +67,12 @@ Specifies the field to which the top classes are written. Defaults to
 
 [discrete]
 [[inference-processor-config-example]]
-==== `inference` examples
+==== `inference_config` examples
 
 [source,js]
 --------------------------------------------------
 {
-  "inference": {
+  "inference_config": {
     "regression": {
       "results_field": "my_regression"
     }
@@ -89,7 +89,7 @@ object.
 [source,js]
 --------------------------------------------------
 {
-  "inference": {
+  "inference_config": {
     "classification": {
       "num_top_classes": 2,
       "results_field": "prediction",

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -12,7 +12,7 @@ ingested in the pipeline.
 [options="header"]
 |======
 | Name               | Required  | Default                        | Description
-| `model_id`      | yes       | -                              | (String) The ID of the model to load and infer against.
+| `model_id`         | yes       | -                              | (String) The ID of the model to load and infer against.
 | `target_field`     | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
 | `field_mappings`   | yes       | -                              | (Object) Maps the document field names to the known field names of the model.
 | `inference_config` | yes       | -                              | (Object) Contains the inference type and its options. There are two types: <<inference-processor-regression-opt,`regression`>> and <<inference-processor-classification-opt,`classification`>>.
@@ -23,12 +23,12 @@ include::common-options.asciidoc[]
 [source,js]
 --------------------------------------------------
 {
-  	"inference": {
-      	"model_id": "flight_delay_regression-1571767128603",
-      	"target_field": "FlightDelayMin_prediction_infer",
-      	"field_mappings": {},
-      	"inference_config": {"regression": {}},
-      	"model_info_field": "ml"
+  "inference": {
+      "model_id": "flight_delay_regression-1571767128603",
+      "target_field": "FlightDelayMin_prediction_infer",
+      "field_mappings": {},
+      "inference_config": {"regression": {}},
+      "model_info_field": "ml"
     }
 }
 --------------------------------------------------


### PR DESCRIPTION
This PR fixes a wrongly indented line in a code snippet.

Preview available here: http://elasticsearch_51252.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-processor.html