### PR TITLE
[ML][Inference] Fix weighted mode definition

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedMode.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedMode.java
@@ -34,7 +34,7 @@ public class WeightedMode implements OutputAggregator {
 
     public static final String NAME = "weighted_mode";
     public static final ParseField WEIGHTS = new ParseField("weights");
-    public static final ParseField MAX_CLASS_VALUE = new ParseField("max_class_value");
+    public static final ParseField NUM_CLASSES = new ParseField("num_classes");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<WeightedMode, Void> PARSER = new ConstructingObjectParser<>(
@@ -42,7 +42,7 @@ public class WeightedMode implements OutputAggregator {
         true,
         a -> new WeightedMode((Integer)a[0], (List<Double>)a[1]));
     static {
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_CLASS_VALUE);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), NUM_CLASSES);
         PARSER.declareDoubleArray(ConstructingObjectParser.optionalConstructorArg(), WEIGHTS);
     }
 
@@ -51,11 +51,11 @@ public class WeightedMode implements OutputAggregator {
     }
 
     private final List<Double> weights;
-    private final int maxClassValue;
+    private final int numClasses;
 
-    public WeightedMode(int maxClassValue, List<Double> weights) {
+    public WeightedMode(int numClasses, List<Double> weights) {
         this.weights = weights;
-        this.maxClassValue = maxClassValue;
+        this.numClasses = numClasses;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class WeightedMode implements OutputAggregator {
         if (weights != null) {
             builder.field(WEIGHTS.getPreferredName(), weights);
         }
-        builder.field(MAX_CLASS_VALUE.getPreferredName(), maxClassValue);
+        builder.field(NUM_CLASSES.getPreferredName(), numClasses);
         builder.endObject();
         return builder;
     }
@@ -79,11 +79,11 @@ public class WeightedMode implements OutputAggregator {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WeightedMode that = (WeightedMode) o;
-        return Objects.equals(weights, that.weights) && maxClassValue == that.maxClassValue;
+        return Objects.equals(weights, that.weights) && numClasses == that.numClasses;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(weights, maxClassValue);
+        return Objects.hash(weights, numClasses);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedMode.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedMode.java
@@ -34,13 +34,15 @@ public class WeightedMode implements OutputAggregator {
 
     public static final String NAME = "weighted_mode";
     public static final ParseField WEIGHTS = new ParseField("weights");
+    public static final ParseField MAX_CLASS_VALUE = new ParseField("max_class_value");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<WeightedMode, Void> PARSER = new ConstructingObjectParser<>(
         NAME,
         true,
-        a -> new WeightedMode((List<Double>)a[0]));
+        a -> new WeightedMode((Integer)a[0], (List<Double>)a[1]));
     static {
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), MAX_CLASS_VALUE);
         PARSER.declareDoubleArray(ConstructingObjectParser.optionalConstructorArg(), WEIGHTS);
     }
 
@@ -49,9 +51,11 @@ public class WeightedMode implements OutputAggregator {
     }
 
     private final List<Double> weights;
+    private final int maxClassValue;
 
-    public WeightedMode(List<Double> weights) {
+    public WeightedMode(int maxClassValue, List<Double> weights) {
         this.weights = weights;
+        this.maxClassValue = maxClassValue;
     }
 
     @Override
@@ -65,6 +69,7 @@ public class WeightedMode implements OutputAggregator {
         if (weights != null) {
             builder.field(WEIGHTS.getPreferredName(), weights);
         }
+        builder.field(MAX_CLASS_VALUE.getPreferredName(), maxClassValue);
         builder.endObject();
         return builder;
     }
@@ -74,11 +79,11 @@ public class WeightedMode implements OutputAggregator {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WeightedMode that = (WeightedMode) o;
-        return Objects.equals(weights, that.weights);
+        return Objects.equals(weights, that.weights) && maxClassValue == that.maxClassValue;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(weights);
+        return Objects.hash(weights, maxClassValue);
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -77,7 +76,7 @@ public class EnsembleTests extends AbstractXContentTestCase<Ensemble> {
         OutputAggregator outputAggregator = targetType == TargetType.REGRESSION ? new WeightedSum(weights) :
             randomFrom(
                 new WeightedMode(
-                    categoryLabels != null ? categoryLabels.size() - 1 : randomIntBetween(1, 10),
+                    categoryLabels != null ? categoryLabels.size() : randomIntBetween(2, 10),
                     weights),
                 new LogisticRegression(weights));
         double[] thresholds = randomBoolean() && targetType == TargetType.CLASSIFICATION  ?

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
@@ -30,7 +30,9 @@ import java.util.stream.Stream;
 public class WeightedModeTests extends AbstractXContentTestCase<WeightedMode> {
 
     WeightedMode createTestInstance(int numberOfWeights) {
-        return new WeightedMode(Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).collect(Collectors.toList()));
+        return new WeightedMode(
+            randomIntBetween(1, 10),
+            Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).collect(Collectors.toList()));
     }
 
     @Override
@@ -45,7 +47,7 @@ public class WeightedModeTests extends AbstractXContentTestCase<WeightedMode> {
 
     @Override
     protected WeightedMode createTestInstance() {
-        return randomBoolean() ? new WeightedMode(null) : createTestInstance(randomIntBetween(1, 100));
+        return randomBoolean() ? new WeightedMode(randomIntBetween(1, 10), null) : createTestInstance(randomIntBetween(1, 100));
     }
 
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
@@ -31,7 +31,7 @@ public class WeightedModeTests extends AbstractXContentTestCase<WeightedMode> {
 
     WeightedMode createTestInstance(int numberOfWeights) {
         return new WeightedMode(
-            randomIntBetween(1, 10),
+            randomIntBetween(2, 10),
             Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).collect(Collectors.toList()));
     }
 
@@ -47,7 +47,7 @@ public class WeightedModeTests extends AbstractXContentTestCase<WeightedMode> {
 
     @Override
     protected WeightedMode createTestInstance() {
-        return randomBoolean() ? new WeightedMode(randomIntBetween(1, 10), null) : createTestInstance(randomIntBetween(1, 100));
+        return randomBoolean() ? new WeightedMode(randomIntBetween(2, 10), null) : createTestInstance(randomIntBetween(1, 100));
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/WeightedMode.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/WeightedMode.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(WeightedMode.class);
     public static final ParseField NAME = new ParseField("weighted_mode");
     public static final ParseField WEIGHTS = new ParseField("weights");
+    public static final ParseField MAX_CLASS_VALUE = new ParseField("max_class_value");
 
     private static final ConstructingObjectParser<WeightedMode, Void> LENIENT_PARSER = createParser(true);
     private static final ConstructingObjectParser<WeightedMode, Void> STRICT_PARSER = createParser(false);
@@ -38,7 +40,8 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
         ConstructingObjectParser<WeightedMode, Void> parser = new ConstructingObjectParser<>(
             NAME.getPreferredName(),
             lenient,
-            a -> new WeightedMode((List<Double>)a[0]));
+            a -> new WeightedMode((Integer) a[0], (List<Double>)a[1]));
+        parser.declareInt(ConstructingObjectParser.constructorArg(), MAX_CLASS_VALUE);
         parser.declareDoubleArray(ConstructingObjectParser.optionalConstructorArg(), WEIGHTS);
         return parser;
     }
@@ -52,17 +55,23 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
     }
 
     private final double[] weights;
+    private final int maxClassValue;
 
-    WeightedMode() {
-        this((List<Double>) null);
+    WeightedMode(int maxClassValue) {
+        this(maxClassValue, null);
     }
 
-    private WeightedMode(List<Double> weights) {
-        this(weights == null ? null : weights.stream().mapToDouble(Double::valueOf).toArray());
+    private WeightedMode(Integer maxClassValue, List<Double> weights) {
+        this(weights == null ? null : weights.stream().mapToDouble(Double::valueOf).toArray(), maxClassValue);
     }
 
-    public WeightedMode(double[] weights) {
+    public WeightedMode(double[] weights, Integer maxClassValue) {
         this.weights = weights;
+        this.maxClassValue = ExceptionsHelper.requireNonNull(maxClassValue, MAX_CLASS_VALUE);
+        if (this.maxClassValue <= 0) {
+            throw new IllegalArgumentException("[" + MAX_CLASS_VALUE.getPreferredName() + "] must be greater than 0.");
+        }
+
     }
 
     public WeightedMode(StreamInput in) throws IOException {
@@ -71,6 +80,7 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
         } else {
             this.weights = null;
         }
+        this.maxClassValue = in.readVInt();
     }
 
     @Override
@@ -99,7 +109,10 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
                 maxVal = integerValue;
             }
         }
-        List<Double> frequencies = new ArrayList<>(Collections.nCopies(maxVal + 1, Double.NEGATIVE_INFINITY));
+        if (maxVal > maxClassValue) {
+            throw new IllegalArgumentException("values contain entries larger than expected max of [" + maxClassValue + "]");
+        }
+        List<Double> frequencies = new ArrayList<>(Collections.nCopies(maxClassValue + 1, Double.NEGATIVE_INFINITY));
         for (int i = 0; i < freqArray.size(); i++) {
             Double weight = weights == null ? 1.0 : weights[i];
             Integer value = freqArray.get(i);
@@ -133,7 +146,7 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
 
     @Override
     public boolean compatibleWith(TargetType targetType) {
-        return true;
+        return targetType.equals(TargetType.CLASSIFICATION);
     }
 
     @Override
@@ -147,6 +160,7 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
         if (weights != null) {
             out.writeDoubleArray(weights);
         }
+        out.writeVInt(maxClassValue);
     }
 
     @Override
@@ -155,6 +169,7 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
         if (weights != null) {
             builder.field(WEIGHTS.getPreferredName(), weights);
         }
+        builder.field(MAX_CLASS_VALUE.getPreferredName(), maxClassValue);
         builder.endObject();
         return builder;
     }
@@ -164,12 +179,12 @@ public class WeightedMode implements StrictlyParsedOutputAggregator, LenientlyPa
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WeightedMode that = (WeightedMode) o;
-        return Arrays.equals(weights, that.weights);
+        return Arrays.equals(weights, that.weights) && maxClassValue == that.maxClassValue;
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(weights);
+        return Objects.hash(Arrays.hashCode(weights), maxClassValue);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinitionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinitionTests.java
@@ -309,23 +309,26 @@ public class TrainedModelDefinitionTests extends AbstractSerializingTestCase<Tra
     public void testMultiClassIrisInference() throws IOException {
         // Fairly simple, random forest classification model built to fit in our format
         // Trained on the well known Iris dataset
-        String compressedDef = "H4sIAMHqMV4C/+1b7Y6bOhB9lVV+b5HHX9h9g/sMVYVo4iRIbBIBaXtV9d0vJr23uzGKJwwsu" +
-            "73kx0qwgI+xZ+bMmeHHqqny4uA22dNx48rVx4cfK3eo3dOX0nUHTV7tXJM1f5/88Wpd5nVdbIt13hTHw+rxYbV1eXOuX" +
-            "HbIn1zdXvJpVbtTXmalO+yavb/icvyt2FwOT6558e/L8eXfnx+vh8jK/IsrLw/+qyrqD7VrjnXub+wOv7qqLtbH8lj9P" +
-            "lVUu+LQ3t897sX8uue0k6rcXLPzQ2d1U53X/rkXOIcWWlYcNu57e8zaizZuXdR+8v8CKxvnH1a6bZOt90W5aU9Ce6Iqd" +
-            "vvfZ7iHcyqLJvsFuz0n/Jj7ytX7Y3cNSwzrfgCWM8vtz8eHKwRwE0G+zb7m5dmfZOG9HIteBOiB9cDnV/BlYpRHLwxIb" +
-            "VOehhAEFoIMICgUglSFg0rsO4PwXoUFrAPAKWLFIVG2+zGpBVfayBCCJsBPsfBNAN/2wGdX8FVipUdv2s2qFYieFTcE9" +
-            "BZ7L+8xFLythsYKHDF5fb12PSCAMgO0vUKPwUrU7uszFxCEJQOJn/HNgMKS9n2D/8MT9vlnN9ISGt5gaNCojaa7yMCsE" +
-            "jqVAvQMoSHqqqaLE7cNXS8mc6/JGFRwkrEVBywCHiAQiD3HEdGdE6yWYDIp4gWSTWb70kTjfgOCFygvfkOm2oi0z20og" +
-            "tFqgtGmhHEN9q1ZXFwf4Oss2vZYiAFQez/u8iMc7fbmB7TxQmi9IHD0iD3ffcrcTdIiZElQ6CHa9iA0Ps4RS6gS6LaRB" +
-            "qME46noAYHOjyBMkDgM56gaPW4ajstw7L5nWHQ+BWFCBRaXEHbv3Cremgw3sm/lDWXbWMKG5YxyMyUZ4nwhSWPkFUMoy" +
-            "lyak0QxBBtjCASWZMdRvQgsyYzD00aWsQbwtOlUrNuOYzr9KUKSxDhEbXwdC4YwNaDQHE6JV7NxJNBjcURKjgKLOnB34" +
-            "NModUB1ux4sS4U0WsygDkSd5kzigMJJepeNz4WRbYJg3ouetn0Z2hAOE5eSEEotqIRaJSy2YSm6AkOJ0H0Tt5QknpJQT" +
-            "FldWfzqYL/62qrrgFLJ4ldf26+ywdX7kUvYQxJgQ9guFLmFxv3NcHWNJK2mIxUEafVvjdL4oiEV0OYOob2DGieu31NUn" +
-            "y/7uFctjYxslvg8jeAXzTrm0vuGc29CTO7l3teOIk1YrNVnZI2Pz67xDXHZb1Pkoyc+mKrMhM1q86VBIwRZRI/g9EG2N" +
-            "R/2fPNySpAFSpDli8S3hLr30zMXs5qlZ24xmfm+QJicHVpUAifkdORQvwY5pLTJ3dR9zDjF47dZAJ7yAwQ5TufB+E1y1" +
-            "6snrlMjOVsBePkc4Q/urX4/Kv/bbK0OQ6VQkTrD/621mg+uUbxCNzWiTW/CbmpSg09ERDBTfak2QDcY1Bs1oTp/u4EaU" +
-            "px2Ga0vUHQ7oJAzQNsrWFwT+xD5CW2+nOGa2AcQ9D+wtdpfnO92ldvljcuO5+Z0bjq+9M35V/jru/9nZ7qnwH9Pwf3xozzl37MO1jOo/vcP8wTvX0JBAAA=";
+        String compressedDef = "H4sIAPbiMl4C/+1b246bMBD9lVWet8jjG3b/oN9QVYgmToLEkghIL6r23wukl90" +
+            "YxRMGlt2WPKwEC/gYe2bOnBl+rOoyzQq3SR4OG5ev3t/9WLmicg+fc9cd1Gm5c3VSfz+2x6t1nlZVts3Wa" +
+            "Z0ditX93Wrr0vpUuqRIH1zVXPJxVbljmie5K3b1vr3ifPw125wPj65+9u/z8fnfn+4vh0jy9LPLzw/+UGb" +
+            "Vu8rVhyptb+wOv7iyytaH/FD+PZWVu6xo7u8e92x+3XOaSZVurtm1QydVXZ7W7XPPcIoGWpIVG/etOWbNR" +
+            "Ru3zqp28r+B5bVrH5a7bZ2s91m+aU5Cc6LMdvu/Z3gL55hndfILdnNOtGPuS1ftD901LDKs+wFYziy3j/d" +
+            "3FwjgKoJ0m3xJ81N7kvn3cix64aEH1gOfX8CXkVEtemFAahvz2IcgsBCkB0GhEMTKH1Ri3xn49yosYO0Bj" +
+            "hErDpGy3Y9JLbjSRvoQNAF+jIVvPPi2Bz67gK8iK1v0ptmsWoHoWXFDQG+x9/IeQ8Hbqm+swBGT15dr1wM" +
+            "CKDNA2yv0GKxE7b4+cwFBWDKQ+BlfDSgsat43tH94xD49diMtoeEVhgaN2mi6iwzMKqFjKUDPEBqCrmq6O" +
+            "HHd0PViMreajEEFJxlaccAi4B4CgdhzHBHdOcFqCSYTI14g2WS2z0007DfAe4Hy7DdkrI2I+9yGIhitJhh" +
+            "tTBjXYN+axcX1Ab7Oom2P+RgAtffDLj/A0a5vfkAbL/jWCwJHj9jT3afMzSQtQJYEhR6ibQ984+McsYQqg" +
+            "m4baTBKMB6LHhDo/Aj8BInDcI6q0ePG/rgMx+57hkXnU+AnVGBxCWH3zq3ijclwI/tW3lC2jSVsWM4oN1O" +
+            "SIc4XkjRGXjGEosylOUkUQ7AhhkBgSXYc1YvAksw4PG1kGWsAT5tOxbruOKbTnwIkSYxD1MbXsWAIUwMKz" +
+            "eGUeDUbRwI9Fkek5CiwqAM3Bz6NUgdUt+vBslhIo8UM6kDQac4kDiicpHfe+FwY2SQI5q3oadvnoQ3hMHE" +
+            "pCaHUgkqoVcRCG5aiKzCUCN03cUtJ4ikJxZTVlcWvDvarL626DiiVLH71pf0qG1y9H7mEPSQBNoTtQpFba" +
+            "NzfDFfXSNJqPFJBkFb/1iiNLxhSAW3u4Ns7qHHi+i1F9fmyj1vV0sDIZonP0wh+waxjLr1vOPcmxORe7n3" +
+            "pKOKIhVp9Rtb4+Owa3xCX/TpFPnrig6nKTNisNl8aNEKQRfQITh9kG/NhTzcvpwRZoARZvkh8S6h7Oz1zI" +
+            "atZeuYWk5nvC4TJ2aFFJXBCTkcO9UuQQ0qb3FXdx4xTPH6dBeApP0CQ43QejN8kd7l64jI1krMVgJfPEf7" +
+            "h3uq3o/K/ztZqP1QKFagz/G+t1XxwjeIFuqkRbXoTdlOTGnwCIoKZ6ku1AbrBoN6oCdX56w3UEOO0y2B9g" +
+            "aLbAYWcAdpeweKa2IfIT2jz5QzXxD6AoP+DrdXtxeluV7pdWrvkcKqPp7rjS19d+wp/fff/5Ez3FPjzFNy" +
+            "fdpTi9JB0sDp2JR7b309mn5HuPkEAAA==";
 
         TrainedModelDefinition definition = InferenceToXContentCompressor.inflate(compressedDef,
             parser -> TrainedModelDefinition.fromXContent(parser, true).build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -82,7 +82,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             randomFrom(
                 new WeightedMode(
                     weights,
-                    categoryLabels != null ? categoryLabels.size() - 1 : randomIntBetween(1, 10)),
+                    categoryLabels != null ? categoryLabels.size() : randomIntBetween(2, 10)),
                 new LogisticRegression(weights));
 
         double[] thresholds = randomBoolean() && targetType == TargetType.CLASSIFICATION ?
@@ -257,7 +257,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 1))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 2))
             .setClassificationWeights(Arrays.asList(0.7, 0.3))
             .build();
 
