### PR TITLE
Fix ignore_missing in CsvProcessor

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/CsvProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/CsvProcessor.java
@@ -68,7 +68,7 @@ public final class CsvProcessor extends AbstractProcessor {
         }
 
         String line = ingestDocument.getFieldValue(field, String.class, ignoreMissing);
-        if (line == null && ignoreMissing == false) {
+        if (line == null && ignoreMissing) {
             return ingestDocument;
         } else if (line == null) {
             throw new IllegalArgumentException("field [" + field + "] is null, cannot process it.");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
@@ -158,7 +158,7 @@ public class CsvProcessorTests extends ESTestCase {
         items.keySet().stream().skip(numItems - 1).forEach(key -> assertFalse(ingestDocument.hasField(key)));
     }
 
-    public void testWrongStings() throws Exception {
+    public void testWrongStrings() throws Exception {
         assumeTrue("single run only", quote.isEmpty());
         expectThrows(IllegalArgumentException.class, () -> processDocument(new String[]{"a"}, "abc\"abc"));
         expectThrows(IllegalArgumentException.class, () -> processDocument(new String[]{"a"}, "\"abc\"asd"));
@@ -188,6 +188,19 @@ public class CsvProcessorTests extends ESTestCase {
         assertEquals("ooo", document.getFieldValue("d", String.class));
         assertEquals("jjj", document.getFieldValue("e", String.class));
         assertFalse(document.hasField("f"));
+    }
+
+    public void testIgnoreMissing() {
+        assumeTrue("single run only", quote.isEmpty());
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        String fieldName = randomAlphaOfLength(5);
+        if (ingestDocument.hasField(fieldName)) {
+            ingestDocument.removeField(fieldName);
+        }
+        CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(5), fieldName, new String[]{"a"}, false, ',', '"', true);
+        processor.execute(ingestDocument);
+        CsvProcessor processor2 = new CsvProcessor(randomAlphaOfLength(5), fieldName, new String[]{"a"}, false, ',', '"', false);
+        expectThrows(IllegalArgumentException.class, () -> processor2.execute(ingestDocument));
     }
 
     public void testEmptyHeaders() throws Exception {


### PR DESCRIPTION
This change fixes inverted logic around `ignore_missing` in `CsvProcessor`