### PR TITLE
Remove comparison to true for booleans

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/AntFixture.groovy
@@ -25,9 +25,7 @@ import org.elasticsearch.gradle.LoggedExec
 import org.gradle.api.GradleException
 import org.gradle.api.Task
 import org.gradle.api.tasks.Exec
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-
 /**
  * A fixture for integration tests which runs in a separate process launched by Ant.
  */

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -109,7 +109,7 @@ public class DistroTestPlugin implements Plugin<Project> {
 
         TaskProvider<Task> destructiveDistroTest = project.getTasks().register("destructiveDistroTest");
         for (ElasticsearchDistribution distribution : distributions) {
-            if (distribution.getType() != Type.DOCKER || runDockerTests == true) {
+            if (distribution.getType() != Type.DOCKER || runDockerTests) {
                 TaskProvider<?> destructiveTask = configureDistroTest(project, distribution);
                 destructiveDistroTest.configure(t -> t.dependsOn(destructiveTask));
             }
@@ -152,7 +152,7 @@ public class DistroTestPlugin implements Plugin<Project> {
                         //
                         // The shouldTestDocker property could be null, hence we use Boolean.TRUE.equals()
                         boolean shouldExecute = distribution.getType() != Type.DOCKER
-                            || Boolean.TRUE.equals(vmProject.findProperty("shouldTestDocker")) == true;
+                            || Boolean.TRUE.equals(vmProject.findProperty("shouldTestDocker"));
 
                         if (shouldExecute) {
                             t.dependsOn(vmTask);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/tool/DockerUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/tool/DockerUtils.java
@@ -53,19 +53,19 @@ public class DockerUtils {
             // Since we use a multi-stage Docker build, check the Docker version since 17.05
             lastResult = runCommand(project, dockerPath, "version", "--format", "{{.Server.Version}}");
 
-            if (lastResult.isSuccess() == true) {
+            if (lastResult.isSuccess()) {
                 version = Version.fromString(lastResult.stdout.trim(), Version.Mode.RELAXED);
 
                 isVersionHighEnough = version.onOrAfter("17.05.0");
 
-                if (isVersionHighEnough == true) {
+                if (isVersionHighEnough) {
                     // Check that we can execute a privileged command
                     lastResult = runCommand(project, dockerPath, "images");
                 }
             }
         }
 
-        boolean isAvailable = isVersionHighEnough && lastResult.isSuccess() == true;
+        boolean isAvailable = isVersionHighEnough && lastResult.isSuccess();
 
         return new DockerAvailability(isAvailable, isVersionHighEnough, dockerPath, version, lastResult);
     }
@@ -125,7 +125,7 @@ public class DockerUtils {
     public static void assertDockerIsAvailable(Project project, List<String> tasks) {
         DockerAvailability availability = getDockerAvailability(project);
 
-        if (availability.isAvailable == true) {
+        if (availability.isAvailable) {
             return;
         }
 

--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/Version.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/Version.java
@@ -60,7 +60,7 @@ public final class Version implements Comparable<Version> {
         Objects.requireNonNull(s);
         Matcher matcher = mode == Mode.STRICT ? pattern.matcher(s) : relaxedPattern.matcher(s);
         if (matcher.matches() == false) {
-            String expected = mode == Mode.STRICT == true
+            String expected = mode == Mode.STRICT
                 ? "major.minor.revision[-(alpha|beta|rc)Number][-SNAPSHOT]"
                 : "major.minor.revision[-extra]";
             throw new IllegalArgumentException("Invalid version format: '" + s + "'. Should be " + expected);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/TermVectorsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/TermVectorsResponseTests.java
@@ -123,7 +123,7 @@ public class TermVectorsResponseTests extends ESTestCase {
         long tookInMillis = randomNonNegativeLong();
         boolean found = randomBoolean();
         List<TermVectorsResponse.TermVector> tvList = null;
-        if (found == true){
+        if (found){
             boolean hasFieldStatistics = randomBoolean();
             boolean hasTermStatistics = randomBoolean();
             boolean hasScores = randomBoolean();

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownText.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownText.java
@@ -482,7 +482,7 @@ public class WellKnownText {
         double lat = nextNumber(stream);
         double radius = nextNumber(stream);
         double alt = Double.NaN;
-        if (isNumberNext(stream) == true) {
+        if (isNumberNext(stream)) {
             alt = nextNumber(stream);
         }
         Circle circle = new Circle(lon, lat, alt, radius);
@@ -560,7 +560,7 @@ public class WellKnownText {
     }
 
     private String nextComma(StreamTokenizer stream) throws IOException, ParseException {
-        if (nextWord(stream).equals(COMMA) == true) {
+        if (nextWord(stream).equals(COMMA)) {
             return COMMA;
         }
         throw new ParseException("expected " + COMMA + " but found: " + tokenString(stream), stream.lineno());

--- a/libs/grok/src/main/java/org/elasticsearch/grok/MatcherWatchdog.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/MatcherWatchdog.java
@@ -128,7 +128,7 @@ public interface MatcherWatchdog {
         public void register(Matcher matcher) {
             registered.getAndIncrement();
             Long previousValue = registry.put(matcher, relativeTimeSupplier.getAsLong());
-            if (running.compareAndSet(false, true) == true) {
+            if (running.compareAndSet(false, true)) {
                 scheduler.accept(interval, this::interruptLongRunningExecutions);
             }
             assert previousValue == null;

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
@@ -85,7 +85,7 @@ final class MatrixStatsAggregator extends MetricsAggregator {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 // get fields
-                if (includeDocument(doc) == true) {
+                if (includeDocument(doc)) {
                     stats = bigArrays.grow(stats, bucket + 1);
                     RunningStats stat = stats.get(bucket);
                     // add document fields to correlation stats

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStats.java
@@ -155,7 +155,7 @@ public class RunningStats implements Writeable, Cloneable {
             deltas.put(fieldName, fieldValue * docCount - fieldSum.get(fieldName));
 
             // update running mean, variance, skewness, kurtosis
-            if (means.containsKey(fieldName) == true) {
+            if (means.containsKey(fieldName)) {
                 // update running means
                 m1 = means.get(fieldName);
                 d = fieldValue - m1;
@@ -194,7 +194,7 @@ public class RunningStats implements Writeable, Cloneable {
             dR = deltas.get(fieldName);
             HashMap<String, Double> cFieldVals = (covariances.get(fieldName) != null) ? covariances.get(fieldName) : new HashMap<>();
             for (String cFieldName : cFieldNames) {
-                if (cFieldVals.containsKey(cFieldName) == true) {
+                if (cFieldVals.containsKey(cFieldName)) {
                     newVal = cFieldVals.get(cFieldName) + 1.0 / (docCount * (docCount - 1.0)) * dR * deltas.get(cFieldName);
                     cFieldVals.put(cFieldName, newVal);
                 } else {
@@ -224,7 +224,7 @@ public class RunningStats implements Writeable, Cloneable {
                 this.variances.put(fieldName, other.variances.get(fieldName).doubleValue());
                 this.skewness.put(fieldName , other.skewness.get(fieldName).doubleValue());
                 this.kurtosis.put(fieldName, other.kurtosis.get(fieldName).doubleValue());
-                if (other.covariances.containsKey(fieldName) == true) {
+                if (other.covariances.containsKey(fieldName)) {
                     this.covariances.put(fieldName, other.covariances.get(fieldName));
                 }
                 this.docCount = other.docCount;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -293,7 +293,7 @@ public final class PainlessLookupBuilder {
         String importedCanonicalClassName = javaClassName.substring(javaClassName.lastIndexOf('.') + 1).replace('$', '.');
 
         if (canonicalClassName.equals(importedCanonicalClassName)) {
-            if (importClassName == true) {
+            if (importClassName) {
                 throw new IllegalArgumentException("must use no_import parameter on class [" + canonicalClassName + "] with no package");
             }
         } else {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedSearchHit.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedSearchHit.java
@@ -49,7 +49,7 @@ public class RatedSearchHit implements Writeable, ToXContentObject {
     }
 
     RatedSearchHit(StreamInput in) throws IOException {
-        this(new SearchHit(in), in.readBoolean() == true ? OptionalInt.of(in.readVInt()) : OptionalInt.empty());
+        this(new SearchHit(in), in.readBoolean() ? OptionalInt.of(in.readVInt()) : OptionalInt.empty());
     }
 
     @Override

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -328,7 +328,7 @@ public abstract class PackagingTestCase extends Assert {
             Shell.Result error = journaldWrapper.getLogs();
             assertThat(error.stdout, containsString(expectedMessage));
 
-        } else if (Platforms.WINDOWS == true) {
+        } else if (Platforms.WINDOWS) {
 
             // In Windows, we have written our stdout and stderr to files in order to run
             // in the background

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -260,7 +260,7 @@ public abstract class Rounding implements Writeable {
             this.unit = unit;
             this.timeZone = timeZone;
             this.unitRoundsToMidnight = this.unit.field.getBaseUnit().getDuration().toMillis() > 3600000L;
-            this.fixedOffsetMillis = timeZone.getRules().isFixedOffset() == true ?
+            this.fixedOffsetMillis = timeZone.getRules().isFixedOffset() ?
                 timeZone.getRules().getOffset(Instant.EPOCH).getTotalSeconds() * 1000 : TZ_OFFSET_NON_FIXED;
         }
 
@@ -481,7 +481,7 @@ public abstract class Rounding implements Writeable {
                 throw new IllegalArgumentException("Zero or negative time interval not supported");
             this.interval = interval;
             this.timeZone = timeZone;
-            this.fixedOffsetMillis = timeZone.getRules().isFixedOffset() == true ?
+            this.fixedOffsetMillis = timeZone.getRules().isFixedOffset() ?
                 timeZone.getRules().getOffset(Instant.EPOCH).getTotalSeconds() * 1000 : TZ_OFFSET_NON_FIXED;
         }
 

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoShapeType.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoShapeType.java
@@ -170,7 +170,7 @@ public enum GeoShapeType {
             // close linear ring iff coerce is set and ring is open, otherwise throw parse exception
             if (!coordinates.children.get(0).coordinate.equals(
                 coordinates.children.get(coordinates.children.size() - 1).coordinate)) {
-                if (coerce == true) {
+                if (coerce) {
                     coordinates.children.add(coordinates.children.get(0));
                 } else {
                     throw new ElasticsearchParseException("invalid LinearRing found (coordinates are not closed)");

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoWKTParser.java
@@ -152,7 +152,7 @@ public class GeoWKTParser {
             return null;
         }
         PointBuilder pt = new PointBuilder(nextNumber(stream), nextNumber(stream));
-        if (isNumberNext(stream) == true) {
+        if (isNumberNext(stream)) {
             GeoPoint.assertZValue(ignoreZValue, nextNumber(stream));
         }
         nextCloser(stream);
@@ -224,7 +224,7 @@ public class GeoWKTParser {
         int coordinatesNeeded = coerce ? 3 : 4;
         if (coordinates.size() >= coordinatesNeeded) {
             if (!coordinates.get(0).equals(coordinates.get(coordinates.size() - 1))) {
-                if (coerce == true) {
+                if (coerce) {
                     coordinates.add(coordinates.get(0));
                 } else {
                     throw new ElasticsearchParseException("invalid LinearRing found (coordinates are not closed)");
@@ -352,7 +352,7 @@ public class GeoWKTParser {
     }
 
     private static String nextComma(StreamTokenizer stream) throws IOException, ElasticsearchParseException {
-        if (nextWord(stream).equals(COMMA) == true) {
+        if (nextWord(stream).equals(COMMA)) {
             return COMMA;
         }
         throw new ElasticsearchParseException("expected " + COMMA + " but found: " + tokenString(stream), stream.lineno());

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -189,7 +189,7 @@ class JavaDateFormatter implements DateFormatter {
             for (DateTimeFormatter formatter : parsers) {
                 ParsePosition pos = new ParsePosition(0);
                 Object object = formatter.toFormat().parseObject(input, pos);
-                if (parsingSucceeded(object, input, pos) == true) {
+                if (parsingSucceeded(object, input, pos)) {
                     return (TemporalAccessor) object;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeIndexer.java
@@ -51,7 +51,7 @@ public class LegacyGeoShapeIndexer implements AbstractGeometryFieldMapper.Indexe
 
     @Override
     public List<IndexableField>  indexShape(ParseContext context, Shape shape) {
-        if (fieldType.pointsOnly() == true) {
+        if (fieldType.pointsOnly()) {
             // index configured for pointsOnly
             if (shape instanceof XShapeCollection && XShapeCollection.class.cast(shape).pointsOnly()) {
                 // MULTIPOINT data: index each point separately

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -94,7 +94,7 @@ public class RangeFieldMapper extends FieldMapper {
 
         @Override
         public Builder docValues(boolean docValues) {
-            if (docValues == true) {
+            if (docValues) {
                 throw new IllegalArgumentException("field [" + name + "] does not currently support " + TypeParsers.DOC_VALUES);
             }
             return super.docValues(docValues);

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -335,7 +335,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
      * Adds a field to load from the docvalue and return.
      */
     public InnerHitBuilder addDocValueField(String field, String format) {
-        if (docValueFields == null || docValueFields.isEmpty() == true) {
+        if (docValueFields == null || docValueFields.isEmpty()) {
             docValueFields = new ArrayList<>();
         }
         docValueFields.add(new FieldAndFormat(field, format));

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
@@ -215,7 +215,7 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
                     assert lastPosition == chunk.position : "last_position " + lastPosition + " != chunk_position " + chunk.position;
                     lastPosition += chunk.content.length();
                     if (chunk.lastChunk) {
-                        assert pendingChunks.isEmpty() == true : "still have pending chunks [" + pendingChunks + "]";
+                        assert pendingChunks.isEmpty() : "still have pending chunks [" + pendingChunks + "]";
                         fileChunkWriters.remove(chunk.md.name());
                         assert fileChunkWriters.containsValue(this) == false : "chunk writer [" + newChunk.md + "] was not removed";
                     }

--- a/server/src/main/java/org/elasticsearch/search/profile/aggregation/InternalAggregationProfileTree.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/aggregation/InternalAggregationProfileTree.java
@@ -35,7 +35,7 @@ public class InternalAggregationProfileTree extends AbstractInternalProfileTree<
 
         // Anonymous classes (such as NonCollectingAggregator in TermsAgg) won't have a name,
         // we need to get the super class
-        if (element.getClass().getSimpleName().isEmpty() == true) {
+        if (element.getClass().getSimpleName().isEmpty()) {
             return element.getClass().getSuperclass().getSimpleName();
         }
         if (element instanceof MultiBucketAggregatorWrapper) {

--- a/server/src/main/java/org/elasticsearch/search/profile/query/InternalQueryProfileTree.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/InternalQueryProfileTree.java
@@ -43,7 +43,7 @@ final class InternalQueryProfileTree extends AbstractInternalProfileTree<QueryPr
     protected String getTypeFromElement(Query query) {
         // Anonymous classes won't have a name,
         // we need to get the super class
-        if (query.getClass().getSimpleName().isEmpty() == true) {
+        if (query.getClass().getSimpleName().isEmpty()) {
             return query.getClass().getSuperclass().getSimpleName();
         }
         return query.getClass().getSimpleName();

--- a/test/framework/src/main/java/org/elasticsearch/common/util/NamedFormatter.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/NamedFormatter.java
@@ -59,7 +59,7 @@ public class NamedFormatter {
             }
 
             final String paramName = match.group(3);
-            if (values.containsKey(paramName) == true) {
+            if (values.containsKey(paramName)) {
                 return values.get(paramName).toString();
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -658,7 +658,7 @@ public final class InternalTestCluster extends TestCluster {
             onTransportServiceStarted.run(); // reusing an existing node implies its transport service already started
             return nodeAndClient;
         }
-        assert reuseExisting == true || nodeAndClient == null : "node name [" + name + "] already exists but not allowed to use it";
+        assert reuseExisting || nodeAndClient == null : "node name [" + name + "] already exists but not allowed to use it";
 
         SecureSettings secureSettings = Settings.builder().put(settings).getSecureSettings();
         if (secureSettings instanceof MockSecureSettings) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -237,7 +237,7 @@ public class InternalStringStats extends InternalAggregation {
             builder.field(Fields.MAX_LENGTH.getPreferredName(), maxLength);
             builder.field(Fields.AVG_LENGTH.getPreferredName(), getAvgLength());
             builder.field(Fields.ENTROPY.getPreferredName(), getEntropy());
-            if (showDistribution == true) {
+            if (showDistribution) {
                 builder.field(Fields.DISTRIBUTION.getPreferredName(), getDistribution());
             }
             if (format != DocValueFormat.RAW) {
@@ -245,7 +245,7 @@ public class InternalStringStats extends InternalAggregation {
                 builder.field(Fields.MAX_LENGTH_AS_STRING.getPreferredName(), format.format(getMaxLength()));
                 builder.field(Fields.AVG_LENGTH_AS_STRING.getPreferredName(), format.format(getAvgLength()));
                 builder.field(Fields.ENTROPY_AS_STRING.getPreferredName(), format.format(getEntropy()));
-                if (showDistribution == true) {
+                if (showDistribution) {
                     builder.startObject(Fields.DISTRIBUTION_AS_STRING.getPreferredName());
                     for (Map.Entry<String, Double> e: getDistribution().entrySet()) {
                         builder.field(e.getKey(), format.format(e.getValue()).toString());
@@ -259,7 +259,7 @@ public class InternalStringStats extends InternalAggregation {
             builder.nullField(Fields.AVG_LENGTH.getPreferredName());
             builder.field(Fields.ENTROPY.getPreferredName(), 0.0);
 
-            if (showDistribution == true) {
+            if (showDistribution) {
                 builder.nullField(Fields.DISTRIBUTION.getPreferredName());
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -438,7 +438,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         builder.startObject();
         builder.field(ID.getPreferredName(), id);
         builder.field(Job.ID.getPreferredName(), jobId);
-        if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false) == true) {
+        if (params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
             builder.field(CONFIG_TYPE.getPreferredName(), TYPE);
         }
         builder.field(QUERY_DELAY.getPreferredName(), queryDelay.getStringRep());
@@ -461,7 +461,7 @@ public class DatafeedConfig extends AbstractDiffable<DatafeedConfig> implements 
         if (chunkingConfig != null) {
             builder.field(CHUNKING_CONFIG.getPreferredName(), chunkingConfig);
         }
-        if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false) == true) {
+        if (headers.isEmpty() == false && params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false)) {
             builder.field(HEADERS.getPreferredName(), headers);
         }
         if (delayedDataCheckConfig != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SSLService.java
@@ -534,7 +534,7 @@ public class SSLService {
         assert prefix.endsWith(".ssl");
         SSLConfiguration configuration = getSSLConfiguration(prefix);
         final String enabledSetting = prefix + ".enabled";
-        if (settings.getAsBoolean(enabledSetting, false) == true) {
+        if (settings.getAsBoolean(enabledSetting, false)) {
             // Client Authentication _should_ be required, but if someone turns it off, then this check is no longer relevant
             final SSLConfigurationSettings configurationSettings = SSLConfigurationSettings.withPrefix(prefix + ".");
             if (isConfigurationValidForServerUsage(configuration) == false) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -324,7 +324,7 @@ public class TransformConfig extends AbstractDiffable<TransformConfig> implement
         if (params.paramAsBoolean(TransformField.FOR_INTERNAL_STORAGE, false)) {
             builder.field(TransformField.INDEX_DOC_TYPE.getPreferredName(), NAME);
         }
-        if (headers.isEmpty() == false && params.paramAsBoolean(TransformField.FOR_INTERNAL_STORAGE, false) == true) {
+        if (headers.isEmpty() == false && params.paramAsBoolean(TransformField.FOR_INTERNAL_STORAGE, false)) {
             builder.field(HEADERS.getPreferredName(), headers);
         }
         if (description != null) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/GrammarTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/GrammarTests.java
@@ -96,7 +96,7 @@ public class GrammarTests extends ESTestCase {
                 if (line.isEmpty() == false && line.startsWith("//") == false) {
                     query.append(line);
 
-                    if (line.endsWith(";") == true) {
+                    if (line.endsWith(";")) {
                         query.setLength(query.length() - 1);
                         queries.add(new Tuple<>(query.toString(), lineNumber));
                         query.setLength(0);

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -258,7 +258,7 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
             return false;
         }
 
-        if (installingSomething.get() == true) {
+        if (installingSomething.get()) {
             logger.trace("already installing something, waiting for install to complete");
             return false;
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResourceTests.java
@@ -350,7 +350,7 @@ public class PublishableHttpResourceTests extends AbstractPublishableHttpResourc
         verify(logger).trace("checking if {} [{}] exists on the [{}] {}", resourceType, resourceName, owner, ownerType);
         verify(client).performRequestAsync(eq(request), any(ResponseListener.class));
 
-        if (shouldReplace || expected == true) {
+        if (shouldReplace || expected) {
             verify(response).getStatusLine();
             verify(response).getEntity();
         } else if (expected == false) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
@@ -88,7 +88,7 @@ public class Alias extends NamedExpression {
     @Override
     public Attribute toAttribute() {
         if (lazyAttribute == null) {
-            lazyAttribute = resolved() == true ?
+            lazyAttribute = resolved() ?
                 new ReferenceAttribute(source(), name(), dataType(), qualifier, nullable(), id(), synthetic()) :
                 new UnresolvedAttribute(source(), name(), qualifier);
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/AggregateFunction.java
@@ -73,7 +73,7 @@ public abstract class AggregateFunction extends Function {
 
     @Override
     public boolean equals(Object obj) {
-        if (super.equals(obj) == true) {
+        if (super.equals(obj)) {
             AggregateFunction other = (AggregateFunction) obj;
             return Objects.equals(other.field(), field())
                     && Objects.equals(other.parameters(), parameters());

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/Count.java
@@ -57,7 +57,7 @@ public class Count extends AggregateFunction {
 
     @Override
     public boolean equals(Object obj) {
-        if (super.equals(obj) == true) {
+        if (super.equals(obj)) {
             Count other = (Count) obj;
             return Objects.equals(other.distinct(), distinct());
         }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/InnerAggregate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/InnerAggregate.java
@@ -83,7 +83,7 @@ public class InnerAggregate extends AggregateFunction {
 
     @Override
     public boolean equals(Object obj) {
-        if (super.equals(obj) == true) {
+        if (super.equals(obj)) {
             InnerAggregate other = (InnerAggregate) obj;
             return Objects.equals(inner, other.inner)
                     && Objects.equals(outer, other.outer)

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Agg.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Agg.java
@@ -34,13 +34,13 @@ class Agg extends Param<AggregateFunction> {
         else if (agg instanceof Count) {
             Count c = (Count) agg;
             // for literals get the last count
-            if (c.field().foldable() == true) {
+            if (c.field().foldable()) {
                 return COUNT_PATH;
             }
             // when dealing with fields, check whether there's a single-metric (distinct -> cardinality)
             // or a bucket (non-distinct - filter agg)
             else {
-                if (c.distinct() == true) {
+                if (c.distinct()) {
                     return Expressions.id(c);
                 } else {
                     return Expressions.id(c) + "." + COUNT_PATH;

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -529,7 +529,7 @@ public class IndexResolver {
                 // compute the actual indices - if any are specified, take into account the unmapped indices
                 List<String> concreteIndices = null;
                 if (capIndices != null) {
-                    if (unmappedIndices.isEmpty() == true) {
+                    if (unmappedIndices.isEmpty()) {
                         concreteIndices = asList(capIndices);
                     } else {
                         concreteIndices = new ArrayList<>(capIndices.length);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/tree/Node.java
@@ -412,7 +412,7 @@ public abstract class Node<T extends Node<T>> {
             for (Iterator<?> it = ((Iterable<?>) obj).iterator(); it.hasNext();) {
                 Object o = it.next();
                 toString(sb, o);
-                if (it.hasNext() == true) {
+                if (it.hasNext()) {
                     sb.append(", ");
                 }
             }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -249,7 +249,7 @@ public final class StringUtils {
             if (escaped == false && curr == escape && escape != 0) {
                 escaped = true;
             } else {
-                if (escaped == true && (curr == '%' || curr == '_' || curr == escape)) {
+                if (escaped && (curr == '%' || curr == '_' || curr == escape)) {
                     wildcard.append(curr);
                 } else {
                     if (escaped) {
@@ -261,7 +261,7 @@ public final class StringUtils {
             }
         }
         // corner-case when the escape char is the last char
-        if (escaped == true) {
+        if (escaped) {
             wildcard.append(escape);
         }
         return wildcard.toString();

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSet.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSet.java
@@ -79,7 +79,7 @@ class JdbcResultSet implements ResultSet, JdbcWrapper {
         if (columnIndex < 1 || columnIndex > cursor.columnSize()) {
             throw new SQLException("Invalid column index [" + columnIndex + "]");
         }
-        if (wasLast == true || rowNumber < 1) {
+        if (wasLast || rowNumber < 1) {
             throw new SQLException("No row available");
         }
         Object object = null;

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -56,7 +56,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         createIndexWithFieldTypeAndProperties("text", null, explicitSourceSetting ? indexProps : null);
         index("{\"text_field\":\"" + text + "\"}");
         
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", "text_field", "text", JDBCType.VARCHAR, Integer.MAX_VALUE)
@@ -228,7 +228,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         createIndexWithFieldTypeAndProperties(fieldType, fieldProps, explicitSourceSetting ? indexProps : null);
         index("{\"" + fieldName + "\":" + actualValue + "}");
 
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", fieldName, fieldType, jdbcTypeFor(fieldType), Integer.MAX_VALUE)
@@ -262,7 +262,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             index("{\"boolean_field\":" + booleanField + "}");
         }
         
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", "boolean_field", "boolean", JDBCType.BOOLEAN, Integer.MAX_VALUE)
@@ -292,7 +292,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         createIndexWithFieldTypeAndProperties("ip", null, explicitSourceSetting ? indexProps : null);
         index("{\"ip_field\":\"" + ipField + "\"}");
         
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", "ip_field", "ip", JDBCType.VARCHAR, Integer.MAX_VALUE)
@@ -426,7 +426,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         createIndexWithFieldTypeAndSubFields("text", null, explicitSourceSetting ? indexProps : null, subFieldsProps, "keyword");
         index("{\"" + fieldName + "\":\"" + text + "\"}");
 
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
@@ -486,7 +486,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         createIndexWithFieldTypeAndSubFields("text", null, explicitSourceSetting ? indexProps : null, subFieldsProps, "integer");
         index("{\"" + fieldName + "\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
@@ -544,7 +544,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
                 isKeyword ? "keyword" : "text");
         index("{\"" + fieldName + "\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource == true) {
+        if (explicitSourceSetting == false || enableSource) {
             Map<String, Object> expected = new HashMap<>();
             expected.put("columns", Arrays.asList(
                     columnInfo("plain", fieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE),
@@ -590,7 +590,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testIntegerFieldWithByteSubfield() throws IOException {
         boolean isByte = randomBoolean();
-        Integer number = isByte == true ? randomByte() : randomIntBetween(Byte.MAX_VALUE + 1, Integer.MAX_VALUE);
+        Integer number = isByte ? randomByte() : randomIntBetween(Byte.MAX_VALUE + 1, Integer.MAX_VALUE);
         boolean explicitSourceSetting = randomBoolean();   // default (no _source setting) or explicit setting
         boolean enableSource = randomBoolean();            // enable _source at index level
         boolean rootIgnoreMalformed = randomBoolean();     // root field ignore_malformed
@@ -625,15 +625,15 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
                 columnInfo("plain", fieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE),
                 columnInfo("plain", subFieldName, "byte", JDBCType.TINYINT, Integer.MAX_VALUE)
         ));
-        if (explicitSourceSetting == false || enableSource == true) {
-            if (isByte == true || subFieldIgnoreMalformed == true) {
+        if (explicitSourceSetting == false || enableSource) {
+            if (isByte || subFieldIgnoreMalformed) {
                 expected.put("rows", singletonList(Arrays.asList(number, isByte ? number : null)));
             } else {
                 expected.put("rows", Collections.emptyList());
             }
             assertResponse(expected, runSql(query));
         } else {
-            if (isByte == true || subFieldIgnoreMalformed == true) {
+            if (isByte || subFieldIgnoreMalformed) {
                 expectSourceDisabledError(query);
             } else {
                 expected.put("rows", Collections.emptyList());
@@ -656,7 +656,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testByteFieldWithIntegerSubfield() throws IOException {
         boolean isByte = randomBoolean();
-        Integer number = isByte == true ? randomByte() : randomIntBetween(Byte.MAX_VALUE + 1, Integer.MAX_VALUE);
+        Integer number = isByte ? randomByte() : randomIntBetween(Byte.MAX_VALUE + 1, Integer.MAX_VALUE);
         boolean explicitSourceSetting = randomBoolean();   // default (no _source setting) or explicit setting
         boolean enableSource = randomBoolean();            // enable _source at index level
         boolean rootIgnoreMalformed = randomBoolean();     // root field ignore_malformed
@@ -691,15 +691,15 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
                 columnInfo("plain", fieldName, "byte", JDBCType.TINYINT, Integer.MAX_VALUE),
                 columnInfo("plain", subFieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE)
         ));
-        if (explicitSourceSetting == false || enableSource == true) {
-            if (isByte == true || rootIgnoreMalformed == true) {
+        if (explicitSourceSetting == false || enableSource) {
+            if (isByte || rootIgnoreMalformed) {
                 expected.put("rows", singletonList(Arrays.asList(isByte ? number : null, number)));
             } else {
                 expected.put("rows", Collections.emptyList());
             }
             assertResponse(expected, runSql(query));
         } else {
-            if (isByte == true || rootIgnoreMalformed == true) {
+            if (isByte || rootIgnoreMalformed) {
                 expectSourceDisabledError(query);
             } else {
                 expected.put("rows", Collections.emptyList());

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/SqlProtocolTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/SqlProtocolTestCase.java
@@ -141,7 +141,7 @@ public abstract class SqlProtocolTestCase extends ESRestTestCase {
         Map<String, Object> map;
         boolean isBinaryResponse = mode != Mode.PLAIN;
         Response response = client().performRequest(request);
-        if (isBinaryResponse == true) {
+        if (isBinaryResponse) {
             map = XContentHelper.convertToMap(CborXContent.cborXContent, response.getEntity().getContent(), false);
         } else {
             map = XContentHelper.convertToMap(JsonXContent.jsonXContent, response.getEntity().getContent(), false);
@@ -154,7 +154,7 @@ public abstract class SqlProtocolTestCase extends ESRestTestCase {
         List<Object> row = (ArrayList<Object>) rows.get(0);
         assertEquals(4, row.size());
         
-        if (isBinaryResponse == true) {
+        if (isBinaryResponse) {
             assertTrue(row.get(0) instanceof Float);
             assertEquals(row.get(0), 1234.34f);
             assertTrue(row.get(1) instanceof Float);
@@ -202,7 +202,7 @@ public abstract class SqlProtocolTestCase extends ESRestTestCase {
             assertEquals(2, column.size());
         }
         
-        List<Object> rows = (ArrayList<Object>) response.get(columnar == true ? "values" : "rows");
+        List<Object> rows = (ArrayList<Object>) response.get(columnar ? "values" : "rows");
         assertEquals(1, rows.size());
         List<Object> row = (ArrayList<Object>) rows.get(0);
         assertEquals(1, row.size());
@@ -257,7 +257,7 @@ public abstract class SqlProtocolTestCase extends ESRestTestCase {
             // set it explicitly or leave the default (null) as is
             requestContent = new StringBuilder(requestContent)
                     .insert(requestContent.length() - 1, ",\"binary_format\":" + binaryCommunication).toString();
-            binaryCommunication = ((Mode.isDriver(m) || m == Mode.CLI) && binaryCommunication == true);
+            binaryCommunication = ((Mode.isDriver(m) || m == Mode.CLI) && binaryCommunication);
         } else {
             binaryCommunication = Mode.isDriver(m) || m == Mode.CLI;
         }
@@ -276,7 +276,7 @@ public abstract class SqlProtocolTestCase extends ESRestTestCase {
 
         Response response = client().performRequest(request);
         try (InputStream content = response.getEntity().getContent()) {
-            if (binaryCommunication == true) {
+            if (binaryCommunication) {
                 return XContentHelper.convertToMap(CborXContent.cborXContent, content, false);
             }
             switch(format) {

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -179,7 +179,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
                     }
                     
                     currentParam = new SqlTypedParamValue(type, value, false);
-                    if ((previousParam != null && previousParam.hasExplicitType() == true) || result.isEmpty()) {
+                    if ((previousParam != null && previousParam.hasExplicitType()) || result.isEmpty()) {
                         currentParam.tokenLocation(loc);
                     }
                 }
@@ -198,7 +198,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
                 throw new XContentParseException(param.tokenLocation(), "[params] must be an array where each entry is an object with a "
                         + "value/type pair");
             }
-            if (Mode.isDriver(mode) == false && param.hasExplicitType() == true) {
+            if (Mode.isDriver(mode) == false && param.hasExplicitType()) {
                 throw new XContentParseException(param.tokenLocation(), "[params] must be an array where each entry is a single field (no "
                         + "objects supported)");
             }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -812,7 +812,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 if (p.child() instanceof Filter) {
                     Filter f = (Filter) p.child();
                     Expression condition = f.condition();
-                    if (condition.resolved() == false && f.childrenResolved() == true) {
+                    if (condition.resolved() == false && f.childrenResolved()) {
                         Expression newCondition = replaceAliases(condition, p.projections());
                         if (newCondition != condition) {
                             return new Project(p.source(), new Filter(f.source(), f.child(), newCondition), p.projections());
@@ -826,7 +826,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 if (a.child() instanceof Filter) {
                     Filter f = (Filter) a.child();
                     Expression condition = f.condition();
-                    if (condition.resolved() == false && f.childrenResolved() == true) {
+                    if (condition.resolved() == false && f.childrenResolved()) {
                         Expression newCondition = replaceAliases(condition, a.aggregates());
                         if (newCondition != condition) {
                             return new Aggregate(a.source(), new Filter(f.source(), f.child(), newCondition), a.groupings(),
@@ -998,7 +998,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     if (n.foldable() == false && Functions.isAggregate(n) == false
                             // folding might not work (it might wait for the optimizer)
                             // so check whether any column is referenced
-                            && n.anyMatch(e -> e instanceof FieldAttribute) == true) {
+                            && n.anyMatch(e -> e instanceof FieldAttribute)) {
                         return f;
                     }
                 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -707,7 +707,7 @@ public final class Verifier {
             Filter filter = (Filter) p;
             if ((filter.child() instanceof Aggregate) == false) {
                 filter.condition().forEachDown(e -> {
-                    if (Functions.isAggregate(attributeRefs.getOrDefault(e, e)) == true) {
+                    if (Functions.isAggregate(attributeRefs.getOrDefault(e, e))) {
                         localFailures.add(
                                 fail(e, "Cannot use WHERE filtering on aggregate function [{}], use HAVING instead", Expressions.name(e)));
                     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/PivotCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/PivotCursor.java
@@ -35,7 +35,7 @@ public class PivotCursor extends CompositeAggCursor {
 
     public PivotCursor(StreamInput in) throws IOException {
         super(in);
-        previousKey = in.readBoolean() == true ? in.readMap() : null;
+        previousKey = in.readBoolean() ? in.readMap() : null;
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IfConditional.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/predicate/conditional/IfConditional.java
@@ -75,7 +75,7 @@ public class IfConditional extends Expression {
 
     @Override
     public boolean equals(Object o) {
-        if (super.equals(o) == true) {
+        if (super.equals(o)) {
             IfConditional that = (IfConditional) o;
             return Objects.equals(condition, that.condition) 
                     && Objects.equals(result, that.result);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -474,7 +474,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                             });
                         }
 
-                        if (isMatching.get() == true) {
+                        if (isMatching.get()) {
                             // move grouping in front
                             groupings.remove(group);
                             groupings.add(0, group);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumns.java
@@ -141,7 +141,7 @@ public class SysColumns extends Command {
             session.indexResolver().resolveAsMergedMapping(idx, regex, includeFrozen, ActionListener.wrap(r -> {
                 List<List<?>> rows = new ArrayList<>();
                 // populate the data only when a target is found
-                if (r.isValid() == true) {
+                if (r.isValid()) {
                     EsIndex esIndex = r.get();
                     fillInRows(cluster, indexName, esIndex.mapping(), null, rows, columnMatcher, mode);
                 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -264,7 +264,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
          * Creates the list of GroupBy keys
          */
         static GroupingContext groupBy(List<? extends Expression> groupings) {
-            if (groupings.isEmpty() == true) {
+            if (groupings.isEmpty()) {
                 return null;
             }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -549,7 +549,7 @@ final class QueryTranslator {
                     name = ((FieldAttribute) bc.left()).exactAttribute().name();
                 }
                 Query query;
-                if (isDateLiteralComparison == true) {
+                if (isDateLiteralComparison) {
                     // dates equality uses a range query because it's the one that has a "format" parameter
                     query = new RangeQuery(source, name, value, true, value, true, format);
                 } else {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
@@ -59,7 +59,7 @@ public class RestSqlQueryAction extends BaseRestHandler {
         String accept = null;
 
         if ((Mode.isDriver(sqlRequest.requestInfo().mode()) || sqlRequest.requestInfo().mode() == Mode.CLI)
-                && (sqlRequest.binaryCommunication() == null || sqlRequest.binaryCommunication() == true)) {
+                && (sqlRequest.binaryCommunication() == null || sqlRequest.binaryCommunication())) {
             // enforce CBOR response for drivers and CLI (unless instructed differently through the config param)
             accept = XContentType.CBOR.name();
         } else {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -256,7 +256,7 @@ public class PivotTests extends ESTestCase {
         }));
 
         assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
-        if (expectValid == true && exceptionHolder.get() != null) {
+        if (expectValid && exceptionHolder.get() != null) {
             throw exceptionHolder.get();
         } else if (expectValid == false && exceptionHolder.get() == null) {
             fail("Expected config to be invalid");

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherIndexingListener.java
@@ -371,7 +371,7 @@ final class WatcherIndexingListener implements IndexingOperationListener, Cluste
          * @return false if watcher is not active or the passed index is not the watcher index
          */
         public boolean isIndexAndActive(String index) {
-            return active == true && index.equals(this.index);
+            return active && index.equals(this.index);
         }
     }
 


### PR DESCRIPTION
While we use `== false` as a more visible form of boolean negation
(instead of `!`), the true case is implied and the true value does not
need to explicitly checked. This commit converts cases that have slipped
into the code checking for `== true`.