### PR TITLE
Use dedicated cache keys instead of relying on an absolute path

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotRepository.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotRepository.java
@@ -86,7 +86,7 @@ public class SearchableSnapshotRepository extends FilterRepository {
         Directory directory = new SearchableSnapshotDirectory(snapshot, blobContainer);
         if (SNAPSHOT_CACHE_ENABLED_SETTING.get(indexSettings.getSettings())) {
             final Path cacheDir = shardPath.getDataPath().resolve("snapshots").resolve(snapshotId.getUUID());
-            directory = new CacheDirectory(directory, cacheService, cacheDir);
+            directory = new CacheDirectory(directory, cacheService, cacheDir, snapshotId, indexId, shardPath.getShardId());
         }
         directory = new InMemoryNoOpCommitDirectory(directory);
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectory.java
@@ -60,10 +60,7 @@ public class CacheDirectory extends FilterDirectory {
         super.close();
         // Ideally we could let the cache evict/remove cached files by itself after the
         // directory has been closed.
-        cacheService.removeFromCache(key ->
-            Objects.equals(key.getSnapshotId(), snapshotId) &&
-            Objects.equals(key.getIndexId(), indexId) &&
-            Objects.equals(key.getShardId(), shardId));
+        cacheService.removeFromCache(cacheKey -> cacheKey.belongsTo(snapshotId, indexId, shardId));
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheFile.java
@@ -50,7 +50,7 @@ class CacheFile {
 
     private final SparseFileTracker tracker;
     private final int rangeSize;
-    private final String name;
+    private final String description;
     private final Path file;
 
     private volatile Set<EvictionListener> listeners;
@@ -59,9 +59,9 @@ class CacheFile {
     @Nullable // if evicted, or there are no listeners
     private volatile FileChannel channel;
 
-    CacheFile(String name, long length, Path file, int rangeSize) {
+    CacheFile(String description, long length, Path file, int rangeSize) {
         this.tracker = new SparseFileTracker(file.toString(), length);
-        this.name = Objects.requireNonNull(name);
+        this.description = Objects.requireNonNull(description);
         this.file = Objects.requireNonNull(file);
         this.listeners = new HashSet<>();
         this.rangeSize = rangeSize;
@@ -219,7 +219,7 @@ class CacheFile {
     @Override
     public String toString() {
         return "CacheFile{" +
-            "name='" + name + '\'' +
+            "desc='" + description + '\'' +
             ", file=" + file +
             ", length=" + tracker.getLength() +
             ", channel=" + (channel != null ? "yes" : "no") +

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKey.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKey.java
@@ -9,7 +9,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.snapshots.SnapshotId;
 
-import java.nio.file.Path;
 import java.util.Objects;
 
 public class CacheKey {
@@ -17,29 +16,29 @@ public class CacheKey {
     private final SnapshotId snapshotId;
     private final IndexId indexId;
     private final ShardId shardId;
-    private final Path cacheDir;
     private final String fileName;
-    private final long fileLength;
 
-    CacheKey(SnapshotId snapshotId, IndexId indexId, ShardId shardId, Path cacheDir, String fileName, long fileLength) {
+    CacheKey(SnapshotId snapshotId, IndexId indexId, ShardId shardId, String fileName) {
         this.snapshotId = Objects.requireNonNull(snapshotId);
         this.indexId = Objects.requireNonNull(indexId);
         this.shardId = Objects.requireNonNull(shardId);
-        this.cacheDir = Objects.requireNonNull(cacheDir);
         this.fileName = Objects.requireNonNull(fileName);
-        this.fileLength = fileLength;
+    }
+
+    SnapshotId getSnapshotId() {
+        return snapshotId;
+    }
+
+    IndexId getIndexId() {
+        return indexId;
+    }
+
+    ShardId getShardId() {
+        return shardId;
     }
 
     String getFileName() {
         return fileName;
-    }
-
-    long getFileLength() {
-        return fileLength;
-    }
-
-    Path getCacheDir() {
-        return cacheDir;
     }
 
     @Override
@@ -51,17 +50,15 @@ public class CacheKey {
             return false;
         }
         final CacheKey cacheKey = (CacheKey) o;
-        return fileLength == cacheKey.fileLength
-            && Objects.equals(snapshotId, cacheKey.snapshotId)
+        return Objects.equals(snapshotId, cacheKey.snapshotId)
             && Objects.equals(indexId, cacheKey.indexId)
             && Objects.equals(shardId, cacheKey.shardId)
-            && Objects.equals(cacheDir, cacheKey.cacheDir)
             && Objects.equals(fileName, cacheKey.fileName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotId, indexId, shardId, cacheDir, fileName, fileLength);
+        return Objects.hash(snapshotId, indexId, shardId, fileName);
     }
 
     @Override
@@ -71,8 +68,6 @@ public class CacheKey {
             ", indexId=" + indexId +
             ", shardId=" + shardId +
             ", fileName='" + fileName + '\'' +
-            ", fileLength=" + fileLength +
-            ", cacheDir=" + cacheDir +
             ']';
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKey.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKey.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots.cache;
+
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class CacheKey {
+
+    private final SnapshotId snapshotId;
+    private final IndexId indexId;
+    private final ShardId shardId;
+    private final Path cacheDir;
+    private final String fileName;
+    private final long fileLength;
+
+    CacheKey(SnapshotId snapshotId, IndexId indexId, ShardId shardId, Path cacheDir, String fileName, long fileLength) {
+        this.snapshotId = Objects.requireNonNull(snapshotId);
+        this.indexId = Objects.requireNonNull(indexId);
+        this.shardId = Objects.requireNonNull(shardId);
+        this.cacheDir = Objects.requireNonNull(cacheDir);
+        this.fileName = Objects.requireNonNull(fileName);
+        this.fileLength = fileLength;
+    }
+
+    String getFileName() {
+        return fileName;
+    }
+
+    long getFileLength() {
+        return fileLength;
+    }
+
+    Path getCacheDir() {
+        return cacheDir;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CacheKey cacheKey = (CacheKey) o;
+        return fileLength == cacheKey.fileLength
+            && Objects.equals(snapshotId, cacheKey.snapshotId)
+            && Objects.equals(indexId, cacheKey.indexId)
+            && Objects.equals(shardId, cacheKey.shardId)
+            && Objects.equals(cacheDir, cacheKey.cacheDir)
+            && Objects.equals(fileName, cacheKey.fileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(snapshotId, indexId, shardId, cacheDir, fileName, fileLength);
+    }
+
+    @Override
+    public String toString() {
+        return "[" +
+            "snapshotId=" + snapshotId +
+            ", indexId=" + indexId +
+            ", shardId=" + shardId +
+            ", fileName='" + fileName + '\'' +
+            ", fileLength=" + fileLength +
+            ", cacheDir=" + cacheDir +
+            ']';
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKey.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKey.java
@@ -70,4 +70,10 @@ public class CacheKey {
             ", fileName='" + fileName + '\'' +
             ']';
     }
+
+    boolean belongsTo(SnapshotId snapshotId, IndexId indexId, ShardId shardId) {
+        return Objects.equals(this.snapshotId, snapshotId)
+            && Objects.equals(this.indexId, indexId)
+            && Objects.equals(this.shardId, shardId);
+    }
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheService.java
@@ -96,17 +96,17 @@ public class CacheService extends AbstractLifecycleComponent {
         return Math.toIntExact(rangeSize.getBytes());
     }
 
-    public CacheFile get(final CacheKey cacheKey) throws Exception {
+    public CacheFile get(final CacheKey cacheKey, final long fileLength, final Path cacheDir) throws Exception {
         ensureLifecycleStarted();
         return cache.computeIfAbsent(cacheKey, key -> {
             ensureLifecycleStarted();
             // generate a random UUID for the name of the cache file on disk
             final String uuid = UUIDs.randomBase64UUID();
             // resolve the cache file on disk w/ the expected cached file
-            final Path path = key.getCacheDir().resolve(uuid);
+            final Path path = cacheDir.resolve(uuid);
             assert Files.notExists(path) : "cache file already exists " + path;
 
-            return new CacheFile(key.toString(), key.getFileLength(), path, getRangeSize());
+            return new CacheFile(key.toString(), fileLength, path, getRangeSize());
         });
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKeyTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheKeyTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots.cache;
+
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+
+public class CacheKeyTests extends ESTestCase {
+
+    public void testEqualsAndHashCode() {
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(createInstance(), this::copy, this::mutate);
+    }
+
+    private CacheKey createInstance() {
+        return new CacheKey(
+            new SnapshotId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10)),
+            new IndexId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10)),
+            new ShardId(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10), randomInt(5)),
+            randomAlphaOfLengthBetween(5, 10)
+        );
+    }
+
+    private CacheKey copy(final CacheKey origin) {
+        SnapshotId snapshotId = origin.getSnapshotId();
+        if (randomBoolean()) {
+            snapshotId = new SnapshotId(origin.getSnapshotId().getName(), origin.getSnapshotId().getUUID());
+        }
+        IndexId indexId = origin.getIndexId();
+        if (randomBoolean()) {
+            indexId = new IndexId(origin.getIndexId().getName(), origin.getIndexId().getId());
+        }
+        ShardId shardId = origin.getShardId();
+        if (randomBoolean()) {
+            shardId = new ShardId(new Index(shardId.getIndex().getName(), shardId.getIndex().getUUID()), shardId.id());
+        }
+        return new CacheKey(snapshotId, indexId, shardId, origin.getFileName());
+    }
+
+    private CacheKey mutate(CacheKey origin) {
+        SnapshotId snapshotId = origin.getSnapshotId();
+        IndexId indexId = origin.getIndexId();
+        ShardId shardId = origin.getShardId();
+        String fileName = origin.getFileName();
+
+        switch (randomInt(3)) {
+            case 0:
+                snapshotId = new SnapshotId(randomAlphaOfLength(4), randomAlphaOfLength(4));
+                break;
+            case 1:
+                indexId = new IndexId(randomAlphaOfLength(4), randomAlphaOfLength(4));
+                break;
+            case 2:
+                shardId = new ShardId(randomAlphaOfLength(4), randomAlphaOfLength(4), randomIntBetween(6, 10));
+                break;
+            case 3:
+                fileName = randomAlphaOfLength(15);
+                break;
+            default:
+                throw new AssertionError("Unsupported mutation");
+        }
+        return new CacheKey(snapshotId, indexId, shardId, fileName);
+    }
+
+}


### PR DESCRIPTION
Today cache files are identified in cache using a string representing an absolute path to a file on disk. This path is a sub directory of the current shard data path and as such already contains identification bits like the current index id and the shard id. It also contains the snapshot id that is passed at `CacheDirectory` creation time.

While this has been done for quick prototyping and already been improved in #51520, it feels wrong to rely on a path converted to a string as cache keys. Instead we should have a distinct `CacheKey` object to identify `CacheFile` in cache. 

Relates https://github.com/elastic/elasticsearch/pull/50693#discussion_r369702994