### PR TITLE
[7.x] Test: match the \ilm/ and \slm/ test name too (#51811)

### DIFF
--- a/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
+++ b/docs/src/test/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java
@@ -143,14 +143,14 @@ public class DocsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     protected boolean isSLMTest() {
         String testName = getTestName();
-        return testName != null && (testName.contains("/slm/") || testName.contains("\\slm\\") ||
+        return testName != null && (testName.contains("/slm/") || testName.contains("\\slm\\") || (testName.contains("\\slm/")) ||
             // TODO: Remove after backport of https://github.com/elastic/elasticsearch/pull/48705 which moves SLM docs to correct folder
-            testName.contains("/ilm/") || testName.contains("\\ilm\\"));
+            testName.contains("/ilm/") || testName.contains("\\ilm\\") || testName.contains("\\ilm/"));
     }
 
     protected boolean isILMTest() {
         String testName = getTestName();
-        return testName != null && (testName.contains("/ilm/") || testName.contains("\\ilm\\"));
+        return testName != null && (testName.contains("/ilm/") || testName.contains("\\ilm\\") || testName.contains("\\ilm/"));
     }
 
     protected boolean isMachineLearningTest() {


### PR DESCRIPTION
We only drop ilm/slm policies on teardown only if the running docs tests
are ilm/slm related.

This updates the test name pattern to match the ilm/slm related tests
when running on windows
(eg.`reference\ilm/update-lifecycle-policy/line_29`).

(cherry picked from commit 4bb5bbd52eee59bd3eee6d766a9efc159822d9b9)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #51811 