@@ -355,7 +355,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 1))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 2))
             .build();
 
         List<Double> featureVector = Arrays.asList(0.4, 0.0);
@@ -426,7 +426,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 2))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 3))
             .build();
 
         List<Double> featureVector = Arrays.asList(0.4, 0.0);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -72,14 +72,19 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
         double[] weights = randomBoolean() ?
             null :
             Stream.generate(ESTestCase::randomDouble).limit(numberOfModels).mapToDouble(Double::valueOf).toArray();
-        OutputAggregator outputAggregator = randomFrom(new WeightedMode(weights),
-            new WeightedSum(weights),
-            new LogisticRegression(weights));
         TargetType targetType = randomFrom(TargetType.values());
         List<String> categoryLabels = null;
         if (randomBoolean() && targetType == TargetType.CLASSIFICATION) {
-            categoryLabels = Arrays.asList(generateRandomStringArray(randomIntBetween(1, 10), randomIntBetween(1, 10), false, false));
+            categoryLabels = randomList(2, randomIntBetween(3, 10), () -> randomAlphaOfLength(10));
         }
+
+        OutputAggregator outputAggregator = targetType == TargetType.REGRESSION ? new WeightedSum(weights) :
+            randomFrom(
+                new WeightedMode(
+                    weights,
+                    categoryLabels != null ? categoryLabels.size() - 1 : randomIntBetween(1, 10)),
+                new LogisticRegression(weights));
+
         double[] thresholds = randomBoolean() && targetType == TargetType.CLASSIFICATION ?
             Stream.generate(ESTestCase::randomDouble)
                 .limit(categoryLabels == null ? randomIntBetween(1, 10) : categoryLabels.size())
