### PR TITLE
Use local checkpoint to calculate min translog gen for recovery

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -10,6 +10,13 @@
       cluster.health:
         wait_for_no_initializing_shards: true
         wait_for_events: languid
+  # Before 8.0, an empty shard has two empty translog files as we used the translog_generation commit tag as the minimum required
+  # translog generation for recovery. Here we force-flush to have a consistent translog stats for both old and new indices.
+  - do:
+      indices.flush:
+        index: test
+        force: true
+        wait_if_ongoing: true
   - do:
       indices.stats:
         metric: [ translog ]
@@ -37,10 +44,9 @@
   - do:
       indices.stats:
         metric: [ translog ]
-  # after flushing we have one empty translog file while an empty index before flushing has two empty translog files.
-  - lt: { indices.test.primaries.translog.size_in_bytes: $creation_size }
+  - match: { indices.test.primaries.translog.size_in_bytes: $creation_size }
   - match: { indices.test.primaries.translog.operations: 0 }
-  - lt: { indices.test.primaries.translog.uncommitted_size_in_bytes: $creation_size }
+  - match: { indices.test.primaries.translog.uncommitted_size_in_bytes: $creation_size }
   - match: { indices.test.primaries.translog.uncommitted_operations: 0 }
 
 ---

--- a/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -123,9 +123,7 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
         assert safeCommit.isDeleted() == false : "The safe commit must not be deleted";
         assert lastCommit.isDeleted() == false : "The last commit must not be deleted";
         final long localCheckpointOfSafeCommit = Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
