### PR TITLE
Add Cache Range Size setting

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -61,7 +61,8 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Rep
             SearchableSnapshotRepository.SNAPSHOT_SNAPSHOT_ID_SETTING,
             SearchableSnapshotRepository.SNAPSHOT_INDEX_ID_SETTING,
             SearchableSnapshotRepository.SNAPSHOT_CACHE_ENABLED_SETTING,
-            CacheService.SNAPSHOT_CACHE_SIZE_SETTING
+            CacheService.SNAPSHOT_CACHE_SIZE_SETTING,
+            CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING
         );
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -58,8 +58,14 @@ public class SearchableSnapshotsIntegTests extends ESIntegTestCase {
         final Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal));
         if (randomBoolean()) {
             builder.put(CacheService.SNAPSHOT_CACHE_SIZE_SETTING.getKey(),
-                randomBoolean() ?
+                rarely() ?
                     new ByteSizeValue(randomIntBetween(0, 10), ByteSizeUnit.KB) :
+                    new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB));
+        }
+        if (randomBoolean()) {
+            builder.put(CacheService.SNAPSHOT_CACHE_RANGE_SIZE_SETTING.getKey(),
+                rarely() ?
+                    new ByteSizeValue(randomIntBetween(4, 1024), ByteSizeUnit.KB) :
                     new ByteSizeValue(randomIntBetween(1, 10), ByteSizeUnit.MB));
         }
         return builder.build();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheFileTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheFileTests.java
@@ -27,7 +27,7 @@ public class CacheFileTests extends ESTestCase {
 
     public void testAcquireAndRelease() throws Exception {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file);
+        final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file, randomIntBetween(1, 100));
 
         assertThat("Cache file is not acquired: no channel exists", cacheFile.getChannel(), nullValue());
         assertThat("Cache file is not acquired: file does not exist", Files.exists(file), is(false));
@@ -70,7 +70,7 @@ public class CacheFileTests extends ESTestCase {
 
     public void testCacheFileNotAcquired() throws IOException {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file);
+        final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file, randomIntBetween(1, 100));
 
         assertThat(Files.exists(file), is(false));
         assertThat(cacheFile.getChannel(), nullValue());
@@ -94,7 +94,7 @@ public class CacheFileTests extends ESTestCase {
 
     public void testDeleteOnCloseAfterLastRelease() throws Exception {
         final Path file = createTempDir().resolve("file.cache");
-        final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file);
+        final CacheFile cacheFile = new CacheFile("test", randomLongBetween(1, 100), file, randomIntBetween(1, 100));
 
         final List<TestEvictionListener> acquiredListeners = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(1, 20); i++) {


### PR DESCRIPTION
Note: this pull request targets the `feature/searchable-snapshots` branch

This pull request changes the current cache range size from `32kb` to `32mb` and makes it configurable through a globally defined `xpack.searchable.snapshot.cache.range_size` setting. This setting is set to low values in unit tests (see https://github.com/elastic/elasticsearch/pull/50693#discussion_r370172483) but a bit higher values in integration tests so that they don't take too much time to complete.