### PR TITLE
[DOCS] Minor fixes in transform documentation

### DIFF
--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -79,8 +79,11 @@ If you want to use more complex queries, you can create your {dataframe} from a
 {kibana-ref}/save-open-search.html[saved search].
 
 If you prefer, you can use the
-<<preview-transform,preview {transforms} API>>:
+<<preview-transform,preview {transforms} API>>.
 
+.API example
+[%collapsible]
+====
 [source,console]
 --------------------------------------------------
 POST _transform/_preview
@@ -129,6 +132,7 @@ POST _transform/_preview
 }
 --------------------------------------------------
 // TEST[skip:set up sample data]
+====
 --
 
 . When you are satisfied with what you see in the preview, create the
@@ -151,9 +155,11 @@ entities have changed. In general, it's a good idea to use the ingest timestamp
 field. In this example, however, you can use the `order_date` field.
 
 If you prefer, you can use the
-<<put-transform,create {transforms} API>>. For
-example:
+<<put-transform,create {transforms} API>>.
 
+.API example
+[%collapsible]
+====
 [source,console]
 --------------------------------------------------
 PUT _transform/ecommerce-customer-transform
@@ -209,6 +215,7 @@ PUT _transform/ecommerce-customer-transform
 }
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
+====
 --
 
 . Start the {transform}.
@@ -227,14 +234,17 @@ image::images/manage-transforms.jpg["Managing {transforms} in {kib}"]
 
 Alternatively, you can use the
 <<start-transform,start {transforms}>> and
-<<stop-transform,stop {transforms}>> APIs. For
-example:
+<<stop-transform,stop {transforms}>> APIs.
 
+.API example
+[%collapsible]
+====
 [source,console]
 --------------------------------------------------
 POST _transform/ecommerce-customer-transform/_start
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
+====
 
 TIP: If you chose a batch {transform}, it is a single operation that has a
 single checkpoint. You cannot restart it when it's complete. {ctransforms-cap}

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -37,29 +37,17 @@ suitable for writing beats output to {es}.
 
 --
 
-[[built-in-roles-transform-admin]] `transform_admin` :: 
-Grants `manage_transform` cluster privileges, which enable you to manage 
-{transforms}. This role also includes all 
-{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
-
-[[built-in-roles-transform-user]] `transform_user` ::
-Grants `monitor_transform` cluster privileges, which enable you to use 
-{transforms}. This role also includes all
-{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
-
 [[built-in-roles-data-frame-transforms-admin]] `data_frame_transforms_admin` ::
-(This role is deprecated, please use the 
-<<built-in-roles-transform-admin,`transform_admin`>> role instead.) Grants 
-`manage_data_frame_transforms` cluster privileges, which enable you to manage 
-{transforms}. This role also includes all
+Grants `manage_data_frame_transforms` cluster privileges, which enable you to
+manage {transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
+deprecated:[7.5.0,"Replaced by <<built-in-roles-transform-admin,`transform_admin`>>"].
 
 [[built-in-roles-data-frame-transforms-user]] `data_frame_transforms_user` ::
-(This role is deprecated, please use the 
-<<built-in-roles-transform-user,`transform_user`>> role instead.) Grants 
-`monitor_data_frame_transforms` cluster privileges, which enable you to use 
-{transforms}. This role also includes all
+Grants `monitor_data_frame_transforms` cluster privileges, which enable you to
+use {transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
+deprecated:[7.5.0,"Replaced by <<built-in-roles-transform-user,`transform_user`>>"].
 
 [[built-in-roles-enrich-user]] `enrich_user` ::
 Grants access to manage *all* enrich indices (`.enrich-*`) and *all* operations on
@@ -166,6 +154,16 @@ Grants full access to the cluster, including all indices and data. A user with
 the `superuser` role can also manage users and roles and
 <<run-as-privilege, impersonate>> any other user in the system. Due to the
 permissive nature of this role, take extra care when assigning it to a user.
+
+[[built-in-roles-transform-admin]] `transform_admin`:: 
+Grants `manage_transform` cluster privileges, which enable you to manage 
+{transforms}. This role also includes all 
+{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
+
+[[built-in-roles-transform-user]] `transform_user`::
+Grants `monitor_transform` cluster privileges, which enable you to use 
+{transforms}. This role also includes all
+{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-transport-client]] `transport_client`::
 Grants the privileges required to access the cluster through the Java Transport


### PR DESCRIPTION
This PR adds the missing deprecation indicators (https://github.com/elastic/docs#additions-and-deprecations) for the data_frame_transform_admin and data_frame_transform_user roles (
https://www.elastic.co/guide/en/elasticsearch/reference/master/built-in-roles.html). It also sorts the list so that the new transform_admin and transform_user are in the right place alphabetically.

It also updates the eCommerce tutorial (https://www.elastic.co/guide/en/elasticsearch/reference/master/ecommerce-transforms.html) such that the API examples are collapsed by default. The steps can all be done in Kibana, which is why it's optional to view the API details.

Preview: 
* http://elasticsearch_51633.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ecommerce-transforms.html
* http://elasticsearch_51633.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/built-in-roles.html