-        final long localCheckpointOfLastCommit = Long.parseLong(lastCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
         softDeletesPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
-        translogDeletionPolicy.setLocalCheckpointOfLastCommit(localCheckpointOfLastCommit);
         translogDeletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -121,16 +121,12 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
         assert Thread.holdsLock(this);
         logger.debug("Safe commit [{}], last commit [{}]", commitDescription(safeCommit), commitDescription(lastCommit));
         assert safeCommit.isDeleted() == false : "The safe commit must not be deleted";
-        final long minRequiredGen = Long.parseLong(safeCommit.getUserData().get(Translog.TRANSLOG_GENERATION_KEY));
         assert lastCommit.isDeleted() == false : "The last commit must not be deleted";
-        final long lastGen = Long.parseLong(lastCommit.getUserData().get(Translog.TRANSLOG_GENERATION_KEY));
-
-        assert minRequiredGen <= lastGen : "minRequiredGen must not be greater than lastGen";
-        translogDeletionPolicy.setTranslogGenerationOfLastCommit(lastGen);
-        translogDeletionPolicy.setMinTranslogGenerationForRecovery(minRequiredGen);
-
-        softDeletesPolicy.setLocalCheckpointOfSafeCommit(
-            Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)));
+        final long localCheckpointOfSafeCommit = Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        final long localCheckpointOfLastCommit = Long.parseLong(lastCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        softDeletesPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
+        translogDeletionPolicy.setLocalCheckpointOfLastCommit(localCheckpointOfLastCommit);
+        translogDeletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
     }
 
     protected int getDocCountOfCommit(IndexCommit indexCommit) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -474,6 +474,8 @@ public class InternalEngine extends Engine {
         assert pendingTranslogRecovery.get() : "translogRecovery is not pending but should be";
         pendingTranslogRecovery.set(false); // we are good - now we can commit
         if (opsRecovered > 0) {
+            logger.trace("flushing post recovery from translog: ops recovered [{}], current translog generation [{}]",
+                opsRecovered, translog.currentFileGeneration());
             commitIndexWriter(indexWriter, translog);
             refreshLastCommittedSegmentInfos();
             refresh("translog_recovery");

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -385,7 +385,7 @@ public class InternalEngine extends Engine {
         try (ReleasableLock ignored = readLock.acquire()) {
             ensureOpen();
             final long localCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
-            try (Translog.Snapshot snapshot = getTranslog().newSnapshotFromMinSeqNo(localCheckpoint + 1)) {
+            try (Translog.Snapshot snapshot = getTranslog().newSnapshot(localCheckpoint + 1, Long.MAX_VALUE)) {
                 return translogRecoveryRunner.run(this, snapshot);
             }
         }
@@ -458,23 +458,22 @@ public class InternalEngine extends Engine {
     }
 
     private void recoverFromTranslogInternal(TranslogRecoveryRunner translogRecoveryRunner, long recoverUpToSeqNo) throws IOException {
-        Translog.TranslogGeneration translogGeneration = translog.getGeneration();
         final int opsRecovered;
-        final long translogFileGen = Long.parseLong(lastCommittedSegmentInfos.getUserData().get(Translog.TRANSLOG_GENERATION_KEY));
-        try (Translog.Snapshot snapshot = translog.newSnapshotFromGen(
-            new Translog.TranslogGeneration(translog.getTranslogUUID(), translogFileGen), recoverUpToSeqNo)) {
-            opsRecovered = translogRecoveryRunner.run(this, snapshot);
-        } catch (Exception e) {
-            throw new EngineException(shardId, "failed to recover from translog", e);
+        final long localCheckpoint = getProcessedLocalCheckpoint();
+        if (localCheckpoint < recoverUpToSeqNo) {
+            try (Translog.Snapshot snapshot = translog.newSnapshot(localCheckpoint + 1, recoverUpToSeqNo)) {
+                opsRecovered = translogRecoveryRunner.run(this, snapshot);
+            } catch (Exception e) {
+                throw new EngineException(shardId, "failed to recover from translog", e);
+            }
+        } else {
+            opsRecovered = 0;
         }
         // flush if we recovered something or if we have references to older translogs
         // note: if opsRecovered == 0 and we have older translogs it means they are corrupted or 0 length.
         assert pendingTranslogRecovery.get() : "translogRecovery is not pending but should be";
         pendingTranslogRecovery.set(false); // we are good - now we can commit
         if (opsRecovered > 0) {
-            logger.trace("flushing post recovery from translog. ops recovered [{}]. committed translog id [{}]. current id [{}]",
-                opsRecovered, translogGeneration == null ? null :
-                    translogGeneration.translogFileGeneration, translog.currentFileGeneration());
             commitIndexWriter(indexWriter, translog);
             refreshLastCommittedSegmentInfos();
             refresh("translog_recovery");
@@ -486,7 +485,8 @@ public class InternalEngine extends Engine {
                                   LongSupplier globalCheckpointSupplier, LongConsumer persistedSequenceNumberConsumer) throws IOException {
 
         final TranslogConfig translogConfig = engineConfig.getTranslogConfig();
-        final String translogUUID = loadTranslogUUIDFromLastCommit();
+        final Map<String, String> userData = store.readLastCommittedSegmentsInfo().getUserData();
+        final String translogUUID = Objects.requireNonNull(userData.get(Translog.TRANSLOG_UUID_KEY));
         // We expect that this shard already exists, so it must already have an existing translog else something is badly wrong!
         return new Translog(translogConfig, translogUUID, translogDeletionPolicy, globalCheckpointSupplier,
             engineConfig.getPrimaryTermSupplier(), persistedSequenceNumberConsumer);
@@ -549,18 +549,6 @@ public class InternalEngine extends Engine {
     @Override
     public long getWritingBytes() {
         return indexWriter.getFlushingBytes() + versionMap.getRefreshingBytes();
-    }
-
-    /**
-     * Reads the current stored translog ID from the last commit data.
-     */
-    @Nullable
-    private String loadTranslogUUIDFromLastCommit() throws IOException {
-        final Map<String, String> commitUserData = store.readLastCommittedSegmentsInfo().getUserData();
-        if (commitUserData.containsKey(Translog.TRANSLOG_GENERATION_KEY) == false) {
-            throw new IllegalStateException("commit doesn't contain translog generation id");
-        }
-        return commitUserData.get(Translog.TRANSLOG_UUID_KEY);
     }
 
     /**
@@ -1588,8 +1576,10 @@ public class InternalEngine extends Engine {
         if (shouldPeriodicallyFlushAfterBigMerge.get()) {
             return true;
         }
+        final long localCheckpointOfLastCommit =
+            Long.parseLong(lastCommittedSegmentInfos.userData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
         final long translogGenerationOfLastCommit =
-            Long.parseLong(lastCommittedSegmentInfos.userData.get(Translog.TRANSLOG_GENERATION_KEY));
+            translog.getMinGenerationForSeqNo(localCheckpointOfLastCommit + 1).translogFileGeneration;
         final long flushThreshold = config().getIndexSettings().getFlushThresholdSize().getBytes();
         if (translog.sizeInBytesByMinGen(translogGenerationOfLastCommit) < flushThreshold) {
             return false;
@@ -2281,11 +2271,6 @@ public class InternalEngine extends Engine {
         ensureCanFlush();
         try {
             final long localCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
-            final Translog.TranslogGeneration translogGeneration = translog.getMinGenerationForSeqNo(localCheckpoint + 1);
-            final String translogFileGeneration = Long.toString(translogGeneration.translogFileGeneration);
-            final String translogUUID = translogGeneration.translogUUID;
-            final String localCheckpointValue = Long.toString(localCheckpoint);
-
             writer.setLiveCommitData(() -> {
                 /*
                  * The user data captured above (e.g. local checkpoint) contains data that must be evaluated *before* Lucene flushes
@@ -2296,10 +2281,9 @@ public class InternalEngine extends Engine {
                  * {@link IndexWriter#commit()} call flushes all documents, we defer computation of the maximum sequence number to the time
                  * of invocation of the commit data iterator (which occurs after all documents have been flushed to Lucene).
                  */
-                final Map<String, String> commitData = new HashMap<>(7);
-                commitData.put(Translog.TRANSLOG_GENERATION_KEY, translogFileGeneration);
-                commitData.put(Translog.TRANSLOG_UUID_KEY, translogUUID);
-                commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, localCheckpointValue);
+                final Map<String, String> commitData = new HashMap<>(6);
+                commitData.put(Translog.TRANSLOG_UUID_KEY, translog.getTranslogUUID());
+                commitData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(localCheckpoint));
                 commitData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(localCheckpointTracker.getMaxSeqNo()));
                 commitData.put(MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID, Long.toString(maxUnsafeAutoIdTimestamp.get()));
                 commitData.put(HISTORY_UUID_KEY, historyUUID);

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -28,6 +28,7 @@ import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
@@ -137,31 +138,26 @@ public final class NoOpEngine extends ReadOnlyEngine {
         try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             final List<IndexCommit> commits = DirectoryReader.listCommits(store.directory());
-            if (commits.size() == 1) {
+            if (commits.size() == 1 &&
+                translogStats.getUncommittedOperations() == 0 &&
+                translogStats.getTranslogSizeInBytes() > translogStats.getUncommittedSizeInBytes()) {
                 final Map<String, String> commitUserData = getLastCommittedSegmentInfos().getUserData();
                 final String translogUuid = commitUserData.get(Translog.TRANSLOG_UUID_KEY);
                 if (translogUuid == null) {
                     throw new IllegalStateException("commit doesn't contain translog unique id");
                 }
-                if (commitUserData.containsKey(Translog.TRANSLOG_GENERATION_KEY) == false) {
-                    throw new IllegalStateException("commit doesn't contain translog generation id");
-                }
-                final long lastCommitGeneration = Long.parseLong(commitUserData.get(Translog.TRANSLOG_GENERATION_KEY));
                 final TranslogConfig translogConfig = engineConfig.getTranslogConfig();
-                final long minTranslogGeneration = Translog.readMinTranslogGeneration(translogConfig.getTranslogPath(), translogUuid);
-
-                if (minTranslogGeneration < lastCommitGeneration) {
-                    // a translog deletion policy that retains nothing but the last translog generation from safe commit
-                    final TranslogDeletionPolicy translogDeletionPolicy = new TranslogDeletionPolicy();
-                    translogDeletionPolicy.setTranslogGenerationOfLastCommit(lastCommitGeneration);
-                    translogDeletionPolicy.setMinTranslogGenerationForRecovery(lastCommitGeneration);
-
-                    try (Translog translog = new Translog(translogConfig, translogUuid, translogDeletionPolicy,
-                        engineConfig.getGlobalCheckpointSupplier(), engineConfig.getPrimaryTermSupplier(), seqNo -> {})) {
-                        translog.trimUnreferencedReaders();
-                        // refresh the translog stats
-                        this.translogStats = translog.stats();
-                    }
+                final long localCheckpoint = Long.parseLong(commitUserData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+                final TranslogDeletionPolicy translogDeletionPolicy = new TranslogDeletionPolicy();
+                translogDeletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
+                translogDeletionPolicy.setLocalCheckpointOfLastCommit(localCheckpoint);
+                try (Translog translog = new Translog(translogConfig, translogUuid, translogDeletionPolicy,
+                    engineConfig.getGlobalCheckpointSupplier(), engineConfig.getPrimaryTermSupplier(), seqNo -> {})) {
+                    translog.trimUnreferencedReaders();
+                    // refresh the translog stats
+                    this.translogStats = translog.stats();
+                    assert translog.currentFileGeneration() == translog.getMinFileGeneration() : "translog was not trimmed "
+                        + " current gen " + translog.currentFileGeneration() + " != min gen " + translog.getMinFileGeneration();
                 }
             }
         } catch (final Exception e) {

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -150,7 +150,6 @@ public final class NoOpEngine extends ReadOnlyEngine {
                 final long localCheckpoint = Long.parseLong(commitUserData.get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
                 final TranslogDeletionPolicy translogDeletionPolicy = new TranslogDeletionPolicy();
                 translogDeletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
-                translogDeletionPolicy.setLocalCheckpointOfLastCommit(localCheckpoint);
                 try (Translog translog = new Translog(translogConfig, translogUuid, translogDeletionPolicy,
                     engineConfig.getGlobalCheckpointSupplier(), engineConfig.getPrimaryTermSupplier(), seqNo -> {})) {
                     translog.trimUnreferencedReaders();

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -138,9 +138,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
         try (ReleasableLock lock = readLock.acquire()) {
             ensureOpen();
             final List<IndexCommit> commits = DirectoryReader.listCommits(store.directory());
-            if (commits.size() == 1 &&
-                translogStats.getUncommittedOperations() == 0 &&
-                translogStats.getTranslogSizeInBytes() > translogStats.getUncommittedSizeInBytes()) {
+            if (commits.size() == 1 && translogStats.getTranslogSizeInBytes() > translogStats.getUncommittedSizeInBytes()) {
                 final Map<String, String> commitUserData = getLastCommittedSegmentInfos().getUserData();
                 final String translogUuid = commitUserData.get(Translog.TRANSLOG_UUID_KEY);
                 if (translogUuid == null) {

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -220,11 +220,10 @@ public class ReadOnlyEngine extends Engine {
         if (translogUuid == null) {
             throw new IllegalStateException("commit doesn't contain translog unique id");
         }
-        final long translogGenOfLastCommit = Long.parseLong(infos.getUserData().get(Translog.TRANSLOG_GENERATION_KEY));
         final TranslogConfig translogConfig = config.getTranslogConfig();
         final TranslogDeletionPolicy translogDeletionPolicy = new TranslogDeletionPolicy();
-        translogDeletionPolicy.setTranslogGenerationOfLastCommit(translogGenOfLastCommit);
-
+        final long localCheckpoint = Long.parseLong(infos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
+        translogDeletionPolicy.setLocalCheckpointOfLastCommit(localCheckpoint);
         try (Translog translog = new Translog(translogConfig, translogUuid, translogDeletionPolicy, config.getGlobalCheckpointSupplier(),
                 config.getPrimaryTermSupplier(), seqNo -> {})
         ) {

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -223,7 +223,7 @@ public class ReadOnlyEngine extends Engine {
         final TranslogConfig translogConfig = config.getTranslogConfig();
         final TranslogDeletionPolicy translogDeletionPolicy = new TranslogDeletionPolicy();
         final long localCheckpoint = Long.parseLong(infos.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
-        translogDeletionPolicy.setLocalCheckpointOfLastCommit(localCheckpoint);
+        translogDeletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
         try (Translog translog = new Translog(translogConfig, translogUuid, translogDeletionPolicy, config.getGlobalCheckpointSupplier(),
                 config.getPrimaryTermSupplier(), seqNo -> {})
         ) {

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1449,10 +1449,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
             if (translogUUID.equals(getUserData(writer).get(Translog.TRANSLOG_UUID_KEY))) {
                 throw new IllegalArgumentException("a new translog uuid can't be equal to existing one. got [" + translogUUID + "]");
             }
-            final Map<String, String> map = new HashMap<>();
-            map.put(Translog.TRANSLOG_GENERATION_KEY, "1");
-            map.put(Translog.TRANSLOG_UUID_KEY, translogUUID);
-            updateCommitData(writer, map);
+            updateCommitData(writer, Map.of(Translog.TRANSLOG_UUID_KEY, translogUUID));
         } finally {
             metadataLock.writeLock().unlock();
         }

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -843,7 +843,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     public TranslogStats stats() {
         // acquire lock to make the two numbers roughly consistent (no file change half way)
         try (ReleasableLock lock = readLock.acquire()) {
-            final long uncommittedGen = minGenerationForSeqNo(deletionPolicy.getLocalCheckpointOfLastCommit() + 1, current, readers);
+            final long uncommittedGen = minGenerationForSeqNo(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, current, readers);
             return new TranslogStats(totalOperations(), sizeInBytes(), totalOperationsByMinGen(uncommittedGen),
                 sizeInBytesByMinGen(uncommittedGen), earliestLastModifiedAge());
         }

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -74,9 +74,7 @@ import java.util.stream.Stream;
 
 /**
  * A Translog is a per index shard component that records all non-committed index operations in a durable manner.
- * In Elasticsearch there is one Translog instance per {@link org.elasticsearch.index.engine.InternalEngine}. The engine
- * records the current translog generation {@link Translog#getGeneration()} in it's commit metadata using {@link #TRANSLOG_GENERATION_KEY}
- * to reference the generation that contains all operations that have not yet successfully been committed to the engines lucene index.
+ * In Elasticsearch there is one Translog instance per {@link org.elasticsearch.index.engine.InternalEngine}.
  * Additionally, since Elasticsearch 2.0 the engine also records a {@link #TRANSLOG_UUID_KEY} with each commit to ensure a strong
  * association between the lucene index an the transaction log file. This UUID is used to prevent accidental recovery from a transaction
  * log that belongs to a
@@ -107,7 +105,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      *  - we need to page align the last write before we sync, we can take advantage of ensureSynced for this since we might have already
      *    fsynced far enough
      */
-    public static final String TRANSLOG_GENERATION_KEY = "translog_generation";
     public static final String TRANSLOG_UUID_KEY = "translog_uuid";
     public static final String TRANSLOG_FILE_PREFIX = "translog-";
     public static final String TRANSLOG_FILE_SUFFIX = ".tlog";
@@ -602,33 +599,28 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         }
     }
 
-    /**
-     * Snapshots the current transaction log allowing to safely iterate over the snapshot.
-     * Snapshots are fixed in time and will not be updated with future operations.
-     */
+    // for testing
     public Snapshot newSnapshot() throws IOException {
-        try (ReleasableLock ignored = readLock.acquire()) {
-            return newSnapshotFromGen(new TranslogGeneration(translogUUID, getMinFileGeneration()), Long.MAX_VALUE);
-        }
+        return newSnapshot(0, Long.MAX_VALUE);
     }
 
-    public Snapshot newSnapshotFromGen(TranslogGeneration fromGeneration, long upToSeqNo) throws IOException {
+    /**
+     * Creates a new translog snapshot containing operations from the given range.
+     *
+     * @param fromSeqNo the lower bound of the range (inclusive)
+     * @param toSeqNo   the upper bound of the range (inclusive)
+     * @return the new snapshot
+     */
+    public Snapshot newSnapshot(long fromSeqNo, long toSeqNo) throws IOException {
+        assert fromSeqNo <= toSeqNo : fromSeqNo + " > " + toSeqNo;
+        assert fromSeqNo >= 0 : "from_seq_no must be non-negative " + fromSeqNo;
         try (ReleasableLock ignored = readLock.acquire()) {
             ensureOpen();
-            final long fromFileGen = fromGeneration.translogFileGeneration;
-            if (fromFileGen < getMinFileGeneration()) {
-                throw new IllegalArgumentException("requested snapshot generation [" + fromFileGen + "] is not available. " +
-                    "Min referenced generation is [" + getMinFileGeneration() + "]");
-            }
             TranslogSnapshot[] snapshots = Stream.concat(readers.stream(), Stream.of(current))
-                .filter(reader -> reader.getGeneration() >= fromFileGen && reader.getCheckpoint().minSeqNo <= upToSeqNo)
+                .filter(reader -> reader.getCheckpoint().minSeqNo <= toSeqNo && fromSeqNo <= reader.getCheckpoint().maxEffectiveSeqNo())
                 .map(BaseTranslogReader::newSnapshot).toArray(TranslogSnapshot[]::new);
             final Snapshot snapshot = newMultiSnapshot(snapshots);
-            if (upToSeqNo == Long.MAX_VALUE) {
-                return snapshot;
-            } else {
-                return new SeqNoFilterSnapshot(snapshot, Long.MIN_VALUE, upToSeqNo);
-            }
+            return new SeqNoFilterSnapshot(snapshot, fromSeqNo, toSeqNo);
         }
     }
 
@@ -660,15 +652,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             throw ex;
         }
         return null;
-    }
-
-    public Snapshot newSnapshotFromMinSeqNo(long minSeqNo) throws IOException {
-        try (ReleasableLock ignored = readLock.acquire()) {
-            ensureOpen();
-            TranslogSnapshot[] snapshots = readersAboveMinSeqNo(minSeqNo).map(BaseTranslogReader::newSnapshot)
-                .toArray(TranslogSnapshot[]::new);
-            return newMultiSnapshot(snapshots);
-        }
     }
 
     private Snapshot newMultiSnapshot(TranslogSnapshot[] snapshots) throws IOException {
@@ -860,7 +843,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
     public TranslogStats stats() {
         // acquire lock to make the two numbers roughly consistent (no file change half way)
         try (ReleasableLock lock = readLock.acquire()) {
-            final long uncommittedGen = deletionPolicy.getTranslogGenerationOfLastCommit();
+            final long uncommittedGen = minGenerationForSeqNo(deletionPolicy.getLocalCheckpointOfLastCommit() + 1, current, readers);
             return new TranslogStats(totalOperations(), sizeInBytes(), totalOperationsByMinGen(uncommittedGen),
                 sizeInBytesByMinGen(uncommittedGen), earliestLastModifiedAge());
         }
@@ -961,7 +944,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * shares the same underlying resources with the {@code delegate} snapshot, therefore we should not
      * use the {@code delegate} after passing it to this filtered snapshot.
      */
-    static final class SeqNoFilterSnapshot implements Snapshot {
+    private static final class SeqNoFilterSnapshot implements Snapshot {
         private final Snapshot delegate;
         private int filteredOpsCount;
         private final long fromSeqNo; // inclusive
@@ -1617,20 +1600,18 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      */
     public TranslogGeneration getMinGenerationForSeqNo(final long seqNo) {
         try (ReleasableLock ignored = readLock.acquire()) {
-            /*
-             * When flushing, the engine will ask the translog for the minimum generation that could contain any sequence number after the
-             * local checkpoint. Immediately after flushing, there will be no such generation, so this minimum generation in this case will
-             * be the current translog generation as we do not need any prior generations to have a complete history up to the current local
-             * checkpoint.
-             */
-            long minTranslogFileGeneration = this.currentFileGeneration();
-            for (final TranslogReader reader : readers) {
-                if (seqNo <= reader.getCheckpoint().maxEffectiveSeqNo()) {
-                    minTranslogFileGeneration = Math.min(minTranslogFileGeneration, reader.getGeneration());
-                }
-            }
-            return new TranslogGeneration(translogUUID, minTranslogFileGeneration);
+            return new TranslogGeneration(translogUUID, minGenerationForSeqNo(seqNo, current, readers));
         }
+    }
+
+    private static long minGenerationForSeqNo(long seqNo, TranslogWriter writer, List<TranslogReader> readers) {
+        long minGen = writer.generation;
+        for (final TranslogReader reader : readers) {
+            if (seqNo <= reader.getCheckpoint().maxEffectiveSeqNo()) {
+                minGen = Math.min(minGen, reader.getGeneration());
+            }
+        }
+        return minGen;
     }
 
     /**
@@ -1672,7 +1653,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 // we're shutdown potentially on some tragic event, don't delete anything
                 return;
             }
-            long minReferencedGen = deletionPolicy.minTranslogGenRequired();
+            long minReferencedGen = Math.min(
+                deletionPolicy.getMinTranslogGenRequiredByLocks(),
+                minGenerationForSeqNo(deletionPolicy.getLocalCheckpointOfSafeCommit() + 1, current, readers));
             assert minReferencedGen >= getMinFileGeneration() :
                 "deletion policy requires a minReferenceGen of [" + minReferencedGen + "] but the lowest gen available is ["
                     + getMinFileGeneration() + "]";
@@ -1801,20 +1784,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             throw new TranslogCorruptedException(location.toString(), ex);
         }
         return checkpoint;
-    }
-
-    /**
-     * Returns the minimum translog generation retained by the translog at the given location.
-     * This ensures that the translogUUID from this translog matches with the provided translogUUID.
-     *
-     * @param location the location of the translog
-     * @return the minimum translog generation
-     * @throws IOException                if an I/O exception occurred reading the checkpoint
-     * @throws TranslogCorruptedException if the translog is corrupted or mismatched with the given uuid
-     */
-    public static long readMinTranslogGeneration(final Path location, final String expectedTranslogUUID) throws IOException {
-        final Checkpoint checkpoint = readCheckpoint(location, expectedTranslogUUID);
-        return checkpoint.minTranslogGeneration;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.translog;
 import org.apache.lucene.util.Counter;
 import org.elasticsearch.Assertions;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,17 +46,8 @@ public final class TranslogDeletionPolicy {
      * translog generation
      */
     private final Map<Long, Counter> translogRefCounts = new HashMap<>();
-
-    /**
-     * the translog generation that is requires to properly recover from the oldest non deleted
-     * {@link org.apache.lucene.index.IndexCommit}.
-     */
-    private long minTranslogGenerationForRecovery = 1;
-
-    /**
-     * This translog generation is used to calculate the number of uncommitted operations since the last index commit.
-     */
-    private long translogGenerationOfLastCommit = 1;
+    private long localCheckpointOfSafeCommit = SequenceNumbers.NO_OPS_PERFORMED;
+    private long localCheckpointOfLastCommit = SequenceNumbers.NO_OPS_PERFORMED;
 
 
     public TranslogDeletionPolicy() {
@@ -66,23 +58,20 @@ public final class TranslogDeletionPolicy {
         }
     }
 
-    public synchronized void setMinTranslogGenerationForRecovery(long newGen) {
-        if (newGen < minTranslogGenerationForRecovery || newGen > translogGenerationOfLastCommit) {
-            throw new IllegalArgumentException("Invalid minTranslogGenerationForRecovery can't go backwards; new [" + newGen + "]," +
-                "current [" + minTranslogGenerationForRecovery + "], lastGen [" + translogGenerationOfLastCommit + "]");
+    public synchronized void setLocalCheckpointOfSafeCommit(long newCheckpoint) {
+        if (newCheckpoint < this.localCheckpointOfSafeCommit) {
+            throw new IllegalArgumentException("local checkpoint of the safe commit can't go backwards: " +
+                "current [" + this.localCheckpointOfSafeCommit + "] new [" + newCheckpoint + "]");
         }
-        minTranslogGenerationForRecovery = newGen;
+        this.localCheckpointOfSafeCommit = newCheckpoint;
     }
 
-    /**
-     * Sets the translog generation of the last index commit.
-     */
-    public synchronized void setTranslogGenerationOfLastCommit(long lastGen) {
-        if (lastGen < translogGenerationOfLastCommit || lastGen < minTranslogGenerationForRecovery) {
-            throw new IllegalArgumentException("Invalid translogGenerationOfLastCommit; new [" + lastGen + "]," +
-                "current [" + translogGenerationOfLastCommit + "], minRequiredGen [" + minTranslogGenerationForRecovery + "]");
+    public synchronized void setLocalCheckpointOfLastCommit(long newCheckpoint) {
+        if (newCheckpoint < this.localCheckpointOfLastCommit) {
+            throw new IllegalArgumentException("local checkpoint of the last commit can't go backwards: " +
+                "current [" + this.localCheckpointOfLastCommit + "] new [" + newCheckpoint + "]");
         }
-        translogGenerationOfLastCommit = lastGen;
+        this.localCheckpointOfLastCommit = newCheckpoint;
     }
 
     /**
@@ -132,27 +121,24 @@ public final class TranslogDeletionPolicy {
     }
 
     /**
-     * returns the minimum translog generation that is still required by the system. Any generation below
-     * the returned value may be safely deleted
+     * Returns the minimum translog generation that is still required by the locks (via {@link #acquireTranslogGen(long)}.
      */
-    synchronized long minTranslogGenRequired() {
-        return Math.min(getMinTranslogGenRequiredByLocks(), minTranslogGenerationForRecovery);
-    }
-
-    private long getMinTranslogGenRequiredByLocks() {
+    synchronized long getMinTranslogGenRequiredByLocks() {
         return translogRefCounts.keySet().stream().reduce(Math::min).orElse(Long.MAX_VALUE);
     }
 
-    /** returns the translog generation that will be used as a basis of a future store/peer recovery */
-    public synchronized long getMinTranslogGenerationForRecovery() {
-        return minTranslogGenerationForRecovery;
+    /**
+     * Returns the local checkpoint of the safe commit. This value is used to calculate the min required generation for recovery.
+     */
+    public synchronized long getLocalCheckpointOfSafeCommit() {
+        return localCheckpointOfSafeCommit;
     }
 
     /**
-     * Returns a translog generation that will be used to calculate the number of uncommitted operations since the last index commit.
+     * Returns the local checkpoint of the last commit. This value is used to calculate the translog stats.
      */
-    public synchronized long getTranslogGenerationOfLastCommit() {
-        return translogGenerationOfLastCommit;
+    public synchronized long getLocalCheckpointOfLastCommit() {
+        return localCheckpointOfLastCommit;
     }
 
     synchronized long getTranslogRefCount(long gen) {

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
@@ -47,7 +47,6 @@ public final class TranslogDeletionPolicy {
      */
     private final Map<Long, Counter> translogRefCounts = new HashMap<>();
     private long localCheckpointOfSafeCommit = SequenceNumbers.NO_OPS_PERFORMED;
-    private long localCheckpointOfLastCommit = SequenceNumbers.NO_OPS_PERFORMED;
 
 
     public TranslogDeletionPolicy() {
@@ -64,14 +63,6 @@ public final class TranslogDeletionPolicy {
                 "current [" + this.localCheckpointOfSafeCommit + "] new [" + newCheckpoint + "]");
         }
         this.localCheckpointOfSafeCommit = newCheckpoint;
-    }
-
-    public synchronized void setLocalCheckpointOfLastCommit(long newCheckpoint) {
-        if (newCheckpoint < this.localCheckpointOfLastCommit) {
-            throw new IllegalArgumentException("local checkpoint of the last commit can't go backwards: " +
-                "current [" + this.localCheckpointOfLastCommit + "] new [" + newCheckpoint + "]");
-        }
-        this.localCheckpointOfLastCommit = newCheckpoint;
     }
 
     /**
@@ -134,12 +125,6 @@ public final class TranslogDeletionPolicy {
         return localCheckpointOfSafeCommit;
     }
 
-    /**
-     * Returns the local checkpoint of the last commit. This value is used to calculate the translog stats.
-     */
-    public synchronized long getLocalCheckpointOfLastCommit() {
-        return localCheckpointOfLastCommit;
-    }
 
     synchronized long getTranslogRefCount(long gen) {
         final Counter counter = translogRefCounts.get(gen);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -124,7 +124,6 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
             assertNotNull(commitStats);
             assertThat(commitStats.getGeneration(), greaterThan(0L));
             assertThat(commitStats.getId(), notNullValue());
-            assertThat(commitStats.getUserData(), hasKey(Translog.TRANSLOG_GENERATION_KEY));
             assertThat(commitStats.getUserData(), hasKey(Translog.TRANSLOG_UUID_KEY));
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -42,10 +42,8 @@ import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -386,8 +384,6 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
             .put(TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING.getKey(), "100ms")
             .build());
         Translog translog = IndexShardTestCase.getTranslog(indexService.getShard(0));
-        final Path translogPath = translog.getConfig().getTranslogPath();
-        final String translogUuid = translog.getTranslogUUID();
 
         int translogOps = 0;
         final int numDocs = scaledRandomIntBetween(10, 100);
@@ -408,15 +404,9 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(indexService.index());
         assertTrue(indexService.getTrimTranslogTask().mustReschedule());
 
-        final long lastCommitedTranslogGeneration;
-        try (Engine.IndexCommitRef indexCommitRef = getEngine(indexService.getShard(0)).acquireLastIndexCommit(false)) {
-            Map<String, String> lastCommittedUserData = indexCommitRef.getIndexCommit().getUserData();
-            lastCommitedTranslogGeneration = Long.parseLong(lastCommittedUserData.get(Translog.TRANSLOG_GENERATION_KEY));
-        }
-        assertBusy(() -> {
-            long minTranslogGen = Translog.readMinTranslogGeneration(translogPath, translogUuid);
-            assertThat(minTranslogGen, equalTo(lastCommitedTranslogGeneration));
-        });
+        final Engine readOnlyEngine = getEngine(indexService.getShard(0));
+        assertBusy(() ->
+            assertThat(readOnlyEngine.getTranslogStats().getTranslogSizeInBytes(), equalTo((long) Translog.DEFAULT_HEADER_SIZE_IN_BYTES)));
 
         assertAcked(client().admin().indices().prepareOpen("test"));
 
@@ -424,6 +414,8 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         translog = IndexShardTestCase.getTranslog(indexService.getShard(0));
         assertThat(translog.totalOperations(), equalTo(0));
         assertThat(translog.stats().estimatedNumberOfOperations(), equalTo(0));
+        assertThat(getEngine(indexService.getShard(0)).getTranslogStats().getTranslogSizeInBytes(),
+            equalTo((long) Translog.DEFAULT_HEADER_SIZE_IN_BYTES));
     }
 
     public void testIllegalFsyncInterval() {

--- a/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
@@ -84,7 +84,6 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             }
         }
         assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(keptIndex))));
-        assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
         assertThat(softDeletesPolicy.getMinRetainedSeqNo(),
             equalTo(Math.max(NO_OPS_PERFORMED,
                 Math.min(getLocalCheckpoint(commitList.get(keptIndex)) + 1, globalCheckpoint.get() + 1 - extraRetainedOps))));
@@ -149,7 +148,6 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             snapshottingCommits.forEach(snapshot -> assertThat(snapshot.isDeleted(), equalTo(false)));
             // We don't need to retain translog for snapshotting commits.
             assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(safeIndex))));
-            assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
             assertThat(softDeletesPolicy.getMinRetainedSeqNo(), equalTo(
                 Math.max(NO_OPS_PERFORMED,
                     Math.min(getLocalCheckpoint(commitList.get(safeIndex)) + 1, globalCheckpoint.get() + 1 - extraRetainedOps))));
@@ -163,7 +161,6 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         }
         assertThat(commitList.get(commitList.size() - 1).isDeleted(), equalTo(false));
         assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
-        assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
         IndexCommit safeCommit = CombinedDeletionPolicy.findSafeCommitPoint(commitList, globalCheckpoint.get());
         assertThat(softDeletesPolicy.getMinRetainedSeqNo(), equalTo(
             Math.max(NO_OPS_PERFORMED, Math.min(getLocalCheckpoint(safeCommit) + 1, globalCheckpoint.get() + 1 - extraRetainedOps))));
@@ -224,7 +221,6 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         if (safeCommitIndex == commitList.size() - 1) {
             // Safe commit is the last commit - no need to clean up
             assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
-            assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
             assertThat(indexPolicy.hasUnreferencedCommits(), equalTo(false));
         } else {
             // Advanced but not enough for any commit after the safe commit becomes safe
@@ -242,7 +238,6 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             indexPolicy.onCommit(commitList);
             // Safe commit is the last commit - no need to clean up
             assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
-            assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
             assertThat(indexPolicy.hasUnreferencedCommits(), equalTo(false));
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
@@ -57,20 +57,16 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         CombinedDeletionPolicy indexPolicy = newCombinedDeletionPolicy(translogPolicy, softDeletesPolicy, globalCheckpoint);
 
         final LongArrayList maxSeqNoList = new LongArrayList();
-        final LongArrayList translogGenList = new LongArrayList();
         final List<IndexCommit> commitList = new ArrayList<>();
         int totalCommits = between(2, 20);
         long lastMaxSeqNo = 0;
         long lastCheckpoint = lastMaxSeqNo;
-        long lastTranslogGen = 0;
         final UUID translogUUID = UUID.randomUUID();
         for (int i = 0; i < totalCommits; i++) {
             lastMaxSeqNo += between(1, 10000);
             lastCheckpoint = randomLongBetween(lastCheckpoint, lastMaxSeqNo);
-            lastTranslogGen += between(1, 100);
-            commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, translogUUID, lastTranslogGen));
+            commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, translogUUID));
             maxSeqNoList.add(lastMaxSeqNo);
-            translogGenList.add(lastTranslogGen);
         }
 
         int keptIndex = randomInt(commitList.size() - 1);
@@ -87,8 +83,8 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
                 verify(commitList.get(i), never()).delete();
             }
         }
-        assertThat(translogPolicy.getMinTranslogGenerationForRecovery(), equalTo(translogGenList.get(keptIndex)));
-        assertThat(translogPolicy.getTranslogGenerationOfLastCommit(), equalTo(lastTranslogGen));
+        assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(keptIndex))));
+        assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
         assertThat(softDeletesPolicy.getMinRetainedSeqNo(),
             equalTo(Math.max(NO_OPS_PERFORMED,
                 Math.min(getLocalCheckpoint(commitList.get(keptIndex)) + 1, globalCheckpoint.get() + 1 - extraRetainedOps))));
@@ -104,7 +100,6 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         CombinedDeletionPolicy indexPolicy = newCombinedDeletionPolicy(translogPolicy, softDeletesPolicy, globalCheckpoint);
         long lastMaxSeqNo = between(1, 1000);
         long lastCheckpoint = randomLongBetween(-1, lastMaxSeqNo);
-        long lastTranslogGen = between(1, 20);
         int safeIndex = 0;
         List<IndexCommit> commitList = new ArrayList<>();
         List<IndexCommit> snapshottingCommits = new ArrayList<>();
@@ -114,8 +109,7 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             for (int n = 0; n < newCommits; n++) {
                 lastMaxSeqNo += between(1, 1000);
                 lastCheckpoint = randomLongBetween(lastCheckpoint, lastMaxSeqNo);
-                lastTranslogGen += between(1, 20);
-                commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, translogUUID, lastTranslogGen));
+                commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, translogUUID));
             }
             // Advance the global checkpoint to between [safeIndex, safeIndex + 1)
             safeIndex = randomIntBetween(safeIndex, commitList.size() - 1);
@@ -154,10 +148,8 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             // Snapshotting commits must not be deleted.
             snapshottingCommits.forEach(snapshot -> assertThat(snapshot.isDeleted(), equalTo(false)));
             // We don't need to retain translog for snapshotting commits.
-            assertThat(translogPolicy.getMinTranslogGenerationForRecovery(),
-                equalTo(Long.parseLong(commitList.get(safeIndex).getUserData().get(Translog.TRANSLOG_GENERATION_KEY))));
-            assertThat(translogPolicy.getTranslogGenerationOfLastCommit(),
-                equalTo(Long.parseLong(commitList.get(commitList.size() - 1).getUserData().get(Translog.TRANSLOG_GENERATION_KEY))));
+            assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(safeIndex))));
+            assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
             assertThat(softDeletesPolicy.getMinRetainedSeqNo(), equalTo(
                 Math.max(NO_OPS_PERFORMED,
                     Math.min(getLocalCheckpoint(commitList.get(safeIndex)) + 1, globalCheckpoint.get() + 1 - extraRetainedOps))));
@@ -170,8 +162,8 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             assertThat(commitList.get(i).isDeleted(), equalTo(true));
         }
         assertThat(commitList.get(commitList.size() - 1).isDeleted(), equalTo(false));
-        assertThat(translogPolicy.getMinTranslogGenerationForRecovery(), equalTo(lastTranslogGen));
-        assertThat(translogPolicy.getTranslogGenerationOfLastCommit(), equalTo(lastTranslogGen));
+        assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
+        assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
         IndexCommit safeCommit = CombinedDeletionPolicy.findSafeCommitPoint(commitList, globalCheckpoint.get());
         assertThat(softDeletesPolicy.getMinRetainedSeqNo(), equalTo(
             Math.max(NO_OPS_PERFORMED, Math.min(getLocalCheckpoint(safeCommit) + 1, globalCheckpoint.get() + 1 - extraRetainedOps))));
@@ -187,19 +179,17 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         final List<IndexCommit> commitList = new ArrayList<>();
         for (int i = 0; i < invalidCommits; i++) {
             long maxSeqNo = randomNonNegativeLong();
-            commitList.add(mockIndexCommit(randomLongBetween(-1, maxSeqNo), maxSeqNo, UUID.randomUUID(), randomNonNegativeLong()));
+            commitList.add(mockIndexCommit(randomLongBetween(-1, maxSeqNo), maxSeqNo, UUID.randomUUID()));
         }
 
         final UUID expectedTranslogUUID = UUID.randomUUID();
-        long lastTranslogGen = 0;
         final int validCommits = between(1, 10);
         long lastMaxSeqNo = between(1, 1000);
         long lastCheckpoint = randomLongBetween(-1, lastMaxSeqNo);
         for (int i = 0; i < validCommits; i++) {
-            lastTranslogGen += between(1, 1000);
             lastMaxSeqNo += between(1, 1000);
             lastCheckpoint = randomLongBetween(lastCheckpoint, lastMaxSeqNo);
-            commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, expectedTranslogUUID, lastTranslogGen));
+            commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, expectedTranslogUUID));
         }
 
         // We should never keep invalid commits regardless of the value of the global checkpoint.
@@ -221,12 +211,10 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         int totalCommits = between(2, 20);
         long lastMaxSeqNo = between(1, 1000);
         long lastCheckpoint = randomLongBetween(-1, lastMaxSeqNo);
-        long lastTranslogGen = between(1, 50);
         for (int i = 0; i < totalCommits; i++) {
             lastMaxSeqNo += between(1, 10000);
-            lastTranslogGen += between(1, 100);
             lastCheckpoint = randomLongBetween(lastCheckpoint, lastMaxSeqNo);
-            commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, translogUUID, lastTranslogGen));
+            commitList.add(mockIndexCommit(lastCheckpoint, lastMaxSeqNo, translogUUID));
         }
         int safeCommitIndex = randomIntBetween(0, commitList.size() - 1);
         globalCheckpoint.set(Long.parseLong(commitList.get(safeCommitIndex).getUserData().get(SequenceNumbers.MAX_SEQ_NO)));
@@ -235,8 +223,8 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
 
         if (safeCommitIndex == commitList.size() - 1) {
             // Safe commit is the last commit - no need to clean up
-            assertThat(translogPolicy.getMinTranslogGenerationForRecovery(), equalTo(lastTranslogGen));
-            assertThat(translogPolicy.getTranslogGenerationOfLastCommit(), equalTo(lastTranslogGen));
+            assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
+            assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
             assertThat(indexPolicy.hasUnreferencedCommits(), equalTo(false));
         } else {
             // Advanced but not enough for any commit after the safe commit becomes safe
@@ -253,8 +241,8 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             commitList.forEach(this::resetDeletion);
             indexPolicy.onCommit(commitList);
             // Safe commit is the last commit - no need to clean up
-            assertThat(translogPolicy.getMinTranslogGenerationForRecovery(), equalTo(lastTranslogGen));
-            assertThat(translogPolicy.getTranslogGenerationOfLastCommit(), equalTo(lastTranslogGen));
+            assertThat(translogPolicy.getLocalCheckpointOfSafeCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
+            assertThat(translogPolicy.getLocalCheckpointOfLastCommit(), equalTo(getLocalCheckpoint(commitList.get(commitList.size() - 1))));
             assertThat(indexPolicy.hasUnreferencedCommits(), equalTo(false));
         }
     }
@@ -270,12 +258,11 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         };
     }
 
-    IndexCommit mockIndexCommit(long localCheckpoint, long maxSeqNo, UUID translogUUID, long translogGen) throws IOException {
+    IndexCommit mockIndexCommit(long localCheckpoint, long maxSeqNo, UUID translogUUID) throws IOException {
         final Map<String, String> userData = new HashMap<>();
         userData.put(SequenceNumbers.LOCAL_CHECKPOINT_KEY, Long.toString(localCheckpoint));
         userData.put(SequenceNumbers.MAX_SEQ_NO, Long.toString(maxSeqNo));
         userData.put(Translog.TRANSLOG_UUID_KEY, translogUUID.toString());
-        userData.put(Translog.TRANSLOG_GENERATION_KEY, Long.toString(translogGen));
         final IndexCommit commit = mock(IndexCommit.class);
         final Directory directory = mock(Directory.class);
         when(commit.getUserData()).thenReturn(userData);

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -5652,8 +5652,8 @@ public class InternalEngineTests extends EngineTestCase {
                 for (Engine.Operation op : operations) {
                     applyOperation(engine, op);
                     if (randomBoolean()) {
-                        globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getProcessedLocalCheckpoint()));
                         engine.syncTranslog();
+                        globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getPersistedLocalCheckpoint()));
                     }
                     if (randomInt(100) < 10) {
                         engine.refresh("test");

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -36,14 +36,12 @@ import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
-import org.elasticsearch.index.translog.TranslogDeletionPolicy;
 import org.elasticsearch.test.IndexSettingsModule;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -130,7 +128,7 @@ public class NoOpEngineTests extends EngineTestCase {
                     }
                 }
                 engine.getLocalCheckpointTracker().waitForProcessedOpsToComplete(numDocs + deletions - 1);
-                flushAndTrimTranslog(engine);
+                engine.flush(true, true);
             }
 
             final DocsStats expectedDocStats;
