### PR TITLE
[DOCS] Adds recommendation on dedicated master-eligible nodes

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -91,7 +91,7 @@ IMPORTANT: Master nodes must have access to the `data/` directory (just like
 `data` nodes) as this is where the cluster state is persisted between node 
 restarts.
 
-
+[float]
 [[dedicated-master-node]]
 ==== Dedicated master-eligible node
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -164,9 +164,9 @@ node.voting_only: true <1>
 -------------------
 <1> The default for `node.voting_only` is `false`.
 
-IMPORTANT: The `voting_only` role requires the {default-dist} of Elasticsearch
-and is not supported in the {oss-dist}. If you use the {oss-dist} and set
-`node.voting_only` then the node will fail to start.  Also note that only
+IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not 
+supported in the {oss-dist}. If you use the {oss-dist} and set 
+`node.voting_only` then the node will fail to start.  Also note that only 
 master-eligible nodes can be marked as voting-only.
 
 High availability (HA) clusters require at least three master-eligible nodes, at
@@ -213,8 +213,8 @@ nodes handle data related operations like CRUD, search, and aggregations.
 These operations are I/O-, memory-, and CPU-intensive. It is important to
 monitor these resources and to add more data nodes if they are overloaded.
 
-The main benefit of having dedicated data nodes is the separation of the
-master and data roles.
+The main benefit of having dedicated data nodes is the separation of the master 
+and data roles.
 
 To create a dedicated data node in the {default-dist}, set:
 [source,yaml]
@@ -250,7 +250,7 @@ cluster.remote.connect: false <4>
 [[node-ingest-node]]
 === Ingest Node
 
-Ingest nodes can execute pre-processing pipelines, composed of one or more
+Ingest nodes can execute pre-processing pipelines, composed of one or more 
 ingest processors. Depending on the type of operations performed by the ingest
 processors and the required resources, it may make sense to have dedicated
 ingest nodes, that will only perform this specific task.
@@ -344,7 +344,7 @@ cluster.remote.connect: false <4>
 [[ml-node]]
 === [xpack]#Machine learning node#
 
-The {ml-features} provide {ml} nodes, which run jobs and handle {ml} API
+The {ml-features} provide {ml} nodes, which run jobs and handle {ml} API 
 requests. If `xpack.ml.enabled` is set to true and `node.ml` is set to `false`,
 the node can service API requests but it cannot run jobs.
 
@@ -442,9 +442,9 @@ Like all node settings, it can also be specified on the command line as:
 -----------------------
 
 TIP: When using the `.zip` or `.tar.gz` distributions, the `path.data` setting
-should be configured to locate the data directory outside the Elasticsearch
-home directory, so that the home directory can be deleted without deleting
-your data! The RPM and Debian distributions do this for you already.
+should be configured to locate the data directory outside the {es} home 
+directory, so that the home directory can be deleted without deleting your data! 
+The RPM and Debian distributions do this for you already.
 
 
 [float]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -2,14 +2,13 @@
 == Node
 
 Any time that you start an instance of Elasticsearch, you are starting a
-_node_. A collection of connected nodes is called a
-<<modules-cluster,cluster>>. If you are running a single node of Elasticsearch,
-then you have a cluster of one node.
+_node_. A collection of connected nodes is called a <<modules-cluster,cluster>>. 
+If you are running a single node of {es}, then you have a cluster of one node.
 
 Every node in the cluster can handle <<modules-http,HTTP>> and
-<<modules-transport,Transport>> traffic by default. The transport layer
-is used exclusively for communication between nodes; the HTTP layer is
-used by REST clients.
+<<modules-transport,Transport>> traffic by default. The transport layer is used 
+exclusively for communication between nodes; the HTTP layer is used by REST 
+clients.
 
 All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node. 
@@ -17,15 +16,15 @@ requests to the appropriate node.
 By default, a node is all of the following types: master-eligible, data, ingest,
 and machine learning (if available).
 
-TIP: As the cluster grows and in particular if you have large {ml} jobs,
+TIP: As the cluster grows and in particular if you have large {ml} jobs, 
 consider separating dedicated master-eligible nodes from dedicated data nodes
 and dedicated {ml} nodes.
 
 <<master-node,Master-eligible node>>::
 
 A node that has `node.master` set to `true` (default), which makes it eligible
-to be <<modules-discovery,elected as the _master_ node>>, which controls
-the cluster.
+to be <<modules-discovery,elected as the _master_ node>>, which controls the 
+cluster.
 
 <<data-node,Data node>>::
 
@@ -46,7 +45,7 @@ A node that has `xpack.ml.enabled` and `node.ml` set to `true`, which is the
 default behavior in the {es} {default-dist}. If you want to use {ml-features},
 there must be at least one {ml} node in your cluster. For more information about
 {ml-features}, see
