### PR TITLE
The watcher indexing listener didn't handle document level exceptions.

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
@@ -135,8 +135,19 @@ final class WatcherIndexingListener implements IndexingOperationListener, Cluste
     }
 
     /**
-     *
-     * In case of an error, we have to ensure that the triggerservice does not leave anything behind
+     * In case of a document related failure (for example version conflict), then clean up resources for a watch
+     * in the trigger service.
+     */
+    @Override
+    public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) {
+        if (result.getResultType() == Engine.Result.Type.FAILURE) {
+            assert result.getFailure() != null;
+            postIndex(shardId, index, result.getFailure());
+        }
+    }
+
+    /**
+     * In case of an engine related error, we have to ensure that the triggerservice does not leave anything behind
      *
      * TODO: If the configuration changes between preindex and postindex methods and we add a
      *       watch, that could not be indexed
@@ -153,10 +164,6 @@ final class WatcherIndexingListener implements IndexingOperationListener, Cluste
         if (isWatchDocument(shardId.getIndexName())) {
             logger.debug(() -> new ParameterizedMessage("removing watch [{}] from trigger", index.id()), ex);
             triggerService.remove(index.id());
-        } else {
-            logger.debug(
-                () -> new ParameterizedMessage("not removing watch [{}] from trigger, because [{}] != [{}] configuration.active=[{}]",
-                index.id(), shardId.getIndexName(), configuration.index, configuration.active), ex);
         }
     }
 

--- a/x-pack/qa/smoke-test-watcher/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
+++ b/x-pack/qa/smoke-test-watcher/src/test/java/org/elasticsearch/smoketest/SmokeTestWatcherTestSuiteIT.java
@@ -110,7 +110,6 @@ public class SmokeTestWatcherTestSuiteIT extends ESRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/32299")
     public void testMonitorClusterHealth() throws Exception {
         final String watchId = "cluster_health_watch";
 


### PR DESCRIPTION
Prior to the change the watcher index listener didn't implement the
`postIndex(ShardId, Engine.Index, Engine.IndexResult)` method. This
caused document level exceptions like VersionConflictEngineException
to be ignored. This commit fixes this.

The watcher indexing listener did implement the `postIndex(ShardId, Engine.Index, Exception)`
method, but that only handles engine level exceptions.

This change also unmutes the SmokeTestWatcherTestSuiteIT#testMonitorClusterHealth test again.

Relates to #32299 (this should fix the watch count bug, which wasn't subtracted from 1 to 0 due to VersionConflictEngineException being thrown after watcher updating the watch after it was deleted)