### PR TITLE
Cleanup test user in HLRC test (#49477)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SecurityIT.java
@@ -44,6 +44,7 @@ import org.elasticsearch.client.security.user.privileges.IndicesPrivilegesTests;
 import org.elasticsearch.client.security.user.privileges.Role;
 import org.elasticsearch.common.CharArrays;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -71,10 +72,8 @@ public class SecurityIT extends ESRestHighLevelClientTestCase {
         final PutUserResponse updateUserResponse = execute(updateUserRequest, securityClient::putUser, securityClient::putUserAsync);
         // assert user not created
         assertThat(updateUserResponse.isCreated(), is(false));
-        // delete user
-        final Request deleteUserRequest = new Request(HttpDelete.METHOD_NAME,
-            "/_security/user/" + putUserRequest.getUser().getUsername());
-        highLevelClient().getLowLevelClient().performRequest(deleteUserRequest);
+        // cleanup
+        deleteUser(putUserRequest.getUser());
     }
 
     public void testGetUser() throws Exception {
@@ -91,6 +90,8 @@ public class SecurityIT extends ESRestHighLevelClientTestCase {
         ArrayList<User> users = new ArrayList<>();
         users.addAll(getUsersResponse.getUsers());
         assertThat(users.get(0), is(putUserRequest.getUser()));
+
+        deleteUser(putUserRequest.getUser());
     }
 
     public void testAuthenticate() throws Exception {
@@ -161,12 +162,17 @@ public class SecurityIT extends ESRestHighLevelClientTestCase {
         assertThat(deleteRoleResponse.isFound(), is(true));
     }
 
-    private static User randomUser() {
+    private void deleteUser(User user) throws IOException {
+        final Request deleteUserRequest = new Request(HttpDelete.METHOD_NAME, "/_security/user/" + user.getUsername());
+        highLevelClient().getLowLevelClient().performRequest(deleteUserRequest);
+    }
+
+    private User randomUser() {
         final String username = randomAlphaOfLengthBetween(1, 4);
         return randomUser(username);
     }
 
-    private static User randomUser(String username) {
+    private User randomUser(String username) {
         final List<String> roles = Arrays.asList(generateRandomStringArray(3, 3, false, true));
         final String fullName = randomFrom(random(), null, randomAlphaOfLengthBetween(0, 3));
         final String email = randomFrom(random(), null, randomAlphaOfLengthBetween(0, 3));
@@ -182,6 +188,8 @@ public class SecurityIT extends ESRestHighLevelClientTestCase {
         } else {
             metadata.put("string_list", Arrays.asList(generateRandomStringArray(4, 4, false, true)));
         }
+        metadata.put("test-case", getTestName());
+
         return new User(username, roles, metadata, fullName, email);
     }
 
@@ -207,7 +215,7 @@ public class SecurityIT extends ESRestHighLevelClientTestCase {
         return roleBuilder.build();
     }
 
-    private static PutUserRequest randomPutUserRequest(boolean enabled) {
+    private PutUserRequest randomPutUserRequest(boolean enabled) {
         final User user = randomUser();
         return randomPutUserRequest(user, enabled);
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -150,7 +150,6 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
                 .build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/48440")
     public void testGetUsers() throws Exception {
         final RestHighLevelClient client = highLevelClient();
         String[] usernames = new String[] {"user1", "user2", "user3"};
@@ -241,7 +240,6 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(users.get(0).getUsername(), equalTo(usernames[0]));
         }
     }
-
 
     public void testPutUser() throws Exception {
         RestHighLevelClient client = highLevelClient();


### PR DESCRIPTION
SecurityIT.testGetUser creates a user for testing purposes, but did
not delete the user at the end of the test. This could leave the
cluster in an unexpected state for other tests.

This commit:
- Deletes the user at the end of `testGetUser`
- Adds the test-name as metadata to the users that are created in `SecurityIT`
  so that their origin is clear if they do interfere with other tests
- Enables SecurityDocumentationIT.testGetUsers on the expectation that
  the new cleanup step will resolve the unreliability of that test.

Relates: #48440
