### PR TITLE
Centralize mocks initialization in ILM steps tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncActionStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncActionStep.java
@@ -29,11 +29,6 @@ public abstract class AsyncActionStep extends Step {
         return client;
     }
 
-    //visible for testing
-    void setClient(Client client){
-        this.client = client;
-    }
-
     public static TimeValue getMasterTimeout(ClusterState clusterState){
         Objects.requireNonNull(clusterState, "cannot determine master timeout when cluster state is null");
         return LifecycleSettings.LIFECYCLE_STEP_MASTER_TIMEOUT_SETTING.get(clusterState.metaData().settings());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractStepTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractStepTestCase.java
@@ -5,12 +5,31 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+import org.junit.Before;
+import org.mockito.Mockito;
 
 public abstract class AbstractStepTestCase<T extends Step> extends ESTestCase {
+
+    protected Client client;
+    protected AdminClient adminClient;
+    protected IndicesAdminClient indicesClient;
+
+    @Before
+    public void setupClient() {
+        client = Mockito.mock(Client.class);
+        adminClient = Mockito.mock(AdminClient.class);
+        indicesClient = Mockito.mock(IndicesAdminClient.class);
+
+        Mockito.when(client.admin()).thenReturn(adminClient);
+        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
+    }
 
     protected static final int NUMBER_OF_TEST_RUNS = 20;
     protected static final TimeValue MASTER_TIMEOUT = TimeValue.timeValueSeconds(30);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractUnfollowIndexStepTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractUnfollowIndexStepTestCase.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.mockito.Mockito;
 
@@ -19,7 +18,7 @@ public abstract class AbstractUnfollowIndexStepTestCase<T extends AbstractUnfoll
     protected final T createRandomInstance() {
         Step.StepKey stepKey = randomStepKey();
         Step.StepKey nextStepKey = randomStepKey();
-        return newInstance(stepKey, nextStepKey, Mockito.mock(Client.class));
+        return newInstance(stepKey, nextStepKey);
     }
 
     @Override
@@ -33,12 +32,12 @@ public abstract class AbstractUnfollowIndexStepTestCase<T extends AbstractUnfoll
             nextKey = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
         }
 
-        return newInstance(key, nextKey, instance.getClient());
+        return newInstance(key, nextKey);
     }
 
     @Override
     protected final T copyInstance(T instance) {
-        return newInstance(instance.getKey(), instance.getNextStepKey(), instance.getClient());
+        return newInstance(instance.getKey(), instance.getNextStepKey());
     }
 
     public final void testNotAFollowerIndex() {
@@ -48,8 +47,7 @@ public abstract class AbstractUnfollowIndexStepTestCase<T extends AbstractUnfoll
             .numberOfReplicas(0)
             .build();
 
-        Client client = Mockito.mock(Client.class);
-        T step = newInstance(randomStepKey(), randomStepKey(), client);
+        T step = newInstance(randomStepKey(), randomStepKey());
 
         Boolean[] completed = new Boolean[1];
         Exception[] failure = new Exception[1];
@@ -69,5 +67,5 @@ public abstract class AbstractUnfollowIndexStepTestCase<T extends AbstractUnfoll
         Mockito.verifyZeroInteractions(client);
     }
 
-    protected abstract T newInstance(Step.StepKey key, Step.StepKey nextKey, Client client);
+    protected abstract T newInstance(Step.StepKey key, Step.StepKey nextKey);
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
@@ -9,9 +9,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.mockito.Mockito;
 
