### PR TITLE
[ML] Make MachineLearningLicensingTests an integ test

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -59,7 +59,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
+public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
     @Before
     public void resetLicensing() {


### PR DESCRIPTION
Because it is a slow test and sometimes means the unit tests take much longer to run and I'm not taking it anymore.

`MachineLearningLicensingTests` is an integ test it inherits from `BaseMlIntegTestCase` and should run under the `:x-pack:plugin:ml:internalClusterTest` target not `:x-pack:plugin:ml:test`. Renaming the file achieves that