### PR TITLE
Disable reindex against 0.90 on mac

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -100,7 +100,13 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
 } else {
   /* Set up tasks to unzip and run the old versions of ES before running the
    * integration tests. */
-  for (String version : ['2', '1', '090']) {
+  def versions = ['2', '1', '090']
+  if (Os.isFamily(Os.FAMILY_MAC)) {
+    // 0.90 fails sometimes on mac, given that it is so old, let us disable it
+    // see: https://github.com/elastic/elasticsearch/issues/51202
+    versions = ['2', '1']
+  }
+  for (String version : versions) {
     Task unzip = task("unzipEs${version}", type: Sync) {
       Configuration oldEsDependency = configurations['es' + version]
       dependsOn oldEsDependency


### PR DESCRIPTION
We still test remote reindex against version 0.90. This failed on mac a
few times and rather than spend time investigating this, we no longer
test remote reindex against 0.90 on mac.

Closes #51202
