### PR TITLE
Remove docker exlucsions for no longer supported OSes

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -4,9 +4,7 @@
 # Docker tests to be skipped on that OS. If /etc/os-release doesn't exist
 # (as is the case on centos-6, for example) then that OS will again be
 # excluded.
-centos-6
 debian-8
 opensuse-15-1
-ol-6.10
 ol-7.7
 sles-12


### PR DESCRIPTION
This commit removes CI exclusions for running docker on OSes we no
longer support or test on for 8.0.

relates #51499