### PR TITLE
[7.6] [ML][Inference] stream inflate to parser + throw when byte limit is reached (#51644)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/SimpleBoundedInputStream.java
@@ -28,17 +28,16 @@ public final class SimpleBoundedInputStream extends InputStream {
         this.maxBytes = maxBytes;
     }
 
-
     /**
      * A simple wrapper around the injected input stream that restricts the total number of bytes able to be read.
-     * @return The byte read. -1 on internal stream completion or when maxBytes is exceeded.
-     * @throws IOException on failure
+     * @return The byte read.
+     * @throws IOException on failure or when byte limit is exceeded
      */
     @Override
     public int read() throws IOException {
         // We have reached the maximum, signal stream completion.
         if (numBytes >= maxBytes) {
-            return -1;
+            throw new IOException("input stream exceeded maximum bytes of [" + maxBytes + "]");
         }
         numBytes++;
         return in.read();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceToXContentCompressorTests.java
@@ -5,15 +5,17 @@
  */
 package org.elasticsearch.xpack.core.ml.inference;
 
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.FrequencyEncodingTests;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncodingTests;
+import org.elasticsearch.xpack.core.ml.inference.preprocessing.TargetMeanEncodingTests;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -33,20 +35,22 @@ public class InferenceToXContentCompressorTests extends ESTestCase {
     }
 
     public void testInflateTooLargeStream() throws IOException {
-        TrainedModelDefinition definition = TrainedModelDefinitionTests.createRandomBuilder().build();
+        TrainedModelDefinition definition = TrainedModelDefinitionTests.createRandomBuilder()
+            .setPreProcessors(Stream.generate(() -> randomFrom(FrequencyEncodingTests.createRandom(),
+                OneHotEncodingTests.createRandom(),
+                TargetMeanEncodingTests.createRandom()))
+                .limit(100)
+                .collect(Collectors.toList()))
+            .build();
         String firstDeflate = InferenceToXContentCompressor.deflate(definition);
-        BytesReference inflatedBytes = InferenceToXContentCompressor.inflate(firstDeflate, 10L);
-        assertThat(inflatedBytes.length(), equalTo(10));
-        try(XContentParser parser = XContentHelper.createParser(xContentRegistry(),
-            LoggingDeprecationHandler.INSTANCE,
-            inflatedBytes,
-            XContentType.JSON)) {
-            expectThrows(IOException.class, () -> TrainedModelConfig.fromXContent(parser, true));
-        }
+        int max = firstDeflate.getBytes(StandardCharsets.UTF_8).length + 10;
+        IOException ex = expectThrows(IOException.class,
+            () -> Streams.readFully(InferenceToXContentCompressor.inflate(firstDeflate, max)));
+        assertThat(ex.getMessage(), equalTo("input stream exceeded maximum bytes of [" + max + "]"));
     }
 
     public void testInflateGarbage() {
-        expectThrows(IOException.class, () -> InferenceToXContentCompressor.inflate(randomAlphaOfLength(10), 100L));
+        expectThrows(IOException.class, () -> Streams.readFully(InferenceToXContentCompressor.inflate(randomAlphaOfLength(10), 100L)));
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [ML][Inference] stream inflate to parser + throw when byte limit is reached  (#51644)