### PR TITLE
Fix custom policy in plugins in FIPS 140

### DIFF
--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -56,12 +58,34 @@ task writeTestJavaPolicy {
       throw new GradleException("failed to create temporary directory [${tmp}]")
     }
     final File javaPolicy = file("${tmp}/java.policy")
-    javaPolicy.write(
-      [
-        "grant {",
-        "  permission java.util.PropertyPermission \"com.amazonaws.sdk.ec2MetadataServiceEndpointOverride\", \"write\";",
-        "};"
-      ].join("\n"))
+    if (BuildParams.inFipsJvm) {
+      javaPolicy.write(
+        [
+          "grant {",
+          "permission java.security.SecurityPermission \"putProviderProperty.BCFIPS\";",
+          "permission java.security.SecurityPermission \"putProviderProperty.BCJSSE\";",
+          "permission java.lang.RuntimePermission \"getProtectionDomain\";",
+          "permission java.util.PropertyPermission \"java.runtime.name\", \"read\";",
+          "permission org.bouncycastle.crypto.CryptoServicesPermission \"tlsAlgorithmsEnabled\";",
+          "permission java.lang.RuntimePermission \"accessClassInPackage.sun.security.internal.spec\";",
+          "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+          "permission java.util.PropertyPermission \"intellij.debug.agent\", \"read\";",
+          "permission java.util.PropertyPermission \"intellij.debug.agent\", \"write\";",
+          "permission org.bouncycastle.crypto.CryptoServicesPermission \"exportSecretKey\";",
+          "permission org.bouncycastle.crypto.CryptoServicesPermission \"exportPrivateKey\";",
+          "permission java.io.FilePermission \"\${javax.net.ssl.trustStore}\", \"read\";",
+          "  permission java.util.PropertyPermission \"com.amazonaws.sdk.ec2MetadataServiceEndpointOverride\", \"write\";",
+          "};"
+        ].join("\n")
+      )
+    } else {
+      javaPolicy.write(
+        [
+          "grant {",
+          "  permission java.util.PropertyPermission \"com.amazonaws.sdk.ec2MetadataServiceEndpointOverride\", \"write\";",
+          "};"
+        ].join("\n"))
+    }
   }
 }
 
@@ -72,7 +96,11 @@ test {
 
   // this is needed to manipulate com.amazonaws.sdk.ec2MetadataServiceEndpointOverride system property
   // it is better rather disable security manager at all with `systemProperty 'tests.security.manager', 'false'`
-  systemProperty 'java.security.policy', "file://${buildDir}/tmp/java.policy"
+  if (BuildParams.inFipsJvm){
+    systemProperty 'java.security.policy', "=file://${buildDir}/tmp/java.policy"
+  } else {
+    systemProperty 'java.security.policy', "file://${buildDir}/tmp/java.policy"
+  }
 }
 
 check {

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/EC2RetriesTests.java
@@ -101,7 +101,6 @@ public class EC2RetriesTests extends ESTestCase {
     }
 
     public void testEC2DiscoveryRetriesOnRateLimiting() throws IOException {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/51685", inFipsJvm());
         final String accessKey = "ec2_access";
         final List<String> hosts = List.of("127.0.0.1:9000");
         final Map<String, Integer> failedRequests = new ConcurrentHashMap<>();

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
@@ -26,13 +27,35 @@ task writeJavaPolicy {
     if (policyFile.parentFile.exists() == false && policyFile.parentFile.mkdirs() == false) {
       throw new GradleException("failed to create temporary directory [${tmp}]")
     }
-    policyFile.write(
-      [
-        "grant {",
-        "  permission java.io.FilePermission \"${-> testClusters."follow-cluster".getFirstNode().getServerLog()}\", \"read\";",
-        "};"
-      ].join("\n")
-    )
+    if (BuildParams.inFipsJvm) {
+      policyFile.write(
+        [
+          "grant {",
+          "permission java.security.SecurityPermission \"putProviderProperty.BCFIPS\";",
+          "permission java.security.SecurityPermission \"putProviderProperty.BCJSSE\";",
+          "permission java.lang.RuntimePermission \"getProtectionDomain\";",
+          "permission java.util.PropertyPermission \"java.runtime.name\", \"read\";",
+          "permission org.bouncycastle.crypto.CryptoServicesPermission \"tlsAlgorithmsEnabled\";",
+          "permission java.lang.RuntimePermission \"accessClassInPackage.sun.security.internal.spec\";",
+          "permission java.lang.RuntimePermission \"accessDeclaredMembers\";",
+          "permission java.util.PropertyPermission \"intellij.debug.agent\", \"read\";",
+          "permission java.util.PropertyPermission \"intellij.debug.agent\", \"write\";",
+          "permission org.bouncycastle.crypto.CryptoServicesPermission \"exportSecretKey\";",
+          "permission org.bouncycastle.crypto.CryptoServicesPermission \"exportPrivateKey\";",
+          "permission java.io.FilePermission \"\${javax.net.ssl.trustStore}\", \"read\";",
+          "permission java.io.FilePermission \"${-> testClusters."follow-cluster".getFirstNode().getServerLog()}\", \"read\";",
+          "};"
+        ].join("\n")
+      )
+    } else {
+      policyFile.write(
+        [
+          "grant {",
+          "  permission java.io.FilePermission \"${-> testClusters."follow-cluster".getFirstNode().getServerLog()}\", \"read\";",
+          "};"
+        ].join("\n")
+      )
+    }
   }
 }
 
@@ -40,7 +63,11 @@ task "follow-cluster"(type: RestIntegTestTask) {
   dependsOn 'writeJavaPolicy', "leader-cluster"
   runner {
     useCluster testClusters."leader-cluster"
-    systemProperty 'java.security.policy', "file://${policyFile}"
+    if (BuildParams.inFipsJvm){
+      systemProperty 'java.security.policy', "=file://${policyFile}"
+    } else {
+      systemProperty 'java.security.policy', "file://${policyFile}"
+    }
     systemProperty 'tests.target_cluster', 'follow'
     nonInputProperties.systemProperty 'tests.leader_host', "${-> testClusters."leader-cluster".getAllHttpSocketURI().get(0)}"
     nonInputProperties.systemProperty 'log', "${-> testClusters."follow-cluster".getFirstNode().getServerLog()}"


### PR DESCRIPTION
Our FIPS 140 testing depends on setting the appropriate java policy
in order to configure the JVM in FIPS mode. Some tests (
discovery-ec2 and ccr qa ) also needed to set a custom policy file
to grant a specific permission, which overwrote the FIPS related
policy and tests would fail. This change ensures that when a
custom policy needs to be set in these tests, the permissions that
are necessary for FIPS are also set.

Resolves: #51685, #52034