### PR TITLE
Always use one shard in vector REST tests.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/10_dense_vector_basic.yml
@@ -10,6 +10,7 @@ setup:
         index: test-index
         body:
           settings:
+            number_of_shards: 1
             number_of_replicas: 0
           mappings:
             properties:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/15_dense_vector_l1l2.yml
@@ -10,6 +10,7 @@ setup:
         index: test-index
         body:
           settings:
+            number_of_shards: 1
             number_of_replicas: 0
           mappings:
             properties:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/20_dense_vector_special_cases.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/20_dense_vector_special_cases.yml
@@ -10,9 +10,8 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
-            # we need to have 1 shard to get request failure in test "Dense vectors should error with sparse vector functions"
             number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               my_dense_vector:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/30_sparse_vector_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/30_sparse_vector_basic.yml
@@ -12,6 +12,7 @@ setup:
         index: test-index
         body:
           settings:
+            number_of_shards: 1
             number_of_replicas: 0
           mappings:
             properties:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/35_sparse_vector_l1l2.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/35_sparse_vector_l1l2.yml
@@ -12,6 +12,7 @@ setup:
         index: test-index
         body:
           settings:
+            number_of_shards: 1
             number_of_replicas: 0
           mappings:
             properties:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/40_sparse_vector_special_cases.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/40_sparse_vector_special_cases.yml
@@ -12,9 +12,8 @@ setup:
         index: test-index
         body:
           settings:
-            number_of_replicas: 0
-            # we need to have 1 shard to get request failure in test "Sparse vectors should error with dense vector functions"
             number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               my_sparse_vector:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/50_vector_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/vectors/50_vector_stats.yml
@@ -17,6 +17,9 @@ setup:
       indices.create:
         index: test-index1
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               my_dense_vector1:


### PR DESCRIPTION
This PR tries to address the intermittent vector test failures on 7.x by making
sure we create indices with one shard.

The fix is based on this theory as to what's happening:
* On 7.x, the default number of shards is 1, but in REST tests we randomly use
2 in order to cover the multiple shards case. In the failing test run, we use 2
shards and all documents end up on only one shard.
* During a search, the response from the empty shard doesn't produce
deprecation warnings because  we never try to execute the script. If not all
shard responses contain the warning headers, then certain deprecation warnings
can be lost (due to the bug described in #33936).

Addresses #50716.
Relates to #50061.