### PR TITLE
[ML] Remove stray field from inference processor docs

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -27,8 +27,7 @@ include::common-options.asciidoc[]
     "model_id": "flight_delay_regression-1571767128603",
     "target_field": "FlightDelayMin_prediction_infer",
     "field_mappings": {},
-    "inference_config": { "regression": {} },
-    "model_info_field": "ml"
+    "inference_config": { "regression": {} }
   }
 }
 --------------------------------------------------


### PR DESCRIPTION
The example in the inference processor docs has an extra field that isn't a valid option
```
{
  "inference": {
  .....
    "model_info_field": "ml"       <-- this one
  }
}
```

This removes the invalid field