### PR TITLE
Replace the confusing `timeout` search option with `shard_timeout`

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -612,7 +612,7 @@ final class RequestConverters {
             .withRouting(updateByQueryRequest.getRouting())
             .withPipeline(updateByQueryRequest.getPipeline())
             .withRefresh(updateByQueryRequest.isRefresh())
-            .withTimeout(updateByQueryRequest.getTimeout())
+            .withShardTimeout(updateByQueryRequest.getTimeout())
             .withWaitForActiveShards(updateByQueryRequest.getWaitForActiveShards())
             .withRequestsPerSecond(updateByQueryRequest.getRequestsPerSecond())
             .withIndicesOptions(updateByQueryRequest.indicesOptions())
@@ -937,6 +937,10 @@ final class RequestConverters {
 
         Params withTimeout(TimeValue timeout) {
             return putParam("timeout", timeout);
+        }
+
+        Params withShardTimeout(TimeValue timeout) {
+            return putParam("shard_timeout", timeout);
         }
 
         Params withVersion(long version) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
@@ -164,7 +164,7 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
             sourceBuilder.query(QueryBuilders.termQuery("user", "kimchy")); // <2>
             sourceBuilder.from(0); // <3>
             sourceBuilder.size(5); // <4>
-            sourceBuilder.timeout(new TimeValue(60, TimeUnit.SECONDS)); // <5>
+            sourceBuilder.shardTimeout(new TimeValue(60, TimeUnit.SECONDS)); // <5>
             // end::search-source-basics
 
             // tag::search-source-sorting

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -706,12 +706,12 @@ tag::scroll_size[]
 Defaults to 100.
 end::scroll_size[]
 
-tag::search_timeout[]
+tag::shard_search_timeout[]
 `shard_timeout`::
 (Optional, <<time-units, time units>>)
 Explicit shard search timeout.
 Defaults to no timeout.
-end::search_timeout[]
+end::shard_search_timeout[]
 
 tag::search_type[]
 `search_type`::

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -707,9 +707,9 @@ Defaults to 100.
 end::scroll_size[]
 
 tag::search_timeout[]
-`search_timeout`::
+`shard_timeout`::
 (Optional, <<time-units, time units>>)
-Explicit timeout for each search request.
+Explicit shard search timeout.
 Defaults to no timeout.
 end::search_timeout[]
 

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -106,15 +106,19 @@ POST /_search
 
 [float]
 [[global-search-timeout]]
-=== Global Search Timeout
+=== Global Shard Search Timeout
 
-Individual searches can have a timeout as part of the
+Individual searches can have a shard timeout as part of the
 <<search-request-body>>. Since search requests can originate from many
 sources, Elasticsearch has a dynamic cluster-level setting for a global
 search timeout that applies to all search requests that do not set a
-timeout in the request body. These requests will be cancelled after
-the specified time using the mechanism described in the following section on
-<<global-search-cancellation>>. Therefore the same caveats about timeout
+shard timeout in the request body. These requests will collect hits on shards
+within the specified time value and bail with the hits accumulated up to that
+point when expired. The timeout is per shard so the overall latency of the search
+request will depend on the number of shards that participate in the query and the
+number of shard requests that executed concurrently. Shard requests will be
+cancelled after the specified time using the mechanism described in the following
+section on <<global-search-cancellation>>. Therefore the same caveats about timeout
 responsiveness apply.
 
 The setting key is `search.default_search_timeout` and can be set using the

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -3,22 +3,22 @@
 
 WARNING: The Profile API is a debugging tool and adds significant overhead to search execution.
 
-Provides detailed timing information about the execution of individual 
+Provides detailed timing information about the execution of individual
 components in a search request.
 
 
 [[search-profile-api-desc]]
 ==== {api-description-title}
 
-The Profile API gives the user insight into how search requests are executed at 
-a low level so that the user can understand why certain requests are slow, and 
-take steps to improve them. Note that the Profile API, 
-<<profile-limitations, amongst other things>>, doesn't measure network latency, 
-time spent in the search fetch phase, time spent while the requests spends in 
+The Profile API gives the user insight into how search requests are executed at
+a low level so that the user can understand why certain requests are slow, and
+take steps to improve them. Note that the Profile API,
+<<profile-limitations, amongst other things>>, doesn't measure network latency,
+time spent in the search fetch phase, time spent while the requests spends in
 queues or while merging shard responses on the coordinating node.
 
-The output from the Profile API is *very* verbose, especially for complicated 
-requests executed across many shards. Pretty-printing the response is 
+The output from the Profile API is *very* verbose, especially for complicated
+requests executed across many shards. Pretty-printing the response is
 recommended to help understand the output.
 
 
@@ -173,7 +173,7 @@ The API returns the following result:
 
 <1> Search results are returned, but were omitted here for brevity.
 
-Even for a simple query, the response is relatively complicated.  Let's break it 
+Even for a simple query, the response is relatively complicated.  Let's break it
 down piece-by-piece before moving to more complex examples.
 
 
@@ -205,36 +205,36 @@ The overall structure of the profile response is as follows:
 // TESTRESPONSE[s/"query": \[...\]/"query": $body.$_path/]
 // TESTRESPONSE[s/"collector": \[...\]/"collector": $body.$_path/]
 // TESTRESPONSE[s/"aggregations": \[...\]/"aggregations": []/]
-<1> A profile is returned for each shard that participated in the response, and 
+<1> A profile is returned for each shard that participated in the response, and
 is identified by a unique ID.
-<2> Each profile contains a section which holds details about the query 
+<2> Each profile contains a section which holds details about the query
 execution.
 <3> Each profile has a single time representing the cumulative rewrite time.
-<4> Each profile also contains a section about the Lucene Collectors which run 
+<4> Each profile also contains a section about the Lucene Collectors which run
 the search.
-<5> Each profile contains a section which holds the details about the 
+<5> Each profile contains a section which holds the details about the
 aggregation execution.
 
-Because a search request may be executed against one or more shards in an index, 
-and a search may cover one or more indices, the top level element in the profile 
-response is an array of `shard` objects. Each shard object lists its `id` which 
-uniquely identifies the shard.  The ID's format is 
+Because a search request may be executed against one or more shards in an index,
+and a search may cover one or more indices, the top level element in the profile
+response is an array of `shard` objects. Each shard object lists its `id` which
+uniquely identifies the shard.  The ID's format is
 `[nodeID][indexName][shardID]`.
 
-The profile itself may consist of one or more "searches", where a search is a 
-query executed against the underlying Lucene index.  Most search requests 
-submitted by the user will only execute a single `search` against the Lucene 
-index. But occasionally multiple searches will be executed, such as including a 
-global aggregation (which needs to execute a secondary "match_all" query for the 
+The profile itself may consist of one or more "searches", where a search is a
+query executed against the underlying Lucene index.  Most search requests
+submitted by the user will only execute a single `search` against the Lucene
+index. But occasionally multiple searches will be executed, such as including a
+global aggregation (which needs to execute a secondary "match_all" query for the
 global context).
 
 Inside each `search` object there will be two arrays of profiled information:
-a `query` array and a `collector` array.  Alongside the `search` object is an 
-`aggregations` object that contains the profile information for the 
-aggregations. In the future, more sections may be added, such as `suggest`, 
+a `query` array and a `collector` array.  Alongside the `search` object is an
+`aggregations` object that contains the profile information for the
+aggregations. In the future, more sections may be added, such as `suggest`,
 `highlight`, etc.
 
-There will also be a `rewrite` metric showing the total time spent rewriting the 
+There will also be a `rewrite` metric showing the total time spent rewriting the
 query (in nanoseconds).
 
 NOTE: As with other statistics apis, the Profile API supports human readable outputs. This can be turned on by adding
@@ -260,10 +260,10 @@ the `advance` phase of that query is the cause, for example.
 [[query-section]]
 ===== `query` Section
 
-The `query` section contains detailed timing of the query tree executed by 
-Lucene on a particular shard. The overall structure of this query tree will 
-resemble your original Elasticsearch query, but may be slightly (or sometimes 
-very) different.  It will also use similar but not always identical naming. 
+The `query` section contains detailed timing of the query tree executed by
+Lucene on a particular shard. The overall structure of this query tree will
+resemble your original Elasticsearch query, but may be slightly (or sometimes
+very) different.  It will also use similar but not always identical naming.
 Using our previous `match` query example, let's analyze the `query` section:
 
 [source,console-result]
@@ -297,27 +297,27 @@ Using our previous `match` query example, let's analyze the `query` section:
 // TESTRESPONSE[s/"breakdown": \{...\}/"breakdown": $body.$_path/]
 <1> The breakdown timings are omitted for simplicity.
 
-Based on the profile structure, we can see that our `match` query was rewritten 
-by Lucene into a BooleanQuery with two clauses (both holding a TermQuery).  The 
-`type` field displays the Lucene class name, and often aligns with the 
-equivalent name in Elasticsearch.  The `description` field displays the Lucene 
-explanation text for the query, and is made available to help differentiating 
-between parts of your query (e.g. both `message:search` and `message:test` are 
+Based on the profile structure, we can see that our `match` query was rewritten
+by Lucene into a BooleanQuery with two clauses (both holding a TermQuery).  The
+`type` field displays the Lucene class name, and often aligns with the
+equivalent name in Elasticsearch.  The `description` field displays the Lucene
+explanation text for the query, and is made available to help differentiating
+between parts of your query (e.g. both `message:search` and `message:test` are
 TermQuery's and would appear identical otherwise.
 
-The `time_in_nanos` field shows that this query took ~1.8ms for the entire 
+The `time_in_nanos` field shows that this query took ~1.8ms for the entire
 BooleanQuery to execute.  The recorded time is inclusive of all children.
 
-The `breakdown` field will give detailed stats about how the time was spent, 
-we'll look at that in a moment.  Finally, the `children` array lists any 
-sub-queries that may be present.  Because we searched for two values ("search 
-test"), our BooleanQuery holds two children TermQueries.  They have identical 
-information (type, time, breakdown, etc).  Children are allowed to have their 
+The `breakdown` field will give detailed stats about how the time was spent,
+we'll look at that in a moment.  Finally, the `children` array lists any
+sub-queries that may be present.  Because we searched for two values ("search
+test"), our BooleanQuery holds two children TermQueries.  They have identical
+information (type, time, breakdown, etc).  Children are allowed to have their
 own children.
 
 ===== Timing Breakdown
 
-The `breakdown` component lists detailed timing statistics about low-level 
+The `breakdown` component lists detailed timing statistics about low-level
 Lucene execution:
 
 [source,console-result]
@@ -347,11 +347,11 @@ Lucene execution:
 // TESTRESPONSE[s/}$/},\n"children": $body.$_path}],\n"rewrite_time": $body.$_path, "collector": $body.$_path}], "aggregations": []}]}}/]
 // TESTRESPONSE[s/(?<=[" ])\d+(\.\d+)?/$body.$_path/]
 
-Timings are listed in wall-clock nanoseconds and are not normalized at all. All 
-caveats about the overall `time_in_nanos` apply here.  The intention of the 
-breakdown is to give you a feel for A) what machinery in Lucene is actually 
-eating time, and B) the magnitude of differences in times between the various 
-components. Like the overall time, the breakdown is inclusive of all children 
+Timings are listed in wall-clock nanoseconds and are not normalized at all. All
+caveats about the overall `time_in_nanos` apply here.  The intention of the
+breakdown is to give you a feel for A) what machinery in Lucene is actually
+eating time, and B) the magnitude of differences in times between the various
+components. Like the overall time, the breakdown is inclusive of all children
 times.
 
 The meaning of the stats are as follows:
@@ -426,10 +426,10 @@ The meaning of the stats are as follows:
 [[collectors-section]]
 ===== `collectors` Section
 
-The Collectors portion of the response shows high-level execution details. 
-Lucene works by defining a "Collector" which is responsible for coordinating the 
-traversal, scoring, and collection of matching documents.  Collectors are also 
-how a single query can record aggregation results, execute unscoped "global" 
+The Collectors portion of the response shows high-level execution details.
+Lucene works by defining a "Collector" which is responsible for coordinating the
+traversal, scoring, and collection of matching documents.  Collectors are also
+how a single query can record aggregation results, execute unscoped "global"
 queries, execute post-query filters, etc.
 
 Looking at the previous example:
@@ -449,18 +449,18 @@ Looking at the previous example:
 // TESTRESPONSE[s/(?<=[" ])\d+(\.\d+)?/$body.$_path/]
 
 
-We see a single collector named `SimpleTopScoreDocCollector` wrapped into 
-`CancellableCollector`. `SimpleTopScoreDocCollector` is the default "scoring and 
-sorting" `Collector` used by {es}. The `reason` field attempts to give a plain 
-English description of the class name.  The `time_in_nanos` is similar to the 
-time in the Query tree: a wall-clock time inclusive of all children. Similarly, 
-`children` lists all sub-collectors. The `CancellableCollector` that wraps 
-`SimpleTopScoreDocCollector` is used by {es} to detect if the current search was 
+We see a single collector named `SimpleTopScoreDocCollector` wrapped into
+`CancellableCollector`. `SimpleTopScoreDocCollector` is the default "scoring and
+sorting" `Collector` used by {es}. The `reason` field attempts to give a plain
+English description of the class name.  The `time_in_nanos` is similar to the
+time in the Query tree: a wall-clock time inclusive of all children. Similarly,
+`children` lists all sub-collectors. The `CancellableCollector` that wraps
+`SimpleTopScoreDocCollector` is used by {es} to detect if the current search was
 cancelled and stop collecting documents as soon as it occurs.
 
-It should be noted that Collector times are **independent** from the Query 
-times.  They are calculated, combined, and normalized independently! Due to the 
-nature of Lucene's execution, it is impossible to "merge" the times from the 
+It should be noted that Collector times are **independent** from the Query
+times.  They are calculated, combined, and normalized independently! Due to the
+nature of Lucene's execution, it is impossible to "merge" the times from the
 Collectors into the Query section, so they are displayed in separate portions.
 
 For reference, the various collector reasons are:
@@ -493,7 +493,7 @@ For reference, the various collector reasons are:
 
 `search_timeout`::
 
-    A collector that halts execution after a specified period of time.  This is seen when a `timeout` top-level
+    A collector that halts execution after a specified period of time.  This is seen when a `shard_timeout` top-level
     parameter has been specified.
 
 `aggregation`::
@@ -512,21 +512,21 @@ For reference, the various collector reasons are:
 [[rewrite-section]]
 ===== `rewrite` Section
 
-All queries in Lucene undergo a "rewriting" process.  A query (and its 
-sub-queries) may be rewritten one or more times, and the process continues until 
-the query stops changing.  This process allows Lucene to perform optimizations, 
-such as removing redundant clauses, replacing one query for a more efficient 
-execution path, etc. For example a Boolean -> Boolean -> TermQuery can be 
+All queries in Lucene undergo a "rewriting" process.  A query (and its
+sub-queries) may be rewritten one or more times, and the process continues until
+the query stops changing.  This process allows Lucene to perform optimizations,
+such as removing redundant clauses, replacing one query for a more efficient
+execution path, etc. For example a Boolean -> Boolean -> TermQuery can be
 rewritten to a TermQuery, because all the Booleans are unnecessary in this case.
 
-The rewriting process is complex and difficult to display, since queries can 
-change drastically. Rather than showing the intermediate results, the total 
-rewrite time is simply displayed as a value (in nanoseconds). This value is 
+The rewriting process is complex and difficult to display, since queries can
+change drastically. Rather than showing the intermediate results, the total
+rewrite time is simply displayed as a value (in nanoseconds). This value is
 cumulative and contains the total time for all queries being rewritten.
 
 ===== A more complex example
 
-To demonstrate a slightly more complex query and the associated results, we can 
+To demonstrate a slightly more complex query and the associated results, we can
 profile the following query:
 
 [source,console]
@@ -679,44 +679,44 @@ The API returns the following result:
 // TESTRESPONSE[s/\.\.\.//]
 // TESTRESPONSE[s/(?<=[" ])\d+(\.\d+)?/$body.$_path/]
 // TESTRESPONSE[s/"id": "\[P6-vulHtQRWuD4YnubWb7A\]\[test\]\[0\]"/"id": $body.profile.shards.0.id/]
-<1> The `"aggregations"` portion has been omitted because it will be covered in 
+<1> The `"aggregations"` portion has been omitted because it will be covered in
 the next section.
 
-As you can see, the output is significantly more verbose than before.  All the 
+As you can see, the output is significantly more verbose than before.  All the
 major portions of the query are represented:
 
 1. The first `TermQuery` (user:test) represents the main `term` query.
 2. The second `TermQuery` (message:some) represents the `post_filter` query.
 
-The Collector tree is fairly straightforward, showing how a single 
-CancellableCollector wraps a MultiCollector which also wraps a FilteredCollector 
-to execute the post_filter (and in turn wraps the normal scoring 
+The Collector tree is fairly straightforward, showing how a single
+CancellableCollector wraps a MultiCollector which also wraps a FilteredCollector
+to execute the post_filter (and in turn wraps the normal scoring
 SimpleCollector), a BucketCollector to run all scoped aggregations.
 
 ===== Understanding MultiTermQuery output
 
-A special note needs to be made about the `MultiTermQuery` class of queries. 
-This includes wildcards, regex, and fuzzy queries. These queries emit very 
+A special note needs to be made about the `MultiTermQuery` class of queries.
+This includes wildcards, regex, and fuzzy queries. These queries emit very
 verbose responses, and are not overly structured.
 
-Essentially, these queries rewrite themselves on a per-segment basis. If you 
-imagine the wildcard query `b*`, it technically can match any token that begins 
-with the letter "b".  It would be impossible to enumerate all possible 
-combinations, so Lucene rewrites the query in context of the segment being 
-evaluated, e.g., one segment may contain the tokens `[bar, baz]`, so the query 
-rewrites to a BooleanQuery combination of "bar" and "baz".  Another segment may 
-only have the token `[bakery]`, so the query rewrites to a single TermQuery for 
+Essentially, these queries rewrite themselves on a per-segment basis. If you
+imagine the wildcard query `b*`, it technically can match any token that begins
+with the letter "b".  It would be impossible to enumerate all possible
+combinations, so Lucene rewrites the query in context of the segment being
+evaluated, e.g., one segment may contain the tokens `[bar, baz]`, so the query
+rewrites to a BooleanQuery combination of "bar" and "baz".  Another segment may
+only have the token `[bakery]`, so the query rewrites to a single TermQuery for
 "bakery".
 
-Due to this dynamic, per-segment rewriting, the clean tree structure becomes 
-distorted and no longer follows a clean "lineage" showing how one query rewrites 
-into the next.  At present time, all we can do is apologize, and suggest you 
-collapse the details for that query's children if it is too confusing. Luckily, 
-all the timing statistics are correct, just not the physical layout in the 
+Due to this dynamic, per-segment rewriting, the clean tree structure becomes
+distorted and no longer follows a clean "lineage" showing how one query rewrites
+into the next.  At present time, all we can do is apologize, and suggest you
+collapse the details for that query's children if it is too confusing. Luckily,
+all the timing statistics are correct, just not the physical layout in the
 response, so it is sufficient to just analyze the top-level MultiTermQuery and
 ignore its children if you find the details too tricky to interpret.
 
-Hopefully this will be fixed in future iterations, but it is a tricky problem to 
+Hopefully this will be fixed in future iterations, but it is a tricky problem to
 solve and still in-progress. :)
 
 [[profiling-aggregations]]
@@ -727,9 +727,9 @@ solve and still in-progress. :)
 ====== `aggregations` Section
 
 
-The `aggregations` section contains detailed timing of the aggregation tree 
-executed by a particular shard. The overall structure of this aggregation tree 
-will resemble your original {es} request. Let's execute the previous query again 
+The `aggregations` section contains detailed timing of the aggregation tree
+executed by a particular shard. The overall structure of this aggregation tree
+will resemble your original {es} request. Let's execute the previous query again
 and look at the aggregation profile this time:
 
 [source,console]
@@ -838,19 +838,19 @@ This yields the following aggregation profile output:
 // TESTRESPONSE[s/(?<=[" ])\d+(\.\d+)?/$body.$_path/]
 // TESTRESPONSE[s/"id": "\[P6-vulHtQRWuD4YnubWb7A\]\[test\]\[0\]"/"id": $body.profile.shards.0.id/]
 
-From the profile structure we can see that the `my_scoped_agg` is internally 
-being run as a `LongTermsAggregator` (because the field it is aggregating, 
-`likes`, is a numeric field). At the same level, we see a `GlobalAggregator` 
-which comes from `my_global_agg`. That aggregation then has a child 
+From the profile structure we can see that the `my_scoped_agg` is internally
+being run as a `LongTermsAggregator` (because the field it is aggregating,
+`likes`, is a numeric field). At the same level, we see a `GlobalAggregator`
+which comes from `my_global_agg`. That aggregation then has a child
 `LongTermsAggregator` which comes from the second term's aggregation on `likes`.
 
-The `time_in_nanos` field shows the time executed by each aggregation, and is 
-inclusive of all children.  While the overall time is useful, the `breakdown` 
+The `time_in_nanos` field shows the time executed by each aggregation, and is
+inclusive of all children.  While the overall time is useful, the `breakdown`
 field will give detailed stats about how the time was spent.
 
 ===== Timing Breakdown
 
-The `breakdown` component lists detailed timing statistics about low-level 
+The `breakdown` component lists detailed timing statistics about low-level
 Lucene execution:
 
 [source,js]
@@ -869,10 +869,10 @@ Lucene execution:
 --------------------------------------------------
 // NOTCONSOLE
 
-Timings are listed in wall-clock nanoseconds and are not normalized at all. All 
-caveats about the overall `time` apply here.  The intention of the breakdown is 
-to give you a feel for A) what machinery in {es} is actually eating time, and B) 
-the magnitude of differences in times between the various components. Like the 
+Timings are listed in wall-clock nanoseconds and are not normalized at all. All
+caveats about the overall `time` apply here.  The intention of the breakdown is
+to give you a feel for A) what machinery in {es} is actually eating time, and B)
+the magnitude of differences in times between the various components. Like the
 overall time, the breakdown is inclusive of all children times.
 
 The meaning of the stats are as follows:
