### PR TITLE
Add link to .NET client BulkAllObservable

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -105,6 +105,10 @@ Perl::
 Python::
 
     See http://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
+    
+.NET::
+
+    See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#_multiple_documents_with_bulkallobservable_helper[Indexing multiple documents with `BulkAllObservable`]
 
 [float]
 [[bulk-curl]]


### PR DESCRIPTION
This PR adds a link in the Bulk API documentation to the
.NET client's `BulkAllObservable` type and associated methods.