@@ -168,7 +166,6 @@ public class NoOpEngineTests extends EngineTestCase {
         tracker.updateFromMaster(1L, Collections.singleton(allocationId.getId()), table);
         tracker.activatePrimaryMode(SequenceNumbers.NO_OPS_PERFORMED);
 
-        boolean softDeleteEnabled = engine.config().getIndexSettings().isSoftDeleteEnabled();
         final int numDocs = scaledRandomIntBetween(10, 3000);
         for (int i = 0; i < numDocs; i++) {
             engine.index(indexForDoc(createParsedDoc(Integer.toString(i), null)));
@@ -176,41 +173,21 @@ public class NoOpEngineTests extends EngineTestCase {
             if (rarely()) {
                 engine.flush();
             }
+            if (randomBoolean()) {
+                engine.rollTranslogGeneration();
+            }
         }
+        // prevent translog from trimming so we can test trimUnreferencedFiles in NoOpEngine.
+        final Translog.Snapshot snapshot = engine.getTranslog().newSnapshot();
         engine.flush(true, true);
-
-        final String translogUuid = engine.getTranslog().getTranslogUUID();
-        final long minFileGeneration = engine.getTranslog().getMinFileGeneration();
-        final long currentFileGeneration = engine.getTranslog().currentFileGeneration();
         engine.close();
 
         final NoOpEngine noOpEngine = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir, tracker));
