### PR TITLE
Mute ec2 test in FIPS 140 mode (#51686)

### DIFF
--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
@@ -101,6 +101,7 @@ public class EC2RetriesTests extends ESTestCase {
     }
 
     public void testEC2DiscoveryRetriesOnRateLimiting() throws IOException {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/51685", inFipsJvm());
         final String accessKey = "ec2_access";
         final List<String> hosts = Collections.singletonList("127.0.0.1:9000");
         final Map<String, Integer> failedRequests = new ConcurrentHashMap<>();


### PR DESCRIPTION
as it needs an extra permission, until we can figure out how to
grant the permission in FIPS 140 mode too.

See: https://github.com/elastic/elasticsearch/issues/51685
