### PR TITLE
Restore docker build exclusions

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -9,7 +9,7 @@ opensuse-15-1
 ol-7.7
 sles-12
 
-# These OSes are deprecated and filtered on master, but need to be excluded 
+# These OSes are deprecated and filtered starting with 8.0.0, but need to be excluded 
 # for PR checks
 centos-6
 ol-6.10

--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -8,3 +8,8 @@ debian-8
 opensuse-15-1
 ol-7.7
 sles-12
+
+# These OSes are deprecated and filtered on master, but need to be excluded 
+# for PR checks
+centos-6
+ol-6.10


### PR DESCRIPTION
We have deprecated some old OSes and prevented them from running tests
on the master branch, but that filter doesn't apply to PR branches
pointed at master. This commit restores docker exclusions for those
deprecated OSes in order to allow PR checks to pass for packaging PRs.