### PR TITLE
[7.x] [ML] allow close/stop for jobs/datafeeds with missing configs (#51888)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/JobAndDatafeedResilienceIT.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
+import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
+import org.elasticsearch.xpack.core.ml.job.config.Detector;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
+import org.junit.After;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.createDatafeedBuilder;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class JobAndDatafeedResilienceIT extends MlNativeAutodetectIntegTestCase {
+
+    private String index = "empty_index";
+
+    @After
+    public void cleanUpTest() {
+        cleanUp();
+    }
+
+    public void testCloseOpenJobWithMissingConfig() throws Exception {
+        final String jobId = "job-with-missing-config";
+        Job.Builder job = createJob(jobId, TimeValue.timeValueMinutes(5), "count", null);
+
+        putJob(job);
+        openJob(job.getId());
+
+        client().prepareDelete(AnomalyDetectorsIndexFields.CONFIG_INDEX, "_doc", Job.documentId(jobId)).get();
+        client().admin().indices().prepareRefresh(AnomalyDetectorsIndexFields.CONFIG_INDEX).get();
+
+        ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> {
+            CloseJobAction.Request request = new CloseJobAction.Request(jobId);
+            request.setAllowNoJobs(false);
+            client().execute(CloseJobAction.INSTANCE, request).actionGet();
+        });
+        assertThat(ex.getMessage(), equalTo("No known job with id 'job-with-missing-config'"));
+
+        forceCloseJob(jobId);
+        assertBusy(() ->
+            assertThat(client().admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(MlTasks.JOB_TASK_NAME + "[c]")
+                .get()
+                .getTasks()
+                .size(), equalTo(0))
+        );
+    }
+
+    public void testStopStartedDatafeedWithMissingConfig() throws Exception {
+        client().admin().indices().prepareCreate(index)
+            .addMapping("type", "time", "type=date", "value", "type=long")
+            .get();
+        final String jobId = "job-with-missing-datafeed-with-config";
+        Job.Builder job = createJob(jobId, TimeValue.timeValueMinutes(5), "count", null);
+
+        DatafeedConfig.Builder datafeedConfigBuilder =
+            createDatafeedBuilder(job.getId() + "-datafeed", job.getId(), Collections.singletonList(index));
+        DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
+        registerJob(job);
+        putJob(job);
+        openJob(job.getId());
+
+        registerDatafeed(datafeedConfig);
+        putDatafeed(datafeedConfig);
+        startDatafeed(datafeedConfig.getId(), 0L, null);
+
+        client().prepareDelete(AnomalyDetectorsIndexFields.CONFIG_INDEX, "_doc", DatafeedConfig.documentId(datafeedConfig.getId())).get();
+        client().admin().indices().prepareRefresh(AnomalyDetectorsIndexFields.CONFIG_INDEX).get();
+
+        ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> {
+            StopDatafeedAction.Request request = new StopDatafeedAction.Request(datafeedConfig.getId());
+            request.setAllowNoDatafeeds(false);
+            client().execute(StopDatafeedAction.INSTANCE, request).actionGet();
+        });
+        assertThat(ex.getMessage(), equalTo("No datafeed with id [job-with-missing-datafeed-with-config-datafeed] exists"));
+
+
+        forceStopDatafeed(datafeedConfig.getId());
+        assertBusy(() ->
+            assertThat(client().admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(MlTasks.DATAFEED_TASK_NAME + "[c]")
+                .get()
+                .getTasks()
+                .size(), equalTo(0))
+        );
+        closeJob(jobId);
+        waitUntilJobIsClosed(jobId);
+    }
+
+    public void testGetJobStats() throws Exception {
+        final String jobId1 = "job-with-missing-config-stats";
+        final String jobId2 = "job-with-config-stats";
+
+        Job.Builder job1 = createJob(jobId1, TimeValue.timeValueMinutes(5), "count", null);
+        Job.Builder job2 = createJob(jobId2, TimeValue.timeValueMinutes(5), "count", null);
+
+        putJob(job1);
+        openJob(job1.getId());
+        registerJob(job2);
+        putJob(job2);
+        openJob(job2.getId());
+
+        client().prepareDelete(AnomalyDetectorsIndexFields.CONFIG_INDEX, "_doc", Job.documentId(jobId1)).get();
+        client().admin().indices().prepareRefresh(AnomalyDetectorsIndexFields.CONFIG_INDEX).get();
+
+        List<GetJobsStatsAction.Response.JobStats> jobStats = client().execute(GetJobsStatsAction.INSTANCE,
+            new GetJobsStatsAction.Request("*"))
+            .get()
+            .getResponse()
+            .results();
+        assertThat(jobStats.size(), equalTo(2));
+        assertThat(jobStats.get(0).getJobId(), equalTo(jobId2));
+        assertThat(jobStats.get(1).getJobId(), equalTo(jobId1));
+        forceCloseJob(jobId1);
+        closeJob(jobId2);
+        assertBusy(() ->
+            assertThat(client().admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(MlTasks.JOB_TASK_NAME + "[c]")
+                .get()
+                .getTasks()
+                .size(), equalTo(0))
+        );
+    }
+
+    public void testGetDatafeedStats() throws Exception {
+        client().admin().indices().prepareCreate(index)
+            .addMapping("type", "time", "type=date", "value", "type=long")
+            .get();
+        final String jobId1 = "job-with-datafeed-missing-config-stats";
+        final String jobId2 = "job-with-datafeed-config-stats";
+
+        Job.Builder job1 = createJob(jobId1, TimeValue.timeValueMinutes(5), "count", null);
+        Job.Builder job2 = createJob(jobId2, TimeValue.timeValueMinutes(5), "count", null);
+
+        registerJob(job1);
+        putJob(job1);
+        openJob(job1.getId());
+        registerJob(job2);
+        putJob(job2);
+        openJob(job2.getId());
+
+        DatafeedConfig.Builder datafeedConfigBuilder1 =
+            createDatafeedBuilder(job1.getId() + "-datafeed", job1.getId(), Collections.singletonList(index));
+        DatafeedConfig datafeedConfig1 = datafeedConfigBuilder1.build();
+
+        putDatafeed(datafeedConfig1);
+        startDatafeed(datafeedConfig1.getId(), 0L, null);
+
+        DatafeedConfig.Builder datafeedConfigBuilder2 =
+            createDatafeedBuilder(job2.getId() + "-datafeed", job2.getId(), Collections.singletonList(index));
+        DatafeedConfig datafeedConfig2 = datafeedConfigBuilder2.build();
+
+        putDatafeed(datafeedConfig2);
+        startDatafeed(datafeedConfig2.getId(), 0L, null);
+
+        client().prepareDelete(AnomalyDetectorsIndexFields.CONFIG_INDEX, "_doc", DatafeedConfig.documentId(datafeedConfig1.getId())).get();
+        client().admin().indices().prepareRefresh(AnomalyDetectorsIndexFields.CONFIG_INDEX).get();
+
+        List<GetDatafeedsStatsAction.Response.DatafeedStats> dfStats = client().execute(GetDatafeedsStatsAction.INSTANCE,
+            new GetDatafeedsStatsAction.Request("*"))
+            .get()
+            .getResponse()
+            .results();
+        assertThat(dfStats.size(), equalTo(2));
+        assertThat(dfStats.get(0).getDatafeedId(), equalTo(datafeedConfig2.getId()));
+        assertThat(dfStats.get(1).getDatafeedId(), equalTo(datafeedConfig1.getId()));
+
+        forceStopDatafeed(datafeedConfig1.getId());
+        stopDatafeed(datafeedConfig2.getId());
+        assertBusy(() ->
+            assertThat(client().admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(MlTasks.DATAFEED_TASK_NAME + "[c]")
+                .get()
+                .getTasks()
+                .size(), equalTo(0))
+        );
+        closeJob(jobId1);
+        closeJob(jobId2);
+        waitUntilJobIsClosed(jobId1);
+        waitUntilJobIsClosed(jobId2);
+    }
+
+    private CloseJobAction.Response forceCloseJob(String jobId) {
+        CloseJobAction.Request request = new CloseJobAction.Request(jobId);
+        request.setForce(true);
+        return client().execute(CloseJobAction.INSTANCE, request).actionGet();
+    }
+
+    private StopDatafeedAction.Response forceStopDatafeed(String datafeedId) {
+        StopDatafeedAction.Request request = new StopDatafeedAction.Request(datafeedId);
+        request.setForce(true);
+        return client().execute(StopDatafeedAction.INSTANCE, request).actionGet();
+    }
+
+    private Job.Builder createJob(String id, TimeValue bucketSpan, String function, String field) {
+        return createJob(id, bucketSpan, function, field, null);
+    }
+
+    private Job.Builder createJob(String id, TimeValue bucketSpan, String function, String field, String summaryCountField) {
+        DataDescription.Builder dataDescription = new DataDescription.Builder();
+        dataDescription.setFormat(DataDescription.DataFormat.XCONTENT);
+        dataDescription.setTimeField("time");
+        dataDescription.setTimeFormat(DataDescription.EPOCH_MS);
+
+        Detector.Builder d = new Detector.Builder(function, field);
+        AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(d.build()));
+        analysisConfig.setBucketSpan(bucketSpan);
+        analysisConfig.setSummaryCountFieldName(summaryCountField);
+
+        Job.Builder builder = new Job.Builder();
+        builder.setId(id);
+        builder.setAnalysisConfig(analysisConfig);
+        builder.setDataDescription(dataDescription);
+        return builder;
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -209,7 +209,17 @@ public class TransportDeleteJobAction extends TransportMasterNodeAction<DeleteJo
                 auditor.info(request.getJobId(), Messages.getMessage(Messages.JOB_AUDIT_DELETING, taskId));
                 markJobAsDeletingIfNotUsed(request.getJobId(), markAsDeletingListener);
             },
