### PR TITLE
Use #name() instead of #simpleName() when generating doc values

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -373,7 +373,7 @@ public class HistogramFieldMapper extends FieldMapper {
                     }
                 }
                 BytesRef docValue = new BytesRef(dataOutput.toArrayCopy(), 0, Math.toIntExact(dataOutput.size()));
-                Field field = new BinaryDocValuesField(simpleName(), docValue);
+                Field field = new BinaryDocValuesField(name(), docValue);
                 if (context.doc().getByKey(fieldType().name()) != null) {
                     throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() +
                         "] doesn't not support indexing multiple values for the same field in the same document");


### PR DESCRIPTION
 We should use the fully qualified name when generating doc values. In addition we have increase the precision of the TDigest test.

Fixes #51847
Fixes #50307
