### PR TITLE
Mute ReplicaShardAllocatorSyncIdIT.testPreferCopyCanPerformNoopRecovery

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
@@ -126,6 +126,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/51969")
     public void testPreferCopyCanPerformNoopRecovery() throws Exception {
         String indexName = "test";
         String nodeWithPrimary = internalCluster().startNode();


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/51969