### PR TITLE
index.lifecycle.origination_date expects a long value

### DIFF
--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -43,4 +43,4 @@ the index creation will fail.
 `index.lifecycle.origination_date`::
 The timestamp that will be used to calculate the index age for its phase
 transitions. This allows the users to create an index containing old data and
-use the original creation date of the old data to calculate the index age.
+use the original creation date of the old data to calculate the index age.  Must be a long (Unix epoch) value.


### PR DESCRIPTION
We are currently not specifying the format `index.lifecycle.origination_date` accepts.
This new field accepts a long (unix epoch) value.

(We will want to merge this into master, 7.x and 7.5).
