### PR TITLE
Unmute SnapshotLifecycleTemplateRegistryTests.testThatNonExistingTemplatesAreAddedImmediately

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/history/SnapshotLifecycleTemplateRegistryTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/history/SnapshotLifecycleTemplateRegistryTests.java
@@ -107,7 +107,6 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
         assertThat(disabledRegistry.getPolicyConfigs(), hasSize(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/43950")
     public void testThatNonExistingTemplatesAreAddedImmediately() throws Exception {
         DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();


### PR DESCRIPTION
The test has been re-designed since the failure spotted on the PR build and I wasn't able to reproduce any flakiness given ~300k runs.

Closes #43950 