### PR TITLE
[ML] Fix possible race condition starting datafeed

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -524,7 +524,7 @@ public class DatafeedManager {
                 if (holder != null) {
                     innerRun(holder, task.getDatafeedStartTime(), task.getEndTime());
                 } else {
-                    logger.warn("Datafeed [{}] was closed while being opened", task.getDatafeedId());
+                    logger.warn("Datafeed [{}] was stopped while being started", task.getDatafeedId());
                 }
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -520,7 +520,12 @@ public class DatafeedManager {
             // a context with sufficient permissions would coincidentally be in force in some single node
             // tests, leading to bugs not caught in CI due to many tests running in single node test clusters.
             try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
-                innerRun(runningDatafeedsOnThisNode.get(task.getAllocationId()), task.getDatafeedStartTime(), task.getEndTime());
+                Holder holder = runningDatafeedsOnThisNode.get(task.getAllocationId());
+                if (holder != null) {
+                    innerRun(holder, task.getDatafeedStartTime(), task.getEndTime());
+                } else {
+                    logger.warn("Datafeed [{}] was closed while being opened", task.getDatafeedId());
+                }
             }
         }
 


### PR DESCRIPTION
Datafeeds being closed while starting could result in and NPE. This was
handled as any other failure, masking out the NPE. However, this
conflicts with the changes in #50886.

Related to #50886 and #51302
