### PR TITLE
[Transform] fix TransformRobustnessIT intermittent test failures part 2

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -89,7 +89,7 @@ public class TransformRobustnessIT extends TransformRestTestCase {
         assertThat(stopTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 
         // the task is gone
-        assertEquals(1, getNumberOfTransformTasks());
+        assertEquals(0, getNumberOfTransformTasks());
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -81,6 +81,10 @@ public class TransformRobustnessIT extends TransformRestTestCase {
             containsString("Detected transforms with no config [" + transformId + "]. Use force to stop/delete them.")
         );
         stopTransformRequest.addParameter(TransformField.FORCE.getPreferredName(), Boolean.toString(true));
+
+        // make sync, to avoid in-flux state, see gh#51347
+        stopTransformRequest.addParameter(TransformField.WAIT_FOR_COMPLETION.getPreferredName(), Boolean.toString(true));
+
         Map<String, Object> stopTransformResponse = entityAsMap(client().performRequest(stopTransformRequest));
         assertThat(stopTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
 


### PR DESCRIPTION
add wait for completion in transform robustness test to avoid occasional test failures during cleanup

fixes #51347

Note: #51406 was supposed to fix this issue but did not. I still see it as a good addition, therefore not reverting it.