### PR TITLE
[DOCS] Add EQL syntax page

### DIFF
--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -29,6 +29,8 @@ Consider using EQL if you:
 [[eql-toc]]
 === In this section
 
-* <<eql-requirements,EQL requirements>>
+* <<eql-requirements>>
+* <<eql-syntax>>
 
 include::requirements.asciidoc[]
+include::syntax.asciidoc[]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -225,7 +225,7 @@ cannot end in an odd number of backslashes.
 ====
 
 [discrete]
-[[eql-syntax-non-alpha-field-namess]]
+[[eql-syntax-non-alpha-field-names]]
 ==== Non-alphanumeric field names
 
 Field names containing non-alphanumeric characters, such as underscores (`_`),

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -142,7 +142,7 @@ Multiplies the values to the left and right of the operator.
 Divides the value to the left of the operator by the value to the right.
 
 `%` (modulo)::
-Divides the value to the left of the operator by the value to the right. Returns  only the remainder.
+Divides the value to the left of the operator by the value to the right. Returns only the remainder.
 ====
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -26,7 +26,7 @@ field value of `svchost.exe`:
 
 [source,eql]
 ----
-process where name == "svchost.exe"
+process where process.name == "svchost.exe"
 ----
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -211,13 +211,16 @@ characters in the string except single quote (`'`) and double quote (`"`).
 ----
 
 [discrete]
-[[eql-syntax-nested-fields]]
-==== Nested fields
+[[eql-syntax-non-alpha-field-namess]]
+==== Non-alphanumeric field names
 
-When using dot notation to specify nested object fields, the field name and path
-are escaped using backticks (+++`+++).
+Field names containing non-alphanumeric characters, such as underscores (`_`),
+dots (`.`), hyphens (`-`), or spaces, must be escaped using backticks (+++`+++).
 
 [source,eql]
 ----
