### PR TITLE
[7.x] Always test against default distribution when in a FIPS JVM

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -34,6 +34,8 @@ import org.elasticsearch.gradle.precommit.PrecommitTasks
 import org.elasticsearch.gradle.test.ErrorReportingTestListener
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin
+import org.elasticsearch.gradle.testclusters.TestDistribution
+import org.elasticsearch.gradle.tool.Boilerplate
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
@@ -158,6 +160,7 @@ class BuildPlugin implements Plugin<Project> {
                         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = project.extensions.findByName(TestClustersPlugin.EXTENSION_NAME) as NamedDomainObjectContainer<ElasticsearchCluster>
                         if (testClusters != null) {
                             testClusters.all { ElasticsearchCluster cluster ->
+                                cluster.setTestDistribution(TestDistribution.DEFAULT)
                                 cluster.systemProperty 'javax.net.ssl.trustStorePassword', 'password'
                                 cluster.systemProperty 'javax.net.ssl.keyStorePassword', 'password'
                                 // Can't use our DiagnosticTrustManager with SunJSSE in FIPS mode

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -1,9 +1,18 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 // Subprojects aren't published so do not assemble
 gradle.projectsEvaluated {
   subprojects {
     Task assemble = project.tasks.findByName('assemble')
     if (assemble) {
       assemble.enabled = false
+    }
+
+    // Disable example project testing with FIPS JVM
+    tasks.withType(Test) {
+      onlyIf {
+        BuildParams.inFipsJvm == false
+      }
     }
   }
 }


### PR DESCRIPTION
Backport of #51273