### PR TITLE
Fix the "slices" parameter for the Delete By Query API in the REST specification

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -173,9 +173,9 @@
         "description":"The throttle for this request in sub-requests per second. -1 means no throttle."
       },
       "slices":{
-        "type":"number",
+        "type":"number|auto",
         "default":1,
-        "description":"The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."
+        "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks."
       }
     },
     "body":{


### PR DESCRIPTION
This patch updates the `type` parameter in the Delete By Query API: according to [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html#docs-delete-by-query-slice), it can be set to "auto", but the type in the documentation allows only numerical values.

This prevents people from setting the parameter to "auto" eg. in the Go client, which generates source from the specification, and sets the corresponding Go type as number.

The patch uses the `|` notation, which we have discussed previously for encoding a "polymorphic" parameter like this.

Related: https://github.com/elastic/go-elasticsearch/issues/77

/cc @elastic/es-clients 
