### PR TITLE
[ML] Make Ensemble feature names optional

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -103,7 +103,7 @@ public class Ensemble implements TrainedModel {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         builder.startObject();
-        if (featureNames != null) {
+        if (featureNames != null && featureNames.isEmpty() == false) {
             builder.field(FEATURE_NAMES.getPreferredName(), featureNames);
         }
         if (models != null) {
@@ -157,7 +157,7 @@ public class Ensemble implements TrainedModel {
     }
 
     public static class Builder {
-        private List<String> featureNames;
+        private List<String> featureNames = Collections.emptyList();
         private List<TrainedModel> trainedModels;
         private OutputAggregator outputAggregator;
         private TargetType targetType;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -86,7 +86,7 @@ public class EnsembleTests extends AbstractXContentTestCase<Ensemble> {
                 .toArray() :
             null;
 
-        return new Ensemble(featureNames,
+        return new Ensemble(randomBoolean() ? featureNames : Collections.emptyList(),
             models,
             outputAggregator,
             targetType,

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -150,7 +150,7 @@ See <<ml-put-inference-preprocessor-example>> for more details.
 The definition for a binary decision tree.
 
 `tree`.`feature_names`:::
-(Required, string) 
+(Optional, string)
 Features expected by the tree, in their expected order.
 
 `tree`.`tree_structure`:::

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -150,7 +150,7 @@ See <<ml-put-inference-preprocessor-example>> for more details.
 The definition for a binary decision tree.
 
 `tree`.`feature_names`:::
-(Optional, string)
+(Required, string)
 Features expected by the tree, in their expected order.
 
 `tree`.`tree_structure`:::
@@ -221,7 +221,7 @@ children).
 The definition for an ensemble model.
 
 `ensemble`.`feature_names`:::
-(Required, string) 
+(Optional, string)
 Features expected by the ensemble, in their expected order.
 
 `ensemble`.`trained_models`:::

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -321,7 +321,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
     }
 
     public static class Builder {
-        private List<String> featureNames ;
+        private List<String> featureNames;
         private List<TrainedModel> trainedModels;
         private OutputAggregator outputAggregator = new WeightedSum();
         private TargetType targetType = TargetType.REGRESSION;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -319,7 +319,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
     }
 
     public static class Builder {
-        private List<String> featureNames;
+        private List<String> featureNames ;
         private List<TrainedModel> trainedModels;
         private OutputAggregator outputAggregator = new WeightedSum();
         private TargetType targetType = TargetType.REGRESSION;
@@ -327,8 +327,9 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
         private double[] classificationWeights;
         private boolean modelsAreOrdered;
 
-        private Builder (boolean modelsAreOrdered) {
+        private Builder(boolean modelsAreOrdered) {
             this.modelsAreOrdered = modelsAreOrdered;
+            this.featureNames = Collections.emptyList();
         }
 
         private static Builder builderForParser() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -207,7 +207,9 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(FEATURE_NAMES.getPreferredName(), featureNames);
+        if (featureNames.isEmpty() == false) {
+            builder.field(FEATURE_NAMES.getPreferredName(), featureNames);
+        }
         NamedXContentObjectHelper.writeNamedObjects(builder, params, true, TRAINED_MODELS.getPreferredName(), models);
         NamedXContentObjectHelper.writeNamedObjects(builder,
             params,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -92,7 +92,7 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
                 .toArray() :
             null;
 
-        return new Ensemble(featureNames,
+        return new Ensemble(randomBoolean() ? featureNames : Collections.emptyList(),
             models,
             outputAggregator,
             targetType,


### PR DESCRIPTION
Feature names are requisite in individual models are not required by the Ensemble. 

While an empty list is acceptable this change means the field does not have to be defined in the JSON config.