### PR TITLE
Make sorting by an agg results a real abstraction

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -240,6 +241,22 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    /**
+     * Get value to use when sorting by this aggregation.
+     */
+    public double sortValue(String key) {
+        // subclasses will override this with a real implementation if they can be sorted
+        throw new IllegalArgumentException("Can't sort a [" + getType() + "] aggregation [" + getName() + "]");
+    }
+
+    /**
+     * Get value to use when sorting by a descendant of this aggregation.
+     */
+    public double sortValue(AggregationPath.PathElement head, Iterator<AggregationPath.PathElement> tail) {
+        // subclasses will override this with a real implementation if you can sort on a descendant
+        throw new IllegalArgumentException("Can't sort by a descendant of a [" + getType() + "] aggregation [" + head + "]");
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -24,12 +24,14 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.SiblingPipelineAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -95,6 +97,20 @@ public final class InternalAggregations extends Aggregations implements Writeabl
     @SuppressWarnings("unchecked")
     private List<InternalAggregation> getInternalAggregations() {
         return (List<InternalAggregation>) aggregations;
+    }
+
+    /**
+     * Get value to use when sorting by a descendant of the aggregation containing this.
+     */
+    public double sortValue(AggregationPath.PathElement head, Iterator<AggregationPath.PathElement> tail) {
+        InternalAggregation aggregation = get(head.name);
+        if (aggregation == null) {
+            throw new IllegalArgumentException("Cannot find aggregation named [" + head.name + "]");
+        }
+        if (tail.hasNext()) {
+            return aggregation.sortValue(tail.next(), tail);
+        }
+        return aggregation.sortValue(head.key);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -192,5 +192,6 @@ public abstract class InternalMultiBucketAggregation<A extends InternalMultiBuck
             }
             return aggregation.getProperty(path.subList(1, path.size()));
         }
+
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -153,8 +153,8 @@ public class InternalOrder extends BucketOrder {
 
             @Override
             public int compare(Bucket b1, Bucket b2) {
-                double v1 = path.resolveValue(b1);
-                double v2 = path.resolveValue(b2);
+                double v1 = path.resolveValue(((InternalAggregations) b1.getAggregations()));
+                double v2 = path.resolveValue(((InternalAggregations) b2.getAggregations()));
                 return Comparators.compareDiscardNaN(v1, v2, asc);
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -25,9 +25,11 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -150,6 +152,21 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
         builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
         aggregations.toXContentInternal(builder, params);
         return builder;
+    }
+
+    @Override
+    public final double sortValue(String key) {
+        if (key != null && false == key.equals("doc_count")) {
+            throw new IllegalArgumentException(
+                    "Unknown value key [" + key + "] for single-bucket aggregation [" + getName() +
+                    "]. Either use [doc_count] as key or drop the key all together.");
+        }
+        return docCount;
+    }
+
+    @Override
+    public final double sortValue(AggregationPath.PathElement head, Iterator<AggregationPath.PathElement> tail) {
+        return aggregations.sortValue(head, tail);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/AggregationPathTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/AggregationPathTests.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class PathTests extends ESTestCase {
+public class AggregationPathTests extends ESTestCase {
     public void testInvalidPaths() throws Exception {
         assertInvalidPath("[foo]", "brackets at the beginning of the token expression");
         assertInvalidPath("foo[bar", "open brackets without closing at the token expression");
@@ -49,13 +49,8 @@ public class PathTests extends ESTestCase {
         assertValidPath("foo.bar>baz[qux]", tokens().add("foo.bar").add("baz", "qux"));
     }
 
-    private void assertInvalidPath(String path, String reason) {
-        try {
-            AggregationPath.parse(path);
-            fail("Expected parsing path [" + path + "] to fail - " + reason);
-        } catch (AggregationExecutionException aee) {
-            // expected
-        }
+    private AggregationExecutionException assertInvalidPath(String path, String reason) {
+        return expectThrows(AggregationExecutionException.class, () -> AggregationPath.parse(path));
     }
 
     private void assertValidPath(String path, Tokens tokenz) {


### PR DESCRIPTION
This removes a bunch of `instanceof`s in favor of two new methods on
`InernalAggregation`. The default implementations of these methods just
throw exceptions explaining that you can't sort on this aggregation.
They are overridden by all of the classes that used to have `instanceof`
checks against them.

I doubt this is really any faster in practice. The real benefit here is
that it is a little more obvious *that* you can sort by the results of
an aggregation and it should be *much* more obvious where to look at
*how* aggregations sort themselves.

There are still a bunch more `instanceof`s in left in `AggregationPath`
but those will wait for a followup change.
