### PR TITLE
[WIP] Throw exception when setting ctx.op to random string

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -369,9 +369,9 @@ public class UpdateHelper {
                 case "none":
                     return UpdateOpType.NONE;
                 default:
-                    // TODO: can we remove this leniency yet??
-                    logger.warn("Used upsert operation [{}] for script [{}], doing nothing...", operation, scriptId);
-                    return UpdateOpType.NONE;
+                    throw new IllegalArgumentException("The update operation must be one of [create, index, delete, none], but received: "
+                        + operation);
+
             }
         }
 


### PR DESCRIPTION
Throw exception when setting ctx.op to random string. For details, please see #43514