### PR TITLE
Fix version parser used by gradle

### DIFF
--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/Version.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/Version.java
@@ -29,9 +29,9 @@ public final class Version implements Comparable<Version> {
         RELAXED
     }
 
-    private static final Pattern pattern = Pattern.compile("(\\d)+\\.(\\d+)\\.(\\d+)(-alpha\\d+|-beta\\d+|-rc\\d+)?(-SNAPSHOT)?");
+    private static final Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-alpha\\d+|-beta\\d+|-rc\\d+)?(-SNAPSHOT)?");
 
-    private static final Pattern relaxedPattern = Pattern.compile("(\\d)+\\.(\\d+)\\.(\\d+)(-[a-zA-Z0-9_]+)*?");
+    private static final Pattern relaxedPattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-[a-zA-Z0-9_]+)*?");
 
     public Version(int major, int minor, int revision) {
         Objects.requireNonNull(major, "major version can't be null");

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/VersionTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/VersionTests.java
@@ -38,6 +38,7 @@ public class VersionTests extends GradleUnitTestCase {
         assertVersionEquals("5.1.2-rc3", 5, 1, 2);
         assertVersionEquals("6.1.2-SNAPSHOT", 6, 1, 2);
         assertVersionEquals("6.1.2-beta1-SNAPSHOT", 6, 1, 2);
+        assertVersionEquals("17.03.11", 17, 3, 11);
     }
 
     public void testRelaxedVersionParsing() {
@@ -46,6 +47,7 @@ public class VersionTests extends GradleUnitTestCase {
         assertVersionEquals("6.1.2-beta1-SNAPSHOT", 6, 1, 2, Version.Mode.RELAXED);
         assertVersionEquals("6.1.2-foo", 6, 1, 2, Version.Mode.RELAXED);
         assertVersionEquals("6.1.2-foo-bar", 6, 1, 2, Version.Mode.RELAXED);
+        assertVersionEquals("16.01.22", 16, 1, 22, Version.Mode.RELAXED);
     }
 
     public void testCompareWithStringVersions() {
@@ -91,6 +93,7 @@ public class VersionTests extends GradleUnitTestCase {
 
     public void testCompareVersions() {
         assertEquals(0, new Version(7, 0, 0).compareTo(new Version(7, 0, 0)));
+        assertOrder(Version.fromString("19.0.1"), Version.fromString("20.0.3"));
     }
 
     public void testExceptionEmpty() {


### PR DESCRIPTION
Due to of a typo in the version regex pattern only the last digit of a major
version number is taken into consideration. So docker's version 17.0.1 is parsed
as 7.0.1.

That's not really an issue until docker 20.x.x is released, so not sure how far
back it should be backported. 
