### PR TITLE
Fix wildfly test to use shadow configuration of HLRC

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -426,7 +426,7 @@ class BuildPlugin implements Plugin<Project> {
                             dependencyNode.appendNode('groupId', dependency.group)
                             dependencyNode.appendNode('artifactId', dependency.getDependencyProject().convention.getPlugin(BasePluginConvention).archivesBaseName)
                             dependencyNode.appendNode('version', dependency.version)
-                            dependencyNode.appendNode('scope', 'runtime')
+                            dependencyNode.appendNode('scope', 'compile')
                         }
                     }
                 }

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   compile "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:${versions.jackson}"
   compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   compile "org.apache.logging.log4j:log4j-core:${versions.log4j}"
-  compile project(':client:rest-high-level')
+  compile project(path: ':client:rest-high-level', configuration: 'shadow')
   wildfly "org.jboss:wildfly:${wildflyVersion}@zip"
   testCompile project(':test:framework')
 }

--- a/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
+++ b/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
@@ -56,7 +56,6 @@ public class WildflyIT extends LuceneTestCase {
 
     private Logger logger = LogManager.getLogger(WildflyIT.class);
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/45625")
     public void testRestClient() throws URISyntaxException, IOException {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             final String str = String.format(


### PR DESCRIPTION
The HLRC is shipped as a fat jar, except the Elasticsearch server jar
and LLRC are still normal dependencies. To accurately mimic this in the
wildfly tests, we need to use the shadow configuration of the HLRC.
Additionally, this commit changes the scope of these deps in the
generated pom to be compile, since a user would need the server
request/response classes when compiling against the HLRC.

closes #45625