### PR TITLE
[DOCS] Correct `source.index` parm def in reindex API

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -442,8 +442,10 @@ Defaults to `abort`.
 
 `source`::
 `index`:::
-(Required, string) The name of the index you are copying _from_. 
-Also accepts a comma-separated list of indices to reindex from multiple sources.  
+(Required, string or array of strings)
+The name of the index you are copying _from_. 
+Also accepts an array of indices (e.g. `["index1", "index2"]`) to reindex from
+multiple sources.  
 
 `max_docs`:::
 (Optional, integer) The maximum number of documents to reindex.


### PR DESCRIPTION
Corrects the `source.index` request body parameter definition to
state that arrays, not comma-separated values, are accepted.

Relates to #51949