### PR TITLE
Fix assertion in sync flush simulation

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
@@ -88,7 +88,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
         void syncFlush(String syncId) throws IOException {
             assertNotNull(indexWriter);
             try (ReleasableLock ignored = writeLock.acquire()) {
-                assertThat(getTranslogStats().getUncommittedOperations(), equalTo(0));
+                assertFalse(indexWriter.hasUncommittedChanges());
                 Map<String, String> userData = new HashMap<>(getLastCommittedSegmentInfos().userData);
                 userData.put(Engine.SYNC_COMMIT_ID, syncId);
                 indexWriter.setLiveCommitData(userData.entrySet());


### PR DESCRIPTION
We perform a non-force flush in this test. It can be a noop on replicas if indexing are processed out of order. We should assert the IndexWriter instead of the translog before simulating a sync flush.

Closes #51750