### PR TITLE
[DOCS] Fix 'disk.used_percent' typo in _cat/nodes docs

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -87,7 +87,7 @@ Used disk space, such as `259.8gb`.
 Available disk space, such as `198.4gb`.
 
 `disk.used_percent`, `dup`, `diskUsedPercent`::
-Used disk space percentage, such as `198.4gb`.
+Used disk space percentage, such as `47`.
 
 `heap.current`, `hc`, `heapCurrent`::
 Used heap, such as `311.2mb`.


### PR DESCRIPTION
 such as `198.4gb` ->  such as `47`

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
