### PR TITLE
Disable build cache for packaging tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -46,6 +46,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.TaskInputs;
 import org.gradle.api.tasks.TaskProvider;
@@ -325,6 +326,7 @@ public class DistroTestPlugin implements Plugin<Project> {
 
     private static TaskProvider<?> configureDistroTest(Project project, ElasticsearchDistribution distribution) {
         return project.getTasks().register(destructiveDistroTestTaskName(distribution), Test.class, t -> {
+            t.getOutputs().doNotCacheIf("Build cache is disabled for packaging tests", Specs.satisfyAll());
             t.setMaxParallelForks(1);
             t.setWorkingDir(project.getProjectDir());
             t.systemProperty(DISTRIBUTION_SYSPROP, distribution.toString());

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -137,6 +137,7 @@ processTestResources {
 }
 
 task integTest(type: Test) {
+  outputs.doNotCacheIf('Build cache is disabled for Docker tests') { true }
   maxParallelForks = '1'
   include '**/*IT.class'
   // don't add the tasks to build the docker images if we have no way of testing them


### PR DESCRIPTION
For packaging tests, calculating inputs is complicated as the thing we are testing could be an archive (tar/zip), a installer package (deb/rpm) or a Docker image. In our build logic we don't make any attempt to track any of these things as an input to the Java packaging tests so there are times where we might be getting false cache hits for these tests. In practice, this hasn't happened because the build cache has been disabled for our packaging test CI builds, but a) we _should_ enable the cache there, and for all other builds and b) we could get incorrect results when running locally with the cache.