### PR TITLE
[7.6] Increase the number of indexed documents to increase a chance that there are at least 2 training rows. (#51607)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -260,7 +260,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
     public void testTwoJobsWithSameRandomizeSeedUseSameTrainingSet() throws Exception {
         String sourceIndex = "regression_two_jobs_with_same_randomize_seed_source";
-        indexData(sourceIndex, 10, 0);
+        indexData(sourceIndex, 100, 0);
 
         String firstJobId = "regression_two_jobs_with_same_randomize_seed_1";
         String firstJobDestIndex = firstJobId + "_dest";


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Increase the number of indexed documents to increase a chance that there are at least 2 training rows.  (#51607)