### PR TITLE
Fix RareClusterStateIT Cancelling Publication too Early

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -54,12 +54,14 @@ import org.elasticsearch.transport.TransportSettings;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -141,7 +143,13 @@ public class RareClusterStateIT extends ESIntegTestCase {
         // Wait for no publication in progress to not accidentally cancel a publication different from the one triggered by the given
         // request.
         assertBusy(
-            () -> assertFalse(((Coordinator) internalCluster().getCurrentMasterNodeInstance(Discovery.class)).publicationInProgress()));
+            () -> {
+                assertFalse(((Coordinator) internalCluster().getCurrentMasterNodeInstance(Discovery.class)).publicationInProgress());
+                assertThat(StreamSupport.stream(
+                    internalCluster().getInstances(Discovery.class).spliterator(), false)
+                    .map(coordinator -> ((Coordinator) coordinator).getLastAcceptedState().version())
+                    .distinct().toArray(), arrayWithSize(1));
+            });
         ActionFuture<Res> future = req.execute();
         assertBusy(
             () -> assertTrue(((Coordinator)internalCluster().getCurrentMasterNodeInstance(Discovery.class)).cancelCommittedPublication()));
@@ -265,11 +273,9 @@ public class RareClusterStateIT extends ESIntegTestCase {
 
         // Now make sure the indexing request finishes successfully
         disruption.stopDisrupting();
-        assertBusy(() -> {
-            assertTrue(putMappingResponse.get(10, TimeUnit.SECONDS).isAcknowledged());
-            assertThat(docIndexResponse.get(10, TimeUnit.SECONDS), instanceOf(IndexResponse.class));
-            assertEquals(1, docIndexResponse.get(10, TimeUnit.SECONDS).getShardInfo().getTotal());
-        });
+        assertTrue(putMappingResponse.get(10, TimeUnit.SECONDS).isAcknowledged());
+        assertThat(docIndexResponse.get(10, TimeUnit.SECONDS), instanceOf(IndexResponse.class));
+        assertEquals(1, docIndexResponse.get(10, TimeUnit.SECONDS).getShardInfo().getTotal());
     }
 
     public void testDelayedMappingPropagationOnReplica() throws Exception {
@@ -370,11 +376,9 @@ public class RareClusterStateIT extends ESIntegTestCase {
 
         // Now make sure the indexing request finishes successfully
         disruption.stopDisrupting();
-        assertBusy(() -> {
-            assertTrue(putMappingResponse.get(10, TimeUnit.SECONDS).isAcknowledged());
-            assertThat(docIndexResponse.get(10, TimeUnit.SECONDS), instanceOf(IndexResponse.class));
-            assertEquals(2, docIndexResponse.get(10, TimeUnit.SECONDS).getShardInfo().getTotal()); // both shards should have succeeded
-        });
+        assertTrue(putMappingResponse.get(10, TimeUnit.SECONDS).isAcknowledged());
+        assertThat(docIndexResponse.get(10, TimeUnit.SECONDS), instanceOf(IndexResponse.class));
+        assertEquals(2, docIndexResponse.get(10, TimeUnit.SECONDS).getShardInfo().getTotal()); // both shards should have succeeded
 
         assertThat(dynamicMappingsFut.get(10, TimeUnit.SECONDS).getResult(), equalTo(CREATED));
     }


### PR DESCRIPTION
Wait for the cluster to have settled down and have the same accepted version on all nodes before
executing and cancelling request so that a slow CS accept on one node doesn't make it fall behind
and then get sent the full CS because of the diff-version mismatch, breaking the mechanics of this test.

i.e. avoiding this situation:

```
[2020-01-23T11:26:39,636][DEBUG][o.e.c.c.PublicationTransportHandler] [node_t1] resending full cluster state to node {node_t0}{EepGi72fSguZAbAbXr4DPg}{hzfbHTkWTHqL2eX1Ig-_wA}{127.0.0.1}{127.0.0.1:35891}{dim} reason org.elasticsearch.transport.RemoteTransportException: [node_t0][127.0.0.1:35891][internal:cluster/coordination/publish_state]; org.elasticsearch.cluster.IncompatibleClusterStateVersionException: Expected diff for version 7 with uuid DkERyyF6QM28qJjg6gMSUA got version 9 and uuid 1IYFeZdnRIGqItz6VcFRXg
[2020-01-23T11:26:39,637][DEBUG][o.e.c.c.PublicationTransportHandler] [node_t0] received full cluster state version [9] with size [670]
[2020-01-23T11:26:39,652][DEBUG][o.e.g.PersistedClusterStateService] [node_t1] writing cluster state took [0ms]; wrote global metadata [false] and metadata for [1] indices and skipped [0] unchanged indices
[2020-01-23T11:26:39,652][DEBUG][o.e.g.PersistedClusterStateService] [node_t0] writing cluster state took [0ms]; wrote global metadata [false] and metadata for [1] indices and skipped [0] unchanged indices
[2020-01-23T11:26:39,652][DEBUG][o.e.c.c.CoordinationState] [node_t0] handleCommit: ignored commit request due to version mismatch (term 1, expected: [9], actual: [8])
[2020-01-23T11:26:39,653][DEBUG][o.e.c.c.C.CoordinatorPublication] [node_t1] ApplyCommitResponseHandler: [{node_t0}{EepGi72fSguZAbAbXr4DPg}{hzfbHTkWTHqL2eX1Ig-_wA}{127.0.0.1}{127.0.0.1:35891}{dim}] failed
org.elasticsearch.transport.RemoteTransportException: [node_t0][127.0.0.1:35891][internal:cluster/coordination/commit_state]
```


Closes #51308
