### PR TITLE
[DOCS] Removes beta qualifiers from transform documentation

### DIFF
--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Deletes an existing {transform}.
 
-beta[]
-
 [[delete-transform-request]]
 ==== {api-request-title}
 

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -10,8 +10,6 @@
 
 Retrieves usage information for {transforms}.
 
-beta[]
-
 
 [[get-transform-stats-request]]
 ==== {api-request-title}

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Retrieves configuration information for {transforms}.
 
-beta[]
-
 [[get-transform-request]]
 ==== {api-request-title}
 

--- a/docs/reference/transform/apis/index.asciidoc
+++ b/docs/reference/transform/apis/index.asciidoc
@@ -4,18 +4,16 @@
 == {transform-cap} APIs
 
 * <<put-transform>> 
-* <<update-transform>>
 * <<delete-transform>>
 * <<get-transform>>
 * <<get-transform-stats>>
 * <<preview-transform>>
 * <<start-transform>>
 * <<stop-transform>>
+* <<update-transform>>
 
 //CREATE
 include::put-transform.asciidoc[]
-//UPDATE
-include::update-transform.asciidoc[]
 //DELETE
 include::delete-transform.asciidoc[]
 //GET
@@ -27,3 +25,5 @@ include::preview-transform.asciidoc[]
 include::start-transform.asciidoc[]
 //STOP
 include::stop-transform.asciidoc[]
+//UPDATE
+include::update-transform.asciidoc[]

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Previews a {transform}.
 
-beta[]
-
 [[preview-transform-request]]
 ==== {api-request-title}
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Instantiates a {transform}.
 
-beta[]
-
 [[put-transform-request]]
 ==== {api-request-title}
 

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Starts one or more {transforms}.
 
-beta[]
-
 [[start-transform-request]]
 ==== {api-request-title}
 

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Stops one or more {transforms}.
 
-beta[]
-
 
 [[stop-transform-request]]
 ==== {api-request-title}

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -10,8 +10,6 @@
 
 Updates certain properties of a {transform}.
 
-beta[]
-
 [[update-transform-request]]
 ==== {api-request-title}
 

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>How checkpoints work</titleabbrev>
 ++++
 
-beta[]
-
 Each time a {transform} examines the source indices and creates or
 updates the destination index, it generates a _checkpoint_.
 

--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -3,8 +3,6 @@
 [[ecommerce-transforms]]
 === Tutorial: Transforming the eCommerce sample data
 
-beta[]
-
 <<transforms,{transforms-cap}>> enable you to retrieve information
 from an {es} index, transform it, and store it in another index. Let's use the
 {kibana-ref}/add-sample-data.html[{kib} sample data] to demonstrate how you can

--- a/docs/reference/transform/examples.asciidoc
+++ b/docs/reference/transform/examples.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Examples</titleabbrev>
 ++++
 
-beta[]
-
 These examples demonstrate how to use {transforms} to derive useful 
 insights from your data. All the examples use one of the 
 {kibana-ref}/add-sample-data.html[{kib} sample datasets]. For a more detailed, 

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -6,22 +6,8 @@
 <titleabbrev>Limitations</titleabbrev>
 ++++
 
-beta[]
-
 The following limitations and known problems apply to the {version} release of 
 the Elastic {transform} feature:
-
-
-[float]
-[[transform-compatibility-limitations]]
-==== Beta {transforms} do not have guaranteed backwards or forwards compatibility
-
-Whilst {transforms} are beta, it is not guaranteed that a {transform} created in 
-a previous version of the {stack} will be able to start and operate in a future 
-version. Neither can support be provided for {transform} tasks to be able to 
-operate in a cluster with mixed node versions. Please note that the output of a 
-{transform} is persisted to a destination index. This is a normal {es} index and 
-is not affected by the beta status. 
 
 
 [float]

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Overview</titleabbrev>
 ++++
 
-beta[]
-
 You can use {transforms} to _pivot_ your data into a new entity-centric index. 
 By transforming and summarizing your data, it becomes possible to visualize and 
 analyze it in alternative and interesting ways.


### PR DESCRIPTION
This PR removes the "beta[]" macro from the documentation in the following sections https://www.elastic.co/guide/en/elasticsearch/reference/master/transforms.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/transform-apis.html

It also sorts the transform APIs alphabetically and removes a limitation that seems specific to beta transforms.