### PR TITLE
exists query - misleading specification about the `null`

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -36,8 +36,8 @@ GET /_search
 While a field is deemed non-existent if the JSON value is `null` or `[]`, these
 values will indicate the field does exist:
 +
-* Empty strings, such as `""` or `"-"`
-* Arrays containing `null` and another value, such as `[null, "foo"]`
+* Empty strings, such as `""`
+* Arrays is `null` or `[]`
 * A custom <<null-value, `null-value`>>, defined in field mapping
 
 [[exists-query-notes]]


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html#exists-query-top-level-params

As the following tests shows, at least in `6.2` I've tested; only `null`, `[]`, `null_value` will take effect. 

Please elaborate the causes, if I am wrong. 

Thank you ;)

```
DELETE index

PUT index
{
  "settings": {
    "analysis": {
      "normalizer": {
        "my_normalizer": {
          "type": "custom",
          "char_filter": [],
          "filter": ["lowercase", "asciifolding"]
        }
      }
    }
  },
  "mappings": {
    "_doc": {
      "properties": {
        "foo": {
          "type": "keyword",
          "normalizer": "my_normalizer"
        }
      }
    }
  }
}

PUT index/_mapping/_doc
{
    "properties": {
      "buzz": {
        "type": "keyword",
        "null_value": "NULL"
      }
    }
}

PUT index/_doc/1
{
  "foo": "BÀR"
}

PUT index/_doc/2
{
  "foo": "bar"
}

PUT index/_doc/3
{
  "foo": "baz"
}

PUT index/_doc/4
{
  "foo": "-"
}

PUT index/_doc/5
{
  "foo": [null, "test"]
}

PUT index/_doc/6
{
  "foo": null
}

PUT index/_doc/7
{
  "foo": []
}

PUT index/_doc/8
{
  "buzz": "NULL"
}

GET index/_search

GET index/_search
{
  "query": {
    "exists": {
      "field": "buzz"
    }
  }
}

GET index/_search
{
  "query": {
    "exists": {
      "field": "foo"
    }
  }
}
```

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
