### PR TITLE
Update ForceMergeAction's BWC constants

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ForceMergeAction.java
@@ -68,7 +68,7 @@ public class ForceMergeAction implements LifecycleAction {
 
     public ForceMergeAction(StreamInput in) throws IOException {
         this.maxNumSegments = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             this.codec = in.readOptionalString();
         } else {
             this.codec = null;
@@ -86,7 +86,7 @@ public class ForceMergeAction implements LifecycleAction {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(maxNumSegments);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeOptionalString(codec);
         }
     }


### PR DESCRIPTION
Once #51819 is merged the `codec` parameter will be available in the 7.x branch. This updates the
version constants so master (8.0) and 7.7 can talk to each other.
