### PR TITLE
Disallow duplicate `dynamic_templates` names

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -607,7 +607,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
                         .endObject()
                     .endObject()
                     .startObject()
-                        .startObject("dates")
+                        .startObject("dates_with_explicit_format")
                             .field("match_mapping_type", "date")
                             .field("match", "*3")
                             .startObject("mapping")


### PR DESCRIPTION
Currently the same `dynamic_templates` name can be used more than once in the
same mappings file. This most certainly is unintentional and can create issues like
those reported in #28988. Furthermore, when templates are matched later in
`RootObjectMapper#findTemplate`, it looks like we simply pick the first matching
one we see in the input array, so using the same template name twice sounds like
an error prone idea anyway. This change checks for duplicate names on parsing
and throws an error if we encounter the same name twice.

Closes #28988