### PR TITLE
Test cluster throttle should never be less than 1

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -67,7 +67,7 @@ public class TestClustersPlugin implements Plugin<Project> {
             .registerIfAbsent(
                 THROTTLE_SERVICE_NAME,
                 TestClustersThrottle.class,
-                spec -> spec.getMaxParallelUsages().set(Math.min(1, project.getGradle().getStartParameter().getMaxWorkerCount() / 2))
+                spec -> spec.getMaxParallelUsages().set(Math.max(1, project.getGradle().getStartParameter().getMaxWorkerCount() / 2))
             );
 
         // register cluster hooks


### PR DESCRIPTION
Follow up to #51561. Should have used `max` not `min` here 🤦‍♂.