### PR TITLE
Put values source types on fields

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -59,6 +59,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -290,6 +292,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                     return new ScaledFloatIndexFieldData(scaledValues, scalingFactor);
                 }
             };
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.NUMERIC;
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -31,6 +31,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.List;
@@ -93,6 +95,11 @@ public class MetaJoinFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -41,6 +41,8 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -116,6 +118,11 @@ public final class ParentIdFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -43,6 +43,8 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -225,6 +227,11 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -46,6 +46,8 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -137,6 +139,11 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -39,6 +39,8 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TypeParsers;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.List;
@@ -122,6 +124,11 @@ public class Murmur3FieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.NUMERIC;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -40,6 +40,8 @@ import org.elasticsearch.index.fielddata.plain.BytesBinaryDVIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -134,6 +136,11 @@ public class BinaryFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new BytesBinaryDVIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -40,6 +40,8 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -187,6 +189,11 @@ public class BooleanFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().numericType(NumericType.BOOLEAN);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BOOLEAN;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -52,6 +52,8 @@ import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -463,6 +465,11 @@ public final class DateFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().numericType(resolution.numericType());
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.DATE;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -40,6 +40,8 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLatLonPointDVIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -233,6 +235,11 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new AbstractLatLonPointDVIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.GEOPOINT;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -46,6 +46,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -151,6 +153,12 @@ public class IdFieldMapper extends MetadataFieldMapper {
                 bytesRefs[i] = Uid.encodeId(idObject.toString());
             }
             return new TermInSetQuery(name(), bytesRefs);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            // TODO: should this even exist? Is aggregating on the ID field valid?
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -33,6 +33,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.List;
@@ -188,6 +190,12 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             return new ConstantIndexFieldData.Builder(mapperService -> fullyQualifiedIndexName);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            // TODO: Should Index fields be aggregatable?  What even is an IndexField?
+            return CoreValuesSourceType.BYTES;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -44,6 +44,8 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -292,6 +294,11 @@ public class IpFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().scriptFunction(IpScriptDocValues::new);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.IP;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -43,6 +43,8 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -269,6 +271,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -115,6 +116,16 @@ public abstract class MappedFieldType extends FieldType {
      */
     public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
         throw new IllegalArgumentException("Fielddata is not supported on field [" + name() + "] of type [" + typeName() + "]");
+    }
+
+    /**
+     * Returns the {@link ValuesSourceType} which supports this field type.  This is tightly coupled to field data and aggregations support,
+     * so any implementation that returns a value from {@link MappedFieldType#fielddataBuilder} should also return a value from  here.
+     *
+     * @return The appropriate {@link ValuesSourceType} for this field type.
+     */
+    public ValuesSourceType getValuesSourceType() {
+        throw new IllegalArgumentException("Aggregations are not supported on field [" + name() + "] of type [" + typeName() + "]");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -55,6 +55,8 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -956,6 +958,11 @@ public class NumberFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().numericType(type.numericType());
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.NUMERIC;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -45,6 +45,8 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -240,6 +242,11 @@ public class RangeFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().setRangeType(rangeType);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.RANGE;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -37,6 +37,8 @@ import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.List;
@@ -218,6 +220,10 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
             return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
         }
 
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.NUMERIC;
+        }
     }
 
     public SeqNoFieldMapper(Settings indexSettings) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -70,6 +70,8 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.query.IntervalBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -754,6 +756,11 @@ public class TextFieldMapper extends FieldMapper {
                                 + "use significant memory. Alternatively use a keyword field instead.");
             }
             return new PagedBytesIndexFieldData.Builder(fielddataMinFrequency, fielddataMaxFrequency, fielddataMinSegmentSize);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -42,6 +42,8 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -111,6 +113,11 @@ public class TypeFieldMapper extends MetadataFieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             Function<MapperService, String> typeFunction = mapperService -> mapperService.documentMapper().type();
             return new ConstantIndexFieldData.Builder(typeFunction);
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
@@ -74,7 +74,7 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
         );
 
         valuesSourceRegistry.register(HistogramAggregationBuilder.NAME,
-            List.of(CoreValuesSourceType.NUMERIC, CoreValuesSourceType.DATE),
+            List.of(CoreValuesSourceType.NUMERIC, CoreValuesSourceType.DATE, CoreValuesSourceType.BOOLEAN),
             new HistogramAggregatorSupplier() {
                 @Override
                 public Aggregator build(String name, AggregatorFactories factories, double interval, double offset,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -72,11 +70,11 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
                     return new RangeHistogramAggregator(name, factories, interval, offset, order, keyed, minDocCount, minBound,
                         maxBound, rangeValueSource, formatter, context, parent, pipelineAggregators, metaData);
                 }
-            },
-            (fieldType, indexFieldData) -> fieldType instanceof RangeFieldMapper.RangeFieldType
+            }
         );
 
