### PR TITLE
Fix TranslogTests#testWithRandomException

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2657,9 +2657,9 @@ public class TranslogTests extends ESTestCase {
                             committing = true;
                             failableTLog.getDeletionPolicy().setTranslogGenerationOfLastCommit(failableTLog.currentFileGeneration());
                             failableTLog.getDeletionPolicy().setMinTranslogGenerationForRecovery(failableTLog.currentFileGeneration());
+                            syncedDocs.clear();
                             failableTLog.trimUnreferencedReaders();
                             committing = false;
-                            syncedDocs.clear();
                         }
                     }
                     // we survived all the randomness!!!
@@ -2675,7 +2675,7 @@ public class TranslogTests extends ESTestCase {
                     assertEquals(failableTLog.getTragicException(), ex);
                 } catch (RuntimeException ex) {
                     assertEquals(ex.getMessage(), "simulated");
-                    assertEquals(failableTLog.getTragicException(), ex);
+                    assertNull("Don't consider failures while trimming unreferenced readers as tragedy", failableTLog.getTragicException());
                 } finally {
                     Checkpoint checkpoint = Translog.readCheckpoint(config.getTranslogPath());
                     if (checkpoint.numOps == unsynced.size() + syncedDocs.size()) {


### PR DESCRIPTION
Before #51417, `trimUnreferencedReaders` in this test was a noop as the default translog retention policy was 512MB and 12h, which was long enough to keep all translog files. Two problems in this test:

- We do not consider any failure while trimming unreferenced readers as a tragedy.
- We should clear the `synced` list before calling `trimUnreferencedReaders`.

Relates #51505 
Closes #51694