### PR TITLE
Remove references to mapping type in FieldTypeLookup.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -70,10 +70,8 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
      * to use the new type from the given field mapper. Similarly if an alias already
      * exists, it will be updated to reference the field type from the new mapper.
      */
-    public FieldTypeLookup copyAndAddAll(String type,
-                                         Collection<FieldMapper> fieldMappers,
+    public FieldTypeLookup copyAndAddAll(Collection<FieldMapper> fieldMappers,
                                          Collection<FieldAliasMapper> fieldAliasMappers) {
-        Objects.requireNonNull(type, "type must not be null");
 
         CopyOnWriteHashMap<String, MappedFieldType> fullName = this.fullNameToFieldType;
         CopyOnWriteHashMap<String, String> aliases = this.aliasToConcreteName;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -360,7 +360,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         checkPartitionedIndexConstraints(newMapper);
 
         // update lookup data-structures
-        fieldTypes = fieldTypes.copyAndAddAll(newMapper.type(), fieldMappers, fieldAliasMappers);
+        fieldTypes = fieldTypes.copyAndAddAll(fieldMappers, fieldAliasMappers);
 
         for (ObjectMapper objectMapper : objectMappers) {
             if (fullPathObjectMappers == this.fullPathObjectMappers) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -49,7 +49,7 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testAddNewField() {
         FieldTypeLookup lookup = new FieldTypeLookup();
         MockFieldMapper f = new MockFieldMapper("foo");
-        FieldTypeLookup lookup2 = lookup.copyAndAddAll("type", newList(f), emptyList());
+        FieldTypeLookup lookup2 = lookup.copyAndAddAll(newList(f), emptyList());
         assertNull(lookup.get("foo"));
         assertNull(lookup.get("bar"));
         assertEquals(f.fieldType(), lookup2.get("foo"));
@@ -61,8 +61,8 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper f = new MockFieldMapper("foo");
         MockFieldMapper f2 = new MockFieldMapper("foo");
         FieldTypeLookup lookup = new FieldTypeLookup();
-        lookup = lookup.copyAndAddAll("type1", newList(f), emptyList());
-        FieldTypeLookup lookup2 = lookup.copyAndAddAll("type2", newList(f2), emptyList());
+        lookup = lookup.copyAndAddAll(newList(f), emptyList());
+        FieldTypeLookup lookup2 = lookup.copyAndAddAll(newList(f2), emptyList());
 
         assertEquals(1, size(lookup2.iterator()));
         assertSame(f.fieldType(), lookup2.get("foo"));
@@ -74,7 +74,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         FieldAliasMapper alias = new FieldAliasMapper("alias", "alias", "foo");
 
         FieldTypeLookup lookup = new FieldTypeLookup();
-        lookup = lookup.copyAndAddAll("type", newList(field), newList(alias));
+        lookup = lookup.copyAndAddAll(newList(field), newList(alias));
 
         MappedFieldType aliasType = lookup.get("alias");
         assertEquals(field.fieldType(), aliasType);
@@ -87,7 +87,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         FieldAliasMapper alias1 = new FieldAliasMapper("alias", "alias", "foo");
 
         FieldTypeLookup lookup = new FieldTypeLookup();
-        lookup = lookup.copyAndAddAll("type", newList(field1), newList(alias1));
+        lookup = lookup.copyAndAddAll(newList(field1), newList(alias1));
 
         // Check that the alias refers to 'foo'.
         MappedFieldType aliasType1 = lookup.get("alias");
@@ -99,7 +99,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper field2 = new MockFieldMapper("bar", fieldType2);
 
         FieldAliasMapper alias2 = new FieldAliasMapper("alias", "alias", "bar");
-        lookup = lookup.copyAndAddAll("type", newList(field2), newList(alias2));
+        lookup = lookup.copyAndAddAll(newList(field2), newList(alias2));
 
         // Check that the alias now refers to 'bar'.
         MappedFieldType aliasType2 = lookup.get("alias");
@@ -114,7 +114,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper field1 = new MockFieldMapper("foo", fieldType1);
 
         FieldTypeLookup lookup = new FieldTypeLookup();
-        lookup = lookup.copyAndAddAll("type", newList(field1), newList(alias1));
+        lookup = lookup.copyAndAddAll(newList(field1), newList(alias1));
 
         // Check that the alias maps to this field type.
         MappedFieldType aliasType1 = lookup.get("alias");
@@ -124,7 +124,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         MockFieldMapper.FakeFieldType fieldType2 = new MockFieldMapper.FakeFieldType();
         fieldType2.setBoost(2.0f);
         MockFieldMapper field2 = new MockFieldMapper("foo", fieldType2);
-        lookup = lookup.copyAndAddAll("type", newList(field2), emptyList());
+        lookup = lookup.copyAndAddAll(newList(field2), emptyList());
 
         // Check that the alias maps to the new field type.
         MappedFieldType aliasType2 = lookup.get("alias");
@@ -139,9 +139,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         FieldAliasMapper alias2 = new FieldAliasMapper("barometer", "barometer", "bar");
 
         FieldTypeLookup lookup = new FieldTypeLookup();
-        lookup = lookup.copyAndAddAll("type",
-            newList(field1, field2),
-            newList(alias1, alias2));
+        lookup = lookup.copyAndAddAll(newList(field1, field2), newList(alias1, alias2));
 
         Collection<String> names = lookup.simpleMatchToFullName("b*");
 
@@ -155,7 +153,7 @@ public class FieldTypeLookupTests extends ESTestCase {
     public void testIteratorImmutable() {
         MockFieldMapper f1 = new MockFieldMapper("foo");
         FieldTypeLookup lookup = new FieldTypeLookup();
-        lookup = lookup.copyAndAddAll("type", newList(f1), emptyList());
+        lookup = lookup.copyAndAddAll(newList(f1), emptyList());
 
         try {
             Iterator<MappedFieldType> itr = lookup.iterator();

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperMergeValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperMergeValidatorTests.java
@@ -37,7 +37,7 @@ public class MapperMergeValidatorTests extends ESTestCase {
     public void testMismatchedFieldTypes() {
         FieldMapper existingField = new MockFieldMapper("foo");
         FieldTypeLookup lookup = new FieldTypeLookup()
-            .copyAndAddAll("type", singletonList(existingField), emptyList());
+            .copyAndAddAll(singletonList(existingField), emptyList());
 
         FieldTypeLookupTests.OtherFakeFieldType newFieldType = new FieldTypeLookupTests.OtherFakeFieldType();
         newFieldType.setName("foo");
@@ -55,7 +55,7 @@ public class MapperMergeValidatorTests extends ESTestCase {
     public void testConflictingFieldTypes() {
         FieldMapper existingField = new MockFieldMapper("foo");
         FieldTypeLookup lookup = new FieldTypeLookup()
-            .copyAndAddAll("type", singletonList(existingField), emptyList());
+            .copyAndAddAll(singletonList(existingField), emptyList());
 
         MappedFieldType newFieldType = new MockFieldMapper.FakeFieldType();
         newFieldType.setName("foo");

--- a/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlatObjectFieldLookupTests.java
+++ b/x-pack/plugin/mapper-flattened/src/test/java/org/elasticsearch/index/mapper/FlatObjectFieldLookupTests.java
@@ -38,7 +38,7 @@ public class FlatObjectFieldLookupTests extends ESTestCase {
         FlatObjectFieldMapper mapper = createFlatObjectMapper(fieldName);
 
         FieldTypeLookup lookup = new FieldTypeLookup()
-            .copyAndAddAll("type", singletonList(mapper), emptyList());
+            .copyAndAddAll(singletonList(mapper), emptyList());
         assertEquals(mapper.fieldType(), lookup.get(fieldName));
 
         String objectKey = "key1.key2";
@@ -60,7 +60,7 @@ public class FlatObjectFieldLookupTests extends ESTestCase {
         FieldAliasMapper alias = new FieldAliasMapper(aliasName, aliasName, fieldName);
 
         FieldTypeLookup lookup = new FieldTypeLookup()
-            .copyAndAddAll("type", singletonList(mapper), singletonList(alias));
+            .copyAndAddAll(singletonList(mapper), singletonList(alias));
         assertEquals(mapper.fieldType(), lookup.get(aliasName));
 
         String objectKey = "key1.key2";
@@ -84,11 +84,11 @@ public class FlatObjectFieldLookupTests extends ESTestCase {
         FlatObjectFieldMapper mapper3 = createFlatObjectMapper(field3);
 
         FieldTypeLookup lookup = new FieldTypeLookup()
-            .copyAndAddAll("type", Arrays.asList(mapper1, mapper2), emptyList());
+            .copyAndAddAll(Arrays.asList(mapper1, mapper2), emptyList());
         assertNotNull(lookup.get(field1 + ".some.key"));
         assertNotNull(lookup.get(field2 + ".some.key"));
 
-        lookup = lookup.copyAndAddAll("type", singletonList(mapper3), emptyList());
+        lookup = lookup.copyAndAddAll(singletonList(mapper3), emptyList());
         assertNotNull(lookup.get(field1 + ".some.key"));
         assertNotNull(lookup.get(field2 + ".some.key"));
         assertNotNull(lookup.get(field3 + ".some.key"));
@@ -101,26 +101,26 @@ public class FlatObjectFieldLookupTests extends ESTestCase {
         // Add a flattened object field.
         String flatObjectName = "object1.object2.field";
         FlatObjectFieldMapper flatObjectField = createFlatObjectMapper(flatObjectName);
-        lookup = lookup.copyAndAddAll("type", singletonList(flatObjectField), emptyList());
+        lookup = lookup.copyAndAddAll(singletonList(flatObjectField), emptyList());
         assertEquals(3, lookup.maxKeyedLookupDepth());
 
         // Add a short alias to that field.
         String aliasName = "alias";
         FieldAliasMapper alias = new FieldAliasMapper(aliasName, aliasName, flatObjectName);
-        lookup = lookup.copyAndAddAll("type", emptyList(), singletonList(alias));
+        lookup = lookup.copyAndAddAll(emptyList(), singletonList(alias));
         assertEquals(3, lookup.maxKeyedLookupDepth());
 
         // Add a longer alias to that field.
         String longAliasName = "object1.object2.object3.alias";
         FieldAliasMapper longAlias = new FieldAliasMapper(longAliasName, longAliasName, flatObjectName);
-        lookup = lookup.copyAndAddAll("type", emptyList(), singletonList(longAlias));
+        lookup = lookup.copyAndAddAll(emptyList(), singletonList(longAlias));
         assertEquals(4, lookup.maxKeyedLookupDepth());
 
         // Update the long alias to refer to a non-flattened object field.
         String fieldName = "field";
         MockFieldMapper field = new MockFieldMapper(fieldName);
         longAlias = new FieldAliasMapper(longAliasName, longAliasName, fieldName);
-        lookup = lookup.copyAndAddAll("type", singletonList(field), singletonList(longAlias));
+        lookup = lookup.copyAndAddAll(singletonList(field), singletonList(longAlias));
         assertEquals(3, lookup.maxKeyedLookupDepth());
     }
 
@@ -129,7 +129,7 @@ public class FlatObjectFieldLookupTests extends ESTestCase {
         FlatObjectFieldMapper flatObjectMapper = createFlatObjectMapper("object1.object2.field");
 
         FieldTypeLookup lookup = new FieldTypeLookup()
-            .copyAndAddAll("type", Arrays.asList(mapper, flatObjectMapper), emptyList());
+            .copyAndAddAll(Arrays.asList(mapper, flatObjectMapper), emptyList());
 
         Set<String> fieldNames = new HashSet<>();
         for (MappedFieldType fieldType : lookup) {


### PR DESCRIPTION
The mapping type parameter in `FieldTypeLookup#copyAndAddAll` is no longer needed.