### PR TITLE
Add xpack/basic scope to SLM documentation

### DIFF
--- a/docs/reference/slm/apis/slm-delete.asciidoc
+++ b/docs/reference/slm/apis/slm-delete.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-delete-policy]]
 === Delete snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-execute-retention.asciidoc
+++ b/docs/reference/slm/apis/slm-execute-retention.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-execute-retention]]
 === Execute snapshot retention policy API
 ++++

--- a/docs/reference/slm/apis/slm-execute.asciidoc
+++ b/docs/reference/slm/apis/slm-execute.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-execute-lifecycle]]
 === Execute snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-get-status.asciidoc
+++ b/docs/reference/slm/apis/slm-get-status.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-get-status]]
 === Get {slm} status API
 

--- a/docs/reference/slm/apis/slm-get.asciidoc
+++ b/docs/reference/slm/apis/slm-get.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-get-policy]]
 === Get snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-put-policy]]
 === Put snapshot lifecycle policy API
 ++++

--- a/docs/reference/slm/apis/slm-start.asciidoc
+++ b/docs/reference/slm/apis/slm-start.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-start]]
 === Start {slm} API
 

--- a/docs/reference/slm/apis/slm-stats.asciidoc
+++ b/docs/reference/slm/apis/slm-stats.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-get-stats]]
 === Get snapshot lifecycle stats API
 ++++

--- a/docs/reference/slm/apis/slm-stop.asciidoc
+++ b/docs/reference/slm/apis/slm-stop.asciidoc
@@ -1,3 +1,5 @@
+[role="xpack"]
+[testenv="basic"]
 [[slm-api-stop]]
 === Stop {slm} API
 


### PR DESCRIPTION
This adds the required

```
[role="xpack"]
[testenv="basic"]
```

To the top of the SLM documentation

Relates to #51678