-        final Path translogPath = noOpEngine.config().getTranslogConfig().getTranslogPath();
-
-        final long lastCommitedTranslogGeneration;
-        try (Engine.IndexCommitRef indexCommitRef = noOpEngine.acquireLastIndexCommit(false)) {
-            Map<String, String> lastCommittedUserData = indexCommitRef.getIndexCommit().getUserData();
-            lastCommitedTranslogGeneration = Long.parseLong(lastCommittedUserData.get(Translog.TRANSLOG_GENERATION_KEY));
-            assertThat(lastCommitedTranslogGeneration, equalTo(currentFileGeneration));
-        }
-
-        assertThat(Translog.readMinTranslogGeneration(translogPath, translogUuid), equalTo(minFileGeneration));
-        assertThat(noOpEngine.getTranslogStats().estimatedNumberOfOperations(), equalTo(softDeleteEnabled ? 0 : numDocs));
-        assertThat(noOpEngine.getTranslogStats().getUncommittedOperations(), equalTo(0));
-
         noOpEngine.trimUnreferencedTranslogFiles();
-
-        assertThat(Translog.readMinTranslogGeneration(translogPath, translogUuid), equalTo(lastCommitedTranslogGeneration));
         assertThat(noOpEngine.getTranslogStats().estimatedNumberOfOperations(), equalTo(0));
         assertThat(noOpEngine.getTranslogStats().getUncommittedOperations(), equalTo(0));
-
+        assertThat(noOpEngine.getTranslogStats().getTranslogSizeInBytes(), equalTo((long)Translog.DEFAULT_HEADER_SIZE_IN_BYTES));
+        snapshot.close();
         noOpEngine.close();
