### PR TITLE
[DOCS] Adds missing testenv attribute

### DIFF
--- a/docs/reference/ml/anomaly-detection/categories.asciidoc
+++ b/docs/reference/ml/anomaly-detection/categories.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="platinum"]
 [[ml-configuring-categories]]
 === Detecting anomalous categories of data
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/51678

This PR addresses a failure in the elasticsearch-ci/oss-distro-docs PR check.