@@ -122,7 +127,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
         for (int i = 0; i < numberOfModels + 2; i++) {
             weights[i] = randomDouble();
         }
-        OutputAggregator outputAggregator = randomFrom(new WeightedMode(weights), new WeightedSum(weights));
+        OutputAggregator outputAggregator = new WeightedSum(weights);
 
         List<TrainedModel> models = new ArrayList<>(numberOfModels);
         for (int i = 0; i < numberOfModels; i++) {
@@ -252,7 +257,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 1))
             .setClassificationWeights(Arrays.asList(0.7, 0.3))
             .build();
 
@@ -350,7 +355,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 1))
             .build();
 
         List<Double> featureVector = Arrays.asList(0.4, 0.0);
@@ -373,6 +378,77 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
             put("bar", null);
         }};
         assertThat(0.0,
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new ClassificationConfig(0))).value(), 0.00001));
+    }
+
+    public void testMultiClassClassificationInference() {
+        List<String> featureNames = Arrays.asList("foo", "bar");
+        Tree tree1 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(0)
+                .setThreshold(0.5))
+            .addNode(TreeNode.builder(1).setLeafValue(2.0))
+            .addNode(TreeNode.builder(2)
+                .setThreshold(0.8)
+                .setSplitFeature(1)
+                .setLeftChild(3)
+                .setRightChild(4))
+            .addNode(TreeNode.builder(3).setLeafValue(0.0))
+            .addNode(TreeNode.builder(4).setLeafValue(1.0))
+            .setTargetType(randomFrom(TargetType.CLASSIFICATION, TargetType.REGRESSION))
+            .build();
+        Tree tree2 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(1)
+                .setThreshold(0.5))
+            .addNode(TreeNode.builder(1).setLeafValue(2.0))
+            .addNode(TreeNode.builder(2).setLeafValue(1.0))
+            .setTargetType(randomFrom(TargetType.CLASSIFICATION, TargetType.REGRESSION))
+            .build();
+        Tree tree3 = Tree.builder()
+            .setFeatureNames(featureNames)
+            .setRoot(TreeNode.builder(0)
+                .setLeftChild(1)
+                .setRightChild(2)
+                .setSplitFeature(1)
+                .setThreshold(2.0))
+            .addNode(TreeNode.builder(1).setLeafValue(1.0))
+            .addNode(TreeNode.builder(2).setLeafValue(0.0))
+            .setTargetType(randomFrom(TargetType.CLASSIFICATION, TargetType.REGRESSION))
+            .build();
+        Ensemble ensemble = Ensemble.builder()
+            .setTargetType(TargetType.CLASSIFICATION)
+            .setFeatureNames(featureNames)
+            .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 2))
+            .build();
+
+        List<Double> featureVector = Arrays.asList(0.4, 0.0);
+        Map<String, Object> featureMap = zipObjMap(featureNames, featureVector);
+        assertThat(2.0,
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new ClassificationConfig(0))).value(), 0.00001));
+
+        featureVector = Arrays.asList(2.0, 0.7);
+        featureMap = zipObjMap(featureNames, featureVector);
+        assertThat(1.0,
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new ClassificationConfig(0))).value(), 0.00001));
+
+        featureVector = Arrays.asList(0.0, 1.0);
+        featureMap = zipObjMap(featureNames, featureVector);
+        assertThat(1.0,
+            closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new ClassificationConfig(0))).value(), 0.00001));
+
+        featureMap = new HashMap<>(2) {{
+            put("foo", 0.6);
+            put("bar", null);
+        }};
+        assertThat(1.0,
             closeTo(((SingleValueInferenceResults)ensemble.infer(featureMap, new ClassificationConfig(0))).value(), 0.00001));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
 public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
