### PR TITLE
SQL: Add string to interval converters

### DIFF
--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
@@ -47,4 +47,12 @@ public class RestSqlIT extends RestSqlTestCase {
             containsString("Invalid parameter data type [invalid]")
         );
     }
+
+    public void testErrorMessageForInvalidParamSpec() throws IOException {
+        expectBadRequest(() -> runTranslateSql(
+            "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"SHAPE\", \"value\":false}]}"
+            ),
+            containsString("Cannot cast value [false] of type [BOOLEAN] to parameter type [SHAPE]")
+        );
+    }
 }

--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
@@ -39,4 +39,12 @@ public class RestSqlIT extends RestSqlTestCase {
             containsString("Cannot generate a query DSL for a special SQL command " +
                 "(e.g.: DESCRIBE, SHOW), sql statement: [SHOW FUNCTIONS]"));
     }
+
+    public void testErrorMessageForInvalidParamDataType() throws IOException {
+        expectBadRequest(() -> runTranslateSql(
+            "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"invalid\", \"value\":\"irrelevant\"}]}"
+            ),
+            containsString("Invalid parameter data type [invalid]")
+        );
+    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -721,7 +721,8 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         // otherwise we need to make sure that xcontent-serialized value is converted to the correct type
         try {
             if (SqlDataTypeConverter.canConvert(sourceType, dataType) == false) {
-                throw new ParsingException(source, "Can not cast value [{}] as [{}]", param.value, dataType);
+                throw new ParsingException(source, "Cannot cast value [{}] of type [{}] to parameter type [{}]", param.value, sourceType,
+                    dataType);
             }
             return new Literal(source, SqlDataTypeConverter.converterFor(sourceType, dataType).convert(param.value), dataType);
         } catch (QlIllegalArgumentException ex) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverter.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverter.java
@@ -404,7 +404,7 @@ public final class SqlDataTypeConverter {
         STRING_ISO8601_PERIOD_TO_TEMPORAL(fromString(Period::parse, SqlConverter.INTERVAL_TYPE_NAME)),
         STRING_ISO8601_DURATION_TO_TEMPORAL(fromString(Duration::parse, SqlConverter.INTERVAL_TYPE_NAME));
 
-        private static final String INTERVAL_TYPE_NAME = "INTERVAL(period)";
+        private static final String INTERVAL_TYPE_NAME = "INTERVAL";
         public static final String NAME = "dtc-sql";
 
         private final Function<Object, Object> converter;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverter.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverter.java
@@ -401,9 +401,10 @@ public final class SqlDataTypeConverter {
         DATE_TO_BOOLEAN(delegate(DATETIME_TO_BOOLEAN)),
         TIME_TO_BOOLEAN(fromTime(value -> value != 0)),
 
-        STRING_ISO8601_PERIOD_TO_TEMPORAL(fromString(Period::parse, "duration")),
-        STRING_ISO8601_DURATION_TO_TEMPORAL(fromString(Duration::parse, "duration"));
+        STRING_ISO8601_PERIOD_TO_TEMPORAL(fromString(Period::parse, SqlConverter.INTERVAL_TYPE_NAME)),
+        STRING_ISO8601_DURATION_TO_TEMPORAL(fromString(Duration::parse, SqlConverter.INTERVAL_TYPE_NAME));
 
+        private static final String INTERVAL_TYPE_NAME = "INTERVAL(period)";
         public static final String NAME = "dtc-sql";
 
         private final Function<Object, Object> converter;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverterTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/type/SqlDataTypeConverterTests.java
@@ -600,22 +600,31 @@ public class SqlDataTypeConverterTests extends ESTestCase {
     }
 
     public void testConversionToInterval() {
-        assertNull(converterFor(KEYWORD, INTERVAL_YEAR).convert(null));
+        {
+            assertNull(converterFor(KEYWORD, INTERVAL_YEAR).convert(null));
+        }
+        {
+            assertEquals(converterFor(KEYWORD, INTERVAL_YEAR).convert("P200Y"), Period.of(200, 0, 0));
+            assertEquals(converterFor(KEYWORD, INTERVAL_MONTH).convert("P11M"), Period.of(0, 11, 0));
+            assertEquals(converterFor(KEYWORD, INTERVAL_YEAR_TO_MONTH).convert("P200Y11M"), Period.of(200, 11, 0));
 
-        assertEquals(converterFor(KEYWORD, INTERVAL_YEAR).convert("P200Y"), Period.of(200, 0, 0));
-        assertEquals(converterFor(KEYWORD, INTERVAL_MONTH).convert("P11M"), Period.of(0, 11, 0));
-        assertEquals(converterFor(KEYWORD, INTERVAL_YEAR_TO_MONTH).convert("P200Y11M"), Period.of(200, 11, 0));
+            assertEquals(converterFor(KEYWORD, INTERVAL_DAY).convert("P20D"), Duration.ofDays(20));
+            assertEquals(converterFor(KEYWORD, INTERVAL_HOUR).convert("PT20H"), Duration.ofHours(20));
+            assertEquals(converterFor(KEYWORD, INTERVAL_MINUTE).convert("PT20M"), Duration.ofMinutes(20));
+            assertEquals(converterFor(KEYWORD, INTERVAL_SECOND).convert("PT20S"), Duration.ofSeconds(20));
 
-        assertEquals(converterFor(KEYWORD, INTERVAL_DAY).convert("P20D"), Duration.ofDays(20));
-        assertEquals(converterFor(KEYWORD, INTERVAL_HOUR).convert("PT20H"), Duration.ofHours(20));
-        assertEquals(converterFor(KEYWORD, INTERVAL_MINUTE).convert("PT20M"), Duration.ofMinutes(20));
-        assertEquals(converterFor(KEYWORD, INTERVAL_SECOND).convert("PT20S"), Duration.ofSeconds(20));
+            assertEquals(converterFor(KEYWORD, INTERVAL_DAY_TO_HOUR).convert("P1DT1H"), Duration.ofHours(24 + 1));
+            assertEquals(converterFor(KEYWORD, INTERVAL_DAY_TO_MINUTE).convert("P1DT1H1M"), Duration.ofMinutes((24 + 1) * 60 + 1));
+            assertEquals(converterFor(KEYWORD, INTERVAL_DAY_TO_SECOND).convert("P1DT1.1S"), Duration.ofSeconds(24 * 3600 + 1, 100_000_000));
 
-        assertEquals(converterFor(KEYWORD, INTERVAL_DAY_TO_HOUR).convert("P1DT1H"), Duration.ofHours(24 + 1));
-        assertEquals(converterFor(KEYWORD, INTERVAL_DAY_TO_MINUTE).convert("P1DT1H1M"), Duration.ofMinutes((24 + 1) * 60 + 1));
-        assertEquals(converterFor(KEYWORD, INTERVAL_DAY_TO_SECOND).convert("P1DT1.1S"), Duration.ofSeconds(24 * 3600 + 1, 100_000_000  ));
-
-        assertEquals(converterFor(KEYWORD, INTERVAL_MINUTE_TO_SECOND).convert("PT1M1S"), Duration.ofSeconds(60 + 1));
+            assertEquals(converterFor(KEYWORD, INTERVAL_MINUTE_TO_SECOND).convert("PT1M1S"), Duration.ofSeconds(60 + 1));
+        }
+        {
+            Converter conversion = converterFor(KEYWORD, INTERVAL_YEAR);
+            final String duration = "PT1S";
+            Exception e = expectThrows(QlIllegalArgumentException.class, () -> conversion.convert(duration));
+            assertEquals("cannot cast [" + duration + "] to [INTERVAL]: Text cannot be parsed to a Period", e.getMessage());
+        }
     }
 
     public void testConversionToNull() {


### PR DESCRIPTION
This PR switches the parameter conversion from QL's to SQL
converter.
It then checks if the returned converter is non-null (i.e. a conversion
is possible) and generates an appropriate exception otherwise.
It also adds checks again the validity of the parameter's data type (i.e.
the declared data type is resolved to an ES or Java type.

Finally, keyword to interval converters are added, so that the interval
types can be accepted as parameters.

Closes #45915
