### PR TITLE
[DOCS] Enable EQL on docs integ tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -46,6 +46,7 @@ testClusters.integTest {
     setting 'xpack.license.self_generated.type', 'trial'
     if (BuildParams.isSnapshotBuild()) {
       setting 'xpack.autoscaling.enabled', 'true'
+      setting 'xpack.eql.enabled', 'true'
     }
   }
 


### PR DESCRIPTION
Enables the EQL feature flags on docs integration tests.
Ensures example snippets for the `_eql/search` endpoint don't fail CI.