### PR TITLE
ILM reenable ilm explain policy rest test

### DIFF
--- a/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
+++ b/x-pack/plugin/ilm/qa/rest/src/test/resources/rest-api-spec/test/ilm/40_explain_lifecycle.yml
@@ -162,10 +162,6 @@ teardown:
 
 ---
 "Test All Indexes Lifecycle Explain":
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/47275
-      version: "6.7.0 - "
-
   - do:
       ilm.explain_lifecycle:
         index: "*"
@@ -218,7 +214,6 @@ teardown:
 
   - match: { indices.index_with_policy_that_doesnt_exist.index: "index_with_policy_that_doesnt_exist" }
   - match: { indices.index_with_policy_that_doesnt_exist.policy: "a_policy_that_doesnt_exist" }
-  - match: { indices.index_with_policy_that_doesnt_exist.step_info.reason: "policy [a_policy_that_doesnt_exist] does not exist" }
   - is_true: indices.index_with_policy_that_doesnt_exist.managed
   - is_false: indices.index_with_policy_that_doesnt_exist.phase
   - is_false: indices.index_with_policy_that_doesnt_exist.action


### PR DESCRIPTION
The test was disabled as it was flaky. The flakiness comes from a timing
issue that saw ILM not run _yet_ for the index that had an invalid
policy attached. This meant the step info was not attached to the
lifecycle execution state for this index.

This commit drops this assertion as we're already testing it (in an
async way) in TimeSeriesLifecycleActionsIT.testNonexistentPolicy.

Resolves #47275 