-    }
-
-    private void flushAndTrimTranslog(final InternalEngine engine) {
-        engine.flush(true, true);
-        final TranslogDeletionPolicy deletionPolicy = engine.getTranslog().getDeletionPolicy();
-        deletionPolicy.setMinTranslogGenerationForRecovery(engine.getTranslog().getGeneration().translogFileGeneration);
-        engine.flush(true, true);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -734,7 +734,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
             shards.assertAllEqual(initDocs + inFlightOpsOnNewPrimary + moreDocsAfterRollback);
             done.set(true);
             thread.join();
-
+            shards.syncGlobalCheckpoint();
             for (IndexShard shard : shards) {
                 shard.flush(new FlushRequest().force(true).waitIfOngoing(true));
                 assertThat(shard.translogStats().getUncommittedOperations(), equalTo(0));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -333,7 +333,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         assertFalse(shard.shouldPeriodicallyFlush());
         client().admin().indices().prepareUpdateSettings("test").setSettings(Settings.builder()
             .put(IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey(),
-                new ByteSizeValue(190 /* size of the operation + two generations header&footer*/, ByteSizeUnit.BYTES)).build()).get();
+                new ByteSizeValue(135 /* size of the operation + one generation header&footer*/, ByteSizeUnit.BYTES)).build()).get();
         client().prepareIndex("test").setId("0")
             .setSource("{}", XContentType.JSON).setRefreshPolicy(randomBoolean() ? IMMEDIATE : NONE).get();
         assertFalse(shard.shouldPeriodicallyFlush());