@@ -904,31 +904,31 @@ The meaning of the stats are as follows:
 [[profiling-considerations]]
 ===== Profiling Considerations
 
-Like any profiler, the Profile API introduces a non-negligible overhead to 
-search execution. The act of instrumenting low-level method calls such as 
-`collect`, `advance`, and `next_doc` can be fairly expensive, since these 
-methods are called in tight loops.  Therefore, profiling should not be enabled 
-in production settings by default, and should not be compared against 
+Like any profiler, the Profile API introduces a non-negligible overhead to
+search execution. The act of instrumenting low-level method calls such as
+`collect`, `advance`, and `next_doc` can be fairly expensive, since these
+methods are called in tight loops.  Therefore, profiling should not be enabled
+in production settings by default, and should not be compared against
 non-profiled query times. Profiling is just a diagnostic tool.
 
-There are also cases where special Lucene optimizations are disabled, since they 
-are not amenable to profiling. This could cause some queries to report larger 
-relative times than their non-profiled counterparts, but in general should not 
+There are also cases where special Lucene optimizations are disabled, since they
+are not amenable to profiling. This could cause some queries to report larger
+relative times than their non-profiled counterparts, but in general should not
 have a drastic effect compared to other components in the profiled query.
 
 [[profile-limitations]]
 ===== Limitations
 