@@ -23,7 +24,7 @@ public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
     @Override
     WeightedMode createTestInstance(int numberOfWeights) {
         double[] weights = Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).mapToDouble(Double::valueOf).toArray();
-        return new WeightedMode(weights, randomIntBetween(1, 10));
+        return new WeightedMode(weights, randomIntBetween(2, 10));
     }
 
     @Override
@@ -33,7 +34,7 @@ public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
 
     @Override
     protected WeightedMode createTestInstance() {
-        return randomBoolean() ? new WeightedMode(randomIntBetween(1, 10)) : createTestInstance(randomIntBetween(1, 100));
+        return randomBoolean() ? new WeightedMode(randomIntBetween(2, 10)) : createTestInstance(randomIntBetween(1, 100));
     }
 
     @Override
@@ -45,16 +46,28 @@ public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
         double[] ones = new double[]{1.0, 1.0, 1.0, 1.0, 1.0};
         List<Double> values = Arrays.asList(1.0, 2.0, 2.0, 3.0, 5.0);
 
-        WeightedMode weightedMode = new WeightedMode(ones, 5);
+        WeightedMode weightedMode = new WeightedMode(ones, 6);
         assertThat(weightedMode.aggregate(weightedMode.processValues(values)), equalTo(2.0));
 
         double[] variedWeights = new double[]{1.0, -1.0, .5, 1.0, 5.0};
 
