### PR TITLE
Ignore virtual ethernet devices that disappear

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -172,6 +172,10 @@ public abstract class NetworkUtils {
         try {
             return intf.isUp();
         } catch (final SocketException e) {
+            // virtual ethernet devices come and go, we will treat such a device that disappeared as not being up
+            if (intf.getName().startsWith("veth") && e.getMessage().equals("No such device (getFlags() failed)")) {
+                return false;
+            }
             throw new IOException("failed to check if interface [" + intf.getName() + "] is up", e);
         }
     }


### PR DESCRIPTION
When checking if a device is up, today we can run into virtual ethernet devices that disappear while we are in the middle of checking. This leads to "no such device". This commit addresses such devices by treating them as not being up, if they are virtual ethernet devices that disappeared while we were checking.

Closes #49914