-- Profiling currently does not measure the search fetch phase nor the network 
+- Profiling currently does not measure the search fetch phase nor the network
 overhead.
-- Profiling also does not account for time spent in the queue, merging shard 
-responses on the coordinating node, or additional work such as building global 
+- Profiling also does not account for time spent in the queue, merging shard
+responses on the coordinating node, or additional work such as building global
 ordinals (an internal data structure used to speed up search).
-- Profiling statistics are currently not available for suggestions, 
+- Profiling statistics are currently not available for suggestions,
 highlighting, `dfs_query_then_fetch`.
 - Profiling of the reduce phase of aggregation is currently not available.
-- The Profiler is still highly experimental. The Profiler is instrumenting parts 
-of Lucene that were never designed to be exposed in this manner, and so all 
-results should be viewed as a best effort to provide detailed diagnostics. We 
-hope to improve this over time. If you find obviously wrong numbers, strange 
+- The Profiler is still highly experimental. The Profiler is instrumenting parts
+of Lucene that were never designed to be exposed in this manner, and so all
+results should be viewed as a best effort to provide detailed diagnostics. We
+hope to improve this over time. If you find obviously wrong numbers, strange
 query structures, or other bugs, please report them!

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -41,44 +41,44 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 [[search-request-body-api-request-body]]
 ==== {api-request-body-title}
 
