### PR TITLE
Add HLRC docs for AuthN and TLS

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -51,6 +51,7 @@ import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -474,7 +475,8 @@ public class RestClientDocumentation {
             String apiKeySecret = "HxHWk2m4RN-V_qg9cDpuX";
             String apiKeyAuth =
                 Base64.getEncoder().encodeToString(
-                    (apiKeyId + ":" + apiKeySecret).getBytes());
+                    (apiKeyId + ":" + apiKeySecret)
+                        .getBytes(StandardCharsets.UTF_8));
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200, "http"));
             Header[] defaultHeaders =

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -382,11 +382,11 @@ public class RestClientDocumentation {
             //end::rest-client-config-disable-preemptive-auth
         }
         {
-            Path keyStorePath = Paths.get("");
             String keyStorePass = "";
             //tag::rest-client-config-encrypted-communication
+            Path trustStorePath = Paths.get("/path/to/your/truststore.p12");
             KeyStore truststore = KeyStore.getInstance("pkcs12");
-            try (InputStream is = Files.newInputStream(keyStorePath)) {
+            try (InputStream is = Files.newInputStream(trustStorePath)) {
                 truststore.load(is, keyStorePass.toCharArray());
             }
             SSLContextBuilder sslBuilder = SSLContexts.custom()
@@ -404,8 +404,8 @@ public class RestClientDocumentation {
             //end::rest-client-config-encrypted-communication
         }
         {
-            Path caCertificatePath = Paths.get("");
             //tag::rest-client-config-trust-ca-pem
+            Path caCertificatePath = Paths.get("/path/to/your/ca.crt");
             CertificateFactory factory = CertificateFactory.getInstance("X.509");
             Certificate trustedCa;
             try (InputStream is = Files.newInputStream(caCertificatePath)) {
@@ -427,11 +427,11 @@ public class RestClientDocumentation {
             //end::rest-client-config-trust-ca-pem
         }
         {
-            Path trustStorePath = Paths.get("");
             String trustStorePass = "";
-            Path keyStorePath = Paths.get("");
             String keyStorePass = "";
             //tag::rest-client-config-mutual-tls-authentication
+            Path trustStorePath = Paths.get("/path/to/your/truststore.p12");
+            Path keyStorePath = Paths.get("/path/to/your/keystore.p12");
             KeyStore trustStore = KeyStore.getInstance("pkcs12");
             KeyStore keyStore = KeyStore.getInstance("pkcs12");
             try (InputStream is = Files.newInputStream(trustStorePath)) {

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -27,7 +27,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
@@ -384,7 +383,7 @@ public class RestClientDocumentation {
         {
             String keyStorePass = "";
             //tag::rest-client-config-encrypted-communication
-            Path trustStorePath = Paths.get("/path/to/your/truststore.p12");
+            Path trustStorePath = Paths.get("/path/to/truststore.p12");
             KeyStore truststore = KeyStore.getInstance("pkcs12");
             try (InputStream is = Files.newInputStream(trustStorePath)) {
                 truststore.load(is, keyStorePass.toCharArray());
@@ -405,22 +404,25 @@ public class RestClientDocumentation {
         }
         {
             //tag::rest-client-config-trust-ca-pem
-            Path caCertificatePath = Paths.get("/path/to/your/ca.crt");
-            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            Path caCertificatePath = Paths.get("/path/to/ca.crt");
+            CertificateFactory factory =
+                CertificateFactory.getInstance("X.509");
             Certificate trustedCa;
             try (InputStream is = Files.newInputStream(caCertificatePath)) {
                 trustedCa = factory.generateCertificate(is);
             }
-            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            KeyStore trustStore = KeyStore.getInstance("pkcs12");
             trustStore.load(null, null);
             trustStore.setCertificateEntry("ca", trustedCa);
-            SSLContextBuilder sslContextBuilder = SSLContexts.custom().loadTrustMaterial(trustStore, null);
+            SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+                .loadTrustMaterial(trustStore, null);
             final SSLContext sslContext = sslContextBuilder.build();
             RestClient.builder(
                 new HttpHost("localhost", 9200, "https"))
-                .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback() {
+                .setHttpClientConfigCallback(new HttpClientConfigCallback() {
                     @Override
-                    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                    public HttpAsyncClientBuilder customizeHttpClient(
+                        HttpAsyncClientBuilder httpClientBuilder) {
                         return httpClientBuilder.setSSLContext(sslContext);
                     }
                 });
@@ -459,7 +461,9 @@ public class RestClientDocumentation {
             //tag::rest-client-auth-bearer-token
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200, "http"));
-            Header[] defaultHeaders = new Header[]{new BasicHeader("Authorization", "Bearer u6iuAxZ0RG1Kcm5jVFI4eU4tZU9aVFEwT2F3")};
+            Header[] defaultHeaders =
+                new Header[]{new BasicHeader("Authorization",
+                    "Bearer u6iuAxZ0RG1Kcm5jVFI4eU4tZU9aVFEwT2F3")};
             builder.setDefaultHeaders(defaultHeaders);
             //end::rest-client-auth-bearer-token
         }
@@ -467,7 +471,9 @@ public class RestClientDocumentation {
             //tag::rest-client-auth-api-key
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200, "http"));
-            Header[] defaultHeaders = new Header[]{new BasicHeader("Authorization", "ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==")};
+            Header[] defaultHeaders =
+                new Header[]{new BasicHeader("Authorization",
+                    "ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVhT3gdWkybHAdzw==")};
             builder.setDefaultHeaders(defaultHeaders);
             //end::rest-client-auth-api-key
         }

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -57,6 +57,7 @@ import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 
@@ -469,11 +470,16 @@ public class RestClientDocumentation {
         }
         {
             //tag::rest-client-auth-api-key
+            String apiKeyId = "uqlEyn8B_gQ_jlvwDIvM";
+            String apiKeySecret = "HxHWk2m4RN-V_qg9cDpuX";
+            String apiKeyAuth =
+                Base64.getEncoder().encodeToString(
+                    (apiKeyId + ":" + apiKeySecret).getBytes());
             RestClientBuilder builder = RestClient.builder(
                 new HttpHost("localhost", 9200, "http"));
             Header[] defaultHeaders =
                 new Header[]{new BasicHeader("Authorization",
-                    "ApiKey VnVhQ2ZHY0JDZGJrUW0tZTVhT3gdWkybHAdzw==")};
+                    apiKeyAuth)};
             builder.setDefaultHeaders(defaultHeaders);
             //end::rest-client-auth-api-key
         }

--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -481,7 +481,7 @@ public class RestClientDocumentation {
                 new HttpHost("localhost", 9200, "http"));
             Header[] defaultHeaders =
                 new Header[]{new BasicHeader("Authorization",
-                    apiKeyAuth)};
+                    "ApiKey " + apiKeyAuth)};
             builder.setDefaultHeaders(defaultHeaders);
             //end::rest-client-auth-api-key
         }

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -129,7 +129,8 @@ directly to build an SSLContext, without relying on external libraries to parse 
 can use external tools to build a keystore from your PEM files, as shown in the following example:
 
 ```
-openssl pkcs12 -export -in client.crt -inkey private_key.pem -name "client" -out client.p12
+openssl pkcs12 -export -in client.crt -inkey private_key.pem \
+        -name "client" -out client.p12
 ```
 
 If no explicit configuration is provided, the http://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html#CustomizingStores[system default configuration]

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -115,7 +115,7 @@ that CA certificate is available as a PEM encoded file.
 include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-trust-ca-pem]
 --------------------------------------------------
 
-When Elasticsearch is configured to require client TLS authentication, i.e. when a PKI realm is configured, the client needs to provide
+When Elasticsearch is configured to require client TLS authentication, for example when a PKI realm is configured, the client needs to provide
 a client certificate during the TLS handshake in order to authenticate. The following is an example of setting up the client for TLS
 authentication with a certificate and a private key that are stored in a PKCS#12 keystore.
 

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -64,20 +64,73 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-disa
 --------------------------------------------------
 <1> Disable preemptive authentication
 
+=== Other authentication methods
+
+==== Elasticsearch Token Service tokens
+
+Configuring the client to authenticate with an elasticsearch access token can be accomplished by setting the relevant HTTP request header.
+If the client makes requests on behalf of a single user only, you can set the necessary `Authorization` header as a default header as shown
+in the following example
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-auth-bearer-token]
+--------------------------------------------------
+
+==== Elasticsearch API keys
+
+Configuring the client to authenticate with an elasticsearch API Key can be also accomplished by setting the relevant HTTP request header.
+If the client makes requests on behalf of a single user only, you can set the necessary `Authorization` header as a default header as shown
+in the following example
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-auth-api-key]
+--------------------------------------------------
+
 === Encrypted communication
 
