### PR TITLE
index.mapping.total_fields.limit is important only for query operations

### DIFF
--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -85,10 +85,12 @@ causing a mapping explosion:
 ====
 The limit is in place to prevent mappings and searches from becoming too
 large. Higher values can lead to performance degradations and memory issues,
-especially in clusters with a high load or few resources.
+especially in clusters with a high load or few resources. 
 
-If you increase this setting, we recommend you also increase the
-<<search-settings,`indices.query.bool.max_clause_count`>> setting, which
+You can have mapping with even more amount of fields, but searching by significant
+amount of fields (>=1000) simultaneously is inappropriate from performance point
+of view. In case you deside to increase this setting, we recommend you also increase
+the <<search-settings,`indices.query.bool.max_clause_count`>> setting, which
 limits the maximum number of <<query-dsl-bool-query,boolean clauses>> in a query.
 ====
 


### PR DESCRIPTION
I just want to clarify this:
It's definitely not important for Lucene indexes, as each document field is the independent Lucene index.
I can assume that this settings makes sense only in case of performing query to search by all 1000 fields together. In this case I can understand the limit, I even think that it has to be even smaller. Even such queries is unbelievable for me =)

