### PR TITLE
Use standard format for reload settings API

### DIFF
--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -4,76 +4,51 @@
 <titleabbrev>Nodes reload secure settings</titleabbrev>
 ++++
 
-The cluster nodes reload secure settings API is used to re-load the keystore on each node.
+Reloads the keystore on nodes in the cluster.
 
 [[cluster-nodes-reload-secure-settings-api-request]]
 ==== {api-request-title}
+
 `POST _nodes/reload_secure_settings` +
-
-`POST _nodes/nodeId1,nodeId2/reload_secure_settings` +
-
-`POST _nodes/_local/reload_secure_settings`
+`POST _nodes/<nodes/reload_secure_settings`
 
 [[cluster-nodes-reload-secure-settings-api-desc]]
 ==== {api-description-title}
-<<secure-settings, Secure settings>> are stored in an on-disk keystore.
-Certain of these settings are <<reloadable-secure-settings,reloadable>>.
-That is, you can change them on disk and reload them without
-restarting any nodes in the cluster. When you have updated reloadable secure
-settings in your keystore, you can use this API to reload those
-settings on each node.
+
+<<secure-settings,Secure settings>> are stored in an on-disk keystore. Certain
+of these settings are <<reloadable-secure-settings,reloadable>>. That is, you
+can change them on disk and reload them without restarting any nodes in the
+cluster. When you have updated reloadable secure settings in your keystore, you
+can use this API to reload those settings on each node.
+
+When the {es} keystore is password protected and not simply obfuscated, you must
+provide the password for the keystore when you reload the secure settings.
+Reloading the settings for the whole cluster assumes that all nodes' keystores
+are protected with the same password; this method is allowed only when
+<<tls-transport,inter-node communications are encrypted>>. Alternatively, you can
+reload the secure settings on each node by locally accessing the API and passing
+the node-specific {es} keystore password.
 
 [[cluster-nodes-reload-secure-settings-path-params]]
 ==== {api-path-parms-title}
 
 `<nodes>`::
     (Optional, string) The names of particular nodes in the cluster to target.
-    For example, you may also selectively target `nodeId1` and `nodeId2`. The
-    node selection options are detailed <<cluster-nodes,here>>.
-
-NOTE: {es} requires consistent secure settings across the cluster nodes, but this consistency is not enforced.
-Hence, reloading specific nodes is not standard. It is only justifiable when retrying failed reload operations.
+    For example, `nodeId1,nodeId2`. For node selection options, see
+    <<cluster-nodes>>.
+    
+NOTE: {es} requires consistent secure settings across the cluster nodes, but
+this consistency is not enforced. Hence, reloading specific nodes is not
+standard. It is justifiable only when retrying failed reload operations.
 
 [[cluster-nodes-reload-secure-settings-api-request-body]]
 ==== {api-request-body-title}
 
-When the {es} keystore is password protected and not simply obfuscated, the password for the keystore needs
-to be provided in the request to reload the secure settings.
-Reloading the settings for the whole cluster assumes that all nodes' keystores are protected with the same password
-and is only allowed when {ref}/configuring-tls.html#tls-transport[node to node communications are encrypted]
-
 `reload_secure_settings`::
-  (Optional, string) The password for the Elasticsearch keystore.
-
-[source,js]
---------------------------------------------------
-POST _nodes/reload_secure_settings
-{
-  "reload_secure_settings": "s3cr3t" <1>
-}
---------------------------------------------------
-// NOTCONSOLE
-
-<1> The common password that the {es} keystore is encrypted with in every node of the cluster.
-
-Alternatively the secure settings can be reloaded on a per node basis, locally accessing the API and passing the
-node-specific {es} keystore password.
-
-[source,js]
---------------------------------------------------
-POST _nodes/_local/reload_secure_settings
-{
-  "reload_secure_settings": "s3cr3t" <1>
-}
---------------------------------------------------
-// NOTCONSOLE
-
-<1> The password that the {es} keystore is encrypted with on the local node.
+  (Optional, string) The password for the {es} keystore.
 
 [[cluster-nodes-reload-secure-settings-api-example]]
 ==== {api-examples-title}
-
-Rest example:
 
 [source,console]
 --------------------------------------------------
@@ -106,3 +81,27 @@ that was thrown during the reload process, if any.
 --------------------------------------------------
 // TESTRESPONSE[s/"my_cluster"/$body.cluster_name/]
 // TESTRESPONSE[s/"pQHNt5rXTTWNvUgOrdynKg"/\$node_name/]
