### PR TITLE
Fix the type for "slices" in the Reindex and Update By Query REST API specification

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -45,9 +45,9 @@
         "default":"5m"
       },
       "slices":{
-        "type":"number",
+        "type":"number|string",
         "default":1,
-        "description":"The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."
+        "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       },
       "max_docs":{
         "type":"number",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -204,9 +204,9 @@
         "description":"The throttle to set on this request in sub-requests per second. -1 means no throttle."
       },
       "slices":{
-        "type":"number",
+        "type":"number|string",
         "default":1,
-        "description":"The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."
+        "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       }
     },
     "body":{


### PR DESCRIPTION
This is a backport of https://github.com/elastic/elasticsearch/pull/51908 into `7.x`.

This patch supplements #51792 and #51535 where the type of the "slices" parameter has been fixed.
