### PR TITLE
Mute failing tests on Windows (#50825)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -46,6 +46,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.isEmptyString;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -53,6 +54,9 @@ public class ArchiveTests extends PackagingTestCase {
 
     @BeforeClass
     public static void filterDistros() {
+        // Muted on Windows see: https://github.com/elastic/elasticsearch/issues/50825
+        assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+
         assumeTrue("only archives", distribution.isArchive());
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/CertGenCliTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.packaging.util.FileUtils;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -48,6 +49,9 @@ public class CertGenCliTests extends PackagingTestCase {
 
     @Before
     public void filterDistros() {
+        // Muted on Windows see: https://github.com/elastic/elasticsearch/issues/50825
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+
         assumeTrue("only default distro", distribution.flavor == Distribution.Flavor.DEFAULT);
         assumeTrue("no docker", distribution.packaging != Distribution.Packaging.DOCKER);
     }
@@ -100,7 +104,7 @@ public class CertGenCliTests extends PackagingTestCase {
     public void test40RunWithCert() throws Exception {
         // windows 2012 r2 has powershell 4.0, which lacks Expand-Archive
         assumeFalse(Platforms.OS_NAME.equals("Windows Server 2012 R2"));
-        
+
         append(installation.config("elasticsearch.yml"), String.join("\n",
             "node.name: mynode",
             "xpack.security.transport.ssl.key: " + escapePath(installation.config("certs/mynode/mynode.key")),


### PR DESCRIPTION
These tests are regularly failing and account for a substantial portion of our build failures. Muting these for now until they get addressed.

Relates to https://github.com/elastic/elasticsearch/issues/50825