+
+The following example uses a common password for the {es} keystore on every
+node of the cluster:
+
+[source,js]
+--------------------------------------------------
+POST _nodes/reload_secure_settings
+{
+  "reload_secure_settings": "s3cr3t" <1>
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+The following example uses a password for the {es} keystore on the local node:
+
+[source,js]
+--------------------------------------------------
+POST _nodes/_local/reload_secure_settings
+{
+  "reload_secure_settings": "s3cr3t" <1>
+}
+--------------------------------------------------
+// NOTCONSOLE
+

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -16,17 +16,20 @@ The cluster nodes reload secure settings API is used to re-load the keystore on 
 
 [[cluster-nodes-reload-secure-settings-api-desc]]
 ==== {api-description-title}
-Secure settings are stored in an on-disk keystore. When you have updated
-the secure settings in your keystore, you can use this API to reload those
-settings on each node. You may also selectively target `nodeId1` and
-`nodeId2`. The node selection options are detailed <<cluster-nodes,here>>.
+<<secure-settings, Secure settings>> are stored in an on-disk keystore.
+Certain of these settings are <<reloadable-secure-settings,reloadable>>.
+That is, you can change them on disk and reload them without
+restarting any nodes in the cluster. When you have updated reloadable secure
+settings in your keystore, you can use this API to reload those
+settings on each node.
 
 [[cluster-nodes-reload-secure-settings-path-params]]
 ==== {api-path-parms-title}
 
 `<nodes>`::
     (Optional, string) The names of particular nodes in the cluster to target.
-    May also be `_local` to reload settings on just the local node.
+    For example, you may also selectively target `nodeId1` and `nodeId2`. The
+    node selection options are detailed <<cluster-nodes,here>>.
 
 NOTE: {es} requires consistent secure settings across the cluster nodes, but this consistency is not enforced.
 Hence, reloading specific nodes is not standard. It is only justifiable when retrying failed reload operations.

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -89,7 +89,7 @@ node of the cluster:
 --------------------------------------------------
 POST _nodes/reload_secure_settings
 {
-  "reload_secure_settings": "s3cr3t" <1>
+  "reload_secure_settings": "s3cr3t"
 }
 --------------------------------------------------
 // NOTCONSOLE
@@ -100,7 +100,7 @@ The following example uses a password for the {es} keystore on the local node:
 --------------------------------------------------
 POST _nodes/_local/reload_secure_settings
 {
-  "reload_secure_settings": "s3cr3t" <1>
+  "reload_secure_settings": "s3cr3t"
 }
 --------------------------------------------------
 // NOTCONSOLE

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -67,10 +67,18 @@ POST _nodes/_local/reload_secure_settings
 
 <1> The password that the {es} keystore is encrypted with on the local node.
 
+[[cluster-nodes-reload-secure-settings-api-example]]
+==== {api-examples-title}
 
-[float]
-[[cluster-nodes-reload-secure-settings-api-response-body]]
-==== {api-response-body-title}
+Rest example:
+
+[source,console]
+--------------------------------------------------
+POST _nodes/reload_secure_settings
+POST _nodes/nodeId1,nodeId2/reload_secure_settings
+--------------------------------------------------
+// TEST[setup:node]
+// TEST[s/nodeId1,nodeId2/*/]
 
 The response contains the `nodes` object, which is a map, keyed by the
 node id. Each value has the node `name` and an optional `reload_exception`
@@ -95,14 +103,3 @@ that was thrown during the reload process, if any.
 --------------------------------------------------
 // TESTRESPONSE[s/"my_cluster"/$body.cluster_name/]
 // TESTRESPONSE[s/"pQHNt5rXTTWNvUgOrdynKg"/\$node_name/]
-
-[[cluster-nodes-reload-secure-settings-api-example]]
-==== {api-examples-title}
-
-[source,console]
---------------------------------------------------
-POST _nodes/reload_secure_settings
-POST _nodes/nodeId1,nodeId2/reload_secure_settings
---------------------------------------------------
-// TEST[setup:node]
-// TEST[s/nodeId1,nodeId2/*/]

--- a/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
+++ b/docs/reference/cluster/nodes-reload-secure-settings.asciidoc
@@ -4,30 +4,43 @@
 <titleabbrev>Nodes reload secure settings</titleabbrev>
 ++++
 
-
 The cluster nodes reload secure settings API is used to re-load the keystore on each node.
 
-[source,console]
---------------------------------------------------
-POST _nodes/reload_secure_settings
-POST _nodes/nodeId1,nodeId2/reload_secure_settings
---------------------------------------------------
-// TEST[setup:node]
-// TEST[s/nodeId1,nodeId2/*/]
+[[cluster-nodes-reload-secure-settings-api-request]]
+==== {api-request-title}
+`POST _nodes/reload_secure_settings` +
 
-The first command reloads the keystore on each node. The seconds allows
-to selectively target `nodeId1` and `nodeId2`. The node selection options are
-detailed <<cluster-nodes,here>>.
+`POST _nodes/nodeId1,nodeId2/reload_secure_settings` +
+
+`POST _nodes/_local/reload_secure_settings`
+
+[[cluster-nodes-reload-secure-settings-api-desc]]
+==== {api-description-title}
+Secure settings are stored in an on-disk keystore. When you have updated
+the secure settings in your keystore, you can use this API to reload those
+settings on each node. You may also selectively target `nodeId1` and
+`nodeId2`. The node selection options are detailed <<cluster-nodes,here>>.
+
+[[cluster-nodes-reload-secure-settings-path-params]]
+==== {api-path-parms-title}
+
+`<nodes>`::
+    (Optional, string) The names of particular nodes in the cluster to target.
+    May also be `_local` to reload settings on just the local node.
 
 NOTE: {es} requires consistent secure settings across the cluster nodes, but this consistency is not enforced.
 Hence, reloading specific nodes is not standard. It is only justifiable when retrying failed reload operations.
 
-==== Reload Password Protected Secure Settings
+[[cluster-nodes-reload-secure-settings-api-request-body]]
+==== {api-request-body-title}
 
 When the {es} keystore is password protected and not simply obfuscated, the password for the keystore needs
 to be provided in the request to reload the secure settings.
 Reloading the settings for the whole cluster assumes that all nodes' keystores are protected with the same password
 and is only allowed when {ref}/configuring-tls.html#tls-transport[node to node communications are encrypted]
+
+`reload_secure_settings`::
+  (Optional, string) The password for the Elasticsearch keystore.
 
 [source,js]
 --------------------------------------------------
@@ -56,8 +69,8 @@ POST _nodes/_local/reload_secure_settings
 
 
 [float]
-[[rest-reload-secure-settings]]
-==== REST Reload Secure Settings Response
+[[cluster-nodes-reload-secure-settings-api-response-body]]
+==== {api-response-body-title}
 
 The response contains the `nodes` object, which is a map, keyed by the
 node id. Each value has the node `name` and an optional `reload_exception`
@@ -82,3 +95,14 @@ that was thrown during the reload process, if any.
 --------------------------------------------------
 // TESTRESPONSE[s/"my_cluster"/$body.cluster_name/]
 // TESTRESPONSE[s/"pQHNt5rXTTWNvUgOrdynKg"/\$node_name/]
+
+[[cluster-nodes-reload-secure-settings-api-example]]
+==== {api-examples-title}
+
+[source,console]
+--------------------------------------------------
+POST _nodes/reload_secure_settings
+POST _nodes/nodeId1,nodeId2/reload_secure_settings
+--------------------------------------------------
+// TEST[setup:node]
+// TEST[s/nodeId1,nodeId2/*/]

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -25,7 +25,7 @@ are node-specific settings that must have the same value on every node.
 Just like the settings values in `elasticsearch.yml`, changes to the keystore
 contents are not automatically applied to the running {es} node. Re-reading
 settings requires a node restart. However, certain secure settings are marked as
-*reloadable*. Such settings can be re-read and applied on a running node.
+*reloadable*. Such settings can be {ref}/nodes-reload-secure-settings.html[re-read and applied on a running node].
 
 The values of all secure settings, *reloadable* or not, must be identical
 across all cluster nodes. After making the desired secure settings changes,
@@ -50,7 +50,7 @@ dependent on these settings have been changed. Everything should look as if the
 settings had the new value from the start.
 
 When changing multiple *reloadable* secure settings, modify all of them on each
-cluster node, then issue a `reload_secure_settings` call instead of reloading
+cluster node, then issue a {ref}/nodes-reload-secure-settings.html[`reload_secure_settings`] call instead of reloading
 after each modification.
 
 There are reloadable secure settings for:

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -25,7 +25,7 @@ are node-specific settings that must have the same value on every node.
 Just like the settings values in `elasticsearch.yml`, changes to the keystore
 contents are not automatically applied to the running {es} node. Re-reading
 settings requires a node restart. However, certain secure settings are marked as
-*reloadable*. Such settings can be {ref}/nodes-reload-secure-settings.html[re-read and applied on a running node].
+*reloadable*. Such settings can be <<cluster-nodes-reload-secure-settings, re-read and applied on a running node>>.
 
 The values of all secure settings, *reloadable* or not, must be identical
 across all cluster nodes. After making the desired secure settings changes,
@@ -50,8 +50,8 @@ dependent on these settings have been changed. Everything should look as if the
 settings had the new value from the start.
 
 When changing multiple *reloadable* secure settings, modify all of them on each
-cluster node, then issue a {ref}/nodes-reload-secure-settings.html[`reload_secure_settings`] call instead of reloading
-after each modification.
+cluster node, then issue a <<cluster-nodes-reload-secure-settings, `reload_secure_settings`>>
+call instead of reloading after each modification.
 
 There are reloadable secure settings for:
 


### PR DESCRIPTION
The reload-secure-settings API page was not reorganized for the standard
API format, so this commit is reorganizing the page and adding some
links to the page in related documentation.

This is a follow-up to #51123 .

Preview: http://elasticsearch_51560.docs-preview.app.elstc.co/diff