### PR TITLE
[DOCS] Adds release highlight for transforms

### DIFF
--- a/docs/reference/release-notes/highlights-7.7.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.7.0.asciidoc
@@ -1,0 +1,20 @@
+[[release-highlights-7.7.0]]
+== 7.7.0 release highlights
+++++
+<titleabbrev>7.7.0</titleabbrev>
+++++
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+[discrete]
+=== {transforms-cap}
+
+We introduced {transforms} in 7.2.0 as a beta feature. It is now mature enough
+to declare the feature GA (general availability). {transforms-cap} enable you to
+pivot and summarize your data and store it in a new index. See
+{ref}/transforms.html[{transforms-cap}] and
+{ref}//transform-apis.html[{transform-cap} APIs].
+
+// end::notable-highlights[]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -6,6 +6,7 @@
 This section summarizes the most important changes in each release. For the
 full list, see <<es-release-notes>> and <<breaking-changes>>.
 
+* <<release-highlights-7.7.0>>
 * <<release-highlights-7.6.0>>
 * <<release-highlights-7.5.0>>
 * <<release-highlights-7.4.0>>
@@ -16,6 +17,7 @@ full list, see <<es-release-notes>> and <<breaking-changes>>.
 
 --
 
+include::highlights-7.7.0.asciidoc[]
 include::highlights-7.6.0.asciidoc[]
 include::highlights-7.5.0.asciidoc[]
 include::highlights-7.4.0.asciidoc[]


### PR DESCRIPTION
This PR adds a release highlight for transforms.

It is based on a similar highlight for CCR in 6.7 (https://www.elastic.co/guide/en/elasticsearch/reference/6.7/release-highlights-6.7.0.html#_cross_cluster_replication).