### PR TITLE
Separate aliases used for tests in TimeSeriesLifecycleActionsIT

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -79,11 +79,13 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
 
     private String index;
     private String policy;
+    private String alias;
 
     @Before
     public void refreshIndex() {
-        index = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        policy = randomAlphaOfLength(5);
+        index = "index-" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        policy = "policy-" + randomAlphaOfLength(5);
+        alias = "alias-" + randomAlphaOfLength(5);
     }
 
     public static void updatePolicy(String indexName, String policy) throws IOException {
@@ -101,7 +103,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         createIndexWithSettings(originalIndex, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 4)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put("index.routing.allocation.include._name", "integTest-0")
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"));
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias));
 
         // create policy
         createFullPolicy(TimeValue.ZERO);
@@ -163,7 +165,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         createIndexWithSettings(originalIndex, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 4)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put("index.routing.allocation.include._name", "integTest-0")
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"));
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias));
 
         createFullPolicy(TimeValue.timeValueHours(10));
         // update policy on index
@@ -243,7 +245,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         String secondIndex = index + "-000002";
         createIndexWithSettings(originalIndex, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"));
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias));
 
         // create policy
         createNewSingletonPolicy("hot", new RolloverAction(null, null, 1L));
@@ -261,7 +263,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         String secondIndex = index + "-000002";
         createIndexWithSettings(originalIndex, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"));
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias));
 
         Request updateSettingsRequest = new Request("PUT", "/" + originalIndex + "/_settings");
         updateSettingsRequest.setJsonEntity("{\n" +
@@ -276,7 +278,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    {\n" +
             "      \"add\": {\n" +
             "        \"index\": \"" + originalIndex + "\",\n" +
-            "        \"alias\": \"alias\",\n" +
+            "        \"alias\": \"" + alias + "\",\n" +
             "        \"is_write_index\": false\n" +
             "      }\n" +
             "    }\n" +
@@ -352,7 +354,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         request = new Request("DELETE", "/_snapshot/" + repo);
         assertOK(client().performRequest(request));
     }
-    
+
     public void testWaitForSnapshotSlmExecutedBefore() throws Exception {
         createIndexWithSettings(index, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
@@ -776,7 +778,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"));
+                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias));
 
         // Index a document
         index(client(), originalIndex, "_id", "foo", "bar");
@@ -794,7 +796,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         addPolicyRequest.setJsonEntity("{\n" +
             "  \"settings\": {\n" +
             "    \"index.lifecycle.name\": \"" + policy + "\",\n" +
-            "    \"index.lifecycle.rollover_alias\": \"alias\"\n" +
+            "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
         client().performRequest(addPolicyRequest);
@@ -811,7 +813,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         createIndexWithSettings(index, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 3)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"));
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias));
 
         assertBusy(() -> assertThat(getStepKeyForIndex(index), equalTo(new StepKey("new", "complete", "complete"))));
 
@@ -847,7 +849,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"),
+                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias),
             true);
 
         assertBusy(() -> assertThat(getStepKeyForIndex("test-1"), equalTo(new StepKey("hot", "rollover", "check-rollover-ready"))));
@@ -924,7 +926,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         }
 
         createIndexWithSettings(goodIndex, Settings.builder()
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias")
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(LifecycleSettings.LIFECYCLE_NAME, policy)
         );
@@ -983,7 +985,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias")
+                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias)
                 .put("index.blocks.read_only", true),
             true
         );
@@ -1018,7 +1020,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    \"number_of_shards\": 1,\n" +
             "    \"number_of_replicas\": 0,\n" +
             "    \"index.lifecycle.name\": \"" + policy + "\", \n" +
-            "    \"index.lifecycle.rollover_alias\": \"alias\"\n" +
+            "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
         client().performRequest(createIndexTemplate);
@@ -1036,7 +1038,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         client().performRequest(refreshOriginalIndex);
 
         // Manual rollover
-        Request rolloverRequest = new Request("POST", "/alias/_rollover");
+        Request rolloverRequest = new Request("POST", "/" + alias + "/_rollover");
         rolloverRequest.setJsonEntity("{\n" +
             "  \"conditions\": {\n" +
             "    \"max_docs\": \"1\"\n" +
@@ -1057,9 +1059,9 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         assertBusy(() -> assertTrue((boolean) explainIndex(secondIndex).getOrDefault("managed", true)));
 
         // index some documents to trigger an ILM rollover
-        index(client(), "alias", "1", "foo", "bar");
-        index(client(), "alias", "2", "foo", "bar");
-        index(client(), "alias", "3", "foo", "bar");
+        index(client(), alias, "1", "foo", "bar");
+        index(client(), alias, "2", "foo", "bar");
+        index(client(), alias, "3", "foo", "bar");
         Request refreshSecondIndex = new Request("POST", "/" + secondIndex + "/_refresh");
         client().performRequest(refreshSecondIndex).getStatusLine();
 
@@ -1079,7 +1081,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             rolledIndex,
             Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"),
+                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias),
             false
         );
 
