### PR TITLE
[7.6][ML] Validate classification dependent_variable cardinality is a…

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -245,9 +245,9 @@ public class Classification implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Long> getFieldCardinalityLimits() {
+    public List<FieldCardinalityConstraint> getFieldCardinalityConstraints() {
         // This restriction is due to the fact that currently the C++ backend only supports binomial classification.
-        return Collections.singletonMap(dependentVariable, 2L);
+        return Collections.singletonList(FieldCardinalityConstraint.between(dependentVariable, 2, 2));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -37,9 +37,9 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
     List<RequiredField> getRequiredFields();
 
     /**
-     * @return {@link Map} containing cardinality limits for the selected (analysis-specific) fields
+     * @return {@link List} containing cardinality constraints for the selected (analysis-specific) fields
      */
-    Map<String, Long> getFieldCardinalityLimits();
+    List<FieldCardinalityConstraint> getFieldCardinalityConstraints();
 
     /**
      * Returns fields for which the mappings should be either predefined or copied from source index to destination index.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/FieldCardinalityConstraint.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/FieldCardinalityConstraint.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.dataframe.analyses;
+
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+
+import java.util.Objects;
+
+/**
+ * Allows checking a field's cardinality against given lower and upper bounds
+ */
+public class FieldCardinalityConstraint {
+
+    private final String field;
+    private final long lowerBound;
+    private final long upperBound;
+
+    public static FieldCardinalityConstraint between(String field, long lowerBound, long upperBound) {
+        return new FieldCardinalityConstraint(field, lowerBound, upperBound);
+    }
+
+    private FieldCardinalityConstraint(String field, long lowerBound, long upperBound) {
+        this.field = Objects.requireNonNull(field);
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public long getLowerBound() {
+        return lowerBound;
+    }
+
+    public long getUpperBound() {
+        return upperBound;
+    }
+
+    public void check(long fieldCardinality) {
+        if (fieldCardinality < lowerBound) {
+            throw ExceptionsHelper.badRequestException(
+                                    "Field [{}] must have at least [{}] distinct values but there were [{}]",
+                                    field, lowerBound, fieldCardinality);
+        }
+        if (fieldCardinality > upperBound) {
+            throw ExceptionsHelper.badRequestException(
+                "Field [{}] must have at most [{}] distinct values but there were at least [{}]",
+                field, upperBound, fieldCardinality);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -225,8 +225,8 @@ public class OutlierDetection implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Long> getFieldCardinalityLimits() {
-        return Collections.emptyMap();
+    public List<FieldCardinalityConstraint> getFieldCardinalityConstraints() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -182,8 +182,8 @@ public class Regression implements DataFrameAnalysis {
     }
 
     @Override
-    public Map<String, Long> getFieldCardinalityLimits() {
-        return Collections.emptyMap();
+    public List<FieldCardinalityConstraint> getFieldCardinalityConstraints() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/ClassificationTests.java
@@ -22,6 +22,7 @@ import org.hamcrest.Matchers;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -169,7 +170,13 @@ public class ClassificationTests extends AbstractSerializingTestCase<Classificat
     }
 
     public void testFieldCardinalityLimitsIsNonEmpty() {
-        assertThat(createTestInstance().getFieldCardinalityLimits(), is(not(anEmptyMap())));
+        Classification classification = createTestInstance();
+        List<FieldCardinalityConstraint> constraints = classification.getFieldCardinalityConstraints();
+
+        assertThat(constraints.size(), equalTo(1));
+        assertThat(constraints.get(0).getField(), equalTo(classification.getDependentVariable()));
+        assertThat(constraints.get(0).getLowerBound(), equalTo(2L));
+        assertThat(constraints.get(0).getUpperBound(), equalTo(2L));
     }
 
     public void testGetExplicitlyMappedFields() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/FieldCardinalityConstraintTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/FieldCardinalityConstraintTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.dataframe.analyses;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldCardinalityConstraintTests extends ESTestCase {
+
+    public void testBetween_GivenWithinLimits() {
+        FieldCardinalityConstraint constraint = FieldCardinalityConstraint.between("foo", 3, 6);
+
+        constraint.check(3);
+        constraint.check(4);
+        constraint.check(5);
+        constraint.check(6);
+    }
+
+    public void testBetween_GivenLessThanLowerBound() {
+        FieldCardinalityConstraint constraint = FieldCardinalityConstraint.between("foo", 3, 6);
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> constraint.check(2L));
+        assertThat(e.getMessage(), equalTo("Field [foo] must have at least [3] distinct values but there were [2]"));
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+    }
+
+    public void testBetween_GivenGreaterThanUpperBound() {
+        FieldCardinalityConstraint constraint = FieldCardinalityConstraint.between("foo", 3, 6);
+
+        ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> constraint.check(7L));
+        assertThat(e.getMessage(), equalTo("Field [foo] must have at most [6] distinct values but there were at least [7]"));
+        assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -89,7 +89,7 @@ public class OutlierDetectionTests extends AbstractSerializingTestCase<OutlierDe
     }
 
     public void testFieldCardinalityLimitsIsEmpty() {
-        assertThat(createTestInstance().getFieldCardinalityLimits(), is(anEmptyMap()));
+        assertThat(createTestInstance().getFieldCardinalityConstraints(), is(empty()));
     }
 
     public void testGetExplicitlyMappedFields() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -107,7 +106,7 @@ public class RegressionTests extends AbstractSerializingTestCase<Regression> {
     }
 
     public void testFieldCardinalityLimitsIsEmpty() {
-        assertThat(createTestInstance().getFieldCardinalityLimits(), is(anEmptyMap()));
+        assertThat(createTestInstance().getFieldCardinalityConstraints(), is(empty()));
     }
 
     public void testGetExplicitlyMappedFields() {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
@@ -43,7 +43,11 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
         String sourceIndex = "test-source-query-is-applied";
 
         client().admin().indices().prepareCreate(sourceIndex)
-            .addMapping("_doc", "numeric_1", "type=double", "numeric_2", "type=float", "categorical", "type=keyword")
+            .addMapping("_doc",
+                "numeric_1", "type=double",
+                "numeric_2", "type=float",
+                "categorical", "type=keyword",
+                "filtered_field", "type=keyword")
             .get();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
@@ -51,9 +55,11 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
 
         for (int i = 0; i < 30; i++) {
             IndexRequest indexRequest = new IndexRequest(sourceIndex);
-
-            // We insert one odd value out of 5 for one feature
-            indexRequest.source("numeric_1", 1.0, "numeric_2", 2.0, "categorical", i == 0 ? "only-one" : "normal");
+            indexRequest.source(
+                "numeric_1", 1.0,
+                "numeric_2", 2.0,
+                "categorical", i % 2 == 0 ? "class_1" : "class_2",
+                "filtered_field", i < 2 ? "bingo" : "rest"); // We tag bingo on the first two docs to ensure we have 2 classes
             bulkRequestBuilder.add(indexRequest);
         }
         BulkResponse bulkResponse = bulkRequestBuilder.get();
@@ -66,7 +72,7 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder()
             .setId(id)
             .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex },
-                QueryProvider.fromParsedQuery(QueryBuilders.termQuery("categorical", "only-one")),
+                QueryProvider.fromParsedQuery(QueryBuilders.termQuery("filtered_field", "bingo")),
                 null))
             .setAnalysis(new Classification("categorical"))
             .buildForExplain();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -19,6 +19,7 @@ import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.FieldCardinalityConstraint;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.RequiredField;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Types;
 import org.elasticsearch.xpack.core.ml.dataframe.explain.FieldSelection;
@@ -284,15 +285,8 @@ public class ExtractedFieldsDetector {
     }
 
     private void checkFieldsWithCardinalityLimit() {
-        for (Map.Entry<String, Long> entry : config.getAnalysis().getFieldCardinalityLimits().entrySet()) {
-            String fieldName = entry.getKey();
-            long limit = entry.getValue();
-            long cardinality = fieldCardinalities.get(fieldName);
-            if (cardinality > limit) {
-                throw ExceptionsHelper.badRequestException(
-                        "Field [{}] must have at most [{}] distinct values but there were at least [{}]",
-                        fieldName, limit, cardinality);
-            }
+        for (FieldCardinalityConstraint constraint : config.getAnalysis().getFieldCardinalityConstraints()) {
+            constraint.check(fieldCardinalities.get(constraint.getField()));
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -109,9 +109,6 @@ public class AnalyticsProcessManager {
                 }
             }
 
-            // Refresh the dest index to ensure data is searchable
-            refreshDest(config);
-
             // Fetch existing model state (if any)
             BytesReference state = getModelState(config);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -560,8 +560,13 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("some_integer", "integer")
             .build();
 
+        Map<String, Long> fieldCardinalities = new HashMap<>(2);
+        fieldCardinalities.put("some_boolean", 2L);
+        fieldCardinalities.put("some_integer", 2L);
+
+
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
-            SOURCE_INDEX, config, 100, fieldCapabilities, config.getAnalysis().getFieldCardinalityLimits());
+            SOURCE_INDEX, config, 100, fieldCapabilities, fieldCardinalities);
         Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
 
         List<ExtractedField> allFields = fieldExtraction.v1().getAllFields();

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_data_frame_analytics.yml
@@ -142,7 +142,7 @@
         id: "start_given_empty_dest_index"
 
 ---
-"Test start classification analysis when the dependent variable cardinality is too high":
+"Test start classification analysis when the dependent variable cardinality is too low or too high":
   - do:
       indices.create:
         index: index-with-dep-var-with-too-high-card
@@ -153,9 +153,32 @@
               keyword_field: { type: "keyword" }
 
   - do:
+      ml.put_data_frame_analytics:
+        id: "classification-cardinality-limits"
+        body: >
+          {
+            "source": {
+              "index": "index-with-dep-var-with-too-high-card"
+            },
+            "dest": {
+              "index": "index-with-dep-var-with-too-high-card-dest"
+            },
+            "analysis": { "classification": { "dependent_variable": "keyword_field" } }
+          }
+
+  - do:
       index:
         index: index-with-dep-var-with-too-high-card
         body: { numeric_field: 1.0, keyword_field: "class_a" }
+
+  - do:
+      indices.refresh:
+        index: index-with-dep-var-with-too-high-card
+
+  - do:
+      catch: /Field \[keyword_field\] must have at least \[2\] distinct values but there were \[1\]/
+      ml.start_data_frame_analytics:
+        id: "classification-cardinality-limits"
 
   - do:
       index:
@@ -172,20 +195,6 @@
         index: index-with-dep-var-with-too-high-card
 
   - do:
-      ml.put_data_frame_analytics:
-        id: "too-high-card"
-        body: >
-          {
-            "source": {
-              "index": "index-with-dep-var-with-too-high-card"
-            },
-            "dest": {
-              "index": "index-with-dep-var-with-too-high-card-dest"
-            },
-            "analysis": { "classification": { "dependent_variable": "keyword_field" } }
-          }
-
-  - do:
       catch: /Field \[keyword_field\] must have at most \[2\] distinct values but there were at least \[3\]/
       ml.start_data_frame_analytics:
-        id: "too-high-card"
+        id: "classification-cardinality-limits"


### PR DESCRIPTION
…t lea… (#51232)

Data frame analytics classification currently only supports 2 classes for the
dependent variable. We were checking that the field's cardinality is not higher
than 2 but we should also check it is not less than that as otherwise the process
fails.

Backport of #51232
