### PR TITLE
Avoid running docker-compose tasks concurrently in CI

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/DockerComposeThrottle.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testfixtures/DockerComposeThrottle.java
@@ -1,0 +1,6 @@
+package org.elasticsearch.gradle.testfixtures;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+public abstract class DockerComposeThrottle implements BuildService<BuildServiceParameters.None> {}


### PR DESCRIPTION
My latest theory regarding #48027 is that running `docker-compose up` concurrently is what's causing our `device or resource busy` on certain CI builds. This PR registers a throttle such that we only ever run one of these tasks at a time, effectively serializing them, hopefully making whatever race condition we are encountering go away.