### PR TITLE
Enable autoscaling in snapshot docs tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -42,7 +42,7 @@ buildRestTests.expectedUnconvertedCandidates = [
 testClusters.integTest {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
-    if ("true".equals(System.getProperty("xpack.autoscaling.enabled")) == false) {
+    if ("true".equals(System.getProperty("build.snapshot")) == false) {
       setting 'xpack.autoscaling.enabled', 'true'
     }
   }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -42,6 +42,9 @@ buildRestTests.expectedUnconvertedCandidates = [
 testClusters.integTest {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
+    if ("true".equals(System.getProperty("xpack.autoscaling.enabled")) == false) {
+      setting 'xpack.autoscaling.enabled', 'true'
+    }
   }
 
   // enable regexes in painless so our tests don't complain about example snippets that use them

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -42,7 +42,7 @@ buildRestTests.expectedUnconvertedCandidates = [
 testClusters.integTest {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
-    if ("true".equals(System.getProperty("build.snapshot")) == false) {
+    if ("false".equals(System.getProperty("build.snapshot")) == false) {
       setting 'xpack.autoscaling.enabled', 'true'
     }
   }


### PR DESCRIPTION
This commit enables autoscaling in docs tests based on snapshot builds. This is done so that when the API docs are added to the docs, then the cluster will have been started to enable autoscaling so these APIs are available for testing.