-`obj1.name`
+`my_field`
+`my.field`
+`my-field`
+`my field`
 ----

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -1,0 +1,224 @@
+[role="xpack"]
+[testenv="basic"]
+[[eql-syntax]]
+== EQL syntax reference
+
+experimental::[]
+
+[IMPORTANT]
+====
+{es} supports a subset of EQL syntax.
+====
+
+[discrete]
+[[eql-basic-syntax]]
+=== Basic syntax
+
+EQL queries require an event type and a matching condition. The `where` keyword connects them.
+
+[source,eql]
+----
+event_type where condition
+----
+
+For example, the following EQL query matches `process` events with a `name`
+field value of `svchost.exe`:
+
+[source,eql]
+----
+process where name == "svchost.exe"
+----
+
+[discrete]
+[[eql-syntax-conditions]]
+==== Conditions
+
+A condition consists of one or more criteria an event must match.
+You can specify and combine these criteria using the following operators:
+
+[discrete]
+[[eql-syntax-comparison-operators]]
+===== Comparison operators
+
+[source,eql]
+----
+<   <=   ==   !=   >=   >
+----
+
+.*Definitions*
+[%collapsible]
+====
+`<` (less than)::
+Returns `true` if the value to the left of the operator is less than the value
+to the right. Otherwise returns `false`.
+
+`<=` (less than or equal) ::
+Returns `true` if the value to the left of the operator is less than or equal to
+the value to the right. Otherwise returns `false`.
+
+`==` (equal)::
+Returns `true` if the values to the left and right of the operator are equal.
+Otherwise returns `false`.
+
+`!=` (not equal)::
+Returns `true` if the values to the left and right of the operator are not
+equal. Otherwise returns `false`.
+
+`>=` (greater than or equal) ::
+Returns `true` if the value to the left of the operator is greater than or equal
+to the value to the right. Otherwise returns `false`.
+
+`>` (greater than)::
+Returns `true` if the value to the left of the operator is greater than the
+value to the right. Otherwise returns `false`.
+====
+
+[discrete]
+[[eql-syntax-logical-operators]]
+===== Logical operators
+
+[source,eql]
+----
+and  or  not
+----
+
+.*Definitions*
+[%collapsible]
+====
+`and`::
+Returns `true` only if the condition to the left and right _both_ return `true`.
+Otherwise returns `false.
+
+`or`::
+Returns `true` if one of the conditions to the left or right `true`.
+Otherwise returns `false.
+
+`not`::
+Returns `true` if the condition to the right is `false`.
+====
+
+[discrete]
+[[eql-syntax-lookup-operators]]
+===== Lookup operators
+
+[source,eql]
+----
+user.name in ("Administrator", "SYSTEM", "NETWORK SERVICE")
+user.name not in ("Administrator", "SYSTEM", "NETWORK SERVICE")
+----
+
+.*Definitions*
+[%collapsible]
+====
+`in`::
+Returns `true` if the value is contained in the provided list.
+
+`not in`::
+Returns `true` if the value is not contained in the provided list.
+====
+
+[discrete]
+[[eql-syntax-math-operators]]
+===== Math operators
+
+[source,eql]
+----
++  -  *  /  %
+----
+
+.*Definitions*
+[%collapsible]
+====
+`+` (add)::
+Adds the values to the left and right of the operator.
+
+`-` (Subtract)::
+Subtracts the value to the right of the operator from the value to the left.
+
+`*` (Subtract)::
+Multiplies the values to the left and right of the operator.
+
+`/` (Divide)::
+Divides the value to the left of the operator by the value to the right.
+
+`%` (modulo)::
+Divides the value to the left of the operator by the value to the right. Returns  only the remainder.
+====
+
+[discrete]
+[[eql-syntax-strings]]
+==== Strings
+
+Strings are enclosed with double quotes (`"`) or single quotes (`'`).
+
+[source,eql]
+----
+"hello world"
+"hello world with 'substring'"
+----
+
+[discrete]
+[[eql-syntax-wildcards]]
+===== Wildcards 
+
+You can use the wildcard operator (`*`) within a string to match specific
+patterns.
+
+The following example string matches any value that ends with `.txt`.
+
+[source,eql]
+----
+"*.txt"
+----
+
+[discrete]
+[[eql-syntax-escaped-characters]]
+===== Escaped characters 
+
+When used within a string, special characters, such as a carriage return or
+double quote (`"`), must be escaped with a preceding `\`.
+
+[source,eql]
+----
+"example \t of \n escaped \r characters"
+----
+
+.*Escape sequences*
+[%collapsible]
+====
+[options="header"]
+|====
+| Escape sequence | Literal character
+|`\n`             | A newline (linefeed) character
+|`\r`             | A carriage return character
+|`\t`             | A tab character
+|`\\`             | A backslash (`\`) character
+|`\"`             | A double quote (`"`) character
+|`\'`             | A single quote (`'`) character
+|`\*`             | A wildcard (`*`) character
+|====
+====
+
+[discrete]
+[[eql-syntax-raw-strings]]
+===== Raw strings
+
+Raw strings are preceded by a question mark (`?`), which escapes all special
+characters in the string except single quote (`'`) and double quote (`"`).
+
+[source,eql]
+----
+?"String with literal 'slash' \ characters included"
+----
+
+[discrete]
+[[eql-syntax-nested-fields]]
+==== Nested fields
+
+When using dot notation to specify nested object fields, the field name and path
+are escaped using backticks (+++`+++).
+
+[source,eql]
+----
+`obj1.name`
+----

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -162,8 +162,8 @@ Strings are enclosed with double quotes (`"`) or single quotes (`'`).
 ===== Wildcards 
 
 You can use the wildcard operator (`*`) within a string to match specific
-patterns. Wildcards are interpreted if they are used with `==` (equal) or `!=`
-(not equal):
+patterns. You can use wildcards with the `==` (equal) or `!=` (not equal)
+operators:
 
 [source,eql]
 ----

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -176,7 +176,7 @@ The following example string matches any value that ends with `.txt`.
 ===== Escaped characters 
 
 When used within a string, special characters, such as a carriage return or
-double quote (`"`), must be escaped with a preceding `\`.
+double quote (`"`), must be escaped with a preceding backslash (`\`).
 
 [source,eql]
 ----
@@ -202,13 +202,27 @@ double quote (`"`), must be escaped with a preceding `\`.
 [[eql-syntax-raw-strings]]
 ===== Raw strings
 
-Raw strings are preceded by a question mark (`?`), which escapes all special
-characters in the string except single quote (`'`) and double quote (`"`).
+Raw strings are preceded by a question mark (`?`) and treat backslashes (`\`) as
+literal characters.
 
 [source,eql]
 ----
-?"String with literal 'slash' \ characters included"
+?"String with a literal 'blackslash' \ character included"
 ----
+
+You can escape single quotes (`'`) and double quotes (`"`) with a backslash, but
+the backslash remains in the resulting string.
+
+[source,eql]
+----
+?"\""
+----
+
+[NOTE]
+====
+Raw strings cannot contain only a single backslash. Additionally, raw strings
+cannot end in an odd number of backslashes.
+====
 
 [discrete]
 [[eql-syntax-non-alpha-field-namess]]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -162,13 +162,13 @@ Strings are enclosed with double quotes (`"`) or single quotes (`'`).
 ===== Wildcards 
 
 You can use the wildcard operator (`*`) within a string to match specific
-patterns.
-
-The following example string matches any value that ends with `.txt`.
+patterns. Wildcards are interpreted if they are used with `==` (equal) or `!=`
+(not equal):
 
 [source,eql]
 ----
-"*.txt"
+field == "example*wildcard"
+field != "example*wildcard"
 ----
 
 [discrete]

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -195,7 +195,6 @@ double quote (`"`), must be escaped with a preceding `\`.
 |`\\`             | A backslash (`\`) character
 |`\"`             | A double quote (`"`) character
 |`\'`             | A single quote (`'`) character
-|`\*`             | A wildcard (`*`) character
 |====
 ====
 

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -21,7 +21,7 @@ EQL queries require an event type and a matching condition. The `where` keyword 
 event_type where condition
 ----
 
-For example, the following EQL query matches `process` events with a `name`
+For example, the following EQL query matches `process` events with a `process.name`
 field value of `svchost.exe`:
 
 [source,eql]


### PR DESCRIPTION
Adds documentation for basic EQL syntax.

Joins, sequences, and other syntax to be added as its supported in future development.

### Preview
http://elasticsearch_51821.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/eql-syntax.html