### PR TITLE
[ML][Inference] stream inflate to parser + throw when byte limit is reached

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.ml.inference;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -17,6 +16,8 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.xpack.core.ml.inference.utils.SimpleBoundedInputStream;
 
 import java.io.IOException;
@@ -33,7 +34,10 @@ import java.util.zip.GZIPOutputStream;
  */
 public final class InferenceToXContentCompressor {
     private static final int BUFFER_SIZE = 4096;
-    private static final long MAX_INFLATED_BYTES = 1_000_000_000; // 1 gb maximum
+    // Either 10% of the configured JVM heap, or 1 GB, which ever is smaller
+    private static final long MAX_INFLATED_BYTES = Math.min(
+        (long)((0.10) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()),
+        1_000_000_000); // 1 gb maximum
 
     private InferenceToXContentCompressor() {}
 
@@ -45,29 +49,30 @@ public final class InferenceToXContentCompressor {
     static <T> T inflate(String compressedString,
                          CheckedFunction<XContentParser, T, IOException> parserFunction,
                          NamedXContentRegistry xContentRegistry) throws IOException {
-        try(XContentParser parser = XContentHelper.createParser(xContentRegistry,
+        try(XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry,
             LoggingDeprecationHandler.INSTANCE,
-            inflate(compressedString, MAX_INFLATED_BYTES),
-            XContentType.JSON)) {
+            inflate(compressedString, MAX_INFLATED_BYTES))) {
             return parserFunction.apply(parser);
         }
     }
 
     static Map<String, Object> inflateToMap(String compressedString) throws IOException {
         // Don't need the xcontent registry as we are not deflating named objects.
-        try(XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+        try(XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
             LoggingDeprecationHandler.INSTANCE,
-            inflate(compressedString, MAX_INFLATED_BYTES),
-            XContentType.JSON)) {
+            inflate(compressedString, MAX_INFLATED_BYTES))) {
             return parser.mapOrdered();
         }
     }
 
-    static BytesReference inflate(String compressedString, long streamSize) throws IOException {
+    static InputStream inflate(String compressedString, long streamSize) throws IOException {
+        // If the compressed length is already too large, it make sense that the inflated length would be as well
         byte[] compressedBytes = Base64.getDecoder().decode(compressedString.getBytes(StandardCharsets.UTF_8));
+        if (compressedBytes.length > streamSize) {
+            throw new IOException("compressed stream is longer than maximum allowed bytes [" + streamSize +"]");
+        }
         InputStream gzipStream = new GZIPInputStream(new BytesArray(compressedBytes).streamInput(), BUFFER_SIZE);
-        InputStream inflateStream = new SimpleBoundedInputStream(gzipStream, streamSize);
-        return Streams.readFully(inflateStream);
+        return new SimpleBoundedInputStream(gzipStream, streamSize, true);
     }
 
     //Public for testing (for now)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -66,17 +66,16 @@ public final class InferenceToXContentCompressor {
     }
 
     static InputStream inflate(String compressedString, long streamSize) throws IOException {
-        // If the compressed length is already too large, it make sense that the inflated length would be as well
         byte[] compressedBytes = Base64.getDecoder().decode(compressedString.getBytes(StandardCharsets.UTF_8));
+        // If the compressed length is already too large, it make sense that the inflated length would be as well
         if (compressedBytes.length > streamSize) {
-            throw new IOException("compressed stream is longer than maximum allowed bytes [" + streamSize +"]");
+            throw new IOException("compressed stream is longer than maximum allowed bytes [" + streamSize + "]");
         }
         InputStream gzipStream = new GZIPInputStream(new BytesArray(compressedBytes).streamInput(), BUFFER_SIZE);
-        return new SimpleBoundedInputStream(gzipStream, streamSize, true);
+        return new SimpleBoundedInputStream(gzipStream, streamSize);
     }
 
-    //Public for testing (for now)
-    public static String deflate(BytesReference reference) throws IOException {
+    private static String deflate(BytesReference reference) throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
         try (OutputStream compressedOutput = new GZIPOutputStream(out, BUFFER_SIZE)) {
             reference.writeTo(compressedOutput);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressor.java
@@ -68,7 +68,8 @@ public final class InferenceToXContentCompressor {
     static InputStream inflate(String compressedString, long streamSize) throws IOException {
         byte[] compressedBytes = Base64.getDecoder().decode(compressedString.getBytes(StandardCharsets.UTF_8));
         // If the compressed length is already too large, it make sense that the inflated length would be as well
-        if (compressedBytes.length > streamSize) {
+        // In the extremely small string case, the compressed data could actually be longer than the compressed stream
+        if (compressedBytes.length > Math.max(100L, streamSize)) {
             throw new IOException("compressed stream is longer than maximum allowed bytes [" + streamSize + "]");
         }
         InputStream gzipStream = new GZIPInputStream(new BytesArray(compressedBytes).streamInput(), BUFFER_SIZE);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
@@ -19,15 +19,16 @@ public final class SimpleBoundedInputStream extends InputStream {
     private final InputStream in;
     private final long maxBytes;
     private long numBytes;
+    private final boolean throwWhenExceeded;
 
-    public SimpleBoundedInputStream(InputStream inputStream, long maxBytes) {
+    public SimpleBoundedInputStream(InputStream inputStream, long maxBytes, boolean throwWhenExceeded) {
         this.in = ExceptionsHelper.requireNonNull(inputStream, "inputStream");
         if (maxBytes < 0) {
             throw new IllegalArgumentException("[maxBytes] must be greater than or equal to 0");
         }
         this.maxBytes = maxBytes;
+        this.throwWhenExceeded = throwWhenExceeded;
     }
-
 
     /**
      * A simple wrapper around the injected input stream that restricts the total number of bytes able to be read.
@@ -38,6 +39,9 @@ public final class SimpleBoundedInputStream extends InputStream {
     public int read() throws IOException {
         // We have reached the maximum, signal stream completion.
         if (numBytes >= maxBytes) {
+            if (throwWhenExceeded) {
+                throw new IOException("input stream exceeded maximum bytes of [" + maxBytes +"]");
+            }
             return -1;
         }
         numBytes++;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
@@ -19,30 +19,25 @@ public final class SimpleBoundedInputStream extends InputStream {
     private final InputStream in;
     private final long maxBytes;
     private long numBytes;
-    private final boolean throwWhenExceeded;
 
-    public SimpleBoundedInputStream(InputStream inputStream, long maxBytes, boolean throwWhenExceeded) {
+    public SimpleBoundedInputStream(InputStream inputStream, long maxBytes) {
         this.in = ExceptionsHelper.requireNonNull(inputStream, "inputStream");
         if (maxBytes < 0) {
             throw new IllegalArgumentException("[maxBytes] must be greater than or equal to 0");
         }
         this.maxBytes = maxBytes;
-        this.throwWhenExceeded = throwWhenExceeded;
     }
 
     /**
      * A simple wrapper around the injected input stream that restricts the total number of bytes able to be read.
-     * @return The byte read. -1 on internal stream completion or when maxBytes is exceeded.
-     * @throws IOException on failure
+     * @return The byte read.
+     * @throws IOException on failure or when byte limit is exceeded
      */
     @Override
     public int read() throws IOException {
         // We have reached the maximum, signal stream completion.
         if (numBytes >= maxBytes) {
-            if (throwWhenExceeded) {
-                throw new IOException("input stream exceeded maximum bytes of [" + maxBytes +"]");
-            }
-            return -1;
+            throw new IOException("input stream exceeded maximum bytes of [" + maxBytes + "]");
         }
         numBytes++;
         return in.read();


### PR DESCRIPTION
Three fixes for when the `compressed_definition` is utilized on PUT

* Update the inflate byte limit to be the minimum of 10% the max heap, or 1GB (what it was previously)
* Stream data directly to the JSON parser, so if it is invalid, we don't have to inflate the whole stream to find out
* Throw when the maximum bytes are reach indicating that is why the request was rejected

