### PR TITLE
Remove 8fips from our runtime matrix

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -7,7 +7,6 @@
 
 ES_RUNTIME_JAVA:
   - java8
-  - java8fips
   - java11
   - java12
   - openjdk12


### PR DESCRIPTION
The relevant handling part has been removed in infra, FIPS 140
testing needs to be enabled in the same manner as it happened for
master and 7.x in #48378 and #49485

resolves: #51924