@@ -1088,7 +1090,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"),
+                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias),
             true
         );
 
@@ -1151,7 +1153,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
                 .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(LifecycleSettings.LIFECYCLE_NAME, policy)
-                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"),
+                .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias),
             true
         );
 
@@ -1191,7 +1193,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
 
         // manual rollover the index so the "update-rollover-lifecycle-date" ILM step can continue and finish successfully as the index
         // will have rollover information now
-        Request rolloverRequest = new Request("POST", "/alias/_rollover");
+        Request rolloverRequest = new Request("POST", "/" + alias + "/_rollover");
         rolloverRequest.setJsonEntity("{\n" +
             "  \"conditions\": {\n" +
             "    \"max_docs\": \"1\"\n" +
@@ -1207,7 +1209,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         String secondIndex = index + "-000002";
         createIndexWithSettings(originalIndex, Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, "alias"),
+            .put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias),
             true);
 
         // create policy
@@ -1249,7 +1251,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    \"number_of_shards\": 1,\n" +
             "    \"number_of_replicas\": 0,\n" +
             "    \"index.lifecycle.name\": \"" + policy+ "\",\n" +
-            "    \"index.lifecycle.rollover_alias\": \"alias\"\n" +
+            "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
         client().performRequest(createIndexTemplate);
@@ -1402,7 +1404,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             "    \"number_of_shards\": 1,\n" +
             "    \"number_of_replicas\": 0,\n" +
             "    \"index.lifecycle.name\": \"" + policy+ "\",\n" +
-            "    \"index.lifecycle.rollover_alias\": \"alias\"\n" +
+            "    \"index.lifecycle.rollover_alias\": \"" + alias + "\"\n" +
             "  }\n" +
             "}");
         client().performRequest(createIndexTemplate);
@@ -1584,7 +1586,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             writeIndexSnippet = "\"is_write_index\": true";
         }
         request.setJsonEntity("{\n \"settings\": " + Strings.toString(settings.build())
-            + ", \"aliases\" : { \"alias\": { " + writeIndexSnippet + " } } }");
+            + ", \"aliases\" : { \"" + alias + "\": { " + writeIndexSnippet + " } } }");
         client().performRequest(request);
         // wait for the shards to initialize
         ensureGreen(index);

--- a/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/20_move_to_step.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/20_move_to_step.yml
@@ -102,7 +102,7 @@ teardown:
             action: "forcemerge"
             name: "forcemerge"
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
-  - match: { error.root_cause.0.reason: "index [my_index] is not on current step [{\"phase\":\"warm\",\"action\":\"forcemerge\",\"name\":\"forcemerge\"}]" }
+  - match: { error.root_cause.0.reason: "index [my_index] is not on current step [{\"phase\":\"warm\",\"action\":\"forcemerge\",\"name\":\"forcemerge\"}], currently: [{\"phase\":\"new\",\"action\":\"complete\",\"name\":\"complete\"}]" }
 
 
   - do:

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -72,8 +72,10 @@ public final class IndexLifecycleTransition {
         }
 
         LifecycleExecutionState lifecycleState = LifecycleExecutionState.fromIndexMetadata(idxMeta);
-        if (currentStepKey != null && currentStepKey.equals(LifecycleExecutionState.getCurrentStepKey(lifecycleState)) == false) {
-            throw new IllegalArgumentException("index [" + indexName + "] is not on current step [" + currentStepKey + "]");
+        Step.StepKey realKey = LifecycleExecutionState.getCurrentStepKey(lifecycleState);
+        if (currentStepKey != null && currentStepKey.equals(realKey) == false) {
+            throw new IllegalArgumentException("index [" + indexName + "] is not on current step [" + currentStepKey +
+                "], currently: [" + realKey + "]");
         }
 
         if (stepRegistry.stepExists(indexPolicySetting, newStepKey) == false) {


### PR DESCRIPTION
This is related to #51375 and hopes to help illuminate why some of those tests are failing. This
commit switches the aliases used in the test to use a random alias name every time (since there were
some complaints in the tests about aliases having more than one write index). With this we hope to
determine the actual cause of the failure in the test.

This also adds additional information to the exception returned when calling move-to-step with the
incorrect current step.
