### PR TITLE
Forbid equality checks against 'true'

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -18,7 +18,7 @@
     <property name="message" value="Empty javadoc comments are forbidden"/>
   </module>
 
-  <!-- 
+  <!--
     We include snippets that are wrapped in `// tag` and `// end` into the
     docs, stripping the leading spaces. If the context is wider than 76
     characters then it'll need to scroll. This fails the build if it sees
@@ -103,5 +103,31 @@
       <property name="ignoreComments" value="true" />
     </module>
     <!-- end Orwellian suppression of Serializable -->
+
+    <!-- Forbid equality comparisons with `true` -->
+    <module name="DescendantToken">
+      <property name="tokens" value="EQUAL"/>
+      <property name="limitedTokens" value="LITERAL_TRUE"/>
+      <property name="maximumNumber" value="0"/>
+      <property name="maximumDepth" value="1"/>
+      <message key="descendant.token.max" value="Do not check for equality with 'true', since it is implied"/>
+    </module>
+
+    <!-- Forbid using '!' for logical negations in favour of checking
+         against 'false' explicitly. -->
+    <!-- This is disabled for now because there are many, many violations,
+         hence the rule is reporting at the "warning" severity. -->
+
+    <!--
+    <module name="DescendantToken">
+      <property name="severity" value="warning"/>
+      <property name="tokens" value="EXPR"/>
+      <property name="limitedTokens" value="LNOT"/>
+      <property name="maximumNumber" value="0"/>
+      <property name="maximumDepth" value="1"/>
+      <message key="descendant.token.max" value="Do not negate boolean expressions with '!', but check explicitly with '== false' as it is more explicit"/>
+    </module>
+    -->
+
   </module>
 </module>

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcResultSetMetaData.java
@@ -72,7 +72,7 @@ class JdbcResultSetMetaData implements ResultSetMetaData, JdbcWrapper {
     @Override
     public String getColumnLabel(int column) throws SQLException {
         JdbcColumnInfo info = column(column);
-        return true == EMPTY.equals(info.label) ? info.name : info.label;
+        return EMPTY.equals(info.label) ? info.name : info.label;
     }
 
     @Override


### PR DESCRIPTION
Add a Checkstyle rule to forbid equality checks against a literal 'true' value, since this is redundant. Follow up to #51723.

I also built a rule to prohibit logical negations i.e. `!`, but there are thousands of violations, so I left it in place for interest but commented it out. Maybe at some point we'll feel that we want it. It's probably an expensive rule.