### PR TITLE
Test: REST": Fix the `accept_enterprise` parameter for Get License API

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/license/30_enterprise_license.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/license/30_enterprise_license.yml
@@ -34,7 +34,7 @@ teardown:
       warnings:
         - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
       license.get:
-        accept_enterprise: "true"
+        accept_enterprise: true
 
   ## a v5 license object has 12 attributes
   - length: { license: 12 }
@@ -48,5 +48,5 @@ teardown:
       warnings:
         - "Including [accept_enterprise] in get license requests is deprecated. The parameter will be removed in the next major version"
       license.get:
-        accept_enterprise: "false"
+        accept_enterprise: false
 


### PR DESCRIPTION
The Get License API specifies the `accept_enterprise` parameter as a `boolean`:

https://github.com/elastic/elasticsearch/blob/0ca5cb8cb636a4be9c36b8e38e565af66abc423b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json#L22-L23

In the test, a `string` is passed however, which makes the test compilation fail in the Go client.

/cc @tvernum
