### PR TITLE
[7.x] Truncate SAML Response in trace log (#51237)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticator.java
@@ -68,7 +68,8 @@ class SamlAuthenticator extends SamlRequestHandler {
             try {
                 return authenticateResponse(root, token.getAllowedSamlRequestIds());
             } catch (ElasticsearchSecurityException e) {
-                logger.trace("Rejecting SAML response {} because {}", SamlUtils.toString(root), e.getMessage());
+                logger.trace("Rejecting SAML response [{}...] because {}", Strings.cleanTruncate(SamlUtils.toString(root), 512),
+                    e.getMessage());
                 throw e;
             }
         } else {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Truncate SAML Response in trace log (#51237)