### PR TITLE
[DOCS] Remove 'analyzed string' references

### DIFF
--- a/docs/reference/mapping/params/analyzer.asciidoc
+++ b/docs/reference/mapping/params/analyzer.asciidoc
@@ -1,7 +1,7 @@
 [[analyzer]]
 === `analyzer`
 
-The values of <<mapping-index,`analyzed`>> string fields are passed through an
+The values of <<text,`text`>> fields are passed through an
 <<analysis,analyzer>> to convert the string into a stream of _tokens_ or
 _terms_.  For instance, the string `"The quick Brown Foxes."` may, depending
 on which analyzer is used,  be analyzed to the tokens: `quick`, `brown`,

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -30,8 +30,8 @@ following settings:
 
 NOTE: <<number,Numeric fields>> don't support the `index_options` parameter any longer.
 
-<<mapping-index,Analyzed>> string fields use `positions` as the default, and
-all other fields use `docs` as the default.
+<<text,`text`>> fields use `positions` as the default, and all other fields use
+`docs` as the default.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/mapping/types/search-as-you-type.asciidoc
+++ b/docs/reference/mapping/types/search-as-you-type.asciidoc
@@ -184,7 +184,7 @@ the same way.
 <<analyzer,`analyzer`>>::
 
     The <<analysis,analyzer>> which should be used for
-    <<mapping-index,`analyzed`>> string fields, both at index-time and at
+    `text` fields, both at index-time and at
     search-time (unless overridden by the
     <<search-analyzer,`search_analyzer`>>). Defaults to the default index
     analyzer, or the <<analysis-standard-analyzer,`standard` analyzer>>.
@@ -215,7 +215,7 @@ the same way.
 <<search-analyzer,`search_analyzer`>>::
 
     The <<analyzer,`analyzer`>> that should be used at search time on
-    <<mapping-index,`analyzed`>> fields. Defaults to the `analyzer` setting.
+    <<text,`text`>> fields. Defaults to the `analyzer` setting.
 
 <<search-quote-analyzer,`search_quote_analyzer`>>::
 
@@ -229,8 +229,7 @@ the same way.
 
 <<term-vector,`term_vector`>>::
 
-    Whether term vectors should be stored for an <<mapping-index,`analyzed`>>
-    field. Defaults to `no`. This option configures the root field and shingle
+    Whether term vectors should be stored for the field. Defaults to `no`. This option configures the root field and shingle
     subfields, but not the prefix subfield.
 
 

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -49,7 +49,7 @@ The following parameters are accepted by `text` fields:
 <<analyzer,`analyzer`>>::
 
     The <<analysis,analyzer>> which should be used for
-    <<mapping-index,`analyzed`>> string fields, both at index-time and at
+    the `text` field, both at index-time and at
     search-time (unless overridden by the  <<search-analyzer,`search_analyzer`>>).
     Defaults to the default index analyzer, or the
     <<analysis-standard-analyzer,`standard` analyzer>>.
@@ -122,7 +122,7 @@ The following parameters are accepted by `text` fields:
 <<search-analyzer,`search_analyzer`>>::
 
     The <<analyzer,`analyzer`>> that should be used at search time on
-    <<mapping-index,`analyzed`>> fields. Defaults to the `analyzer` setting.
+    the `text` field. Defaults to the `analyzer` setting.
 
 <<search-quote-analyzer,`search_quote_analyzer`>>::
 
@@ -136,8 +136,7 @@ The following parameters are accepted by `text` fields:
 
 <<term-vector,`term_vector`>>::
 
-    Whether term vectors should be stored for an <<mapping-index,`analyzed`>>
-    field. Defaults to `no`.
+    Whether term vectors should be stored for the field. Defaults to `no`.
 
 <<mapping-field-meta,`meta`>>::
 

--- a/docs/reference/mapping/types/token-count.asciidoc
+++ b/docs/reference/mapping/types/token-count.asciidoc
@@ -45,7 +45,8 @@ GET my_index/_search
 }
 --------------------------------------------------
 
-<1> The `name` field is an analyzed string field which uses the default `standard` analyzer.
+<1> The `name` field is a <<text,`text`>> field which uses the default
+`standard` analyzer.
 <2> The `name.length` field is a `token_count` <<multi-fields,multi-field>> which will index the number of tokens in the `name` field.
 <3> This query matches only the document containing `Rachel Alice Williams`, as it contains three tokens.
 


### PR DESCRIPTION
The `string` field datatype was replaced by the `text` and `keyword`
field datatypes in [5.0][0].

This removes several outdated references to 'analyzed string' fields.

[0]:https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_mapping_changes.html#_string_fields_replaced_by_textkeyword_fields