### PR TITLE
Rare Function ML Doc: Fix wording in the notes section

### DIFF
--- a/docs/reference/ml/anomaly-detection/functions/rare.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/rare.asciidoc
@@ -21,7 +21,7 @@ number of times (frequency) rare values occur.
 looking for rare events. The functions model whether something happens in a
 bucket at least once. With longer bucket spans, it is more likely that
 entities will be seen in a bucket and therefore they appear less rare.
-Picking the ideal the bucket span depends on the characteristics of the data
+Picking the ideal bucket span depends on the characteristics of the data
 with shorter bucket spans typically being measured in minutes, not hours.
 * To model rare data, a learning period of at least 20 buckets is required
 for typical data.


### PR DESCRIPTION
Doc versions: This is present in `master`, `7.x`, `7.6`, `7.5 (current)`, and `6.8`
There is an extra `the` in the **NOTE** section at the top of doc.