-{ml-docs}/xpack-ml.html[Machine learning in the {stack}].
+{ml-docs}/index.html[Machine learning in the {stack}].
 +
 IMPORTANT: If you use the {oss-dist}, do not set `node.ml`. Otherwise, the node
 fails to start.
@@ -77,7 +76,7 @@ phase.
 
 [float]
 [[master-node]]
-=== Master Eligible Node
+=== Master-Eligible Node
 
 The master node is responsible for lightweight cluster-wide actions such as
 creating or deleting an index, tracking which nodes are part of the cluster,
@@ -89,19 +88,25 @@ be elected to become the master node by the <<modules-discovery,master election
 process>>.
 
 IMPORTANT: Master nodes must have access to the `data/` directory (just like
-`data` nodes) as this is where the cluster state is persisted between node restarts.
+`data` nodes) as this is where the cluster state is persisted between node 
+restarts.
 
-Indexing and searching your data is CPU-, memory-, and I/O-intensive work
-which can put pressure on a node's resources. To ensure that your master
-node is stable and not under pressure, it is a good idea in a bigger
-cluster to split the roles between dedicated master-eligible nodes and
-dedicated data nodes.
+
+[[dedicated-master-node]]
+==== Dedicated master-eligible node
+
+Indexing and searching your data is CPU-, memory-, and I/O-intensive work which 
+can put pressure on a node's resources. To ensure that your master node is 
+stable and not under pressure, it is a good idea to split the roles between 
+dedicated master-eligible nodes and dedicated data nodes. 
 
 While master nodes can also behave as <<coordinating-node,coordinating nodes>>
 and route search and indexing requests from clients to data nodes, it is
-better _not_ to use dedicated master nodes for this purpose. It is important
-for the stability of the cluster that master-eligible nodes do as little work
-as possible.
+better _not_ to use dedicated master-eligible nodes for this purpose. It is 
+important for the stability of the cluster that master-eligible nodes do as 
+little work as possible. For this reason, in larger deployments, it is 
+recommended to run three dedicated master-eligible nodes and remove the `master` 
+role from all remaining nodes in the cluster.
 
 To create a dedicated master-eligible node in the {default-dist}, set:
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -76,7 +76,7 @@ phase.
 
 [float]
 [[master-node]]
-=== Master-Eligible Node
+=== Master-eligible node
 
 The master node is responsible for lightweight cluster-wide actions such as
 creating or deleting an index, tracking which nodes are part of the cluster,

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -1,9 +1,9 @@
 [[modules-node]]
 == Node
 
-Any time that you start an instance of Elasticsearch, you are starting a
-_node_. A collection of connected nodes is called a <<modules-cluster,cluster>>. 
-If you are running a single node of {es}, then you have a cluster of one node.
+Any time that you start an instance of Elasticsearch, you are starting a _node_. 
+A collection of connected nodes is called a <<modules-cluster,cluster>>. If you 
+are running a single node of {es}, then you have a cluster of one node.
 
 Every node in the cluster can handle <<modules-http,HTTP>> and
 <<modules-transport,Transport>> traffic by default. The transport layer is used 
@@ -76,7 +76,7 @@ phase.
 
 [float]
 [[master-node]]
-=== Master-Eligible Node
+=== Master-eligible node
 
 The master node is responsible for lightweight cluster-wide actions such as
 creating or deleting an index, tracking which nodes are part of the cluster,
@@ -95,18 +95,15 @@ restarts.
 [[dedicated-master-node]]
 ==== Dedicated master-eligible node
 
-Indexing and searching your data is CPU-, memory-, and I/O-intensive work which 
-can put pressure on a node's resources. To ensure that your master node is 
-stable and not under pressure, it is a good idea to split the roles between 
-dedicated master-eligible nodes and dedicated data nodes. 
-
-While master nodes can also behave as <<coordinating-node,coordinating nodes>>
-and route search and indexing requests from clients to data nodes, it is
-better _not_ to use dedicated master-eligible nodes for this purpose. It is 
-important for the stability of the cluster that master-eligible nodes do as 
-little work as possible. For this reason, in larger deployments, it is 
-recommended to run three dedicated master-eligible nodes and remove the `master` 
-role from all remaining nodes in the cluster.
+It is important for the health of the cluster that the elected master node has 
+the resources it needs to fulfil its responsibilities. If the elected master 
+node is overloaded with other tasks then the cluster may not operate well. In 
+particular, indexing and searching your data can be very resource-intensive, so 
+in large or high-throughput clusters it is a good idea to avoid using the 
+master-eligible nodes for tasks such as indexing and searching. You can do this 
+by configuring three of your nodes to be dedicated master-eligible nodes. 
+Dedicated master-eligible nodes only have the `master` role, allowing them to 
+focus on managing the cluster.
 
 To create a dedicated master-eligible node in the {default-dist}, set:
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -6,8 +6,8 @@ A collection of connected nodes is called a <<modules-cluster,cluster>>. If you
 are running a single node of {es}, then you have a cluster of one node.
 
 Every node in the cluster can handle <<modules-http,HTTP>> and
