### PR TITLE
Disable diagnostic trust manager in tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1113,7 +1113,7 @@ public final class InternalTestCluster extends TestCluster {
                 .put("logger.prefix", nodeSettings.get("logger.prefix", ""))
                 .put("logger.level", nodeSettings.get("logger.level", "INFO"))
                 .put(settings);
-            if (inFipsJvm()){
+            if (inFipsJvm()) {
                 builder.put("xpack.security.ssl.diagnose.trust", false);
             }
             if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings)) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -158,6 +158,7 @@ import static org.elasticsearch.discovery.FileBasedSeedHostsProvider.UNICAST_HOS
 import static org.elasticsearch.discovery.zen.ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.getTestTransportType;
+import static org.elasticsearch.test.ESTestCase.inFipsJvm;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
@@ -1112,6 +1113,9 @@ public final class InternalTestCluster extends TestCluster {
                 .put("logger.prefix", nodeSettings.get("logger.prefix", ""))
                 .put("logger.level", nodeSettings.get("logger.level", "INFO"))
                 .put(settings);
+            if (inFipsJvm()){
+                builder.put("xpack.security.ssl.diagnose.trust", false);
+            }
             if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings)) {
                 builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), NetworkModule.TRANSPORT_TYPE_SETTING.get(settings));
             } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -277,6 +277,8 @@ public class XPackSettings {
         settings.add(TRANSFORM_ENABLED);
         settings.add(FLATTENED_ENABLED);
         settings.add(VECTORS_ENABLED);
+        settings.add(DIAGNOSE_TRUST_EXCEPTIONS_SETTING);
+        settings.add(FIPS_MODE_ENABLED);
         return Collections.unmodifiableList(settings);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/TestXPackTransportClient.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/TestXPackTransportClient.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.ESTestCase.getTestTransportPlugin;
+import static org.elasticsearch.test.ESTestCase.inFipsJvm;
 
 /**
  * TransportClient.Builder that installs the XPackPlugin by default.
@@ -31,7 +32,7 @@ public class TestXPackTransportClient extends TransportClient {
     }
 
     public TestXPackTransportClient(Settings settings, Collection<Class<? extends Plugin>> plugins) {
-        super(settings, Settings.EMPTY, addPlugins(plugins, getTestTransportPlugin()), null);
+        super(possiblyDisableTlsDiagnostic(settings), Settings.EMPTY, addPlugins(plugins, getTestTransportPlugin()), null);
     }
 
     @Override
@@ -50,5 +51,13 @@ public class TestXPackTransportClient extends TransportClient {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    private static Settings possiblyDisableTlsDiagnostic(Settings settings){
+        Settings.Builder builder = Settings.builder().put(settings);
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return builder.build();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/TestXPackTransportClient.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/TestXPackTransportClient.java
@@ -53,9 +53,9 @@ public class TestXPackTransportClient extends TransportClient {
         }
     }
 
-    private static Settings possiblyDisableTlsDiagnostic(Settings settings){
+    private static Settings possiblyDisableTlsDiagnostic(Settings settings) {
         Settings.Builder builder = Settings.builder().put(settings);
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return builder.build();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -642,10 +642,6 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
             return settingsList;
         }
 
-        // The following just apply in node mode
-        settingsList.add(XPackSettings.FIPS_MODE_ENABLED);
-
-        settingsList.add(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING);
         // IP Filter settings
         IPFilter.addSettings(settingsList);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -246,6 +246,9 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
         builder.put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, randomBoolean() ? SecurityField.NAME4 : SecurityField.NIO);
         builder.put(NetworkModule.HTTP_TYPE_KEY, randomBoolean() ? SecurityField.NAME4 : SecurityField.NIO);
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
         Settings.Builder customBuilder = Settings.builder().put(customSettings);
         if (customBuilder.getSecureSettings() != null) {
             SecuritySettingsSource.addSecureSettings(builder, secureSettings ->
@@ -430,8 +433,8 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
                     aliasAdded = true;
                 }
             }
-            // If we get to this point and we haven't added an alias to the request we need to add one 
-            // or the request will fail so use noAliasAdded to force adding the alias in this case 
+            // If we get to this point and we haven't added an alias to the request we need to add one
+            // or the request will fail so use noAliasAdded to force adding the alias in this case
             if (aliasAdded == false || randomBoolean()) {
                 //one alias pointing to all indices
                 for (String index : indices) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -246,7 +246,7 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
         builder.put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, randomBoolean() ? SecurityField.NAME4 : SecurityField.NIO);
         builder.put(NetworkModule.HTTP_TYPE_KEY, randomBoolean() ? SecurityField.NAME4 : SecurityField.NIO);
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings.Builder customBuilder = Settings.builder().put(customSettings);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -147,6 +147,9 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
                 .put("xpack.security.authc.realms." + FileRealmSettings.TYPE + ".file.order", 0)
                 .put("xpack.security.authc.realms." + NativeRealmSettings.TYPE + ".index.order", "1")
                 .put("xpack.license.self_generated.type", "trial");
+        if (inFipsJvm()){
+            builder.put("xpack.security.ssl.diagnose.trust", false);
+        }
         addNodeSSLSettings(builder);
         return builder.build();
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -147,7 +147,7 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
                 .put("xpack.security.authc.realms." + FileRealmSettings.TYPE + ".file.order", 0)
                 .put("xpack.security.authc.realms." + NativeRealmSettings.TYPE + ".index.order", "1")
                 .put("xpack.license.self_generated.type", "trial");
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put("xpack.security.ssl.diagnose.trust", false);
         }
         addNodeSSLSettings(builder);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -168,7 +168,7 @@ public abstract class SecuritySingleNodeTestCase extends ESSingleNodeTestCase {
         builder.put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
         builder.put("transport.type", "security4");
         builder.put("path.home", customSecuritySettingsSource.nodePath(0));
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings.Builder customBuilder = Settings.builder().put(customSettings);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -22,6 +22,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -167,6 +168,9 @@ public abstract class SecuritySingleNodeTestCase extends ESSingleNodeTestCase {
         builder.put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial");
         builder.put("transport.type", "security4");
         builder.put("path.home", customSecuritySettingsSource.nodePath(0));
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
         Settings.Builder customBuilder = Settings.builder().put(customSettings);
         if (customBuilder.getSecureSettings() != null) {
             SecuritySettingsSource.addSecureSettings(builder, secureSettings ->

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
@@ -146,9 +146,9 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         assertThat(check.check(createTestContext(settings, null)).isFailure(), Matchers.equalTo(expectFail));
     }
 
-    private Settings.Builder getSettingsBuilder(){
+    private Settings.Builder getSettingsBuilder() {
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return builder;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/PkiRealmBootstrapCheckTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.hamcrest.Matchers;
 
@@ -19,7 +20,7 @@ import java.nio.file.Path;
 public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testPkiRealmBootstrapDefault() throws Exception {
-        final Settings settings = Settings.EMPTY;
+        final Settings settings = getSettingsBuilder().build();
         final Environment env = TestEnvironment.newEnvironment(Settings.builder().put("path.home", createTempDir()).build());
         assertFalse(runCheck(settings, env).isFailure());
     }
@@ -29,7 +30,7 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         final Path keyPath = getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem");
 
         MockSecureSettings secureSettings = new MockSecureSettings();
-        Settings settings = Settings.builder()
+        Settings settings = getSettingsBuilder()
                 .put("xpack.security.authc.realms.pki.test_pki.order", 0)
                 .put("path.home", createTempDir())
                 .setSecureSettings(secureSettings)
@@ -39,7 +40,7 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
 
         // enable transport tls
         secureSettings.setString("xpack.security.transport.ssl.secure_key_passphrase", "testnode");
-        settings = Settings.builder().put(settings)
+        settings = getSettingsBuilder().put(settings)
                 .put("xpack.security.transport.ssl.enabled", true)
                 .put("xpack.security.transport.ssl.certificate", certPath)
                 .put("xpack.security.transport.ssl.key", keyPath)
@@ -48,7 +49,7 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
 
         // enable ssl for http
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
-        settings = Settings.builder().put(settings)
+        settings = getSettingsBuilder().put(settings)
                 .put("xpack.security.transport.ssl.enabled", false)
                 .put("xpack.security.http.ssl.enabled", true)
                 .put("xpack.security.http.ssl.certificate", certPath)
@@ -58,28 +59,28 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         assertTrue(runCheck(settings, env).isFailure());
 
         // enable client auth for http
-        settings = Settings.builder().put(settings)
+        settings = getSettingsBuilder().put(settings)
                 .put("xpack.security.http.ssl.client_authentication", randomFrom("required", "optional"))
                 .build();
         env = TestEnvironment.newEnvironment(settings);
         assertFalse(runCheck(settings, env).isFailure());
 
         // disable http ssl
-        settings = Settings.builder().put(settings)
+        settings = getSettingsBuilder().put(settings)
                 .put("xpack.security.http.ssl.enabled", false)
                 .build();
         env = TestEnvironment.newEnvironment(settings);
         assertTrue(runCheck(settings, env).isFailure());
 
         // set transport client auth
-        settings = Settings.builder().put(settings)
+        settings = getSettingsBuilder().put(settings)
                 .put("xpack.security.transport.client_authentication", randomFrom("required", "optional"))
                 .build();
         env = TestEnvironment.newEnvironment(settings);
         assertTrue(runCheck(settings, env).isFailure());
 
         // test with transport profile
-        settings = Settings.builder().put(settings)
+        settings = getSettingsBuilder().put(settings)
                 .put("xpack.security.transport.ssl.enabled", true)
                 .put("xpack.security.transport.client_authentication", "none")
                 .put("transport.profiles.foo.xpack.security.ssl.client_authentication", randomFrom("required", "optional"))
@@ -93,7 +94,7 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
     }
 
     public void testBootstrapCheckWithDisabledRealm() throws Exception {
-        Settings settings = Settings.builder()
+        Settings settings = getSettingsBuilder()
                 .put("xpack.security.authc.realms.pki.test_pki.enabled", false)
                 .put("xpack.security.transport.ssl.enabled", false)
                 .put("xpack.security.transport.ssl.client_authentication", "none")
@@ -109,7 +110,7 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         MockSecureSettings secureSettings = new MockSecureSettings();
         // enable transport tls
         secureSettings.setString("xpack.security.transport.ssl.secure_key_passphrase", "testnode");
-        Settings settings = Settings.builder()
+        Settings settings = getSettingsBuilder()
                 .put("xpack.security.authc.realms.pki.test_pki.enabled", true)
                 .put("xpack.security.authc.realms.pki.test_pki.delegation.enabled", true)
                 .put("xpack.security.transport.ssl.enabled", randomBoolean())
@@ -127,7 +128,7 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         final boolean expectFail = randomBoolean();
         final MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
-        Settings settings = Settings.builder()
+        Settings settings = getSettingsBuilder()
             .put("xpack.security.authc.realms.pki.test_pki.order", 0)
             .put("xpack.security.http.ssl.enabled", true)
             .put("xpack.security.http.ssl.client_authentication", expectFail ? "none" : "optional")
@@ -143,5 +144,13 @@ public class PkiRealmBootstrapCheckTests extends AbstractBootstrapCheckTestCase 
         final PkiRealmBootstrapCheck check = new PkiRealmBootstrapCheck(new SSLService(settings, env));
         secureSettings.close();
         assertThat(check.check(createTestContext(settings, null)).isFailure(), Matchers.equalTo(expectFail));
+    }
+
+    private Settings.Builder getSettingsBuilder(){
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return builder;
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -102,7 +102,7 @@ public class SecurityTests extends ESTestCase {
             .put("xpack.security.enabled", true)
             .put(testSettings)
             .put("path.home", createTempDir());
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder.build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -98,10 +98,14 @@ public class SecurityTests extends ESTestCase {
         if (security != null) {
             throw new IllegalStateException("Security object already exists (" + security + ")");
         }
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder()
             .put("xpack.security.enabled", true)
             .put(testSettings)
-            .put("path.home", createTempDir()).build();
+            .put("path.home", createTempDir());
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder.build();
         Environment env = TestEnvironment.newEnvironment(settings);
         licenseState = new TestUtils.UpdatableLicenseState(settings);
         SSLService sslService = new SSLService(settings, env);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
@@ -93,7 +93,7 @@ public class TransportOpenIdConnectLogoutActionTests extends OpenIdConnectTestCa
             .put("path.home", createTempDir())
             .build();
         Settings.Builder sslSettingsBuilder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             sslSettingsBuilder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         final Settings sslSettings = sslSettingsBuilder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
@@ -92,7 +92,11 @@ public class TransportOpenIdConnectLogoutActionTests extends OpenIdConnectTestCa
             .put(XPackSettings.TOKEN_SERVICE_ENABLED_SETTING.getKey(), true)
             .put("path.home", createTempDir())
             .build();
-        final Settings sslSettings = Settings.builder()
+        Settings.Builder sslSettingsBuilder = Settings.builder();
+        if (inFipsJvm()){
+            sslSettingsBuilder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        final Settings sslSettings = sslSettingsBuilder
             .put("xpack.security.authc.realms.oidc.oidc-realm.ssl.verification_mode", "certificate")
             .put("path.home", createTempDir())
             .build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeMigrateToolTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ESNativeMigrateToolTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.NativeRealmIntegTestCase;
 import org.elasticsearch.common.CharArrays;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.client.SecurityClient;
 import org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames;
 import org.junit.BeforeClass;
@@ -93,7 +94,7 @@ public class ESNativeMigrateToolTests extends NativeRealmIntegTestCase {
         String url = getHttpURL();
         ESNativeRealmMigrateTool.MigrateUserOrRoles muor = new ESNativeRealmMigrateTool.MigrateUserOrRoles();
 
-        Settings.Builder builder = Settings.builder()
+        Settings.Builder builder = getSettingsBuilder()
                 .put("path.home", home)
                 .put("path.conf", conf.toString())
                 .put("xpack.security.http.ssl.client_authentication", "none");
@@ -143,7 +144,7 @@ public class ESNativeMigrateToolTests extends NativeRealmIntegTestCase {
         String password = new String(CharArrays.toUtf8Bytes(nodeClientPassword().getChars()), StandardCharsets.UTF_8);
         String url = getHttpURL();
         ESNativeRealmMigrateTool.MigrateUserOrRoles muor = new ESNativeRealmMigrateTool.MigrateUserOrRoles();
-        Settings.Builder builder = Settings.builder()
+        Settings.Builder builder = getSettingsBuilder()
                 .put("path.home", home)
                 .put("xpack.security.http.ssl.client_authentication", "none");
         addSSLSettingsForPEMFiles(builder,
@@ -171,5 +172,13 @@ public class ESNativeMigrateToolTests extends NativeRealmIntegTestCase {
             () -> muor.getParser().parse("-u", "elastic", "-U", "http://localhost:9200"));
 
         assertThat(ex.getMessage(), containsString("password"));
+    }
+
+    private Settings.Builder getSettingsBuilder() {
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()) {
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return builder;
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClientTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClientTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ssl.SSLConfigurationSettingsTests;
 import org.elasticsearch.xpack.core.ssl.TestsSSLService;
 import org.elasticsearch.xpack.core.ssl.VerificationMode;
@@ -70,7 +71,11 @@ public class CommandLineHttpClientTests extends ESTestCase {
     }
 
     public void testGetDefaultURLFailsWithHelpfulMessage() {
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder
             .put("network.host", "_ec2:privateIpv4_")
             .build();
         CommandLineHttpClient client = new CommandLineHttpClient(settings, environment);
@@ -87,7 +92,11 @@ public class CommandLineHttpClientTests extends ESTestCase {
     private Settings.Builder getHttpSslSettings() {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
-        return Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return builder
             .put("xpack.security.http.ssl.enabled", true)
             .put("xpack.security.http.ssl.key", keyPath.toString())
             .put("xpack.security.http.ssl.certificate", certPath.toString())

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClientTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/CommandLineHttpClientTests.java
@@ -72,7 +72,7 @@ public class CommandLineHttpClientTests extends ESTestCase {
 
     public void testGetDefaultURLFailsWithHelpfulMessage() {
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder
@@ -93,7 +93,7 @@ public class CommandLineHttpClientTests extends ESTestCase {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
@@ -144,7 +144,7 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
         threadPool = new TestThreadPool("active directory realm tests");
         resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         globalSettings = builder.put("path.home", createTempDir()).build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.ldap.ActiveDirectorySessionFactorySettings;
@@ -142,7 +143,11 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
         }
         threadPool = new TestThreadPool("active directory realm tests");
         resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
-        globalSettings = Settings.builder().put("path.home", createTempDir()).build();
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        globalSettings = builder.put("path.home", createTempDir()).build();
         sslService = new SSLService(globalSettings, TestEnvironment.newEnvironment(globalSettings));
         licenseState = new TestUtils.UpdatableLicenseState();
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -100,7 +100,7 @@ public class LdapRealmTests extends LdapTestCase {
         threadPool = new TestThreadPool("ldap realm tests");
         resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         defaultGlobalSettings = builder.put("path.home", createTempDir()).build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.script.mustache.MustacheScriptEngine;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
@@ -98,7 +99,11 @@ public class LdapRealmTests extends LdapTestCase {
     public void init() throws Exception {
         threadPool = new TestThreadPool("ldap realm tests");
         resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
-        defaultGlobalSettings = Settings.builder().put("path.home", createTempDir()).build();
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        defaultGlobalSettings = builder.put("path.home", createTempDir()).build();
         sslService = new SSLService(defaultGlobalSettings, TestEnvironment.newEnvironment(defaultGlobalSettings));
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isAuthorizationRealmAllowed()).thenReturn(true);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
@@ -61,7 +61,7 @@ public class LdapSessionFactoryTests extends LdapTestCase {
         ldapCaPath = createTempFile();
         Files.copy(origCa, ldapCaPath, StandardCopyOption.REPLACE_EXISTING);
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         globalSettings = builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapSessionFactoryTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.support.LdapSearchScope;
@@ -59,7 +60,11 @@ public class LdapSessionFactoryTests extends LdapTestCase {
         final Path origCa = getDataPath("/org/elasticsearch/xpack/security/authc/ldap/support/ldap-ca.crt");
         ldapCaPath = createTempFile();
         Files.copy(origCa, ldapCaPath, StandardCopyOption.REPLACE_EXISTING);
-        globalSettings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        globalSettings = builder
             .put("path.home", createTempDir())
             .putList(RealmSettings.realmSslPrefix(REALM_IDENTIFIER) + "certificate_authorities", ldapCaPath.toString())
             .build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
@@ -64,7 +64,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
          * verification tests since a re-established connection does not perform hostname verification.
          */
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         globalSettings = builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.ldap.LdapUserSearchSessionFactorySettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.PoolingSessionFactorySettings;
@@ -62,8 +63,11 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
          * If we re-use an SSLContext, previously connected sessions can get re-established which breaks hostname
          * verification tests since a re-established connection does not perform hostname verification.
          */
-
-        globalSettings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        globalSettings = builder
             .put("path.home", createTempDir())
             .put("xpack.security.transport.ssl.enabled", false)
             .put("xpack.security.transport.ssl.certificate_authorities", certPath)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
@@ -172,7 +172,7 @@ public abstract class LdapTestCase extends ESTestCase {
         if (serverSetType != null) {
             builder.put(getFullSettingKey(realmId, LdapLoadBalancingSettings.LOAD_BALANCE_TYPE_SETTING), serverSetType.toString());
         }
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return builder.build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
@@ -172,6 +172,9 @@ public abstract class LdapTestCase extends ESTestCase {
         if (serverSetType != null) {
             builder.put(getFullSettingKey(realmId, LdapLoadBalancingSettings.LOAD_BALANCE_TYPE_SETTING), serverSetType.toString());
         }
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
         return builder.build();
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.mocksocket.MockServerSocket;
 import org.elasticsearch.mocksocket.MockSocket;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.common.socket.SocketAccess;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.ldap.support.LdapSearchScope;
@@ -292,7 +293,11 @@ public class SessionFactoryLoadBalancingTests extends LdapTestCase {
         Settings globalSettings = Settings.builder().put("path.home", createTempDir()).put(settings).build();
         RealmConfig config = new RealmConfig(REALM_IDENTIFIER, globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
-        return new TestSessionFactory(config, new SSLService(Settings.EMPTY, TestEnvironment.newEnvironment(config.settings())),
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return new TestSessionFactory(config, new SSLService(builder.build(), TestEnvironment.newEnvironment(config.settings())),
                 threadPool);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/SessionFactoryLoadBalancingTests.java
@@ -294,7 +294,7 @@ public class SessionFactoryLoadBalancingTests extends LdapTestCase {
         RealmConfig config = new RealmConfig(REALM_IDENTIFIER, globalSettings,
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(Settings.EMPTY));
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return new TestSessionFactory(config, new SSLService(builder.build(), TestEnvironment.newEnvironment(config.settings())),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.junit.After;
@@ -93,7 +94,11 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
     @Before
     public void setup() {
-        globalSettings = Settings.builder().put("path.home", createTempDir())
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        globalSettings = builder.put("path.home", createTempDir())
             .put("xpack.security.authc.realms.oidc.oidc-realm.ssl.verification_mode", "certificate").build();
         env = TestEnvironment.newEnvironment(globalSettings);
         threadContext = new ThreadContext(globalSettings);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
@@ -95,7 +95,7 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
     @Before
     public void setup() {
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         globalSettings = builder.put("path.home", createTempDir())

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
@@ -81,7 +81,11 @@ public abstract class AbstractSimpleSecurityTransportTestCase extends AbstractSi
         secureSettings.setString("xpack.security.transport.ssl.secure_key_passphrase", "testnode");
         // Some tests use a client profile. Put the passphrase in the secure settings for the profile (secure settings cannot be set twice)
         secureSettings.setString("transport.profiles.client.xpack.security.ssl.secure_key_passphrase", "testnode");
-        Settings settings1 = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings1 = builder
             .put("xpack.security.transport.ssl.enabled", true)
             .put("xpack.security.transport.ssl.key", testnodeKey)
             .put("xpack.security.transport.ssl.certificate", testnodeCert)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/AbstractSimpleSecurityTransportTestCase.java
@@ -82,7 +82,7 @@ public abstract class AbstractSimpleSecurityTransportTestCase extends AbstractSi
         // Some tests use a client profile. Put the passphrase in the secure settings for the profile (secure settings cannot be set twice)
         secureSettings.setString("transport.profiles.client.xpack.security.ssl.secure_key_passphrase", "testnode");
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings1 = builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
@@ -205,9 +205,9 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
         }
     }
 
-    private Settings.Builder getSettingsBuilder(){
+    private Settings.Builder getSettingsBuilder() {
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return builder;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
@@ -93,7 +93,7 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
         String unicastHost = NetworkAddress.format(transportAddress.address());
 
         // test that starting up a node works
-        Settings.Builder nodeSettings = Settings.builder()
+        Settings.Builder nodeSettings = getSettingsBuilder()
             .put("node.name", "my-test-node")
             .put("network.host", "localhost")
             .put("cluster.name", internalCluster().getClusterName())
@@ -131,7 +131,7 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
         String unicastHost = NetworkAddress.format(transportAddress.address());
 
         // test that starting up a node works
-        Settings.Builder nodeSettings = Settings.builder()
+        Settings.Builder nodeSettings = getSettingsBuilder()
             .put("xpack.security.authc.realms.file.file.order", 0)
             .put("node.name", "my-test-node")
             .put(SecurityField.USER_SETTING.getKey(), "test_user:" + SecuritySettingsSourceField.TEST_PASSWORD)
@@ -203,6 +203,14 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
                 latch.await();
             }
         }
+    }
+
+    private Settings.Builder getSettingsBuilder(){
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return builder;
     }
 
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.junit.annotations.Network;
 import org.elasticsearch.transport.Transport;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.junit.Before;
@@ -265,7 +266,11 @@ public class IPFilterTests extends ESTestCase {
     }
 
     public void testThatNodeStartsWithIPFilterDisabled() throws Exception {
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder
                 .put("path.home", createTempDir())
                 .put("xpack.security.transport.filter.enabled", randomBoolean())
                 .put("xpack.security.http.filter.enabled", randomBoolean())

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -267,7 +267,7 @@ public class IPFilterTests extends ESTestCase {
 
     public void testThatNodeStartsWithIPFilterDisabled() throws Exception {
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -47,7 +47,11 @@ public class SecurityNetty4HttpServerTransportTests extends ESTestCase {
 
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder
             .put("xpack.security.http.ssl.enabled", true)
             .put("xpack.security.http.ssl.key", testnodeKey)
             .put("xpack.security.http.ssl.certificate", testnodeCert)
@@ -150,7 +154,11 @@ public class SecurityNetty4HttpServerTransportTests extends ESTestCase {
     public void testNoExceptionWhenConfiguredWithoutSslKeySSLDisabled() throws Exception {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder
             .put("xpack.security.http.ssl.enabled", false)
             .put("xpack.security.http.ssl.key", testnodeKey)
             .put("xpack.security.http.ssl.certificate", testnodeCert)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -48,7 +48,7 @@ public class SecurityNetty4HttpServerTransportTests extends ESTestCase {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder
@@ -155,7 +155,7 @@ public class SecurityNetty4HttpServerTransportTests extends ESTestCase {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SecurityNioHttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SecurityNioHttpServerTransportTests.java
@@ -55,7 +55,11 @@ public class SecurityNioHttpServerTransportTests extends ESTestCase {
         Path testNodeCert = getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt");
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder
             .put("xpack.security.http.ssl.enabled", true)
             .put("xpack.security.http.ssl.key", testNodeKey)
             .put("xpack.security.http.ssl.certificate", testNodeCert)
@@ -183,7 +187,11 @@ public class SecurityNioHttpServerTransportTests extends ESTestCase {
     public void testNoExceptionWhenConfiguredWithoutSslKeySSLDisabled() {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.truststore.secure_password", "testnode");
-        Settings settings = Settings.builder()
+        Settings.Builder builder = Settings.builder();
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        Settings settings = builder
             .put("xpack.security.http.ssl.enabled", false)
             .put("xpack.security.http.ssl.truststore.path",
                 getDataPath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks"))

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SecurityNioHttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/SecurityNioHttpServerTransportTests.java
@@ -56,7 +56,7 @@ public class SecurityNioHttpServerTransportTests extends ESTestCase {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.secure_key_passphrase", "testnode");
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder
@@ -188,7 +188,7 @@ public class SecurityNioHttpServerTransportTests extends ESTestCase {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("xpack.security.http.ssl.truststore.secure_password", "testnode");
         Settings.Builder builder = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         Settings settings = builder

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ssl/SslIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ssl/SslIntegrationTests.java
@@ -118,7 +118,7 @@ public class SslIntegrationTests extends SecurityIntegTestCase {
 
     public void testThatConnectionToHTTPWorks() throws Exception {
         Settings.Builder builder = Settings.builder().put("xpack.security.http.ssl.enabled", true);
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         addSSLSettingsForPEMFiles(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ssl/SslIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ssl/SslIntegrationTests.java
@@ -118,6 +118,9 @@ public class SslIntegrationTests extends SecurityIntegTestCase {
 
     public void testThatConnectionToHTTPWorks() throws Exception {
         Settings.Builder builder = Settings.builder().put("xpack.security.http.ssl.enabled", true);
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
         addSSLSettingsForPEMFiles(
             builder, "/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testclient.pem",
             "testclient",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -186,7 +186,7 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
             .put(prefix + ".key", getPath(keyPath))
             .put(prefix + ".client_authentication", clientAuth.name())
             .put(prefix + ".verification_mode", verificationMode.name());
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         if (caPath != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.common.socket.SocketAccess;
 import org.elasticsearch.xpack.core.ssl.SSLClientAuth;
 import org.elasticsearch.xpack.core.ssl.SSLConfiguration;
@@ -96,6 +97,7 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
     }
 
     public void testDiagnosticTrustManagerForHostnameVerificationFailure() throws Exception {
+        assumeFalse("We disable Diagnostic trust manager in FIPS 140 mode", inFipsJvm());
         final Settings settings = getPemSSLSettings(HTTP_SERVER_SSL, "not-this-host.crt", "not-this-host.key",
             SSLClientAuth.NONE, VerificationMode.FULL, null)
             .putList("xpack.http.ssl.certificate_authorities", getPath("ca1.crt"))
@@ -184,6 +186,9 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
             .put(prefix + ".key", getPath(keyPath))
             .put(prefix + ".client_authentication", clientAuth.name())
             .put(prefix + ".verification_mode", verificationMode.name());
+        if (inFipsJvm()){
+            builder.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
         if (caPath != null) {
             builder.putList(prefix + ".certificate_authorities", getPath(caPath));
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.junit.Before;
 
@@ -55,7 +56,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
 
     @Before
     public void setup() throws Exception {
-        env = TestEnvironment.newEnvironment(Settings.builder().put("path.home", createTempDir()).build());
+        env = TestEnvironment.newEnvironment(getSettingsBuilder().put("path.home", createTempDir()).build());
         paths = new HashMap<>();
 
         requirePath("ca1.p12");
@@ -130,7 +131,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
 
     public void testMessageForTransportSslEnabledWithoutKeys() throws Exception {
         final String prefix = "xpack.security.transport.ssl";
-        final Settings.Builder settings = Settings.builder();
+        final Settings.Builder settings = getSettingsBuilder();
         settings.put(prefix + ".enabled", true);
         configureWorkingTruststore(prefix, settings);
 
@@ -142,7 +143,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
 
     public void testNoErrorIfTransportSslDisabledWithoutKeys() throws Exception {
         final String prefix = "xpack.security.transport.ssl";
-        final Settings.Builder settings = Settings.builder();
+        final Settings.Builder settings = getSettingsBuilder();
         settings.put(prefix + ".enabled", false);
         configureWorkingTruststore(prefix, settings);
         expectSuccess(settings);
@@ -210,7 +211,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     private void checkMissingResource(String sslManagerType, String fileType, String configKey,
                                       BiConsumer<String, Settings.Builder> configure) {
         final String prefix = randomSslPrefix();
-        final Settings.Builder settings = Settings.builder();
+        final Settings.Builder settings = getSettingsBuilder();
         configure.accept(prefix, settings);
 
         final String fileName = missingFile();
@@ -234,7 +235,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     private void checkUnreadableResource(String sslManagerType, String fromResource, String fileType, String configKey,
                                          BiConsumer<String, Settings.Builder> configure) throws Exception {
         final String prefix = randomSslPrefix();
-        final Settings.Builder settings = Settings.builder();
+        final Settings.Builder settings =getSettingsBuilder();
         configure.accept(prefix, settings);
 
         final String fileName = unreadableFile(fromResource);
@@ -258,7 +259,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     private void checkBlockedResource(String sslManagerType, String fileType, String configKey,
                                       BiConsumer<String, Settings.Builder> configure) throws Exception {
         final String prefix = randomSslPrefix();
-        final Settings.Builder settings = Settings.builder();
+        final Settings.Builder settings = getSettingsBuilder();
         configure.accept(prefix, settings);
 
         final String fileName = blockedFile();
@@ -281,7 +282,7 @@ public class SSLErrorMessageFileTests extends ESTestCase {
     }
 
     private void checkUnusedConfiguration(String prefix, String settingsConfigured, BiConsumer<String, Settings.Builder> configure) {
-        final Settings.Builder settings = Settings.builder();
+        final Settings.Builder settings = getSettingsBuilder();
         configure.accept(prefix, settings);
 
         expectSuccess(settings);
@@ -323,12 +324,12 @@ public class SSLErrorMessageFileTests extends ESTestCase {
 
     private Settings.Builder withKey(String fileName) {
         assertThat(fileName, endsWith(".key"));
-        return Settings.builder().put("key", resource(fileName));
+        return getSettingsBuilder().put("key", resource(fileName));
     }
 
     private Settings.Builder withCertificate(String fileName) {
         assertThat(fileName, endsWith(".crt"));
-        return Settings.builder().put("certificate", resource(fileName));
+        return getSettingsBuilder().put("certificate", resource(fileName));
     }
 
     private Settings.Builder configureWorkingTruststore(String prefix, Settings.Builder settings) {
@@ -377,5 +378,13 @@ public class SSLErrorMessageFileTests extends ESTestCase {
             "xpack.security.authc.realms.saml.saml1.ssl",
             "xpack.monitoring.exporters.http.ssl"
         );
+    }
+
+    private Settings.Builder getSettingsBuilder(){
+        final Settings.Builder settings = Settings.builder();
+        if (inFipsJvm()){
+            settings.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
+        }
+        return settings;
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -380,9 +380,9 @@ public class SSLErrorMessageFileTests extends ESTestCase {
         );
     }
 
-    private Settings.Builder getSettingsBuilder(){
+    private Settings.Builder getSettingsBuilder() {
         final Settings.Builder settings = Settings.builder();
-        if (inFipsJvm()){
+        if (inFipsJvm()) {
             settings.put(XPackSettings.DIAGNOSE_TRUST_EXCEPTIONS_SETTING.getKey(), false);
         }
         return settings;


### PR DESCRIPTION
This commit sets `xpack.security.ssl.diagnose.trust` to false in all
of our tests when running in FIPS 140 mode and when settings objects
are used to create an instance of the SSLService. This is needed
in 7.x because setting xpack.security.ssl.diagnose.trust to true
wraps SunJSSE TrustManager with our own DiagnosticTrustManager and
this is not allowed when SunJSSE is in FIPS mode.
An alternative would be to set xpack.security.fips.enabled to
true which would also implicitly disable
xpack.security.ssl.diagnose.trust but would have additional effects
(would require that we set PBKDF2 for password hashing algorithm in
all test clusters, would prohibit using JKS keystores in nodes even
if relevant tests have been muted in FIPS mode etc.)

Relates: #49900
Resoles: #51268