### PR TITLE
[DOCS] Add EQL limitations page

### DIFF
--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -31,6 +31,8 @@ Consider using EQL if you:
 
 * <<eql-requirements>>
 * <<eql-syntax>>
+* <<eql-limitations>>
 
 include::requirements.asciidoc[]
 include::syntax.asciidoc[]
+include::limitations.asciidoc[]

--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -1,0 +1,29 @@
+[role="xpack"]
+[testenv="basic"]
+[[eql-limitations]]
+== EQL limitations
+++++
+<titleabbrev>Limitations</titleabbrev>
+++++
+
+experimental::[]
+
+[discrete]
+[[eql-unsupported-syntax]]
+=== Unsupported syntax
+
+{es} supports a subset of {eql-ref}/index.html[EQL syntax]. {es} cannot run EQL
+queries that contain:
+
+* {eql-ref}/functions.html[Functions]
+
+* {eql-ref}/joins.html[Joins]
+
+* {eql-ref}/basic-syntax.html#event-relationships[Lineage-related keywords]:
+** `child of`
+** `descendant of`
+** `event of`
+
+* {eql-ref}/pipes.html[Pipes]
+
+* {eql-ref}/sequences.html[Sequences]


### PR DESCRIPTION
Documents limitations for EQL in ES.

The page is intended to capture EQL functionality as set out in "Milestone 1"  of #49581. I will continue to update the page as we support new syntax, find new limitations, etc.

Will backport to 7.x branch.