### PR TITLE
Remove ValuesSourceType.ANY

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceParser.java
@@ -35,13 +35,6 @@ import java.util.Map;
 
 public abstract class ArrayValuesSourceParser<VS extends ValuesSource> implements Aggregator.Parser {
 
-    public abstract static class AnyValuesSourceParser extends ArrayValuesSourceParser<ValuesSource> {
-
-        protected AnyValuesSourceParser(boolean formattable) {
-            super(formattable, CoreValuesSourceType.ANY, null);
-        }
-    }
-
     public abstract static class NumericValuesSourceParser extends ArrayValuesSourceParser<ValuesSource.Numeric> {
 
         protected NumericValuesSourceParser(boolean formattable) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -43,31 +43,6 @@ import java.util.function.LongSupplier;
  * {@link CoreValuesSourceType} holds the {@link ValuesSourceType} implementations for the core aggregations package.
  */
 public enum CoreValuesSourceType implements ValuesSourceType {
-    ANY(EquivalenceType.STRING) {
-        // ANY still has a lot of special handling in ValuesSourceConfig, and as such doesn't adhere to this interface yet
-        @Override
-        public ValuesSource getEmpty() {
-            // TODO: Implement this or get rid of ANY
-            throw new UnsupportedOperationException("CoreValuesSourceType.ANY is still a special case");
-        }
-
-        @Override
-        public ValuesSource getScript(AggregationScript.LeafFactory script, ValueType scriptValueType) {
-            // TODO: Implement this or get rid of ANY
-            throw new UnsupportedOperationException("CoreValuesSourceType.ANY is still a special case");
-        }
-
-        @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
-            // TODO: Implement this or get rid of ANY
-            throw new UnsupportedOperationException("CoreValuesSourceType.ANY is still a special case");
-        }
-
-        @Override
-        public ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier now) {
-            return BYTES.replaceMissing(valuesSource, rawMissing, docValueFormat, now);
-        }
-    },
     NUMERIC(EquivalenceType.NUMBER) {
         @Override
         public ValuesSource getEmpty() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -260,16 +260,11 @@ public class ValuesSourceConfig {
             }
         } else {
             if (fieldContext() == null) {
+                // Script case
                 vs = valueSourceType().getScript(script(), scriptValueType());
             } else {
-                if (valueSourceType() == CoreValuesSourceType.ANY) {
-                    // TODO: Clean up special cases around CoreValuesSourceType.ANY
-                    // falling back to bytes values
-                    vs = CoreValuesSourceType.BYTES.getField(fieldContext(), script());
-                } else {
-                    // TODO: Better docs for Scripts vs Scripted Fields
-                    vs = valueSourceType().getField(fieldContext(), script());
-                }
+                // Field or Value Script case
+                vs = valueSourceType().getField(fieldContext(), script());
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class CoreValuesSourceTypeTests extends ESTestCase {
 
     public void testFromString() {
-        assertThat(CoreValuesSourceType.fromString("any"), equalTo(CoreValuesSourceType.ANY));
         assertThat(CoreValuesSourceType.fromString("numeric"), equalTo(CoreValuesSourceType.NUMERIC));
         assertThat(CoreValuesSourceType.fromString("bytes"), equalTo(CoreValuesSourceType.BYTES));
         assertThat(CoreValuesSourceType.fromString("geopoint"), equalTo(CoreValuesSourceType.GEOPOINT));


### PR DESCRIPTION
The refactor has been building up to not needing the concept of ANY, and we're finally there!  This PR removes the last references to it (which were on unused or unreachable code paths), and the entry from the enum.  