-`allow_partial_search_results`:: 
-  (Optional, boolean) Set to `false` to fail the request if only partial results 
-  are available. Defaults to `true`, which returns partial results in the event 
-  of timeouts or partial failures You can override the default behavior for all 
-  requests by setting `search.default_allow_partial_results` to `false` in the 
+`allow_partial_search_results`::
+  (Optional, boolean) Set to `false` to fail the request if only partial results
+  are available. Defaults to `true`, which returns partial results in the event
+  of shard timeouts or partial failures You can override the default behavior for all
+  requests by setting `search.default_allow_partial_results` to `false` in the
   cluster settings.
 
-`batched_reduce_size`:: 
-  (Optional, integer) The number of shard results that should be reduced at once 
-  on the coordinating node. This value should be used as a protection mechanism 
-  to reduce the memory overhead per search request if the potential number of 
+`batched_reduce_size`::
+  (Optional, integer) The number of shard results that should be reduced at once
+  on the coordinating node. This value should be used as a protection mechanism
+  to reduce the memory overhead per search request if the potential number of
   shards in the request can be large.
 
 [[ccs-minimize-roundtrips]]
 `ccs_minimize_roundtrips`::
-  (Optional, boolean) If `true`, the network round-trips between the 
-  coordinating node and the remote clusters ewill be minimized when executing 
-  {ccs} requests. See <<ccs-network-delays>>. Defaults to `true`. 
+  (Optional, boolean) If `true`, the network round-trips between the
+  coordinating node and the remote clusters ewill be minimized when executing
+  {ccs} requests. See <<ccs-network-delays>>. Defaults to `true`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
 
 `request_cache`::
-  (Optional, boolean) If `true`, the caching of search results is enabled for 
+  (Optional, boolean) If `true`, the caching of search results is enabled for
   requests where `size` is `0`. See <<shard-request-cache>>.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
 
-`size`:: 
+`size`::
   (Optional, integer) The number of hits to return. Defaults to `10`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_timeout]
+include::{docdir}/rest-api/common-parms.asciidoc[tag=shard_search_timeout]
 
 
-Out of the above, the `search_type`, `request_cache` and the 
-`allow_partial_search_results` settings must be passed as query-string 
-parameters. The rest of the search request should be passed within the body 
+Out of the above, the `search_type`, `request_cache` and the
+`allow_partial_search_results` settings must be passed as query-string
+parameters. The rest of the search request should be passed within the body
 itself. The body content can also be passed as a REST parameter named `source`.
 
 Both HTTP GET and HTTP POST can be used to execute search with body. Since not

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -25,7 +25,7 @@ GET /twitter/_search?q=tag:wow
 [[search-search-api-desc]]
 ==== {api-description-title}
 
-Allows you to execute a search query and get back search hits that match the 
+Allows you to execute a search query and get back search hits that match the
 query. The query can either be provided using a simple
 <<search-uri-request,query string as a parameter>>, or using a
 <<search-request-body,request body>>.
@@ -33,8 +33,8 @@ query. The query can either be provided using a simple
 [[search-partial-responses]]
 ===== Partial responses
 
-To ensure fast responses, the search API will respond with partial results if 
-one or more shards fail. See <<shard-failures, Shard failures>> for more 
+To ensure fast responses, the search API will respond with partial results if
+one or more shards fail. See <<shard-failures, Shard failures>> for more
 information.
 
 [[search-search-api-path-params]]
@@ -47,165 +47,165 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 ==== {api-query-parms-title}
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
-  
+
 `allow_partial_search_results`::
-  (Optional, boolean) Indicates if an error should be returned if there is a 
-  partial search failure or timeout. Defaults to `true`.
+  (Optional, boolean) Indicates if an error should be returned if there is a
+  partial search failure or shard timeout(s). Defaults to `true`.
 
 `analyzer`::
   (Optional, string) Defines the analyzer to use for the query string.
-  
+
 `analyze_wildcard`::
-  (Optional, boolean) If `true`, wildcard and prefix queries will also be 
+  (Optional, boolean) If `true`, wildcard and prefix queries will also be
   analyzed. Defaults to `false`.
