### PR TITLE
Skip date_histogram on range fields before 7.4.1

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -309,11 +309,8 @@ setup:
 ---
 "date_histogram on range":
   - skip:
-      version: "all"
-      reason:  "AwaitsFix https://github.com/elastic/elasticsearch/issues/51525"
-      # When fixed, reinstate these lines
-      #version: " - 7.1.99"
-      #reason:  calendar_interval introduced in 7.2.0
+      version: " - 7.4.1"
+      reason:  doc values on ranges implemented in 7.4.1
 
   - do:
       indices.create:
@@ -364,11 +361,8 @@ setup:
 ---
 "date_histogram on range with offset":
   - skip:
-      version: "all"
-      reason:  "AwaitsFix https://github.com/elastic/elasticsearch/issues/51525"
-      # When fixed, reinstate these lines
-      #version: " - 7.1.99"
-      #reason:  calendar_interval introduced in 7.2.0
+      version: " - 7.4.1"
+      reason:  doc values on ranges implemented in 7.4.1
 
   - do:
       indices.create:


### PR DESCRIPTION
range fields didn't have doc_values before 7.4.1. They were added in
 #47472.

 Closes #51525