### PR TITLE
Backport: unmute rolling upgrade watcher tests and

### DIFF
--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -102,6 +102,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
       }
 
       javaHome = BuildParams.runtimeJavaHome
+      setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
     }
   }
 

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
@@ -1,17 +1,11 @@
 ---
 "CRUD watch APIs":
-
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/33185
-      version: "6.7.0 - "
-
   # no need to put watch, exists already
   - do:
       watcher.get_watch:
         id: "my_watch"
   - match: { found : true}
   - match: { _id: "my_watch" }
-
 
   # execute watch
   - do:
@@ -48,7 +42,7 @@
       watcher.deactivate_watch:
         watch_id: "my_watch"
   - match: { status.state.active : false }
-  
+
   - do:
       watcher.get_watch:
         id: "my_watch"
@@ -56,13 +50,12 @@
   - match: { _id: "my_watch" }
   - match: { status.state.active: false }
 
-
   # activate watch again, check with GET API as well
   - do:
       watcher.activate_watch:
         watch_id: "my_watch"
   - match: { status.state.active : true }
-  
+
   - do:
       watcher.get_watch:
         id: "my_watch"
@@ -70,14 +63,8 @@
   - match: { _id: "my_watch" }
   - match: { status.state.active: true }
 
-
 ---
 "Test watcher stats output":
-
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/33185
-      version: "6.7.0 - "
-
   - do:
       watcher.stats: {}
   - match: { "manually_stopped": false }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
@@ -1,9 +1,5 @@
 ---
 "CRUD watch APIs":
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/33185
-      version: "6.7.0 - "
-
   - do:
       watcher.put_watch:
         id: "my_watch"
@@ -30,7 +26,6 @@
         id: "my_watch"
   - match: { found : true}
   - match: { _id: "my_watch" }
-
 
   # execute watch
   - do:
@@ -67,7 +62,7 @@
       watcher.deactivate_watch:
         watch_id: "my_watch"
   - match: { status.state.active : false }
-  
+
   - do:
       watcher.get_watch:
         id: "my_watch"
@@ -81,7 +76,7 @@
       watcher.activate_watch:
         watch_id: "my_watch"
   - match: { status.state.active : true }
-  
+
   - do:
       watcher.get_watch:
         id: "my_watch"
@@ -89,14 +84,8 @@
   - match: { _id: "my_watch" }
   - match: { status.state.active: true }
 
-
 ---
 "Test watcher stats output":
-
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/33185
-      version: "6.7.0 - "
-
   - do:
       watcher.stats: {}
   - match: { "manually_stopped": false }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
@@ -1,17 +1,11 @@
 ---
 "CRUD watch APIs":
-
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/33185
-      version: "6.7.0 - "
-
   # no need to put watch, exists already
   - do:
       watcher.get_watch:
         id: "my_watch"
   - match: { found : true}
   - match: { _id: "my_watch" }
-
 
   # execute watch
   - do:
@@ -48,7 +42,7 @@
       watcher.deactivate_watch:
         watch_id: "my_watch"
   - match: { status.state.active : false }
-  
+
   - do:
       watcher.get_watch:
         id: "my_watch"
@@ -62,7 +56,7 @@
       watcher.activate_watch:
         watch_id: "my_watch"
   - match: { status.state.active : true }
-  
+
   - do:
       watcher.get_watch:
         id: "my_watch"
@@ -72,11 +66,6 @@
 
 ---
 "Test watcher stats output":
-
-  - skip:
-      reason: https://github.com/elastic/elasticsearch/issues/33185
-      version: "6.7.0 - "
-
   - do:
       watcher.stats: {}
   - match: { "manually_stopped": false }


### PR DESCRIPTION
set watcher logger to debug level.

These tests haven't run in such a long time,
we first need to get a better picture how/if
these tests fail today.

Backport of #51478
See #33185