### PR TITLE
Use '--cursor-after' flag to get recent journal messages

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -46,7 +46,6 @@ import static org.elasticsearch.packaging.util.FileUtils.slurp;
 import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
 import static org.elasticsearch.packaging.util.Packages.assertInstalled;
 import static org.elasticsearch.packaging.util.Packages.assertRemoved;
-import static org.elasticsearch.packaging.util.Packages.clearJournal;
 import static org.elasticsearch.packaging.util.Packages.installPackage;
 import static org.elasticsearch.packaging.util.Packages.remove;
 import static org.elasticsearch.packaging.util.Packages.restartElasticsearch;
@@ -342,10 +341,9 @@ public class PackageTests extends PackagingTestCase {
             append(tempConf.resolve("elasticsearch.yml"), "discovery.zen.ping.unicast.hosts:15172.30.5.3416172.30.5.35, 172.30.5.17]\n");
 
             // Make sure we don't pick up the journal entries for previous ES instances.
-            clearJournal(sh);
+            String elasticsearchStartTime = sh.run("sleep 2 && date +\"%Y-%m-%d %H:%M:%S\"").stdout.trim();
             runElasticsearchStartCommand();
-
-            final Result logs = sh.run("journalctl -u elasticsearch.service");
+            final Result logs = sh.run("journalctl -u elasticsearch.service --since=\"" + elasticsearchStartTime + "\"");
 
             assertThat(logs.stdout, containsString("Failed to load settings from [elasticsearch.yml]"));
         });

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.packaging.test;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import org.apache.http.client.fluent.Request;
 import org.elasticsearch.packaging.util.FileUtils;
+import org.elasticsearch.packaging.util.Packages;
 import org.elasticsearch.packaging.util.Shell.Result;
 import org.junit.BeforeClass;
 
@@ -341,9 +342,9 @@ public class PackageTests extends PackagingTestCase {
             append(tempConf.resolve("elasticsearch.yml"), "discovery.zen.ping.unicast.hosts:15172.30.5.3416172.30.5.35, 172.30.5.17]\n");
 
             // Make sure we don't pick up the journal entries for previous ES instances.
-            String elasticsearchStartTime = sh.run("sleep 2 && date +\"%Y-%m-%d %H:%M:%S\"").stdout.trim();
+            Packages.JournaldWrapper journald = new Packages.JournaldWrapper(sh);
             runElasticsearchStartCommand();
-            final Result logs = sh.run("journalctl -u elasticsearch.service --since=\"" + elasticsearchStartTime + "\"");
+            final Result logs = journald.getLogs();
 
             assertThat(logs.stdout, containsString("Failed to load settings from [elasticsearch.yml]"));
         });

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -49,7 +49,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class Packages {
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -306,4 +306,41 @@ public class Packages {
         }
         assertElasticsearchStarted(sh, installation);
     }
+
+    /**
+     * A small wrapper for retrieving only recent journald logs for the
+     * Elasticsearch service. It works by creating a cursor for the logs
+     * when instantiated, and advancing that cursor when the {@code clear()}
+     * method is called.
+     */
+    public static class JournaldWrapper {
+        private Shell sh;
+        private String cursor;
+
+        /**
+         * Create a new wrapper for Elasticsearch JournalD logs.
+         * @param sh A shell with appropriate permissions.
+         */
+        public JournaldWrapper(Shell sh) {
+            this.sh = sh;
+            clear();
+        }
+
+        /**
+         * "Clears" the journaled messages by retrieving the latest cursor
+         * for Elasticsearch logs and storing it in class state.
+         */
+        public void clear() {
+            cursor = sh.run("sudo journalctl --unit=elasticsearch.service --lines=0 --show-cursor -o cat" +
+                " | sed -e 's/-- cursor: //'").stdout.trim();
+        }
+
+        /**
+         * Retrieves all log messages coming after the stored cursor.
+         * @return Recent journald logs for the Elasticsearch service.
+         */
+        public Result getLogs() {
+            return sh.run("journalctl -u elasticsearch.service --after-cursor='" + this.cursor + "'");
+        }
+    }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -280,31 +280,6 @@ public class Packages {
         return sh.runIgnoreExitCode("service elasticsearch start");
     }
 
-    /**
-     * Clears the systemd journal. This is intended to clear the <code>journalctl</code> output
-     * before a test that checks the journal output.
-     */
-    public static void clearJournal(Shell sh) {
-        if (isSystemd()) {
-            sh.run("rm -rf /run/log/journal/*");
-            final Result result = sh.runIgnoreExitCode("systemctl restart systemd-journald");
-
-            // Sometimes the restart fails on Debian 10 with:
-            //    Job for systemd-journald.service failed because the control process exited with error code.
-            //    See "systemctl status systemd-journald.service" and "journalctl -xe" for details.]
-            //
-            // ...so run these commands in an attempt to figure out what's going on.
-            if (result.isSuccess() == false) {
-                logger.error("Failed to restart systemd-journald: " + result);
-
-                logger.error(sh.runIgnoreExitCode("systemctl status systemd-journald.service"));
-                logger.error(sh.runIgnoreExitCode("journalctl -xe"));
-
-                fail("Couldn't clear the systemd journal as restarting systemd-journald failed");
-            }
-        }
-    }
-
     public static void assertElasticsearchStarted(Shell sh, Installation installation) throws Exception {
         waitForElasticsearch(installation);
 


### PR DESCRIPTION
When we get Elasticsearch logs from journald, we want to fetch only log
messages from the last run. There are two reasons for this. First, if
there are many logs, we might get a string that's too large for our
utility methods. Second, when we're looking for a specific message or
error, we almost certainly want to look only at messages from the last
execution.

Previously, we've been trying to do this by clearing out the physical
files under the journald process. But there seems to be some contention
over these directories: if journald writes a log file in between when
our deletion command deletes the file and when it deletes the log
directory, the deletion will fail.

It seems to me that we might be able to use journald's "--since" flag to
retrieve only log messages from the last run, and that this might be
less likely to fail due to race conditions in file deletion.

Unfortunately, it looks as if the "--since" flag has a granularity of
one-second. I've added a two-second sleep to make sure that there's a
sufficient gap between the test that will read from journald and the
test before it.

Specifically, I hope this will fix issues with `test90DoNotCloseStderrWhenQuiet` in `PackageTests`. The two error messages related to this issue are:

```
java.lang.AssertionError: 
Expected: a string containing "Failed to load settings from [elasticsearch.yml]"
     but: was "<<Too large to read: 119812 bytes>>"
```

and

```
java.lang.RuntimeException: Command was not successful: [bash -c rm -rf /run/log/journal/*]
   result: exitCode = [1] stdout = [] stderr = [rm: cannot remove '/run/log/journal/1c27adbf8016dcaa47e05e24d8b6a7a7': Directory not empty]
```

See a build-stats report [here](https://build-stats.elastic.co/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-30d,mode:quick,to:now))&_a=(columns:!(branch,message),index:e58bf320-7efd-11e8-bf69-63c8ef516157,interval:auto,query:(language:lucene,query:'class:%22org.elasticsearch.packaging.test.PackageTests%22%20AND%20test:%22test90DoNotCloseStderrWhenQuiet%22'),sort:!(time,desc))), if you have access.