### PR TITLE
Allow x-pack user to manage async-search indices

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/XPackUser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/XPackUser.java
@@ -19,9 +19,15 @@ public class XPackUser extends User {
     public static final String ROLE_NAME = UsernamesField.XPACK_ROLE;
     public static final Role ROLE = Role.builder(new RoleDescriptor(ROLE_NAME, new String[] { "all" },
             new RoleDescriptor.IndicesPrivileges[] {
-                    RoleDescriptor.IndicesPrivileges.builder().indices("/@&~(\\.security.*)/").privileges("all").build(),
+                    RoleDescriptor.IndicesPrivileges.builder()
+                        .indices("/@&~(\\.security.*)/")
+                        .privileges("all")
+                        // true for async-search indices
+                        .allowRestrictedIndices(true)
+                        .build(),
                     RoleDescriptor.IndicesPrivileges.builder().indices(IndexAuditTrailField.INDEX_NAME_PREFIX + "-*")
-                            .privileges("read").build()
+                        .privileges("read")
+                        .build()
             },
             new String[] { "*" },
             MetadataUtils.DEFAULT_RESERVED_METADATA), null).build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/user/XPackUserTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/user/XPackUserTests.java
@@ -28,13 +28,15 @@ public class XPackUserTests extends ESTestCase {
         assertThat(predicate.test(index), Matchers.is(true));
     }
 
-    public void testXPackUserCannotAccessRestrictedIndices() {
+    public void testXPackUserAndRestrictedIndices() {
         final String action = randomFrom(GetAction.NAME, SearchAction.NAME, IndexAction.NAME);
         final Predicate<String> predicate = XPackUser.ROLE.indices().allowedIndicesMatcher(action);
         for (String index : RestrictedIndicesNames.RESTRICTED_NAMES) {
-            assertThat(predicate.test(index), Matchers.is(false));
+            // access should be authorized for async-search indices only
+            boolean authorize = index.startsWith(RestrictedIndicesNames.ASYNC_SEARCH_PREFIX);
+            assertThat(predicate.test(index), Matchers.is(authorize));
         }
-        assertThat(predicate.test(RestrictedIndicesNames.ASYNC_SEARCH_PREFIX + randomAlphaOfLengthBetween(0, 2)), Matchers.is(false));
+        assertThat(predicate.test(RestrictedIndicesNames.ASYNC_SEARCH_PREFIX + randomAlphaOfLengthBetween(0, 2)), Matchers.is(true));
     }
 
     public void testXPackUserCanReadAuditTrail() {


### PR DESCRIPTION
The x-pack user has all privileges on all indices except security indices and restricted indices.
This change adds the authorization for restricted indices in order to allow the system user to manage these indices internally. This will allow the async-search restricted indices to be accessed only with the x-pack user.