### PR TITLE
Remove unnecessary dirname command from bin/elasticsearch

### DIFF
--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -38,7 +38,7 @@ fi
 unset KEYSTORE_PASSWORD
 KEYSTORE_PASSWORD=
 if [[ $CHECK_KEYSTORE = true ]] \
-    && "`dirname "$0"`"/elasticsearch-keystore has-passwd --silent
+    && bin/elasticsearch-keystore has-passwd --silent
 then
   if ! read -s -r -p "Elasticsearch keystore password: " KEYSTORE_PASSWORD ; then
     echo "Failed to read keystore password on console" 1>&2


### PR DESCRIPTION
The elasticsearch-env script changes the working directory to `ES_HOME`, so we can just use bin/elasticsearch-keystore to invoke the keystore.

This issue was discovered by @danhermann when he invoked Elasticsearch from the parent directory of the archive expansion. For example, `./elasticsearch-8.0.0-SNAPSHOT/bin/elasticsearch` output the following error:

```
./elasticsearch-8.0.0-SNAPSHOT/bin/elasticsearch: line 41: ./elasticsearch-8.0.0-SNAPSHOT/bin/elasticsearch-keystore: No such file or directory
```

Elasticsearch then started up successfully, but it might not do so if the keystore were password-protected.

This is not an issue on Windows. It was discovered by @danhermann while he was invoking.