### PR TITLE
Read the full REST spec from a common directory 

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -83,6 +83,7 @@ import org.elasticsearch.client.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -813,7 +814,8 @@ public class RestHighLevelClientTests extends ESTestCase {
         deprecatedMethods.add("multi_search");
         deprecatedMethods.add("search_scroll");
 
-        ClientYamlSuiteRestSpec restSpec = ClientYamlSuiteRestSpec.load("/rest-api-spec/api");
+        ClientYamlSuiteRestSpec restSpec =
+            ClientYamlSuiteRestSpec.load(PathUtils.get(RestHighLevelClientTests.class.getResource("/rest-api-spec/api").toURI()));
         Set<String> apiSpec = restSpec.getApis().stream().map(ClientYamlSuiteRestApi::getName).collect(Collectors.toSet());
         Set<String> apiUnsupported = new HashSet<>(apiSpec);
         Set<String> apiNotFound = new HashSet<>();

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -140,6 +140,7 @@ task integTest(type: Test) {
   outputs.doNotCacheIf('Build cache is disabled for Docker tests') { true }
   maxParallelForks = '1'
   include '**/*IT.class'
+  nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   // don't add the tasks to build the docker images if we have no way of testing them
   if (TestFixturesPlugin.dockerComposeSupported()) {
     dependsOn assemble

--- a/plugins/examples/rest-handler/build.gradle
+++ b/plugins/examples/rest-handler/build.gradle
@@ -29,6 +29,22 @@ esplugin {
   noticeFile rootProject.file('NOTICE.txt')
 }
 
+configurations {
+  restSpec
+}
+
+dependencies {
+  restSpec project(':rest-api-spec')
+}
+
+processTestResources {
+  from({ zipTree(configurations.restSpec.singleFile) }) {
+    includeEmptyDirs = false
+    include 'rest-api-spec/api/**'
+  }
+  dependsOn configurations.restSpec
+}
+
 // No unit tests in this example
 test.enabled = false
 
@@ -43,6 +59,7 @@ integTest {
   dependsOn exampleFixture
   runner {
     nonInputProperties.systemProperty 'external.address', "${-> exampleFixture.addressAndPort}"
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 }
 

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -52,6 +52,7 @@ for (Version bwcVersion : bwcVersions.indexCompatible) {
     }
 
     systemProperty 'tests.is_old_cluster', 'true'
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.register("${baseName}#upgradedClusterTest", RestTestRunnerTask) {
@@ -61,6 +62,7 @@ for (Version bwcVersion : bwcVersions.indexCompatible) {
       testClusters."${baseName}".goToNextVersion()
     }
     systemProperty 'tests.is_old_cluster', 'false'
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -52,7 +52,6 @@ for (Version bwcVersion : bwcVersions.indexCompatible) {
     }
 
     systemProperty 'tests.is_old_cluster', 'true'
-    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.register("${baseName}#upgradedClusterTest", RestTestRunnerTask) {
@@ -62,7 +61,6 @@ for (Version bwcVersion : bwcVersions.indexCompatible) {
       testClusters."${baseName}".goToNextVersion()
     }
     systemProperty 'tests.is_old_cluster', 'false'
-    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -78,6 +78,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
 
       nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
       nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+      nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     }
     systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     onlyIf { project.bwc_tests_enabled }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -83,6 +83,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'old_cluster'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.register("${baseName}#oneThirdUpgradedTest", RestTestRunnerTask) {
@@ -95,6 +96,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.first_round', 'true'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.register("${baseName}#twoThirdsUpgradedTest", RestTestRunnerTask) {
@@ -107,6 +109,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.first_round', 'false'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.register("${baseName}#upgradedClusterTest", RestTestRunnerTask) {
@@ -118,6 +121,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   if (project.bwc_tests_enabled) {

--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -109,4 +109,6 @@ grant codeBase "file:${gradle.worker.jar}" {
 grant {
   // since the gradle test worker jar is on the test classpath, our tests should be able to read it
   permission java.io.FilePermission "${gradle.worker.jar}", "read";
+   // the rest specs are copied here and used across most modules and plugins
+   permission java.io.FilePermission "${tests.rest.spec_root}/-", "read";
 };

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.rest.yaml.restspec;
 
-import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -79,11 +78,10 @@ public class ClientYamlSuiteRestSpec {
     /**
      * Parses the complete set of REST spec available under the provided directories
      */
-    public static ClientYamlSuiteRestSpec load(String classpathPrefix) throws Exception {
-        Path dir = PathUtils.get(ClientYamlSuiteRestSpec.class.getResource(classpathPrefix).toURI());
+    public static ClientYamlSuiteRestSpec load(Path specPath) throws Exception {
         ClientYamlSuiteRestSpec restSpec = new ClientYamlSuiteRestSpec();
         ClientYamlSuiteRestApiParser restApiParser = new ClientYamlSuiteRestApiParser();
-        try (Stream<Path> stream = Files.walk(dir)) {
+        try (Stream<Path> stream = Files.walk(specPath)) {
             stream.forEach(item -> {
                 if (item.toString().endsWith(".json")) {
                     parseSpecFile(restApiParser, item, restSpec);

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -69,6 +69,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
@@ -82,6 +83,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'false'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
@@ -95,6 +97,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
   }

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -71,6 +71,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
       nonInputProperties.systemProperty('tests.leader_remote_cluster_seed', "${-> testClusters."${baseName}-leader".allTransportPortURI.last()}")
       nonInputProperties.systemProperty('tests.follower_host', "${-> testClusters."${baseName}-follower".allHttpSocketURI.last()}")
       nonInputProperties.systemProperty('tests.follower_remote_cluster_seed', "${-> testClusters."${baseName}-follower".allTransportPortURI.last()}")
+      nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     }
   }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -111,6 +111,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     systemProperty 'tests.upgrade_from_version', version.toString().replace('-SNAPSHOT', '')
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
   }
 
   tasks.register("${baseName}#oneThirdUpgradedTest", RestTestRunnerTask) {
@@ -121,6 +122,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'true'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
@@ -145,6 +147,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     systemProperty 'tests.rest.suite', 'mixed_cluster'
     systemProperty 'tests.first_round', 'false'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
@@ -158,6 +161,7 @@ for (Version bwcVersion : bwcVersions.wireCompatible) {
     }
     nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}".allHttpSocketURI.join(",")}")
     nonInputProperties.systemProperty('tests.clustername', "${-> testClusters."${baseName}".getName()}")
+    nonInputProperties.systemProperty('tests.rest.spec_root', project.sourceSets.test.output.resourcesDir)
     systemProperty 'tests.rest.suite', 'upgraded_cluster'
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
   }


### PR DESCRIPTION
This commit changes where the REST API specs are read. The REST API 
spec is required to run the REST YAML tests and are currently copied
to every project that has REST YAML tests. 

The REST API specs are now copied to the build directory of the root
gradle project under a "rest-spec-api-current" directory. Since
each module or plugin (including all x-pack plugins) can contribute
to the REST API spec, they too are copied to the common directory. 
The result is a single directory created during the build which 
includes the full REST API spec. A system property has been 
introduced to allow the testing framework to know where this common
directory lives on disk. 

Additionally, the BWC based tests continue to copy the API 
and tests locally since they are special cases of the REST 
YAML testing. 

-------

Note - this change related (but not dependent) to how the REST testing strategy https://github.com/elastic/elasticsearch/issues/51816 will work. For example, that testing plans to use a "rest-spec-api-prior" directory for it's REST specs.  