### PR TITLE
[7.x] Use ESSingleNodeTestCase instead of ESIntegTestCase (#51345)

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
@@ -21,8 +21,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.ilm.AsyncActionStep;
@@ -30,25 +29,16 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.elasticsearch.xpack.core.ilm.UpdateSettingsStep;
 import org.junit.After;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.ilm.UpdateSettingsStepTests.SettingsTestingService.INVALID_VALUE;
 import static org.hamcrest.Matchers.is;
 
-@ClusterScope(scope = SUITE, supportsDedicatedMasters = false, numDataNodes = 1, numClientNodes = 0)
-public class UpdateSettingsStepTests extends ESIntegTestCase {
-
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(SettingsListenerPlugin.class);
-    }
+public class UpdateSettingsStepTests extends ESSingleNodeTestCase {
 
     private static final SettingsTestingService service = new SettingsTestingService();
 
@@ -56,7 +46,7 @@ public class UpdateSettingsStepTests extends ESIntegTestCase {
 
         @Override
         public List<Setting<?>> getSettings() {
-            return Arrays.asList(SettingsTestingService.VALUE);
+            return List.of(SettingsTestingService.VALUE);
         }
 
         @Override
@@ -69,13 +59,13 @@ public class UpdateSettingsStepTests extends ESIntegTestCase {
                                                    ResourceWatcherService resourceWatcherService, ScriptService scriptService,
                                                    NamedXContentRegistry xContentRegistry, Environment environment,
                                                    NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
-            return Collections.singletonList(service);
+            return List.of(service);
         }
+
     }
-
     public static class SettingsListenerModule extends AbstractModule {
-        private final SettingsTestingService service;
 
+        private final SettingsTestingService service;
         SettingsListenerModule(SettingsTestingService service) {
             this.service = service;
         }
@@ -84,12 +74,12 @@ public class UpdateSettingsStepTests extends ESIntegTestCase {
         protected void configure() {
             bind(SettingsTestingService.class).toInstance(service);
         }
-    }
 
+    }
     static class SettingsTestingService {
+
         public static final String INVALID_VALUE = "INVALID";
         static Setting<String> VALUE = Setting.simpleString("index.test.setting", Property.Dynamic, Property.IndexScope);
-
         public volatile String value;
 
         void setValue(String value) {
@@ -105,21 +95,27 @@ public class UpdateSettingsStepTests extends ESIntegTestCase {
         void resetValues() {
             this.value = "";
         }
-    }
 
+    }
     @After
     public void resetSettingValue() {
         service.resetValues();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(SettingsListenerPlugin.class);
     }
 
     public void testUpdateSettingsStepRetriesOnError() throws InterruptedException {
         assertAcked(client().admin().indices().prepareCreate("test").setSettings(Settings.builder()
             .build()).get());
 
-        ClusterState state = clusterService().state();
+        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        ClusterState state = clusterService.state();
         IndexMetaData indexMetaData = state.metaData().index("test");
-        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class);
-        ClusterStateObserver observer = new ClusterStateObserver(clusterService(), null, logger, threadPool.getThreadContext());
+        ThreadPool threadPool = getInstanceFromNode(ThreadPool.class);
+        ClusterStateObserver observer = new ClusterStateObserver(clusterService, null, logger, threadPool.getThreadContext());
 
         CountDownLatch latch = new CountDownLatch(2);
 
@@ -162,11 +158,9 @@ public class UpdateSettingsStepTests extends ESIntegTestCase {
             }
         });
 
-
         latch.await(10, TimeUnit.SECONDS);
 
-        for (SettingsTestingService instance : internalCluster().getDataNodeInstances(SettingsTestingService.class)) {
-            assertThat(instance.value, is("valid"));
-        }
+        SettingsTestingService instance = getInstanceFromNode(SettingsTestingService.class);
+        assertThat(instance.value, is("valid"));
     }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.core.ilm.UpdateSettingsStep;
 import org.junit.After;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -46,7 +47,7 @@ public class UpdateSettingsStepTests extends ESSingleNodeTestCase {
 
         @Override
         public List<Setting<?>> getSettings() {
-            return List.of(SettingsTestingService.VALUE);
+            return Collections.singletonList(SettingsTestingService.VALUE);
         }
 
         @Override
@@ -59,7 +60,7 @@ public class UpdateSettingsStepTests extends ESSingleNodeTestCase {
                                                    ResourceWatcherService resourceWatcherService, ScriptService scriptService,
                                                    NamedXContentRegistry xContentRegistry, Environment environment,
                                                    NodeEnvironment nodeEnvironment, NamedWriteableRegistry namedWriteableRegistry) {
-            return List.of(service);
+            return Collections.singletonList(service);
         }
 
     }
@@ -104,7 +105,7 @@ public class UpdateSettingsStepTests extends ESSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return List.of(SettingsListenerPlugin.class);
+        return Collections.singletonList(SettingsListenerPlugin.class);
     }
 
     public void testUpdateSettingsStepRetriesOnError() throws InterruptedException {


### PR DESCRIPTION
(cherry picked from commit abcf1c41faf05a0b0196fb06e57c3de8c3d67688)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #51345 