### PR TITLE
Tag "nested" Gradle build scans

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -196,6 +196,7 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
         }
 
         args "-Dbuild.snapshot=true"
+        args "-Dscan.tag.NESTED"
         final LogLevel logLevel = gradle.startParameter.logLevel
         if ([LogLevel.QUIET, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG].contains(logLevel)) {
           args "--${logLevel.name().toLowerCase(Locale.ENGLISH)}"


### PR DESCRIPTION
Many of our builds themselves run "nested" Gradle builds for things like building snapshot versions of Elasticsearch for BWC testing. These builds also [produce build scans](https://gradle-enterprise.elastic.co/s/rz6d3nnn76jcs), which can in many cases cause a lot of noise in Gradle Enterprise and can throw off some of our analytics if we are doing things like talking about failure rates or build times for a given job configuration.

This PR adds a `NESTED` tag to these builds so we can filter them out when they aren't applicable to the query at hand. 