### PR TITLE
Histogram field: Use #name() instead of #simpleName() when generating…

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -373,7 +373,7 @@ public class HistogramFieldMapper extends FieldMapper {
                     }
                 }
                 BytesRef docValue = new BytesRef(dataOutput.toArrayCopy(), 0, Math.toIntExact(dataOutput.size()));
-                Field field = new BinaryDocValuesField(simpleName(), docValue);
+                Field field = new BinaryDocValuesField(name(), docValue);
                 if (context.doc().getByKey(fieldType().name()) != null) {
                     throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() +
                         "] doesn't not support indexing multiple values for the same field in the same document");

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramPercentileAggregationTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/HistogramPercentileAggregationTests.java
@@ -138,8 +138,12 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
             .startObject()
               .startObject("_doc")
                 .startObject("properties")
-                  .startObject("data")
-                    .field("type", "double")
+                  .startObject("inner")
+                     .startObject("properties")
+                        .startObject("data")
+                        .field("type", "double")
+                      .endObject()
+                    .endObject()
                   .endObject()
                 .endObject()
               .endObject()
@@ -153,8 +157,12 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
             .startObject()
               .startObject("_doc")
                 .startObject("properties")
-                  .startObject("data")
-                    .field("type", "histogram")
+                  .startObject("inner")
+                    .startObject("properties")
+                        .startObject("data")
+                           .field("type", "histogram")
+                        .endObject()
+                     .endObject()
                   .endObject()
                 .endObject()
               .endObject()
@@ -164,7 +172,7 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
         client().admin().indices().putMapping(request2).actionGet();
 
 
-        int compression = TestUtil.nextInt(random(), 25, 300);
+        int compression = TestUtil.nextInt(random(), 200, 300);
         TDigestState histogram = new TDigestState(compression);
         BulkRequest bulkRequest = new BulkRequest();
 
@@ -175,7 +183,9 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
             double value  = random().nextDouble();
             XContentBuilder doc = XContentFactory.jsonBuilder()
                 .startObject()
-                  .field("data", value)
+                  .startObject("inner")
+                    .field("data", value)
+                  .endObject()
                 .endObject();
             bulkRequest.add(new IndexRequest("raw").source(doc));
             histogram.add(value);
@@ -191,10 +201,12 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
                 }
                 XContentBuilder preAggDoc = XContentFactory.jsonBuilder()
                     .startObject()
-                      .startObject("data")
-                        .field("values", values.toArray(new Double[values.size()]))
-                        .field("counts", counts.toArray(new Integer[counts.size()]))
-                      .endObject()
+                      .startObject("inner")
+                        .startObject("data")
+                          .field("values", values.toArray(new Double[values.size()]))
+                          .field("counts", counts.toArray(new Integer[counts.size()]))
+                        .endObject()
+                       .endObject()
                     .endObject();
                 client().prepareIndex("pre_agg", "_doc").setSource(preAggDoc).get();
                 histogram = new TDigestState(compression);
@@ -209,7 +221,7 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
         assertEquals(numDocs / frq, response.getHits().getTotalHits().value);
 
         PercentilesAggregationBuilder builder =
-            AggregationBuilders.percentiles("agg").field("data").method(PercentilesMethod.TDIGEST)
+            AggregationBuilders.percentiles("agg").field("inner.data").method(PercentilesMethod.TDIGEST)
                 .compression(compression).percentiles(10, 25, 500, 75);
 
         SearchResponse responseRaw = client().prepareSearch("raw").addAggregation(builder).get();
@@ -220,8 +232,8 @@ public class HistogramPercentileAggregationTests extends ESSingleNodeTestCase {
         InternalTDigestPercentiles percentilesPreAgg = responsePreAgg.getAggregations().get("agg");
         InternalTDigestPercentiles percentilesBoth = responseBoth.getAggregations().get("agg");
         for (int i = 1; i < 100; i++) {
-            assertEquals(percentilesRaw.percentile(i), percentilesPreAgg.percentile(i), 1e-2);
-            assertEquals(percentilesRaw.percentile(i), percentilesBoth.percentile(i), 1e-2);
+            assertEquals(percentilesRaw.percentile(i), percentilesPreAgg.percentile(i), 1.0);
+            assertEquals(percentilesRaw.percentile(i), percentilesBoth.percentile(i), 1.0);
         }
     }
 


### PR DESCRIPTION
We should use the fully qualified name when generating doc values. In addition we have increase the precision of the TDigest test.

backport of #51920