### PR TITLE
[DOCS] Document node stats response meta

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -143,8 +143,8 @@ Name of the cluster. Based on the <<cluster.name>> setting.
 
 `nodes.<node_id>.timestamp`::
 (integer)
-Last time the node statistics were refreshed. Recorded in milliseconds since the
-https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
+Time the node stats were collected for this response. Recorded in milliseconds
+since the https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
 
 `nodes.<node_id>.name`::
 (string)

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -167,19 +167,9 @@ IP address and port for the node.
 (array of strings)
 Roles assigned to the node. See <<modules-node>>.
 
-`nodes.<node_id>.attributes.ml.machine_memory`::
-(string)
-Total bytes of memory used for {ml-docs}/index.html[machine learning].
-
-`nodes.<node_id>.attributes.xpack.installed`::
-(string)
-If `true`, X-Pack features are enabled. See <<license-settings>>.
-
-`nodes.<node_id>.attributes.ml.max_open_jobs`::
-(string)
-Maximum number of {ml-docs}/index.html[machine learning] jobs that can run
-simultaneously on the node. Based on the
-<<xpack.ml.max_open_jobs,xpack.ml.max_open_jobs>> setting.
+`nodes.<node_id>.attributes`::
+(object)
+Object containing a list of attributes for the node.
 
 [NOTE]
 ====

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -152,7 +152,8 @@ Human-readable identifier for the node. Based on the <<node.name>> setting.
 
 `nodes.<node_id>.transport_address`::
 (string)
-Host and port where HTTP connections for the node are accepted.
+Host and port for the <<modules-transport,transport layer>>, used for internal
+communication between nodes in a cluster.
 
 `nodes.<node_id>.host`::
 (string)

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -137,6 +137,54 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=include-segment-file-sizes]
 [[cluster-nodes-stats-api-response-body]]
 ==== {api-response-body-title}
 
+`cluster_name`::
+(string)
+Name of the cluster. Based on the <<cluster.name>> setting.
+
+`nodes.<node_id>.timestamp`::
+(integer)
+Last time the node statistics were refreshed. Recorded in milliseconds since the
+https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
+
+`nodes.<node_id>.name`::
+(string)
+Human-readable identifier for the node. Based on the <<node.name>> setting.
+
+`nodes.<node_id>.transport_address`::
+(string)
+Host and port where HTTP connections for the node are accepted.
+
+`nodes.<node_id>.host`::
+(string)
+Network host for the node, based on the <<network.host>> setting.
+
+`nodes.<node_id>.ip`::
+(string)
+IP address and port for the node.
+
+`nodes.<node_id>.roles`::
+(array of strings)
+Roles assigned to the node. See <<modules-node>>.
+
+`nodes.<node_id>.attributes.ml.machine_memory`::
+(string)
+Total bytes of memory used for {ml-docs}/index.html[machine learning].
+
+`nodes.<node_id>.attributes.xpack.installed`::
+(string)
+If `true`, X-Pack features are enabled. See <<license-settings>>.
+
+`nodes.<node_id>.attributes.ml.max_open_jobs`::
+(string)
+Maximum number of {ml-docs}/index.html[machine learning] jobs that can run
+simultaneously on the node. Based on the
+<<xpack.ml.max_open_jobs,xpack.ml.max_open_jobs>> setting.
+
+[NOTE]
+====
+The remaining node statistics are grouped by section. Each statistic is keyed by `nodes.<node_id>`.
+====
+
 [[cluster-nodes-stats-api-response-body-indices]]
 ===== `indices` section
 
@@ -475,8 +523,8 @@ for <<parent-join,join>> fields.
 
 `indices.segments.max_unsafe_auto_id_timestamp`::
 (integer)
-Timestamp of the
-most recent retry request.
+Time of the most recently retried indexing request. Recorded in milliseconds
+since the https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
 
 `indices.segments.file_sizes.size_in_bytes`::
 (integer)
@@ -1120,8 +1168,6 @@ Number of compatible differences between published cluster states.
 
 [%collapsible]
 ====
-The `adaptive_selection` statistics are keyed by node. For each node:
-
 `adaptive_selection.outgoing_searches`::
     The number of outstanding search requests from the node these stats are for 
     to the keyed node.

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -83,6 +83,7 @@ that is greater than this setting value, an error occurs. Existing jobs are not
 affected when you update this setting. For more information about the
 `model_memory_limit` property, see <<put-analysislimits>>.
 
+[[xpack.ml.max_open_jobs]]
 `xpack.ml.max_open_jobs` (<<cluster-update-settings,Dynamic>>)::
 The maximum number of jobs that can run simultaneously on a node. Defaults to
 `20`. In this context, jobs include both {anomaly-jobs} and {dfanalytics-jobs}. 


### PR DESCRIPTION
Documents several metadata-related parameters returned by the `GET _nodes/stats` API.

Also adds a note indicated that stats in other sections are keyed by `nodes.<node_id>`.