-        valuesSourceRegistry.register(HistogramAggregationBuilder.NAME, CoreValuesSourceType.NUMERIC,
+        valuesSourceRegistry.register(HistogramAggregationBuilder.NAME,
+            List.of(CoreValuesSourceType.NUMERIC, CoreValuesSourceType.DATE),
             new HistogramAggregatorSupplier() {
                 @Override
                 public Aggregator build(String name, AggregatorFactories factories, double interval, double offset,
@@ -87,8 +85,7 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
                     return new NumericHistogramAggregator(name, factories, interval, offset, order, keyed, minDocCount, minBound,
                         maxBound, (ValuesSource.Numeric) valuesSource, formatter, context, parent, pipelineAggregators, metaData);
                 }
-            },
-            (fieldType, indexFieldData) -> indexFieldData instanceof IndexNumericFieldData
+            }
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -120,8 +120,8 @@ public class ValuesSourceConfig {
                 }
             } else {
                 IndexFieldData<?> indexFieldData = context.getForField(fieldType);
-                valuesSourceType = ValuesSourceRegistry.getInstance().getValuesSourceType(fieldType, indexFieldData,
-                    aggregationName, userValueTypeHint, script, defaultValueSourceType);
+                valuesSourceType = ValuesSourceRegistry.getInstance().getValuesSourceType(fieldType, aggregationName, indexFieldData,
+                    userValueTypeHint, script, defaultValueSourceType);
                 config = new ValuesSourceConfig(valuesSourceType);
 
                 config.fieldContext(new FieldContext(field, indexFieldData, fieldType));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
@@ -30,8 +30,7 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
-import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 /*
 This is a _very_ crude prototype for the ValuesSourceRegistry which basically hard-codes everything.  The intent is to define the API
@@ -40,10 +39,7 @@ for aggregations using the registry to resolve aggregators.
 public enum ValuesSourceRegistry {
     INSTANCE {
         // Maps Aggregation names to (ValuesSourceType, Supplier) pairs, keyed by ValuesSourceType
-        Map<String, Map<ValuesSourceType, AggregatorSupplier>> aggregatorRegistry = Map.of();
-        // We use a List of Entries here to approximate an ordered map
-        Map<String, List<AbstractMap.SimpleEntry<BiFunction<MappedFieldType, IndexFieldData, Boolean>, ValuesSourceType>>> resolverRegistry
-            = Map.of();
+        Map<String, List<Map.Entry<Predicate<ValuesSourceType>, AggregatorSupplier>>> aggregatorRegistry = Map.of();
 
         /**
          * Threading behavior notes: This call is both synchronized and expensive. It copies the entire existing mapping structure each
@@ -53,55 +49,42 @@ public enum ValuesSourceRegistry {
          * different worker threads.  Thus we want to optimize the read case to be thread safe and fast, which the immutable
          * collections do well.  Using immutable collections requires a copy on write mechanic, thus the somewhat non-intuitive
          * implementation of this method.
-         *
          * @param aggregationName The name of the family of aggregations, typically found via ValuesSourceAggregationBuilder.getType()
-         * @param valuesSourceType The ValuesSourceType this mapping applies to.
+         * @param appliesTo The ValuesSourceType this mapping applies to.
          * @param aggregatorSupplier An Aggregation-specific specialization of AggregatorSupplier which will construct the mapped aggregator
-         *                           from the aggregation standard set of parameters
-         * @param resolveValuesSourceType A predicate operating on MappedFieldType and IndexFieldData instances which decides if the mapped
          */
         @Override
-        public synchronized void register(String aggregationName, ValuesSourceType valuesSourceType, AggregatorSupplier aggregatorSupplier,
-                             BiFunction<MappedFieldType, IndexFieldData, Boolean> resolveValuesSourceType) {
-            // Aggregator registry block - do this first in case we need to throw on duplicate registration
-            Map<ValuesSourceType, AggregatorSupplier> innerMap;
-            if (aggregatorRegistry.containsKey(aggregationName)) {
-                if (aggregatorRegistry.get(aggregationName).containsKey(valuesSourceType)) {
-                    throw new IllegalStateException("Attempted to register already registered pair [" + aggregationName + ", "
-                        + valuesSourceType.toString() + "]");
-                }
-                innerMap = copyAndAdd(aggregatorRegistry.get(aggregationName),
-                    new AbstractMap.SimpleEntry<>(valuesSourceType, aggregatorSupplier));
-            } else {
-                innerMap = Map.of(valuesSourceType, aggregatorSupplier);
-            }
-            aggregatorRegistry = copyAndAdd(aggregatorRegistry, new AbstractMap.SimpleEntry<>(aggregationName, innerMap));
-
-            // Resolver registry block
+        public synchronized void register(String aggregationName, Predicate<ValuesSourceType> appliesTo, AggregatorSupplier aggregatorSupplier) {
             AbstractMap.SimpleEntry[] mappings;
-            if (resolverRegistry.containsKey(aggregationName)) {
-                List currentMappings = resolverRegistry.get(aggregationName);
+            if (aggregatorRegistry.containsKey(aggregationName)) {
+                List currentMappings = aggregatorRegistry.get(aggregationName);
                 mappings = (AbstractMap.SimpleEntry[]) currentMappings.toArray(new AbstractMap.SimpleEntry[currentMappings.size() + 1]);
             } else {
                 mappings = new AbstractMap.SimpleEntry[1];
             }
-            mappings[mappings.length - 1] = new AbstractMap.SimpleEntry<>(resolveValuesSourceType, valuesSourceType);
-            resolverRegistry = copyAndAdd(resolverRegistry,new AbstractMap.SimpleEntry<>(aggregationName, List.of(mappings)));
+            mappings[mappings.length - 1] = new AbstractMap.SimpleEntry<>(appliesTo, aggregatorSupplier);
+            aggregatorRegistry = copyAndAdd(aggregatorRegistry,new AbstractMap.SimpleEntry<>(aggregationName, List.of(mappings)));
+        }
+
+        private AggregatorSupplier findMatchingSuppier(ValuesSourceType valuesSourceType,
+                                                       List<Map.Entry<Predicate<ValuesSourceType>, AggregatorSupplier>> supportedTypes) {
+            for (Map.Entry<Predicate<ValuesSourceType>, AggregatorSupplier> candidate : supportedTypes) {
+                if (candidate.getKey().test(valuesSourceType)) {
+                    return candidate.getValue();
+                }
+            }
+            return null;
         }
 
         @Override
         public AggregatorSupplier getAggregator(ValuesSourceType valuesSourceType, String aggregationName) {
-            StringJoiner validSourceTypes = new StringJoiner(",", "[", "]");
             if (aggregationName != null && aggregatorRegistry.containsKey(aggregationName)) {
-                Map<ValuesSourceType, AggregatorSupplier> innerMap = aggregatorRegistry.get(aggregationName);
-                if (valuesSourceType != null && innerMap.containsKey(valuesSourceType)) {
-                    return innerMap.get(valuesSourceType);
+                AggregatorSupplier supplier = findMatchingSuppier(valuesSourceType, aggregatorRegistry.get(aggregationName));
+                if (supplier == null) {
+                    throw new AggregationExecutionException("ValuesSource type " + valuesSourceType.toString() +
+                        " is not supported for aggregation" + aggregationName);
                 }
-                for (ValuesSourceType validVST : innerMap.keySet()) {
-                    validSourceTypes.add(validVST.toString());
-                }
-                throw new AggregationExecutionException("ValuesSource type " + valuesSourceType.toString() +
-                    " is not supported for aggregation" + aggregationName + ".  Valid choices are " + validSourceTypes.toString());
+                return supplier;
             }
             throw  new AggregationExecutionException("Unregistered Aggregation [" + aggregationName + "]");
         }
@@ -116,13 +99,12 @@ public enum ValuesSourceRegistry {
                 // This will throw if the field doesn't support values sources, although really we probably threw much earlier in that case
                 ValuesSourceType valuesSourceType = fieldType.getValuesSourceType();
                 if (aggregatorRegistry.get(aggregationName) != null
-                    && aggregatorRegistry.get(aggregationName).containsKey(valuesSourceType)) {
+                    && findMatchingSuppier(valuesSourceType, aggregatorRegistry.get(aggregationName)) != null) {
                     return valuesSourceType;
                 }
-                // TODO: Error message should list valid field types
-                String fieldDescription = fieldType.name() + "(" + fieldType.toString() + ")";
-                throw new IllegalArgumentException("Field type " + fieldDescription + " is not supported for aggregation "
-                    + aggregationName);
+                String fieldDescription = fieldType.typeName() + "(" + fieldType.toString() + ")";
+                throw new IllegalArgumentException("Field [" + fieldType.name() + "] of type [" + fieldDescription +
+                    "] is not supported for aggregation [" + aggregationName + "]");
             } else {
                 // TODO: Legacy resolve logic; remove this after converting all aggregations to the new system
                 if (indexFieldData instanceof IndexNumericFieldData) {
@@ -145,17 +127,45 @@ public enum ValuesSourceRegistry {
     };
 
     /**
-     * Register a ValuesSource to Aggregator mapping.
-     *
-     * @param aggregationName The name of the family of aggregations, typically found via ValuesSourceAggregationBuilder.getType()
+     * Register a ValuesSource to Aggregator mapping.  This version provides a convenience method for mappings that only apply to a single
+     * {@link ValuesSourceType}, to allow passing in the type and auto-wrapping it in a predicate
+     *  @param aggregationName The name of the family of aggregations, typically found via ValuesSourceAggregationBuilder.getType()
      * @param valuesSourceType The ValuesSourceType this mapping applies to.
      * @param aggregatorSupplier An Aggregation-specific specialization of AggregatorSupplier which will construct the mapped aggregator
-     *                           from the aggregation standard set of parameters
-     * @param resolveValuesSourceType A predicate operating on MappedFieldType and IndexFieldData instances which decides if the mapped
-     *                                ValuesSourceType can be applied to the given field.
+ *                           from the aggregation standard set of parameters
      */
-    public abstract void register(String aggregationName, ValuesSourceType valuesSourceType, AggregatorSupplier aggregatorSupplier,
-                                  BiFunction<MappedFieldType, IndexFieldData, Boolean> resolveValuesSourceType);
+    public void register(String aggregationName, ValuesSourceType valuesSourceType, AggregatorSupplier aggregatorSupplier) {
+        register(aggregationName, (candidate) -> valuesSourceType.equals(candidate), aggregatorSupplier);
+    }
+
+    /**
+     * Register a ValuesSource to Aggregator mapping.  This version provides a convenience method for mappings that only apply to a known
+     * list of {@link ValuesSourceType}, to allow passing in the type and auto-wrapping it in a predicate
+     *  @param aggregationName The name of the family of aggregations, typically found via ValuesSourceAggregationBuilder.getType()
+     * @param valuesSourceTypes The ValuesSourceTypes this mapping applies to.
+     * @param aggregatorSupplier An Aggregation-specific specialization of AggregatorSupplier which will construct the mapped aggregator
+     *                           from the aggregation standard set of parameters
+     */
+    public void register(String aggregationName, List<ValuesSourceType> valuesSourceTypes, AggregatorSupplier aggregatorSupplier) {
+        register(aggregationName, (candidate) -> {
+            for (ValuesSourceType valuesSourceType : valuesSourceTypes) {
+                if (valuesSourceType.equals(candidate)) {
+                    return true;
+                }
+            }
+            return false;
+        }, aggregatorSupplier);
+    }
+
+
+    /**
+     * Register a ValuesSource to Aggregator mapping.
+     * @param aggregationName The name of the family of aggregations, typically found via ValuesSourceAggregationBuilder.getType()
+     * @param appliesTo A predicate which accepts the resolved {@link ValuesSourceType} and decides if the given aggregator can be applied
+     *                  to that type.
+     * @param aggregatorSupplier An Aggregation-specific specialization of AggregatorSupplier which will construct the mapped aggregator
+     */
+    public abstract void register(String aggregationName, Predicate<ValuesSourceType> appliesTo, AggregatorSupplier aggregatorSupplier);
 
     public abstract AggregatorSupplier getAggregator(ValuesSourceType valuesSourceType, String aggregationName);
     // TODO: ValueType argument is only needed for legacy logic

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
@@ -54,7 +54,8 @@ public enum ValuesSourceRegistry {
          * @param aggregatorSupplier An Aggregation-specific specialization of AggregatorSupplier which will construct the mapped aggregator
          */
         @Override
-        public synchronized void register(String aggregationName, Predicate<ValuesSourceType> appliesTo, AggregatorSupplier aggregatorSupplier) {
+        public synchronized void register(String aggregationName, Predicate<ValuesSourceType> appliesTo,
+                                          AggregatorSupplier aggregatorSupplier) {
             AbstractMap.SimpleEntry[] mappings;
             if (aggregatorRegistry.containsKey(aggregationName)) {
                 List currentMappings = aggregatorRegistry.get(aggregationName);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -48,6 +48,8 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -263,6 +265,12 @@ public class HistogramFieldMapper extends FieldMapper {
                     };
                 }
             };
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            // TODO: Histogram ValuesSourceType should move into this plugin.
+            return CoreValuesSourceType.HISTOGRAM;
         }
 
         @Override

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -50,6 +50,8 @@ import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -344,6 +346,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
             failIfNoDocValues();
             return new KeyedFlatObjectFieldData.Builder(key);
         }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
+        }
     }
 
     /**
@@ -522,6 +529,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
     }
 

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -27,6 +27,8 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.vectors.query.VectorDVIndexFieldData;
 
 import java.io.IOException;
@@ -148,6 +150,11 @@ public class DenseVectorFieldMapper extends FieldMapper implements ArrayValueMap
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             return new VectorDVIndexFieldData.Builder();
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return CoreValuesSourceType.BYTES;
         }
 
         @Override


### PR DESCRIPTION
This PR makes the mapping from `MappedFieldType` to `ValuesSourceType` a function of and on the `MappedFieldType`.  This eliminates redundant mappings from the aggregator registration steps, and makes it explicit how fields with aggregation support will behave in aggregations.