### PR TITLE
Use deprecated object to deprecate synced flush API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush_synced.json
@@ -2,7 +2,11 @@
   "indices.flush_synced":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-synced-flush-api.html",
-      "description":"Performs a synced flush operation on one or more indices. Synced flush is deprecated and will be removed in 8.0. Use flush instead"
+      "description":"Performs a synced flush operation on one or more indices."
+    },
+    "deprecated" : {
+      "version" : "7.6.0",
+      "description" : "Synced flush is deprecated and will be removed in 8.0. Use flush instead"
     },
     "stability":"stable",
     "url":{


### PR DESCRIPTION
Relates: #50835

This commit updates the synced flush REST API to use the deprecated object to [deprecate the whole API](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec#entire-api). Client generators can pick up the deprecated object to apply language specific deprecation warnings.