### PR TITLE
Wire Cardinality aggregation to work with the ValuesSourceRegistry

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -358,7 +358,8 @@ public class SearchModule {
                 MedianAbsoluteDeviationAggregationBuilder::new, MedianAbsoluteDeviationAggregationBuilder::parse)
                         .addResultReader(InternalMedianAbsoluteDeviation::new));
         registerAggregation(new AggregationSpec(CardinalityAggregationBuilder.NAME, CardinalityAggregationBuilder::new,
-                CardinalityAggregationBuilder::parse).addResultReader(InternalCardinality::new));
+                CardinalityAggregationBuilder::parse).addResultReader(InternalCardinality::new)
+            .setAggregatorRegistrar(CardinalityAggregationBuilder::registerAggregators));
         registerAggregation(new AggregationSpec(GlobalAggregationBuilder.NAME, GlobalAggregationBuilder::new,
                 GlobalAggregationBuilder::parse).addResultReader(InternalGlobal::new));
         registerAggregation(new AggregationSpec(MissingAggregationBuilder.NAME, MissingAggregationBuilder::new,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -35,11 +35,13 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceParserHelper;
+import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class CardinalityAggregationBuilder
     extends ValuesSourceAggregationBuilder.LeafOnly<ValuesSource, CardinalityAggregationBuilder> {
@@ -59,6 +61,13 @@ public final class CardinalityAggregationBuilder
 
     public static AggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {
         return PARSER.parse(parser, new CardinalityAggregationBuilder(aggregationName), null);
+    }
+
+    private static AtomicBoolean wasRegistered = new AtomicBoolean(false);
+    public static void registerAggregators(ValuesSourceRegistry valuesSourceRegistry) {
+        if (wasRegistered.compareAndSet(false, true) == true) {
+            CardinalityAggregatorFactory.registerAggregators(valuesSourceRegistry);
+        }
     }
 
     private Long precisionThreshold = null;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -19,15 +19,6 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.mapper.BinaryFieldMapper;
-import org.elasticsearch.index.mapper.BooleanFieldMapper;
-import org.elasticsearch.index.mapper.DateFieldMapper;
-import org.elasticsearch.index.mapper.IdFieldMapper;
-import org.elasticsearch.index.mapper.IndexFieldMapper;
-import org.elasticsearch.index.mapper.IpFieldMapper;
-import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -35,7 +26,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregatorSupplier;
-import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -61,34 +51,7 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory {
     }
 
     static void registerAggregators(ValuesSourceRegistry valuesSourceRegistry) {
-        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, CoreValuesSourceType.BOOLEAN, cardinalityAggregatorSupplier(),
-            (fieldType, indexFieldData) -> fieldType.typeName().equals(BooleanFieldMapper.CONTENT_TYPE));
-
-        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, CoreValuesSourceType.NUMERIC, cardinalityAggregatorSupplier(),
-            (fieldType, indexFieldData) -> {
-                for (NumberFieldMapper.NumberType type : NumberFieldMapper.NumberType.values()) {
-                    if (fieldType.typeName().equals(type.typeName())) {
-                        return true;
-                    }
-                }
-                return false;
-            });
-
-        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, CoreValuesSourceType.IP, cardinalityAggregatorSupplier(),
-            (fieldType, indexFieldData) -> fieldType.typeName().equals(IpFieldMapper.CONTENT_TYPE));
-
-        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, CoreValuesSourceType.RANGE, cardinalityAggregatorSupplier(),
-            (fieldType, indexFieldData) -> fieldType instanceof RangeFieldMapper.RangeFieldType);
-
-        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, CoreValuesSourceType.DATE, cardinalityAggregatorSupplier(),
-            (fieldType, indexFieldData) -> fieldType.typeName().equals(DateFieldMapper.CONTENT_TYPE));
-
-        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, CoreValuesSourceType.BYTES, cardinalityAggregatorSupplier(),
-            (fieldType, indexFieldData) -> fieldType.typeName().equals(KeywordFieldMapper.CONTENT_TYPE)
-                || fieldType.typeName().equals(BinaryFieldMapper.CONTENT_TYPE)
-                || fieldType.typeName().equals(IdFieldMapper.CONTENT_TYPE)
-                || fieldType.typeName().equals(IndexFieldMapper.CONTENT_TYPE));
-
+        valuesSourceRegistry.register(CardinalityAggregationBuilder.NAME, (ignored) -> true, cardinalityAggregatorSupplier());
     }
 
     private static CardinalityAggregatorSupplier cardinalityAggregatorSupplier(){

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.support.AggregatorSupplier;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public interface CardinalityAggregatorSupplier extends AggregatorSupplier {
+    Aggregator build(String name,
+                     ValuesSource valuesSource,
+                     int precision,
+                     SearchContext context,
+                     Aggregator parent,
+                     List<PipelineAggregator> pipelineAggregators,
+                     Map<String, Object> metaData) throws IOException;
+
+}


### PR DESCRIPTION
I didn't pull the `pickCollector` logic up to the factory layer.  PickCollector depends on the internal state of the aggregation, notably the HLL++ state.  We could pass all the necessary information in, but after tinkering with it for a while, everything I tried looked less readable than what we have now.  In particular, creating subclasses for each collector adds a lot of needless duplication, and a lambda would look like `(SearchContext, HyperLogLogPlusPlus)-> Collector`, which seemed more confusing than clarifying.