### PR TITLE
Increase scroll timeout for upgrade test

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -32,7 +32,7 @@
         rest_total_hits_as_int: true
         index: upgraded_scroll
         size: 1
-        scroll: 10m
+        scroll: 60m
         sort: foo
         body:
           query:


### PR DESCRIPTION
Slow tests are slow.

Bumps the timeout already bumped in #50195, which was 10 min, clearly violated by the following test run in https://gradle-enterprise.elastic.co/s/nbpoqsmt4jlcu:



```
> [2020-02-05T07:29:17,900][INFO ][o.e.c.m.MetaDataMappingService] [v6.8.7-2] [upgraded_scroll/iQJ1jGknS-aL_ZPuk3SWNA] create_mapping [test]****
> [2020-02-05T07:40:21,035][DEBUG][o.e.a.s.TransportSearchScrollAction] [v6.8.7-0] [12] Failed to execute query phase
org.elasticsearch.transport.RemoteTransportException: [v6.8.7-1][127.0.0.1:43755][indices:data/read/search[phase/query/scroll]]
Caused by: org.elasticsearch.search.SearchContextMissingException: No search context found for id [12]
...
```