### PR TITLE
Mute LangPainlessClientYamlTestSuiteIT context API tests

### DIFF
--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/71_context_api.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/71_context_api.yml
@@ -1,4 +1,7 @@
 "Action to list contexts":
+    - skip:
+        version: "all"
+        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/51939"
     - do:
         scripts_painless_context: {}
     - match: { contexts.0: aggregation_selector}
@@ -6,6 +9,9 @@
 ---
 
 "Action to get all API values for score context":
+    - skip:
+        version: "all"
+        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/51939"
     - do:
         scripts_painless_context:
             context: score


### PR DESCRIPTION
These test failures account for a substantial portion of our test failures in CI. Muting these for now until #51939 is addressed.

Relates to #51939.