### PR TITLE
Fix ByteBuf Leak in Nio HTTP Tests (#51444)

### DIFF
--- a/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/HttpReadWriteHandlerTests.java
+++ b/plugins/transport-nio/src/test/java/org/elasticsearch/http/nio/HttpReadWriteHandlerTests.java
@@ -75,6 +75,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -92,6 +93,10 @@ public class HttpReadWriteHandlerTests extends ESTestCase {
     @Before
     public void setMocks() {
         transport = mock(NioHttpServerTransport.class);
+        doAnswer(invocation -> {
+            ((HttpRequest) invocation.getArguments()[0]).releaseAndCopy();
+            return null;
+        }).when(transport).incomingRequest(any(HttpRequest.class), any(HttpChannel.class));
         Settings settings = Settings.builder().put(SETTING_HTTP_MAX_CONTENT_LENGTH.getKey(), new ByteSizeValue(1024)).build();
         HttpHandlingSettings httpHandlingSettings = HttpHandlingSettings.fromSettings(settings);
         channel = mock(NioHttpChannel.class);


### PR DESCRIPTION
It is the job of the http server transport to release the request in the handler
but the mock fails to do so since we never override `incomingRequest`.

backport of #51444 
