### PR TITLE
Rename MapperService#fullName to fieldType.

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregationBuilder.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregationBuilder.java
@@ -282,7 +282,7 @@ public abstract class ArrayValuesSourceAggregationBuilder<VS extends ValuesSourc
             return config.format(resolveFormat(format, valueType));
         }
 
-        MappedFieldType fieldType = queryShardContext.getMapperService().fullName(field);
+        MappedFieldType fieldType = queryShardContext.getMapperService().fieldType(field);
         if (fieldType == null) {
             ValuesSourceType valuesSourceType = valueType != null ? valueType.getValuesSourceType() : this.valuesSourceType;
             ValuesSourceConfig<VS> config = new ValuesSourceConfig<>(valuesSourceType);

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -456,7 +456,7 @@ public class ExpressionScriptEngine implements ScriptEngine {
         }
 
         String fieldname = parts[1].text;
-        MappedFieldType fieldType = lookup.doc().mapperService().fullName(fieldname);
+        MappedFieldType fieldType = lookup.doc().mapperService().fieldType(fieldname);
 
         if (fieldType == null) {
             throw new ParseException("Field [" + fieldname + "] does not exist in mappings", 5);

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionFieldScriptTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionFieldScriptTests.java
@@ -49,8 +49,8 @@ public class ExpressionFieldScriptTests extends ESTestCase {
 
         NumberFieldMapper.NumberFieldType fieldType = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.DOUBLE);
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName("field")).thenReturn(fieldType);
-        when(mapperService.fullName("alias")).thenReturn(fieldType);
+        when(mapperService.fieldType("field")).thenReturn(fieldType);
+        when(mapperService.fieldType("alias")).thenReturn(fieldType);
 
         SortedNumericDoubleValues doubleValues = mock(SortedNumericDoubleValues.class);
         when(doubleValues.advanceExact(anyInt())).thenReturn(true);

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionNumberSortScriptTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionNumberSortScriptTests.java
@@ -49,8 +49,8 @@ public class ExpressionNumberSortScriptTests extends ESTestCase {
 
         NumberFieldType fieldType = new NumberFieldType(NumberType.DOUBLE);
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName("field")).thenReturn(fieldType);
-        when(mapperService.fullName("alias")).thenReturn(fieldType);
+        when(mapperService.fieldType("field")).thenReturn(fieldType);
+        when(mapperService.fieldType("alias")).thenReturn(fieldType);
 
         SortedNumericDoubleValues doubleValues = mock(SortedNumericDoubleValues.class);
         when(doubleValues.advanceExact(anyInt())).thenReturn(true);

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTermsSetQueryTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTermsSetQueryTests.java
@@ -49,8 +49,8 @@ public class ExpressionTermsSetQueryTests extends ESTestCase {
 
         NumberFieldType fieldType = new NumberFieldType(NumberType.DOUBLE);
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName("field")).thenReturn(fieldType);
-        when(mapperService.fullName("alias")).thenReturn(fieldType);
+        when(mapperService.fieldType("field")).thenReturn(fieldType);
+        when(mapperService.fieldType("alias")).thenReturn(fieldType);
 
         SortedNumericDoubleValues doubleValues = mock(SortedNumericDoubleValues.class);
         when(doubleValues.advanceExact(anyInt())).thenReturn(true);

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureMetaFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureMetaFieldMapper.java
@@ -74,7 +74,7 @@ public class RankFeatureMetaFieldMapper extends MetadataFieldMapper {
         @Override
         public MetadataFieldMapper.Builder<?,?> parse(String name,
                 Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            return new Builder(parserContext.mapperService().fullName(NAME));
+            return new Builder(parserContext.mapperService().fieldType(NAME));
         }
 
         @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -258,14 +258,14 @@ public class SearchAsYouTypeFieldMapperTests extends ESSingleNodeTestCase {
             fields.add(path);
             final MapperService mapperService =
                 createIndex(index, Settings.EMPTY, mapping).mapperService();
-            FieldType fieldType = mapperService.fullName(path + "._index_prefix");
+            FieldType fieldType = mapperService.fieldType(path + "._index_prefix");
             assertThat(fieldType, instanceOf(PrefixFieldType.class));
             PrefixFieldType prefixFieldType = (PrefixFieldType) fieldType;
             assertEquals(path, prefixFieldType.parentField);
             for (int i = 2; i < shingleSize; i++) {
                 String name = path + "._" + i + "gram";
                 fields.add(name);
-                fieldType = mapperService.fullName(name);
+                fieldType = mapperService.fieldType(name);
                 assertThat(fieldType, instanceOf(ShingleFieldType.class));
                 ShingleFieldType ft = (ShingleFieldType) fieldType;
                 assertEquals(i, ft.shingleSize);

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -83,7 +83,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
      */
     public static ParentJoinFieldMapper getMapper(MapperService service) {
         MetaJoinFieldMapper.MetaJoinFieldType fieldType =
-            (MetaJoinFieldMapper.MetaJoinFieldType) service.fullName(MetaJoinFieldMapper.NAME);
+            (MetaJoinFieldMapper.MetaJoinFieldType) service.fieldType(MetaJoinFieldMapper.NAME);
         return fieldType == null ? null : fieldType.getMapper();
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentChildInnerHitContextBuilder.java
@@ -131,7 +131,7 @@ class ParentChildInnerHitContextBuilder extends InnerHitContextBuilder {
                         result[i] = new TopDocsAndMaxScore(Lucene.EMPTY_TOP_DOCS, Float.NaN);
                         continue;
                     }
-                    q = context.mapperService().fullName(IdFieldMapper.NAME).termQuery(parentId, qsc);
+                    q = context.mapperService().fieldType(IdFieldMapper.NAME).termQuery(parentId, qsc);
                 }
 
                 Weight weight = context.searcher().createWeight(context.searcher().rewrite(q), ScoreMode.COMPLETE_NO_SCORES, 1f);

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
@@ -277,7 +277,7 @@ public class ChildrenToParentAggregatorTests extends AggregatorTestCase {
         MapperService mapperService = mock(MapperService.class);
         MetaJoinFieldMapper.MetaJoinFieldType metaJoinFieldType = mock(MetaJoinFieldMapper.MetaJoinFieldType.class);
         when(metaJoinFieldType.getMapper()).thenReturn(joinFieldMapper);
-        when(mapperService.fullName("_parent_join")).thenReturn(metaJoinFieldType);
+        when(mapperService.fieldType("_parent_join")).thenReturn(metaJoinFieldType);
         return mapperService;
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregatorTests.java
@@ -165,7 +165,7 @@ public class ParentToChildrenAggregatorTests extends AggregatorTestCase {
         MapperService mapperService = mock(MapperService.class);
         MetaJoinFieldMapper.MetaJoinFieldType metaJoinFieldType = mock(MetaJoinFieldMapper.MetaJoinFieldType.class);
         when(metaJoinFieldType.getMapper()).thenReturn(joinFieldMapper);
-        when(mapperService.fullName("_parent_join")).thenReturn(metaJoinFieldType);
+        when(mapperService.fieldType("_parent_join")).thenReturn(metaJoinFieldType);
         return mapperService;
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -446,11 +446,11 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
         assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
-        assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fullName("join_field#parent"));
-        assertTrue(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fullName("join_field#child"));
-        assertTrue(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
+        assertFalse(service.mapperService().fieldType("join_field").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fieldType("join_field#parent"));
+        assertTrue(service.mapperService().fieldType("join_field#parent").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fieldType("join_field#child"));
+        assertTrue(service.mapperService().fieldType("join_field#child").eagerGlobalOrdinals());
 
         mapping = Strings.toString(XContentFactory.jsonBuilder().startObject()
             .startObject("properties")
@@ -466,10 +466,10 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject());
         service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fullName("join_field#parent"));
-        assertFalse(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
-        assertNotNull(service.mapperService().fullName("join_field#child"));
-        assertFalse(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
+        assertFalse(service.mapperService().fieldType("join_field").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fieldType("join_field#parent"));
+        assertFalse(service.mapperService().fieldType("join_field#parent").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fieldType("join_field#child"));
+        assertFalse(service.mapperService().fieldType("join_field#child").eagerGlobalOrdinals());
     }
 }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -197,7 +197,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         }
         Collections.sort(intValues);
 
-        MappedFieldType intFieldType = mapperService.fullName("int_field");
+        MappedFieldType intFieldType = mapperService.fieldType("int_field");
 
         List<Supplier<Query>> queryFunctions = new ArrayList<>();
         queryFunctions.add(MatchNoDocsQuery::new);
@@ -329,7 +329,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         stringValues.add("value2");
         stringValues.add("value3");
 
-        MappedFieldType intFieldType = mapperService.fullName("int_field");
+        MappedFieldType intFieldType = mapperService.fieldType("int_field");
         List<int[]> ranges = new ArrayList<>();
         ranges.add(new int[]{-5, 5});
         ranges.add(new int[]{0, 10});

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -170,7 +170,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject(fieldName).field("type", "percolator").endObject().endObject()
                 .endObject().endObject());
         mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
-        fieldType = (PercolatorFieldMapper.FieldType) mapperService.fullName(fieldName);
+        fieldType = (PercolatorFieldMapper.FieldType) mapperService.fieldType(fieldName);
     }
 
     public void testExtractTerms() throws Exception {
@@ -229,10 +229,10 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testExtractRanges() throws Exception {
         addQueryFieldMappings();
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
-        Query rangeQuery1 = mapperService.fullName("number_field1")
+        Query rangeQuery1 = mapperService.fieldType("number_field1")
             .rangeQuery(10, 20, true, true, null, null, null, null);
         bq.add(rangeQuery1, Occur.MUST);
-        Query rangeQuery2 = mapperService.fullName("number_field1")
+        Query rangeQuery2 = mapperService.fieldType("number_field1")
             .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
@@ -264,7 +264,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         // Range queries on different fields:
         bq = new BooleanQuery.Builder();
         bq.add(rangeQuery1, Occur.MUST);
-        rangeQuery2 = mapperService.fullName("number_field2")
+        rangeQuery2 = mapperService.fieldType("number_field2")
             .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -90,7 +90,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
         @Override
         public MetadataFieldMapper.Builder<?, ?> parse(String name, Map<String, Object> node,
                                                        ParserContext parserContext) throws MapperParsingException {
-            Builder builder = new Builder(parserContext.mapperService().fullName(NAME),
+            Builder builder = new Builder(parserContext.mapperService().fieldType(NAME),
                 parserContext.indexVersionCreated());
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -177,7 +177,7 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeAc
             if (indexService == null) {
                 throw new IllegalArgumentException("analysis based on a specific field requires an index");
             }
-            MappedFieldType fieldType = indexService.mapperService().fullName(request.field());
+            MappedFieldType fieldType = indexService.mapperService().fieldType(request.field());
             if (fieldType != null) {
                 if (fieldType.tokenized() || fieldType instanceof KeywordFieldMapper.KeywordFieldType) {
                     return fieldType.indexAnalyzer();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -86,7 +86,7 @@ public class TransportFieldCapabilitiesIndexAction extends TransportSingleShardA
         Predicate<String> fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
         Map<String, IndexFieldCapabilities> responseMap = new HashMap<>();
         for (String field : fieldNames) {
-            MappedFieldType ft = mapperService.fullName(field);
+            MappedFieldType ft = mapperService.fieldType(field);
             if (ft != null) {
                 if (indicesService.isMetaDataField(mapperService.getIndexSettings().getIndexVersionCreated(), field)
                         || fieldPredicate.test(ft.name())) {
@@ -105,7 +105,7 @@ public class TransportFieldCapabilitiesIndexAction extends TransportSingleShardA
                         break;
                     }
                     // checks if the parent field contains sub-fields
-                    if (mapperService.fullName(parentField) == null) {
+                    if (mapperService.fieldType(parentField) == null) {
                         // no field type, it must be an object field
                         ObjectMapper mapper = mapperService.getObjectMapper(parentField);
                         String type = mapper.nested().isNested() ? "nested" : "object";

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -183,7 +183,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 // we delay the actual creation of the sort order for this index because the mapping has not been merged yet.
                 // The sort order is validated right after the merge of the mapping later in the process.
                 this.indexSortSupplier = () -> indexSettings.getIndexSortConfig().buildIndexSort(
-                    mapperService::fullName,
+                    mapperService::fieldType,
                     indexFieldData::getForField
                 );
             } else {

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -54,7 +54,7 @@ public class PerFieldMappingPostingFormatCodec extends Lucene84Codec {
 
     @Override
     public PostingsFormat getPostingsFormatForField(String field) {
-        final MappedFieldType fieldType = mapperService.fullName(field);
+        final MappedFieldType fieldType = mapperService.fieldType(field);
         if (fieldType == null) {
             logger.warn("no index mapper found for field: [{}] returning default postings format", field);
         } else if (fieldType instanceof CompletionFieldMapper.CompletionFieldType) {

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/FieldsVisitor.java
@@ -89,7 +89,7 @@ public class FieldsVisitor extends StoredFieldVisitor {
 
     public void postProcess(MapperService mapperService) {
         for (Map.Entry<String, List<Object>> entry : fields().entrySet()) {
-            MappedFieldType fieldType = mapperService.fullName(entry.getKey());
+            MappedFieldType fieldType = mapperService.fieldType(entry.getKey());
             if (fieldType == null) {
                 throw new IllegalStateException("Field [" + entry.getKey()
                     + "] exists in the index but not in mappings");

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -71,7 +71,7 @@ public final class DocumentFieldMappers implements Iterable<Mapper> {
      * Returns the leaf mapper associated with this field name. Note that the returned mapper
      * could be either a concrete {@link FieldMapper}, or a {@link FieldAliasMapper}.
      *
-     * To access a field's type information, {@link MapperService#fullName} should be used instead.
+     * To access a field's type information, {@link MapperService#fieldType} should be used instead.
      */
     public Mapper getMapper(String field) {
         return fieldMappers.get(field);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -803,7 +803,7 @@ final class DocumentParser {
         }
         final String path = context.path().pathAsText(currentFieldName);
         final Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
-        final MappedFieldType existingFieldType = context.mapperService().fullName(path);
+        final MappedFieldType existingFieldType = context.mapperService().fieldType(path);
         final Mapper.Builder builder;
         if (existingFieldType != null) {
             // create a builder of the same type

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -102,7 +102,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         @Override
         public MetadataFieldMapper.Builder<?,?> parse(String name, Map<String, Object> node,
                                                       ParserContext parserContext) throws MapperParsingException {
-            Builder builder = new Builder(parserContext.mapperService().fullName(NAME));
+            Builder builder = new Builder(parserContext.mapperService().fieldType(NAME));
 
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredFieldMapper.java
@@ -75,7 +75,7 @@ public final class IgnoredFieldMapper extends MetadataFieldMapper {
         @Override
         public MetadataFieldMapper.Builder<?,?> parse(String name, Map<String, Object> node,
                 ParserContext parserContext) throws MapperParsingException {
-            return new Builder(parserContext.mapperService().fullName(NAME));
+            return new Builder(parserContext.mapperService().fieldType(NAME));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -584,11 +584,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
-     * Returns the {@link MappedFieldType} for the give fullName.
-     *
-     * If multiple types have fields with the same full name, the first is returned.
+     * Given the full name of a field, returns its {@link MappedFieldType}.
      */
-    public MappedFieldType fullName(String fullName) {
+    public MappedFieldType fieldType(String fullName) {
         return fieldTypes.get(fullName);
     }
 
@@ -688,7 +686,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
         @Override
         protected Analyzer getWrappedAnalyzer(String fieldName) {
-            MappedFieldType fieldType = fullName(fieldName);
+            MappedFieldType fieldType = fieldType(fieldName);
             if (fieldType != null) {
                 Analyzer analyzer = extractAnalyzer.apply(fieldType);
                 if (analyzer != null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -83,7 +83,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
         @Override
         public MetadataFieldMapper.Builder<?,?> parse(String name, Map<String, Object> node,
                                                       ParserContext parserContext) throws MapperParsingException {
-            Builder builder = new Builder(parserContext.mapperService().fullName(NAME));
+            Builder builder = new Builder(parserContext.mapperService().fieldType(NAME));
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
                 String fieldName = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -130,7 +130,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     public static Query newFilter(QueryShardContext context, String fieldPattern) {
 
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                .getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                .getMapperService().fieldType(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
             // can only happen when no types exist, so no docs exist either
             return Queries.newMatchNoDocsQuery("Missing types in \"" + NAME + "\" query.");
@@ -158,7 +158,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     private static Query newFieldExistsQuery(QueryShardContext context, String field) {
-        MappedFieldType fieldType = context.getMapperService().fullName(field);
+        MappedFieldType fieldType = context.getMapperService().fieldType(field);
         if (fieldType == null) {
             // The field does not exist as a leaf but could be an object so
             // check for an object mapper
@@ -175,7 +175,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         Collection<String> fields = context.simpleMatchToIndexNames(objField + ".*");
         for (String field : fields) {
-            Query existsQuery = context.getMapperService().fullName(field).existsQuery(context);
+            Query existsQuery = context.getMapperService().fieldType(field).existsQuery(context);
             booleanQuery.add(existsQuery, Occur.SHOULD);
         }
         return new ConstantScoreQuery(booleanQuery.build());

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -220,7 +220,7 @@ public class QueryShardContext extends QueryRewriteContext {
         if (name.equals(TypeFieldMapper.NAME)) {
             deprecationLogger.deprecatedAndMaybeLog("query_with_types", TYPES_DEPRECATION_MESSAGE);
         }
-        return failIfFieldMappingNotFound(name, mapperService.fullName(name));
+        return failIfFieldMappingNotFound(name, mapperService.fieldType(name));
     }
 
     public ObjectMapper getObjectMapper(String name) {

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -438,7 +438,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
             return MappedFieldType.Relation.INTERSECTS;
         }
         final MapperService mapperService = shardContext.getMapperService();
-        final MappedFieldType fieldType = mapperService.fullName(fieldName);
+        final MappedFieldType fieldType = mapperService.fieldType(fieldName);
         if (fieldType == null) {
             // no field means we have no values
             return MappedFieldType.Relation.DISJOINT;
@@ -491,7 +491,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
              * if the {@link FieldNamesFieldMapper} is enabled.
              */
             final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-                (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fieldType(FieldNamesFieldMapper.NAME);
             if (fieldNamesFieldType == null) {
                 return new MatchNoDocsQuery("No mappings yet");
             }

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FieldValueFactorFunctionBuilder.java
@@ -144,7 +144,7 @@ public class FieldValueFactorFunctionBuilder extends ScoreFunctionBuilder<FieldV
 
     @Override
     protected ScoreFunction doToFunction(QueryShardContext context) {
-        MappedFieldType fieldType = context.getMapperService().fullName(field);
+        MappedFieldType fieldType = context.getMapperService().fieldType(field);
         IndexNumericFieldData fieldData = null;
         if (fieldType == null) {
             if(missing == null) {

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/RandomScoreFunctionBuilder.java
@@ -161,11 +161,11 @@ public class RandomScoreFunctionBuilder extends ScoreFunctionBuilder<RandomScore
         } else {
             final MappedFieldType fieldType;
             if (field != null) {
-                fieldType = context.getMapperService().fullName(field);
+                fieldType = context.getMapperService().fieldType(field);
             } else {
                 deprecationLogger.deprecated(
                         "As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");
-                fieldType = context.getMapperService().fullName(IdFieldMapper.NAME);
+                fieldType = context.getMapperService().fieldType(IdFieldMapper.NAME);
             }
             if (fieldType == null) {
                 if (context.getMapperService().documentMapper() == null) {

--- a/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/NestedHelper.java
@@ -103,7 +103,7 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (mapperService.fullName(field) == null) {
+        if (mapperService.fieldType(field) == null) {
             // field does not exist
             return false;
         }
@@ -172,7 +172,7 @@ public final class NestedHelper {
             // we might add a nested filter when it is nor required.
             return true;
         }
-        if (mapperService.fullName(field) == null) {
+        if (mapperService.fieldType(field) == null) {
             return false;
         }
         for (String parent = parentObject(field); parent != null; parent = parentObject(parent)) {

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -140,7 +140,7 @@ public final class QueryParserHelper {
                 fieldName = fieldName + fieldSuffix;
             }
 
-            MappedFieldType fieldType = context.getMapperService().fullName(fieldName);
+            MappedFieldType fieldType = context.getMapperService().fieldType(fieldName);
             if (fieldType == null) {
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -613,7 +613,7 @@ public class QueryStringQueryParser extends XQueryParser {
 
     private Query existsQuery(String fieldName) {
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-            (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fullName(FieldNamesFieldMapper.NAME);
+            (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fieldType(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
             return new MatchNoDocsQuery("No mappings yet");
         }

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -161,7 +161,7 @@ public final class SimilarityService extends AbstractIndexComponent {
 
         @Override
         public Similarity get(String name) {
-            MappedFieldType fieldType = mapperService.fullName(name);
+            MappedFieldType fieldType = mapperService.fieldType(name);
             return (fieldType != null && fieldType.similarity() != null) ? fieldType.similarity().get() : defaultSimilarity;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -193,7 +193,7 @@ public class TermVectorsService  {
         /* only keep valid fields */
         Set<String> validFields = new HashSet<>();
         for (String field : selectedFields) {
-            MappedFieldType fieldType = indexShard.mapperService().fullName(field);
+            MappedFieldType fieldType = indexShard.mapperService().fieldType(field);
             if (!isValidField(fieldType)) {
                 continue;
             }
@@ -230,7 +230,7 @@ public class TermVectorsService  {
         if (perFieldAnalyzer != null && perFieldAnalyzer.containsKey(field)) {
             analyzer = mapperService.getIndexAnalyzers().get(perFieldAnalyzer.get(field).toString());
         } else {
-            MappedFieldType fieldType = mapperService.fullName(field);
+            MappedFieldType fieldType = mapperService.fieldType(field);
             analyzer = fieldType.indexAnalyzer();
         }
         if (analyzer == null) {
@@ -300,7 +300,7 @@ public class TermVectorsService  {
         Set<String> seenFields = new HashSet<>();
         Collection<DocumentField> documentFields = new HashSet<>();
         for (IndexableField field : doc.getFields()) {
-            MappedFieldType fieldType = indexShard.mapperService().fullName(field.name());
+            MappedFieldType fieldType = indexShard.mapperService().fieldType(field.name());
             if (!isValidField(fieldType)) {
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -778,7 +778,7 @@ final class DefaultSearchContext extends SearchContext {
 
     @Override
     public MappedFieldType smartNameFieldType(String name) {
-        return mapperService().fullName(name);
+        return mapperService().fieldType(name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
@@ -93,7 +93,7 @@ public final class DocValueFieldsFetchSubPhase implements FetchSubPhase {
 
         for (FieldAndFormat fieldAndFormat : context.docValueFieldsContext().fields()) {
             String field = fieldAndFormat.field;
-            MappedFieldType fieldType = context.mapperService().fullName(field);
+            MappedFieldType fieldType = context.mapperService().fieldType(field);
             if (fieldType != null) {
                 final IndexFieldData<?> indexFieldData = context.getForField(fieldType);
                 final boolean isNanosecond;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -74,7 +74,7 @@ public class HighlightPhase implements FetchSubPhase {
 
             boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
-                MappedFieldType fieldType = context.getMapperService().fullName(fieldName);
+                MappedFieldType fieldType = context.getMapperService().fieldType(fieldName);
                 if (fieldType == null) {
                     continue;
                 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -82,7 +82,7 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
         String fieldName = key.toString();
         ScriptDocValues<?> scriptValues = localCacheFieldData.get(fieldName);
         if (scriptValues == null) {
-            final MappedFieldType fieldType = mapperService.fullName(fieldName);
+            final MappedFieldType fieldType = mapperService.fieldType(fieldName);
             if (fieldType == null) {
                 throw new IllegalArgumentException("No field found for [" + fieldName + "] in mapping");
             }
@@ -110,7 +110,7 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
         String fieldName = key.toString();
         ScriptDocValues<?> scriptValues = localCacheFieldData.get(fieldName);
         if (scriptValues == null) {
-            MappedFieldType fieldType = mapperService.fullName(fieldName);
+            MappedFieldType fieldType = mapperService.fieldType(fieldName);
             if (fieldType == null) {
                 return false;
             }

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafFieldsLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafFieldsLookup.java
@@ -129,7 +129,7 @@ public class LeafFieldsLookup implements Map<Object, Object> {
     private FieldLookup loadFieldData(String name) {
         FieldLookup data = cachedFieldData.get(name);
         if (data == null) {
-            MappedFieldType fieldType = mapperService.fullName(name);
+            MappedFieldType fieldType = mapperService.fieldType(name);
             if (fieldType == null) {
                 throw new IllegalArgumentException("No field found for [" + name + "] in mapping");
             }

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -420,7 +420,7 @@ public class QueryPhase implements SearchPhase {
         String fieldName = sortField.getField();
         if (fieldName == null) return null; // happens when _score or _doc is the 1st sort field
         if (searchContext.mapperService() == null) return null; // mapperService can be null in tests
-        final MappedFieldType fieldType = searchContext.mapperService().fullName(fieldName);
+        final MappedFieldType fieldType = searchContext.mapperService().fieldType(fieldName);
         if (fieldType == null) return null; // for unmapped fields, default behaviour depending on "unmapped_type" flag
         if ((fieldType.typeName().equals("long") == false) && (fieldType instanceof DateFieldType == false)) return null;
         if (fieldType.indexOptions() == IndexOptions.NONE) return null; //TODO: change to pointDataDimensionCount() when implemented
@@ -435,7 +435,7 @@ public class QueryPhase implements SearchPhase {
                 if (SortField.FIELD_DOC.equals(sField) == false) return null;
             } else {
                 //TODO: find out how to cover _script sort that don't use _score
-                if (searchContext.mapperService().fullName(sFieldName) == null) return null; // could be _script sort that uses _score
+                if (searchContext.mapperService().fieldType(sFieldName) == null) return null; // could be _script sort that uses _score
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -302,7 +302,7 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
 
         Objects.requireNonNull(field, "field must not be null");
 
-        MappedFieldType fieldType = mapperService.fullName(field);
+        MappedFieldType fieldType = mapperService.fieldType(field);
         if (fieldType == null) {
             throw new IllegalArgumentException("no mapping found for field [" + field + "]");
         } else if (analyzer == null) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -292,7 +292,7 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
         if (shardSize != null) {
             suggestionContext.setShardSize(shardSize);
         }
-        MappedFieldType mappedFieldType = mapperService.fullName(suggestionContext.getField());
+        MappedFieldType mappedFieldType = mapperService.fieldType(suggestionContext.getField());
         if (mappedFieldType == null || mappedFieldType instanceof CompletionFieldMapper.CompletionFieldType == false) {
             throw new IllegalArgumentException("Field [" + suggestionContext.getField() + "] is not a completion suggest field");
         }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -146,7 +146,7 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
     @Override
     public Set<String> parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
         if (fieldName != null) {
-            MappedFieldType fieldType = parseContext.mapperService().fullName(fieldName);
+            MappedFieldType fieldType = parseContext.mapperService().fieldType(fieldName);
             if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
                 throw new ElasticsearchParseException("referenced field must be mapped to geo_point");
             }

--- a/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -95,7 +95,7 @@ public class PreBuiltAnalyzerTests extends ESSingleNodeTestCase {
                 .field("analyzer", analyzerName).endObject().endObject().endObject().endObject();
         MapperService mapperService = createIndex("test", indexSettings, mapping).mapperService();
 
-        MappedFieldType fieldType = mapperService.fullName("field");
+        MappedFieldType fieldType = mapperService.fieldType("field");
         assertThat(fieldType.searchAnalyzer(), instanceOf(NamedAnalyzer.class));
         NamedAnalyzer fieldMapperNamedAnalyzer = fieldType.searchAnalyzer();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -60,7 +60,7 @@ public class BinaryFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
 
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
-        MappedFieldType fieldType = mapperService.fullName("field");
+        MappedFieldType fieldType = mapperService.fieldType("field");
 
         assertThat(fieldType, instanceOf(BinaryFieldMapper.BinaryFieldType.class));
         assertThat(fieldType.stored(), equalTo(false));
@@ -97,7 +97,7 @@ public class BinaryFieldMapperTests extends ESSingleNodeTestCase {
             BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
             assertEquals(new BytesRef(value), indexedValue);
 
-            MappedFieldType fieldType = mapperService.fullName("field");
+            MappedFieldType fieldType = mapperService.fieldType("field");
             Object originalValue = fieldType.valueForDisplay(indexedValue);
             assertEquals(new BytesArray(value), originalValue);
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -370,8 +370,8 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         indexService.mapperService().merge("movie", new CompressedXContent(initMapping),
             MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertThat(indexService.mapperService().fullName("release_date"), notNullValue());
-        assertFalse(indexService.mapperService().fullName("release_date").stored());
+        assertThat(indexService.mapperService().fieldType("release_date"), notNullValue());
+        assertFalse(indexService.mapperService().fieldType("release_date").stored());
 
         String updateFormatMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("movie")
             .startObject("properties")

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -116,7 +116,7 @@ public class DocumentMapperTests extends ESSingleNodeTestCase {
         .endObject().endObject();
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping1).mapperService();
 
-        assertThat(mapperService.fullName("field").searchAnalyzer().name(), equalTo("whitespace"));
+        assertThat(mapperService.fieldType("field").searchAnalyzer().name(), equalTo("whitespace"));
 
         String mapping2 = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("properties").startObject("field")
@@ -127,7 +127,7 @@ public class DocumentMapperTests extends ESSingleNodeTestCase {
         .endObject().endObject());
 
         mapperService.merge("type", new CompressedXContent(mapping2), MapperService.MergeReason.MAPPING_UPDATE);
-        assertThat(mapperService.fullName("field").searchAnalyzer().name(), equalTo("keyword"));
+        assertThat(mapperService.fieldType("field").searchAnalyzer().name(), equalTo("keyword"));
     }
 
     public void testChangeSearchAnalyzerToDefault() throws Exception {
@@ -140,7 +140,7 @@ public class DocumentMapperTests extends ESSingleNodeTestCase {
         .endObject().endObject();
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping1).mapperService();
 
-        assertThat(mapperService.fullName("field").searchAnalyzer().name(), equalTo("whitespace"));
+        assertThat(mapperService.fieldType("field").searchAnalyzer().name(), equalTo("whitespace"));
 
         String mapping2 = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("properties").startObject("field")
@@ -150,7 +150,7 @@ public class DocumentMapperTests extends ESSingleNodeTestCase {
         .endObject().endObject());
 
         mapperService.merge("type", new CompressedXContent(mapping2), MapperService.MergeReason.MAPPING_UPDATE);
-        assertThat(mapperService.fullName("field").searchAnalyzer().name(), equalTo("standard"));
+        assertThat(mapperService.fieldType("field").searchAnalyzer().name(), equalTo("standard"));
     }
 
     public void testConcurrentMergeTest() throws Throwable {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
@@ -70,25 +70,25 @@ public class DoubleIndexingDocTests extends ESSingleNodeTestCase {
         IndexReader reader = DirectoryReader.open(writer);
         IndexSearcher searcher = new IndexSearcher(reader);
 
-        TopDocs topDocs = searcher.search(mapperService.fullName("field1").termQuery("value1", context), 10);
+        TopDocs topDocs = searcher.search(mapperService.fieldType("field1").termQuery("value1", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
 
-        topDocs = searcher.search(mapperService.fullName("field2").termQuery("1", context), 10);
+        topDocs = searcher.search(mapperService.fieldType("field2").termQuery("1", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
 
-        topDocs = searcher.search(mapperService.fullName("field3").termQuery("1.1", context), 10);
+        topDocs = searcher.search(mapperService.fieldType("field3").termQuery("1.1", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
 
-        topDocs = searcher.search(mapperService.fullName("field4").termQuery("2010-01-01", context), 10);
+        topDocs = searcher.search(mapperService.fieldType("field4").termQuery("2010-01-01", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
 
-        topDocs = searcher.search(mapperService.fullName("field5").termQuery("1", context), 10);
+        topDocs = searcher.search(mapperService.fieldType("field5").termQuery("1", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
 
-        topDocs = searcher.search(mapperService.fullName("field5").termQuery("2", context), 10);
+        topDocs = searcher.search(mapperService.fieldType("field5").termQuery("2", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
 
-        topDocs = searcher.search(mapperService.fullName("field5").termQuery("3", context), 10);
+        topDocs = searcher.search(mapperService.fieldType("field5").termQuery("3", context), 10);
         assertThat(topDocs.totalHits.value, equalTo(2L));
         writer.close();
         reader.close();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -190,7 +190,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
     public void testDynamicMappingOnEmptyString() throws Exception {
         IndexService service = createIndex("test");
         client().prepareIndex("test").setSource("empty_field", "").get();
-        MappedFieldType fieldType = service.mapperService().fullName("empty_field");
+        MappedFieldType fieldType = service.mapperService().fieldType("empty_field");
         assertNotNull(fieldType);
     }
 
@@ -672,7 +672,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
         IndexService index = createIndex("test", Settings.EMPTY, mapping);
         client().prepareIndex("test").setId("1").setSource("foo", "abc").get();
-        assertThat(index.mapperService().fullName("foo"), instanceOf(KeywordFieldMapper.KeywordFieldType.class));
+        assertThat(index.mapperService().fieldType("foo"), instanceOf(KeywordFieldMapper.KeywordFieldType.class));
     }
 
     public void testMappingVersionAfterDynamicMappingUpdate() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -55,11 +55,11 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         client().admin().indices().preparePutMapping("test")
             .setSource(parsedDoc.dynamicMappingsUpdate().toString(), XContentType.JSON).get();
 
-        assertThat(mapperService.fullName("s"), notNullValue());
-        assertEquals(IndexOptions.NONE, mapperService.fullName("s").indexOptions());
+        assertThat(mapperService.fieldType("s"), notNullValue());
+        assertEquals(IndexOptions.NONE, mapperService.fieldType("s").indexOptions());
 
-        assertThat(mapperService.fullName("l"), notNullValue());
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("l").indexOptions());
+        assertThat(mapperService.fieldType("l"), notNullValue());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("l").indexOptions());
     }
 
     public void testSimple() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperTests.java
@@ -110,7 +110,7 @@ public class FieldAliasMapperTests extends ESSingleNodeTestCase {
             .endObject());
         mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
-        MappedFieldType firstFieldType = mapperService.fullName("alias-field");
+        MappedFieldType firstFieldType = mapperService.fieldType("alias-field");
         assertEquals("first-field", firstFieldType.name());
         assertTrue(firstFieldType instanceof KeywordFieldMapper.KeywordFieldType);
 
@@ -129,7 +129,7 @@ public class FieldAliasMapperTests extends ESSingleNodeTestCase {
             .endObject());
         mapperService.merge("type", new CompressedXContent(newMapping), MergeReason.MAPPING_UPDATE);
 
-        MappedFieldType secondFieldType = mapperService.fullName("alias-field");
+        MappedFieldType secondFieldType = mapperService.fieldType("alias-field");
         assertEquals("second-field", secondFieldType.name());
         assertTrue(secondFieldType instanceof TextFieldMapper.TextFieldType);
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -62,8 +62,8 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
         IndexSettings indexSettings = new IndexSettings(
                 new IndexMetaData.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(), settings);
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName("_field_names")).thenReturn(fieldNamesFieldType);
-        when(mapperService.fullName("field_name")).thenReturn(fieldType);
+        when(mapperService.fieldType("_field_names")).thenReturn(fieldNamesFieldType);
+        when(mapperService.fieldType("field_name")).thenReturn(fieldType);
         when(mapperService.simpleMatchToFullName("field_name")).thenReturn(Collections.singleton("field_name"));
 
         QueryShardContext queryShardContext = new QueryShardContext(0,

--- a/server/src/test/java/org/elasticsearch/index/mapper/GenericStoreDynamicTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GenericStoreDynamicTemplateTests.java
@@ -50,7 +50,7 @@ public class GenericStoreDynamicTemplateTests extends ESSingleNodeTestCase {
         assertThat(f.stringValue(), equalTo("some name"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        MappedFieldType fieldType = mapperService.fullName("name");
+        MappedFieldType fieldType = mapperService.fieldType("name");
         assertThat(fieldType.stored(), equalTo(true));
 
         boolean stored = false;
@@ -59,7 +59,7 @@ public class GenericStoreDynamicTemplateTests extends ESSingleNodeTestCase {
         }
         assertTrue(stored);
 
-        fieldType = mapperService.fullName("age");
+        fieldType = mapperService.fieldType("age");
         assertThat(fieldType.stored(), equalTo(true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdFieldMapperTests.java
@@ -80,7 +80,7 @@ public class IdFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test", Settings.EMPTY);
         MapperService mapperService = service.mapperService();
         mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
-        IdFieldMapper.IdFieldType ft = (IdFieldMapper.IdFieldType) service.mapperService().fullName("_id");
+        IdFieldMapper.IdFieldType ft = (IdFieldMapper.IdFieldType) service.mapperService().fieldType("_id");
 
         IllegalArgumentException exc = expectThrows(IllegalArgumentException.class,
             () -> ft.fielddataBuilder("test").build(mapperService.getIndexSettings(),

--- a/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
@@ -40,8 +40,8 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
 
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
-        assertThat(mapperService.fullName("name.indexed"), nullValue());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
+        assertThat(mapperService.fieldType("name.indexed"), nullValue());
 
         BytesReference json = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("name", "some name").endObject());
         Document doc = mapperService.documentMapper().parse(
@@ -54,12 +54,12 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping2.json");
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
 
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed2"), nullValue());
-        assertThat(mapperService.fullName("name.not_indexed3"), nullValue());
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed2"), nullValue());
+        assertThat(mapperService.fieldType("name.not_indexed3"), nullValue());
 
         doc = mapperService.documentMapper().parse(new SourceToParse("test", "1", json, XContentType.JSON)).rootDoc();
         f = doc.getField("name");
@@ -70,22 +70,22 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping3.json");
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
 
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed2"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed3"), nullValue());
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed2"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed3"), nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping4.json");
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
 
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed2"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed3"), notNullValue());
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed2"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed3"), notNullValue());
     }
 
     public void testUpgradeFromMultiFieldTypeToMultiFields() throws Exception {
@@ -94,8 +94,8 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
 
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
-        assertThat(mapperService.fullName("name.indexed"), nullValue());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
+        assertThat(mapperService.fieldType("name.indexed"), nullValue());
 
         BytesReference json = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("name", "some name").endObject());
         Document doc = mapperService.documentMapper().parse(
@@ -109,12 +109,12 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade1.json");
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
 
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed2"), nullValue());
-        assertThat(mapperService.fullName("name.not_indexed3"), nullValue());
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed2"), nullValue());
+        assertThat(mapperService.fieldType("name.not_indexed3"), nullValue());
 
         doc = mapperService.documentMapper().parse(
             new SourceToParse("test", "1", json, XContentType.JSON)).rootDoc();
@@ -126,12 +126,12 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade2.json");
         mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
 
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed2"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed3"), nullValue());
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed2"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed3"), nullValue());
 
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade3.json");
@@ -144,10 +144,10 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         }
 
         // There are conflicts, so the `name.not_indexed3` has not been added
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed2"), notNullValue());
-        assertThat(mapperService.fullName("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed2"), notNullValue());
+        assertThat(mapperService.fieldType("name.not_indexed3"), nullValue());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -510,12 +510,12 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
         indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
-        MappedFieldType fieldType = indexService.mapperService().fullName("field");
+        MappedFieldType fieldType = indexService.mapperService().fieldType("field");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         KeywordFieldMapper.KeywordFieldType ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
         assertTokenStreamContents(ft.searchAnalyzer().analyzer().tokenStream("", "Hello World"), new String[] {"Hello World"});
 
-        fieldType = indexService.mapperService().fullName("field_with_normalizer");
+        fieldType = indexService.mapperService().fieldType("field_with_normalizer");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
         assertThat(ft.searchAnalyzer().name(), equalTo("my_lowercase"));
@@ -537,12 +537,12 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
         indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
-        fieldType = indexService.mapperService().fullName("field");
+        fieldType = indexService.mapperService().fieldType("field");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
         assertTokenStreamContents(ft.searchAnalyzer().analyzer().tokenStream("", "Hello World"), new String[] {"Hello", "World"});
 
-        fieldType = indexService.mapperService().fullName("field_with_normalizer");
+        fieldType = indexService.mapperService().fieldType("field_with_normalizer");
         assertThat(fieldType, instanceOf(KeywordFieldMapper.KeywordFieldType.class));
         ft = (KeywordFieldMapper.KeywordFieldType) fieldType;
         assertThat(ft.searchAnalyzer().name(), equalTo("my_lowercase"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -78,9 +78,9 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
         final MapperService mapperService = createIndex("test1").mapperService();
         final CompressedXContent mapping = createMappingSpecifyingNumberOfFields(1);
         mapperService.merge("type", mapping, MergeReason.MAPPING_UPDATE_PREFLIGHT);
-        assertThat("field was not created by preflight check", mapperService.fullName("field0"), nullValue());
+        assertThat("field was not created by preflight check", mapperService.fieldType("field0"), nullValue());
         mapperService.merge("type", mapping, MergeReason.MAPPING_UPDATE);
-        assertThat("field was not created by mapping update", mapperService.fullName("field0"), notNullValue());
+        assertThat("field was not created by mapping update", mapperService.fieldType("field0"), notNullValue());
     }
 
     /**
@@ -404,8 +404,8 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
         assertSame(current.getDefaultSearchQuoteAnalyzer(), updatedAnalyzers.getDefaultSearchQuoteAnalyzer());
 
         assertFalse(assertSameContainedFilters(originalTokenFilters, current.get("reloadableAnalyzer")));
-        assertFalse(assertSameContainedFilters(originalTokenFilters, mapperService.fullName("field").searchAnalyzer()));
-        assertFalse(assertSameContainedFilters(originalTokenFilters, mapperService.fullName("otherField").searchQuoteAnalyzer()));
+        assertFalse(assertSameContainedFilters(originalTokenFilters, mapperService.fieldType("field").searchAnalyzer()));
+        assertFalse(assertSameContainedFilters(originalTokenFilters, mapperService.fieldType("otherField").searchQuoteAnalyzer()));
     }
 
     private boolean assertSameContainedFilters(TokenFilterFactory[] originalTokenFilter, NamedAnalyzer updatedAnalyzer) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
@@ -91,37 +91,37 @@ public class MultiFieldTests extends ESSingleNodeTestCase {
         assertThat(f.name(), equalTo("object1.multi1.string"));
         assertThat(f.binaryValue(), equalTo(new BytesRef("2010-01-01")));
 
-        assertThat(mapperService.fullName("name"), notNullValue());
-        assertThat(mapperService.fullName("name"), instanceOf(TextFieldType.class));
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name").indexOptions());
-        assertThat(mapperService.fullName("name").stored(), equalTo(true));
-        assertThat(mapperService.fullName("name").tokenized(), equalTo(true));
+        assertThat(mapperService.fieldType("name"), notNullValue());
+        assertThat(mapperService.fieldType("name"), instanceOf(TextFieldType.class));
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name").indexOptions());
+        assertThat(mapperService.fieldType("name").stored(), equalTo(true));
+        assertThat(mapperService.fieldType("name").tokenized(), equalTo(true));
 
-        assertThat(mapperService.fullName("name.indexed"), notNullValue());
-        assertThat(mapperService.fullName("name"), instanceOf(TextFieldType.class));
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name.indexed").indexOptions());
-        assertThat(mapperService.fullName("name.indexed").stored(), equalTo(false));
-        assertThat(mapperService.fullName("name.indexed").tokenized(), equalTo(true));
+        assertThat(mapperService.fieldType("name.indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name"), instanceOf(TextFieldType.class));
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name.indexed").indexOptions());
+        assertThat(mapperService.fieldType("name.indexed").stored(), equalTo(false));
+        assertThat(mapperService.fieldType("name.indexed").tokenized(), equalTo(true));
 
-        assertThat(mapperService.fullName("name.not_indexed"), notNullValue());
-        assertThat(mapperService.fullName("name"), instanceOf(TextFieldType.class));
-        assertEquals(IndexOptions.NONE, mapperService.fullName("name.not_indexed").indexOptions());
-        assertThat(mapperService.fullName("name.not_indexed").stored(), equalTo(true));
-        assertThat(mapperService.fullName("name.not_indexed").tokenized(), equalTo(true));
+        assertThat(mapperService.fieldType("name.not_indexed"), notNullValue());
+        assertThat(mapperService.fieldType("name"), instanceOf(TextFieldType.class));
+        assertEquals(IndexOptions.NONE, mapperService.fieldType("name.not_indexed").indexOptions());
+        assertThat(mapperService.fieldType("name.not_indexed").stored(), equalTo(true));
+        assertThat(mapperService.fieldType("name.not_indexed").tokenized(), equalTo(true));
 
-        assertThat(mapperService.fullName("name.test1"), notNullValue());
-        assertThat(mapperService.fullName("name"), instanceOf(TextFieldType.class));
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("name.test1").indexOptions());
-        assertThat(mapperService.fullName("name.test1").stored(), equalTo(true));
-        assertThat(mapperService.fullName("name.test1").tokenized(), equalTo(true));
-        assertThat(mapperService.fullName("name.test1").eagerGlobalOrdinals(), equalTo(true));
+        assertThat(mapperService.fieldType("name.test1"), notNullValue());
+        assertThat(mapperService.fieldType("name"), instanceOf(TextFieldType.class));
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("name.test1").indexOptions());
+        assertThat(mapperService.fieldType("name.test1").stored(), equalTo(true));
+        assertThat(mapperService.fieldType("name.test1").tokenized(), equalTo(true));
+        assertThat(mapperService.fieldType("name.test1").eagerGlobalOrdinals(), equalTo(true));
 
-        assertThat(mapperService.fullName("object1.multi1"), notNullValue());
-        assertThat(mapperService.fullName("object1.multi1"), instanceOf(DateFieldMapper.DateFieldType.class));
-        assertThat(mapperService.fullName("object1.multi1.string"), notNullValue());
-        assertThat(mapperService.fullName("object1.multi1.string"), instanceOf(KeywordFieldMapper.KeywordFieldType.class));
-        assertNotSame(IndexOptions.NONE, mapperService.fullName("object1.multi1.string").indexOptions());
-        assertThat(mapperService.fullName("object1.multi1.string").tokenized(), equalTo(false));
+        assertThat(mapperService.fieldType("object1.multi1"), notNullValue());
+        assertThat(mapperService.fieldType("object1.multi1"), instanceOf(DateFieldMapper.DateFieldType.class));
+        assertThat(mapperService.fieldType("object1.multi1.string"), notNullValue());
+        assertThat(mapperService.fieldType("object1.multi1.string"), instanceOf(KeywordFieldMapper.KeywordFieldType.class));
+        assertNotSame(IndexOptions.NONE, mapperService.fieldType("object1.multi1.string").indexOptions());
+        assertThat(mapperService.fieldType("object1.multi1.string").tokenized(), equalTo(false));
     }
 
     public void testBuildThenParse() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/PathMatchDynamicTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PathMatchDynamicTemplateTests.java
@@ -50,26 +50,26 @@ public class PathMatchDynamicTemplateTests extends ESSingleNodeTestCase {
         assertThat(f.stringValue(), equalTo("top_level"));
         assertThat(f.fieldType().stored(), equalTo(false));
 
-        MappedFieldType fieldType = mapperService.fullName("name");
+        MappedFieldType fieldType = mapperService.fieldType("name");
         assertThat(fieldType.stored(), equalTo(false));
 
         f = doc.getField("obj1.name");
         assertThat(f.name(), equalTo("obj1.name"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        fieldType = mapperService.fullName("obj1.name");
+        fieldType = mapperService.fieldType("obj1.name");
         assertThat(fieldType.stored(), equalTo(true));
 
         f = doc.getField("obj1.obj2.name");
         assertThat(f.name(), equalTo("obj1.obj2.name"));
         assertThat(f.fieldType().stored(), equalTo(false));
 
-        fieldType = mapperService.fullName("obj1.obj2.name");
+        fieldType = mapperService.fieldType("obj1.obj2.name");
         assertThat(fieldType.stored(), equalTo(false));
 
         // verify more complex path_match expressions
 
-        fieldType = mapperService.fullName("obj3.obj4.prop1");
+        fieldType = mapperService.fieldType("obj3.obj4.prop1");
         assertNotNull(fieldType);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -735,7 +735,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject());
 
             indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
-            MappedFieldType textField = indexService.mapperService().fullName("object.field");
+            MappedFieldType textField = indexService.mapperService().fieldType("object.field");
             assertNotNull(textField);
             assertThat(textField, instanceOf(TextFieldType.class));
             MappedFieldType prefix = ((TextFieldType) textField).getPrefixFieldType();
@@ -761,7 +761,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject());
 
             indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
-            MappedFieldType textField = indexService.mapperService().fullName("body.with_prefix");
+            MappedFieldType textField = indexService.mapperService().fieldType("body.with_prefix");
             assertNotNull(textField);
             assertThat(textField, instanceOf(TextFieldType.class));
             MappedFieldType prefix = ((TextFieldType) textField).getPrefixFieldType();

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldMapperTests.java
@@ -67,7 +67,7 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
         DirectoryReader r = DirectoryReader.open(w);
         w.close();
 
-        MappedFieldType ft = mapperService.fullName(TypeFieldMapper.NAME);
+        MappedFieldType ft = mapperService.fieldType(TypeFieldMapper.NAME);
         IndexOrdinalsFieldData fd = (IndexOrdinalsFieldData) ft.fielddataBuilder("test").build(mapperService.getIndexSettings(),
                 ft, new IndexFieldDataCache.None(), new NoneCircuitBreakerService(), mapperService);
         AtomicOrdinalsFieldData afd = fd.load(r.leaves().get(0));

--- a/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/DistanceFeatureQueryBuilderTests.java
@@ -86,7 +86,7 @@ public class DistanceFeatureQueryBuilderTests extends AbstractQueryTestCase<Dist
             expectedQuery = LatLonPoint.newDistanceFeatureQuery(fieldName, boost, originGeoPoint.lat(), originGeoPoint.lon(), pivotDouble);
         } else { // if (fieldName.equals(DATE_FIELD_NAME))
             MapperService mapperService = context.getMapperService();
-            DateFieldType fieldType = (DateFieldType) mapperService.fullName(fieldName);
+            DateFieldType fieldType = (DateFieldType) mapperService.fieldType(fieldName);
             long originLong = fieldType.parseToLong(origin, true, null, null, context::nowInMillis);
             TimeValue pivotVal = TimeValue.parseTimeValue(pivot, DistanceFeatureQueryBuilder.class.getSimpleName() + ".pivot");
             long pivotLong;

--- a/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
         String fieldPattern = queryBuilder.fieldName();
         Collection<String> fields = context.simpleMatchToIndexNames(fieldPattern);
         Collection<String> mappedFields = fields.stream().filter((field) -> context.getObjectMapper(field) != null
-                || context.getMapperService().fullName(field) != null).collect(Collectors.toList());
+                || context.getMapperService().fieldType(field) != null).collect(Collectors.toList());
         if (fields.size() == 1 && mappedFields.size() == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;
@@ -82,11 +82,11 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
                     BooleanClause booleanClause = booleanQuery.clauses().get(i);
                     assertThat(booleanClause.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
                 }
-            } else if (context.getMapperService().fullName(field).hasDocValues()) {
+            } else if (context.getMapperService().fieldType(field).hasDocValues()) {
                 assertThat(constantScoreQuery.getQuery(), instanceOf(DocValuesFieldExistsQuery.class));
                 DocValuesFieldExistsQuery dvExistsQuery = (DocValuesFieldExistsQuery) constantScoreQuery.getQuery();
                 assertEquals(field, dvExistsQuery.getField());
-            } else if (context.getMapperService().fullName(field).omitNorms() == false) {
+            } else if (context.getMapperService().fieldType(field).omitNorms() == false) {
                 assertThat(constantScoreQuery.getQuery(), instanceOf(NormsFieldExistsQuery.class));
                 NormsFieldExistsQuery normsExistsQuery = (NormsFieldExistsQuery) constantScoreQuery.getQuery();
                 assertEquals(field, normsExistsQuery.getField());

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -81,7 +81,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 query.to(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.format(end));
                 // Create timestamp option only then we have a date mapper,
                 // otherwise we could trigger exception.
-                if (createShardContext().getMapperService().fullName(DATE_FIELD_NAME) != null) {
+                if (createShardContext().getMapperService().fieldType(DATE_FIELD_NAME) != null) {
                     if (randomBoolean()) {
                         query.timeZone(randomZone().getId());
                     }
@@ -137,9 +137,9 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         String expectedFieldName = expectedFieldName(queryBuilder.fieldName());
         if (queryBuilder.from() == null && queryBuilder.to() == null) {
             final Query expectedQuery;
-            if (context.getMapperService().fullName(queryBuilder.fieldName()).hasDocValues()) {
+            if (context.getMapperService().fieldType(queryBuilder.fieldName()).hasDocValues()) {
                 expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(expectedFieldName));
-            } else if (context.getMapperService().fullName(queryBuilder.fieldName()).omitNorms() == false) {
+            } else if (context.getMapperService().fieldType(queryBuilder.fieldName()).omitNorms() == false) {
                 expectedQuery = new ConstantScoreQuery(new NormsFieldExistsQuery(expectedFieldName));
             } else {
                 expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, expectedFieldName)));
@@ -161,7 +161,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
             query = ((IndexOrDocValuesQuery) query).getIndexQuery();
             assertThat(query, instanceOf(PointRangeQuery.class));
             MapperService mapperService = context.getMapperService();
-            MappedFieldType mappedFieldType = mapperService.fullName(expectedFieldName);
+            MappedFieldType mappedFieldType = mapperService.fieldType(expectedFieldName);
             final Long fromInMillis;
             final Long toInMillis;
             // we have to normalize the incoming value into milliseconds since it could be literally anything

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -63,7 +63,7 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         MapperService mapperService = Mockito.mock(MapperService.class);
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType(NumberType.LONG);
         ft.setName("foo");
-        Mockito.when(mapperService.fullName(Mockito.anyString())).thenReturn(ft);
+        Mockito.when(mapperService.fieldType(Mockito.anyString())).thenReturn(ft);
         Mockito.when(context.getMapperService()).thenReturn(mapperService);
         builder.toFunction(context);
         assertWarnings("As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set");

--- a/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
@@ -118,28 +118,28 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     public void testTermsQuery() {
-        Query termsQuery = mapperService.fullName("foo").termsQuery(Collections.singletonList("bar"), null);
+        Query termsQuery = mapperService.fieldType("foo").termsQuery(Collections.singletonList("bar"), null);
         assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
 
-        termsQuery = mapperService.fullName("nested1.foo").termsQuery(Collections.singletonList("bar"), null);
+        termsQuery = mapperService.fieldType("nested1.foo").termsQuery(Collections.singletonList("bar"), null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
         assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
 
-        termsQuery = mapperService.fullName("nested2.foo").termsQuery(Collections.singletonList("bar"), null);
+        termsQuery = mapperService.fieldType("nested2.foo").termsQuery(Collections.singletonList("bar"), null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested_missing"));
 
-        termsQuery = mapperService.fullName("nested3.foo").termsQuery(Collections.singletonList("bar"), null);
+        termsQuery = mapperService.fieldType("nested3.foo").termsQuery(Collections.singletonList("bar"), null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termsQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termsQuery, "nested2"));
@@ -148,28 +148,28 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     public void testTermQuery() {
-        Query termQuery = mapperService.fullName("foo").termQuery("bar", null);
+        Query termQuery = mapperService.fieldType("foo").termQuery("bar", null);
         assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
 
-        termQuery = mapperService.fullName("nested1.foo").termQuery("bar", null);
+        termQuery = mapperService.fieldType("nested1.foo").termQuery("bar", null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
         assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
 
-        termQuery = mapperService.fullName("nested2.foo").termQuery("bar", null);
+        termQuery = mapperService.fieldType("nested2.foo").termQuery("bar", null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested_missing"));
 
-        termQuery = mapperService.fullName("nested3.foo").termQuery("bar", null);
+        termQuery = mapperService.fieldType("nested3.foo").termQuery("bar", null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(termQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(termQuery, "nested2"));
@@ -178,28 +178,28 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
     }
 
     public void testRangeQuery() {
-        Query rangeQuery = mapperService.fullName("foo2").rangeQuery(2, 5, true, true, null, null, null, null);
+        Query rangeQuery = mapperService.fieldType("foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertFalse(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
-        rangeQuery = mapperService.fullName("nested1.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
+        rangeQuery = mapperService.fieldType("nested1.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertFalse(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
-        rangeQuery = mapperService.fullName("nested2.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
+        rangeQuery = mapperService.fieldType("nested2.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested3"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested_missing"));
 
-        rangeQuery = mapperService.fullName("nested3.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
+        rangeQuery = mapperService.fieldType("nested3.foo2").rangeQuery(2, 5, true, true, null, null, null, null);
         assertTrue(new NestedHelper(mapperService).mightMatchNestedDocs(rangeQuery));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested1"));
         assertTrue(new NestedHelper(mapperService).mightMatchNonNestedDocs(rangeQuery, "nested2"));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2435,7 +2435,7 @@ public class IndexShardTests extends IndexShardTestCase {
         shard.refresh("created segment 2");
 
         // test global ordinals are evicted
-        MappedFieldType foo = shard.mapperService().fullName("foo");
+        MappedFieldType foo = shard.mapperService().fieldType("foo");
         IndicesFieldDataCache indicesFieldDataCache = new IndicesFieldDataCache(shard.indexSettings.getNodeSettings(),
             new IndexFieldDataCache.Listener() {});
         IndexFieldDataService indexFieldDataService = new IndexFieldDataService(shard.indexSettings, indicesFieldDataCache,

--- a/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -79,9 +79,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.discount_overlaps", false)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fullName("field1").similarity().get(), instanceOf(LegacyBM25Similarity.class));
+        assertThat(mapperService.fieldType("field1").similarity().get(), instanceOf(LegacyBM25Similarity.class));
 
-        LegacyBM25Similarity similarity = (LegacyBM25Similarity) mapperService.fullName("field1").similarity().get();
+        LegacyBM25Similarity similarity = (LegacyBM25Similarity) mapperService.fieldType("field1").similarity().get();
         assertThat(similarity.getK1(), equalTo(2.0f));
         assertThat(similarity.getB(), equalTo(0.5f));
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
@@ -95,7 +95,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .endObject().endObject();
 
         MapperService mapperService = createIndex("foo", Settings.EMPTY, mapping).mapperService();
-        assertThat(mapperService.fullName("field1").similarity().get(), instanceOf(BooleanSimilarity.class));
+        assertThat(mapperService.fieldType("field1").similarity().get(), instanceOf(BooleanSimilarity.class));
     }
 
     public void testResolveSimilaritiesFromMapping_DFR() throws IOException {
@@ -113,9 +113,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fullName("field1").similarity().get(), instanceOf(DFRSimilarity.class));
+        assertThat(mapperService.fieldType("field1").similarity().get(), instanceOf(DFRSimilarity.class));
 
-        DFRSimilarity similarity = (DFRSimilarity) mapperService.fullName("field1").similarity().get();
+        DFRSimilarity similarity = (DFRSimilarity) mapperService.fieldType("field1").similarity().get();
         assertThat(similarity.getBasicModel(), instanceOf(BasicModelG.class));
         assertThat(similarity.getAfterEffect(), instanceOf(AfterEffectL.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -137,9 +137,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.normalization.h2.c", 3f)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fullName("field1").similarity().get(), instanceOf(IBSimilarity.class));
+        assertThat(mapperService.fieldType("field1").similarity().get(), instanceOf(IBSimilarity.class));
 
-        IBSimilarity similarity = (IBSimilarity) mapperService.fullName("field1").similarity().get();
+        IBSimilarity similarity = (IBSimilarity) mapperService.fieldType("field1").similarity().get();
         assertThat(similarity.getDistribution(), instanceOf(DistributionSPL.class));
         assertThat(similarity.getLambda(), instanceOf(LambdaTTF.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -158,7 +158,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.independence_measure", "chisquared")
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        MappedFieldType fieldType = mapperService.fullName("field1");
+        MappedFieldType fieldType = mapperService.fieldType("field1");
 
         assertThat(fieldType.similarity().get(), instanceOf(DFISimilarity.class));
         DFISimilarity similarity = (DFISimilarity) fieldType.similarity().get();
@@ -178,9 +178,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
 
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fullName("field1").similarity().get(), instanceOf(LMDirichletSimilarity.class));
+        assertThat(mapperService.fieldType("field1").similarity().get(), instanceOf(LMDirichletSimilarity.class));
 
-        LMDirichletSimilarity similarity = (LMDirichletSimilarity) mapperService.fullName("field1").similarity().get();
+        LMDirichletSimilarity similarity = (LMDirichletSimilarity) mapperService.fieldType("field1").similarity().get();
         assertThat(similarity.getMu(), equalTo(3000f));
     }
 
@@ -196,9 +196,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .put("index.similarity.my_similarity.lambda", 0.7f)
             .build();
         MapperService mapperService = createIndex("foo", indexSettings, mapping).mapperService();
-        assertThat(mapperService.fullName("field1").similarity().get(), instanceOf(LMJelinekMercerSimilarity.class));
+        assertThat(mapperService.fieldType("field1").similarity().get(), instanceOf(LMJelinekMercerSimilarity.class));
 
-        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) mapperService.fullName("field1").similarity().get();
+        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) mapperService.fieldType("field1").similarity().get();
         assertThat(similarity.getLambda(), equalTo(0.7f));
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -301,7 +301,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
             assertThat("index service doesn't exists on " + node, indexService, notNullValue());
             MapperService mapperService = indexService.mapperService();
             for (String fieldName : fieldNames) {
-                MappedFieldType fieldType = mapperService.fullName(fieldName);
+                MappedFieldType fieldType = mapperService.fieldType(fieldName);
                 assertNotNull("field " + fieldName + " doesn't exists on " + node, fieldType);
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoShapeIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoShapeIntegrationIT.java
@@ -72,7 +72,7 @@ public class GeoShapeIntegrationIT extends ESIntegTestCase {
         // left orientation test
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName));
         IndexService indexService = indicesService.indexService(resolveIndex(idxName));
-        MappedFieldType fieldType = indexService.mapperService().fullName("location");
+        MappedFieldType fieldType = indexService.mapperService().fieldType("location");
         assertThat(fieldType, instanceOf(GeoShapeFieldMapper.GeoShapeFieldType.class));
 
         GeoShapeFieldMapper.GeoShapeFieldType gsfm = (GeoShapeFieldMapper.GeoShapeFieldType)fieldType;
@@ -84,7 +84,7 @@ public class GeoShapeIntegrationIT extends ESIntegTestCase {
         // right orientation test
         indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName+"2"));
         indexService = indicesService.indexService(resolveIndex((idxName+"2")));
-        fieldType = indexService.mapperService().fullName("location");
+        fieldType = indexService.mapperService().fieldType("location");
         assertThat(fieldType, instanceOf(GeoShapeFieldMapper.GeoShapeFieldType.class));
 
         gsfm = (GeoShapeFieldMapper.GeoShapeFieldType)fieldType;

--- a/server/src/test/java/org/elasticsearch/search/geo/LegacyGeoShapeIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/LegacyGeoShapeIntegrationIT.java
@@ -74,7 +74,7 @@ public class LegacyGeoShapeIntegrationIT extends ESIntegTestCase {
         // left orientation test
         IndicesService indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName));
         IndexService indexService = indicesService.indexService(resolveIndex(idxName));
-        MappedFieldType fieldType = indexService.mapperService().fullName("location");
+        MappedFieldType fieldType = indexService.mapperService().fieldType("location");
         assertThat(fieldType, instanceOf(LegacyGeoShapeFieldMapper.GeoShapeFieldType.class));
 
         LegacyGeoShapeFieldMapper.GeoShapeFieldType gsfm = (LegacyGeoShapeFieldMapper.GeoShapeFieldType)fieldType;
@@ -86,7 +86,7 @@ public class LegacyGeoShapeIntegrationIT extends ESIntegTestCase {
         // right orientation test
         indicesService = internalCluster().getInstance(IndicesService.class, findNodeName(idxName+"2"));
         indexService = indicesService.indexService(resolveIndex((idxName+"2")));
-        fieldType = indexService.mapperService().fullName("location");
+        fieldType = indexService.mapperService().fieldType("location");
         assertThat(fieldType, instanceOf(LegacyGeoShapeFieldMapper.GeoShapeFieldType.class));
 
         gsfm = (LegacyGeoShapeFieldMapper.GeoShapeFieldType)fieldType;

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -45,8 +45,8 @@ public class LeafDocLookupTests extends ESTestCase {
         when(fieldType.valueForDisplay(anyObject())).then(returnsFirstArg());
 
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName("field")).thenReturn(fieldType);
-        when(mapperService.fullName("alias")).thenReturn(fieldType);
+        when(mapperService.fieldType("field")).thenReturn(fieldType);
+        when(mapperService.fieldType("alias")).thenReturn(fieldType);
 
         docValues = mock(ScriptDocValues.class);
         IndexFieldData<?> fieldData = createFieldData(docValues);

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafFieldsLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafFieldsLookupTests.java
@@ -52,8 +52,8 @@ public class LeafFieldsLookupTests extends ESTestCase {
                 (Double) invocation.getArguments()[0] + 10);
 
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName("field")).thenReturn(fieldType);
-        when(mapperService.fullName("alias")).thenReturn(fieldType);
+        when(mapperService.fieldType("field")).thenReturn(fieldType);
+        when(mapperService.fieldType("alias")).thenReturn(fieldType);
 
         FieldInfo mockFieldInfo = new FieldInfo("field", 1, false, false, true,
             IndexOptions.NONE, DocValuesType.NONE, -1, Collections.emptyMap(), 0, 0, 0, false);

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -640,8 +640,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
         MappedFieldType fieldTypeLong = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.LONG);
         MappedFieldType fieldTypeDate = new DateFieldMapper.Builder(fieldNameDate).fieldType();
         MapperService mapperService = mock(MapperService.class);
-        when(mapperService.fullName(fieldNameLong)).thenReturn(fieldTypeLong);
-        when(mapperService.fullName(fieldNameDate)).thenReturn(fieldTypeDate);
+        when(mapperService.fieldType(fieldNameLong)).thenReturn(fieldTypeLong);
+        when(mapperService.fieldType(fieldNameDate)).thenReturn(fieldTypeDate);
 
         final int numDocs = 7000;
         Directory dir = newDirectory();

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -174,7 +174,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
                 when(mapperService.searchAnalyzer())
                         .thenReturn(new NamedAnalyzer("mapperServiceSearchAnalyzer", AnalyzerScope.INDEX, new SimpleAnalyzer()));
             }
-            when(mapperService.fullName(any(String.class))).thenReturn(fieldType);
+            when(mapperService.fieldType(any(String.class))).thenReturn(fieldType);
             when(mapperService.getNamedAnalyzer(any(String.class))).then(
                     invocation -> new NamedAnalyzer((String) invocation.getArguments()[0], AnalyzerScope.INDEX, new SimpleAnalyzer()));
             when(scriptService.compile(any(Script.class), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -718,7 +718,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
 
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
-        CompletionFieldType completionFieldType = (CompletionFieldType) mapperService.fullName("completion");
+        CompletionFieldType completionFieldType = (CompletionFieldType) mapperService.fieldType("completion");
 
         Exception e = expectThrows(IllegalArgumentException.class, () -> completionFieldType.getContextMappings().get("brand"));
         assertEquals("Unknown context name [brand], must be one of [ctx, type]", e.getMessage());

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
@@ -62,7 +62,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
 
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
-        MappedFieldType completionFieldType = mapperService.fullName("completion");
+        MappedFieldType completionFieldType = mapperService.fieldType("completion");
         ParsedDocument parsedDocument = mapperService.documentMapper().parse(new SourceToParse("test", "1",
             BytesReference.bytes(jsonBuilder()
                         .startObject()
@@ -101,7 +101,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
 
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
-        MappedFieldType completionFieldType = mapperService.fullName("completion");
+        MappedFieldType completionFieldType = mapperService.fieldType("completion");
         ParsedDocument parsedDocument = mapperService.documentMapper().parse(new SourceToParse("test", "1",
             BytesReference.bytes(jsonBuilder()
                         .startObject()
@@ -137,7 +137,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
 
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
-        MappedFieldType completionFieldType = mapperService.fullName("completion");
+        MappedFieldType completionFieldType = mapperService.fieldType("completion");
         ParsedDocument parsedDocument = mapperService.documentMapper().parse(new SourceToParse("test", "1",
             BytesReference.bytes(jsonBuilder()
                         .startObject()
@@ -181,7 +181,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject();
 
         MapperService mapperService = createIndex("test", Settings.EMPTY, mapping).mapperService();
-        MappedFieldType completionFieldType = mapperService.fullName("completion");
+        MappedFieldType completionFieldType = mapperService.fieldType("completion");
         XContentBuilder builder = jsonBuilder()
                 .startObject()
                 .startArray("completion")

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -121,7 +121,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             String fieldName = entry.getKey();
             MappedFieldType fieldType = entry.getValue();
 
-            when(mapperService.fullName(fieldName)).thenReturn(fieldType);
+            when(mapperService.fieldType(fieldName)).thenReturn(fieldType);
             when(searchContext.smartNameFieldType(fieldName)).thenReturn(fieldType);
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -577,7 +577,7 @@ public class TestSearchContext extends SearchContext {
     @Override
     public MappedFieldType smartNameFieldType(String name) {
         if (mapperService() != null) {
-            return mapperService().fullName(name);
+            return mapperService().fieldType(name);
         }
         return null;
     }

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlatObjectFieldLookupTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlatObjectFieldLookupTests.java
@@ -158,10 +158,10 @@ public class FlatObjectFieldLookupTests extends ESTestCase {
         IndexFieldData<?> fieldData2 = createFieldData(docValues2);
 
         KeyedFlatObjectFieldType fieldType1 = new KeyedFlatObjectFieldType("key1");
-        when(mapperService.fullName("json.key1")).thenReturn(fieldType1);
+        when(mapperService.fieldType("json.key1")).thenReturn(fieldType1);
 
         KeyedFlatObjectFieldType fieldType2 = new KeyedFlatObjectFieldType( "key2");
-        when(mapperService.fullName("json.key2")).thenReturn(fieldType2);
+        when(mapperService.fieldType("json.key2")).thenReturn(fieldType2);
 
         Function<MappedFieldType, IndexFieldData<?>> fieldDataSupplier = fieldType -> {
             KeyedFlatObjectFieldType keyedFieldType = (KeyedFlatObjectFieldType) fieldType;

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapperTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapperTests.java
@@ -480,12 +480,12 @@ public class FlatObjectFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
         mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        RootFlatObjectFieldType rootFieldType = (RootFlatObjectFieldType) mapperService.fullName("field");
+        RootFlatObjectFieldType rootFieldType = (RootFlatObjectFieldType) mapperService.fieldType("field");
         assertThat(rootFieldType.searchAnalyzer().name(), equalTo("whitespace"));
         assertTokenStreamContents(rootFieldType.searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] {"Hello", "World"});
 
-        KeyedFlatObjectFieldType keyedFieldType = (KeyedFlatObjectFieldType) mapperService.fullName("field.key");
+        KeyedFlatObjectFieldType keyedFieldType = (KeyedFlatObjectFieldType) mapperService.fieldType("field.key");
         assertThat(keyedFieldType.searchAnalyzer().name(), equalTo("whitespace"));
         assertTokenStreamContents(keyedFieldType.searchAnalyzer().analyzer().tokenStream("", "Hello World"),
             new String[] {"Hello", "World"});


### PR DESCRIPTION
The new name more accurately describes what the method returns.