### PR TITLE
Adjust jarHell and 3rd party audit exclusions

### DIFF
--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -42,12 +42,6 @@ test {
   systemProperty 'tests.security.manager', 'false'
 }
 
-thirdPartyAudit.onlyIf {
-  // FIPS JVM includes manny classes from bouncycastle which count as jar hell for the third party audit,
-  // rather than provide a long list of exclusions, disable the check on FIPS.
-  BuildParams.inFipsJvm == false
-}
-
 /*
  * these two classes intentionally use the following JDK internal APIs in order to offer the necessary
  * functionality

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -195,11 +195,3 @@ thirdPartyAudit {
     'io.netty.handler.ssl.util.OpenJdkSelfSignedCertGenerator'
   )
 }
-
-if (BuildParams.inFipsJvm == false) {
-  // BouncyCastleFIPS provides this class, so the exclusion is invalid when running CI in
-  // a FIPS JVM with BouncyCastleFIPS Provider
-  thirdPartyAudit.ignoreMissingClasses(
-    'org.bouncycastle.asn1.x500.X500Name'
-  )
-}

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -88,7 +88,7 @@ thirdPartyAudit {
   ignoreMissingClasses()
 }
 
-thirdPartyAudit.onlyIf {
+jarHell.onlyIf {
   // FIPS JVM includes many classes from bouncycastle which count as jar hell for the third party audit,
   // rather than provide a long list of exclusions, disable the check on FIPS.
   BuildParams.inFipsJvm == false

--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -156,11 +156,3 @@ thirdPartyAudit {
   )
 }
 
-if (BuildParams.inFipsJvm == false) {
-  // BouncyCastleFIPS provides this class, so the exclusion is invalid when running CI in
-  // a FIPS JVM with BouncyCastleFIPS Provider
-  thirdPartyAudit.ignoreMissingClasses(
-    'org.bouncycastle.asn1.x500.X500Name'
-  )
-}
-

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -26,14 +26,11 @@ forbiddenPatterns {
 
 if (BuildParams.inFipsJvm) {
   test.enabled = false
+  jarHell.enabled = false
   testingConventions.enabled = false
   // Forbiden APIs non-portable checks fail because bouncy castle classes being used from the FIPS JDK since those are
   // not part of the Java specification - all of this is as designed, so we have to relax this check for FIPS.
   tasks.withType(CheckForbiddenApis) {
     bundledSignatures -= "jdk-non-portable"
   }
-  // FIPS JVM includes many classes from bouncycastle which count as jar hell for the third party audit,
-  // rather than provide a long list of exclusions, disable the check on FIPS.
-  thirdPartyAudit.enabled = false
-
 }


### PR DESCRIPTION
Now that the FIPS 140 security provider is simply a test dependency
we don't need the thirdPartyAudit exceptions, but plugin-cli and
transport-netty4 do need jarHell disabled as they use the non fips
BouncyCastle security provider as a test dependency too.