### PR TITLE
Increase shard inactive time to 1h in upgrade tests

### DIFF
--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -38,7 +38,7 @@ for (Version bwcVersion : bwcVersions.indexCompatible) {
       versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 2
       // some tests rely on the translog not being flushed
-      setting 'indices.memory.shard_inactive_time', '20m'
+      setting 'indices.memory.shard_inactive_time', '60m'
       setting 'http.content_type.required', 'true'
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     }


### PR DESCRIPTION
`testRecovery` relies on the fact that shards are not flushed on inactive. Our CI recently was too slow. It took more than 20 minutes to complete the full cluster restart suite. This slowness caused some shards of `testRecovery` were flushed on inactive.

This commit increases the inactive time to 1h to reduce this noise.

Closes #51640


```
[2020-01-29T16:25:23,529][INFO ][o.e.n.Node               ] [v8.0.0-0] JVM home [/var/lib/jenkins/.java/openjdk-11.0.2-linux]
...
[2020-01-29T16:47:08,275][INFO ][o.e.n.Node               ] [v8.0.0-0] JVM home [/var/lib/jenkins/.java/openjdk-11.0.2-linux]
```
