### PR TITLE
Fix Source Only Snapshot Uploading Files for Unchanged Shards

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/SourceOnlySnapshotRepository.java
@@ -147,11 +147,13 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
             Supplier<Query> querySupplier = mapperService.hasNested() ? Queries::newNestedFilter : null;
             // SourceOnlySnapshot will take care of soft- and hard-deletes no special casing needed here
             SourceOnlySnapshot snapshot = new SourceOnlySnapshot(tempStore.directory(), querySupplier);
-            snapshot.syncSnapshot(snapshotIndexCommit);
+            final List<String> newFiles = snapshot.syncSnapshot(snapshotIndexCommit);
             // we will use the lucene doc ID as the seq ID so we set the local checkpoint to maxDoc with a new index UUID
             SegmentInfos segmentInfos = tempStore.readLastCommittedSegmentsInfo();
-            final long maxDoc = segmentInfos.totalMaxDoc();
-            tempStore.bootstrapNewHistory(maxDoc, maxDoc);
+            if (newFiles.isEmpty() == false) {
+                final long maxDoc = segmentInfos.totalMaxDoc();
+                tempStore.bootstrapNewHistory(maxDoc, maxDoc);
+            }
             store.incRef();
             toClose.add(store::decRef);
             DirectoryReader reader = DirectoryReader.open(tempStore.directory(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/SourceOnlySnapshotShardTests.java
@@ -135,11 +135,23 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             totalFileCount = copy.getTotalFileCount();
             assertEquals(copy.getStage(), IndexShardSnapshotStatus.Stage.DONE);
         }
+        try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
+            IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(shardGeneration);
+            SnapshotId snapshotId = new SnapshotId("test_1", "test_1");
+            final PlainActionFuture<String> future = PlainActionFuture.newFuture();
+            runAsSnapshot(shard.getThreadPool(), () -> repository.snapshotShard(shard.store(), shard.mapperService(), snapshotId, indexId,
+                snapshotRef.getIndexCommit(), indexShardSnapshotStatus, true, Collections.emptyMap(), future));
+            shardGeneration = future.actionGet();
+            IndexShardSnapshotStatus.Copy copy = indexShardSnapshotStatus.asCopy();
+            assertEquals(0, copy.getIncrementalFileCount());
+            assertEquals(totalFileCount, copy.getTotalFileCount());
+            assertEquals(copy.getStage(), IndexShardSnapshotStatus.Stage.DONE);
+        }
 
         indexDoc(shard, "_doc", Integer.toString(10));
         indexDoc(shard, "_doc", Integer.toString(11));
         try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
-            SnapshotId snapshotId = new SnapshotId("test_1", "test_1");
+            SnapshotId snapshotId = new SnapshotId("test_2", "test_2");
 
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(shardGeneration);
             final PlainActionFuture<String> future = PlainActionFuture.newFuture();
@@ -155,7 +167,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         }
         deleteDoc(shard, Integer.toString(10));
         try (Engine.IndexCommitRef snapshotRef = shard.acquireLastIndexCommit(true)) {
-            SnapshotId snapshotId = new SnapshotId("test_2", "test_2");
+            SnapshotId snapshotId = new SnapshotId("test_3", "test_3");
 
             IndexShardSnapshotStatus indexShardSnapshotStatus = IndexShardSnapshotStatus.newInitializing(shardGeneration);
             final PlainActionFuture<String> future = PlainActionFuture.newFuture();


### PR DESCRIPTION
We shouldn't be creating a new commit (by bootstrapping an new history)
if nothing has changed about the shard.

Relates #50231 in that it prevents a bunch of redundant `segments_N` from being uploaded
and makes a fix shorter/clearer
