### PR TITLE
Expose the logic to cancel task when the rest channel is closed

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/RestCancellableNodeClient.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestCancellableNodeClient.java
@@ -17,54 +17,84 @@
  * under the License.
  */
 
-package org.elasticsearch.rest.action.search;
+package org.elasticsearch.rest.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
-import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.FilterClient;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.HttpChannel;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
+
 /**
- * This class executes a request and associates the corresponding {@link Task} with the {@link HttpChannel} that it was originated from,
- * so that the tasks associated with a certain channel get cancelled when the underlying connection gets closed.
+ * A {@linkplain Client} that cancels tasks executed locally when the provided {@link HttpChannel}
+ * is closed before completion.
  */
-public final class HttpChannelTaskHandler {
+public class RestCancellableNodeClient extends FilterClient {
+    private static final Map<HttpChannel, CloseListener> httpChannels = new ConcurrentHashMap<>();
 
-    public static final HttpChannelTaskHandler INSTANCE = new HttpChannelTaskHandler();
-    //package private for testing
-    final Map<HttpChannel, CloseListener> httpChannels = new ConcurrentHashMap<>();
+    private final NodeClient client;
+    private final HttpChannel httpChannel;
 
-    private HttpChannelTaskHandler() {
+    public RestCancellableNodeClient(NodeClient client, HttpChannel httpChannel) {
+        super(client);
+        this.client = client;
+        this.httpChannel = httpChannel;
     }
 
-    <Response extends ActionResponse> void execute(NodeClient client, HttpChannel httpChannel, ActionRequest request,
-                                                   ActionType<Response> actionType, ActionListener<Response> listener) {
+    /**
+     * Returns the number of channels tracked globally.
+     */
+    public static int getNumChannels() {
+        return httpChannels.size();
+    }
 
-        CloseListener closeListener = httpChannels.computeIfAbsent(httpChannel, channel -> new CloseListener(client));
+    /**
+     * Returns the number of tasks tracked globally.
+     */
+    static int getNumTasks() {
+        return httpChannels.values().stream()
+            .mapToInt(CloseListener::getNumTasks)
+            .sum();
+    }
+
+    /**
+     * Returns the number of tasks tracked by the provided {@link HttpChannel}.
+     */
+    static int getNumTasks(HttpChannel channel) {
+        CloseListener listener = httpChannels.get(channel);
+        return listener == null ? 0 : listener.getNumTasks();
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+        ActionType<Response> action, Request request, ActionListener<Response> listener) {
+        CloseListener closeListener = httpChannels.computeIfAbsent(httpChannel, channel -> new CloseListener());
         TaskHolder taskHolder = new TaskHolder();
-        Task task = client.executeLocally(actionType, request,
+        Task task = client.executeLocally(action, request,
             new ActionListener<>() {
                 @Override
-                public void onResponse(Response searchResponse) {
+                public void onResponse(Response response) {
                     try {
                         closeListener.unregisterTask(taskHolder);
                     } finally {
-                        listener.onResponse(searchResponse);
+                        listener.onResponse(response);
                     }
                 }
 
@@ -77,25 +107,28 @@ public final class HttpChannelTaskHandler {
                     }
                 }
             });
-        closeListener.registerTask(taskHolder, new TaskId(client.getLocalNodeId(), task.getId()));
+        final TaskId taskId = new TaskId(client.getLocalNodeId(), task.getId());
+        closeListener.registerTask(taskHolder, taskId);
         closeListener.maybeRegisterChannel(httpChannel);
     }
 
-    public int getNumChannels() {
-        return httpChannels.size();
+    private void cancelTask(TaskId taskId) {
+        CancelTasksRequest req = new CancelTasksRequest()
+            .setTaskId(taskId)
+            .setReason("channel closed");
+        // force the origin to execute the cancellation as a system user
+        new OriginSettingClient(client, TASKS_ORIGIN).admin().cluster().cancelTasks(req, ActionListener.wrap(() -> {}));
     }
 
-    final class CloseListener implements ActionListener<Void> {
-        private final Client client;
+    private class CloseListener implements ActionListener<Void> {
         private final AtomicReference<HttpChannel> channel = new AtomicReference<>();
-        private final Set<TaskId> taskIds = new HashSet<>();
+        private final Set<TaskId> tasks = new HashSet<>();
 
-        CloseListener(Client client) {
-            this.client = client;
+        CloseListener() {
         }
 
         int getNumTasks() {
-            return taskIds.size();
+            return tasks.size();
         }
 
         void maybeRegisterChannel(HttpChannel httpChannel) {
@@ -111,35 +144,27 @@ public final class HttpChannelTaskHandler {
         synchronized void registerTask(TaskHolder taskHolder, TaskId taskId) {
             taskHolder.taskId = taskId;
             if (taskHolder.completed == false) {
-                this.taskIds.add(taskId);
+                this.tasks.add(taskId);
             }
         }
 
         synchronized void unregisterTask(TaskHolder taskHolder) {
             if (taskHolder.taskId != null) {
-                this.taskIds.remove(taskHolder.taskId);
+                this.tasks.remove(taskHolder.taskId);
             }
             taskHolder.completed = true;
         }
 
         @Override
-        public synchronized void onResponse(Void aVoid) {
-            //When the channel gets closed it won't be reused: we can remove it from the map and forget about it.
-            CloseListener closeListener = httpChannels.remove(channel.get());
-            assert closeListener != null : "channel not found in the map of tracked channels";
-            for (TaskId taskId : taskIds) {
-                ThreadContext threadContext = client.threadPool().getThreadContext();
-                try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-                    // we stash any context here since this is an internal execution and should not leak any existing context information
-                    threadContext.markAsSystemContext();
-                    ContextPreservingActionListener<CancelTasksResponse> contextPreservingListener = new ContextPreservingActionListener<>(
-                        threadContext.newRestorableContext(false),  ActionListener.wrap(r -> {}, e -> {}));
-                    CancelTasksRequest cancelTasksRequest = new CancelTasksRequest();
-                    cancelTasksRequest.setTaskId(taskId);
-                    //We don't wait for cancel tasks to come back. Task cancellation is just best effort.
-                    client.admin().cluster().cancelTasks(cancelTasksRequest, contextPreservingListener);
-                }
+        public void onResponse(Void aVoid) {
+            final List<TaskId> toCancel;
+            synchronized (this) {
+                // when the channel gets closed it won't be reused: we can remove it from the map and forget about it.
+                CloseListener closeListener = httpChannels.remove(channel.get());
+                assert closeListener != null : "channel not found in the map of tracked channels";
+                toCancel = new ArrayList<>(tasks);
             }
+            toCancel.stream().forEach(taskId -> cancelTask(taskId));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -21,7 +21,6 @@ package org.elasticsearch.rest.action.search;
 
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Booleans;
@@ -32,6 +31,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -100,8 +100,8 @@ public class RestSearchAction extends BaseRestHandler {
             parseSearchRequest(searchRequest, request, parser, setSize));
 
         return channel -> {
-            RestStatusToXContentListener<SearchResponse> listener = new RestStatusToXContentListener<>(channel);
-            HttpChannelTaskHandler.INSTANCE.execute(client, request.getHttpChannel(), searchRequest, SearchAction.INSTANCE, listener);
+            RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
+            cancelClient.execute(SearchAction.INSTANCE, searchRequest, new RestStatusToXContentListener<>(channel));
         };
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -113,7 +113,7 @@ import org.elasticsearch.node.NodeMocksPlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.search.HttpChannelTaskHandler;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.search.SearchHit;
@@ -511,9 +511,11 @@ public abstract class ESIntegTestCase extends ESTestCase {
             restClient.close();
             restClient = null;
         }
-        assertBusy(() -> assertEquals(HttpChannelTaskHandler.INSTANCE.getNumChannels() + " channels still being tracked in " +
-                    HttpChannelTaskHandler.class.getSimpleName() + " while there should be none", 0,
-                HttpChannelTaskHandler.INSTANCE.getNumChannels()));
+        assertBusy(() -> {
+            int numChannels = RestCancellableNodeClient.getNumChannels();
+            assertEquals( numChannels+ " channels still being tracked in " + RestCancellableNodeClient.class.getSimpleName()
+                + " while there should be none", 0, numChannels);
+        });
     }
 
     private void afterInternal(boolean afterClass) throws Exception {


### PR DESCRIPTION
This commit moves the logic that cancels search requests when the rest channel is closed
to a generic client that can be used by other APIs. This will be useful for any rest action
that wants to cancel the execution of a task if the underlying rest channel is closed by the
client before completion.

Relates #49931
Relates #50990
Relates #49581