### PR TITLE
[DOCS] Fixes create dataframe analytics job API example

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -392,7 +392,7 @@ The API returns the following result:
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "7.5.0"/"version": $body.version/]
+// TESTRESPONSE[s/"version": "7.5.2"/"version": $body.version/]
 
 
 [[ml-put-dfanalytics-example-r]]


### PR DESCRIPTION
This PR addresses a failure in the code snippet testing in the following page:
https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html

The example was checking for a mismatched version of the product.