### PR TITLE
[DOCS] Add redirects, update JSON spec to fix docs build

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -331,6 +331,11 @@ See <<slm-api-delete-policy>>.
 
 See <<slm-api-execute-lifecycle>>.
 
+[role="exclude",id="slm-api-execute-policy"]
+=== {slm-init} execute lifecycle API
+
+See <<slm-api-execute-lifecycle>>.
+
 [role="exclude",id="slm-api-get"]
 === {slm-init} get policy API
 
@@ -341,7 +346,27 @@ See <<slm-api-get-policy>>.
 
 See <<slm-api-get-stats>>.
 
+[role="exclude",id="slm-get-status"]
+=== {slm-init} status API
+
+See <<slm-api-get-status>>.
+
 [role="exclude",id="slm-api-put"]
 === {slm-init} put policy API
 
 See <<slm-api-put-policy>>.
+
+[role="exclude",id="slm-start"]
+=== Start {slm} API
+
+See <<slm-api-start>>.
+
+[role="exclude",id="slm-stop"]
+=== Stop {slm} API
+
+See <<slm-api-stop>>.
+
+[role="exclude",id="eql-search"]
+=== EQL search  API
+
+See <<eql>>.

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
@@ -1,7 +1,7 @@
 {
   "eql.search":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html"
     },
     "stability": "beta",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -1,7 +1,7 @@
 {
   "slm.execute_lifecycle":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-policy.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute-lifecycle.html"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
@@ -1,7 +1,7 @@
 {
   "slm.get_status":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-get-status.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-status.html"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
@@ -1,7 +1,7 @@
 {
   "slm.start":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-start.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-start.html"
     },
     "stability":"stable",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
@@ -1,7 +1,7 @@
 {
   "slm.stop":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-stop.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-stop.html"
     },
     "stability":"stable",
     "url":{


### PR DESCRIPTION
Docs build [#11556][0] broke due to several outdated or incorrect links
in the JSON REST spec.

This fixes those links where possible and adds redirects.

[0]: https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/11556/
