### PR TITLE
[DOCS] More fixes for create dataframe analytics job API example

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -392,7 +392,7 @@ The API returns the following result:
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "7.5.2"/"version": $body.version/]
+// TESTRESPONSE[s/"version" : "7.5.2"/"version" : $body.version/]
 
 
 [[ml-put-dfanalytics-example-r]]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/51262, which was accidentally merged before all of the build check failures were addressed.