### PR TITLE
Avoid NPE in Gradle build when max-workers is set to 1

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -67,7 +67,7 @@ public class TestClustersPlugin implements Plugin<Project> {
             .registerIfAbsent(
                 THROTTLE_SERVICE_NAME,
                 TestClustersThrottle.class,
-                spec -> spec.getMaxParallelUsages().set(project.getGradle().getStartParameter().getMaxWorkerCount() / 2)
+                spec -> spec.getMaxParallelUsages().set(Math.min(1, project.getGradle().getStartParameter().getMaxWorkerCount() / 2))
             );
 
         // register cluster hooks


### PR DESCRIPTION
This PR is a follow up to #51338 which fixes a bug when we set `max-workers` to 1. This incorrect sets the throttle value of our limiter to `0` which causes Gradle to throw an obscure NPE when trying to schedule tasks that depend on that build service.