### PR TITLE
Add openjdk 15 to Java matrix testing rotation

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -9,6 +9,7 @@ ES_RUNTIME_JAVA:
   - java11
   - openjdk13
   - openjdk14
+  - openjdk15
   - zulu11
   - corretto11
   - adoptopenjdk11


### PR DESCRIPTION
Adding the EA release of Java 15 to our Java matrix testing configuration.

Closes #50764