-Encrypted communication can also be configured through the
+Encrypted communication using TLS can also be configured through the
 `HttpClientConfigCallback`. The
 https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html[`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`]
  received as an argument exposes multiple methods to configure encrypted
  communication: `setSSLContext`, `setSSLSessionStrategy` and
  `setConnectionManager`, in order of precedence from the least important.
- The following is an example:
+
+When accessing an elasticsearch cluster that is setup for TLS on the HTTP layer, the client needs to trust the certificate that
+elasticsearch is using.
+ The following is an example of setting up the client to trust the CA that has signed the certificate that elasticsearch is using, when
+ that CA certificate is available in a PKCS#12 keystore:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-encrypted-communication]
 --------------------------------------------------
+
+The following is an example of setting up the client to trust the CA that has signed the certificate that elasticsearch is using, when
+that CA certificate is available as a PEM encoded file.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-trust-ca-pem]
+--------------------------------------------------
+
+When elasticsearch is configured to require client TLS authentication, i.e. when a PKI realm is configured, the client needs to provide
+a client certificate during the TLS handshake in order to authenticate. The following is an example of setting up the client for TLS
+authentication with a certificate and a private key that are stored in a PKCS#12 keystore.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-mutual-tls-authentication]
+--------------------------------------------------
+
+if the client certificate and key are not available in a keystore but as PEM encoded files, there is no possibility to use them
+directly to build an SSLContext, without relying on external libraries to parse the PEM key into a PrivateKey instance. Alternatively, you
+can use external tools to build a keystore from your PEM files, as shown in the following example:
+
+```
+openssl pkcs12 -export -in client.crt -inkey private_key.pem -name "client" -out client.p12
+```
 
 If no explicit configuration is provided, the http://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html#CustomizingStores[system default configuration]
 will be used.

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -68,9 +68,9 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-disa
 
 ==== Elasticsearch Token Service tokens
 
