### PR TITLE
Fix testHashcodeAndEquals mutation for WaitForSnapshotStep

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -41,7 +41,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
                 nextKey = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
                 break;
             case 2:
-                policy = randomAlphaOfLengthBetween(1, 10);
+                policy = randomValueOtherThan(policy, () -> randomAlphaOfLengthBetween(1, 10));
                 break;
             default:
                 throw new AssertionError("Illegal randomisation branch");


### PR DESCRIPTION
This fixes the test failure, it was randomness returning the same policy
rather than a new one. Switched to use `randomValueOtherThan`.

Resolves #51377
