### PR TITLE
Formalize build snapshot

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -273,8 +273,17 @@ class VersionPropertiesLoader {
       }
       elasticsearch += "-" + qualifier
     }
-    if ("true".equals(systemProperties.getProperty("build.snapshot", "true"))) {
-      elasticsearch += "-SNAPSHOT"
+    final String buildSnapshotSystemProperty = systemProperties.getProperty("build.snapshot", "true");
+    switch (buildSnapshotSystemProperty) {
+      case "true":
+        elasticsearch += "-SNAPSHOT"
+        break;
+      case "false":
+        // do nothing
+        break;
+      default:
+        throw new IllegalArgumentException(
+          "build.snapshot was set to [" + buildSnapshotSystemProperty + "] but can only be unset or [true|false]");
     }
     loadedProps.put("elasticsearch", elasticsearch)
   }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -59,6 +59,19 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             testSeed = testSeedProperty;
         }
 
+        final String buildSnapshotSystemProperty = System.getProperty("build.snapshot", "true");
+        final boolean isSnapshotBuild;
+        switch (buildSnapshotSystemProperty) {
+            case "true":
+                isSnapshotBuild = true;
+                break;
+            case "false":
+                isSnapshotBuild = false;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                    "build.snapshot was set to [" + buildSnapshotSystemProperty + "] but can only be unset or [true|false]");
+        }
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {
             if (System.getenv(getJavaHomeEnvVarName(Integer.toString(version))) != null) {
@@ -102,6 +115,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setIsInternal(GlobalBuildInfoPlugin.class.getResource("/buildSrc.marker") != null);
             params.setDefaultParallel(findDefaultParallel(project));
             params.setInFipsJvm(isInFipsJvm());
+            params.setIsSnapshotBuild(isSnapshotBuild);
         });
 
         project.allprojects(

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -70,7 +70,8 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
                 break;
             default:
                 throw new IllegalArgumentException(
-                    "build.snapshot was set to [" + buildSnapshotSystemProperty + "] but can only be unset or [true|false]");
+                    "build.snapshot was set to [" + buildSnapshotSystemProperty + "] but can only be unset or [true|false]"
+                );
         }
         final List<JavaHome> javaVersions = new ArrayList<>();
         for (int version = 8; version <= Integer.parseInt(minimumCompilerVersion.getMajorVersion()); version++) {

--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/info/BuildParams.java
@@ -33,6 +33,7 @@ public class BuildParams {
     private static Boolean isCi;
     private static Boolean isInternal;
     private static Integer defaultParallel;
+    private static Boolean isSnapshotBuild;
 
     /**
      * Initialize global build parameters. This method accepts and a initialization function which in turn accepts a
@@ -110,6 +111,10 @@ public class BuildParams {
 
     public static Integer getDefaultParallel() {
         return value(defaultParallel);
+    }
+
+    public static boolean isSnapshotBuild() {
+        return value(BuildParams.isSnapshotBuild);
     }
 
     private static <T> T value(T object) {
@@ -225,6 +230,11 @@ public class BuildParams {
         public void setDefaultParallel(int defaultParallel) {
             BuildParams.defaultParallel = defaultParallel;
         }
+
+        public void setIsSnapshotBuild(final boolean isSnapshotBuild) {
+            BuildParams.isSnapshotBuild = isSnapshotBuild;
+        }
+
     }
 
     /**

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -15,11 +15,11 @@
  * KIND, either express or implied.  See the License for the
  */
 
-
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.MavenFilteringHack
-import org.redline_rpm.header.Flags
 import org.elasticsearch.gradle.OS
+import org.elasticsearch.gradle.info.BuildParams
+import org.redline_rpm.header.Flags
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -281,7 +281,7 @@ ospackage {
   url 'https://www.elastic.co/'
 
   // signing setup
-  if (project.hasProperty('signing.password') && BuildParams.isSnapshot() == false) {
+  if (project.hasProperty('signing.password') && BuildParams.isSnapshotBuild() == false) {
     signingKeyId = project.hasProperty('signing.keyId') ? project.property('signing.keyId') : 'D88E42B4'
     signingKeyPassphrase = project.property('signing.password')
     signingKeyRingFile = project.hasProperty('signing.secretKeyRingFile') ?

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -281,7 +281,7 @@ ospackage {
   url 'https://www.elastic.co/'
 
   // signing setup
-  if (project.hasProperty('signing.password') && System.getProperty('build.snapshot', 'true') == 'false') {
+  if (project.hasProperty('signing.password') && BuildParams.isSnapshot() == false) {
     signingKeyId = project.hasProperty('signing.keyId') ? project.property('signing.keyId') : 'D88E42B4'
     signingKeyPassphrase = project.property('signing.password')
     signingKeyRingFile = project.hasProperty('signing.secretKeyRingFile') ?

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 import static org.elasticsearch.gradle.testclusters.TestDistribution.DEFAULT
 
 /*
@@ -42,7 +44,7 @@ buildRestTests.expectedUnconvertedCandidates = [
 testClusters.integTest {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
-    if ("false".equals(System.getProperty("build.snapshot")) == false) {
+    if (BuildParams.isSnapshotBuild()) {
       setting 'xpack.autoscaling.enabled', 'true'
     }
   }

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -65,8 +67,7 @@ integTest.runner {
 
   // TODO: fix this rest test to not depend on a hardcoded port!
   def blacklist = ['getting_started/10_monitor_cluster_health/*']
-  boolean snapshot = Boolean.valueOf(System.getProperty("build.snapshot", "true"))
-  if (!snapshot) {
+  if (BuildParams.isSnapshotBuild() == false) {
     // these tests attempt to install basic/internal licenses signed against the dev/public.key
     // Since there is no infrastructure in place (anytime soon) to generate licenses using the production
     // private key, these tests are blacklisted in non-snapshot test runs

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.MavenFilteringHack
+import org.elasticsearch.gradle.info.BuildParams
 
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -68,11 +69,10 @@ processResources {
     inputs.properties(expansions)
     MavenFilteringHack.filter(it, expansions)
   }
-  boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"))
   String licenseKey = System.getProperty("license.key")
   if (licenseKey != null) {
     println "Using provided license key from ${licenseKey}"
-  } else if (snapshot) {
+  } else if (BuildParams.isSnapshotBuild()) {
     licenseKey = Paths.get(project.projectDir.path, 'snapshot.key')
   } else {
     throw new IllegalArgumentException('Property license.key must be set for release build')


### PR DESCRIPTION
Today we are repeatedly checking if the current build is a snapshot build or not by reading the system property build.snapshot. This commit formalizes this by adding a build parameter to indicate whether or not the current build is a snapshot build.
