### PR TITLE
Add xpack.eql.enabled feature flag, disabled by default. Enabled for gradle run task and integration tests.

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -431,7 +431,6 @@ testClusters {
       }
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.monitoring.enabled', 'true'
-      setting 'xpack.eql.enabled', 'true'
       setting 'xpack.sql.enabled', 'true'
       setting 'xpack.rollup.enabled', 'true'
       keystore 'bootstrap.password', 'password'

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -422,6 +422,7 @@ testClusters {
     if (System.getProperty('run.distribution', 'default') == 'default') {
       String licenseType = System.getProperty("run.license_type", "basic")
       if (licenseType == 'trial') {
+        setting 'xpack.eql.enabled', 'true'
         setting 'xpack.ml.enabled', 'true'
         setting 'xpack.graph.enabled', 'true'
         setting 'xpack.watcher.enabled', 'true'

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -422,7 +422,6 @@ testClusters {
     if (System.getProperty('run.distribution', 'default') == 'default') {
       String licenseType = System.getProperty("run.license_type", "basic")
       if (licenseType == 'trial') {
-        setting 'xpack.eql.enabled', 'true'
         setting 'xpack.ml.enabled', 'true'
         setting 'xpack.graph.enabled', 'true'
         setting 'xpack.watcher.enabled', 'true'
@@ -432,6 +431,7 @@ testClusters {
       }
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.monitoring.enabled', 'true'
+      setting 'xpack.eql.enabled', 'true'
       setting 'xpack.sql.enabled', 'true'
       setting 'xpack.rollup.enabled', 'true'
       keystore 'bootstrap.password', 'password'

--- a/x-pack/plugin/eql/qa/rest/build.gradle
+++ b/x-pack/plugin/eql/qa/rest/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
 testClusters.integTest {
   testDistribution = 'DEFAULT'
+  setting 'xpack.eql.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'basic'
   setting 'xpack.monitoring.collection.enabled', 'true'
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/plugin/EqlPluginTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/plugin/EqlPluginTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.eql.plugin;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+public class EqlPluginTests extends ESTestCase {
+    public void testEnabledSettingRegisteredInSnapshotBuilds() {
+        final EqlPlugin plugin = new EqlPlugin() {
+
+            @Override
+            protected boolean isSnapshot() {
+                return true;
+            }
+
+        };
+        assertThat(plugin.getSettings(), hasItem(EqlPlugin.EQL_ENABLED_SETTING));
+    }
+
+    public void testEnabledSettingNotRegisteredInNonSnapshotBuilds() {
+        final EqlPlugin plugin = new EqlPlugin() {
+
+            @Override
+            protected boolean isSnapshot() {
+                return false;
+            }
+
+        };
+        assertThat(plugin.getSettings(), not(hasItem(EqlPlugin.EQL_ENABLED_SETTING)));
+    }
+}


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/49581