@@ -37,12 +34,6 @@ public class CloseFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCa
 
     public void testCloseFollowingIndex() {
         IndexMetaData indexMetadata = getIndexMetaData();
-
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Mockito.doAnswer(invocation -> {
             CloseIndexRequest closeIndexRequest = (CloseIndexRequest) invocation.getArguments()[0];
@@ -75,12 +66,6 @@ public class CloseFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCa
         IndexMetaData indexMetadata = getIndexMetaData();
 
         // Mock pause follow api call:
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-
         Exception error = new RuntimeException();
         Mockito.doAnswer(invocation -> {
             CloseIndexRequest closeIndexRequest = (CloseIndexRequest) invocation.getArguments()[0];
@@ -118,7 +103,6 @@ public class CloseFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCa
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        Client client = Mockito.mock(Client.class);
         CloseFollowerIndexStep step = new CloseFollowerIndexStep(randomStepKey(), randomStepKey(), client);
         step.performAction(indexMetadata, null, null, new AsyncActionStep.Listener() {
             @Override
@@ -138,7 +122,7 @@ public class CloseFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCa
     protected CloseFollowerIndexStep createRandomInstance() {
         Step.StepKey stepKey = randomStepKey();
         Step.StepKey nextStepKey = randomStepKey();
-        return new CloseFollowerIndexStep(stepKey, nextStepKey, Mockito.mock(Client.class));
+        return new CloseFollowerIndexStep(stepKey, nextStepKey, client);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
@@ -11,26 +11,13 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
-import org.junit.Before;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteStep> {
-
-    private Client client;
-
-    @Before
-    public void setup() {
-        client = Mockito.mock(Client.class);
-    }
 
     @Override
     public DeleteStep createRandomInstance() {
@@ -77,11 +64,6 @@ public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteSte
     public void testDeleted() {
         IndexMetaData indexMetaData = getIndexMetaData();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
         Mockito.doAnswer(invocation -> {
                 DeleteIndexRequest request = (DeleteIndexRequest) invocation.getArguments()[0];
                 @SuppressWarnings("unchecked")
@@ -119,25 +101,15 @@ public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteSte
         IndexMetaData indexMetaData = getIndexMetaData();
         Exception exception = new RuntimeException();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                DeleteIndexRequest request = (DeleteIndexRequest) invocation.getArguments()[0];
-                @SuppressWarnings("unchecked")
-                ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocation.getArguments()[1];
-                assertNotNull(request);
-                assertEquals(1, request.indices().length);
-                assertEquals(indexMetaData.getIndex().getName(), request.indices()[0]);
-                listener.onFailure(exception);
-                return null;
-            }
-
+        Mockito.doAnswer(invocation -> {
+            DeleteIndexRequest request = (DeleteIndexRequest) invocation.getArguments()[0];
+            @SuppressWarnings("unchecked")
+            ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocation.getArguments()[1];
+            assertNotNull(request);
+            assertEquals(1, request.indices().length);
+            assertEquals(indexMetaData.getIndex().getName(), request.indices()[0]);
+            listener.onFailure(exception);
+            return null;
         }).when(indicesClient).delete(Mockito.any(), Mockito.any());
 
         SetOnce<Boolean> exceptionThrown = new SetOnce<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
@@ -11,9 +11,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
@@ -70,11 +67,6 @@ public class ForceMergeStepTests extends AbstractStepTestCase<ForceMergeStep> {
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
         int maxNumSegments = randomIntBetween(1, 10);
-        Client client = mock(Client.class);
-        AdminClient adminClient = mock(AdminClient.class);
-        IndicesAdminClient indicesClient = mock(IndicesAdminClient.class);
-        when(client.admin()).thenReturn(adminClient);
-        when(adminClient.indices()).thenReturn(indicesClient);
         ForceMergeResponse forceMergeResponse = Mockito.mock(ForceMergeResponse.class);
         Mockito.when(forceMergeResponse.getStatus()).thenReturn(RestStatus.OK);
         Mockito.doAnswer(invocationOnMock -> {
@@ -109,11 +101,6 @@ public class ForceMergeStepTests extends AbstractStepTestCase<ForceMergeStep> {
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
         int maxNumSegments = randomIntBetween(1, 10);
-        Client client = mock(Client.class);
-        AdminClient adminClient = mock(AdminClient.class);
-        IndicesAdminClient indicesClient = mock(IndicesAdminClient.class);
-        when(client.admin()).thenReturn(adminClient);
-        when(adminClient.indices()).thenReturn(indicesClient);
         ForceMergeResponse forceMergeResponse = Mockito.mock(ForceMergeResponse.class);
         Mockito.when(forceMergeResponse.getStatus()).thenReturn(RestStatus.OK);
         Mockito.doAnswer(invocationOnMock -> {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
@@ -18,8 +18,6 @@ import org.mockito.Mockito;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ForceMergeStepTests extends AbstractStepTestCase<ForceMergeStep> {
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/FreezeStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/FreezeStepTests.java
@@ -10,27 +10,15 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.protocol.xpack.frozen.FreezeRequest;
 import org.elasticsearch.xpack.core.frozen.action.FreezeIndexAction;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
-import org.junit.Before;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class FreezeStepTests extends AbstractStepMasterTimeoutTestCase<FreezeStep> {
-
-    private Client client;
-
-    @Before
-    public void setup() {
-        client = Mockito.mock(Client.class);
-    }
 
     @Override
     public FreezeStep createRandomInstance() {
@@ -77,11 +65,6 @@ public class FreezeStepTests extends AbstractStepMasterTimeoutTestCase<FreezeSte
     public void testFreeze() {
         IndexMetaData indexMetaData = getIndexMetaData();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
         Mockito.doAnswer(invocation -> {
             assertSame(invocation.getArguments()[0], FreezeIndexAction.INSTANCE);
             FreezeRequest request = (FreezeRequest) invocation.getArguments()[1];
@@ -120,12 +103,7 @@ public class FreezeStepTests extends AbstractStepMasterTimeoutTestCase<FreezeSte
         IndexMetaData indexMetaData = getIndexMetaData();
         Exception exception = new RuntimeException();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer((Answer<Void>) invocation -> {
+        Mockito.doAnswer(invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocation.getArguments()[2];
             listener.onFailure(exception);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/OpenFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/OpenFollowerIndexStepTests.java
@@ -9,9 +9,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.mockito.Mockito;
 
@@ -29,7 +26,7 @@ public class OpenFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCas
     protected OpenFollowerIndexStep createRandomInstance() {
         Step.StepKey stepKey = randomStepKey();
         Step.StepKey nextStepKey = randomStepKey();
-        return new OpenFollowerIndexStep(stepKey, nextStepKey, Mockito.mock(Client.class));
+        return new OpenFollowerIndexStep(stepKey, nextStepKey, client);
     }
 
     @Override
@@ -64,7 +61,6 @@ public class OpenFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCas
 
     public void testOpenFollowerIndexIsNoopForAlreadyOpenIndex() {
         IndexMetaData indexMetadata = getIndexMetaData();
-        Client client = Mockito.mock(Client.class);
         OpenFollowerIndexStep step = new OpenFollowerIndexStep(randomStepKey(), randomStepKey(), client);
         step.performAction(indexMetadata, null, null, new AsyncActionStep.Listener() {
             @Override
@@ -88,12 +84,6 @@ public class OpenFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCas
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Mockito.doAnswer(invocation -> {
             OpenIndexRequest closeIndexRequest = (OpenIndexRequest) invocation.getArguments()[0];
@@ -130,12 +120,6 @@ public class OpenFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCas
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Exception error = new RuntimeException();
         Mockito.doAnswer(invocation -> {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/OpenFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/OpenFollowerIndexStepTests.java
@@ -53,14 +53,20 @@ public class OpenFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCas
         return IndexMetaData.builder("follower-index")
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "true"))
             .putCustom(CCR_METADATA_KEY, Collections.emptyMap())
-            .state(IndexMetaData.State.OPEN)
+            .state(IndexMetaData.State.CLOSE)
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
     }
 
     public void testOpenFollowerIndexIsNoopForAlreadyOpenIndex() {
-        IndexMetaData indexMetadata = getIndexMetaData();
+        IndexMetaData indexMetadata = IndexMetaData.builder("follower-index")
+            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "true"))
+            .putCustom(CCR_METADATA_KEY, Collections.emptyMap())
+            .state(IndexMetaData.State.OPEN)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
         OpenFollowerIndexStep step = new OpenFollowerIndexStep(randomStepKey(), randomStepKey(), client);
         step.performAction(indexMetadata, null, null, new AsyncActionStep.Listener() {
             @Override
@@ -77,13 +83,7 @@ public class OpenFollowerIndexStepTests extends AbstractStepMasterTimeoutTestCas
     }
 
     public void testOpenFollowingIndex() {
-        IndexMetaData indexMetadata = IndexMetaData.builder("follower-index")
-            .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, "true"))
-            .putCustom(CCR_METADATA_KEY, Collections.emptyMap())
-            .state(IndexMetaData.State.CLOSE)
-            .numberOfShards(1)
-            .numberOfReplicas(0)
-            .build();
+        IndexMetaData indexMetadata = getIndexMetaData();
 
         Mockito.doAnswer(invocation -> {
             OpenIndexRequest closeIndexRequest = (OpenIndexRequest) invocation.getArguments()[0];

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PauseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PauseFollowerIndexStepTests.java
@@ -8,9 +8,6 @@ package org.elasticsearch.xpack.core.ilm;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.xpack.core.ccr.action.PauseFollowAction;
 import org.mockito.Mockito;
@@ -26,7 +23,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class PauseFollowerIndexStepTests extends AbstractUnfollowIndexStepTestCase<PauseFollowerIndexStep> {
 
     @Override
-    protected PauseFollowerIndexStep newInstance(Step.StepKey key, Step.StepKey nextKey, Client client) {
+    protected PauseFollowerIndexStep newInstance(Step.StepKey key, Step.StepKey nextKey) {
         return new PauseFollowerIndexStep(key, nextKey, client);
     }
 
@@ -38,11 +35,6 @@ public class PauseFollowerIndexStepTests extends AbstractUnfollowIndexStepTestCa
             .numberOfReplicas(0)
             .build();
 
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Mockito.doAnswer(invocation -> {
             PauseFollowAction.Request request = (PauseFollowAction.Request) invocation.getArguments()[1];
@@ -80,7 +72,6 @@ public class PauseFollowerIndexStepTests extends AbstractUnfollowIndexStepTestCa
             .build();
 
         // Mock pause follow api call:
-        Client client = Mockito.mock(Client.class);
         Exception error = new RuntimeException();
         Mockito.doAnswer(invocation -> {
             PauseFollowAction.Request request = (PauseFollowAction.Request) invocation.getArguments()[1];

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
@@ -12,17 +12,11 @@ import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.RolloverInfo;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
-import org.junit.Before;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -31,13 +25,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 
 public class RolloverStepTests extends AbstractStepMasterTimeoutTestCase<RolloverStep> {
-
-    private Client client;
-
-    @Before
-    public void setup() {
-        client = Mockito.mock(Client.class);
-    }
 
     @Override
     public RolloverStep createRandomInstance() {
@@ -99,23 +86,13 @@ public class RolloverStepTests extends AbstractStepMasterTimeoutTestCase<Rollove
 
         RolloverStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
-                @SuppressWarnings("unchecked")
-                ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
-                assertRolloverIndexRequest(request, alias);
-                listener.onResponse(new RolloverResponse(null, null, Collections.emptyMap(), request.isDryRun(), true, true, true));
-                return null;
-            }
-
+        Mockito.doAnswer(invocation -> {
+            RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
+            @SuppressWarnings("unchecked")
+            ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
+            assertRolloverIndexRequest(request, alias);
+            listener.onResponse(new RolloverResponse(null, null, Collections.emptyMap(), request.isDryRun(), true, true, true));
+            return null;
         }).when(indicesClient).rolloverIndex(Mockito.any(), Mockito.any());
 
         SetOnce<Boolean> actionCompleted = new SetOnce<>();
@@ -179,10 +156,6 @@ public class RolloverStepTests extends AbstractStepMasterTimeoutTestCase<Rollove
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
 
         RolloverStep step = createRandomInstance();
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         step.performAction(indexMetaData, null, null, new AsyncActionStep.Listener() {
 
@@ -206,23 +179,13 @@ public class RolloverStepTests extends AbstractStepMasterTimeoutTestCase<Rollove
         Exception exception = new RuntimeException();
         RolloverStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
-                @SuppressWarnings("unchecked")
-                ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
-                assertRolloverIndexRequest(request, alias);
-                listener.onFailure(exception);
-                return null;
-            }
-
+        Mockito.doAnswer(invocation -> {
+            RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
+            @SuppressWarnings("unchecked")
+            ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
+            assertRolloverIndexRequest(request, alias);
+            listener.onFailure(exception);
+            return null;
         }).when(indicesClient).rolloverIndex(Mockito.any(), Mockito.any());
 
         SetOnce<Boolean> exceptionThrown = new SetOnce<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SegmentCountStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SegmentCountStepTests.java
@@ -13,9 +13,6 @@ import org.elasticsearch.action.admin.indices.segments.IndexShardSegments;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentResponse;
 import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -85,9 +82,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
     public void testIsConditionMet() {
         int maxNumSegments = randomIntBetween(3, 10);
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
         IndicesSegmentResponse indicesSegmentResponse = Mockito.mock(IndicesSegmentResponse.class);
         IndexSegments indexSegments = Mockito.mock(IndexSegments.class);
         IndexShardSegments indexShardSegments = Mockito.mock(IndexShardSegments.class);
@@ -104,9 +98,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         Mockito.when(indexSegments.spliterator()).thenReturn(iss);
         Mockito.when(indexShardSegments.getShards()).thenReturn(shardSegmentsArray);
         Mockito.when(shardSegmentsOne.getSegments()).thenReturn(segments);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
@@ -143,9 +134,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
     public void testIsConditionIsTrueEvenWhenMoreSegments() {
         int maxNumSegments = randomIntBetween(3, 10);
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
         IndicesSegmentResponse indicesSegmentResponse = Mockito.mock(IndicesSegmentResponse.class);
         IndexSegments indexSegments = Mockito.mock(IndexSegments.class);
         IndexShardSegments indexShardSegments = Mockito.mock(IndexShardSegments.class);
@@ -162,9 +150,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         Mockito.when(indexSegments.spliterator()).thenReturn(iss);
         Mockito.when(indexShardSegments.getShards()).thenReturn(shardSegmentsArray);
         Mockito.when(shardSegmentsOne.getSegments()).thenReturn(segments);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
@@ -201,9 +186,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
     public void testFailedToRetrieveSomeSegments() {
         int maxNumSegments = randomIntBetween(3, 10);
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
         IndicesSegmentResponse indicesSegmentResponse = Mockito.mock(IndicesSegmentResponse.class);
         IndexSegments indexSegments = Mockito.mock(IndexSegments.class);
         IndexShardSegments indexShardSegments = Mockito.mock(IndexShardSegments.class);
@@ -223,9 +205,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         Mockito.when(indexSegments.spliterator()).thenReturn(iss);
         Mockito.when(indexShardSegments.getShards()).thenReturn(shardSegmentsArray);
         Mockito.when(shardSegmentsOne.getSegments()).thenReturn(segments);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
@@ -262,11 +241,6 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
     public void testThrowsException() {
         Exception exception = new RuntimeException("error");
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Step.StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkSetAliasStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkSetAliasStepTests.java
@@ -11,14 +11,10 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.xpack.core.ilm.AsyncActionStep.Listener;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
-import org.junit.Before;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -29,13 +25,6 @@ import static org.elasticsearch.xpack.core.ilm.AbstractStepMasterTimeoutTestCase
 import static org.hamcrest.Matchers.equalTo;
 
 public class ShrinkSetAliasStepTests extends AbstractStepTestCase<ShrinkSetAliasStep> {
-
-    private Client client;
-
-    @Before
-    public void setup() {
-        client = Mockito.mock(Client.class);
-    }
 
     @Override
     public ShrinkSetAliasStep createRandomInstance() {
@@ -99,11 +88,7 @@ public class ShrinkSetAliasStepTests extends AbstractStepTestCase<ShrinkSetAlias
             IndicesAliasesRequest.AliasActions.add().index(shrunkenIndex).alias(aliasMetaData.alias())
                 .searchRouting(aliasMetaData.searchRouting()).indexRouting(aliasMetaData.indexRouting())
                 .filter(aliasMetaDataFilter).writeIndex(null));
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
 
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
         Mockito.doAnswer( invocation -> {
             IndicesAliasesRequest request = (IndicesAliasesRequest) invocation.getArguments()[0];
             assertThat(request.getAliasActions(), equalTo(expectedAliasActions));
@@ -140,11 +125,6 @@ public class ShrinkSetAliasStepTests extends AbstractStepTestCase<ShrinkSetAlias
         Exception exception = new RuntimeException();
         ShrinkSetAliasStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
         Mockito.doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocation.getArguments()[1];

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UnfollowFollowIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UnfollowFollowIndexStepTests.java
@@ -9,9 +9,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.xpack.core.ccr.action.UnfollowAction;
 import org.mockito.Mockito;
@@ -29,7 +26,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class UnfollowFollowIndexStepTests extends AbstractUnfollowIndexStepTestCase<UnfollowFollowIndexStep> {
 
     @Override
-    protected UnfollowFollowIndexStep newInstance(Step.StepKey key, Step.StepKey nextKey, Client client) {
+    protected UnfollowFollowIndexStep newInstance(Step.StepKey key, Step.StepKey nextKey) {
         return new UnfollowFollowIndexStep(key, nextKey, client);
     }
 
@@ -40,12 +37,6 @@ public class UnfollowFollowIndexStepTests extends AbstractUnfollowIndexStepTestC
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Mockito.doAnswer(invocation -> {
             UnfollowAction.Request request = (UnfollowAction.Request) invocation.getArguments()[1];
@@ -82,12 +73,6 @@ public class UnfollowFollowIndexStepTests extends AbstractUnfollowIndexStepTestC
             .numberOfReplicas(0)
             .build();
 
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-
         // Mock unfollow api call:
         Exception error = new RuntimeException();
         Mockito.doAnswer(invocation -> {
@@ -123,12 +108,6 @@ public class UnfollowFollowIndexStepTests extends AbstractUnfollowIndexStepTestC
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-
-        Client client = Mockito.mock(Client.class);
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         // Mock unfollow api call:
         ElasticsearchException error = new ElasticsearchException("text exception");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateSettingsStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateSettingsStepTests.java
@@ -11,26 +11,15 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.ilm.AsyncActionStep.Listener;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
-import org.junit.Before;
 import org.mockito.Mockito;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public class UpdateSettingsStepTests extends AbstractStepMasterTimeoutTestCase<UpdateSettingsStep> {
-
-    private Client client;
-
-    @Before
-    public void setup() {
-        client = Mockito.mock(Client.class);
-    }
 
     @Override
     public UpdateSettingsStep createRandomInstance() {
@@ -75,16 +64,10 @@ public class UpdateSettingsStepTests extends AbstractStepMasterTimeoutTestCase<U
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
     }
 
-    public void testPerformAction() throws Exception {
+    public void testPerformAction() {
         IndexMetaData indexMetaData = getIndexMetaData();
 
         UpdateSettingsStep step = createRandomInstance();
-
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
 
         Mockito.doAnswer(invocation -> {
             UpdateSettingsRequest request = (UpdateSettingsRequest) invocation.getArguments()[0];
@@ -123,11 +106,6 @@ public class UpdateSettingsStepTests extends AbstractStepMasterTimeoutTestCase<U
         Exception exception = new RuntimeException();
         UpdateSettingsStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
         Mockito.doAnswer(invocation -> {
             UpdateSettingsRequest request = (UpdateSettingsRequest) invocation.getArguments()[0];
             @SuppressWarnings("unchecked")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
@@ -31,7 +31,7 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
     protected WaitForFollowShardTasksStep createRandomInstance() {
         StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
-        return new WaitForFollowShardTasksStep(stepKey, nextStepKey, Mockito.mock(Client.class));
+        return new WaitForFollowShardTasksStep(stepKey, nextStepKey, client);
     }
 
     @Override
@@ -60,18 +60,16 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
             .numberOfShards(2)
             .numberOfReplicas(0)
             .build();
-        Client client = Mockito.mock(Client.class);
         List<FollowStatsAction.StatsResponse> statsResponses = Arrays.asList(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, 9, 9)),
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, 3, 3))
         );
-        mockFollowStatsCall(client, indexMetadata.getIndex().getName(), statsResponses);
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
 
-        WaitForFollowShardTasksStep step = new WaitForFollowShardTasksStep(randomStepKey(), randomStepKey(), client);
         final boolean[] conditionMetHolder = new boolean[1];
         final ToXContentObject[] informationContextHolder = new ToXContentObject[1];
         final Exception[] exceptionHolder = new Exception[1];
-        step.evaluateCondition(indexMetadata, new AsyncWaitStep.Listener() {
+        createRandomInstance().evaluateCondition(indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder[0] = conditionMet;
@@ -96,18 +94,16 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
             .numberOfShards(2)
             .numberOfReplicas(0)
             .build();
-        Client client = Mockito.mock(Client.class);
         List<FollowStatsAction.StatsResponse> statsResponses = Arrays.asList(
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(0, 9, 9)),
             new FollowStatsAction.StatsResponse(createShardFollowTaskStatus(1, 8, 3))
         );
-        mockFollowStatsCall(client, indexMetadata.getIndex().getName(), statsResponses);
+        mockFollowStatsCall(indexMetadata.getIndex().getName(), statsResponses);
 
-        WaitForFollowShardTasksStep step = new WaitForFollowShardTasksStep(randomStepKey(), randomStepKey(), client);
         final boolean[] conditionMetHolder = new boolean[1];
         final ToXContentObject[] informationContextHolder = new ToXContentObject[1];
         final Exception[] exceptionHolder = new Exception[1];
-        step.evaluateCondition(indexMetadata, new AsyncWaitStep.Listener() {
+        createRandomInstance().evaluateCondition(indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder[0] = conditionMet;
@@ -136,13 +132,11 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
             .numberOfShards(2)
             .numberOfReplicas(0)
             .build();
-        Client client = Mockito.mock(Client.class);
 
-        WaitForFollowShardTasksStep step = new WaitForFollowShardTasksStep(randomStepKey(), randomStepKey(), client);
         final boolean[] conditionMetHolder = new boolean[1];
         final ToXContentObject[] informationContextHolder = new ToXContentObject[1];
         final Exception[] exceptionHolder = new Exception[1];
-        step.evaluateCondition(indexMetadata, new AsyncWaitStep.Listener() {
+        createRandomInstance().evaluateCondition(indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder[0] = conditionMet;
@@ -195,7 +189,7 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
         );
     }
 
-    private void mockFollowStatsCall(Client client, String expectedIndexName, List<FollowStatsAction.StatsResponse> statsResponses) {
+    private void mockFollowStatsCall(String expectedIndexName, List<FollowStatsAction.StatsResponse> statsResponses) {
         Mockito.doAnswer(invocationOnMock -> {
             FollowStatsAction.StatsRequest request = (FollowStatsAction.StatsRequest) invocationOnMock.getArguments()[1];
             assertThat(request.indices().length, equalTo(1));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
@@ -13,9 +13,6 @@ import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -43,7 +40,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
     protected WaitForNoFollowersStep createRandomInstance() {
         Step.StepKey stepKey = randomStepKey();
         Step.StepKey nextStepKey = randomStepKey();
-        return new WaitForNoFollowersStep(stepKey, nextStepKey, mock(Client.class));
+        return new WaitForNoFollowersStep(stepKey, nextStepKey, client);
     }
 
     @Override
@@ -77,7 +74,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
             .numberOfReplicas(randomIntBetween(1, 10))
             .build();
 
-        mockIndexStatsCall(step.getClient(), indexName, randomIndexStats(false, numberOfShards));
+        mockIndexStatsCall(indexName, randomIndexStats(false, numberOfShards));
 
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
@@ -110,7 +107,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
             .numberOfReplicas(randomIntBetween(1, 10))
             .build();
 
-        mockIndexStatsCall(step.getClient(), indexName, randomIndexStats(true, numberOfShards));
+        mockIndexStatsCall(indexName, randomIndexStats(true, numberOfShards));
 
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
@@ -147,7 +144,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         ShardStats sStats = new ShardStats(null, mockShardPath(), null, null, null, null);
         ShardStats[] shardStats = new ShardStats[1];
         shardStats[0] = sStats;
-        mockIndexStatsCall(step.getClient(), indexName, new IndexStats(indexName, "uuid", shardStats));
+        mockIndexStatsCall(indexName, new IndexStats(indexName, "uuid", shardStats));
 
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
@@ -182,11 +179,6 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
 
         final Exception expectedException = new RuntimeException(randomAlphaOfLength(5));
 
-        Client client = step.getClient();
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
         Mockito.doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<IndicesStatsResponse> listener = (ActionListener<IndicesStatsResponse>) invocationOnMock.getArguments()[1];
@@ -211,11 +203,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         assertThat(exceptionHolder.get(), equalTo(expectedException));
     }
 
-    private void mockIndexStatsCall(Client client, String expectedIndexName, IndexStats indexStats) {
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
+    private void mockIndexStatsCall(String expectedIndexName, IndexStats indexStats) {
         Mockito.doAnswer(invocationOnMock -> {
             IndicesStatsRequest request = (IndicesStatsRequest) invocationOnMock.getArguments()[0];
             assertThat(request.indices().length, equalTo(1));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -16,19 +16,13 @@ import org.elasticsearch.action.admin.indices.rollover.MaxSizeCondition;
 import org.elasticsearch.action.admin.indices.rollover.RolloverInfo;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.junit.Before;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -41,13 +35,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForRolloverReadyStep> {
-
-    private Client client;
-
-    @Before
-    public void setup() {
-        client = Mockito.mock(Client.class);
-    }
 
     @Override
     protected WaitForRolloverReadyStep createRandomInstance() {
@@ -124,35 +111,25 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         WaitForRolloverReadyStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
-                @SuppressWarnings("unchecked")
-                ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
-                Set<Condition<?>> expectedConditions = new HashSet<>();
-                if (step.getMaxAge() != null) {
-                    expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
-                }
-                if (step.getMaxSize() != null) {
-                    expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
-                }
-                if (step.getMaxDocs() != null) {
-                    expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
-                }
-                assertRolloverIndexRequest(request, alias, expectedConditions);
-                Map<String, Boolean> conditionResults = expectedConditions.stream()
-                    .collect(Collectors.toMap(Condition::toString, condition -> true));
-                listener.onResponse(new RolloverResponse(null, null, conditionResults, request.isDryRun(), false, false, false));
-                return null;
+        Mockito.doAnswer(invocation -> {
+            RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
+            @SuppressWarnings("unchecked")
+            ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
+            Set<Condition<?>> expectedConditions = new HashSet<>();
+            if (step.getMaxAge() != null) {
+                expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
             }
-
+            if (step.getMaxSize() != null) {
+                expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
+            }
+            if (step.getMaxDocs() != null) {
+                expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
+            }
+            assertRolloverIndexRequest(request, alias, expectedConditions);
+            Map<String, Boolean> conditionResults = expectedConditions.stream()
+                .collect(Collectors.toMap(Condition::toString, condition -> true));
+            listener.onResponse(new RolloverResponse(null, null, conditionResults, request.isDryRun(), false, false, false));
+            return null;
         }).when(indicesClient).rolloverIndex(Mockito.any(), Mockito.any());
 
         SetOnce<Boolean> conditionsMet = new SetOnce<>();
@@ -186,7 +163,6 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
 
         WaitForRolloverReadyStep step = createRandomInstance();
-        IndicesAdminClient indicesClient = indicesAdminClientMock();
 
         step.evaluateCondition(indexMetaData, new AsyncWaitStep.Listener() {
 
@@ -216,7 +192,6 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
 
         WaitForRolloverReadyStep step = createRandomInstance();
-        IndicesAdminClient indicesClient = indicesAdminClientMock();
 
         step.evaluateCondition(indexMetaData, new AsyncWaitStep.Listener() {
 
@@ -299,35 +274,25 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         WaitForRolloverReadyStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
-                @SuppressWarnings("unchecked")
-                ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
-                Set<Condition<?>> expectedConditions = new HashSet<>();
-                if (step.getMaxAge() != null) {
-                    expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
-                }
-                if (step.getMaxSize() != null) {
-                    expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
-                }
-                if (step.getMaxDocs() != null) {
-                    expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
-                }
-                assertRolloverIndexRequest(request, alias, expectedConditions);
-                Map<String, Boolean> conditionResults = expectedConditions.stream()
-                    .collect(Collectors.toMap(Condition::toString, condition -> false));
-                listener.onResponse(new RolloverResponse(null, null, conditionResults, request.isDryRun(), false, false, false));
-                return null;
+        Mockito.doAnswer(invocation -> {
+            RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
+            @SuppressWarnings("unchecked")
+            ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
+            Set<Condition<?>> expectedConditions = new HashSet<>();
+            if (step.getMaxAge() != null) {
+                expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
             }
-
+            if (step.getMaxSize() != null) {
+                expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
+            }
+            if (step.getMaxDocs() != null) {
+                expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
+            }
+            assertRolloverIndexRequest(request, alias, expectedConditions);
+            Map<String, Boolean> conditionResults = expectedConditions.stream()
+                .collect(Collectors.toMap(Condition::toString, condition -> false));
+            listener.onResponse(new RolloverResponse(null, null, conditionResults, request.isDryRun(), false, false, false));
+            return null;
         }).when(indicesClient).rolloverIndex(Mockito.any(), Mockito.any());
 
         SetOnce<Boolean> actionCompleted = new SetOnce<>();
@@ -360,33 +325,23 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         Exception exception = new RuntimeException();
         WaitForRolloverReadyStep step = createRandomInstance();
 
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        Mockito.doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
-                @SuppressWarnings("unchecked")
-                ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
-                Set<Condition<?>> expectedConditions = new HashSet<>();
-                if (step.getMaxAge() != null) {
-                    expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
-                }
-                if (step.getMaxSize() != null) {
-                    expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
-                }
-                if (step.getMaxDocs() != null) {
-                    expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
-                }
-                assertRolloverIndexRequest(request, alias, expectedConditions);
-                listener.onFailure(exception);
-                return null;
+        Mockito.doAnswer(invocation -> {
+            RolloverRequest request = (RolloverRequest) invocation.getArguments()[0];
+            @SuppressWarnings("unchecked")
+            ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArguments()[1];
+            Set<Condition<?>> expectedConditions = new HashSet<>();
+            if (step.getMaxAge() != null) {
+                expectedConditions.add(new MaxAgeCondition(step.getMaxAge()));
             }
-
+            if (step.getMaxSize() != null) {
+                expectedConditions.add(new MaxSizeCondition(step.getMaxSize()));
+            }
+            if (step.getMaxDocs() != null) {
+                expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
+            }
+            assertRolloverIndexRequest(request, alias, expectedConditions);
+            listener.onFailure(exception);
+            return null;
         }).when(indicesClient).rolloverIndex(Mockito.any(), Mockito.any());
 
         SetOnce<Boolean> exceptionThrown = new SetOnce<>();
@@ -459,13 +414,5 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         assertThat(exceptionThrown.get().getMessage(), equalTo(String.format(Locale.ROOT,
             "%s [%s] does not point to index [%s]", RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias,
             indexMetaData.getIndex().getName())));
-    }
-
-    private IndicesAdminClient indicesAdminClientMock() {
-        AdminClient adminClient = Mockito.mock(AdminClient.class);
-        IndicesAdminClient indicesClient = Mockito.mock(IndicesAdminClient.class);
-        Mockito.when(client.admin()).thenReturn(adminClient);
-        Mockito.when(adminClient.indices()).thenReturn(indicesClient);
-        return indicesClient;
     }
 }


### PR DESCRIPTION
This change centralizes initialization of `Client`, `AdminClient` and `IndicesAdminClient` for all classes extending `AbstractStepTestCase`.
This removes a lot of code duplication and make it easier to write tests.
This also removes need for `AsyncActionStep#setClient`.