### PR TITLE
Fix flaky testCreateApiKey test (#51223)

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -122,9 +122,9 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         }
     }
     
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/47958")
     public void testCreateApiKey() {
-        final Instant start = Instant.now();
+        // Get an instant without nanoseconds as the expiration has millisecond precision
+        final Instant start = Instant.ofEpochMilli(Instant.now().toEpochMilli());
         final RoleDescriptor descriptor = new RoleDescriptor("role", new String[] { "monitor" }, null, null);
         Client client = client().filterWithHeader(Collections.singletonMap("Authorization",
             UsernamePasswordToken.basicAuthHeaderValue(SecuritySettingsSource.TEST_SUPERUSER,
@@ -140,6 +140,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         assertNotNull(response.getId());
         assertNotNull(response.getKey());
         Instant expiration = response.getExpiration();
+        // Expiration has millisecond precision
         final long daysBetween = ChronoUnit.DAYS.between(start, expiration);
         assertThat(daysBetween, is(7L));
 


### PR DESCRIPTION
API Key expiration value has millisecond precision as we use
{@link Instant#toEpoqueMilli()} when creating the API key
document.
It could often happen that `Instant.now()` Instant in the testCreateApiKey
was close enough to the ApiKeyService's `clock.instant()` Instant,
when the nanos were removed from the latter ( due to the call
to `toEpoqueMilli()` ) the result of comparing these two Instants
was a few nanos short of a 7 days.

Resolves: #47958