### PR TITLE
SQL: Verify Full-Text Search functions not allowed in SELECT

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -223,7 +223,8 @@ public final class Verifier {
             plan.forEachUp(p -> {
                 for (NamedExpression ne : p.projections()) {
                     ne.forEachUp((e) ->
-                            localFailures.add(fail(e, "Cannot use a Full-Text search functions in the SELECT clause")),
+                            localFailures.add(fail(e, "Cannot use MATCH() or QUERY() full-text search " +
+                                    "functions in the SELECT clause")),
                             FullTextPredicate.class);
                 }
             }, Project.class);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -220,11 +220,13 @@ public final class Verifier {
             final Map<Attribute, Expression> collectRefs = new LinkedHashMap<>();
 
             // Full-Text search function are not allowed in the SELECT clause
-            plan.forEachUp(p -> p.forEachExpressionsUp(e -> {
-                if (e instanceof FullTextPredicate) {
-                    localFailures.add(fail(e, "Cannot use a Full-Text search functions in the SELECT clause"));
+            plan.forEachUp(p -> {
+                for (NamedExpression ne : p.projections()) {
+                    ne.forEachUp((e) ->
+                            localFailures.add(fail(e, "Cannot use a Full-Text search functions in the SELECT clause")),
+                            FullTextPredicate.class);
                 }
-            }), Project.class);
+            }, Project.class);
 
             // collect Attribute sources
             // only Aliases are interesting since these are the only ones that hide expressions

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -712,15 +712,15 @@ public class VerifierErrorMessagesTests extends ESTestCase {
             error("SELECT * FROM test WHERE text RLIKE 'foo'"));
     }
 
-    public void testFullTextFunctionsNotAllowedInSelect() {
-        assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause",
+    public void testMatchAndQueryFunctionsNotAllowedInSelect() {
+        assertEquals("1:8: Cannot use MATCH() or QUERY() full-text search functions in the SELECT clause",
                 error("SELECT MATCH(text, 'foo') FROM test"));
-        assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause",
+        assertEquals("1:8: Cannot use MATCH() or QUERY() full-text search functions in the SELECT clause",
                 error("SELECT MATCH(text, 'foo') AS fullTextSearch FROM test"));
-        assertEquals("1:38: Cannot use a Full-Text search functions in the SELECT clause",
+        assertEquals("1:38: Cannot use MATCH() or QUERY() full-text search functions in the SELECT clause",
                 error("SELECT int > 10 AND (bool = false OR QUERY('foo*')) AS fullTextSearch FROM test"));
-        assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause\n" +
-                "line 1:28: Cannot use a Full-Text search functions in the SELECT clause",
+        assertEquals("1:8: Cannot use MATCH() or QUERY() full-text search functions in the SELECT clause\n" +
+                "line 1:28: Cannot use MATCH() or QUERY() full-text search functions in the SELECT clause",
                 error("SELECT MATCH(text, 'foo'), MATCH(text, 'bar') FROM test"));
         accept("SELECT * FROM test WHERE MATCH(text, 'foo')");
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -715,8 +715,14 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     public void testFullTextFunctionsNotAllowedInSelect() {
         assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause",
                 error("SELECT MATCH(text, 'foo') FROM test"));
+        assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause",
+                error("SELECT MATCH(text, 'foo') AS fullTextSearch FROM test"));
         assertEquals("1:38: Cannot use a Full-Text search functions in the SELECT clause",
-                error("SELECT int > 10 AND (bool = false OR QUERY('foo*')) FROM test"));
+                error("SELECT int > 10 AND (bool = false OR QUERY('foo*')) AS fullTextSearch FROM test"));
+        assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause\n" +
+                "line 1:28: Cannot use a Full-Text search functions in the SELECT clause",
+                error("SELECT MATCH(text, 'foo'), MATCH(text, 'bar') FROM test"));
+        accept("SELECT * FROM test WHERE MATCH(text, 'foo')");
     }
 
     public void testAllowCorrectFieldsInIncompatibleMappings() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -511,7 +511,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
         assertEquals("1:8: Cannot use field [x.y] with unsupported type [foobar]", error("SELECT x.y FROM test"));
     }
 
-    public void testTermEqualitOnInexact() {
+    public void testTermEqualityOnInexact() {
         assertEquals("1:26: [text = 'value'] cannot operate on first argument field of data type [text]: " +
                 "No keyword/multi-field defined exact matches for [text]; define one or use MATCH/QUERY instead",
             error("SELECT * FROM test WHERE text = 'value'"));
@@ -710,6 +710,13 @@ public class VerifierErrorMessagesTests extends ESTestCase {
         assertEquals("1:26: [text RLIKE 'foo'] cannot operate on field of data type [text]: " +
                 "No keyword/multi-field defined exact matches for [text]; define one or use MATCH/QUERY instead",
             error("SELECT * FROM test WHERE text RLIKE 'foo'"));
+    }
+
+    public void testFullTextFunctionsNotAllowedInSelect() {
+        assertEquals("1:8: Cannot use a Full-Text search functions in the SELECT clause",
+                error("SELECT MATCH(text, 'foo') FROM test"));
+        assertEquals("1:38: Cannot use a Full-Text search functions in the SELECT clause",
+                error("SELECT int > 10 AND (bool = false OR QUERY('foo*')) FROM test"));
     }
 
     public void testAllowCorrectFieldsInIncompatibleMappings() {


### PR DESCRIPTION
Add a verification that full-text search functions are not
allowed in the SELECT clause, so that a nice error message is
returned to the user early instead of an "ugly" exception.

Fixes: #47446
