### PR TITLE
Increase shard inactive time to 1h in x-pack upgrade tests

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -70,7 +70,7 @@ for (Version bwcVersion : bwcVersions.indexCompatible) {
 
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       // some tests rely on the translog not being flushed
-      setting 'indices.memory.shard_inactive_time', '20m'
+      setting 'indices.memory.shard_inactive_time', '60m'
       setting 'xpack.security.enabled', 'true'
       setting 'xpack.security.transport.ssl.enabled', 'true'
       setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/CoreFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/CoreFullClusterRestartIT.java
@@ -22,9 +22,4 @@ public class CoreFullClusterRestartIT extends FullClusterRestartIT {
                 .build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/52031")
-    @Override
-    public void testRecovery() throws Exception {
-        super.testRecovery();
-    }
 }


### PR DESCRIPTION
Similar to the fix in https://github.com/elastic/elasticsearch/pull/51651, this commit increases the shard inactive timeout for x-pack.

Closes #52031

```
[2020-02-07T04:45:51,703][INFO ][o.e.e.NodeEnvironment    ] [v8.0.0-1] using [1] data paths, mounts [[/dev/shm (tmpfs)]], net usable_space [26.4gb], net total_space [47.1gb], types [tmpfs]
...
[2020-02-07T05:10:26,842][INFO ][o.e.e.NodeEnvironment    ] [v8.0.0-1] using [1] data paths, mounts [[/dev/shm (tmpfs)]], net usable_space [23.1gb], net total_space [47.1gb], types [tmpfs]
```