### PR TITLE
[ML][Inference] Fix model pagination with models as resources

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -475,8 +475,7 @@ public class TrainedModelProvider {
             if (bufferedFrom > 0) {
                 allFoundIds.remove(allFoundIds.first());
                 bufferedFrom--;
-            }
-            else {
+            } else {
                 // If we have removed all items belonging on the previous page, but are still over sized, this means we should
                 // remove items that belong on the next page.
                 allFoundIds.remove(allFoundIds.last());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
@@ -95,55 +95,42 @@ public class TrainedModelProviderTests extends ESTestCase {
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(0, 3),
             Collections.emptySet(),
-            new HashSet<>(Arrays.asList("a", "b", "c")),
-            5),
+            new HashSet<>(Arrays.asList("a", "b", "c"))),
             equalTo(new TreeSet<>(Arrays.asList("a", "b", "c"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(0, 3),
             Collections.singleton("a"),
-            new HashSet<>(Arrays.asList("b", "c", "d")),
-            5),
+            new HashSet<>(Arrays.asList("b", "c", "d"))),
             equalTo(new TreeSet<>(Arrays.asList("a", "b", "c"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(1, 3),
             Collections.singleton("a"),
-            new HashSet<>(Arrays.asList("b", "c", "d")),
-            5),
+            new HashSet<>(Arrays.asList("b", "c", "d"))),
             equalTo(new TreeSet<>(Arrays.asList("b", "c", "d"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(1, 1),
             Collections.singleton("c"),
-            new HashSet<>(Arrays.asList("a", "b")), 5),
+            new HashSet<>(Arrays.asList("a", "b"))),
             equalTo(new TreeSet<>(Arrays.asList("b"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(1, 1),
             Collections.singleton("b"),
-            new HashSet<>(Arrays.asList("a", "c")), 5),
+            new HashSet<>(Arrays.asList("a", "c"))),
             equalTo(new TreeSet<>(Arrays.asList("b"))));
-
-        assertThat(TrainedModelProvider.collectIds(new PageParams(4, 1),
-            Collections.singleton("d"),
-            new HashSet<>(Arrays.asList("c", "e")), 5),
-            equalTo(new TreeSet<>(Arrays.asList("e"))));
-
-        assertThat(TrainedModelProvider.collectIds(new PageParams(4, 100),
-            Collections.singleton("d"),
-            new HashSet<>(Arrays.asList("c", "e")), 5),
-            equalTo(new TreeSet<>(Arrays.asList("e"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(1, 2),
             new HashSet<>(Arrays.asList("a", "b")),
-            new HashSet<>(Arrays.asList("c", "d", "e")), 5),
+            new HashSet<>(Arrays.asList("c", "d", "e"))),
             equalTo(new TreeSet<>(Arrays.asList("b", "c"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(1, 3),
             new HashSet<>(Arrays.asList("a", "b")),
-            new HashSet<>(Arrays.asList("c", "d", "e")), 5),
+            new HashSet<>(Arrays.asList("c", "d", "e"))),
             equalTo(new TreeSet<>(Arrays.asList("b", "c", "d"))));
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(2, 3),
             new HashSet<>(Arrays.asList("a", "b")),
-            new HashSet<>(Arrays.asList("c", "d", "e")), 5),
+            new HashSet<>(Arrays.asList("c", "d", "e"))),
             equalTo(new TreeSet<>(Arrays.asList("c", "d", "e"))));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
@@ -91,7 +91,7 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testExpandIdsPagination() {
-        //NOTE: these test assume that the query pagination results are "buffered"
+        // NOTE: these tests assume that the query pagination results are "buffered"
 
         assertThat(TrainedModelProvider.collectIds(new PageParams(0, 3),
             Collections.emptySet(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
@@ -14,12 +14,16 @@ import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfigTests;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.TreeSet;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -84,6 +88,63 @@ public class TrainedModelProviderTests extends ESTestCase {
             }
             assertThat(qb, is(instanceOf(BoolQueryBuilder.class)));
         });
+    }
+
+    public void testExpandIdsPagination() {
+        //NOTE: these test assume that the query pagination results are "buffered"
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(0, 3),
+            Collections.emptySet(),
+            new HashSet<>(Arrays.asList("a", "b", "c")),
+            5),
+            equalTo(new TreeSet<>(Arrays.asList("a", "b", "c"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(0, 3),
+            Collections.singleton("a"),
+            new HashSet<>(Arrays.asList("b", "c", "d")),
+            5),
+            equalTo(new TreeSet<>(Arrays.asList("a", "b", "c"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(1, 3),
+            Collections.singleton("a"),
+            new HashSet<>(Arrays.asList("b", "c", "d")),
+            5),
+            equalTo(new TreeSet<>(Arrays.asList("b", "c", "d"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(1, 1),
+            Collections.singleton("c"),
+            new HashSet<>(Arrays.asList("a", "b")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("b"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(1, 1),
+            Collections.singleton("b"),
+            new HashSet<>(Arrays.asList("a", "c")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("b"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(4, 1),
+            Collections.singleton("d"),
+            new HashSet<>(Arrays.asList("c", "e")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("e"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(4, 100),
+            Collections.singleton("d"),
+            new HashSet<>(Arrays.asList("c", "e")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("e"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(1, 2),
+            new HashSet<>(Arrays.asList("a", "b")),
+            new HashSet<>(Arrays.asList("c", "d", "e")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("b", "c"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(1, 3),
+            new HashSet<>(Arrays.asList("a", "b")),
+            new HashSet<>(Arrays.asList("c", "d", "e")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("b", "c", "d"))));
+
+        assertThat(TrainedModelProvider.collectIds(new PageParams(2, 3),
+            new HashSet<>(Arrays.asList("a", "b")),
+            new HashSet<>(Arrays.asList("c", "d", "e")), 5),
+            equalTo(new TreeSet<>(Arrays.asList("c", "d", "e"))));
     }
 
     public void testGetModelThatExistsAsResourceButIsMissing() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -153,6 +153,7 @@ setup:
       ml.get_trained_models:
         model_id: "*"
   - match: { count: 6 }
+  - length: { trained_model_configs: 6 }
   - match: { trained_model_configs.0.model_id: "a-classification-model" }
   - match: { trained_model_configs.1.model_id: "a-regression-model-0" }
   - match: { trained_model_configs.2.model_id: "a-regression-model-1" }
@@ -164,6 +165,7 @@ setup:
       ml.get_trained_models:
         model_id: "a-regression*"
   - match: { count: 2 }
+  - length: { trained_model_configs: 2 }
   - match: { trained_model_configs.0.model_id: "a-regression-model-0" }
   - match: { trained_model_configs.1.model_id: "a-regression-model-1" }
 
@@ -173,6 +175,7 @@ setup:
         from: 0
         size: 2
   - match: { count: 6 }
+  - length: { trained_model_configs: 2 }
   - match: { trained_model_configs.0.model_id: "a-classification-model" }
   - match: { trained_model_configs.1.model_id: "a-regression-model-0" }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -229,19 +229,30 @@ setup:
 
   - do:
       ml.get_trained_models:
-        model_id: "*"
-        from: 5
+        model_id: "a-*,lang*,zzz*"
+        allow_no_match: true
+        from: 3
         size: 1
-  - match: { count: 6 }
+  - match: { count: 5 }
+  - length: { trained_model_configs: 1 }
+  - match: { trained_model_configs.0.model_id: "lang_ident_model_1" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "a-*,lang*,zzz*"
+        allow_no_match: true
+        from: 4
+        size: 1
+  - match: { count: 5 }
   - length: { trained_model_configs: 1 }
   - match: { trained_model_configs.0.model_id: "zzz-classification-model" }
 
   - do:
       ml.get_trained_models:
-        model_id: "*"
-        from: 5
-        size: 2
-  - match: { count: 6 }
+        model_id: "a-*,lang*,zzz*"
+        from: 4
+        size: 100
+  - match: { count: 5 }
   - length: { trained_model_configs: 1 }
   - match: { trained_model_configs.0.model_id: "zzz-classification-model" }
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -72,6 +72,56 @@ setup:
                }
             }
           }
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model:
+        model_id: yyy-classification-model
+        body: >
+          {
+            "description": "empty model for tests",
+            "input": {"field_names": ["field1", "field2"]},
+            "tags": ["classification", "tag3"],
+            "definition": {
+               "preprocessors": [],
+               "trained_model": {
+                  "tree": {
+                     "feature_names": ["field1", "field2"],
+                     "tree_structure": [
+                        {"node_index": 0, "leaf_value": 1}
+                     ],
+                     "target_type": "classification",
+                     "classification_labels": ["no", "yes"]
+                  }
+               }
+            }
+          }
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model:
+        model_id: zzz-classification-model
+        body: >
+          {
+            "description": "empty model for tests",
+            "input": {"field_names": ["field1", "field2"]},
+            "tags": ["classification", "tag3"],
+            "definition": {
+               "preprocessors": [],
+               "trained_model": {
+                  "tree": {
+                     "feature_names": ["field1", "field2"],
+                     "tree_structure": [
+                        {"node_index": 0, "leaf_value": 1}
+                     ],
+                     "target_type": "classification",
+                     "classification_labels": ["no", "yes"]
+                  }
+               }
+            }
+          }
 ---
 "Test get given missing trained model":
 
@@ -102,10 +152,13 @@ setup:
   - do:
       ml.get_trained_models:
         model_id: "*"
-  - match: { count: 4 }
+  - match: { count: 6 }
   - match: { trained_model_configs.0.model_id: "a-classification-model" }
   - match: { trained_model_configs.1.model_id: "a-regression-model-0" }
   - match: { trained_model_configs.2.model_id: "a-regression-model-1" }
+  - match: { trained_model_configs.3.model_id: "lang_ident_model_1" }
+  - match: { trained_model_configs.4.model_id: "yyy-classification-model" }
+  - match: { trained_model_configs.5.model_id: "zzz-classification-model" }
 
   - do:
       ml.get_trained_models:
@@ -119,7 +172,7 @@ setup:
         model_id: "*"
         from: 0
         size: 2
-  - match: { count: 4 }
+  - match: { count: 6 }
   - match: { trained_model_configs.0.model_id: "a-classification-model" }
   - match: { trained_model_configs.1.model_id: "a-regression-model-0" }
 
@@ -128,8 +181,67 @@ setup:
         model_id: "*"
         from: 1
         size: 1
-  - match: { count: 4 }
+  - match: { count: 6 }
+  - length: { trained_model_configs: 1 }
   - match: { trained_model_configs.0.model_id: "a-regression-model-0" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "*"
+        from: 2
+        size: 2
+  - match: { count: 6 }
+  - length: { trained_model_configs: 2 }
+  - match: { trained_model_configs.0.model_id: "a-regression-model-1" }
+  - match: { trained_model_configs.1.model_id: "lang_ident_model_1" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "*"
+        from: 3
+        size: 1
+  - match: { count: 6 }
+  - length: { trained_model_configs: 1 }
+  - match: { trained_model_configs.0.model_id: "lang_ident_model_1" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "*"
+        from: 3
+        size: 2
+  - match: { count: 6 }
+  - length: { trained_model_configs: 2 }
+  - match: { trained_model_configs.0.model_id: "lang_ident_model_1" }
+  - match: { trained_model_configs.1.model_id: "yyy-classification-model" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "*"
+        from: 4
+        size: 2
+  - match: { count: 6 }
+  - length: { trained_model_configs: 2 }
+  - match: { trained_model_configs.0.model_id: "yyy-classification-model" }
+  - match: { trained_model_configs.1.model_id: "zzz-classification-model" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "*"
+        from: 5
+        size: 1
+  - match: { count: 6 }
+  - length: { trained_model_configs: 1 }
+  - match: { trained_model_configs.0.model_id: "zzz-classification-model" }
+
+  - do:
+      ml.get_trained_models:
+        model_id: "*"
+        from: 5
+        size: 2
+  - match: { count: 6 }
+  - length: { trained_model_configs: 1 }
+  - match: { trained_model_configs.0.model_id: "zzz-classification-model" }
+
 ---
 "Test get models with tags":
   - do:


### PR DESCRIPTION
This adds logic to handle paging problems when the ID pattern + tags reference models stored as resources. 

Most of the complexity comes from the issue where a model stored as a resource could be at the start, or the end of a page or when we are on the last page. 

closes https://github.com/elastic/elasticsearch/issues/51543