### PR TITLE
[DOCS] Add experimental/beta tracking link to Rollup, GeoSQL docs

### DIFF
--- a/docs/reference/rollup/api-quickref.asciidoc
+++ b/docs/reference/rollup/api-quickref.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>API quick reference</titleabbrev>
 ++++
 
-experimental[]
+experimental[{issue}42720]
 
 Most rollup endpoints have the following base:
 

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -9,7 +9,7 @@
 
 Deletes an existing {rollup-job}. 
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-delete-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -8,7 +8,7 @@
 
 Retrieves the configuration, stats, and status of {rollup-jobs}.
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-get-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -9,7 +9,7 @@
 
 Creates a {rollup-job}.
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-put-job-api-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -9,7 +9,7 @@
 Returns the capabilities of any {rollup-jobs} that have been configured for a
 specific index or index pattern.
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-get-rollup-caps-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -9,7 +9,7 @@
 Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
 index where rollup data is stored).
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-get-rollup-index-caps-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -8,7 +8,7 @@
 
 Enables searching rolled-up data using the standard query DSL.  
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-search-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -9,7 +9,7 @@
 
 Starts an existing, stopped {rollup-job}.
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-start-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -9,7 +9,7 @@
 
 Stops an existing, started {rollup-job}.
 
-experimental[]
+experimental[{issue}42720]
 
 [[rollup-stop-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/index.asciidoc
+++ b/docs/reference/rollup/index.asciidoc
@@ -3,7 +3,7 @@
 [[xpack-rollup]]
 == Rolling up historical data
 
-experimental[]
+experimental[{issue}42720]
 
 Keeping historical data around for analysis is extremely useful but often avoided due to the financial cost of
 archiving massive amounts of data.  Retention periods are thus driven by financial realities rather than by the

--- a/docs/reference/rollup/overview.asciidoc
+++ b/docs/reference/rollup/overview.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Overview</titleabbrev>
 ++++
 
-experimental[]
+experimental[{issue}42720]
 
 Time-based data (documents that are predominantly identified by their timestamp) often have associated retention policies
 to manage data growth.  For example, your system may be generating 500 documents every second.  That will generate

--- a/docs/reference/rollup/rollup-agg-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-agg-limitations.asciidoc
@@ -3,7 +3,7 @@
 [[rollup-agg-limitations]]
 === {rollup-cap} aggregation limitations
 
-experimental[]
+experimental[{issue}42720]
 
 There are some limitations to how fields can be rolled up / aggregated.  This page highlights the major limitations so that
 you are aware of them.

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Getting started</titleabbrev>
 ++++
 
-experimental[]
+experimental[{issue}42720]
 
 To use the Rollup feature, you need to create one or more "Rollup Jobs".  These jobs run continuously in the background
 and rollup the index or indices that you specify, placing the rolled documents in a secondary index (also of your choosing).

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -3,7 +3,7 @@
 [[rollup-search-limitations]]
 === {rollup-cap} search limitations
 
-experimental[]
+experimental[{issue}42720]
 
 While we feel the Rollup function is extremely flexible, the nature of summarizing data means there will be some limitations.  Once
 live data is thrown away, you will always lose some flexibility.

--- a/docs/reference/rollup/understanding-groups.asciidoc
+++ b/docs/reference/rollup/understanding-groups.asciidoc
@@ -3,7 +3,7 @@
 [[rollup-understanding-groups]]
 === Understanding groups
 
-experimental[]
+experimental[{issue}42720]
 
 To preserve flexibility, Rollup Jobs are defined based on how future queries may need to use the data.  Traditionally, systems force
 the admin to make decisions about what metrics to rollup and on what interval.  E.g. The average of `cpu_time` on an hourly basis.  This

--- a/docs/reference/sql/functions/geo.asciidoc
+++ b/docs/reference/sql/functions/geo.asciidoc
@@ -3,7 +3,7 @@
 [[sql-functions-geo]]
 === Geo Functions
 
-beta[]
+beta[{issue}48521]
 
 The geo functions work with geometries stored in `geo_point`, `geo_shape` and `shape` fields, or returned by other geo functions.
 


### PR DESCRIPTION
Adds experimental/beta tracking links to the documentation for Rollup and GeoSQL docs