@@ -416,7 +416,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         final Settings settings;
         if (flush) {
             // size of the operation plus two generations of overhead.
-            settings = Settings.builder().put("index.translog.flush_threshold_size", "180b").build();
+            settings = Settings.builder().put("index.translog.flush_threshold_size", "125b").build();
         } else {
             // size of the operation plus header and footer
             settings = Settings.builder().put("index.translog.generation_threshold_size", "117b").build();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -415,7 +415,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         final boolean flush = randomBoolean();
         final Settings settings;
         if (flush) {
-            // size of the operation plus two generations of overhead.
+            // size of the operation plus the overhead of one generation.
             settings = Settings.builder().put("index.translog.flush_threshold_size", "125b").build();
         } else {
             // size of the operation plus header and footer

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -114,7 +114,6 @@ import org.elasticsearch.index.store.StoreUtils;
 import org.elasticsearch.index.translog.TestTranslog;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogStats;
-import org.elasticsearch.index.translog.TranslogTests;
 import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
@@ -1400,7 +1399,7 @@ public class IndexShardTests extends IndexShardTestCase {
                         latch.await();
                         for (int i = 0; i < 10000; i++) {
                             semaphore.acquire();
-                            shard.sync(TranslogTests.randomTranslogLocation(), (ex) -> semaphore.release());
+                            shard.sync(new Translog.Location(randomLong(), randomLong(), randomInt()), (ex) -> semaphore.release());
                         }
                     } catch (Exception ex) {
                         throw new RuntimeException(ex);
@@ -2022,17 +2021,20 @@ public class IndexShardTests extends IndexShardTestCase {
         shard.sync(); // advance local checkpoint
 
         final int translogOps;
+        final int replayedOps;
         if (randomBoolean()) {
             // Advance the global checkpoint to remove the 1st commit; this shard will recover the 2nd commit.
             shard.updateGlobalCheckpointOnReplica(3, "test");
             logger.info("--> flushing shard");
             shard.flush(new FlushRequest().force(true).waitIfOngoing(true));
             translogOps = 4; // delete #1 won't be replayed.
-        } else if (randomBoolean())  {
-            shard.getEngine().rollTranslogGeneration();
-            translogOps = 5;
+            replayedOps = 3;
         } else {
+            if (randomBoolean()) {
+                shard.getEngine().rollTranslogGeneration();
+            }
             translogOps = 5;
+            replayedOps = 5;
         }
 
         final ShardRouting replicaRouting = shard.routingEntry();
@@ -2042,10 +2044,9 @@ public class IndexShardTests extends IndexShardTestCase {
         DiscoveryNode localNode = new DiscoveryNode("foo", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         newShard.markAsRecovering("store", new RecoveryState(newShard.routingEntry(), localNode, null));
         assertTrue(recoverFromStore(newShard));
-        assertEquals(translogOps, newShard.recoveryState().getTranslog().recoveredOperations());
+        assertEquals(replayedOps, newShard.recoveryState().getTranslog().recoveredOperations());
         assertEquals(translogOps, newShard.recoveryState().getTranslog().totalOperations());
         assertEquals(translogOps, newShard.recoveryState().getTranslog().totalOperationsOnStart());
-        assertEquals(100.0f, newShard.recoveryState().getTranslog().recoveredPercent(), 0.01f);
         updateRoutingEntry(newShard, ShardRoutingHelper.moveToStarted(newShard.routingEntry()));
         assertDocCount(newShard, 3);
         closeShards(newShard);

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -67,7 +67,6 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.seqno.RetentionLease;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetaData;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
@@ -842,9 +841,7 @@ public class StoreTests extends ESTestCase {
         writer.addDocument(doc);
         Map<String, String> commitData = new HashMap<>(2);
         String syncId = "a sync id";
-        String translogId = "a translog id";
         commitData.put(Engine.SYNC_COMMIT_ID, syncId);
-        commitData.put(Translog.TRANSLOG_GENERATION_KEY, translogId);
         writer.setLiveCommitData(commitData.entrySet());
         writer.commit();
         writer.close();
@@ -853,7 +850,6 @@ public class StoreTests extends ESTestCase {
         assertFalse(metadata.asMap().isEmpty());
         // do not check for correct files, we have enough tests for that above
         assertThat(metadata.getCommitUserData().get(Engine.SYNC_COMMIT_ID), equalTo(syncId));
-        assertThat(metadata.getCommitUserData().get(Translog.TRANSLOG_GENERATION_KEY), equalTo(translogId));
         TestUtil.checkIndex(store.directory());
         assertDeleteContent(store, store.directory());
         IOUtils.close(store);

--- a/server/src/test/java/org/elasticsearch/index/translog/TestTranslog.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TestTranslog.java
@@ -22,12 +22,8 @@ package org.elasticsearch.index.translog;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexCommit;
-import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.index.engine.CombinedDeletionPolicy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -69,7 +65,7 @@ public class TestTranslog {
      * See {@link TestTranslog#corruptFile(Logger, Random, Path, boolean)} for details of the corruption applied.
      */
     public static void corruptRandomTranslogFile(Logger logger, Random random, Path translogDir) throws IOException {
-        corruptRandomTranslogFile(logger, random, translogDir, minTranslogGenUsedInRecovery(translogDir));
+        corruptRandomTranslogFile(logger, random, translogDir, Translog.readCheckpoint(translogDir).minTranslogGeneration);
     }
 
     /**
@@ -185,19 +181,6 @@ public class TestTranslog {
                 logger.info("corruptFile: truncating file {} from length {} to length {}", fileToCorrupt, fileSize, corruptPosition);
                 fileChannel.truncate(corruptPosition);
             }
-        }
-    }
-
-    /**
-     * Lists all existing commits in a given index path, then read the minimum translog generation that will be used in recoverFromTranslog.
-     */
-    private static long minTranslogGenUsedInRecovery(Path translogPath) throws IOException {
-        try (NIOFSDirectory directory = new NIOFSDirectory(translogPath.getParent().resolve("index"))) {
-            List<IndexCommit> commits = DirectoryReader.listCommits(directory);
-            final String translogUUID = commits.get(commits.size() - 1).getUserData().get(Translog.TRANSLOG_UUID_KEY);
-            long globalCheckpoint = Translog.readGlobalCheckpoint(translogPath, translogUUID);
-            IndexCommit recoveringCommit = CombinedDeletionPolicy.findSafeCommitPoint(commits, globalCheckpoint);
-            return Long.parseLong(recoveringCommit.getUserData().get(Translog.TRANSLOG_GENERATION_KEY));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -165,7 +165,8 @@ public class TranslogTests extends ESTestCase {
 
         if (translog.isOpen()) {
             if (translog.currentFileGeneration() > 1) {
-                markCurrentGenAsCommitted(translog);
+                translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(Long.MAX_VALUE);
+                translog.getDeletionPolicy().setLocalCheckpointOfSafeCommit(Long.MAX_VALUE);
                 translog.trimUnreferencedReaders();
                 assertFileDeleted(translog, translog.currentFileGeneration() - 1);
             }
@@ -199,28 +200,6 @@ public class TranslogTests extends ESTestCase {
             () -> SequenceNumbers.NO_OPS_PERFORMED, primaryTerm::get, getPersistedSeqNoConsumer());
     }
 
-
-    private void markCurrentGenAsCommitted(Translog translog) throws IOException {
-        long genToCommit = translog.currentFileGeneration();
-        long genToRetain = randomLongBetween(translog.getDeletionPolicy().getMinTranslogGenerationForRecovery(), genToCommit);
-        commit(translog, genToRetain, genToCommit);
-    }
-
-    private void rollAndCommit(Translog translog) throws IOException {
-        translog.rollGeneration();
-        markCurrentGenAsCommitted(translog);
-    }
-
-    private long commit(Translog translog, long genToRetain, long genToCommit) throws IOException {
-        final TranslogDeletionPolicy deletionPolicy = translog.getDeletionPolicy();
-        deletionPolicy.setTranslogGenerationOfLastCommit(genToCommit);
-        deletionPolicy.setMinTranslogGenerationForRecovery(genToRetain);
-        long minGenRequired = deletionPolicy.minTranslogGenRequired();
-        translog.trimUnreferencedReaders();
-        assertThat(minGenRequired, equalTo(translog.getMinFileGeneration()));
-        assertFilePresences(translog);
-        return minGenRequired;
-    }
 
     @Override
     @Before
@@ -348,7 +327,7 @@ public class TranslogTests extends ESTestCase {
             assertThat(snapshot.totalOperations(), equalTo(ops.size()));
         }
 
-        final long seqNo = randomNonNegativeLong();
+        final long seqNo = randomLongBetween(0, Integer.MAX_VALUE);
         final String reason = randomAlphaOfLength(16);
         final long noopTerm = randomLongBetween(1, primaryTerm.get());
         addToTranslogAndList(translog, ops, new Translog.NoOp(seqNo, noopTerm, reason));
@@ -381,9 +360,7 @@ public class TranslogTests extends ESTestCase {
             assertThat(snapshot.totalOperations(), equalTo(ops.size()));
         }
 
-        markCurrentGenAsCommitted(translog);
-        try (Translog.Snapshot snapshot = translog.newSnapshotFromGen(
-            new Translog.TranslogGeneration(translog.getTranslogUUID(), firstId + 1), randomNonNegativeLong())) {
+        try (Translog.Snapshot snapshot = translog.newSnapshot(seqNo + 1, randomLongBetween(seqNo + 1, Long.MAX_VALUE))) {
             assertThat(snapshot, SnapshotMatchers.size(0));
             assertThat(snapshot.totalOperations(), equalTo(0));
         }
@@ -440,8 +417,8 @@ public class TranslogTests extends ESTestCase {
             assertThat(stats.estimatedNumberOfOperations(), equalTo(1));
             assertThat(stats.getTranslogSizeInBytes(), equalTo(157L));
             assertThat(stats.getUncommittedOperations(), equalTo(1));
-            assertThat(stats.getUncommittedSizeInBytes(), equalTo(157L));
-            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(1L));
+            assertThat(stats.getUncommittedSizeInBytes(), equalTo(102L));
+            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
 
         translog.add(new Translog.Delete("2", 1, primaryTerm.get(), newUid("2")));
@@ -450,8 +427,8 @@ public class TranslogTests extends ESTestCase {
             assertThat(stats.estimatedNumberOfOperations(), equalTo(2));
             assertThat(stats.getTranslogSizeInBytes(), equalTo(200L));
             assertThat(stats.getUncommittedOperations(), equalTo(2));
-            assertThat(stats.getUncommittedSizeInBytes(), equalTo(200L));
-            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(1L));
+            assertThat(stats.getUncommittedSizeInBytes(), equalTo(145L));
+            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
 
         translog.add(new Translog.Delete("3", 2, primaryTerm.get(), newUid("3")));
@@ -460,8 +437,8 @@ public class TranslogTests extends ESTestCase {
             assertThat(stats.estimatedNumberOfOperations(), equalTo(3));
             assertThat(stats.getTranslogSizeInBytes(), equalTo(243L));
             assertThat(stats.getUncommittedOperations(), equalTo(3));
-            assertThat(stats.getUncommittedSizeInBytes(), equalTo(243L));
-            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(1L));
+            assertThat(stats.getUncommittedSizeInBytes(), equalTo(188L));
+            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
 
         translog.add(new Translog.NoOp(3, 1, randomAlphaOfLength(16)));
@@ -470,19 +447,18 @@ public class TranslogTests extends ESTestCase {
             assertThat(stats.estimatedNumberOfOperations(), equalTo(4));
             assertThat(stats.getTranslogSizeInBytes(), equalTo(285L));
             assertThat(stats.getUncommittedOperations(), equalTo(4));
-            assertThat(stats.getUncommittedSizeInBytes(), equalTo(285L));
-            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(1L));
+            assertThat(stats.getUncommittedSizeInBytes(), equalTo(230L));
+            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
 
-        final long expectedSizeInBytes = 340L;
         translog.rollGeneration();
         {
             final TranslogStats stats = stats();
             assertThat(stats.estimatedNumberOfOperations(), equalTo(4));
-            assertThat(stats.getTranslogSizeInBytes(), equalTo(expectedSizeInBytes));
+            assertThat(stats.getTranslogSizeInBytes(), equalTo(340L));
             assertThat(stats.getUncommittedOperations(), equalTo(4));
-            assertThat(stats.getUncommittedSizeInBytes(), equalTo(expectedSizeInBytes));
-            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(1L));
+            assertThat(stats.getUncommittedSizeInBytes(), equalTo(285L));
+            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
 
         {
@@ -491,26 +467,27 @@ public class TranslogTests extends ESTestCase {
             stats.writeTo(out);
             final TranslogStats copy = new TranslogStats(out.bytes().streamInput());
             assertThat(copy.estimatedNumberOfOperations(), equalTo(4));
-            assertThat(copy.getTranslogSizeInBytes(), equalTo(expectedSizeInBytes));
+            assertThat(copy.getTranslogSizeInBytes(), equalTo(340L));
 
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 builder.startObject();
                 copy.toXContent(builder, ToXContent.EMPTY_PARAMS);
                 builder.endObject();
-                assertThat(Strings.toString(builder), equalTo("{\"translog\":{\"operations\":4,\"size_in_bytes\":" + expectedSizeInBytes
-                    + ",\"uncommitted_operations\":4,\"uncommitted_size_in_bytes\":" + expectedSizeInBytes
+                assertThat(Strings.toString(builder), equalTo("{\"translog\":{\"operations\":4,\"size_in_bytes\":" + 340
+                    + ",\"uncommitted_operations\":4,\"uncommitted_size_in_bytes\":" + 285
                     + ",\"earliest_last_modified_age\":" + stats.getEarliestLastModifiedAge() + "}}"));
             }
         }
-
-        commit(translog, translog.currentFileGeneration(), translog.currentFileGeneration());
+        translog.getDeletionPolicy().setLocalCheckpointOfSafeCommit(randomLongBetween(3, Long.MAX_VALUE));
+        translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(randomLongBetween(3, Long.MAX_VALUE));
+        translog.trimUnreferencedReaders();
         {
             final TranslogStats stats = stats();
             assertThat(stats.estimatedNumberOfOperations(), equalTo(0));
             assertThat(stats.getTranslogSizeInBytes(), equalTo(firstOperationPosition));
             assertThat(stats.getUncommittedOperations(), equalTo(0));
             assertThat(stats.getUncommittedSizeInBytes(), equalTo(firstOperationPosition));
-            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(1L));
+            assertThat(stats.getEarliestLastModifiedAge(), greaterThan(0L));
         }
     }
 
@@ -529,7 +506,8 @@ public class TranslogTests extends ESTestCase {
             }
             assertThat(translog.stats().getUncommittedOperations(), equalTo(uncommittedOps));
             if (frequently()) {
-                markCurrentGenAsCommitted(translog);
+                deletionPolicy.setLocalCheckpointOfSafeCommit(randomLongBetween(deletionPolicy.getLocalCheckpointOfSafeCommit(), i));
+                deletionPolicy.setLocalCheckpointOfLastCommit(i);
                 assertThat(translog.stats().getUncommittedOperations(), equalTo(operationsInLastGen));
                 uncommittedOps = operationsInLastGen;
             }
@@ -590,7 +568,7 @@ public class TranslogTests extends ESTestCase {
         assertThat(e, hasToString(containsString("earliestLastModifiedAge must be >= 0")));
     }
 
-    public void testSnapshot() throws IOException {
+    public void testBasicSnapshot() throws IOException {
         ArrayList<Translog.Operation> ops = new ArrayList<>();
         try (Translog.Snapshot snapshot = translog.newSnapshot()) {
             assertThat(snapshot, SnapshotMatchers.size(0));
@@ -598,13 +576,13 @@ public class TranslogTests extends ESTestCase {
 
         addToTranslogAndList(translog, ops, new Translog.Index("1", 0, primaryTerm.get(), new byte[]{1}));
 
-        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
+        try (Translog.Snapshot snapshot = translog.newSnapshot(0, Long.MAX_VALUE)) {
             assertThat(snapshot, SnapshotMatchers.equalsTo(ops));
             assertThat(snapshot.totalOperations(), equalTo(1));
         }
 
-        try (Translog.Snapshot snapshot = translog.newSnapshot();
-             Translog.Snapshot snapshot1 = translog.newSnapshot()) {
+        try (Translog.Snapshot snapshot = translog.newSnapshot(0, randomIntBetween(0, 10));
+             Translog.Snapshot snapshot1 = translog.newSnapshot(0, randomIntBetween(0, 10))) {
             assertThat(snapshot, SnapshotMatchers.equalsTo(ops));
             assertThat(snapshot.totalOperations(), equalTo(1));
 
@@ -647,7 +625,7 @@ public class TranslogTests extends ESTestCase {
 
             Translog.Snapshot snapshot2 = translog.newSnapshot();
             toClose.add(snapshot2);
-            markCurrentGenAsCommitted(translog);
+            translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(2);
             assertThat(snapshot2, containsOperationsInAnyOrder(ops));
             assertThat(snapshot2.totalOperations(), equalTo(ops.size()));
         } finally {
@@ -663,78 +641,62 @@ public class TranslogTests extends ESTestCase {
         assertEquals(ex.getMessage(), "translog is already closed");
     }
 
-    public void testSnapshotFromMinGen() throws Exception {
-        Map<Long, List<Translog.Operation>> operationsByGen = new HashMap<>();
-        try (Translog.Snapshot snapshot = translog.newSnapshotFromGen(
-            new Translog.TranslogGeneration(translog.getTranslogUUID(), 1), randomNonNegativeLong())) {
-            assertThat(snapshot, SnapshotMatchers.size(0));
-        }
-        int iters = between(1, 10);
-        for (int i = 0; i < iters; i++) {
-            long currentGeneration = translog.currentFileGeneration();
-            operationsByGen.putIfAbsent(currentGeneration, new ArrayList<>());
-            int numOps = between(0, 20);
-            for (int op = 0; op < numOps; op++) {
-                long seqNo = randomLongBetween(0, 1000);
-                addToTranslogAndList(translog, operationsByGen.get(currentGeneration), new Translog.Index(
-                    Long.toString(seqNo), seqNo, primaryTerm.get(), new byte[]{1}));
-            }
-            long minGen = randomLongBetween(translog.getMinFileGeneration(), translog.currentFileGeneration());
-            try (Translog.Snapshot snapshot = translog.newSnapshotFromGen(
-                new Translog.TranslogGeneration(translog.getTranslogUUID(), minGen), Long.MAX_VALUE)) {
-                List<Translog.Operation> expectedOps = operationsByGen.entrySet().stream()
-                    .filter(e -> e.getKey() >= minGen)
-                    .flatMap(e -> e.getValue().stream())
-                    .collect(Collectors.toList());
-                assertThat(snapshot, SnapshotMatchers.containsOperationsInAnyOrder(expectedOps));
-            }
-            long upToSeqNo = randomLongBetween(0, 2000);
-            try (Translog.Snapshot snapshot = translog.newSnapshotFromGen(
-                new Translog.TranslogGeneration(translog.getTranslogUUID(), minGen), upToSeqNo)) {
-                List<Translog.Operation> expectedOps = operationsByGen.entrySet().stream()
-                    .filter(e -> e.getKey() >= minGen)
-                    .flatMap(e -> e.getValue().stream().filter(op -> op.seqNo() <= upToSeqNo))
-                    .collect(Collectors.toList());
-                assertThat(snapshot, SnapshotMatchers.containsOperationsInAnyOrder(expectedOps));
-            }
-            translog.rollGeneration();
-        }
-    }
-
-    public void testSeqNoFilterSnapshot() throws Exception {
+    public void testRangeSnapshot() throws Exception {
+        long minSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
+        long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
         final int generations = between(2, 20);
+        Map<Long, List<Translog.Operation>> operationsByGen = new HashMap<>();
         for (int gen = 0; gen < generations; gen++) {
-            List<Long> batch = LongStream.rangeClosed(0, between(0, 100)).boxed().collect(Collectors.toList());
-            Randomness.shuffle(batch);
-            for (long seqNo : batch) {
-                Translog.Index op =
-                    new Translog.Index(randomAlphaOfLength(10), seqNo, primaryTerm.get(), new byte[]{1});
+            Set<Long> seqNos = new HashSet<>();
+            int numOps = randomIntBetween(1, 100);
+            for (int i = 0; i < numOps; i++) {
+                final long seqNo = randomValueOtherThanMany(seqNos::contains, () -> randomLongBetween(0, 1000));
+                minSeqNo = SequenceNumbers.min(minSeqNo, seqNo);
+                maxSeqNo = SequenceNumbers.max(maxSeqNo, seqNo);
+                seqNos.add(seqNo);
+            }
+            List<Translog.Operation> ops = new ArrayList<>(seqNos.size());
+            for (long seqNo : seqNos) {
+                Translog.Index op = new Translog.Index(randomAlphaOfLength(10), seqNo, primaryTerm.get(), new byte[]{randomByte()});
                 translog.add(op);
+                ops.add(op);
             }
+            operationsByGen.put(translog.currentFileGeneration(), ops);
             translog.rollGeneration();
-        }
-        List<Translog.Operation> operations = new ArrayList<>();
-        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
-            Translog.Operation op;
-            while ((op = snapshot.next()) != null) {
-                operations.add(op);
+            if (rarely()) {
+                translog.rollGeneration(); // empty generation
             }
         }
-        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
-            Translog.Snapshot filter = new Translog.SeqNoFilterSnapshot(snapshot, between(200, 300), between(300, 400)); // out range
-            assertThat(filter, SnapshotMatchers.size(0));
-            assertThat(filter.totalOperations(), equalTo(snapshot.totalOperations()));
-            assertThat(filter.skippedOperations(), equalTo(snapshot.totalOperations()));
+
+        if (minSeqNo > 0) {
+            long fromSeqNo = randomLongBetween(0, minSeqNo - 1);
+            long toSeqNo = randomLongBetween(fromSeqNo, minSeqNo - 1);
+            try (Translog.Snapshot snapshot = translog.newSnapshot(fromSeqNo, toSeqNo)) {
+                assertThat(snapshot.totalOperations(), equalTo(0));
+                assertNull(snapshot.next());
+            }
         }
-        try (Translog.Snapshot snapshot = translog.newSnapshot()) {
-            int fromSeqNo = between(-2, 500);
-            int toSeqNo = between(fromSeqNo, 500);
-            List<Translog.Operation> selectedOps = operations.stream()
-                .filter(op -> fromSeqNo <= op.seqNo() && op.seqNo() <= toSeqNo).collect(Collectors.toList());
-            Translog.Snapshot filter = new Translog.SeqNoFilterSnapshot(snapshot, fromSeqNo, toSeqNo);
-            assertThat(filter, SnapshotMatchers.containsOperationsInAnyOrder(selectedOps));
-            assertThat(filter.totalOperations(), equalTo(snapshot.totalOperations()));
-            assertThat(filter.skippedOperations(), equalTo(snapshot.skippedOperations() + operations.size() - selectedOps.size()));
+
+        long fromSeqNo = randomLongBetween(maxSeqNo + 1, Long.MAX_VALUE);
+        long toSeqNo = randomLongBetween(fromSeqNo, Long.MAX_VALUE);
+        try (Translog.Snapshot snapshot = translog.newSnapshot(fromSeqNo, toSeqNo)) {
+            assertThat(snapshot.totalOperations(), equalTo(0));
+            assertNull(snapshot.next());
+        }
+
+        fromSeqNo = randomLongBetween(0, 2000);
+        toSeqNo = randomLongBetween(fromSeqNo, 2000);
+        try (Translog.Snapshot snapshot = translog.newSnapshot(fromSeqNo, toSeqNo)) {
+            Set<Long> seenSeqNos = new HashSet<>();
+            List<Translog.Operation> expectedOps = new ArrayList<>();
+            for (long gen = translog.currentFileGeneration(); gen > 0; gen--) {
+                for (Translog.Operation op : operationsByGen.getOrDefault(gen, Collections.emptyList())) {
+                    if (fromSeqNo <= op.seqNo() && op.seqNo() <= toSeqNo && seenSeqNos.add(op.seqNo())) {
+                        expectedOps.add(op);
+                    }
+                }
+            }
+            assertThat(TestTranslog.drainSnapshot(snapshot, false), equalTo(expectedOps));
         }
     }
 
@@ -756,6 +718,7 @@ public class TranslogTests extends ESTestCase {
         for (long gen = 1; gen < translog.getMinFileGeneration(); gen++) {
             assertFileDeleted(translog, gen);
         }
+
     }
 
     static class LocationOperation implements Comparable<LocationOperation> {
@@ -936,8 +899,8 @@ public class TranslogTests extends ESTestCase {
             assertThat(snapshot.totalOperations(), equalTo(1));
         }
         translog.close();
-
-        assertFileIsPresent(translog, 1);
+        assertFileDeleted(translog, 1);
+        assertFileIsPresent(translog, 2);
     }
 
     /**
@@ -1009,9 +972,8 @@ public class TranslogTests extends ESTestCase {
                                 translog.rollGeneration();
                                 // expose the new checkpoint (simulating a commit), before we trim the translog
                                 lastCommittedLocalCheckpoint.set(localCheckpoint);
-                                deletionPolicy.setTranslogGenerationOfLastCommit(translog.currentFileGeneration());
-                                deletionPolicy.setMinTranslogGenerationForRecovery(
-                                    translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration);
+                                deletionPolicy.setLocalCheckpointOfLastCommit(localCheckpoint);
+                                deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
                                 translog.trimUnreferencedReaders();
                             }
                         }
@@ -1080,7 +1042,7 @@ public class TranslogTests extends ESTestCase {
                         // these are what we expect the snapshot to return (and potentially some more).
                         Set<Translog.Operation> expectedOps = new HashSet<>(writtenOps.keySet());
                         expectedOps.removeIf(op -> op.seqNo() <= committedLocalCheckpointAtView);
-                        try (Translog.Snapshot snapshot = translog.newSnapshotFromMinSeqNo(committedLocalCheckpointAtView + 1L)) {
+                        try (Translog.Snapshot snapshot = translog.newSnapshot(committedLocalCheckpointAtView + 1L, Long.MAX_VALUE)) {
                             Translog.Operation op;
                             while ((op = snapshot.next()) != null) {
                                 expectedOps.remove(op);
@@ -1158,7 +1120,7 @@ public class TranslogTests extends ESTestCase {
                 assertTrue("we only synced a previous operation yet", translog.syncNeeded());
             }
             if (rarely()) {
-                rollAndCommit(translog);
+                translog.rollGeneration();
                 assertFalse("location is from a previous translog - already synced", translog.ensureSynced(location)); // not syncing now
                 assertFalse("no sync needed since no operations in current translog", translog.syncNeeded());
             }
@@ -1178,7 +1140,7 @@ public class TranslogTests extends ESTestCase {
             ArrayList<Location> locations = new ArrayList<>();
             for (int op = 0; op < translogOperations; op++) {
                 if (rarely()) {
-                    rollAndCommit(translog); // do this first so that there is at least one pending tlog entry
+                    translog.rollGeneration();
                 }
                 final Translog.Location location =
                     translog.add(new Translog.Index("" + op, op, primaryTerm.get(),
@@ -1192,7 +1154,7 @@ public class TranslogTests extends ESTestCase {
                 // we are the last location so everything should be synced
                 assertFalse("the last call to ensureSycned synced all previous ops", translog.syncNeeded());
             } else if (rarely()) {
-                rollAndCommit(translog);
+                translog.rollGeneration();
                 // not syncing now
                 assertFalse("location is from a previous translog - already synced", translog.ensureSynced(locations.stream()));
                 assertFalse("no sync needed since no operations in current translog", translog.syncNeeded());
@@ -1215,7 +1177,7 @@ public class TranslogTests extends ESTestCase {
                 translog.add(new Translog.Index("" + op, op,
                     primaryTerm.get(), Integer.toString(++count).getBytes(Charset.forName("UTF-8")))));
             if (rarely() && translogOperations > op + 1) {
-                rollAndCommit(translog);
+                translog.rollGeneration();
             }
         }
         Collections.shuffle(locations, random());
@@ -1398,7 +1360,7 @@ public class TranslogTests extends ESTestCase {
                 Integer.toString(op).getBytes(Charset.forName("UTF-8")))));
             final boolean commit = commitOften ? frequently() : rarely();
             if (commit && op < translogOperations - 1) {
-                rollAndCommit(translog);
+                translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(op);
                 minUncommittedOp = op + 1;
                 translogGeneration = translog.getGeneration();
             }
@@ -1421,7 +1383,7 @@ public class TranslogTests extends ESTestCase {
             assertEquals("lastCommitted must be 1 less than current",
                 translogGeneration.translogFileGeneration + 1, translog.currentFileGeneration());
             assertFalse(translog.syncNeeded());
-            try (Translog.Snapshot snapshot = translog.newSnapshotFromGen(translogGeneration, Long.MAX_VALUE)) {
+            try (Translog.Snapshot snapshot = translog.newSnapshot(minUncommittedOp, Long.MAX_VALUE)) {
                 for (int i = minUncommittedOp; i < translogOperations; i++) {
                     assertEquals("expected operation" + i + " to be in the previous translog but wasn't",
                         translog.currentFileGeneration() - 1, locations.get(i).generation);
@@ -1852,7 +1814,10 @@ public class TranslogTests extends ESTestCase {
             locations.add(translog.add(new Translog.Index("" + op, op, primaryTerm.get(),
                 Integer.toString(op).getBytes(Charset.forName("UTF-8")))));
             if (randomBoolean()) {
-                rollAndCommit(translog);
+                translog.rollGeneration();
+                translog.getDeletionPolicy().setLocalCheckpointOfSafeCommit(op);
+                translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(op);
+                translog.trimUnreferencedReaders();
                 firstUncommitted = op + 1;
             }
         }
@@ -1873,7 +1838,7 @@ public class TranslogTests extends ESTestCase {
         }
         this.translog = new Translog(config, translogUUID, deletionPolicy, () -> SequenceNumbers.NO_OPS_PERFORMED, primaryTerm::get,
             seqNo -> {});
-        try (Translog.Snapshot snapshot = this.translog.newSnapshotFromGen(translogGeneration, Long.MAX_VALUE)) {
+        try (Translog.Snapshot snapshot = this.translog.newSnapshot(randomLongBetween(0, firstUncommitted), Long.MAX_VALUE)) {
             for (int i = firstUncommitted; i < translogOperations; i++) {
                 Translog.Operation next = snapshot.next();
                 assertNotNull("" + i, next);
@@ -2054,7 +2019,7 @@ public class TranslogTests extends ESTestCase {
         }
 
         try {
-            rollAndCommit(translog);
+            translog.rollGeneration();
             fail("already closed");
         } catch (AlreadyClosedException ex) {
             assertNotNull(ex.getCause());
@@ -2231,7 +2196,8 @@ public class TranslogTests extends ESTestCase {
      */
     public void testRecoveryFromAFutureGenerationCleansUp() throws IOException {
         int translogOperations = randomIntBetween(10, 100);
-        for (int op = 0; op < translogOperations / 2; op++) {
+        int op = 0;
+        for (; op < translogOperations / 2; op++) {
             translog.add(new Translog.Index("" + op, op, primaryTerm.get(),
                 Integer.toString(op).getBytes(Charset.forName("UTF-8"))));
             if (rarely()) {
@@ -2239,20 +2205,21 @@ public class TranslogTests extends ESTestCase {
             }
         }
         translog.rollGeneration();
-        long comittedGeneration = randomLongBetween(2, translog.currentFileGeneration());
-        for (int op = translogOperations / 2; op < translogOperations; op++) {
+        long localCheckpoint = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, op);
+        for (op = translogOperations / 2; op < translogOperations; op++) {
             translog.add(new Translog.Index("" + op, op, primaryTerm.get(),
                 Integer.toString(op).getBytes(Charset.forName("UTF-8"))));
             if (rarely()) {
                 translog.rollGeneration();
             }
         }
+        long minRetainedGen = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration;
         // engine blows up, after committing the above generation
         translog.close();
         TranslogConfig config = translog.getConfig();
         final TranslogDeletionPolicy deletionPolicy = new TranslogDeletionPolicy();
-        deletionPolicy.setTranslogGenerationOfLastCommit(randomLongBetween(comittedGeneration, Long.MAX_VALUE));
-        deletionPolicy.setMinTranslogGenerationForRecovery(comittedGeneration);
+        deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
+        deletionPolicy.setLocalCheckpointOfLastCommit(randomLongBetween(localCheckpoint, Long.MAX_VALUE));
         translog = new Translog(config, translog.getTranslogUUID(), deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED, primaryTerm::get, seqNo -> {});
         assertThat(translog.getMinFileGeneration(), equalTo(1L));
@@ -2261,7 +2228,7 @@ public class TranslogTests extends ESTestCase {
             assertFileIsPresent(translog, gen);
         }
         translog.trimUnreferencedReaders();
-        for (long gen = 1; gen < comittedGeneration; gen++) {
+        for (long gen = 1; gen < minRetainedGen; gen++) {
             assertFileDeleted(translog, gen);
         }
     }
@@ -2275,14 +2242,16 @@ public class TranslogTests extends ESTestCase {
         final FailSwitch fail = new FailSwitch();
         fail.failNever();
         final TranslogConfig config = getTranslogConfig(tempDir);
-        final long comittedGeneration;
+        final long localCheckpoint;
         final String translogUUID;
+        long minGenForRecovery = 1L;
         try (Translog translog = getFailableTranslog(fail, config)) {
             final TranslogDeletionPolicy deletionPolicy = translog.getDeletionPolicy();
             // disable retention so we trim things
             translogUUID = translog.getTranslogUUID();
             int translogOperations = randomIntBetween(10, 100);
-            for (int op = 0; op < translogOperations / 2; op++) {
+            int op = 0;
+            for (; op < translogOperations / 2; op++) {
                 translog.add(new Translog.Index("" + op, op, primaryTerm.get(),
                     Integer.toString(op).getBytes(Charset.forName("UTF-8"))));
                 if (rarely()) {
@@ -2290,16 +2259,17 @@ public class TranslogTests extends ESTestCase {
                 }
             }
             translog.rollGeneration();
-            comittedGeneration = randomLongBetween(2, translog.currentFileGeneration());
-            for (int op = translogOperations / 2; op < translogOperations; op++) {
+            localCheckpoint = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, op);
+            for (op = translogOperations / 2; op < translogOperations; op++) {
                 translog.add(new Translog.Index("" + op, op, primaryTerm.get(),
                     Integer.toString(op).getBytes(Charset.forName("UTF-8"))));
                 if (rarely()) {
                     translog.rollGeneration();
                 }
             }
-            deletionPolicy.setTranslogGenerationOfLastCommit(randomLongBetween(comittedGeneration, translog.currentFileGeneration()));
-            deletionPolicy.setMinTranslogGenerationForRecovery(comittedGeneration);
+            deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
+            deletionPolicy.setLocalCheckpointOfLastCommit(randomLongBetween(localCheckpoint, op));
+            minGenForRecovery = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration;
             fail.failRandomly();
             try {
                 translog.trimUnreferencedReaders();
@@ -2308,16 +2278,17 @@ public class TranslogTests extends ESTestCase {
             }
         }
         final TranslogDeletionPolicy deletionPolicy = new TranslogDeletionPolicy();
-        deletionPolicy.setTranslogGenerationOfLastCommit(randomLongBetween(comittedGeneration, Long.MAX_VALUE));
-        deletionPolicy.setMinTranslogGenerationForRecovery(comittedGeneration);
+        deletionPolicy.setLocalCheckpointOfLastCommit(randomLongBetween(localCheckpoint, Long.MAX_VALUE));
+        deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpoint);
         try (Translog translog = new Translog(config, translogUUID, deletionPolicy,
             () -> SequenceNumbers.NO_OPS_PERFORMED, primaryTerm::get, seqNo -> {})) {
             // we don't know when things broke exactly
             assertThat(translog.getMinFileGeneration(), greaterThanOrEqualTo(1L));
-            assertThat(translog.getMinFileGeneration(), lessThanOrEqualTo(comittedGeneration));
+            assertThat(translog.getMinFileGeneration(), lessThanOrEqualTo(minGenForRecovery));
             assertFilePresences(translog);
+            minGenForRecovery = translog.getMinGenerationForSeqNo(localCheckpoint + 1).translogFileGeneration;
             translog.trimUnreferencedReaders();
-            assertThat(translog.getMinFileGeneration(), equalTo(comittedGeneration));
+            assertThat(translog.getMinFileGeneration(), equalTo(minGenForRecovery));
             assertFilePresences(translog);
         }
     }
@@ -2625,7 +2596,7 @@ public class TranslogTests extends ESTestCase {
             fail.failRandomly();
             TranslogConfig config = getTranslogConfig(tempDir);
             final int numOps = randomIntBetween(100, 200);
-            long minGenForRecovery = 1;
+            long localCheckpointOfSafeCommit = SequenceNumbers.NO_OPS_PERFORMED;
             List<String> syncedDocs = new ArrayList<>();
             List<String> unsynced = new ArrayList<>();
             if (randomBoolean()) {
@@ -2655,8 +2626,8 @@ public class TranslogTests extends ESTestCase {
                             unsynced.clear();
                             failableTLog.rollGeneration();
                             committing = true;
-                            failableTLog.getDeletionPolicy().setTranslogGenerationOfLastCommit(failableTLog.currentFileGeneration());
-                            failableTLog.getDeletionPolicy().setMinTranslogGenerationForRecovery(failableTLog.currentFileGeneration());
+                            failableTLog.getDeletionPolicy().setLocalCheckpointOfLastCommit(opsAdded);
+                            failableTLog.getDeletionPolicy().setLocalCheckpointOfSafeCommit(opsAdded);
                             syncedDocs.clear();
                             failableTLog.trimUnreferencedReaders();
                             committing = false;
@@ -2688,7 +2659,7 @@ public class TranslogTests extends ESTestCase {
                         assertThat(unsynced, empty());
                     }
                     generationUUID = failableTLog.getTranslogUUID();
-                    minGenForRecovery = failableTLog.getDeletionPolicy().getMinTranslogGenerationForRecovery();
+                    localCheckpointOfSafeCommit = failableTLog.getDeletionPolicy().getLocalCheckpointOfSafeCommit();
                     IOUtils.closeWhileHandlingException(failableTLog);
                 }
             } catch (TranslogException | MockDirectoryWrapper.FakeIOException ex) {
@@ -2700,8 +2671,8 @@ public class TranslogTests extends ESTestCase {
             if (randomBoolean()) {
                 try {
                     TranslogDeletionPolicy deletionPolicy = new TranslogDeletionPolicy();
-                    deletionPolicy.setTranslogGenerationOfLastCommit(minGenForRecovery);
-                    deletionPolicy.setMinTranslogGenerationForRecovery(minGenForRecovery);
+                    deletionPolicy.setLocalCheckpointOfLastCommit(localCheckpointOfSafeCommit);
+                    deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
                     IOUtils.close(getFailableTranslog(fail, config, randomBoolean(), false, generationUUID, deletionPolicy));
                 } catch (TranslogException | MockDirectoryWrapper.FakeIOException ex) {
                     // failed - that's ok, we didn't even create it
@@ -2712,8 +2683,8 @@ public class TranslogTests extends ESTestCase {
 
             fail.failNever(); // we don't wanna fail here but we might since we write a new checkpoint and create a new tlog file
             TranslogDeletionPolicy deletionPolicy = new TranslogDeletionPolicy();
-            deletionPolicy.setTranslogGenerationOfLastCommit(minGenForRecovery);
-            deletionPolicy.setMinTranslogGenerationForRecovery(minGenForRecovery);
+            deletionPolicy.setLocalCheckpointOfSafeCommit(localCheckpointOfSafeCommit);
+            deletionPolicy.setLocalCheckpointOfLastCommit(localCheckpointOfSafeCommit);
             if (generationUUID == null) {
                 // we never managed to successfully create a translog, make it
                 generationUUID = Translog.createEmptyTranslog(config.getTranslogPath(),
@@ -2721,8 +2692,7 @@ public class TranslogTests extends ESTestCase {
             }
             try (Translog translog = new Translog(config, generationUUID, deletionPolicy,
                 () -> SequenceNumbers.NO_OPS_PERFORMED, primaryTerm::get, seqNo -> {});
-                 Translog.Snapshot snapshot = translog.newSnapshotFromGen(
-                     new Translog.TranslogGeneration(generationUUID, minGenForRecovery), Long.MAX_VALUE)) {
+                 Translog.Snapshot snapshot = translog.newSnapshot(localCheckpointOfSafeCommit + 1, Long.MAX_VALUE)) {
                 assertEquals(syncedDocs.size(), snapshot.totalOperations());
                 for (int i = 0; i < syncedDocs.size(); i++) {
                     Translog.Operation next = snapshot.next();
@@ -2893,15 +2863,22 @@ public class TranslogTests extends ESTestCase {
                 .map(t -> t.getPrimaryTerm()).collect(Collectors.toList());
             assertThat(storedPrimaryTerms, equalTo(primaryTerms));
         }
-        long minGenForRecovery = randomLongBetween(generation, generation + rolls);
-        commit(translog, minGenForRecovery, generation + rolls);
+
+        final BaseTranslogReader minRetainedReader = randomFrom(
+            Stream.concat(translog.getReaders().stream(), Stream.of(translog.getCurrent()))
+                .filter(r -> r.getCheckpoint().minSeqNo >= 0)
+                .collect(Collectors.toList()));
+        deletionPolicy.setLocalCheckpointOfSafeCommit(
+            randomLongBetween(minRetainedReader.getCheckpoint().minSeqNo, minRetainedReader.getCheckpoint().maxSeqNo) - 1);
+        deletionPolicy.setLocalCheckpointOfLastCommit(seqNo);
+        translog.trimUnreferencedReaders();
         assertThat(translog.currentFileGeneration(), equalTo(generation + rolls));
         assertThat(translog.stats().getUncommittedOperations(), equalTo(0));
         // immediate cleanup
-        for (long i = 0; i < minGenForRecovery; i++) {
+        for (long i = 0; i < minRetainedReader.generation; i++) {
             assertFileDeleted(translog, i);
         }
-        for (long i = minGenForRecovery; i < generation + rolls; i++) {
+        for (long i = minRetainedReader.generation; i < generation + rolls; i++) {
             assertFileIsPresent(translog, i);
         }
     }
@@ -2960,7 +2937,7 @@ public class TranslogTests extends ESTestCase {
             }
             assertThat(translog.estimateTotalOperationsFromMinSeq(seqNo), equalTo(expectedSnapshotOps));
             int readFromSnapshot = 0;
-            try (Translog.Snapshot snapshot = translog.newSnapshotFromMinSeqNo(seqNo)) {
+            try (Translog.Snapshot snapshot = translog.newSnapshot(seqNo, Long.MAX_VALUE)) {
                 assertThat(snapshot.totalOperations(), equalTo(expectedSnapshotOps));
                 Translog.Operation op;
                 while ((op = snapshot.next()) != null) {
@@ -2989,8 +2966,8 @@ public class TranslogTests extends ESTestCase {
                 translog.rollGeneration();
             }
         }
-        long lastGen = randomLongBetween(1, translog.currentFileGeneration());
-        commit(translog, randomLongBetween(1, lastGen), lastGen);
+        translog.getDeletionPolicy().setLocalCheckpointOfSafeCommit(randomLongBetween(0, operations));
+        translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(randomLongBetween(operations, Long.MAX_VALUE));
     }
 
     public void testAcquiredLockIsPassedToDeletionPolicy() throws IOException {
@@ -3002,9 +2979,10 @@ public class TranslogTests extends ESTestCase {
                 translog.rollGeneration();
             }
             if (rarely()) {
-                long lastGen = randomLongBetween(deletionPolicy.getTranslogGenerationOfLastCommit(), translog.currentFileGeneration());
-                long minGen = randomLongBetween(deletionPolicy.getMinTranslogGenerationForRecovery(), lastGen);
-                commit(translog, minGen, lastGen);
+                translog.getDeletionPolicy().setLocalCheckpointOfSafeCommit(
+                    randomLongBetween(deletionPolicy.getLocalCheckpointOfSafeCommit(), i));
+                translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(
+                    randomLongBetween(deletionPolicy.getLocalCheckpointOfLastCommit(), Long.MAX_VALUE));
             }
             if (frequently()) {
                 long minGen;
@@ -3027,7 +3005,7 @@ public class TranslogTests extends ESTestCase {
                 translog.rollGeneration();
             }
         }
-        rollAndCommit(translog);
+        translog.rollGeneration();
         translog.close();
         assertThat(Translog.readGlobalCheckpoint(translogDir, translogUUID), equalTo(globalCheckpoint.get()));
         expectThrows(TranslogCorruptedException.class, () -> Translog.readGlobalCheckpoint(translogDir, UUIDs.randomBase64UUID()));
@@ -3158,9 +3136,11 @@ public class TranslogTests extends ESTestCase {
         translog.sync();
         assertThat(translog.getMaxSeqNo(),
             equalTo(maxSeqNoPerGeneration.isEmpty() ? SequenceNumbers.NO_OPS_PERFORMED : Collections.max(maxSeqNoPerGeneration.values())));
-        long minRetainedGen = commit(translog, randomLongBetween(1, translog.currentFileGeneration()), translog.currentFileGeneration());
+        if (randomBoolean()) {
+            translog.getDeletionPolicy().setLocalCheckpointOfLastCommit(randomFrom(maxSeqNoPerGeneration.values()));
+        }
         long expectedMaxSeqNo = maxSeqNoPerGeneration.entrySet().stream()
-            .filter(e -> e.getKey() >= minRetainedGen).mapToLong(e -> e.getValue())
+            .filter(e -> e.getKey() >= translog.getMinFileGeneration()).mapToLong(e -> e.getValue())
             .max().orElse(SequenceNumbers.NO_OPS_PERFORMED);
         assertThat(translog.getMaxSeqNo(), equalTo(expectedMaxSeqNo));
     }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.index.seqno.SeqNoStats;
@@ -177,14 +176,8 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         long globalCheckpoint = populateRandomData(shard).getGlobalCheckpoint();
         Optional<SequenceNumbers.CommitInfo> safeCommit = shard.store().findSafeIndexCommit(globalCheckpoint);
         assertTrue(safeCommit.isPresent());
-        final Translog.TranslogGeneration recoveringTranslogGeneration;
-        try (Engine.IndexCommitRef commitRef = shard.acquireSafeIndexCommit()) {
-            recoveringTranslogGeneration = new Translog.TranslogGeneration(
-                commitRef.getIndexCommit().getUserData().get(Translog.TRANSLOG_UUID_KEY),
-                Long.parseLong(commitRef.getIndexCommit().getUserData().get(Translog.TRANSLOG_GENERATION_KEY)));
-        }
         int expectedTotalLocal = 0;
-        try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshotFromGen(recoveringTranslogGeneration, globalCheckpoint)) {
+        try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint + 1, globalCheckpoint)) {
             Translog.Operation op;
             while ((op = snapshot.next()) != null) {
                 if (op.seqNo() <= globalCheckpoint) {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
@@ -202,21 +202,17 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
                 .setOpenMode(IndexWriterConfig.OpenMode.APPEND);
             Map<String, String> userData = new HashMap<>(replica.store().readLastCommittedSegmentsInfo().getUserData());
             final String translogUUIDtoUse;
-            final long translogGenToUse;
             final String historyUUIDtoUse = UUIDs.randomBase64UUID(random());
             if (randomBoolean()) {
                 // create a new translog
                 translogUUIDtoUse = Translog.createEmptyTranslog(replica.shardPath().resolveTranslog(), flushedDocs,
                     replica.shardId(), replica.getPendingPrimaryTerm());
-                translogGenToUse = 1;
             } else {
                 translogUUIDtoUse = translogGeneration.translogUUID;
-                translogGenToUse = translogGeneration.translogFileGeneration;
             }
             try (IndexWriter writer = new IndexWriter(replica.store().directory(), iwc)) {
                 userData.put(Engine.HISTORY_UUID_KEY, historyUUIDtoUse);
                 userData.put(Translog.TRANSLOG_UUID_KEY, translogUUIDtoUse);
-                userData.put(Translog.TRANSLOG_GENERATION_KEY, Long.toString(translogGenToUse));
                 writer.setLiveCommitData(userData.entrySet());
                 writer.commit();
             }


### PR DESCRIPTION
Today we use the translog_generation of the safe commit as the minimum required translog generation for recovery. This approach has a limitation, where we won't be able to clean up translog unless we flush. Reopening an already recovered engine will create a new empty translog, and we leave it there until we force flush.

This commit removes the translog_generation commit tag and uses the local checkpoint of the safe commit to calculate the minimum required translog generation for recovery instead.

Closes #49970