### PR TITLE
Remove file field from CacheFileReference

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectory.java
@@ -59,13 +59,11 @@ public class CacheDirectory extends FilterDirectory {
 
         private final String fileName;
         private final long fileLength;
-        private final Path file;
         private final AtomicReference<CacheFile> cacheFile = new AtomicReference<>(); // null if evicted or not yet acquired
 
-        private CacheFileReference(String fileName, long fileLength, Path file) {
+        private CacheFileReference(String fileName, long fileLength) {
             this.fileName = fileName;
             this.fileLength = fileLength;
-            this.file = file;
         }
 
         @Nullable
@@ -75,7 +73,7 @@ public class CacheDirectory extends FilterDirectory {
                 return currentCacheFile;
             }
 
-            final CacheFile newCacheFile = cacheService.get(fileName, fileLength, file);
+            final CacheFile newCacheFile = cacheService.get(fileName, fileLength, cacheDir);
             synchronized (this) {
                 currentCacheFile = cacheFile.get();
                 if (currentCacheFile != null) {
@@ -117,7 +115,7 @@ public class CacheDirectory extends FilterDirectory {
             return "CacheFileReference{" +
                 "fileName='" + fileName + '\'' +
                 ", fileLength=" + fileLength +
-                ", file=" + file +
+                ", cacheDir=" + cacheDir +
                 ", acquired=" + (cacheFile.get() != null) +
                 '}';
         }
@@ -135,7 +133,7 @@ public class CacheDirectory extends FilterDirectory {
         private boolean isClone;
 
         CacheBufferedIndexInput(String fileName, long fileLength, IOContext ioContext) {
-            this(new CacheFileReference(fileName, fileLength, cacheDir.resolve(fileName)), ioContext,
+            this(new CacheFileReference(fileName, fileLength), ioContext,
                 "CachedBufferedIndexInput(" + fileName + ")", 0L, fileLength, false);
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheFile.java
@@ -55,8 +55,10 @@ class CacheFile {
     private final Path file;
 
     private volatile Set<EvictionListener> listeners;
-    private volatile FileChannel channel;
     private volatile boolean evicted;
+
+    @Nullable // if evicted, or there are no listeners
+    private volatile FileChannel channel;
 
     CacheFile(String name, long length, Path file) {
         this.tracker = new SparseFileTracker(file.toString(), length);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -64,17 +64,17 @@ public class CacheService extends AbstractLifecycleComponent {
         }
     }
 
-    public CacheFile get(final String name, final long length, final Path file) throws Exception {
+    public CacheFile get(final String fileName, final long length, final Path cacheDir) throws Exception {
         ensureLifecycleStarted();
-        return cache.computeIfAbsent(toCacheKey(file), key -> {
+        return cache.computeIfAbsent(toCacheKey(cacheDir, fileName), key -> {
             ensureLifecycleStarted();
             // generate a random UUID for the name of the cache file on disk
             final String uuid = UUIDs.randomBase64UUID();
             // resolve the cache file on disk w/ the expected cached file
-            final Path path = file.getParent().resolve(uuid);
+            final Path path = cacheDir.resolve(uuid);
             assert Files.notExists(path) : "cache file already exists " + path;
 
-            return new CacheFile(name, length, path);
+            return new CacheFile(fileName, length, path);
         });
     }
 
@@ -94,11 +94,9 @@ public class CacheService extends AbstractLifecycleComponent {
 
     /**
      * Computes the cache key associated to the given Lucene cached file
-     *
-     * @param cacheFile the cached file
-     * @return the cache key
      */
-    private static String toCacheKey(final Path cacheFile) { // TODO Fix this. Cache Key should be computed from snapshot id/index id/shard
-        return cacheFile.toAbsolutePath().toString();
+    private static String toCacheKey(final Path cacheDir, String fileName) {
+        // TODO Fix this. Cache Key should be computed from snapshot id/index id/shard
+        return cacheDir.resolve(fileName).toAbsolutePath().toString();
     }
 }


### PR DESCRIPTION
`CacheFileReference#file` is a path to a file that doesn't exist, for use as a
cache key, but whose parent directory is the location of the actual cache file.
This commit replaces it with the path to the cache directory itself, and
computes the cache key when it is needed.

Relates #50693.