### PR TITLE
Fixed the "Asynchronous usage" title

### DIFF
--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -154,6 +154,8 @@ executes the request. For example, this is the place where you'd specify a
 `NodeSelector` to control which node receives the request. See the
 <<java-rest-low-usage-request-options,low level client documentation>> for
 more examples of customizing the options.
+
+[[java-rest-high-getting-started-asynchronous-usage]]
 === Asynchronous usage
 
 All of the the methods across the different clients exist in a traditional synchronous and 


### PR DESCRIPTION
I noticed a weird "===Asynchronous usage" at the end of a paragraph in the Java high level REST client getting started guide (https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.x/java-rest-high-getting-started-request-options.html). It seems to me that it should be a heading but is missing a newline before it.
I also added the bracket notation thingy which seems to create an anchor and put everything below it on another page.