-        weightedMode = new WeightedMode(variedWeights, 5);
+        weightedMode = new WeightedMode(variedWeights, 6);
         assertThat(weightedMode.aggregate(weightedMode.processValues(values)), equalTo(5.0));
 
-        weightedMode = new WeightedMode(5);
+        weightedMode = new WeightedMode(6);
         assertThat(weightedMode.aggregate(weightedMode.processValues(values)), equalTo(2.0));
+
+        values = Arrays.asList(1.0, 1.0, 1.0, 1.0, 2.0);
+        weightedMode = new WeightedMode(6);
+        List<Double> processedValues = weightedMode.processValues(values);
+        assertThat(processedValues.size(), equalTo(6));
+        assertThat(processedValues.get(0), equalTo(0.0));
+        assertThat(processedValues.get(1), closeTo(0.95257412, 0.00001));
+        assertThat(processedValues.get(2), closeTo((1.0 - 0.95257412), 0.00001));
+        assertThat(processedValues.get(3), equalTo(0.0));
+        assertThat(processedValues.get(4), equalTo(0.0));
+        assertThat(processedValues.get(5), equalTo(0.0));
+        assertThat(weightedMode.aggregate(processedValues), equalTo(1.0));
     }
 
     public void testCompatibleWith() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/WeightedModeTests.java
