### PR TITLE
Simplify plugin install in test clusters

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -431,7 +431,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         if (plugins.isEmpty() == false) {
             if (getVersion().onOrAfter("7.6.0")) {
                 logToProcessStdout("installing " + plugins.size() + " plugins in a single transaction");
-                final String[] arguments = Stream.concat(Stream.of("install", "--batch"), plugins.stream().map(URI::toString)).toArray(String[]::new);
+                final String[] arguments =
+                    Stream.concat(Stream.of("install", "--batch"), plugins.stream().map(URI::toString)).toArray(String[]::new);
                 runElasticsearchBinScript("elasticsearch-plugin", arguments);
             } else {
                 logToProcessStdout("installing " + plugins.size() + " plugins sequentially");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -431,8 +431,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         if (plugins.isEmpty() == false) {
             if (getVersion().onOrAfter("7.6.0")) {
                 logToProcessStdout("installing " + plugins.size() + " plugins in a single transaction");
-                final String[] arguments =
-                    Stream.concat(Stream.of("install", "--batch"), plugins.stream().map(URI::toString)).toArray(String[]::new);
+                final String[] arguments = Stream.concat(Stream.of("install", "--batch"), plugins.stream().map(URI::toString))
+                    .toArray(String[]::new);
                 runElasticsearchBinScript("elasticsearch-plugin", arguments);
             } else {
                 logToProcessStdout("installing " + plugins.size() + " plugins sequentially");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -428,27 +428,16 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
         createConfiguration();
 
-        final List<String> pluginsToInstall = new ArrayList<>();
         if (plugins.isEmpty() == false) {
-            pluginsToInstall.addAll(plugins.stream().map(URI::toString).collect(Collectors.toList()));
-        }
-
-        if (getVersion().before("6.3.0") && testDistribution == TestDistribution.DEFAULT) {
-            logToProcessStdout("emulating the " + testDistribution + " flavor for " + getVersion() + " by installing x-pack");
-            pluginsToInstall.add("x-pack");
-        }
-
-        if (pluginsToInstall.isEmpty() == false) {
             if (getVersion().onOrAfter("7.6.0")) {
-                logToProcessStdout("installing " + pluginsToInstall.size() + " plugins in a single transaction");
-                final String[] arguments = Stream.concat(Stream.of("install", "--batch"), pluginsToInstall.stream()).toArray(String[]::new);
+                logToProcessStdout("installing " + plugins.size() + " plugins in a single transaction");
+                final String[] arguments = Stream.concat(Stream.of("install", "--batch"), plugins.stream().map(URI::toString)).toArray(String[]::new);
                 runElasticsearchBinScript("elasticsearch-plugin", arguments);
-                logToProcessStdout("installed plugins");
             } else {
-                logToProcessStdout("installing " + pluginsToInstall.size() + " plugins sequentially");
-                pluginsToInstall.forEach(plugin -> runElasticsearchBinScript("elasticsearch-plugin", "install", "--batch", plugin));
-                logToProcessStdout("installed plugins");
+                logToProcessStdout("installing " + plugins.size() + " plugins sequentially");
+                plugins.forEach(plugin -> runElasticsearchBinScript("elasticsearch-plugin", "install", "--batch", plugin.toString()));
             }
+            logToProcessStdout("installed plugins");
         }
 
         if (keystoreSettings.isEmpty() == false || keystoreFiles.isEmpty() == false) {


### PR DESCRIPTION
This commit simplifies the plugin installation in test clusters by removing some legacy code against 6.x that is not needed when starting clusters in 8.0.0.

Relates #51433

