### PR TITLE
Formatting: keep simple if / else on the same line

### DIFF
--- a/.eclipseformat.xml
+++ b/.eclipseformat.xml
@@ -51,7 +51,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
-        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
@@ -101,7 +101,7 @@
         <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_if_empty"/>
         <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
@@ -286,7 +286,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
-        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="48"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
@@ -215,8 +215,7 @@ public class JdkDownloadPlugin implements Plugin<Project> {
                     String[] pathSegments = details.getRelativePath().getSegments();
                     int index = 0;
                     for (; index < pathSegments.length; index++) {
-                        if (pathSegments[index].matches("jdk-.*"))
-                            break;
+                        if (pathSegments[index].matches("jdk-.*")) break;
                     }
                     assert index + 1 <= pathSegments.length;
                     String[] newPathSegments = Arrays.copyOfRange(pathSegments, index + 1, pathSegments.length);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionRule.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionRule.java
@@ -87,10 +87,8 @@ public class TestingConventionRule implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         TestingConventionRule that = (TestingConventionRule) o;
         return Objects.equals(suffix, that.suffix);
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tar/SymbolicLinkPreservingTar.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tar/SymbolicLinkPreservingTar.java
@@ -139,8 +139,7 @@ public class SymbolicLinkPreservingTar extends Tar {
                     return false;
                 }
                 for (final File symbolicLink : visitedSymbolicLinks) {
-                    if (isChildOf(symbolicLink, file))
-                        return true;
+                    if (isChildOf(symbolicLink, file)) return true;
                 }
                 return false;
             }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/ErrorReportingTestListener.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/ErrorReportingTestListener.java
@@ -193,10 +193,8 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
-                return true;
-            if (o == null || getClass() != o.getClass())
-                return false;
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
             Descriptor that = (Descriptor) o;
             return Objects.equals(name, that.name) && Objects.equals(className, that.className) && Objects.equals(parent, that.parent);
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -442,10 +442,8 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         ElasticsearchCluster that = (ElasticsearchCluster) o;
         return Objects.equals(clusterName, that.clusterName) && Objects.equals(path, that.path);
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1209,10 +1209,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         ElasticsearchNode that = (ElasticsearchNode) o;
         return Objects.equals(name, that.name) && Objects.equals(path, that.path);
     }

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/precommit/ForbiddenPatternsTaskTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/precommit/ForbiddenPatternsTaskTests.java
@@ -82,8 +82,7 @@ public class ForbiddenPatternsTaskTests extends GradleUnitTestCase {
         file.getParentFile().mkdirs();
         file.createNewFile();
 
-        if (lines.length != 0)
-            Files.write(file.toPath(), Arrays.asList(lines), StandardCharsets.UTF_8);
+        if (lines.length != 0) Files.write(file.toPath(), Arrays.asList(lines), StandardCharsets.UTF_8);
     }
 
     private void checkAndAssertTaskSuccessful(ForbiddenPatternsTask task) throws IOException {

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/test/JUnit3MethodProvider.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/test/JUnit3MethodProvider.java
@@ -40,8 +40,7 @@ public final class JUnit3MethodProvider implements TestMethodProvider {
         ArrayList<Method> result = new ArrayList<>();
         for (MethodModel mm : methods.values()) {
             // Skip any methods that have overrieds/ shadows.
-            if (mm.getDown() != null)
-                continue;
+            if (mm.getDown() != null) continue;
 
             Method m = mm.element;
             if (m.getName().startsWith("test")

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichMetadata.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichMetadata.java
@@ -108,10 +108,8 @@ public final class EnrichMetadata extends AbstractNamedDiffable<MetaData.Custom>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         EnrichMetadata that = (EnrichMetadata) o;
         return policies.equals(that.policies);
     }


### PR DESCRIPTION
Previous the formatter was breaking simple if/else statements (i.e.
without braces) onto separate lines, which could be fragile because the
formatter cannot also introduce braces. Instead, keep such expressions
on the same line.