### PR TITLE
Avoid clash between source field and header field in CsvProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
@@ -223,8 +223,9 @@ public class CsvProcessorTests extends ESTestCase {
     private IngestDocument processDocument(String[] headers, String csv, boolean trim) throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         Arrays.stream(headers).filter(ingestDocument::hasField).forEach(ingestDocument::removeField);
+        String fieldName = randomAlphaOfLength(11);
+        ingestDocument.setFieldValue(fieldName, csv);
 
-        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, csv);
         char quoteChar = quote.isEmpty() ? '"' : quote.charAt(0);
         CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(5), fieldName, headers, trim, separator, quoteChar, false);
 


### PR DESCRIPTION
This change fixes flakiness in `CsvProcessorTests` where source field can be the same as one of the headers used by tests which messes up asserts when we check that field is not present after processor run.

Closes #50209