### PR TITLE
Use Math.fma function in vector computations

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/ScoreScriptUtils.java
@@ -49,7 +49,7 @@ public class ScoreScriptUtils {
             for (int i = 0; i < queryVector.size(); i++) {
                 float value = queryVector.get(i).floatValue();
                 this.queryVector[i] = value;
-                queryMagnitude += value * value;
+                queryMagnitude = Math.fma(value, value, queryMagnitude);
             }
             queryMagnitude = Math.sqrt(queryMagnitude);
 
@@ -116,7 +116,7 @@ public class ScoreScriptUtils {
             double l2norm = 0;
             for (float queryValue : queryVector) {
                 double diff = queryValue - byteBuffer.getFloat();
-                l2norm += diff * diff;
+                l2norm = Math.fma(diff, diff, l2norm);
             }
             return Math.sqrt(l2norm);
         }
@@ -135,7 +135,7 @@ public class ScoreScriptUtils {
 
             double dotProduct = 0;
             for (float queryValue : queryVector) {
-                dotProduct += queryValue * byteBuffer.getFloat();
+                dotProduct = Math.fma(queryValue, byteBuffer.getFloat(), dotProduct);
             }
             return dotProduct;
         }
@@ -156,14 +156,14 @@ public class ScoreScriptUtils {
             double vectorMagnitude = 0.0f;
             if (scoreScript._getIndexVersion().onOrAfter(Version.V_7_5_0)) {
                 for (float queryValue : queryVector) {
-                    dotProduct += queryValue * byteBuffer.getFloat();
+                    dotProduct = Math.fma(queryValue, byteBuffer.getFloat(), dotProduct);
                 }
                 vectorMagnitude = VectorEncoderDecoder.decodeVectorMagnitude(scoreScript._getIndexVersion(), vector);
             } else {
                 for (float queryValue : queryVector) {
                     float docValue = byteBuffer.getFloat();
-                    dotProduct += queryValue * docValue;
-                    vectorMagnitude += docValue * docValue;
+                    dotProduct = Math.fma(queryValue, docValue, dotProduct);
+                    vectorMagnitude = Math.fma(docValue, docValue, vectorMagnitude);
                 }
                 vectorMagnitude = (float) Math.sqrt(vectorMagnitude);
             }

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/DenseVectorFunctionTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/DenseVectorFunctionTests.java
@@ -60,7 +60,7 @@ public class DenseVectorFunctionTests extends ESTestCase {
     private void testDotProduct(ScoreScript scoreScript) {
         DotProduct function = new DotProduct(scoreScript, queryVector, field);
         double result = function.dotProduct();
-        assertEquals("dotProduct result is not equal to the expected value!", 65425.624, result, 0.001);
+        assertEquals("dotProduct result is not equal to the expected value!", 65425.627, result, 0.001);
 
         DotProduct invalidFunction = new DotProduct(scoreScript, invalidQueryVector, field);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, invalidFunction::dotProduct);


### PR DESCRIPTION
Math.fma function provides higher precision for
<a * b + c> computations, and also seems to be
slightly more efficient.