-  
+
 `batched_reduce_size`::
-  (Optional, integer) The number of shard results that should be reduced at once 
-  on the coordinating node. This value should be used as a protection mechanism 
-  to reduce the memory overhead per search request if the potential number of 
+  (Optional, integer) The number of shard results that should be reduced at once
+  on the coordinating node. This value should be used as a protection mechanism
+  to reduce the memory overhead per search request if the potential number of
   shards in the request can be large. Defaults to `512`.
-  
+
 `ccs_minimize_roundtrips`::
-  (Optional, boolean) Indicates whether network round-trips should be minimized 
+  (Optional, boolean) Indicates whether network round-trips should be minimized
   as part of cross-cluster search requests execution. Defaults to `true`.
-  
+
 `default_operator`::
-  (Optional, string) The default operator for query string query (AND or OR). 
+  (Optional, string) The default operator for query string query (AND or OR).
   Defaults to `OR`.
-  
+
 `df`::
-  (Optional, string) Defines the field to use as default where no field prefix 
+  (Optional, string) Defines the field to use as default where no field prefix
   is given in the query string.
-  
+
 `docvalue_fields`::
-  (Optional, string) A comma-separated list of fields to return as the docvalue 
+  (Optional, string) A comma-separated list of fields to return as the docvalue
   representation of a field for each hit.
-  
+
 include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
-  
+
 `explain`::
-  (Optional, boolean) If `true`, returns detailed information about score 
+  (Optional, boolean) If `true`, returns detailed information about score
   computation as part of a hit. Defaults to `false`.
-  
+
 `from`::
   (Optional, integer) Defines the starting offset. Defaults to `0`.
 
 `ignore_throttled`::
-  (Optional, boolean) If `true`, concrete, expanded or aliased indices will be 
+  (Optional, boolean) If `true`, concrete, expanded or aliased indices will be
   ignored when throttled. Defaults to `false`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
-  
+
 `lenient`::