-Configuring the client to authenticate with an elasticsearch access token can be accomplished by setting the relevant HTTP request header.
+If you want the client to authenticate with an Elasticsearch access token, set the relevant HTTP request header.
 If the client makes requests on behalf of a single user only, you can set the necessary `Authorization` header as a default header as shown
-in the following example
+in the following example:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -79,9 +79,9 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-auth-bearer
 
 ==== Elasticsearch API keys
 
-Configuring the client to authenticate with an elasticsearch API Key can be also accomplished by setting the relevant HTTP request header.
+If you want the client to authenticate with an Elasticsearch API key, set the relevant HTTP request header.
 If the client makes requests on behalf of a single user only, you can set the necessary `Authorization` header as a default header as shown
-in the following example
+in the following example:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
@@ -97,9 +97,9 @@ https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org
  communication: `setSSLContext`, `setSSLSessionStrategy` and
  `setConnectionManager`, in order of precedence from the least important.
 
-When accessing an elasticsearch cluster that is setup for TLS on the HTTP layer, the client needs to trust the certificate that
-elasticsearch is using.
- The following is an example of setting up the client to trust the CA that has signed the certificate that elasticsearch is using, when
+When accessing an Elasticsearch cluster that is setup for TLS on the HTTP layer, the client needs to trust the certificate that
+Elasticsearch is using.
+ The following is an example of setting up the client to trust the CA that has signed the certificate that Elasticsearch is using, when
  that CA certificate is available in a PKCS#12 keystore:
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -107,7 +107,7 @@ elasticsearch is using.
 include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-encrypted-communication]
 --------------------------------------------------
 
-The following is an example of setting up the client to trust the CA that has signed the certificate that elasticsearch is using, when
+The following is an example of setting up the client to trust the CA that has signed the certificate that Elasticsearch is using, when
 that CA certificate is available as a PEM encoded file.
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -115,7 +115,7 @@ that CA certificate is available as a PEM encoded file.
 include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-trust-ca-pem]
 --------------------------------------------------
 
-When elasticsearch is configured to require client TLS authentication, i.e. when a PKI realm is configured, the client needs to provide
+When Elasticsearch is configured to require client TLS authentication, i.e. when a PKI realm is configured, the client needs to provide
 a client certificate during the TLS handshake in order to authenticate. The following is an example of setting up the client for TLS
 authentication with a certificate and a private key that are stored in a PKCS#12 keystore.
 
@@ -124,8 +124,8 @@ authentication with a certificate and a private key that are stored in a PKCS#12
 include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-mutual-tls-authentication]
 --------------------------------------------------
 
-if the client certificate and key are not available in a keystore but as PEM encoded files, there is no possibility to use them
-directly to build an SSLContext, without relying on external libraries to parse the PEM key into a PrivateKey instance. Alternatively, you
+If the client certificate and key are not available in a keystore but rather as PEM encoded files, you cannot use them
+directly to build an SSLContext. You must rely on external libraries to parse the PEM key into a PrivateKey instance. Alternatively, you
 can use external tools to build a keystore from your PEM files, as shown in the following example:
 
 ```


### PR DESCRIPTION
This commit adds examples in our documentation for

- An HLRC instance authenticating to an elasticsearch cluster using
an elasticsearch token service access token or an API key
- An HLRC instance connecting to an elasticsearch cluster that is
setup for TLS on the HTTP layer when the CA certificate of the
cluster is available either as a PEM file or a keystore
- An HLRC instance connecting to an elasticsearch cluster that
requires client authentication where the client key and certificate
are available in a keystore

Resolves:  #44202

---
Docs preview: http://elasticsearch_51355.docs-preview.app.elstc.co/guide/en/elasticsearch/client/java-rest/master/_encrypted_communication.html