### PR TITLE
Limit max concurrency of test cluster nodes to a function of max workers

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.THROTTLE_SERVICE_NAME;
+
 /**
  * Customized version of Gradle {@link Test} task which tracks a collection of {@link ElasticsearchCluster} as a task input. We must do this
  * as a custom task type because the current {@link org.gradle.api.tasks.TaskInputs} runtime API does not have a way to register
@@ -60,10 +62,7 @@ public class RestTestRunnerTask extends Test implements TestClustersAware {
     public List<ResourceLock> getSharedResources() {
         List<ResourceLock> locks = new ArrayList<>(super.getSharedResources());
         BuildServiceRegistryInternal serviceRegistry = getServices().get(BuildServiceRegistryInternal.class);
-        Provider<TestClustersThrottle> throttleProvider = Boilerplate.getBuildService(
-            getProject().getGradle().getSharedServices(),
-            TestClustersPlugin.THROTTLE_SERVICE_NAME
-        );
+        Provider<TestClustersThrottle> throttleProvider = Boilerplate.getBuildService(serviceRegistry, THROTTLE_SERVICE_NAME);
         SharedResource resource = serviceRegistry.forService(throttleProvider);
 
         int nodeCount = (int) clusters.stream().flatMap(cluster -> cluster.getNodes().stream()).count();

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
@@ -65,7 +65,7 @@ public class RestTestRunnerTask extends Test implements TestClustersAware {
         Provider<TestClustersThrottle> throttleProvider = Boilerplate.getBuildService(serviceRegistry, THROTTLE_SERVICE_NAME);
         SharedResource resource = serviceRegistry.forService(throttleProvider);
 
-        int nodeCount = (int) clusters.stream().flatMap(cluster -> cluster.getNodes().stream()).count();
+        int nodeCount = clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum();
         if (nodeCount > 0) {
             locks.add(resource.getResourceLock(Math.min(nodeCount, resource.getMaxUsages())));
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RestTestRunnerTask.java
@@ -1,12 +1,20 @@
 package org.elasticsearch.gradle.testclusters;
 
+import org.elasticsearch.gradle.tool.Boilerplate;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.internal.BuildServiceRegistryInternal;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.resources.ResourceLock;
+import org.gradle.internal.resources.SharedResource;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 /**
  * Customized version of Gradle {@link Test} task which tracks a collection of {@link ElasticsearchCluster} as a task input. We must do this
@@ -47,4 +55,22 @@ public class RestTestRunnerTask extends Test implements TestClustersAware {
         return clusters;
     }
 
+    @Override
+    @Internal
+    public List<ResourceLock> getSharedResources() {
+        List<ResourceLock> locks = new ArrayList<>(super.getSharedResources());
+        BuildServiceRegistryInternal serviceRegistry = getServices().get(BuildServiceRegistryInternal.class);
+        Provider<TestClustersThrottle> throttleProvider = Boilerplate.getBuildService(
+            getProject().getGradle().getSharedServices(),
+            TestClustersPlugin.THROTTLE_SERVICE_NAME
+        );
+        SharedResource resource = serviceRegistry.forService(throttleProvider);
+
+        int nodeCount = (int) clusters.stream().flatMap(cluster -> cluster.getNodes().stream()).count();
+        if (nodeCount > 0) {
+            locks.add(resource.getResourceLock(Math.min(nodeCount, resource.getMaxUsages())));
+        }
+
+        return Collections.unmodifiableList(locks);
+    }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -93,9 +93,7 @@ public class TestClustersPlugin implements Plugin<Project> {
         );
     }
 
-    private static class TestClustersHookPlugin implements Plugin<Project> {
-        public TestClustersHookPlugin() {}
-
+    static class TestClustersHookPlugin implements Plugin<Project> {
         @Override
         public void apply(Project project) {
             if (project != project.getRootProject()) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.testclusters;
 import org.elasticsearch.gradle.DistributionDownloadPlugin;
 import org.elasticsearch.gradle.ReaperPlugin;
 import org.elasticsearch.gradle.ReaperService;
+import org.elasticsearch.gradle.tool.Boilerplate;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -30,53 +31,50 @@ import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskState;
 
 import java.io.File;
 
 public class TestClustersPlugin implements Plugin<Project> {
 
-    private static final String LIST_TASK_NAME = "listTestClusters";
     public static final String EXTENSION_NAME = "testClusters";
-    private static final String REGISTRY_EXTENSION_NAME = "testClustersRegistry";
+    public static final String THROTTLE_SERVICE_NAME = "testClustersThrottle";
 
+    private static final String LIST_TASK_NAME = "listTestClusters";
+    private static final String REGISTRY_SERVICE_NAME = "testClustersRegistry";
     private static final Logger logger = Logging.getLogger(TestClustersPlugin.class);
-
-    private ReaperService reaper;
 
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(DistributionDownloadPlugin.class);
-
         project.getRootProject().getPluginManager().apply(ReaperPlugin.class);
-        reaper = project.getRootProject().getExtensions().getByType(ReaperService.class);
+
+        ReaperService reaper = project.getRootProject().getExtensions().getByType(ReaperService.class);
 
         // enable the DSL to describe clusters
-        NamedDomainObjectContainer<ElasticsearchCluster> container = createTestClustersContainerExtension(project);
+        NamedDomainObjectContainer<ElasticsearchCluster> container = createTestClustersContainerExtension(project, reaper);
 
         // provide a task to be able to list defined clusters.
         createListClustersTask(project, container);
 
-        if (project.getRootProject().getExtensions().findByName(REGISTRY_EXTENSION_NAME) == null) {
-            TestClustersRegistry registry = project.getRootProject()
-                .getExtensions()
-                .create(REGISTRY_EXTENSION_NAME, TestClustersRegistry.class);
+        // register cluster registry as a global build service
+        project.getGradle().getSharedServices().registerIfAbsent(REGISTRY_SERVICE_NAME, TestClustersRegistry.class, spec -> {});
 
-            // When we know what tasks will run, we claim the clusters of those task to differentiate between clusters
-            // that are defined in the build script and the ones that will actually be used in this invocation of gradle
-            // we use this information to determine when the last task that required the cluster executed so that we can
-            // terminate the cluster right away and free up resources.
-            configureClaimClustersHook(project.getGradle(), registry);
+        // register throttle so we only run at most max-workers/2 nodes concurrently
+        project.getGradle()
+            .getSharedServices()
+            .registerIfAbsent(
+                THROTTLE_SERVICE_NAME,
+                TestClustersThrottle.class,
+                spec -> spec.getMaxParallelUsages().set(project.getGradle().getStartParameter().getMaxWorkerCount() / 2)
+            );
 
-            // Before each task, we determine if a cluster needs to be started for that task.
-            configureStartClustersHook(project.getGradle(), registry);
-
-            // After each task we determine if there are clusters that are no longer needed.
-            configureStopClustersHook(project.getGradle(), registry);
-        }
+        // register cluster hooks
+        project.getRootProject().getPluginManager().apply(TestClustersHookPlugin.class);
     }
 
-    private NamedDomainObjectContainer<ElasticsearchCluster> createTestClustersContainerExtension(Project project) {
+    private NamedDomainObjectContainer<ElasticsearchCluster> createTestClustersContainerExtension(Project project, ReaperService reaper) {
         // Create an extensions that allows describing clusters
         NamedDomainObjectContainer<ElasticsearchCluster> container = project.container(
             ElasticsearchCluster.class,
@@ -95,52 +93,80 @@ public class TestClustersPlugin implements Plugin<Project> {
         );
     }
 
-    private static void configureClaimClustersHook(Gradle gradle, TestClustersRegistry registry) {
-        // Once we know all the tasks that need to execute, we claim all the clusters that belong to those and count the
-        // claims so we'll know when it's safe to stop them.
-        gradle.getTaskGraph().whenReady(taskExecutionGraph -> {
-            taskExecutionGraph.getAllTasks()
-                .stream()
-                .filter(task -> task instanceof TestClustersAware)
-                .map(task -> (TestClustersAware) task)
-                .flatMap(task -> task.getClusters().stream())
-                .forEach(registry::claimCluster);
-        });
-    }
+    private static class TestClustersHookPlugin implements Plugin<Project> {
+        public TestClustersHookPlugin() {}
 
-    private static void configureStartClustersHook(Gradle gradle, TestClustersRegistry registry) {
-        gradle.addListener(new TaskActionListener() {
-            @Override
-            public void beforeActions(Task task) {
-                if (task instanceof TestClustersAware == false) {
-                    return;
-                }
-                // we only start the cluster before the actions, so we'll not start it if the task is up-to-date
-                TestClustersAware awareTask = (TestClustersAware) task;
-                awareTask.beforeStart();
-                awareTask.getClusters().forEach(registry::maybeStartCluster);
+        @Override
+        public void apply(Project project) {
+            if (project != project.getRootProject()) {
+                throw new IllegalStateException(this.getClass().getName() + " can only be applied to the root project.");
             }
 
-            @Override
-            public void afterActions(Task task) {}
-        });
-    }
+            Provider<TestClustersRegistry> registryProvider = Boilerplate.getBuildService(
+                project.getGradle().getSharedServices(),
+                REGISTRY_SERVICE_NAME
+            );
+            TestClustersRegistry registry = registryProvider.get();
 
-    private static void configureStopClustersHook(Gradle gradle, TestClustersRegistry registry) {
-        gradle.addListener(new TaskExecutionListener() {
-            @Override
-            public void afterExecute(Task task, TaskState state) {
-                if (task instanceof TestClustersAware == false) {
-                    return;
+            // When we know what tasks will run, we claim the clusters of those task to differentiate between clusters
+            // that are defined in the build script and the ones that will actually be used in this invocation of gradle
+            // we use this information to determine when the last task that required the cluster executed so that we can
+            // terminate the cluster right away and free up resources.
+            configureClaimClustersHook(project.getGradle(), registry);
+
+            // Before each task, we determine if a cluster needs to be started for that task.
+            configureStartClustersHook(project.getGradle(), registry);
+
+            // After each task we determine if there are clusters that are no longer needed.
+            configureStopClustersHook(project.getGradle(), registry);
+        }
+
+        private static void configureClaimClustersHook(Gradle gradle, TestClustersRegistry registry) {
+            // Once we know all the tasks that need to execute, we claim all the clusters that belong to those and count the
+            // claims so we'll know when it's safe to stop them.
+            gradle.getTaskGraph().whenReady(taskExecutionGraph -> {
+                taskExecutionGraph.getAllTasks()
+                    .stream()
+                    .filter(task -> task instanceof TestClustersAware)
+                    .map(task -> (TestClustersAware) task)
+                    .flatMap(task -> task.getClusters().stream())
+                    .forEach(registry::claimCluster);
+            });
+        }
+
+        private static void configureStartClustersHook(Gradle gradle, TestClustersRegistry registry) {
+            gradle.addListener(new TaskActionListener() {
+                @Override
+                public void beforeActions(Task task) {
+                    if (task instanceof TestClustersAware == false) {
+                        return;
+                    }
+                    // we only start the cluster before the actions, so we'll not start it if the task is up-to-date
+                    TestClustersAware awareTask = (TestClustersAware) task;
+                    awareTask.beforeStart();
+                    awareTask.getClusters().forEach(registry::maybeStartCluster);
                 }
-                // always unclaim the cluster, even if _this_ task is up-to-date, as others might not have been
-                // and caused the cluster to start.
-                ((TestClustersAware) task).getClusters().forEach(cluster -> registry.stopCluster(cluster, state.getFailure() != null));
-            }
 
-            @Override
-            public void beforeExecute(Task task) {}
-        });
+                @Override
+                public void afterActions(Task task) {}
+            });
+        }
+
+        private static void configureStopClustersHook(Gradle gradle, TestClustersRegistry registry) {
+            gradle.addListener(new TaskExecutionListener() {
+                @Override
+                public void afterExecute(Task task, TaskState state) {
+                    if (task instanceof TestClustersAware == false) {
+                        return;
+                    }
+                    // always unclaim the cluster, even if _this_ task is up-to-date, as others might not have been
+                    // and caused the cluster to start.
+                    ((TestClustersAware) task).getClusters().forEach(cluster -> registry.stopCluster(cluster, state.getFailure() != null));
+                }
+
+                @Override
+                public void beforeExecute(Task task) {}
+            });
+        }
     }
-
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -2,13 +2,15 @@ package org.elasticsearch.gradle.testclusters;
 
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class TestClustersRegistry {
+public abstract class TestClustersRegistry implements BuildService<BuildServiceParameters.None> {
     private static final Logger logger = Logging.getLogger(TestClustersRegistry.class);
     private static final String TESTCLUSTERS_INSPECT_FAILURE = "testclusters.inspect.failure";
     private final Boolean allowClusterToSurvive = Boolean.valueOf(System.getProperty(TESTCLUSTERS_INSPECT_FAILURE, "false"));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersThrottle.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersThrottle.java
@@ -1,0 +1,6 @@
+package org.elasticsearch.gradle.testclusters;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+public abstract class TestClustersThrottle implements BuildService<BuildServiceParameters.None> {}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
@@ -28,7 +28,6 @@ import org.gradle.api.UnknownTaskException;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
-import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistration;
 import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.api.tasks.SourceSetContainer;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
@@ -108,7 +108,7 @@ public abstract class Boilerplate {
         return task;
     }
 
-    public static <T extends BuildService> Provider<T> getBuildService(BuildServiceRegistry registry, String name) throws GradleException {
+    public static <T extends BuildService<?>> Provider<T> getBuildService(BuildServiceRegistry registry, String name) {
         BuildServiceRegistration<?, ?> registration = registry.getRegistrations().findByName(name);
         if (registration == null) {
             throw new GradleException("Unable to find build service with name '" + name + "'.");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
@@ -19,12 +19,17 @@
 package org.elasticsearch.gradle.tool;
 
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.PolymorphicDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceRegistration;
+import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -101,5 +106,14 @@ public abstract class Boilerplate {
         }
 
         return task;
+    }
+
+    public static <T extends BuildService> Provider<T> getBuildService(BuildServiceRegistry registry, String name) throws GradleException {
+        BuildServiceRegistration<?, ?> registration = registry.getRegistrations().findByName(name);
+        if (registration == null) {
+            throw new GradleException("Unable to find build service with name '" + name + "'.");
+        }
+
+        return (Provider<T>) registration.getService();
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tool/Boilerplate.java
@@ -28,6 +28,7 @@ import org.gradle.api.UnknownTaskException;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistration;
 import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -108,6 +109,7 @@ public abstract class Boilerplate {
         return task;
     }
 
+    @SuppressWarnings("unchecked")
     public static <T extends BuildService<?>> Provider<T> getBuildService(BuildServiceRegistry registry, String name) {
         BuildServiceRegistration<?, ?> registration = registry.getRegistrations().findByName(name);
         if (registration == null) {


### PR DESCRIPTION
We periodically run into issues with resource contention in highly parallelized builds. This is mostly due to the resource cost of running external Elasticsearch cluster nodes during integration test execution. Some integration test suites are more costly in this regard than others, such as some of our upgrade and mixed cluster tests which spin up multiple nodes for a single test suite. Gradle task execution currently doesn't take this into account when scheduling tasks. So we could in theory be running several integration suites, each which requires multiple nodes, a total of which far exceeds the total number of CPUs. This causes a lot of variability in test execution times, and inevitably, timeouts. For local development this makes running parallel builds difficult as it can bring the system to a halt, making it unusable during the build.

This pull request registers a throttle which limits the total number of concurrently running test cluster nodes to `max-workers / 2`. This is probably a reasonable default since for any given external integration test we have _at least_ two JVMs in play, that of the test executor, and then the external cluster node itself.

Some other misc refactoring was done with `TestClustersPlugin` here as well, such as leveraging the new [`BuildService`](https://docs.gradle.org/current/javadoc/org/gradle/api/services/BuildService.html) pattern in Gradle 6.1 for the `TestClustersRegistry` as well as using a root project plugin for an idempotent way of registering task execution hooks.