### PR TITLE
Fix the type for "slices" in the Delete By Query REST API specification (#51792)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -178,9 +178,9 @@
         "description": "The throttle for this request in sub-requests per second. -1 means no throttle."
       },
       "slices": {
-        "type": "number|auto",
+        "type": "number|string",
         "default": 1,
-        "description": "The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks."
+        "description": "The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       }
     },
     "body":{


### PR DESCRIPTION
The previous patch in 050c4d4c890 incorrectly set the `type` for the `slices` parameter of the Delete By Request API to `number|auto`, which is incorrect — the "polymorphic" type, denoted with the `|` sign, should contain only other types, ie. number, string, bool, etc.

Fixes https://github.com/elastic/elasticsearch/pull/51791.
