### PR TITLE
Fix LoggingOutputStream to work on windows

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
@@ -91,7 +91,12 @@ class LoggingOutputStream extends OutputStream {
     public void flush() {
         Buffer buffer = threadLocal.get();
         if (buffer.used == 0) return;
-        log(new String(buffer.bytes, 0, buffer.used, StandardCharsets.UTF_8));
+        int used = buffer.used;
+        if (buffer.bytes[used - 1] == '\r') {
+            // windows case: remove the first part of newlines there too
+            --used;
+        }
+        log(new String(buffer.bytes, 0, used, StandardCharsets.UTF_8));
         if (buffer.bytes.length != DEFAULT_BUFFER_LENGTH) {
             threadLocal.set(new Buffer()); // reset size
         } else {

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
@@ -71,9 +71,17 @@ public class LoggingOutputStreamTests extends ESTestCase {
         assertTrue(loggingStream.lines.isEmpty());
     }
 
-    public void testFlushOnNewline() {
-        printStream.println("hello");
-        printStream.println("world");
+    // this test explicitly outputs the newlines instead of relying on println, to always test the unix behavior
+    public void testFlushOnUnixNewline() {
+        printStream.print("hello\n");
+        printStream.print("world\n");
+        assertThat(loggingStream.lines, contains("hello", "world"));
+    }
+
+    // this test explicitly outputs the newlines instead of relying on println, to always test the windows behavior
+    public void testFlushOnWindowsNewline() {
+        printStream.print("hello\r\n");
+        printStream.print("world\r\n");
         assertThat(loggingStream.lines, contains("hello", "world"));
     }
 


### PR DESCRIPTION
LoggingOutputStream reads a stream and breaks on newlines. This commit
fixes the behavior to account for windows newlines also containing `\r`.

closes #51532