### PR TITLE
Upgrade the bundled JDK to JDK 13.0.2

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.0.0
 lucene            = 8.4.0
 
 bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 13.0.1+9
+bundled_jdk = 13.0.2+8
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
This commit upgrades the bundled JDK to JDK 13.0.2, the latest available patch release of the JDK.