### PR TITLE
Revert e34d7fd

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -160,7 +160,6 @@ class BuildPlugin implements Plugin<Project> {
                     for (File dep : project.getConfigurations().getByName("extraJars").getFiles()){
                         cluster.extraJarFile(dep)
                     }
-                    cluster.setTestDistribution(TestDistribution.DEFAULT)
                     cluster.extraConfigFile("fips_java.security", securityProperties)
                     cluster.extraConfigFile("fips_java.policy", securityPolicy)
                     cluster.extraConfigFile("cacerts.bcfks", bcfksKeystore)

--- a/plugins/examples/painless-whitelist/build.gradle
+++ b/plugins/examples/painless-whitelist/build.gradle
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.esplugin'
@@ -35,7 +34,7 @@ dependencies {
 }
 
 testClusters.integTest {
-  testDistribution = BuildParams.inFipsJvm ? 'DEFAULT' : 'OSS'
+  testDistribution = 'OSS'
 }
 
 test.enabled = false


### PR DESCRIPTION
In e34d7fd we decided to use the default distribution for all tests
when running in a FIPS 140 JVM. This is strictly not necessary in
master, as the problem we originally attempted to fix is that we
set `xpack.security.ssl.diagnose.trust` when running in FIPS 140
JVMs and OSS didn't know of that setting. In master, we do not
need to set `xpack.security.ssl.diagnose.trust` so we don't need
to _always_ run with default distribution.