### PR TITLE
Deprecate translog retention settings (#51588)

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -80,6 +80,10 @@ update, or bulk request. This setting accepts the following parameters:
 [[index-modules-translog-retention]]
 ==== Translog retention
 
+deprecated::[7.4.0, translog retention settings are deprecated in favor of
+<<index-modules-history-retention,soft deletes>>. These settings are
+effectively ignored since 7.4 and will be removed in a future version].
+
 If an index is not using <<index-modules-history-retention,soft deletes>> to
 retain historical operations then {es} recovers each replica shard by replaying
 operations from the primary's translog. This means it is important for the

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -122,6 +122,41 @@
   - match: { indices.test.primaries.translog.uncommitted_operations: 0 }
 
 ---
+"Translog retention settings are deprecated":
+  - skip:
+      version: " - 7.6.99"
+      reason: "translog retention settings are deprecated in 7.6"
+      features: "warnings"
+  - do:
+      warnings:
+        - Translog retention settings [index.translog.retention.age] and [index.translog.retention.size]
+          are deprecated and effectively ignored. They will be removed in a future version.
+      indices.create:
+        index: test
+        body:
+          settings:
+            index.translog.retention.size: 128mb
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.number_of_replicas: 0
+  - do:
+      warnings:
+        - Translog retention settings [index.translog.retention.age] and [index.translog.retention.size]
+          are deprecated and effectively ignored. They will be removed in a future version.
+      indices.put_settings:
+        index: test
+        body:
+          index.translog.retention.age: 1h
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.translog.retention.age: null
+          index.translog.retention.size: null
+
+---
 "Translog last modified age stats":
   - skip:
       version: " - 6.2.99"

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -493,6 +493,7 @@ public class MetaDataCreateIndexService {
                 "Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions. " +
                 "Please do not specify value for setting [index.soft_deletes.enabled] of index [" + request.index() + "].");
         }
+        validateTranslogRetentionSettings(indexSettings);
         return indexSettings;
     }
 
@@ -973,6 +974,15 @@ public class MetaDataCreateIndexService {
             return numShards * 1 << numSplits;
         } else {
             return numShards;
+        }
+    }
+
+    public static void validateTranslogRetentionSettings(Settings indexSettings) {
+        if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings) &&
+            (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
+                || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings))) {
+            deprecationLogger.deprecatedAndMaybeLog("translog_retention", "Translog retention settings [index.translog.retention.age] "
+                + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -981,7 +981,7 @@ public class MetaDataCreateIndexService {
         if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexSettings) &&
             (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(indexSettings)
                 || IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(indexSettings))) {
-            deprecationLogger.deprecatedAndMaybeLog("translog_retention", "Translog retention settings [index.translog.retention.age] "
+            DEPRECATION_LOGGER.deprecatedAndMaybeLog("translog_retention", "Translog retention settings [index.translog.retention.age] "
                 + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -214,6 +215,12 @@ public class MetaDataUpdateSettingsService {
                     }
                 }
 
+                if (IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.exists(normalizedSettings) ||
+                    IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.exists(normalizedSettings)) {
+                    for (String index : actualIndices) {
+                        MetaDataCreateIndexService.validateTranslogRetentionSettings(metaDataBuilder.get(index).getSettings());
+                    }
+                }
                 // increment settings versions
                 for (final String index : actualIndices) {
                     if (same(currentState.metaData().index(index).getSettings(), metaDataBuilder.get(index).getSettings()) == false) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -944,6 +945,21 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
         }
         aggregateIndexSettings(ClusterState.EMPTY_STATE, request, Collections.emptyList(), Collections.emptyMap(),
             null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
+    }
+
+    public void testValidateTranslogRetentionSettings() {
+        request = new CreateIndexClusterStateUpdateRequest("create index", "test", "test");
+        final Settings.Builder settings = Settings.builder();
+        if (randomBoolean()) {
+            settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey(), TimeValue.timeValueMillis(between(1, 120)));
+        } else {
+            settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(), between(1, 128) + "mb");
+        }
+        request.settings(settings.build());
+        aggregateIndexSettings(ClusterState.EMPTY_STATE, request, List.of(), Map.of(),
+            null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
+        assertWarnings("Translog retention settings [index.translog.retention.age] "
+            + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");
     }
 
     private IndexTemplateMetaData addMatchingTemplate(Consumer<IndexTemplateMetaData.Builder> configurator) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
@@ -956,7 +956,7 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
             settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(), between(1, 128) + "mb");
         }
         request.settings(settings.build());
-        aggregateIndexSettings(ClusterState.EMPTY_STATE, request, List.of(), Map.of(),
+        aggregateIndexSettings(ClusterState.EMPTY_STATE, request, Collections.emptyList(), Collections.emptyMap(),
             null, Settings.EMPTY, IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
         assertWarnings("Translog retention settings [index.translog.retention.age] "
             + "and [index.translog.retention.size] are deprecated and effectively ignored. They will be removed in a future version.");


### PR DESCRIPTION
This change deprecates the translog retention settings as they are
effectively ignored since 7.4.

Relates #50775
Relates #45473