-            e -> finalListener.onFailure(e));
+            e -> {
+                if (request.isForce()
+                    && MlTasks.getJobTask(request.getJobId(), state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE)) != null) {
+                    logger.info(
+                        "[{}] config is missing but task exists. Attempting to delete tasks and stop process",
+                        request.getJobId());
+                    forceDeleteJob(parentTaskClient, request, finalListener);
+                } else {
+                    finalListener.onFailure(e);
+                }
+            });
 
         // First check that the job exists, because we don't want to audit
         // the beginning of its deletion if it didn't exist in the first place

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedsStatsAction.java
@@ -32,6 +32,9 @@ import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAction<GetDatafeedsStatsAction.Request,
@@ -67,47 +70,66 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
     protected void masterOperation(GetDatafeedsStatsAction.Request request, ClusterState state,
                                    ActionListener<GetDatafeedsStatsAction.Response> listener) throws Exception {
         logger.debug("Get stats for datafeed '{}'", request.getDatafeedId());
+        final PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+        ActionListener<SortedSet<String>> expandIdsListener = ActionListener.wrap(
+            expandedIds -> {
+                datafeedConfigProvider.expandDatafeedConfigs(
+                    request.getDatafeedId(),
+                    // Already took into account the request parameter when we expanded the IDs with the tasks earlier
+                    // Should allow for no datafeeds in case the config is gone
+                    true,
+                    ActionListener.wrap(
+                        datafeedBuilders -> {
+                            Map<String, DatafeedConfig> existingConfigs = datafeedBuilders.stream()
+                                .map(DatafeedConfig.Builder::build)
+                                .collect(Collectors.toMap(DatafeedConfig::getId, Function.identity()));
 
-        datafeedConfigProvider.expandDatafeedConfigs(
-            request.getDatafeedId(),
-            request.allowNoDatafeeds(),
-            ActionListener.wrap(
-                datafeedBuilders -> {
-                    List<String> jobIds =
-                        datafeedBuilders.stream()
-                            .map(DatafeedConfig.Builder::build)
-                            .map(DatafeedConfig::getJobId)
-                            .collect(Collectors.toList());
-                    jobResultsProvider.datafeedTimingStats(
-                        jobIds,
-                        timingStatsByJobId -> {
-                            PersistentTasksCustomMetaData tasksInProgress = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
-                            List<GetDatafeedsStatsAction.Response.DatafeedStats> results =
-                                datafeedBuilders.stream()
-                                    .map(DatafeedConfig.Builder::build)
-                                    .map(
-                                        datafeed -> getDatafeedStats(
-                                            datafeed.getId(),
-                                            state,
-                                            tasksInProgress,
-                                            datafeed.getJobId(),
-                                            timingStatsByJobId.get(datafeed.getJobId())))
-                                    .collect(Collectors.toList());
-                            QueryPage<GetDatafeedsStatsAction.Response.DatafeedStats> statsPage =
-                                new QueryPage<>(results, results.size(), DatafeedConfig.RESULTS_FIELD);
-                            listener.onResponse(new GetDatafeedsStatsAction.Response(statsPage));
+                            List<String> jobIds = existingConfigs.values()
+                                .stream()
+                                .map(DatafeedConfig::getJobId)
+                                .collect(Collectors.toList());
+                            jobResultsProvider.datafeedTimingStats(
+                                jobIds,
+                                timingStatsByJobId -> {
+                                    List<GetDatafeedsStatsAction.Response.DatafeedStats> results = expandedIds.stream()
+                                        .map(datafeedId -> {
+                                            DatafeedConfig config = existingConfigs.get(datafeedId);
+                                            String jobId = config == null ? null : config.getJobId();
+                                            DatafeedTimingStats timingStats = jobId == null ? null : timingStatsByJobId.get(jobId);
+                                            return buildDatafeedStats(
+                                                datafeedId,
+                                                state,
+                                                tasksInProgress,
+                                                jobId,
+                                                timingStats
+                                            );
+                                        })
+                                        .collect(Collectors.toList());
+                                    QueryPage<GetDatafeedsStatsAction.Response.DatafeedStats> statsPage =
+                                        new QueryPage<>(results, results.size(), DatafeedConfig.RESULTS_FIELD);
+                                    listener.onResponse(new GetDatafeedsStatsAction.Response(statsPage));
+                                },
+                                listener::onFailure);
                         },
-                        listener::onFailure);
-                },
-                listener::onFailure)
+                        listener::onFailure)
+                );
+            },
+            listener::onFailure
         );
+
+        // This might also include datafeed tasks that exist but no longer have a config
+        datafeedConfigProvider.expandDatafeedIds(request.getDatafeedId(),
+            request.allowNoDatafeeds(),
+            tasksInProgress,
+            true,
+            expandIdsListener);
     }
 
-    private static GetDatafeedsStatsAction.Response.DatafeedStats getDatafeedStats(String datafeedId,
-                                                                                   ClusterState state,
-                                                                                   PersistentTasksCustomMetaData tasks,
-                                                                                   String jobId,
-                                                                                   DatafeedTimingStats timingStats) {
+    private static GetDatafeedsStatsAction.Response.DatafeedStats buildDatafeedStats(String datafeedId,
+                                                                                     ClusterState state,
+                                                                                     PersistentTasksCustomMetaData tasks,
+                                                                                     String jobId,
+                                                                                     DatafeedTimingStats timingStats) {
         PersistentTasksCustomMetaData.PersistentTask<?> task = MlTasks.getDatafeedTask(datafeedId, tasks);
         DatafeedState datafeedState = MlTasks.getDatafeedState(datafeedId, tasks);
         DiscoveryNode node = null;
@@ -116,7 +138,7 @@ public class TransportGetDatafeedsStatsAction extends TransportMasterNodeReadAct
             node = state.nodes().get(task.getExecutorNode());
             explanation = task.getAssignment().getExplanation();
         }
-        if (timingStats == null) {
+        if (timingStats == null && jobId != null) {
             timingStats = new DatafeedTimingStats(jobId);
         }
         return new GetDatafeedsStatsAction.Response.DatafeedStats(datafeedId, datafeedState, node, explanation, timingStats);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -75,7 +75,10 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<TransportO
     protected void doExecute(Task task, GetJobsStatsAction.Request request, ActionListener<GetJobsStatsAction.Response> finalListener) {
         logger.debug("Get stats for job [{}]", request.getJobId());
 
-        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), true, ActionListener.wrap(
+        ClusterState state = clusterService.state();
+        PersistentTasksCustomMetaData tasks = state.getMetaData().custom(PersistentTasksCustomMetaData.TYPE);
+        // If there are deleted configs, but the task is still around, we probably want to return the tasks in the stats call
+        jobConfigProvider.expandJobsIds(request.getJobId(), request.allowNoJobs(), true, tasks, true, ActionListener.wrap(
                 expandedIds -> {
                     request.setExpandedJobsIds(new ArrayList<>(expandedIds));
                     ActionListener<GetJobsStatsAction.Response> jobStatsListener = ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportIsolateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportIsolateDatafeedAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
@@ -43,9 +42,6 @@ public class TransportIsolateDatafeedAction extends TransportTasksAction<Transpo
             listener.onResponse(new IsolateDatafeedAction.Response(false));
             return;
         }
-
-        String executorNode = datafeedTask.getExecutorNode();
-        DiscoveryNodes nodes = state.nodes();
 
         request.setNodes(datafeedTask.getExecutorNode());
         super.doExecute(task, request, listener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
@@ -447,7 +449,15 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
                         executeAsyncWithOrigin(client, ML_ORIGIN, FinalizeJobExecutionAction.INSTANCE, finalizeRequest,
                             ActionListener.wrap(
                                 response -> task.markAsCompleted(),
-                                e -> logger.error("error finalizing job [" + jobId + "]", e)
+                                e -> {
+                                    logger.error("error finalizing job [" + jobId + "]", e);
+                                    Throwable unwrapped = ExceptionsHelper.unwrapCause(e);
+                                    if (unwrapped instanceof DocumentMissingException || unwrapped instanceof ResourceNotFoundException) {
+                                        task.markAsCompleted();
+                                    } else {
+                                        task.markAsFailed(e);
+                                    }
+                                }
                             ));
                     } else {
                         task.markAsCompleted();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -42,9 +42,12 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
+import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
@@ -350,9 +353,15 @@ public class DatafeedConfigProvider {
      * @param allowNoDatafeeds if {@code false}, an error is thrown when no name matches the {@code expression}.
      *                     This only applies to wild card expressions, if {@code expression} is not a
      *                     wildcard then setting this true will not suppress the exception
+     * @param tasks The current tasks meta-data. For expanding IDs when datafeeds might have missing configurations
+     * @param allowMissingConfigs If a datafeed has a task, but is missing a config, allow the ID to be expanded via the existing task
      * @param listener The expanded datafeed IDs listener
      */
-    public void expandDatafeedIds(String expression, boolean allowNoDatafeeds, ActionListener<SortedSet<String>> listener) {
+    public void expandDatafeedIds(String expression,
+                                  boolean allowNoDatafeeds,
+                                  PersistentTasksCustomMetaData tasks,
+                                  boolean allowMissingConfigs,
+                                  ActionListener<SortedSet<String>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildDatafeedIdQuery(tokens));
         sourceBuilder.sort(DatafeedConfig.ID.getPreferredName());
@@ -366,6 +375,7 @@ public class DatafeedConfigProvider {
                 .request();
 
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoDatafeeds);
+        Collection<String> matchingStartedDatafeedIds = matchingDatafeedIdsWithTasks(tokens, tasks);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
                 ActionListener.<SearchResponse>wrap(
@@ -374,6 +384,9 @@ public class DatafeedConfigProvider {
                             SearchHit[] hits = response.getHits().getHits();
                             for (SearchHit hit : hits) {
                                 datafeedIds.add(hit.field(DatafeedConfig.ID.getPreferredName()).getValue());
+                            }
+                            if (allowMissingConfigs) {
+                                datafeedIds.addAll(matchingStartedDatafeedIds);
                             }
 
                             requiredMatches.filterMatchedIds(datafeedIds);
@@ -391,10 +404,10 @@ public class DatafeedConfigProvider {
     }
 
     /**
-     * The same logic as {@link #expandDatafeedIds(String, boolean, ActionListener)} but
+     * The same logic as {@link #expandDatafeedIds(String, boolean, PersistentTasksCustomMetaData, boolean, ActionListener)} but
      * the full datafeed configuration is returned.
      *
-     * See {@link #expandDatafeedIds(String, boolean, ActionListener)}
+     * See {@link #expandDatafeedIds(String, boolean, PersistentTasksCustomMetaData, boolean, ActionListener)}
      *
      * @param expression the expression to resolve
      * @param allowNoDatafeeds if {@code false}, an error is thrown when no name matches the {@code expression}.
@@ -476,6 +489,30 @@ public class DatafeedConfigProvider {
         }
 
         return boolQueryBuilder;
+    }
+
+    static Collection<String> matchingDatafeedIdsWithTasks(String[] datafeedIdPatterns, PersistentTasksCustomMetaData tasksMetaData) {
+        Set<String> startedDatafeedIds = MlTasks.startedDatafeedIds(tasksMetaData);
+        if (startedDatafeedIds.isEmpty()) {
+            return Collections.emptyList()  ;
+        }
+        if (Strings.isAllOrWildcard(datafeedIdPatterns)) {
+            return startedDatafeedIds;
+        }
+
+        List<String> matchingDatafeedIds = new ArrayList<>();
+        for (String datafeedIdPattern : datafeedIdPatterns) {
+            if (startedDatafeedIds.contains(datafeedIdPattern))  {
+                matchingDatafeedIds.add(datafeedIdPattern);
+            } else if (Regex.isSimpleMatchPattern(datafeedIdPattern)) {
+                for (String startedDatafeedId : startedDatafeedIds) {
+                    if (Regex.simpleMatch(datafeedIdPattern, startedDatafeedId)) {
+                        matchingDatafeedIds.add(startedDatafeedId);
+                    }
+                }
+            }
+        }
+        return matchingDatafeedIds;
     }
 
     private QueryBuilder buildDatafeedJobIdsQuery(Collection<String> jobIds) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.regex.Regex;
@@ -50,11 +51,13 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.elasticsearch.persistent.PersistentTasksCustomMetaData;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
+import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
@@ -502,9 +505,17 @@ public class JobConfigProvider {
      *                     This only applies to wild card expressions, if {@code expression} is not a
      *                     wildcard then setting this true will not suppress the exception
      * @param excludeDeleting If true exclude jobs marked as deleting
+     * @param tasksCustomMetaData The current persistent task metadata.
+     *                            For resolving jobIds that have tasks, but for some reason, don't have configs
+     * @param allowMissingConfigs If a job has a task, but is missing a config, allow the ID to be expanded via the existing task
      * @param listener The expanded job Ids listener
      */
-    public void expandJobsIds(String expression, boolean allowNoJobs, boolean excludeDeleting, ActionListener<SortedSet<String>> listener) {
+    public void expandJobsIds(String expression,
+                              boolean allowNoJobs,
+                              boolean excludeDeleting,
+                              @Nullable PersistentTasksCustomMetaData tasksCustomMetaData,
+                              boolean allowMissingConfigs,
+                              ActionListener<SortedSet<String>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
         sourceBuilder.sort(Job.ID.getPreferredName());
@@ -519,6 +530,7 @@ public class JobConfigProvider {
                 .request();
 
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoJobs);
+        Set<String> openMatchingJobs = matchingJobIdsWithTasks(tokens, tasksCustomMetaData);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
                 ActionListener.<SearchResponse>wrap(
@@ -533,7 +545,9 @@ public class JobConfigProvider {
                                     groupsIds.addAll(groups.stream().map(Object::toString).collect(Collectors.toList()));
                                 }
                             }
-
+                            if (allowMissingConfigs) {
+                                jobIds.addAll(openMatchingJobs);
+                            }
                             groupsIds.addAll(jobIds);
                             requiredMatches.filterMatchedIds(groupsIds);
                             if (requiredMatches.hasUnmatchedIds()) {
@@ -550,10 +564,10 @@ public class JobConfigProvider {
     }
 
     /**
-     * The same logic as {@link #expandJobsIds(String, boolean, boolean, ActionListener)} but
+     * The same logic as {@link #expandJobsIds(String, boolean, boolean, PersistentTasksCustomMetaData, boolean, ActionListener)} but
      * the full anomaly detector job configuration is returned.
      *
-     * See {@link #expandJobsIds(String, boolean, boolean, ActionListener)}
+     * See {@link #expandJobsIds(String, boolean, boolean, PersistentTasksCustomMetaData, boolean, ActionListener)}
      *
      * @param expression the expression to resolve
      * @param allowNoJobs if {@code false}, an error is thrown when no name matches the {@code expression}.
@@ -611,7 +625,7 @@ public class JobConfigProvider {
 
     /**
      * Expands the list of job group Ids to the set of jobs which are members of the groups.
-     * Unlike {@link #expandJobsIds(String, boolean, boolean, ActionListener)} it is not an error
+     * Unlike {@link #expandJobsIds(String, boolean, boolean, PersistentTasksCustomMetaData, boolean, ActionListener)} it is not an error
      * if a group Id does not exist.
      * Wildcard expansion of group Ids is not supported.
      *
@@ -734,6 +748,31 @@ public class JobConfigProvider {
                 listener::onFailure
         ));
     }
+
+    static Set<String> matchingJobIdsWithTasks(String[] jobIdPatterns, PersistentTasksCustomMetaData tasksMetaData) {
+        Set<String> openjobs = MlTasks.openJobIds(tasksMetaData);
+        if (openjobs.isEmpty()) {
+            return Collections.emptySet();
+        }
+        if (Strings.isAllOrWildcard(jobIdPatterns)) {
+            return openjobs;
+        }
+
+        Set<String> matchingJobIds = new HashSet<>();
+        for (String jobIdPattern : jobIdPatterns) {
+            if (openjobs.contains(jobIdPattern))  {
+                matchingJobIds.add(jobIdPattern);
+            } else if (Regex.isSimpleMatchPattern(jobIdPattern)) {
+                for (String openJobId : openjobs) {
+                    if (Regex.simpleMatch(jobIdPattern, openJobId)) {
+                        matchingJobIds.add(openJobId);
+                    }
+                }
+            }
+        }
+        return matchingJobIds;
+    }
+
 
     private void parseJobLenientlyFromSource(BytesReference source, ActionListener<Job.Builder> jobListener)  {
         try (InputStream stream = source.streamInput();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -276,7 +275,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
 
     private TransportCloseJobAction createAction() {
         return new TransportCloseJobAction(mock(TransportService.class), mock(ThreadPool.class), mock(ActionFilters.class),
-                clusterService, mock(Client.class), mock(AnomalyDetectionAuditor.class), mock(PersistentTasksService.class),
+                clusterService, mock(AnomalyDetectionAuditor.class), mock(PersistentTasksService.class),
                 jobConfigProvider, datafeedConfigProvider);
     }
 
@@ -293,11 +292,11 @@ public class TransportCloseJobActionTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     private void mockJobConfigProviderExpandIds(Set<String> expandedIds) {
         doAnswer(invocation -> {
-            ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[3];
+            ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[5];
             listener.onResponse(expandedIds);
 
             return null;
-        }).when(jobConfigProvider).expandJobsIds(any(), anyBoolean(), anyBoolean(), any(ActionListener.class));
+        }).when(jobConfigProvider).expandJobsIds(any(), anyBoolean(), anyBoolean(), any(), anyBoolean(), any(ActionListener.class));
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] allow close/stop for jobs/datafeeds with missing configs  (#51888)