### PR TITLE
Use an options loop in Elasticsearch startup script

### DIFF
--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -16,6 +16,19 @@
 
 source "`dirname "$0"`"/elasticsearch-env
 
+CHECK_KEYSTORE=true
+DAEMONIZE=false
+for option in "$@"; do
+  case "$option" in
+    -h|--help|-V|--version)
+      CHECK_KEYSTORE=false
+      ;;
+    -d|--daemonize)
+      DAEMONIZE=true
+      ;;
+  esac
+done
+
 if [ -z "$ES_TMPDIR" ]; then
   ES_TMPDIR=`"$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.TempDirectory`
 fi
@@ -24,7 +37,7 @@ fi
 # conflicting GC configurations for the keystore tools
 unset KEYSTORE_PASSWORD
 KEYSTORE_PASSWORD=
-if ! echo $* | grep -E -q '(^-h |-h$| -h |--help$|--help |^-V |-V$| -V |--version$|--version )' \
+if [[ $CHECK_KEYSTORE = true ]] \
     && "`dirname "$0"`"/elasticsearch-keystore has-passwd --silent
 then
   if ! read -s -r -p "Elasticsearch keystore password: " KEYSTORE_PASSWORD ; then
@@ -37,7 +50,7 @@ ES_JVM_OPTIONS="$ES_PATH_CONF"/jvm.options
 ES_JAVA_OPTS=`export ES_TMPDIR; "$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.JvmOptionsParser "$ES_JVM_OPTIONS"`
 
 # manual parsing to find out, if process should be detached
-if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then
+if [[ $DAEMONIZE = false ]]; then
   exec \
     "$JAVA" \
     $ES_JAVA_OPTS \

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -56,6 +56,7 @@ import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallatio
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -208,6 +209,16 @@ public class KeystoreManagementTests extends PackagingTestCase {
         Shell.Result result = startElasticsearchTtyPassword("wrong");
         // error will be on stdout for "expect"
         assertThat(result.stdout, containsString(ERROR_INCORRECT_PASSWORD));
+    }
+
+    /**
+     * If we have an encrypted keystore, we shouldn't require a password to
+     * view help information.
+     */
+    public void test44EncryptedKeystoreAllowsHelpMessage(){
+        assertPasswordProtectedKeystore();
+        Shell.Result r = installation.executables().elasticsearch.run("--help");
+        assertThat(r.stdout, startsWith("Starts Elasticsearch"));
     }
 
     public void test50KeystorePasswordFromFile() throws Exception {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -215,7 +215,16 @@ public class KeystoreManagementTests extends PackagingTestCase {
      * If we have an encrypted keystore, we shouldn't require a password to
      * view help information.
      */
-    public void test44EncryptedKeystoreAllowsHelpMessage(){
+    public void test44EncryptedKeystoreAllowsHelpMessage() throws Exception {
+        assumeTrue("users call elasticsearch directly in archive case",
+            distribution.isArchive());
+
+        String password = "keystorepass";
+
+        rmKeystoreIfExists();
+        createKeystore();
+        setKeystorePassword(password);
+
         assertPasswordProtectedKeystore();
         Shell.Result r = installation.executables().elasticsearch.run("--help");
         assertThat(r.stdout, startsWith("Starts Elasticsearch"));


### PR DESCRIPTION
This is a follow-up to the keystore passphrase PR (#51123). @pugnascotia [suggested](https://github.com/elastic/elasticsearch/pull/51123#discussion_r367966195) that the option-parsing pattern we were using was fragile, and suggested that we add an options loop at the beginning of the script.

This actually matches the pattern we're using in the Windows Batch script (`elasticsearch.bat`).

I've added a test to check the behavior of the `--help` flag as well. 