### PR TITLE
Reenable operation-based recoveries for old copies

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -1265,7 +1265,6 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
      * before we restart the cluster. This is important when we move from translog based to retention leases based
      * peer recoveries.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/51274")
     public void testOperationBasedRecovery() throws Exception {
         if (isRunningAgainstOldCluster()) {
             Settings.Builder settings = Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -175,7 +175,7 @@ public class RecoverySourceHandler {
                 = request.startingSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
                 && isTargetSameHistory()
                 && shard.hasCompleteHistoryOperations("peer-recovery", request.startingSeqNo())
-                && ((retentionLeaseRef.get() == null && (shard.indexSettings().isSoftDeleteEnabled() == false)) ||
+                && ((retentionLeaseRef.get() == null && shard.useRetentionLeasesInPeerRecovery() == false) ||
                    (retentionLeaseRef.get() != null && retentionLeaseRef.get().retainingSequenceNumber() <= request.startingSeqNo()));
             // NB check hasCompleteHistoryOperations when computing isSequenceNumberBasedRecovery, even if there is a retention lease,
             // because when doing a rolling upgrade from earlier than 7.4 we may create some leases that are initially unsatisfied. It's


### PR DESCRIPTION
We accidentally disabled operation-based recoveries for indices with soft-deletes created before 7.6 in #51189.

Relates #51189
Closes #51274 


I labelled this non-issue for an unreleased bug.