### PR TITLE
Increase the number of indexed documents in a test from 10 to 100.

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -260,7 +260,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
     public void testTwoJobsWithSameRandomizeSeedUseSameTrainingSet() throws Exception {
         String sourceIndex = "regression_two_jobs_with_same_randomize_seed_source";
-        indexData(sourceIndex, 10, 0);
+        indexData(sourceIndex, 100, 0);
 
         String firstJobId = "regression_two_jobs_with_same_randomize_seed_1";
         String firstJobDestIndex = firstJobId + "_dest";


### PR DESCRIPTION
This is to increase a chance that there are at least 2 training rows after train/test split.
If there is only one training row, the analysis hangs.

Relates https://github.com/elastic/elasticsearch/issues/51571