### PR TITLE
SQL: [Tests] add tests for literals and GROUP BY

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/agg.sql-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.sql-spec
@@ -559,3 +559,9 @@ aggMultiWithHavingUsingInAndNullHandling
 SELECT MIN(salary) min, MAX(salary) max, gender g, COUNT(*) c FROM "test_emp" WHERE languages > 0 GROUP BY g HAVING max IN(74999, null, 74600) ORDER BY gender;
 aggMultiGroupByMultiWithHavingUsingInAndNullHandling
 SELECT MIN(salary) min, MAX(salary) max, gender g, languages l, COUNT(*) c FROM "test_emp" WHERE languages > 0 GROUP BY g, languages HAVING max IN (74500, null, 74600) ORDER BY gender, languages;
+
+// group by with literal
+implicitGroupByWithLiteral
+SELECT 10, MAX("salary") FROM test_emp;
+groupByWithLiteralAndCount
+SELECT 20, COUNT(*) from test_emp GROUP BY gender ORDER BY 2;


### PR DESCRIPTION
Add unit and integration tests where literals are SELECTed
in combination with GROUP BY and aggregate functions.

Relates to issues #41411 and #34583
which have been fixed.
