### PR TITLE
Increase log level for failing AbstractDisruptionIT tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -108,8 +108,9 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
     @TestIssueLogging(value = "_root:DEBUG,org.elasticsearch.action.bulk:TRACE,org.elasticsearch.action.get:TRACE," +
         "org.elasticsearch.discovery:TRACE,org.elasticsearch.action.support.replication:TRACE," +
         "org.elasticsearch.cluster.service:TRACE,org.elasticsearch.indices.recovery:TRACE," +
-        "org.elasticsearch.indices.cluster:TRACE,org.elasticsearch.index.shard:TRACE",
-        issueUrl = "https://github.com/elastic/elasticsearch/issues/41068")
+        "org.elasticsearch.indices.cluster:TRACE,org.elasticsearch.index.shard:TRACE," +
+        "org.elasticsearch.gateway.PersistedClusterStateService:TRACE",
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/41068,https://github.com/elastic/elasticsearch/issues/51329")
     public void testAckedIndexing() throws Exception {
 
         final int seconds = !(TEST_NIGHTLY && rarely()) ? 1 : 5;

--- a/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.discovery.AbstractDisruptionTestCase;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -130,6 +131,8 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
     // multiple threads doing CAS updates.
     // Wait up to 1 minute (+10s in thread to ensure it does not time out) for threads to complete previous round before initiating next
     // round.
+    @TestIssueLogging(value = "org.elasticsearch.gateway.PersistedClusterStateService:TRACE",
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/51329")
     public void testSeqNoCASLinearizability() {
         final int disruptTimeSeconds = scaledRandomIntBetween(1, 8);
 


### PR DESCRIPTION
Increase log level for two failing tests to include trace logging for
PersistedClusterStateService.

Relates #51329