-<<modules-transport,Transport>> traffic by default. The transport layer is used 
-exclusively for communication between nodes; the HTTP layer is used by REST 
+<<modules-transport,Transport>> traffic by default. The transport layer is used
+exclusively for communication between nodes; the HTTP layer is used by REST
 clients.
 
 All nodes know about all the other nodes in the cluster and can forward client
@@ -16,14 +16,14 @@ requests to the appropriate node.
 By default, a node is all of the following types: master-eligible, data, ingest,
 and machine learning (if available).
 
-TIP: As the cluster grows and in particular if you have large {ml} jobs, 
+TIP: As the cluster grows and in particular if you have large {ml} jobs,
 consider separating dedicated master-eligible nodes from dedicated data nodes
 and dedicated {ml} nodes.
 
 <<master-node,Master-eligible node>>::
 
 A node that has `node.master` set to `true` (default), which makes it eligible
-to be <<modules-discovery,elected as the _master_ node>>, which controls the 
+to be <<modules-discovery,elected as the _master_ node>>, which controls the
 cluster.
 
 <<data-node,Data node>>::
@@ -164,9 +164,9 @@ node.voting_only: true <1>
 -------------------
 <1> The default for `node.voting_only` is `false`.
 
-IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not 
-supported in the {oss-dist}. If you use the {oss-dist} and set 
-`node.voting_only` then the node will fail to start.  Also note that only 
+IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not
+supported in the {oss-dist}. If you use the {oss-dist} and set
+`node.voting_only` then the node will fail to start.  Also note that only
 master-eligible nodes can be marked as voting-only.
 
 High availability (HA) clusters require at least three master-eligible nodes, at
@@ -213,7 +213,7 @@ nodes handle data related operations like CRUD, search, and aggregations.
 These operations are I/O-, memory-, and CPU-intensive. It is important to
 monitor these resources and to add more data nodes if they are overloaded.
 
-The main benefit of having dedicated data nodes is the separation of the master 
+The main benefit of having dedicated data nodes is the separation of the master
 and data roles.
 
 To create a dedicated data node in the {default-dist}, set:
@@ -250,7 +250,7 @@ cluster.remote.connect: false <4>
 [[node-ingest-node]]
 === Ingest Node
 
-Ingest nodes can execute pre-processing pipelines, composed of one or more 
+Ingest nodes can execute pre-processing pipelines, composed of one or more
 ingest processors. Depending on the type of operations performed by the ingest
 processors and the required resources, it may make sense to have dedicated
 ingest nodes, that will only perform this specific task.
@@ -344,7 +344,7 @@ cluster.remote.connect: false <4>
 [[ml-node]]
 === [xpack]#Machine learning node#
 
-The {ml-features} provide {ml} nodes, which run jobs and handle {ml} API 
+The {ml-features} provide {ml} nodes, which run jobs and handle {ml} API
 requests. If `xpack.ml.enabled` is set to true and `node.ml` is set to `false`,
 the node can service API requests but it cannot run jobs.
 
@@ -442,8 +442,8 @@ Like all node settings, it can also be specified on the command line as:
 -----------------------
 
 TIP: When using the `.zip` or `.tar.gz` distributions, the `path.data` setting
-should be configured to locate the data directory outside the {es} home 
-directory, so that the home directory can be deleted without deleting your data! 
+should be configured to locate the data directory outside the {es} home
+directory, so that the home directory can be deleted without deleting your data!
 The RPM and Debian distributions do this for you already.
 
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -102,8 +102,11 @@ particular, indexing and searching your data can be very resource-intensive, so
 in large or high-throughput clusters it is a good idea to avoid using the 
 master-eligible nodes for tasks such as indexing and searching. You can do this 
 by configuring three of your nodes to be dedicated master-eligible nodes. 
-Dedicated master-eligible nodes only have the `master` role, allowing them to 
-focus on managing the cluster.
+Dedicated master-eligible nodes only have the `master` role, allowing them to
+focus on managing the cluster. While master nodes can also behave as 
+<<coordinating-node,coordinating nodes>> and route search and indexing requests
+from clients to data nodes, it is better _not_ to use dedicated master nodes for
+this purpose.
 
 To create a dedicated master-eligible node in the {default-dist}, set:
 


### PR DESCRIPTION
This PR expands Node documentation with the current recommendation on the number of dedicated master-eligible nodes in the case of a larger deployment. It also adds a separate section heading to dedicated master-eligible nodes.

Closes https://github.com/elastic/elasticsearch/issues/42422

Preview: http://elasticsearch_51674.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html#dedicated-master-node