### PR TITLE
[7.6][Transform]fix TransformRobustnessIT intermittent test failures

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -363,9 +363,12 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     @After
-    public void waitForDataFrame() throws Exception {
-        wipeTransforms();
-        waitForPendingDataFrameTasks();
+    public void waitForTransform() throws Exception {
+        if (preserveClusterUponCompletion() == false) {
+            ensureNoInitializingShards();
+            wipeTransforms();
+            waitForPendingTransformTasks();
+        }
     }
 
     @AfterClass
@@ -416,7 +419,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         }
     }
 
-    protected static void waitForPendingDataFrameTasks() throws Exception {
+    protected static void waitForPendingTransformTasks() throws Exception {
         waitForPendingTasks(adminClient(), taskName -> taskName.startsWith(TransformField.TASK_NAME) == false);
     }
 


### PR DESCRIPTION
ensure the cluster is not in some intermediate state when cleaning up.

fixes #51347
backport #51406 
