### PR TITLE
Reindex: allow comma separated source indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -365,7 +365,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
 
     /**
      * Yank a string array from a map. Emulates XContent's permissive String to
-     * String array conversions.
+     * String array conversions and allow comma separated String.
      */
     private static String[] extractStringArray(Map<String, Object> source, String name) {
         Object value = source.remove(name);
@@ -377,9 +377,9 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             List<String> list = (List<String>) value;
             return list.toArray(new String[list.size()]);
         } else if (value instanceof String) {
-            return new String[] {(String) value};
+            return Strings.splitStringByCommaToArray((String) value);
         } else {
-            throw new IllegalArgumentException("Expected [" + name + "] to be a list of a string but was [" + value + ']');
+            throw new IllegalArgumentException("Expected [" + name + "] to be a list or a string but was [" + value + ']');
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.search.slice.SliceBuilder;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -319,5 +320,44 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
         source.put("remote", remote);
 
         return ReindexRequest.buildRemoteInfo(source);
+    }
+
+    public void testCommaSeparatedSourceIndices() throws IOException {
+        ReindexRequest r = parseRequestWithSourceIndices("a,b");
+        assertArrayEquals(new String[]{"a", "b"}, r.getSearchRequest().indices());
+    }
+
+    public void testArraySourceIndices() throws IOException {
+        ReindexRequest r = parseRequestWithSourceIndices(new String[]{"a", "b"});
+        assertArrayEquals(new String[]{"a", "b"}, r.getSearchRequest().indices());
+    }
+
+    public void testEmptyStringSourceIndices() throws IOException {
+        ReindexRequest r = parseRequestWithSourceIndices("");
+        assertArrayEquals(new String[0], r.getSearchRequest().indices());
+        ActionRequestValidationException validationException = r.validate();
+        assertNotNull(validationException);
+        assertEquals(List.of("use _all if you really want to copy from all existing indexes"), validationException.validationErrors());
+    }
+
+    private ReindexRequest parseRequestWithSourceIndices(Object sourceIndices) throws IOException {
+        BytesReference request;
+        try (XContentBuilder b = JsonXContent.contentBuilder()) {
+            b.startObject(); {
+                b.startObject("source"); {
+                    b.field("index", sourceIndices);
+                }
+                b.endObject();
+                b.startObject("dest"); {
+                    b.field("index", "dest");
+                }
+                b.endObject();
+            }
+            b.endObject();
+            request = BytesReference.bytes(b);
+        }
+        try (XContentParser p = createParser(JsonXContent.jsonXContent, request)) {
+            return ReindexRequest.fromXContent(p);
+        }
     }
 }


### PR DESCRIPTION
Added ability to specify comma separated list of source indices without
array. Also fixed so that empty string results in validation error
rather than index does not exist.

Closes #51949
