### PR TITLE
[DOCS] [7.6] Admonition for Apple notarization warning

### DIFF
--- a/docs/reference/setup/install/targz-start.asciidoc
+++ b/docs/reference/setup/install/targz-start.asciidoc
@@ -1,5 +1,17 @@
 ==== Running Elasticsearch from the command line
 
+[IMPORTANT]
+.Unidentified developer warnings
+====
+If using macOS Catalina or later macOS versions, you may receive an unidentified
+developer warning when you first run {es}. Unless turned off, this warning
+prevents you from running {es}.
+
+To turn off this warning, follow the instructions in
+https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac[Open
+a Mac app from an unidentified developer].
+====
+
 Elasticsearch can be started from the command line as follows:
 
 [source,sh]

--- a/docs/reference/setup/install/targz-start.asciidoc
+++ b/docs/reference/setup/install/targz-start.asciidoc
@@ -3,11 +3,12 @@
 [IMPORTANT]
 .Unidentified developer warnings
 ====
-If using macOS Catalina or later macOS versions, you may receive an unidentified
-developer warning when you first run {es}. Unless turned off, this warning
-prevents you from running {es}.
+Apple's rollout of stricter notarization requirements affected the notarization
+of the {version} {es} artifacts. If macOS Catalina displays an unidentified
+developer warning when you first run {es}, you will need to add a security
+override.
 
-To turn off this warning, follow the instructions in
+To add a security override, follow the instructions in
 https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac[Open
 a Mac app from an unidentified developer].
 ====


### PR DESCRIPTION
macOS Catalina requires software to be notarized by Apple prior to distribution. If software is not notarized, Apple may display an 'unidentified developer' warning that prevents the software from running.

This adds a related note to our macOS installation instructions and provides a link to workaround instructions from Apple.

### Note for reviewers

I'm leaving this as a draft to prevent accidental merging. However, please review as normal.