### PR TITLE
Reenable "Date aggregation per day of week" with the correct version

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/310_date_agg_per_day_of_week.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/310_date_agg_per_day_of_week.yml
@@ -1,8 +1,8 @@
 
 setup:
   - skip:
-      version: "all"
-      reason:  "Start of the week Monday was backported to 7.6. Awaitsfix https://github.com/elastic/elasticsearch/issues/51367"
+      version: " - 7.6.99"
+      reason:  "Start of the week Monday was enabled in a backport to 7.7 PR#50916"
       features: "spi_on_classpath_jdk9"
 
   - do:


### PR DESCRIPTION
The Iso week calculations were enabled in 7.7
previously I incorrectly set the skip version to 7.5.99 
relates https://github.com/elastic/elasticsearch/issues/51367