### PR TITLE
Fix issue where runtime Java was not properly respected for test cluster

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -651,7 +651,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private Map<String, String> getESEnvironment() {
         Map<String, String> defaultEnv = new HashMap<>();
         // If we are testing the current version of Elasticsearch, use the configured runtime Java, otherwise use the bundled JDK
-        if (getTestDistribution() == TestDistribution.INTEG_TEST || getVersion().toString().equals(VersionProperties.getElasticsearch())) {
+        if (getTestDistribution() == TestDistribution.INTEG_TEST || getVersion().equals(VersionProperties.getElasticsearchVersion())) {
             defaultEnv.put("JAVA_HOME", BuildParams.getRuntimeJavaHome().getAbsolutePath());
         }
         defaultEnv.put("ES_PATH_CONF", configFile.getParent().toString());


### PR DESCRIPTION
This is a follow up to #51505 in which we weren't properly setting `JAVA_HOME` of local test clusters to the configured `RUNTIME_JAVA_HOME` due to the way were were comparing version strings. `VersionProperterties.getElasticsearch()` includes a `-SNAPSHOT` suffix so comparing strings won't work. We now compare the `Version` objects themselves such that `8.0.0` and `8.0.0-SNAPSHOT` are considered to be the same version.