### PR TITLE
Speed up doc tests using RamDirectory

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -65,6 +65,7 @@ testClusters.integTest {
 
   // TODO: remove this once cname is prepended to transport.publish_address by default in 8.0
   systemProperty 'es.transport.cname_in_publish_address', 'true'
+  systemProperty 'tests.es.use_ram_dir_for_metadata', 'true' // to speed up tests
 }
 
 // build the cluster with all plugins
@@ -931,7 +932,7 @@ buildRestTests.setups['farequote_index'] = '''
                   airline:
                      type: keyword
                   doc_count:
-                     type: integer       
+                     type: integer
 '''
 buildRestTests.setups['farequote_data'] = buildRestTests.setups['farequote_index'] + '''
   - do:
@@ -943,7 +944,7 @@ buildRestTests.setups['farequote_data'] = buildRestTests.setups['farequote_index
             {"airline":"JZA","responsetime":990.4628,"time":"2016-02-07T00:00:00+0000", "doc_count": 5}
             {"index": {"_id":"2"}}
             {"airline":"JBU","responsetime":877.5927,"time":"2016-02-07T00:00:00+0000", "doc_count": 23}
-            {"index": {"_id":"3"}}            
+            {"index": {"_id":"3"}}
             {"airline":"KLM","responsetime":1355.4812,"time":"2016-02-07T00:00:00+0000", "doc_count": 42}
 '''
 buildRestTests.setups['farequote_job'] = buildRestTests.setups['farequote_data'] + '''
@@ -1102,7 +1103,7 @@ buildRestTests.setups['server_metrics_openjob'] = buildRestTests.setups['server_
 buildRestTests.setups['server_metrics_openjob-raw'] = buildRestTests.setups['server_metrics_datafeed-raw'] + '''
   - do:
       raw:
-        method: POST 
+        method: POST
         path: _ml/anomaly_detectors/total-requests/_open
 '''
 buildRestTests.setups['server_metrics_startdf'] = buildRestTests.setups['server_metrics_openjob'] + '''
@@ -1327,7 +1328,7 @@ buildRestTests.setups['logdata_job'] = buildRestTests.setups['setup_logdata'] + 
         id: "loganalytics"
         body:  >
           {
-            "source": { 
+            "source": {
               "index": "logdata"
               },
             "dest": {

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -43,6 +43,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
@@ -132,6 +133,8 @@ public class PersistedClusterStateService {
     public static final Setting<TimeValue> SLOW_WRITE_LOGGING_THRESHOLD = Setting.timeSetting("gateway.slow_write_logging_threshold",
         TimeValue.timeValueSeconds(10), TimeValue.ZERO, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    private static final boolean USE_RAM_DIR = Boolean.parseBoolean(System.getProperty("tests.es.use_ram_dir_for_metadata", "false"));
+
     private final Path[] dataPaths;
     private final String nodeId;
     private final NamedXContentRegistry namedXContentRegistry;
@@ -219,6 +222,9 @@ public class PersistedClusterStateService {
 
     // exposed for tests
     Directory createDirectory(Path path) throws IOException {
+        if (USE_RAM_DIR) {
+            return new RAMDirectory();
+        }
         // it is possible to disable the use of MMapDirectory for indices, and it may be surprising to users that have done so if we still
         // use a MMapDirectory here, which might happen with FSDirectory.open(path). Concurrency is of no concern here so a
         // SimpleFSDirectory is fine:

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -97,4 +97,6 @@ testClusters.integTest {
   user username: "x_pack_rest_user", password: "x-pack-test-password"
   extraConfigFile nodeKey.name, nodeKey
   extraConfigFile nodeCert.name, nodeCert
+
+  systemProperty 'tests.es.use_ram_dir_for_metadata', 'true' // to speed up tests
 }


### PR DESCRIPTION
Speeds up docs / x-pack rest tests by using a RamDirectory for writing out cluster state updates. These tests spin up a single node and do not require the state to be persisted.

Benchmarking on my CI machine for `docs:check` showed:

**RAMDisk**
master: 16:09 minutes
ram-dir-metadata: 14:49 minutes

**SSD**
master: 32:20 minutes
ram-dir-metadata: 16:32 minutes

Relates #49753