### PR TITLE
Introduces validation to restrict API's to single namespace

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -47,6 +47,9 @@ public class ClientYamlSuiteRestApiParser {
         if (location.endsWith(apiName + ".json") == false) {
             throw new IllegalArgumentException("API [" + apiName + "] should have the same name as its file [" + location + "]");
         }
+        if (apiName.chars().filter(c -> c == '.').count() > 1) {
+            throw new IllegalArgumentException("API [" + apiName + "] contains more then one namespace [" + location + "]");
+        }
 
         ClientYamlSuiteRestApi restApi = new ClientYamlSuiteRestApi(location, apiName);
 


### PR DESCRIPTION
To be merged after #51981 lands

cc @elastic/es-clients 