### PR TITLE
Deprecate translog retention settings

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -80,6 +80,10 @@ update, or bulk request. This setting accepts the following parameters:
 [[index-modules-translog-retention]]
 ==== Translog retention
 
+deprecated::[7.4.0, translog retention settings are deprecated in favor of
+<<index-modules-history-retention,soft deletes>>. These settings are
+effectively ignored since 7.4 and will be removed in a future version].
+
 If an index is not using <<index-modules-history-retention,soft deletes>> to
 retain historical operations then {es} recovers each replica shard by replaying
 operations from the primary's translog. This means it is important for the

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -47,7 +47,7 @@
 "Translog retention settings are deprecated":
   - skip:
       version: " - 7.99.99"
-      reason: "translog retention are deprecated in 8.0"
+      reason: "translog retention settings are deprecated in 8.0"
       features: "warnings"
   - do:
       warnings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -44,6 +44,41 @@
   - match: { indices.test.primaries.translog.uncommitted_operations: 0 }
 
 ---
+"Translog retention settings are deprecated":
+  - skip:
+      version: " - 7.99.99"
+      reason: "translog retention are deprecated in 8.0"
+      features: "warnings"
+  - do:
+      warnings:
+        - Translog retention settings [index.translog.retention.age] and [index.translog.retention.size]
+          are deprecated and effectively ignored. They will be removed in a future version.
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.translog.retention.size: 128mb
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.number_of_replicas: 0
+  - do:
+      warnings:
+        - Translog retention settings [index.translog.retention.age] and [index.translog.retention.size]
+          are deprecated and effectively ignored. They will be removed in a future version.
+      indices.put_settings:
+        index: test
+        body:
+          index.translog.retention.age: 1h
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.translog.retention.age: null
+          index.translog.retention.size: null
+
+---
 "Translog last modified age stats":
 
   - do:

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -472,6 +472,7 @@ public class MetaDataCreateIndexService {
             throw new IllegalArgumentException("Creating indices with soft-deletes disabled is no longer supported. " +
                 "Please do not specify a value for setting [index.soft_deletes.enabled].");
         }
+        validateTranslogRetentionSettings(indexSettings);
         return indexSettings;
     }
 
@@ -927,6 +928,15 @@ public class MetaDataCreateIndexService {
             return numShards * 1 << numSplits;
         } else {
             return numShards;
+        }
+    }
+
+    public static void validateTranslogRetentionSettings(Settings indexSettings) {
+        if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings) &&
+            (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
+                || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings))) {
+            deprecationLogger.deprecatedAndMaybeLog("translog_retention", "Translog retention settings [index.translog.retention.age] "
+                + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -214,6 +215,12 @@ public class MetaDataUpdateSettingsService {
                     }
                 }
 
+                if (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(normalizedSettings) ||
+                    IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(normalizedSettings)) {
+                    for (String index : actualIndices) {
+                        MetaDataCreateIndexService.validateTranslogRetentionSettings(metaDataBuilder.get(index).getSettings());
+                    }
+                }
                 // increment settings versions
                 for (final String index : actualIndices) {
                     if (same(currentState.metaData().index(index).getSettings(), metaDataBuilder.get(index).getSettings()) == false) {


### PR DESCRIPTION
This change deprecates the translog retention settings as they are effectively ignored since 7.4.

Relates #50775 
Relates #45473