-  (Optional, boolean) If `true`, format-based query failures (such as 
+  (Optional, boolean) If `true`, format-based query failures (such as
   providing text to a numeric field) will be ignored. Defaults to `false`.
-  
+
 `max_concurrent_shard_requests`::
-  (Optional, integer) Defines the number of concurrent shard requests per node 
-  this search executes concurrently. This value should be used to limit the 
-  impact of the search on the cluster in order to limit the number of concurrent 
+  (Optional, integer) Defines the number of concurrent shard requests per node
+  this search executes concurrently. This value should be used to limit the
+  impact of the search on the cluster in order to limit the number of concurrent
   shard requests. Defaults to `5`.
-  
+
 `pre_filter_shard_size`::
-  (Optional, integer) Defines a threshold that enforces a pre-filter roundtrip 
-  to prefilter search shards based on query rewriting if the number of shards 
-  the search request expands to exceeds the threshold. This filter roundtrip can 
-  limit the number of shards significantly if for instance a shard can not match 
-  any documents based on it's rewrite method ie. if date filters are mandatory 
+  (Optional, integer) Defines a threshold that enforces a pre-filter roundtrip
+  to prefilter search shards based on query rewriting if the number of shards
+  the search request expands to exceeds the threshold. This filter roundtrip can
+  limit the number of shards significantly if for instance a shard can not match
+  any documents based on it's rewrite method ie. if date filters are mandatory
   to match but the shard bounds and the query are disjoint. Defaults to `128`.
 
 `preference`::
-  (Optional, string) Specifies the node or shard the operation should be 
+  (Optional, string) Specifies the node or shard the operation should be
   performed on. Random by default.
-  
+
 `q`::
   (Optional, string) Query in the Lucene query string syntax.
 
 `request_cache`::
-  (Optional, boolean) If `true`, request cache will be used for this request. 
+  (Optional, boolean) If `true`, request cache will be used for this request.
   Defaults to index level settings.
-  
+
 `rest_total_hits_as_int`::
-  (Optional, boolean) Indicates whether hits.total should be rendered as an 
+  (Optional, boolean) Indicates whether hits.total should be rendered as an
   integer or an object in the rest search response. Defaults to `false`.
 
 `routing`::
-  (Optional, <<time-units, time units>>) Specifies how long a consistent view of 
+  (Optional, <<time-units, time units>>) Specifies how long a consistent view of
   the index should be maintained for scrolled search.
-  
+
 `search_type`::
-  (Optional, string) Defines the type of the search operation. Available 
+  (Optional, string) Defines the type of the search operation. Available
   options:
   * `query_then_fetch`
   * `dfs_query_then_fetch`
 
 `seq_no_primary_term`::
-  (Optional, boolean) If `true`, returns sequence number and primary term of the 
+  (Optional, boolean) If `true`, returns sequence number and primary term of the
   last modification of each hit.
 
 `size`::
   (Optional, integer) Defines the number of hits to return. Defaults to `10`.
-  
+
 `sort`::
   (Optional, string) A comma-separated list of <field>:<direction> pairs.
-  
+
 `_source`::
-  (Optional, string) True or false to return the `_source` field or not, or a 
+  (Optional, string) True or false to return the `_source` field or not, or a
   list of fields to return.
-  
+
 `_source_excludes`::
-  (Optional, string) A list of fields to exclude from the returned `_source` 
+  (Optional, string) A list of fields to exclude from the returned `_source`
   field.
-  
+
 `_source_includes`::
-  (Optional, string) A list of fields to extract and return from the `_source` 
+  (Optional, string) A list of fields to extract and return from the `_source`
   field.
-  
+
 `stats`::
-  (Optional, string) Specific `tag` of the request for logging and statistical 
+  (Optional, string) Specific `tag` of the request for logging and statistical
   purposes.
 
 `stored_fields`::
-  (Optional, string) A comma-separated list of stored fields to return as part 
+  (Optional, string) A comma-separated list of stored fields to return as part
   of a hit.
-  
+
 `suggest_field`::
   (Optional, string) Specifies which field to use for suggestions.
-  
+
 `suggest_mode`::
-  (Optional, string) Specifies suggest mode. Defaults to `missing`. Available 
+  (Optional, string) Specifies suggest mode. Defaults to `missing`. Available
   options:
   * `always`
   * `missing`
   * `popular`
-  
+
 `suggest_size`::
   (Optional, integer) Defines how many suggestions to return in response.
-  
+
 `suggest_text`::
-  (Optional, string) The source text for which the suggestions should be 
+  (Optional, string) The source text for which the suggestions should be
   returned.
-  
+
 `terminate_after`::
-  (Optional, integer) The maximum number of documents to collect for each shard, 
+  (Optional, integer) The maximum number of documents to collect for each shard,
   upon reaching which the query execution will terminate early.
-  
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+
+include::{docdir}/rest-api/common-parms.asciidoc[tag=shard_search_timeout]
 
 `track_scores`::
-  (Optional, boolean) If `true`, then calculates and returns scores even if they 
+  (Optional, boolean) If `true`, then calculates and returns scores even if they
   are not used for sorting.
-  
+
 `track_total_hits`::
-  (Optional, boolean) Indicates if the number of documents that match the query 
+  (Optional, boolean) Indicates if the number of documents that match the query
   should be tracked.
-  
+
 `typed_keys`::
-  (Optional, boolean) Specifies whether aggregation and suggester names should 
+  (Optional, boolean) Specifies whether aggregation and suggester names should
   be prefixed by their respective types in the response.
-  
+
 `version`::
   (Optional, boolean) If `true`, returns document version as part of a hit.
 
@@ -214,7 +214,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
 ==== {api-request-body-title}
 
 `query`::
-  (Optional, <<query-dsl,query object>>) Defines the search definition using the 
+  (Optional, <<query-dsl,query object>>) Defines the search definition using the
   <<query-dsl,Query DSL>>.
 
 

--- a/docs/reference/search/uri-request.asciidoc
+++ b/docs/reference/search/uri-request.asciidoc
@@ -19,8 +19,8 @@ GET twitter/_search?q=user:kimchy
 [[search-uri-request-api-desc]]
 ==== {api-description-title}
 
-You can use query parameters to define your search criteria directly in the 
-request URI, rather than in the request body. Request URI searches do not 
+You can use query parameters to define your search criteria directly in the
+request URI, rather than in the request body. Request URI searches do not
 support the full {es} Query DSL, but are handy for testing.
 
 
@@ -33,29 +33,29 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
 [[search-uri-request-api-query-params]]
 ==== {api-query-parms-title}
 
-`allow_partial_search_results`:: 
-  (Optional, boolean) Set to `false` to fail the request if only partial results 
-  are available. Defaults to `true`, which returns partial results in the event 
-  of timeouts or partial failures You can override the default behavior for all 
-  requests by setting `search.default_allow_partial_results` to `false` in the 
+`allow_partial_search_results`::
+  (Optional, boolean) Set to `false` to fail the request if only partial results
+  are available. Defaults to `true`, which returns partial results in the event
+  of shard timeouts or partial failures You can override the default behavior for all
+  requests by setting `search.default_allow_partial_results` to `false` in the
   cluster settings.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
-  
+
 include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
-`batched_reduce_size`:: 
-  (Optional, integer) The number of shard results that should be reduced at once 
-  on the coordinating node. This value should be used as a protection mechanism 
-  to reduce the memory overhead per search request if the potential number of 
+`batched_reduce_size`::
+  (Optional, integer) The number of shard results that should be reduced at once
+  on the coordinating node. This value should be used as a protection mechanism
+  to reduce the memory overhead per search request if the potential number of
   shards in the request can be large.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
 
-`explain`:: 
-  (Optional, string) For each hit, include an explanation of how the score was 
+`explain`::
+  (Optional, string) For each hit, include an explanation of how the score was
   computed.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
@@ -66,7 +66,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
 
-`size`:: 
+`size`::
   (Optional, integer) The number of hits to return. Defaults to `10`.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
@@ -75,33 +75,36 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
-`stored_fields`:: 
-  (Optional, string) The selective stored fields of the document to return for 
-  each hit, comma delimited. Not specifying any value will cause no fields to 
+`stored_fields`::
+  (Optional, string) The selective stored fields of the document to return for
+  each hit, comma delimited. Not specifying any value will cause no fields to
   return.
 
-`sort`:: 
-  (Optional, string) Sorting to perform. Can either be in the form of 
-  `fieldName`, or `fieldName:asc`/`fieldName:desc`. The fieldName can either be 
-  an actual field within the document, or the special `_score` name to indicate 
-  sorting based on scores. There can be several `sort` parameters (order is 
+`sort`::
+  (Optional, string) Sorting to perform. Can either be in the form of
+  `fieldName`, or `fieldName:asc`/`fieldName:desc`. The fieldName can either be
+  an actual field within the document, or the special `_score` name to indicate
+  sorting based on scores. There can be several `sort` parameters (order is
   important).
 
-`track_scores`:: 
-  (Optional, boolean) When sorting, set to `true` in order to still track scores 
+`track_scores`::
+  (Optional, boolean) When sorting, set to `true` in order to still track scores
   and return them as part of each hit.
 
-`track_total_hits`:: 
-  (Optional, integer) Defaults to `10,000`. Set to `false` in order to disable 
-  the tracking of the total number of hits that match the query. It also accepts 
-  an integer which in this case represents the number of hits to count 
-  accurately. (See the <<request-body-search-track-total-hits, request body>> 
+`track_total_hits`::
+  (Optional, integer) Defaults to `10,000`. Set to `false` in order to disable
+  the tracking of the total number of hits that match the query. It also accepts
+  an integer which in this case represents the number of hits to count
+  accurately. (See the <<request-body-search-track-total-hits, request body>>
   documentation for more details).
 
-`timeout`::
-  (Optional, <<time-units, time units>>) A search timeout, bounding the search 
-  request to be executed within the specified time value and bail with the hits 
+`shard_timeout`::
+  (Optional, <<time-units, time units>>) A search timeout, bounding the search on
+  shards to be executed within the specified time value and bail with the hits
   accumulated up to that point when expired. Defaults to no timeout.
+  The timeout is per shard so the overall latency of the search request will depend
+  on the number of shards that participate in the query and the number of shard
+  requests that execute concurrently.
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
@@ -60,11 +60,6 @@ public abstract class AbstractBulkByQueryRestHandler<
         if (conflicts != null) {
             internal.setConflicts(conflicts);
         }
-
-        // Let the requester set search timeout. It is probably only going to be useful for testing but who knows.
-        if (restRequest.hasParam("search_timeout")) {
-            searchRequest.source().timeout(restRequest.paramAsTime("search_timeout", null));
-        }
     }
 
     /**

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_shard_timeout.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/320_shard_timeout.yml
@@ -1,0 +1,36 @@
+setup:
+  - do:
+      index:
+        index: test
+        id: 1
+        body:
+          text: "hello"
+
+  - do:
+      indices.refresh: {}
+
+---
+"timeout deprecation":
+  - skip:
+      version: " - 7.99.99"
+      reason: "Deprecation added in 8.0.0 (change this after backport)"
+      features: ["warnings"]
+
+  - do:
+      warnings:
+        - "Deprecated field [timeout] used, expected [shard_timeout] instead"
+      search:
+        index: test
+        timeout: "10s"
+
+  - match: { hits.total.value: 1 }
+
+  - do:
+      warnings:
+        - "Deprecated field [timeout] used, expected [shard_timeout] instead"
+      search:
+        index: test
+        body:
+          timeout: "10s"
+
+  - match: { hits.total.value: 1 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -101,10 +101,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * An optional timeout to control how long search is allowed to take.
+     * An optional timeout bounding the search on shards to be executed within the specified time
+     * value and bail with the hits accumulated up to that point when expired.
      */
-    public SearchRequestBuilder setTimeout(TimeValue timeout) {
-        sourceBuilder().timeout(timeout);
+    public SearchRequestBuilder setShardTimeout(TimeValue timeout) {
+        sourceBuilder().shardTimeout(timeout);
         return this;
     }
 
@@ -213,7 +214,7 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         sourceBuilder().version(version);
         return this;
     }
-    
+
     /**
      * Should each {@link org.elasticsearch.search.SearchHit} be returned with the
      * sequence number and primary term of the last modification of the document.

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -789,8 +789,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (source.profile()) {
             context.setProfilers(new Profilers(context.searcher()));
         }
-        if (source.timeout() != null) {
-            context.timeout(source.timeout());
+        if (source.shardTimeout() != null) {
+            context.timeout(source.shardTimeout());
         }
         context.terminateAfter(source.terminateAfter());
         if (source.aggregations() != null) {

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -83,7 +83,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     public static final ParseField FROM_FIELD = new ParseField("from");
     public static final ParseField SIZE_FIELD = new ParseField("size");
-    public static final ParseField TIMEOUT_FIELD = new ParseField("timeout");
+    public static final ParseField SHARD_TIMEOUT_FIELD = new ParseField("shard_timeout", "timeout");
     public static final ParseField TERMINATE_AFTER_FIELD = new ParseField("terminate_after");
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField POST_FILTER_FIELD = new ParseField("post_filter");
@@ -163,7 +163,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     private Float minScore;
 
-    private TimeValue timeout = null;
+    private TimeValue shardTimeout = null;
     private int terminateAfter = SearchContext.DEFAULT_TERMINATE_AFTER;
 
     private StoredFieldsContext storedFieldsContext;
@@ -234,7 +234,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         suggestBuilder = in.readOptionalWriteable(SuggestBuilder::new);
         terminateAfter = in.readVInt();
-        timeout = in.readOptionalTimeValue();
+        shardTimeout = in.readOptionalTimeValue();
         trackScores = in.readBoolean();
         version = in.readOptionalBoolean();
         seqNoAndPrimaryTerm = in.readOptionalBoolean();
@@ -288,7 +288,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         }
         out.writeOptionalWriteable(suggestBuilder);
         out.writeVInt(terminateAfter);
-        out.writeOptionalTimeValue(timeout);
+        out.writeOptionalTimeValue(shardTimeout);
         out.writeBoolean(trackScores);
         out.writeOptionalBoolean(version);
         out.writeOptionalBoolean(seqNoAndPrimaryTerm);
@@ -439,16 +439,16 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     /**
      * An optional timeout to control how long search is allowed to take.
      */
-    public SearchSourceBuilder timeout(TimeValue timeout) {
-        this.timeout = timeout;
+    public SearchSourceBuilder shardTimeout(TimeValue timeout) {
+        this.shardTimeout = timeout;
         return this;
     }
 
     /**
      * Gets the timeout to control how long search is allowed to take.
      */
-    public TimeValue timeout() {
-        return timeout;
+    public TimeValue shardTimeout() {
+        return shardTimeout;
     }
 
     /**
@@ -994,7 +994,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         rewrittenBuilder.stats = stats;
         rewrittenBuilder.suggestBuilder = suggestBuilder;
         rewrittenBuilder.terminateAfter = terminateAfter;
-        rewrittenBuilder.timeout = timeout;
+        rewrittenBuilder.shardTimeout = shardTimeout;
         rewrittenBuilder.trackScores = trackScores;
         rewrittenBuilder.trackTotalHitsUpTo = trackTotalHitsUpTo;
         rewrittenBuilder.version = version;
@@ -1030,8 +1030,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     from = parser.intValue();
                 } else if (SIZE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     size = parser.intValue();
-                } else if (TIMEOUT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    timeout = TimeValue.parseTimeValue(parser.text(), null, TIMEOUT_FIELD.getPreferredName());
+                } else if (SHARD_TIMEOUT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    shardTimeout = TimeValue.parseTimeValue(parser.text(), null, SHARD_TIMEOUT_FIELD.getPreferredName());
                 } else if (TERMINATE_AFTER_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     terminateAfter = parser.intValue();
                 } else if (MIN_SCORE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -1183,8 +1183,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             builder.field(SIZE_FIELD.getPreferredName(), size);
         }
 
-        if (timeout != null && !timeout.equals(TimeValue.MINUS_ONE)) {
-            builder.field(TIMEOUT_FIELD.getPreferredName(), timeout.getStringRep());
+        if (shardTimeout != null && !shardTimeout.equals(TimeValue.MINUS_ONE)) {
+            builder.field(SHARD_TIMEOUT_FIELD.getPreferredName(), shardTimeout.getStringRep());
         }
 
         if (terminateAfter != SearchContext.DEFAULT_TERMINATE_AFTER) {
@@ -1528,7 +1528,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public int hashCode() {
         return Objects.hash(aggregations, explain, fetchSourceContext, docValueFields, storedFieldsContext, from, highlightBuilder,
                 indexBoosts, minScore, postQueryBuilder, queryBuilder, rescoreBuilders, scriptFields, size,
-                sorts, searchAfterBuilder, sliceBuilder, stats, suggestBuilder, terminateAfter, timeout, trackScores, version,
+                sorts, searchAfterBuilder, sliceBuilder, stats, suggestBuilder, terminateAfter, shardTimeout, trackScores, version,
                 seqNoAndPrimaryTerm, profile, extBuilders, collapse, trackTotalHitsUpTo);
     }
 
@@ -1561,7 +1561,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 && Objects.equals(stats, other.stats)
                 && Objects.equals(suggestBuilder, other.suggestBuilder)
                 && Objects.equals(terminateAfter, other.terminateAfter)
-                && Objects.equals(timeout, other.timeout)
+                && Objects.equals(shardTimeout, other.shardTimeout)
                 && Objects.equals(trackScores, other.trackScores)
                 && Objects.equals(version, other.version)
                 && Objects.equals(seqNoAndPrimaryTerm, other.seqNoAndPrimaryTerm)

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -375,7 +375,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         }
 
         final long seconds = randomIntBetween(6, 10);
-        searchRequest.source(new SearchSourceBuilder().timeout(TimeValue.timeValueSeconds(seconds)));
+        searchRequest.source(new SearchSourceBuilder().shardTimeout(TimeValue.timeValueSeconds(seconds)));
         final SearchContext context = service.createContext(
                 new ShardSearchRequest(
                         OriginalIndices.NONE,

--- a/server/src/test/java/org/elasticsearch/search/SearchTimeoutIT.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchTimeoutIT.java
@@ -59,7 +59,7 @@ public class SearchTimeoutIT extends ESIntegTestCase {
         }
         refresh("test");
 
-        SearchResponse searchResponse = client().prepareSearch("test").setTimeout(new TimeValue(10, TimeUnit.MILLISECONDS))
+        SearchResponse searchResponse = client().prepareSearch("test").setShardTimeout(new TimeValue(10, TimeUnit.MILLISECONDS))
                 .setQuery(scriptQuery(
                     new Script(ScriptType.INLINE, "mockscript", SCRIPT_NAME, Collections.emptyMap())))
                 .setAllowPartialSearchResults(true)
@@ -71,7 +71,7 @@ public class SearchTimeoutIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
 
         ElasticsearchException ex = expectThrows(ElasticsearchException.class, () ->
-            client().prepareSearch("test").setTimeout(new TimeValue(10, TimeUnit.MILLISECONDS))
+            client().prepareSearch("test").setShardTimeout(new TimeValue(10, TimeUnit.MILLISECONDS))
                 .setQuery(scriptQuery(
                         new Script(ScriptType.INLINE, "mockscript", SCRIPT_NAME, Collections.emptyMap())))
                     .setAllowPartialSearchResults(false) // this line causes timeouts to report failures

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -338,7 +338,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         final String query = "{ \"query\": { \"match_all\": {}}, \"timeout\": \"" + timeout + "\"}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, query)) {
             final SearchSourceBuilder builder = SearchSourceBuilder.fromXContent(parser);
-            assertThat(builder.timeout(), equalTo(TimeValue.parseTimeValue(timeout, null, "timeout")));
+            assertThat(builder.shardTimeout(), equalTo(TimeValue.parseTimeValue(timeout, null, "timeout")));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -335,7 +335,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
 
     public void testTimeoutWithUnits() throws IOException {
         final String timeout = randomTimeValue();
-        final String query = "{ \"query\": { \"match_all\": {}}, \"timeout\": \"" + timeout + "\"}";
+        final String query = "{ \"query\": { \"match_all\": {}}, \"shard_timeout\": \"" + timeout + "\"}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, query)) {
             final SearchSourceBuilder builder = SearchSourceBuilder.fromXContent(parser);
             assertThat(builder.shardTimeout(), equalTo(TimeValue.parseTimeValue(timeout, null, "timeout")));
@@ -344,7 +344,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
 
     public void testTimeoutWithoutUnits() throws IOException {
         final int timeout = randomIntBetween(1, 1024);
-        final String query = "{ \"query\": { \"match_all\": {}}, \"timeout\": \"" + timeout + "\"}";
+        final String query = "{ \"query\": { \"match_all\": {}}, \"shard_timeout\": \"" + timeout + "\"}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, query)) {
             final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SearchSourceBuilder.fromXContent(
                     parser));

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -145,7 +145,7 @@ public class RandomSearchRequestGenerator {
             builder.minScore(randomFloat() * 1000);
         }
         if (randomBoolean()) {
-            builder.timeout(TimeValue.parseTimeValue(randomTimeValue(), null, "timeout"));
+            builder.shardTimeout(TimeValue.parseTimeValue(randomTimeValue(), null, "shard_timeout"));
         }
         if (randomBoolean()) {
             builder.terminateAfter(randomIntBetween(1, 100000));

--- a/test/framework/src/main/java/org/elasticsearch/test/client/RandomizingClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/RandomizingClient.java
@@ -83,7 +83,7 @@ public class RandomizingClient extends FilterClient {
             searchRequestBuilder.setPreFilterShardSize(preFilterShardSize);
         }
         if (doTimeout) {
-            searchRequestBuilder.setTimeout(new TimeValue(1, TimeUnit.DAYS));
+            searchRequestBuilder.setShardTimeout(new TimeValue(1, TimeUnit.DAYS));
         }
         return searchRequestBuilder;
     }

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
@@ -306,7 +306,7 @@ public class TransportGraphExploreAction extends HandledTransportAction<GraphExp
             // Execute the search
             SearchSourceBuilder source = new SearchSourceBuilder().query(rootBool).aggregation(sampleAgg).size(0);
             if (request.timeout() != null) {
-                source.timeout(TimeValue.timeValueMillis(timeRemainingMillis()));
+                source.shardTimeout(TimeValue.timeValueMillis(timeRemainingMillis()));
             }
             searchRequest.source(source);
 
@@ -654,7 +654,7 @@ public class TransportGraphExploreAction extends HandledTransportAction<GraphExp
                     .query(rootBool)
                     .aggregation(rootSampleAgg).size(0);
                 if (request.timeout() != null) {
-                    source.timeout(request.timeout());
+                    source.shardTimeout(request.timeout());
                 }
                 searchRequest.source(source);
                 // System.out.println(source);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredApiKeysRemover.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredApiKeysRemover.java
@@ -54,7 +54,7 @@ public final class ExpiredApiKeysRemover extends AbstractRunnable {
         DeleteByQueryRequest expiredDbq = new DeleteByQueryRequest(RestrictedIndicesNames.SECURITY_MAIN_ALIAS);
         if (timeout != TimeValue.MINUS_ONE) {
             expiredDbq.setTimeout(timeout);
-            expiredDbq.getSearchRequest().source().timeout(timeout);
+            expiredDbq.getSearchRequest().source().shardTimeout(timeout);
         }
         final Instant now = Instant.now();
         expiredDbq

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredTokenRemover.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ExpiredTokenRemover.java
@@ -75,7 +75,7 @@ final class ExpiredTokenRemover extends AbstractRunnable {
         DeleteByQueryRequest expiredDbq = new DeleteByQueryRequest(indicesWithTokens.toArray(new String[0]));
         if (timeout != TimeValue.MINUS_ONE) {
             expiredDbq.setTimeout(timeout);
-            expiredDbq.getSearchRequest().source().timeout(timeout);
+            expiredDbq.getSearchRequest().source().shardTimeout(timeout);
         }
         final Instant now = Instant.now();
         expiredDbq

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -112,7 +112,7 @@ public class Querier {
         SearchSourceBuilder sourceBuilder = SourceGenerator.sourceBuilder(query, filter, size);
         // set query timeout
         if (timeout.getSeconds() > 0) {
-            sourceBuilder.timeout(timeout);
+            sourceBuilder.shardTimeout(timeout);
         }
 
         if (log.isTraceEnabled()) {
@@ -141,16 +141,16 @@ public class Querier {
         client.search(search, l);
     }
 
-    public static SearchRequest prepareRequest(Client client, SearchSourceBuilder source, TimeValue timeout, boolean includeFrozen, 
+    public static SearchRequest prepareRequest(Client client, SearchSourceBuilder source, TimeValue timeout, boolean includeFrozen,
             String... indices) {
         return client.prepareSearch(indices)
                 // always track total hits accurately
-                .setTrackTotalHits(true).setAllowPartialSearchResults(false).setSource(source).setTimeout(timeout)
+                .setTrackTotalHits(true).setAllowPartialSearchResults(false).setSource(source).setShardTimeout(timeout)
                 .setIndicesOptions(
                         includeFrozen ? IndexResolver.FIELD_CAPS_FROZEN_INDICES_OPTIONS : IndexResolver.FIELD_CAPS_INDICES_OPTIONS)
                 .request();
     }
-    
+
     protected static void logSearchResponse(SearchResponse response, Logger logger) {
         List<Aggregation> aggs = Collections.emptyList();
         if (response.getAggregations() != null) {
@@ -160,7 +160,7 @@ public class Querier {
         for (int i = 0; i < aggs.size(); i++) {
             aggsNames.append(aggs.get(i).getName() + (i + 1 == aggs.size() ? "" : ", "));
         }
-        
+
         logger.trace("Got search response [hits {} {}, {} aggregations: [{}], {} failed shards, {} skipped shards, "
                 + "{} successful shards, {} total shards, took {}, timed out [{}]]",
                 response.getHits().getTotalHits().relation.toString(),
@@ -177,7 +177,7 @@ public class Querier {
 
     /**
      * Listener used for local sorting (typically due to aggregations used inside `ORDER BY`).
-     * 
+     *
      * This listener consumes the whole result set, sorts it in memory then sends the paginated
      * results back to the client.
      */
@@ -308,7 +308,7 @@ public class Querier {
             if (log.isTraceEnabled()) {
                 logSearchResponse(response, log);
             }
-            
+
             Aggregations aggs = response.getAggregations();
             if (aggs != null) {
                 Aggregation agg = aggs.get(Aggs.ROOT_GROUP_NAME);


### PR DESCRIPTION
This change deprecates the usage of the `timeout` option in search requests for a more explicit name: `shard_timeout`.
This commit implements the deprecation in order to be able to backport to 7x but the old name
should be removed from master (8.0) in a follow up.
This change also slightly rewrites the documentation around this option to make it clear that the timeout is per shard and not a global one.

Closes #47716