@@ -23,7 +23,7 @@ public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
     @Override
     WeightedMode createTestInstance(int numberOfWeights) {
         double[] weights = Stream.generate(ESTestCase::randomDouble).limit(numberOfWeights).mapToDouble(Double::valueOf).toArray();
-        return new WeightedMode(weights);
+        return new WeightedMode(weights, randomIntBetween(1, 10));
     }
 
     @Override
@@ -33,7 +33,7 @@ public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
 
     @Override
     protected WeightedMode createTestInstance() {
-        return randomBoolean() ? new WeightedMode() : createTestInstance(randomIntBetween(1, 100));
+        return randomBoolean() ? new WeightedMode(randomIntBetween(1, 10)) : createTestInstance(randomIntBetween(1, 100));
     }
 
     @Override
@@ -45,21 +45,21 @@ public class WeightedModeTests extends WeightedAggregatorTests<WeightedMode> {
         double[] ones = new double[]{1.0, 1.0, 1.0, 1.0, 1.0};
         List<Double> values = Arrays.asList(1.0, 2.0, 2.0, 3.0, 5.0);
 
-        WeightedMode weightedMode = new WeightedMode(ones);
+        WeightedMode weightedMode = new WeightedMode(ones, 5);
         assertThat(weightedMode.aggregate(weightedMode.processValues(values)), equalTo(2.0));
 
         double[] variedWeights = new double[]{1.0, -1.0, .5, 1.0, 5.0};
 
-        weightedMode = new WeightedMode(variedWeights);
+        weightedMode = new WeightedMode(variedWeights, 5);
         assertThat(weightedMode.aggregate(weightedMode.processValues(values)), equalTo(5.0));
 
-        weightedMode = new WeightedMode();
+        weightedMode = new WeightedMode(5);
         assertThat(weightedMode.aggregate(weightedMode.processValues(values)), equalTo(2.0));
     }
 
     public void testCompatibleWith() {
         WeightedMode weightedMode = createTestInstance();
         assertThat(weightedMode.compatibleWith(TargetType.CLASSIFICATION), is(true));
-        assertThat(weightedMode.compatibleWith(TargetType.REGRESSION), is(true));
+        assertThat(weightedMode.compatibleWith(TargetType.REGRESSION), is(false));
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -424,7 +424,7 @@ public class InferenceIngestIT extends ESRestTestCase {
         "      ],\n" +
         "      \"aggregate_output\": {\n" +
         "        \"weighted_mode\": {\n" +
-        "          \"num_classes\": \"2\"\n" +
+        "          \"num_classes\": \"2\",\n" +
         "          \"weights\": [\n" +
         "            0.5,\n" +
         "            0.5\n" +

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -424,6 +424,7 @@ public class InferenceIngestIT extends ESRestTestCase {
         "      ],\n" +
         "      \"aggregate_output\": {\n" +
         "        \"weighted_mode\": {\n" +
+        "          \"max_class_value\": \"1\"\n" +
         "          \"weights\": [\n" +
         "            0.5,\n" +
         "            0.5\n" +

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -424,7 +424,7 @@ public class InferenceIngestIT extends ESRestTestCase {
         "      ],\n" +
         "      \"aggregate_output\": {\n" +
         "        \"weighted_mode\": {\n" +
-        "          \"max_class_value\": \"1\"\n" +
+        "          \"num_classes\": \"2\"\n" +
         "          \"weights\": [\n" +
         "            0.5,\n" +
         "            0.5\n" +

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -188,7 +188,7 @@ public class LocalModelTests extends ESTestCase {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 1))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 2))
             .build();
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -188,7 +188,7 @@ public class LocalModelTests extends ESTestCase {
             .setTargetType(TargetType.CLASSIFICATION)
             .setFeatureNames(featureNames)
             .setTrainedModels(Arrays.asList(tree1, tree2, tree3))
-            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}))
+            .setOutputAggregator(new WeightedMode(new double[]{0.7, 0.5, 1.0}, 1))
             .build();
     }
 


### PR DESCRIPTION
Weighted mode inaccurately assumed that the "max value" of the input values would be the maximum class value. This does not make sense. 

Weighted Mode should know how many classes there are. Hence the new parameter `num_classes`. This indicates what the maximum class value to be expected.

