### PR TITLE
Fix the Enrich API documentation in REST specification

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.delete_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.delete_policy.json
@@ -1,6 +1,8 @@
 {
   "enrich.delete_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-delete-policy.html",
+    "documentation": {
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-enrich-policy-api.html"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
@@ -1,6 +1,8 @@
 {
   "enrich.execute_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-execute-policy.html",
+    "documentation": {
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/execute-enrich-policy-api.html"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
@@ -1,6 +1,8 @@
 {
   "enrich.get_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-get-policy.html",
+    "documentation": {
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-enrich-policy-api.html"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.put_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.put_policy.json
@@ -1,6 +1,8 @@
 {
   "enrich.put_policy": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-put-policy.html",
+    "documentation": {
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/put-enrich-policy-api.html"
+    },
     "stability" : "stable",
     "url": {
       "paths": [

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.stats.json
@@ -1,6 +1,8 @@
 {
   "enrich.stats": {
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats.html",
+    "documentation": {
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats-api.html"
+    },
     "stability" : "stable",
     "url": {
       "paths": [


### PR DESCRIPTION
This patch fixes the `documentation` part of the REST specification to conform to the current format. (The old format breaks eg. the Go client code generation.)

/cc @martijnvg 