### PR TITLE
Cat.ml.* introduces an additional depths to namespace API's

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -1,53 +1,36 @@
 {
-  "cat.ml.jobs":{
+  "cat.ml_datafeeds":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
     },
     "stability":"stable",
     "url":{
       "paths":[
         {
-          "path":"/_cat/ml/anomaly_detectors",
+          "path":"/_cat/ml/datafeeds",
           "methods":[
             "GET"
           ]
         },
         {
-          "path":"/_cat/ml/anomaly_detectors/{job_id}",
+          "path":"/_cat/ml/datafeeds/{datafeed_id}",
           "methods":[
             "GET"
           ],
           "parts":{
-            "job_id":{
+            "datafeed_id":{
               "type":"string",
-              "description":"The ID of the jobs stats to fetch"
+              "description":"The ID of the datafeeds stats to fetch"
             }
           }
         }
       ]
     },
     "params":{
-      "allow_no_jobs":{
+      "allow_no_datafeeds":{
         "type":"boolean",
         "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
-      },
-      "bytes":{
-        "type":"enum",
-        "description":"The unit in which to display byte values",
-        "options":[
-          "b",
-          "k",
-          "kb",
-          "m",
-          "mb",
-          "g",
-          "gb",
-          "t",
-          "tb",
-          "p",
-          "pb"
-        ]
+        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
       "format":{
         "type":"string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -1,47 +1,36 @@
 {
-  "cat.ml.trained_models":{
+  "cat.ml_jobs":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference-stats.html"
+      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
     },
     "stability":"stable",
     "url":{
       "paths":[
         {
-          "path":"/_cat/ml/trained_models",
+          "path":"/_cat/ml/anomaly_detectors",
           "methods":[
             "GET"
           ]
         },
         {
-          "path":"/_cat/ml/trained_models/{model_id}",
+          "path":"/_cat/ml/anomaly_detectors/{job_id}",
           "methods":[
             "GET"
           ],
           "parts":{
-            "model_id":{
+            "job_id":{
               "type":"string",
-              "description":"The ID of the trained models stats to fetch"
+              "description":"The ID of the jobs stats to fetch"
             }
           }
         }
       ]
     },
     "params":{
-      "allow_no_match":{
+      "allow_no_jobs":{
         "type":"boolean",
         "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)",
-        "default":true
-      },
-      "from":{
-        "type":"int",
-        "description":"skips a number of trained models",
-        "default":0
-      },
-      "size":{
-        "type":"int",
-        "description":"specifies a max number of trained models to get",
-        "default":100
+        "description":"Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "bytes":{
         "type":"enum",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_trained_models.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_trained_models.json
@@ -1,36 +1,64 @@
 {
-  "cat.ml.datafeeds":{
+  "cat.ml_trained_models":{
     "documentation":{
-      "url":"http://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/get-inference-stats.html"
     },
     "stability":"stable",
     "url":{
       "paths":[
         {
-          "path":"/_cat/ml/datafeeds",
+          "path":"/_cat/ml/trained_models",
           "methods":[
             "GET"
           ]
         },
         {
-          "path":"/_cat/ml/datafeeds/{datafeed_id}",
+          "path":"/_cat/ml/trained_models/{model_id}",
           "methods":[
             "GET"
           ],
           "parts":{
-            "datafeed_id":{
+            "model_id":{
               "type":"string",
-              "description":"The ID of the datafeeds stats to fetch"
+              "description":"The ID of the trained models stats to fetch"
             }
           }
         }
       ]
     },
     "params":{
-      "allow_no_datafeeds":{
+      "allow_no_match":{
         "type":"boolean",
         "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
+        "description":"Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)",
+        "default":true
+      },
+      "from":{
+        "type":"int",
+        "description":"skips a number of trained models",
+        "default":0
+      },
+      "size":{
+        "type":"int",
+        "description":"specifies a max number of trained models to get",
+        "default":100
+      },
+      "bytes":{
+        "type":"enum",
+        "description":"The unit in which to display byte values",
+        "options":[
+          "b",
+          "k",
+          "kb",
+          "m",
+          "mb",
+          "g",
+          "gb",
+          "t",
+          "tb",
+          "p",
+          "pb"
+        ]
       },
       "format":{
         "type":"string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeed_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/datafeed_cat_apis.yml
@@ -82,7 +82,7 @@ setup:
 "Test cat datafeeds":
 
   - do:
-      cat.ml.datafeeds:
+      cat.ml_datafeeds:
         datafeed_id: datafeed-job-stats-test
   - match:
       $body: |
@@ -90,7 +90,7 @@ setup:
         ^ (datafeed\-job\-stats\-test \s+ \w+ \s+  \d+         \s+  \d+         \n)+  $/
 
   - do:
-      cat.ml.datafeeds:
+      cat.ml_datafeeds:
         v: true
         datafeed_id: datafeed-job-stats-test
   - match:
@@ -99,7 +99,7 @@ setup:
            (datafeed\-job\-stats\-test  \s+  \w+   \s+ \d+           \s+ \d+           \n)+  $/
 
   - do:
-      cat.ml.datafeeds:
+      cat.ml_datafeeds:
         h: id,search.count,search.time,search.bucket_avg
         v: true
   - match:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/job_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/job_cat_apis.yml
@@ -86,7 +86,7 @@ setup:
   - match: { flushed: true }
 
   - do:
-      cat.ml.jobs:
+      cat.ml_jobs:
         job_id: job-stats-test
   - match:
       $body: |
@@ -94,7 +94,7 @@ setup:
         ^ (job\-stats\-test \s+  \w+  \s+ \d+                   \s+  .*?        \s+ \w+                 \s+ \d+           \s+  \d+         \n)+  $/
 
   - do:
-      cat.ml.jobs:
+      cat.ml_jobs:
         v: true
         job_id: job-stats-test
   - match:
@@ -103,7 +103,7 @@ setup:
            (job\-stats\-test  \s+  \w+   \s+ \d+                     \s+ .*?         \s+ \w+                  \s+ \d+             \s+ \d+            \n)+  $/
 
   - do:
-      cat.ml.jobs:
+      cat.ml_jobs:
         h: id,data.processed_records,data.processed_fields,data.input_bytes
         v: true
   - match:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/trained_model_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/trained_model_cat_apis.yml
@@ -72,7 +72,7 @@ setup:
 "Test cat trained models":
 
   - do:
-      cat.ml.trained_models:
+      cat.ml_trained_models:
         model_id: a-regression-model-0
   - match:
       $body: |
@@ -80,7 +80,7 @@ setup:
         ^ (a\-regression\-model\-0 \s+  \w+      \s+ \d+       \s+ .*?        \s+ \d+               .*?          \n)+  $/
 
   - do:
-      cat.ml.trained_models:
+      cat.ml_trained_models:
         v: true
         model_id: a-regression-model-0
   - match:
@@ -89,7 +89,7 @@ setup:
            (a\-regression\-model\-0  \s+  \w+       \s+ \d+        \s+ .*?         \s+ \d+               \s+ .*?            \n)+        $/
 
   - do:
-      cat.ml.trained_models:
+      cat.ml_trained_models:
         h: id,license,dfid,ip
         v: true
   - match:
@@ -100,7 +100,7 @@ setup:
            (lang_ident_model_1        \s+  \w+     \s+ prepackaged  \s+ \d+  \n)+  $/
 
   - do:
-      cat.ml.trained_models:
+      cat.ml_trained_models:
         model_id: a-regression-model-1
         h: id,license,dfid,ip
         v: true


### PR DESCRIPTION
Not all clients support this e.g if the java high level rest client were
to map this it would look like `client.cat().ml().api()` which hinders
discoverability.

