### PR TITLE
Improve Painless compilation performance for nested conditionals

### DIFF
--- a/modules/lang-painless/src/main/antlr/PainlessParser.g4
+++ b/modules/lang-painless/src/main/antlr/PainlessParser.g4
@@ -98,25 +98,29 @@ trap
     : CATCH LP TYPE ID RP block
     ;
 
+noncondexpression
+    :               unary                                                               # single
+    |               noncondexpression ( MUL | DIV | REM ) noncondexpression             # binary
+    |               noncondexpression ( ADD | SUB ) noncondexpression                   # binary
+    |               noncondexpression ( FIND | MATCH ) noncondexpression                # binary
+    |               noncondexpression ( LSH | RSH | USH ) noncondexpression             # binary
+    |               noncondexpression ( LT | LTE | GT | GTE ) noncondexpression         # comp
+    |               noncondexpression INSTANCEOF decltype                               # instanceof
+    |               noncondexpression ( EQ | EQR | NE | NER ) noncondexpression         # comp
+    |               noncondexpression BWAND noncondexpression                           # binary
+    |               noncondexpression XOR noncondexpression                             # binary
+    |               noncondexpression BWOR noncondexpression                            # binary
+    |               noncondexpression BOOLAND noncondexpression                         # bool
+    |               noncondexpression BOOLOR noncondexpression                          # bool
+    | <assoc=right> noncondexpression ELVIS noncondexpression                           # elvis
+    ;
+
 expression
-    :               unary                                                 # single
-    |               expression ( MUL | DIV | REM ) expression             # binary
-    |               expression ( ADD | SUB ) expression                   # binary
-    |               expression ( FIND | MATCH ) expression                # binary
-    |               expression ( LSH | RSH | USH ) expression             # binary
-    |               expression ( LT | LTE | GT | GTE ) expression         # comp
-    |               expression INSTANCEOF decltype                        # instanceof
-    |               expression ( EQ | EQR | NE | NER ) expression         # comp
-    |               expression BWAND expression                           # binary
-    |               expression XOR expression                             # binary
-    |               expression BWOR expression                            # binary
-    |               expression BOOLAND expression                         # bool
-    |               expression BOOLOR expression                          # bool
-    | <assoc=right> expression COND expression COLON expression           # conditional
-    | <assoc=right> expression ELVIS expression                           # elvis
-    | <assoc=right> expression ( ASSIGN | AADD | ASUB | AMUL |
-                                 ADIV   | AREM | AAND | AXOR |
-                                 AOR    | ALSH | ARSH | AUSH ) expression # assignment
+    :               noncondexpression                                            # nonconditional
+    | <assoc=right> noncondexpression COND expression COLON expression           # conditional
+    | <assoc=right> noncondexpression ( ASSIGN | AADD | ASUB | AMUL |
+                                        ADIV   | AREM | AAND | AXOR |
+                                        AOR    | ALSH | ARSH | AUSH ) expression # assignment
     ;
 
 unary

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessLexer.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessLexer.java
@@ -1,17 +1,13 @@
 // ANTLR GENERATED CODE: DO NOT EDIT
 package org.elasticsearch.painless.antlr;
-
-import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Lexer;
-import org.antlr.v4.runtime.RuleContext;
-import org.antlr.v4.runtime.RuntimeMetaData;
-import org.antlr.v4.runtime.Vocabulary;
-import org.antlr.v4.runtime.VocabularyImpl;
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNDeserializer;
-import org.antlr.v4.runtime.atn.LexerATNSimulator;
-import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
+import org.antlr.v4.runtime.misc.*;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 abstract class PainlessLexer extends Lexer {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParser.java
@@ -1,25 +1,13 @@
 // ANTLR GENERATED CODE: DO NOT EDIT
 package org.elasticsearch.painless.antlr;
-
-import org.antlr.v4.runtime.FailedPredicateException;
-import org.antlr.v4.runtime.NoViableAltException;
-import org.antlr.v4.runtime.Parser;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.RuleContext;
-import org.antlr.v4.runtime.RuntimeMetaData;
-import org.antlr.v4.runtime.TokenStream;
-import org.antlr.v4.runtime.Vocabulary;
-import org.antlr.v4.runtime.VocabularyImpl;
-import org.antlr.v4.runtime.atn.ATN;
-import org.antlr.v4.runtime.atn.ATNDeserializer;
-import org.antlr.v4.runtime.atn.ParserATNSimulator;
-import org.antlr.v4.runtime.atn.PredictionContextCache;
+import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.tree.ParseTreeVisitor;
-import org.antlr.v4.runtime.tree.TerminalNode;
-
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.misc.*;
+import org.antlr.v4.runtime.tree.*;
 import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 class PainlessParser extends Parser {
@@ -44,19 +32,19 @@ class PainlessParser extends Parser {
     RULE_source = 0, RULE_function = 1, RULE_parameters = 2, RULE_statement = 3, 
     RULE_rstatement = 4, RULE_dstatement = 5, RULE_trailer = 6, RULE_block = 7, 
     RULE_empty = 8, RULE_initializer = 9, RULE_afterthought = 10, RULE_declaration = 11, 
-    RULE_decltype = 12, RULE_declvar = 13, RULE_trap = 14, RULE_expression = 15, 
-    RULE_unary = 16, RULE_chain = 17, RULE_primary = 18, RULE_postfix = 19, 
-    RULE_postdot = 20, RULE_callinvoke = 21, RULE_fieldaccess = 22, RULE_braceaccess = 23, 
-    RULE_arrayinitializer = 24, RULE_listinitializer = 25, RULE_mapinitializer = 26, 
-    RULE_maptoken = 27, RULE_arguments = 28, RULE_argument = 29, RULE_lambda = 30, 
-    RULE_lamtype = 31, RULE_funcref = 32;
+    RULE_decltype = 12, RULE_declvar = 13, RULE_trap = 14, RULE_noncondexpression = 15, 
+    RULE_expression = 16, RULE_unary = 17, RULE_chain = 18, RULE_primary = 19, 
+    RULE_postfix = 20, RULE_postdot = 21, RULE_callinvoke = 22, RULE_fieldaccess = 23, 
+    RULE_braceaccess = 24, RULE_arrayinitializer = 25, RULE_listinitializer = 26, 
+    RULE_mapinitializer = 27, RULE_maptoken = 28, RULE_arguments = 29, RULE_argument = 30, 
+    RULE_lambda = 31, RULE_lamtype = 32, RULE_funcref = 33;
   public static final String[] ruleNames = {
     "source", "function", "parameters", "statement", "rstatement", "dstatement", 
-    "trailer", "block", "empty", "initializer", "afterthought", "declaration",
-    "decltype", "declvar", "trap", "expression", "unary", "chain", "primary", 
-    "postfix", "postdot", "callinvoke", "fieldaccess", "braceaccess", "arrayinitializer", 
-    "listinitializer", "mapinitializer", "maptoken", "arguments", "argument", 
-    "lambda", "lamtype", "funcref"
+    "trailer", "block", "empty", "initializer", "afterthought", "declaration", 
+    "decltype", "declvar", "trap", "noncondexpression", "expression", "unary", 
+    "chain", "primary", "postfix", "postdot", "callinvoke", "fieldaccess", 
+    "braceaccess", "arrayinitializer", "listinitializer", "mapinitializer", 
+    "maptoken", "arguments", "argument", "lambda", "lamtype", "funcref"
   };
 
   private static final String[] _LITERAL_NAMES = {
@@ -164,37 +152,37 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(69);
+      setState(71);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,0,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(66);
+          setState(68);
           function();
           }
           } 
         }
-        setState(71);
+        setState(73);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,0,_ctx);
       }
-      setState(75);
+      setState(77);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << IF) | (1L << WHILE) | (1L << DO) | (1L << FOR) | (1L << CONTINUE) | (1L << BREAK) | (1L << RETURN) | (1L << NEW) | (1L << TRY) | (1L << THROW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
         {
         {
-        setState(72);
+        setState(74);
         statement();
         }
         }
-        setState(77);
+        setState(79);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
-      setState(78);
+      setState(80);
       match(EOF);
       }
     }
@@ -237,13 +225,13 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(80);
-      decltype();
-      setState(81);
-      match(ID);
       setState(82);
-      parameters();
+      decltype();
       setState(83);
+      match(ID);
+      setState(84);
+      parameters();
+      setState(85);
       block();
       }
     }
@@ -293,38 +281,38 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(85);
+      setState(87);
       match(LP);
-      setState(97);
+      setState(99);
       _la = _input.LA(1);
       if (_la==TYPE) {
         {
-        setState(86);
+        setState(88);
         decltype();
-        setState(87);
+        setState(89);
         match(ID);
-        setState(94);
+        setState(96);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(88);
-          match(COMMA);
-          setState(89);
-          decltype();
           setState(90);
+          match(COMMA);
+          setState(91);
+          decltype();
+          setState(92);
           match(ID);
           }
           }
-          setState(96);
+          setState(98);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(99);
+      setState(101);
       match(RP);
       }
     }
@@ -364,7 +352,7 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 6, RULE_statement);
     int _la;
     try {
-      setState(105);
+      setState(107);
       switch (_input.LA(1)) {
       case IF:
       case WHILE:
@@ -372,7 +360,7 @@ class PainlessParser extends Parser {
       case TRY:
         enterOuterAlt(_localctx, 1);
         {
-        setState(101);
+        setState(103);
         rstatement();
         }
         break;
@@ -403,9 +391,9 @@ class PainlessParser extends Parser {
       case ID:
         enterOuterAlt(_localctx, 2);
         {
-        setState(102);
+        setState(104);
         dstatement();
-        setState(103);
+        setState(105);
         _la = _input.LA(1);
         if ( !(_la==EOF || _la==SEMICOLON) ) {
         _errHandler.recoverInline(this);
@@ -577,37 +565,37 @@ class PainlessParser extends Parser {
     int _la;
     try {
       int _alt;
-      setState(167);
+      setState(169);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,12,_ctx) ) {
       case 1:
         _localctx = new IfContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(107);
-        match(IF);
-        setState(108);
-        match(LP);
         setState(109);
-        expression(0);
+        match(IF);
         setState(110);
-        match(RP);
+        match(LP);
         setState(111);
+        expression();
+        setState(112);
+        match(RP);
+        setState(113);
         trailer();
-        setState(115);
+        setState(117);
         _errHandler.sync(this);
         switch ( getInterpreter().adaptivePredict(_input,5,_ctx) ) {
         case 1:
           {
-          setState(112);
+          setState(114);
           match(ELSE);
-          setState(113);
+          setState(115);
           trailer();
           }
           break;
         case 2:
           {
-          setState(114);
+          setState(116);
           if (!( _input.LA(1) != ELSE )) throw new FailedPredicateException(this, " _input.LA(1) != ELSE ");
           }
           break;
@@ -618,15 +606,15 @@ class PainlessParser extends Parser {
         _localctx = new WhileContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(117);
-        match(WHILE);
-        setState(118);
-        match(LP);
         setState(119);
-        expression(0);
+        match(WHILE);
         setState(120);
+        match(LP);
+        setState(121);
+        expression();
+        setState(122);
         match(RP);
-        setState(123);
+        setState(125);
         switch (_input.LA(1)) {
         case LBRACK:
         case LBRACE:
@@ -659,13 +647,13 @@ class PainlessParser extends Parser {
         case TYPE:
         case ID:
           {
-          setState(121);
+          setState(123);
           trailer();
           }
           break;
         case SEMICOLON:
           {
-          setState(122);
+          setState(124);
           empty();
           }
           break;
@@ -678,44 +666,44 @@ class PainlessParser extends Parser {
         _localctx = new ForContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(125);
+        setState(127);
         match(FOR);
-        setState(126);
-        match(LP);
         setState(128);
+        match(LP);
+        setState(130);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
           {
-          setState(127);
+          setState(129);
           initializer();
           }
         }
 
-        setState(130);
-        match(SEMICOLON);
         setState(132);
+        match(SEMICOLON);
+        setState(134);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
           {
-          setState(131);
-          expression(0);
+          setState(133);
+          expression();
           }
         }
 
-        setState(134);
-        match(SEMICOLON);
         setState(136);
+        match(SEMICOLON);
+        setState(138);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
           {
-          setState(135);
+          setState(137);
           afterthought();
           }
         }
 
-        setState(138);
+        setState(140);
         match(RP);
-        setState(141);
+        setState(143);
         switch (_input.LA(1)) {
         case LBRACK:
         case LBRACE:
@@ -748,13 +736,13 @@ class PainlessParser extends Parser {
         case TYPE:
         case ID:
           {
-          setState(139);
+          setState(141);
           trailer();
           }
           break;
         case SEMICOLON:
           {
-          setState(140);
+          setState(142);
           empty();
           }
           break;
@@ -767,21 +755,21 @@ class PainlessParser extends Parser {
         _localctx = new EachContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(143);
-        match(FOR);
-        setState(144);
-        match(LP);
         setState(145);
-        decltype();
+        match(FOR);
         setState(146);
-        match(ID);
+        match(LP);
         setState(147);
-        match(COLON);
+        decltype();
         setState(148);
-        expression(0);
+        match(ID);
         setState(149);
-        match(RP);
+        match(COLON);
         setState(150);
+        expression();
+        setState(151);
+        match(RP);
+        setState(152);
         trailer();
         }
         break;
@@ -789,19 +777,19 @@ class PainlessParser extends Parser {
         _localctx = new IneachContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(152);
-        match(FOR);
-        setState(153);
-        match(LP);
         setState(154);
-        match(ID);
+        match(FOR);
         setState(155);
-        match(IN);
+        match(LP);
         setState(156);
-        expression(0);
+        match(ID);
         setState(157);
-        match(RP);
+        match(IN);
         setState(158);
+        expression();
+        setState(159);
+        match(RP);
+        setState(160);
         trailer();
         }
         break;
@@ -809,11 +797,11 @@ class PainlessParser extends Parser {
         _localctx = new TryContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(160);
+        setState(162);
         match(TRY);
-        setState(161);
+        setState(163);
         block();
-        setState(163); 
+        setState(165); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -821,7 +809,7 @@ class PainlessParser extends Parser {
           case 1:
             {
             {
-            setState(162);
+            setState(164);
             trap();
             }
             }
@@ -829,7 +817,7 @@ class PainlessParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(165); 
+          setState(167); 
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,11,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
@@ -947,24 +935,24 @@ class PainlessParser extends Parser {
     enterRule(_localctx, 10, RULE_dstatement);
     int _la;
     try {
-      setState(186);
+      setState(188);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,14,_ctx) ) {
       case 1:
         _localctx = new DoContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(169);
-        match(DO);
-        setState(170);
-        block();
         setState(171);
-        match(WHILE);
+        match(DO);
         setState(172);
-        match(LP);
+        block();
         setState(173);
-        expression(0);
+        match(WHILE);
         setState(174);
+        match(LP);
+        setState(175);
+        expression();
+        setState(176);
         match(RP);
         }
         break;
@@ -972,7 +960,7 @@ class PainlessParser extends Parser {
         _localctx = new DeclContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(176);
+        setState(178);
         declaration();
         }
         break;
@@ -980,7 +968,7 @@ class PainlessParser extends Parser {
         _localctx = new ContinueContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(177);
+        setState(179);
         match(CONTINUE);
         }
         break;
@@ -988,7 +976,7 @@ class PainlessParser extends Parser {
         _localctx = new BreakContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(178);
+        setState(180);
         match(BREAK);
         }
         break;
@@ -996,14 +984,14 @@ class PainlessParser extends Parser {
         _localctx = new ReturnContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(179);
-        match(RETURN);
         setState(181);
+        match(RETURN);
+        setState(183);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
           {
-          setState(180);
-          expression(0);
+          setState(182);
+          expression();
           }
         }
 
@@ -1013,18 +1001,18 @@ class PainlessParser extends Parser {
         _localctx = new ThrowContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(183);
+        setState(185);
         match(THROW);
-        setState(184);
-        expression(0);
+        setState(186);
+        expression();
         }
         break;
       case 7:
         _localctx = new ExprContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(185);
-        expression(0);
+        setState(187);
+        expression();
         }
         break;
       }
@@ -1062,12 +1050,12 @@ class PainlessParser extends Parser {
     TrailerContext _localctx = new TrailerContext(_ctx, getState());
     enterRule(_localctx, 12, RULE_trailer);
     try {
-      setState(190);
+      setState(192);
       switch (_input.LA(1)) {
       case LBRACK:
         enterOuterAlt(_localctx, 1);
         {
-        setState(188);
+        setState(190);
         block();
         }
         break;
@@ -1102,7 +1090,7 @@ class PainlessParser extends Parser {
       case ID:
         enterOuterAlt(_localctx, 2);
         {
-        setState(189);
+        setState(191);
         statement();
         }
         break;
@@ -1152,34 +1140,34 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(192);
+      setState(194);
       match(LBRACK);
-      setState(196);
+      setState(198);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,16,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(193);
+          setState(195);
           statement();
           }
           } 
         }
-        setState(198);
+        setState(200);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,16,_ctx);
       }
-      setState(200);
+      setState(202);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << DO) | (1L << CONTINUE) | (1L << BREAK) | (1L << RETURN) | (1L << NEW) | (1L << THROW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
         {
-        setState(199);
+        setState(201);
         dstatement();
         }
       }
 
-      setState(202);
+      setState(204);
       match(RBRACK);
       }
     }
@@ -1213,7 +1201,7 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(204);
+      setState(206);
       match(SEMICOLON);
       }
     }
@@ -1250,21 +1238,21 @@ class PainlessParser extends Parser {
     InitializerContext _localctx = new InitializerContext(_ctx, getState());
     enterRule(_localctx, 18, RULE_initializer);
     try {
-      setState(208);
+      setState(210);
       _errHandler.sync(this);
       switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(206);
+        setState(208);
         declaration();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(207);
-        expression(0);
+        setState(209);
+        expression();
         }
         break;
       }
@@ -1301,8 +1289,8 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(210);
-      expression(0);
+      setState(212);
+      expression();
       }
     }
     catch (RecognitionException re) {
@@ -1348,23 +1336,23 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(212);
+      setState(214);
       decltype();
-      setState(213);
+      setState(215);
       declvar();
-      setState(218);
+      setState(220);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==COMMA) {
         {
         {
-        setState(214);
+        setState(216);
         match(COMMA);
-        setState(215);
+        setState(217);
         declvar();
         }
         }
-        setState(220);
+        setState(222);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
@@ -1409,23 +1397,23 @@ class PainlessParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(221);
+      setState(223);
       match(TYPE);
-      setState(226);
+      setState(228);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,20,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(222);
+          setState(224);
           match(LBRACE);
-          setState(223);
+          setState(225);
           match(RBRACE);
           }
           } 
         }
-        setState(228);
+        setState(230);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,20,_ctx);
       }
@@ -1466,16 +1454,16 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(229);
+      setState(231);
       match(ID);
-      setState(232);
+      setState(234);
       _la = _input.LA(1);
       if (_la==ASSIGN) {
         {
-        setState(230);
+        setState(232);
         match(ASSIGN);
-        setState(231);
-        expression(0);
+        setState(233);
+        expression();
         }
       }
 
@@ -1518,17 +1506,17 @@ class PainlessParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(234);
-      match(CATCH);
-      setState(235);
-      match(LP);
       setState(236);
-      match(TYPE);
+      match(CATCH);
       setState(237);
-      match(ID);
+      match(LP);
       setState(238);
-      match(RP);
+      match(TYPE);
       setState(239);
+      match(ID);
+      setState(240);
+      match(RP);
+      setState(241);
       block();
       }
     }
@@ -1539,6 +1527,366 @@ class PainlessParser extends Parser {
     }
     finally {
       exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class NoncondexpressionContext extends ParserRuleContext {
+    public NoncondexpressionContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_noncondexpression; }
+   
+    public NoncondexpressionContext() { }
+    public void copyFrom(NoncondexpressionContext ctx) {
+      super.copyFrom(ctx);
+    }
+  }
+  public static class SingleContext extends NoncondexpressionContext {
+    public UnaryContext unary() {
+      return getRuleContext(UnaryContext.class,0);
+    }
+    public SingleContext(NoncondexpressionContext ctx) { copyFrom(ctx); }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitSingle(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+  public static class CompContext extends NoncondexpressionContext {
+    public List<NoncondexpressionContext> noncondexpression() {
+      return getRuleContexts(NoncondexpressionContext.class);
+    }
+    public NoncondexpressionContext noncondexpression(int i) {
+      return getRuleContext(NoncondexpressionContext.class,i);
+    }
+    public TerminalNode LT() { return getToken(PainlessParser.LT, 0); }
+    public TerminalNode LTE() { return getToken(PainlessParser.LTE, 0); }
+    public TerminalNode GT() { return getToken(PainlessParser.GT, 0); }
+    public TerminalNode GTE() { return getToken(PainlessParser.GTE, 0); }
+    public TerminalNode EQ() { return getToken(PainlessParser.EQ, 0); }
+    public TerminalNode EQR() { return getToken(PainlessParser.EQR, 0); }
+    public TerminalNode NE() { return getToken(PainlessParser.NE, 0); }
+    public TerminalNode NER() { return getToken(PainlessParser.NER, 0); }
+    public CompContext(NoncondexpressionContext ctx) { copyFrom(ctx); }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitComp(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+  public static class BoolContext extends NoncondexpressionContext {
+    public List<NoncondexpressionContext> noncondexpression() {
+      return getRuleContexts(NoncondexpressionContext.class);
+    }
+    public NoncondexpressionContext noncondexpression(int i) {
+      return getRuleContext(NoncondexpressionContext.class,i);
+    }
+    public TerminalNode BOOLAND() { return getToken(PainlessParser.BOOLAND, 0); }
+    public TerminalNode BOOLOR() { return getToken(PainlessParser.BOOLOR, 0); }
+    public BoolContext(NoncondexpressionContext ctx) { copyFrom(ctx); }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitBool(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+  public static class BinaryContext extends NoncondexpressionContext {
+    public List<NoncondexpressionContext> noncondexpression() {
+      return getRuleContexts(NoncondexpressionContext.class);
+    }
+    public NoncondexpressionContext noncondexpression(int i) {
+      return getRuleContext(NoncondexpressionContext.class,i);
+    }
+    public TerminalNode MUL() { return getToken(PainlessParser.MUL, 0); }
+    public TerminalNode DIV() { return getToken(PainlessParser.DIV, 0); }
+    public TerminalNode REM() { return getToken(PainlessParser.REM, 0); }
+    public TerminalNode ADD() { return getToken(PainlessParser.ADD, 0); }
+    public TerminalNode SUB() { return getToken(PainlessParser.SUB, 0); }
+    public TerminalNode FIND() { return getToken(PainlessParser.FIND, 0); }
+    public TerminalNode MATCH() { return getToken(PainlessParser.MATCH, 0); }
+    public TerminalNode LSH() { return getToken(PainlessParser.LSH, 0); }
+    public TerminalNode RSH() { return getToken(PainlessParser.RSH, 0); }
+    public TerminalNode USH() { return getToken(PainlessParser.USH, 0); }
+    public TerminalNode BWAND() { return getToken(PainlessParser.BWAND, 0); }
+    public TerminalNode XOR() { return getToken(PainlessParser.XOR, 0); }
+    public TerminalNode BWOR() { return getToken(PainlessParser.BWOR, 0); }
+    public BinaryContext(NoncondexpressionContext ctx) { copyFrom(ctx); }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitBinary(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+  public static class ElvisContext extends NoncondexpressionContext {
+    public List<NoncondexpressionContext> noncondexpression() {
+      return getRuleContexts(NoncondexpressionContext.class);
+    }
+    public NoncondexpressionContext noncondexpression(int i) {
+      return getRuleContext(NoncondexpressionContext.class,i);
+    }
+    public TerminalNode ELVIS() { return getToken(PainlessParser.ELVIS, 0); }
+    public ElvisContext(NoncondexpressionContext ctx) { copyFrom(ctx); }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitElvis(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+  public static class InstanceofContext extends NoncondexpressionContext {
+    public NoncondexpressionContext noncondexpression() {
+      return getRuleContext(NoncondexpressionContext.class,0);
+    }
+    public TerminalNode INSTANCEOF() { return getToken(PainlessParser.INSTANCEOF, 0); }
+    public DecltypeContext decltype() {
+      return getRuleContext(DecltypeContext.class,0);
+    }
+    public InstanceofContext(NoncondexpressionContext ctx) { copyFrom(ctx); }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitInstanceof(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final NoncondexpressionContext noncondexpression() throws RecognitionException {
+    return noncondexpression(0);
+  }
+
+  private NoncondexpressionContext noncondexpression(int _p) throws RecognitionException {
+    ParserRuleContext _parentctx = _ctx;
+    int _parentState = getState();
+    NoncondexpressionContext _localctx = new NoncondexpressionContext(_ctx, _parentState);
+    NoncondexpressionContext _prevctx = _localctx;
+    int _startState = 30;
+    enterRecursionRule(_localctx, 30, RULE_noncondexpression, _p);
+    int _la;
+    try {
+      int _alt;
+      enterOuterAlt(_localctx, 1);
+      {
+      {
+      _localctx = new SingleContext(_localctx);
+      _ctx = _localctx;
+      _prevctx = _localctx;
+
+      setState(244);
+      unary();
+      }
+      _ctx.stop = _input.LT(-1);
+      setState(287);
+      _errHandler.sync(this);
+      _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+      while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
+        if ( _alt==1 ) {
+          if ( _parseListeners!=null ) triggerExitRuleEvent();
+          _prevctx = _localctx;
+          {
+          setState(285);
+          _errHandler.sync(this);
+          switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
+          case 1:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(246);
+            if (!(precpred(_ctx, 13))) throw new FailedPredicateException(this, "precpred(_ctx, 13)");
+            setState(247);
+            _la = _input.LA(1);
+            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << MUL) | (1L << DIV) | (1L << REM))) != 0)) ) {
+            _errHandler.recoverInline(this);
+            } else {
+              consume();
+            }
+            setState(248);
+            noncondexpression(14);
+            }
+            break;
+          case 2:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(249);
+            if (!(precpred(_ctx, 12))) throw new FailedPredicateException(this, "precpred(_ctx, 12)");
+            setState(250);
+            _la = _input.LA(1);
+            if ( !(_la==ADD || _la==SUB) ) {
+            _errHandler.recoverInline(this);
+            } else {
+              consume();
+            }
+            setState(251);
+            noncondexpression(13);
+            }
+            break;
+          case 3:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(252);
+            if (!(precpred(_ctx, 11))) throw new FailedPredicateException(this, "precpred(_ctx, 11)");
+            setState(253);
+            _la = _input.LA(1);
+            if ( !(_la==FIND || _la==MATCH) ) {
+            _errHandler.recoverInline(this);
+            } else {
+              consume();
+            }
+            setState(254);
+            noncondexpression(12);
+            }
+            break;
+          case 4:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(255);
+            if (!(precpred(_ctx, 10))) throw new FailedPredicateException(this, "precpred(_ctx, 10)");
+            setState(256);
+            _la = _input.LA(1);
+            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LSH) | (1L << RSH) | (1L << USH))) != 0)) ) {
+            _errHandler.recoverInline(this);
+            } else {
+              consume();
+            }
+            setState(257);
+            noncondexpression(11);
+            }
+            break;
+          case 5:
+            {
+            _localctx = new CompContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(258);
+            if (!(precpred(_ctx, 9))) throw new FailedPredicateException(this, "precpred(_ctx, 9)");
+            setState(259);
+            _la = _input.LA(1);
+            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
+            _errHandler.recoverInline(this);
+            } else {
+              consume();
+            }
+            setState(260);
+            noncondexpression(10);
+            }
+            break;
+          case 6:
+            {
+            _localctx = new CompContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(261);
+            if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
+            setState(262);
+            _la = _input.LA(1);
+            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << EQR) | (1L << NE) | (1L << NER))) != 0)) ) {
+            _errHandler.recoverInline(this);
+            } else {
+              consume();
+            }
+            setState(263);
+            noncondexpression(8);
+            }
+            break;
+          case 7:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(264);
+            if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
+            setState(265);
+            match(BWAND);
+            setState(266);
+            noncondexpression(7);
+            }
+            break;
+          case 8:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(267);
+            if (!(precpred(_ctx, 5))) throw new FailedPredicateException(this, "precpred(_ctx, 5)");
+            setState(268);
+            match(XOR);
+            setState(269);
+            noncondexpression(6);
+            }
+            break;
+          case 9:
+            {
+            _localctx = new BinaryContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(270);
+            if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
+            setState(271);
+            match(BWOR);
+            setState(272);
+            noncondexpression(5);
+            }
+            break;
+          case 10:
+            {
+            _localctx = new BoolContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(273);
+            if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
+            setState(274);
+            match(BOOLAND);
+            setState(275);
+            noncondexpression(4);
+            }
+            break;
+          case 11:
+            {
+            _localctx = new BoolContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(276);
+            if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
+            setState(277);
+            match(BOOLOR);
+            setState(278);
+            noncondexpression(3);
+            }
+            break;
+          case 12:
+            {
+            _localctx = new ElvisContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(279);
+            if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
+            setState(280);
+            match(ELVIS);
+            setState(281);
+            noncondexpression(1);
+            }
+            break;
+          case 13:
+            {
+            _localctx = new InstanceofContext(new NoncondexpressionContext(_parentctx, _parentState));
+            pushNewRecursionContext(_localctx, _startState, RULE_noncondexpression);
+            setState(282);
+            if (!(precpred(_ctx, 8))) throw new FailedPredicateException(this, "precpred(_ctx, 8)");
+            setState(283);
+            match(INSTANCEOF);
+            setState(284);
+            decltype();
+            }
+            break;
+          }
+          } 
+        }
+        setState(289);
+        _errHandler.sync(this);
+        _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+      }
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      unrollRecursionContexts(_parentctx);
     }
     return _localctx;
   }
@@ -1554,63 +1902,17 @@ class PainlessParser extends Parser {
       super.copyFrom(ctx);
     }
   }
-  public static class SingleContext extends ExpressionContext {
-    public UnaryContext unary() {
-      return getRuleContext(UnaryContext.class,0);
-    }
-    public SingleContext(ExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitSingle(this);
-      else return visitor.visitChildren(this);
-    }
-  }
-  public static class CompContext extends ExpressionContext {
-    public List<ExpressionContext> expression() {
-      return getRuleContexts(ExpressionContext.class);
-    }
-    public ExpressionContext expression(int i) {
-      return getRuleContext(ExpressionContext.class,i);
-    }
-    public TerminalNode LT() { return getToken(PainlessParser.LT, 0); }
-    public TerminalNode LTE() { return getToken(PainlessParser.LTE, 0); }
-    public TerminalNode GT() { return getToken(PainlessParser.GT, 0); }
-    public TerminalNode GTE() { return getToken(PainlessParser.GTE, 0); }
-    public TerminalNode EQ() { return getToken(PainlessParser.EQ, 0); }
-    public TerminalNode EQR() { return getToken(PainlessParser.EQR, 0); }
-    public TerminalNode NE() { return getToken(PainlessParser.NE, 0); }
-    public TerminalNode NER() { return getToken(PainlessParser.NER, 0); }
-    public CompContext(ExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitComp(this);
-      else return visitor.visitChildren(this);
-    }
-  }
-  public static class BoolContext extends ExpressionContext {
-    public List<ExpressionContext> expression() {
-      return getRuleContexts(ExpressionContext.class);
-    }
-    public ExpressionContext expression(int i) {
-      return getRuleContext(ExpressionContext.class,i);
-    }
-    public TerminalNode BOOLAND() { return getToken(PainlessParser.BOOLAND, 0); }
-    public TerminalNode BOOLOR() { return getToken(PainlessParser.BOOLOR, 0); }
-    public BoolContext(ExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitBool(this);
-      else return visitor.visitChildren(this);
-    }
-  }
   public static class ConditionalContext extends ExpressionContext {
-    public List<ExpressionContext> expression() {
-      return getRuleContexts(ExpressionContext.class);
-    }
-    public ExpressionContext expression(int i) {
-      return getRuleContext(ExpressionContext.class,i);
+    public NoncondexpressionContext noncondexpression() {
+      return getRuleContext(NoncondexpressionContext.class,0);
     }
     public TerminalNode COND() { return getToken(PainlessParser.COND, 0); }
+    public List<ExpressionContext> expression() {
+      return getRuleContexts(ExpressionContext.class);
+    }
+    public ExpressionContext expression(int i) {
+      return getRuleContext(ExpressionContext.class,i);
+    }
     public TerminalNode COLON() { return getToken(PainlessParser.COLON, 0); }
     public ConditionalContext(ExpressionContext ctx) { copyFrom(ctx); }
     @Override
@@ -1620,11 +1922,11 @@ class PainlessParser extends Parser {
     }
   }
   public static class AssignmentContext extends ExpressionContext {
-    public List<ExpressionContext> expression() {
-      return getRuleContexts(ExpressionContext.class);
+    public NoncondexpressionContext noncondexpression() {
+      return getRuleContext(NoncondexpressionContext.class,0);
     }
-    public ExpressionContext expression(int i) {
-      return getRuleContext(ExpressionContext.class,i);
+    public ExpressionContext expression() {
+      return getRuleContext(ExpressionContext.class,0);
     }
     public TerminalNode ASSIGN() { return getToken(PainlessParser.ASSIGN, 0); }
     public TerminalNode AADD() { return getToken(PainlessParser.AADD, 0); }
@@ -1645,326 +1947,67 @@ class PainlessParser extends Parser {
       else return visitor.visitChildren(this);
     }
   }
-  public static class BinaryContext extends ExpressionContext {
-    public List<ExpressionContext> expression() {
-      return getRuleContexts(ExpressionContext.class);
+  public static class NonconditionalContext extends ExpressionContext {
+    public NoncondexpressionContext noncondexpression() {
+      return getRuleContext(NoncondexpressionContext.class,0);
     }
-    public ExpressionContext expression(int i) {
-      return getRuleContext(ExpressionContext.class,i);
-    }
-    public TerminalNode MUL() { return getToken(PainlessParser.MUL, 0); }
-    public TerminalNode DIV() { return getToken(PainlessParser.DIV, 0); }
-    public TerminalNode REM() { return getToken(PainlessParser.REM, 0); }
-    public TerminalNode ADD() { return getToken(PainlessParser.ADD, 0); }
-    public TerminalNode SUB() { return getToken(PainlessParser.SUB, 0); }
-    public TerminalNode FIND() { return getToken(PainlessParser.FIND, 0); }
-    public TerminalNode MATCH() { return getToken(PainlessParser.MATCH, 0); }
-    public TerminalNode LSH() { return getToken(PainlessParser.LSH, 0); }
-    public TerminalNode RSH() { return getToken(PainlessParser.RSH, 0); }
-    public TerminalNode USH() { return getToken(PainlessParser.USH, 0); }
-    public TerminalNode BWAND() { return getToken(PainlessParser.BWAND, 0); }
-    public TerminalNode XOR() { return getToken(PainlessParser.XOR, 0); }
-    public TerminalNode BWOR() { return getToken(PainlessParser.BWOR, 0); }
-    public BinaryContext(ExpressionContext ctx) { copyFrom(ctx); }
+    public NonconditionalContext(ExpressionContext ctx) { copyFrom(ctx); }
     @Override
     public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitBinary(this);
-      else return visitor.visitChildren(this);
-    }
-  }
-  public static class ElvisContext extends ExpressionContext {
-    public List<ExpressionContext> expression() {
-      return getRuleContexts(ExpressionContext.class);
-    }
-    public ExpressionContext expression(int i) {
-      return getRuleContext(ExpressionContext.class,i);
-    }
-    public TerminalNode ELVIS() { return getToken(PainlessParser.ELVIS, 0); }
-    public ElvisContext(ExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitElvis(this);
-      else return visitor.visitChildren(this);
-    }
-  }
-  public static class InstanceofContext extends ExpressionContext {
-    public ExpressionContext expression() {
-      return getRuleContext(ExpressionContext.class,0);
-    }
-    public TerminalNode INSTANCEOF() { return getToken(PainlessParser.INSTANCEOF, 0); }
-    public DecltypeContext decltype() {
-      return getRuleContext(DecltypeContext.class,0);
-    }
-    public InstanceofContext(ExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitInstanceof(this);
+      if ( visitor instanceof PainlessParserVisitor ) return ((PainlessParserVisitor<? extends T>)visitor).visitNonconditional(this);
       else return visitor.visitChildren(this);
     }
   }
 
   public final ExpressionContext expression() throws RecognitionException {
-    return expression(0);
-  }
-
-  private ExpressionContext expression(int _p) throws RecognitionException {
-    ParserRuleContext _parentctx = _ctx;
-    int _parentState = getState();
-    ExpressionContext _localctx = new ExpressionContext(_ctx, _parentState);
-    ExpressionContext _prevctx = _localctx;
-    int _startState = 30;
-    enterRecursionRule(_localctx, 30, RULE_expression, _p);
+    ExpressionContext _localctx = new ExpressionContext(_ctx, getState());
+    enterRule(_localctx, 32, RULE_expression);
     int _la;
     try {
-      int _alt;
-      enterOuterAlt(_localctx, 1);
-      {
-      {
-      _localctx = new SingleContext(_localctx);
-      _ctx = _localctx;
-      _prevctx = _localctx;
-
-      setState(242);
-      unary();
-      }
-      _ctx.stop = _input.LT(-1);
-      setState(294);
+      setState(301);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
-      while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-        if ( _alt==1 ) {
-          if ( _parseListeners!=null ) triggerExitRuleEvent();
-          _prevctx = _localctx;
-          {
-          setState(292);
-          _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
-          case 1:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(244);
-            if (!(precpred(_ctx, 15))) throw new FailedPredicateException(this, "precpred(_ctx, 15)");
-            setState(245);
-            _la = _input.LA(1);
-            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << MUL) | (1L << DIV) | (1L << REM))) != 0)) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(246);
-            expression(16);
-            }
-            break;
-          case 2:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(247);
-            if (!(precpred(_ctx, 14))) throw new FailedPredicateException(this, "precpred(_ctx, 14)");
-            setState(248);
-            _la = _input.LA(1);
-            if ( !(_la==ADD || _la==SUB) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(249);
-            expression(15);
-            }
-            break;
-          case 3:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(250);
-            if (!(precpred(_ctx, 13))) throw new FailedPredicateException(this, "precpred(_ctx, 13)");
-            setState(251);
-            _la = _input.LA(1);
-            if ( !(_la==FIND || _la==MATCH) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(252);
-            expression(14);
-            }
-            break;
-          case 4:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(253);
-            if (!(precpred(_ctx, 12))) throw new FailedPredicateException(this, "precpred(_ctx, 12)");
-            setState(254);
-            _la = _input.LA(1);
-            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LSH) | (1L << RSH) | (1L << USH))) != 0)) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(255);
-            expression(13);
-            }
-            break;
-          case 5:
-            {
-            _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(256);
-            if (!(precpred(_ctx, 11))) throw new FailedPredicateException(this, "precpred(_ctx, 11)");
-            setState(257);
-            _la = _input.LA(1);
-            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(258);
-            expression(12);
-            }
-            break;
-          case 6:
-            {
-            _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(259);
-            if (!(precpred(_ctx, 9))) throw new FailedPredicateException(this, "precpred(_ctx, 9)");
-            setState(260);
-            _la = _input.LA(1);
-            if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << EQR) | (1L << NE) | (1L << NER))) != 0)) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(261);
-            expression(10);
-            }
-            break;
-          case 7:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(262);
-            if (!(precpred(_ctx, 8))) throw new FailedPredicateException(this, "precpred(_ctx, 8)");
-            setState(263);
-            match(BWAND);
-            setState(264);
-            expression(9);
-            }
-            break;
-          case 8:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(265);
-            if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
-            setState(266);
-            match(XOR);
-            setState(267);
-            expression(8);
-            }
-            break;
-          case 9:
-            {
-            _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(268);
-            if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
-            setState(269);
-            match(BWOR);
-            setState(270);
-            expression(7);
-            }
-            break;
-          case 10:
-            {
-            _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(271);
-            if (!(precpred(_ctx, 5))) throw new FailedPredicateException(this, "precpred(_ctx, 5)");
-            setState(272);
-            match(BOOLAND);
-            setState(273);
-            expression(6);
-            }
-            break;
-          case 11:
-            {
-            _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(274);
-            if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
-            setState(275);
-            match(BOOLOR);
-            setState(276);
-            expression(5);
-            }
-            break;
-          case 12:
-            {
-            _localctx = new ConditionalContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(277);
-            if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-            setState(278);
-            match(COND);
-            setState(279);
-            expression(0);
-            setState(280);
-            match(COLON);
-            setState(281);
-            expression(3);
-            }
-            break;
-          case 13:
-            {
-            _localctx = new ElvisContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(283);
-            if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(284);
-            match(ELVIS);
-            setState(285);
-            expression(2);
-            }
-            break;
-          case 14:
-            {
-            _localctx = new AssignmentContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(286);
-            if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(287);
-            _la = _input.LA(1);
-            if ( !(((((_la - 60)) & ~0x3f) == 0 && ((1L << (_la - 60)) & ((1L << (ASSIGN - 60)) | (1L << (AADD - 60)) | (1L << (ASUB - 60)) | (1L << (AMUL - 60)) | (1L << (ADIV - 60)) | (1L << (AREM - 60)) | (1L << (AAND - 60)) | (1L << (AXOR - 60)) | (1L << (AOR - 60)) | (1L << (ALSH - 60)) | (1L << (ARSH - 60)) | (1L << (AUSH - 60)))) != 0)) ) {
-            _errHandler.recoverInline(this);
-            } else {
-              consume();
-            }
-            setState(288);
-            expression(1);
-            }
-            break;
-          case 15:
-            {
-            _localctx = new InstanceofContext(new ExpressionContext(_parentctx, _parentState));
-            pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(289);
-            if (!(precpred(_ctx, 10))) throw new FailedPredicateException(this, "precpred(_ctx, 10)");
-            setState(290);
-            match(INSTANCEOF);
-            setState(291);
-            decltype();
-            }
-            break;
-          }
-          } 
+      switch ( getInterpreter().adaptivePredict(_input,24,_ctx) ) {
+      case 1:
+        _localctx = new NonconditionalContext(_localctx);
+        enterOuterAlt(_localctx, 1);
+        {
+        setState(290);
+        noncondexpression(0);
         }
-        setState(296);
-        _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
-      }
+        break;
+      case 2:
+        _localctx = new ConditionalContext(_localctx);
+        enterOuterAlt(_localctx, 2);
+        {
+        setState(291);
+        noncondexpression(0);
+        setState(292);
+        match(COND);
+        setState(293);
+        expression();
+        setState(294);
+        match(COLON);
+        setState(295);
+        expression();
+        }
+        break;
+      case 3:
+        _localctx = new AssignmentContext(_localctx);
+        enterOuterAlt(_localctx, 3);
+        {
+        setState(297);
+        noncondexpression(0);
+        setState(298);
+        _la = _input.LA(1);
+        if ( !(((((_la - 60)) & ~0x3f) == 0 && ((1L << (_la - 60)) & ((1L << (ASSIGN - 60)) | (1L << (AADD - 60)) | (1L << (ASUB - 60)) | (1L << (AMUL - 60)) | (1L << (ADIV - 60)) | (1L << (AREM - 60)) | (1L << (AAND - 60)) | (1L << (AXOR - 60)) | (1L << (AOR - 60)) | (1L << (ALSH - 60)) | (1L << (ARSH - 60)) | (1L << (AUSH - 60)))) != 0)) ) {
+        _errHandler.recoverInline(this);
+        } else {
+          consume();
+        }
+        setState(299);
+        expression();
+        }
+        break;
       }
     }
     catch (RecognitionException re) {
@@ -1973,7 +2016,7 @@ class PainlessParser extends Parser {
       _errHandler.recover(this, re);
     }
     finally {
-      unrollRecursionContexts(_parentctx);
+      exitRule();
     }
     return _localctx;
   }
@@ -2060,24 +2103,24 @@ class PainlessParser extends Parser {
 
   public final UnaryContext unary() throws RecognitionException {
     UnaryContext _localctx = new UnaryContext(_ctx, getState());
-    enterRule(_localctx, 32, RULE_unary);
+    enterRule(_localctx, 34, RULE_unary);
     int _la;
     try {
-      setState(310);
+      setState(316);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,24,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,25,_ctx) ) {
       case 1:
         _localctx = new PreContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(297);
+        setState(303);
         _la = _input.LA(1);
         if ( !(_la==INCR || _la==DECR) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(298);
+        setState(304);
         chain();
         }
         break;
@@ -2085,9 +2128,9 @@ class PainlessParser extends Parser {
         _localctx = new PostContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(299);
+        setState(305);
         chain();
-        setState(300);
+        setState(306);
         _la = _input.LA(1);
         if ( !(_la==INCR || _la==DECR) ) {
         _errHandler.recoverInline(this);
@@ -2100,7 +2143,7 @@ class PainlessParser extends Parser {
         _localctx = new ReadContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(302);
+        setState(308);
         chain();
         }
         break;
@@ -2108,14 +2151,14 @@ class PainlessParser extends Parser {
         _localctx = new OperatorContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(303);
+        setState(309);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(304);
+        setState(310);
         unary();
         }
         break;
@@ -2123,13 +2166,13 @@ class PainlessParser extends Parser {
         _localctx = new CastContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(305);
+        setState(311);
         match(LP);
-        setState(306);
+        setState(312);
         decltype();
-        setState(307);
+        setState(313);
         match(RP);
-        setState(308);
+        setState(314);
         unary();
         }
         break;
@@ -2208,33 +2251,33 @@ class PainlessParser extends Parser {
 
   public final ChainContext chain() throws RecognitionException {
     ChainContext _localctx = new ChainContext(_ctx, getState());
-    enterRule(_localctx, 34, RULE_chain);
+    enterRule(_localctx, 36, RULE_chain);
     try {
       int _alt;
-      setState(328);
+      setState(334);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
       case 1:
         _localctx = new DynamicContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(312);
+        setState(318);
         primary();
-        setState(316);
+        setState(322);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,25,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(313);
+            setState(319);
             postfix();
             }
             } 
           }
-          setState(318);
+          setState(324);
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,25,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
         }
         }
         break;
@@ -2242,25 +2285,25 @@ class PainlessParser extends Parser {
         _localctx = new StaticContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(319);
+        setState(325);
         decltype();
-        setState(320);
+        setState(326);
         postdot();
-        setState(324);
+        setState(330);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,27,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(321);
+            setState(327);
             postfix();
             }
             } 
           }
-          setState(326);
+          setState(332);
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,26,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,27,_ctx);
         }
         }
         break;
@@ -2268,7 +2311,7 @@ class PainlessParser extends Parser {
         _localctx = new NewarrayContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(327);
+        setState(333);
         arrayinitializer();
         }
         break;
@@ -2425,21 +2468,21 @@ class PainlessParser extends Parser {
 
   public final PrimaryContext primary() throws RecognitionException {
     PrimaryContext _localctx = new PrimaryContext(_ctx, getState());
-    enterRule(_localctx, 36, RULE_primary);
+    enterRule(_localctx, 38, RULE_primary);
     int _la;
     try {
-      setState(348);
+      setState(354);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
       case 1:
         _localctx = new PrecedenceContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(330);
+        setState(336);
         match(LP);
-        setState(331);
-        expression(0);
-        setState(332);
+        setState(337);
+        expression();
+        setState(338);
         match(RP);
         }
         break;
@@ -2447,7 +2490,7 @@ class PainlessParser extends Parser {
         _localctx = new NumericContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(334);
+        setState(340);
         _la = _input.LA(1);
         if ( !(((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)))) != 0)) ) {
         _errHandler.recoverInline(this);
@@ -2460,7 +2503,7 @@ class PainlessParser extends Parser {
         _localctx = new TrueContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(335);
+        setState(341);
         match(TRUE);
         }
         break;
@@ -2468,7 +2511,7 @@ class PainlessParser extends Parser {
         _localctx = new FalseContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(336);
+        setState(342);
         match(FALSE);
         }
         break;
@@ -2476,7 +2519,7 @@ class PainlessParser extends Parser {
         _localctx = new NullContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(337);
+        setState(343);
         match(NULL);
         }
         break;
@@ -2484,7 +2527,7 @@ class PainlessParser extends Parser {
         _localctx = new StringContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(338);
+        setState(344);
         match(STRING);
         }
         break;
@@ -2492,7 +2535,7 @@ class PainlessParser extends Parser {
         _localctx = new RegexContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(339);
+        setState(345);
         match(REGEX);
         }
         break;
@@ -2500,7 +2543,7 @@ class PainlessParser extends Parser {
         _localctx = new ListinitContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(340);
+        setState(346);
         listinitializer();
         }
         break;
@@ -2508,7 +2551,7 @@ class PainlessParser extends Parser {
         _localctx = new MapinitContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(341);
+        setState(347);
         mapinitializer();
         }
         break;
@@ -2516,7 +2559,7 @@ class PainlessParser extends Parser {
         _localctx = new VariableContext(_localctx);
         enterOuterAlt(_localctx, 10);
         {
-        setState(342);
+        setState(348);
         match(ID);
         }
         break;
@@ -2524,9 +2567,9 @@ class PainlessParser extends Parser {
         _localctx = new CalllocalContext(_localctx);
         enterOuterAlt(_localctx, 11);
         {
-        setState(343);
+        setState(349);
         match(ID);
-        setState(344);
+        setState(350);
         arguments();
         }
         break;
@@ -2534,11 +2577,11 @@ class PainlessParser extends Parser {
         _localctx = new NewobjectContext(_localctx);
         enterOuterAlt(_localctx, 12);
         {
-        setState(345);
+        setState(351);
         match(NEW);
-        setState(346);
+        setState(352);
         match(TYPE);
-        setState(347);
+        setState(353);
         arguments();
         }
         break;
@@ -2578,29 +2621,29 @@ class PainlessParser extends Parser {
 
   public final PostfixContext postfix() throws RecognitionException {
     PostfixContext _localctx = new PostfixContext(_ctx, getState());
-    enterRule(_localctx, 38, RULE_postfix);
+    enterRule(_localctx, 40, RULE_postfix);
     try {
-      setState(353);
+      setState(359);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,30,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(350);
+        setState(356);
         callinvoke();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(351);
+        setState(357);
         fieldaccess();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(352);
+        setState(358);
         braceaccess();
         }
         break;
@@ -2637,22 +2680,22 @@ class PainlessParser extends Parser {
 
   public final PostdotContext postdot() throws RecognitionException {
     PostdotContext _localctx = new PostdotContext(_ctx, getState());
-    enterRule(_localctx, 40, RULE_postdot);
+    enterRule(_localctx, 42, RULE_postdot);
     try {
-      setState(357);
+      setState(363);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,30,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,31,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(355);
+        setState(361);
         callinvoke();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(356);
+        setState(362);
         fieldaccess();
         }
         break;
@@ -2689,21 +2732,21 @@ class PainlessParser extends Parser {
 
   public final CallinvokeContext callinvoke() throws RecognitionException {
     CallinvokeContext _localctx = new CallinvokeContext(_ctx, getState());
-    enterRule(_localctx, 42, RULE_callinvoke);
+    enterRule(_localctx, 44, RULE_callinvoke);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(359);
+      setState(365);
       _la = _input.LA(1);
       if ( !(_la==DOT || _la==NSDOT) ) {
       _errHandler.recoverInline(this);
       } else {
         consume();
       }
-      setState(360);
+      setState(366);
       match(DOTID);
-      setState(361);
+      setState(367);
       arguments();
       }
     }
@@ -2736,19 +2779,19 @@ class PainlessParser extends Parser {
 
   public final FieldaccessContext fieldaccess() throws RecognitionException {
     FieldaccessContext _localctx = new FieldaccessContext(_ctx, getState());
-    enterRule(_localctx, 44, RULE_fieldaccess);
+    enterRule(_localctx, 46, RULE_fieldaccess);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(363);
+      setState(369);
       _la = _input.LA(1);
       if ( !(_la==DOT || _la==NSDOT) ) {
       _errHandler.recoverInline(this);
       } else {
         consume();
       }
-      setState(364);
+      setState(370);
       _la = _input.LA(1);
       if ( !(_la==DOTINTEGER || _la==DOTID) ) {
       _errHandler.recoverInline(this);
@@ -2787,15 +2830,15 @@ class PainlessParser extends Parser {
 
   public final BraceaccessContext braceaccess() throws RecognitionException {
     BraceaccessContext _localctx = new BraceaccessContext(_ctx, getState());
-    enterRule(_localctx, 46, RULE_braceaccess);
+    enterRule(_localctx, 48, RULE_braceaccess);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(366);
+      setState(372);
       match(LBRACE);
-      setState(367);
-      expression(0);
-      setState(368);
+      setState(373);
+      expression();
+      setState(374);
       match(RBRACE);
       }
     }
@@ -2887,22 +2930,22 @@ class PainlessParser extends Parser {
 
   public final ArrayinitializerContext arrayinitializer() throws RecognitionException {
     ArrayinitializerContext _localctx = new ArrayinitializerContext(_ctx, getState());
-    enterRule(_localctx, 48, RULE_arrayinitializer);
+    enterRule(_localctx, 50, RULE_arrayinitializer);
     int _la;
     try {
       int _alt;
-      setState(411);
+      setState(417);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,38,_ctx) ) {
       case 1:
         _localctx = new NewstandardarrayContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(370);
+        setState(376);
         match(NEW);
-        setState(371);
+        setState(377);
         match(TYPE);
-        setState(376); 
+        setState(382); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -2910,11 +2953,11 @@ class PainlessParser extends Parser {
           case 1:
             {
             {
-            setState(372);
+            setState(378);
             match(LBRACE);
-            setState(373);
-            expression(0);
-            setState(374);
+            setState(379);
+            expression();
+            setState(380);
             match(RBRACE);
             }
             }
@@ -2922,32 +2965,32 @@ class PainlessParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(378); 
-          _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,31,_ctx);
-        } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
-        setState(387);
-        _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
-        case 1:
-          {
-          setState(380);
-          postdot();
-          setState(384);
+          setState(384); 
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,32,_ctx);
+        } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
+        setState(393);
+        _errHandler.sync(this);
+        switch ( getInterpreter().adaptivePredict(_input,34,_ctx) ) {
+        case 1:
+          {
+          setState(386);
+          postdot();
+          setState(390);
+          _errHandler.sync(this);
+          _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
           while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
             if ( _alt==1 ) {
               {
               {
-              setState(381);
+              setState(387);
               postfix();
               }
               } 
             }
-            setState(386);
+            setState(392);
             _errHandler.sync(this);
-            _alt = getInterpreter().adaptivePredict(_input,32,_ctx);
+            _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
           }
           }
           break;
@@ -2958,58 +3001,58 @@ class PainlessParser extends Parser {
         _localctx = new NewinitializedarrayContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(389);
+        setState(395);
         match(NEW);
-        setState(390);
+        setState(396);
         match(TYPE);
-        setState(391);
+        setState(397);
         match(LBRACE);
-        setState(392);
+        setState(398);
         match(RBRACE);
-        setState(393);
+        setState(399);
         match(LBRACK);
-        setState(402);
+        setState(408);
         _la = _input.LA(1);
         if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
           {
-          setState(394);
-          expression(0);
-          setState(399);
+          setState(400);
+          expression();
+          setState(405);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==COMMA) {
             {
             {
-            setState(395);
-            match(COMMA);
-            setState(396);
-            expression(0);
-            }
-            }
             setState(401);
+            match(COMMA);
+            setState(402);
+            expression();
+            }
+            }
+            setState(407);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
           }
         }
 
-        setState(404);
+        setState(410);
         match(RBRACK);
-        setState(408);
+        setState(414);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,36,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,37,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(405);
+            setState(411);
             postfix();
             }
             } 
           }
-          setState(410);
+          setState(416);
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,36,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,37,_ctx);
         }
         }
         break;
@@ -3052,45 +3095,45 @@ class PainlessParser extends Parser {
 
   public final ListinitializerContext listinitializer() throws RecognitionException {
     ListinitializerContext _localctx = new ListinitializerContext(_ctx, getState());
-    enterRule(_localctx, 50, RULE_listinitializer);
+    enterRule(_localctx, 52, RULE_listinitializer);
     int _la;
     try {
-      setState(426);
+      setState(432);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,39,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,40,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(413);
-        match(LBRACE);
-        setState(414);
-        expression(0);
         setState(419);
+        match(LBRACE);
+        setState(420);
+        expression();
+        setState(425);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(415);
-          match(COMMA);
-          setState(416);
-          expression(0);
-          }
-          }
           setState(421);
+          match(COMMA);
+          setState(422);
+          expression();
+          }
+          }
+          setState(427);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(422);
+        setState(428);
         match(RBRACE);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(424);
+        setState(430);
         match(LBRACE);
-        setState(425);
+        setState(431);
         match(RBRACE);
         }
         break;
@@ -3134,47 +3177,47 @@ class PainlessParser extends Parser {
 
   public final MapinitializerContext mapinitializer() throws RecognitionException {
     MapinitializerContext _localctx = new MapinitializerContext(_ctx, getState());
-    enterRule(_localctx, 52, RULE_mapinitializer);
+    enterRule(_localctx, 54, RULE_mapinitializer);
     int _la;
     try {
-      setState(442);
+      setState(448);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,41,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,42,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(428);
-        match(LBRACE);
-        setState(429);
-        maptoken();
         setState(434);
+        match(LBRACE);
+        setState(435);
+        maptoken();
+        setState(440);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(430);
+          setState(436);
           match(COMMA);
-          setState(431);
+          setState(437);
           maptoken();
           }
           }
-          setState(436);
+          setState(442);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
-        setState(437);
+        setState(443);
         match(RBRACE);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(439);
+        setState(445);
         match(LBRACE);
-        setState(440);
+        setState(446);
         match(COLON);
-        setState(441);
+        setState(447);
         match(RBRACE);
         }
         break;
@@ -3212,16 +3255,16 @@ class PainlessParser extends Parser {
 
   public final MaptokenContext maptoken() throws RecognitionException {
     MaptokenContext _localctx = new MaptokenContext(_ctx, getState());
-    enterRule(_localctx, 54, RULE_maptoken);
+    enterRule(_localctx, 56, RULE_maptoken);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(444);
-      expression(0);
-      setState(445);
+      setState(450);
+      expression();
+      setState(451);
       match(COLON);
-      setState(446);
-      expression(0);
+      setState(452);
+      expression();
       }
     }
     catch (RecognitionException re) {
@@ -3261,40 +3304,40 @@ class PainlessParser extends Parser {
 
   public final ArgumentsContext arguments() throws RecognitionException {
     ArgumentsContext _localctx = new ArgumentsContext(_ctx, getState());
-    enterRule(_localctx, 56, RULE_arguments);
+    enterRule(_localctx, 58, RULE_arguments);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
       {
-      setState(448);
+      setState(454);
       match(LP);
-      setState(457);
+      setState(463);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LBRACE) | (1L << LP) | (1L << NEW) | (1L << THIS) | (1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB) | (1L << INCR) | (1L << DECR))) != 0) || ((((_la - 72)) & ~0x3f) == 0 && ((1L << (_la - 72)) & ((1L << (OCTAL - 72)) | (1L << (HEX - 72)) | (1L << (INTEGER - 72)) | (1L << (DECIMAL - 72)) | (1L << (STRING - 72)) | (1L << (REGEX - 72)) | (1L << (TRUE - 72)) | (1L << (FALSE - 72)) | (1L << (NULL - 72)) | (1L << (TYPE - 72)) | (1L << (ID - 72)))) != 0)) {
         {
-        setState(449);
+        setState(455);
         argument();
-        setState(454);
+        setState(460);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(450);
+          setState(456);
           match(COMMA);
-          setState(451);
+          setState(457);
           argument();
           }
           }
-          setState(456);
+          setState(462);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(459);
+      setState(465);
       match(RP);
       }
       }
@@ -3333,29 +3376,29 @@ class PainlessParser extends Parser {
 
   public final ArgumentContext argument() throws RecognitionException {
     ArgumentContext _localctx = new ArgumentContext(_ctx, getState());
-    enterRule(_localctx, 58, RULE_argument);
+    enterRule(_localctx, 60, RULE_argument);
     try {
-      setState(464);
+      setState(470);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,44,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,45,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(461);
-        expression(0);
+        setState(467);
+        expression();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(462);
+        setState(468);
         lambda();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(463);
+        setState(469);
         funcref();
         }
         break;
@@ -3405,63 +3448,63 @@ class PainlessParser extends Parser {
 
   public final LambdaContext lambda() throws RecognitionException {
     LambdaContext _localctx = new LambdaContext(_ctx, getState());
-    enterRule(_localctx, 60, RULE_lambda);
+    enterRule(_localctx, 62, RULE_lambda);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(479);
+      setState(485);
       switch (_input.LA(1)) {
       case TYPE:
       case ID:
         {
-        setState(466);
+        setState(472);
         lamtype();
         }
         break;
       case LP:
         {
-        setState(467);
+        setState(473);
         match(LP);
-        setState(476);
+        setState(482);
         _la = _input.LA(1);
         if (_la==TYPE || _la==ID) {
           {
-          setState(468);
+          setState(474);
           lamtype();
-          setState(473);
+          setState(479);
           _errHandler.sync(this);
           _la = _input.LA(1);
           while (_la==COMMA) {
             {
             {
-            setState(469);
+            setState(475);
             match(COMMA);
-            setState(470);
+            setState(476);
             lamtype();
             }
             }
-            setState(475);
+            setState(481);
             _errHandler.sync(this);
             _la = _input.LA(1);
           }
           }
         }
 
-        setState(478);
+        setState(484);
         match(RP);
         }
         break;
       default:
         throw new NoViableAltException(this);
       }
-      setState(481);
+      setState(487);
       match(ARROW);
-      setState(484);
+      setState(490);
       switch (_input.LA(1)) {
       case LBRACK:
         {
-        setState(482);
+        setState(488);
         block();
         }
         break;
@@ -3486,8 +3529,8 @@ class PainlessParser extends Parser {
       case TYPE:
       case ID:
         {
-        setState(483);
-        expression(0);
+        setState(489);
+        expression();
         }
         break;
       default:
@@ -3524,21 +3567,21 @@ class PainlessParser extends Parser {
 
   public final LamtypeContext lamtype() throws RecognitionException {
     LamtypeContext _localctx = new LamtypeContext(_ctx, getState());
-    enterRule(_localctx, 62, RULE_lamtype);
+    enterRule(_localctx, 64, RULE_lamtype);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(487);
+      setState(493);
       _la = _input.LA(1);
       if (_la==TYPE) {
         {
-        setState(486);
+        setState(492);
         decltype();
         }
       }
 
-      setState(489);
+      setState(495);
       match(ID);
       }
     }
@@ -3615,20 +3658,20 @@ class PainlessParser extends Parser {
 
   public final FuncrefContext funcref() throws RecognitionException {
     FuncrefContext _localctx = new FuncrefContext(_ctx, getState());
-    enterRule(_localctx, 64, RULE_funcref);
+    enterRule(_localctx, 66, RULE_funcref);
     try {
-      setState(504);
+      setState(510);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,50,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,51,_ctx) ) {
       case 1:
         _localctx = new ClassfuncrefContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(491);
+        setState(497);
         match(TYPE);
-        setState(492);
+        setState(498);
         match(REF);
-        setState(493);
+        setState(499);
         match(ID);
         }
         break;
@@ -3636,11 +3679,11 @@ class PainlessParser extends Parser {
         _localctx = new ConstructorfuncrefContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(494);
+        setState(500);
         decltype();
-        setState(495);
+        setState(501);
         match(REF);
-        setState(496);
+        setState(502);
         match(NEW);
         }
         break;
@@ -3648,11 +3691,11 @@ class PainlessParser extends Parser {
         _localctx = new CapturingfuncrefContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(498);
+        setState(504);
         match(ID);
-        setState(499);
+        setState(505);
         match(REF);
-        setState(500);
+        setState(506);
         match(ID);
         }
         break;
@@ -3660,11 +3703,11 @@ class PainlessParser extends Parser {
         _localctx = new LocalfuncrefContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(501);
+        setState(507);
         match(THIS);
-        setState(502);
+        setState(508);
         match(REF);
-        setState(503);
+        setState(509);
         match(ID);
         }
         break;
@@ -3686,7 +3729,7 @@ class PainlessParser extends Parser {
     case 4:
       return rstatement_sempred((RstatementContext)_localctx, predIndex);
     case 15:
-      return expression_sempred((ExpressionContext)_localctx, predIndex);
+      return noncondexpression_sempred((NoncondexpressionContext)_localctx, predIndex);
     }
     return true;
   }
@@ -3697,237 +3740,235 @@ class PainlessParser extends Parser {
     }
     return true;
   }
-  private boolean expression_sempred(ExpressionContext _localctx, int predIndex) {
+  private boolean noncondexpression_sempred(NoncondexpressionContext _localctx, int predIndex) {
     switch (predIndex) {
     case 1:
-      return precpred(_ctx, 15);
-    case 2:
-      return precpred(_ctx, 14);
-    case 3:
       return precpred(_ctx, 13);
-    case 4:
+    case 2:
       return precpred(_ctx, 12);
-    case 5:
+    case 3:
       return precpred(_ctx, 11);
-    case 6:
-      return precpred(_ctx, 9);
-    case 7:
-      return precpred(_ctx, 8);
-    case 8:
-      return precpred(_ctx, 7);
-    case 9:
-      return precpred(_ctx, 6);
-    case 10:
-      return precpred(_ctx, 5);
-    case 11:
-      return precpred(_ctx, 4);
-    case 12:
-      return precpred(_ctx, 3);
-    case 13:
-      return precpred(_ctx, 2);
-    case 14:
-      return precpred(_ctx, 1);
-    case 15:
+    case 4:
       return precpred(_ctx, 10);
+    case 5:
+      return precpred(_ctx, 9);
+    case 6:
+      return precpred(_ctx, 7);
+    case 7:
+      return precpred(_ctx, 6);
+    case 8:
+      return precpred(_ctx, 5);
+    case 9:
+      return precpred(_ctx, 4);
+    case 10:
+      return precpred(_ctx, 3);
+    case 11:
+      return precpred(_ctx, 2);
+    case 12:
+      return precpred(_ctx, 1);
+    case 13:
+      return precpred(_ctx, 8);
     }
     return true;
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3V\u01fd\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3V\u0203\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
     "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
-    "\t!\4\"\t\"\3\2\7\2F\n\2\f\2\16\2I\13\2\3\2\7\2L\n\2\f\2\16\2O\13\2\3"+
-    "\2\3\2\3\3\3\3\3\3\3\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4_\n\4\f\4\16"+
-    "\4b\13\4\5\4d\n\4\3\4\3\4\3\5\3\5\3\5\3\5\5\5l\n\5\3\6\3\6\3\6\3\6\3\6"+
-    "\3\6\3\6\3\6\5\6v\n\6\3\6\3\6\3\6\3\6\3\6\3\6\5\6~\n\6\3\6\3\6\3\6\5\6"+
-    "\u0083\n\6\3\6\3\6\5\6\u0087\n\6\3\6\3\6\5\6\u008b\n\6\3\6\3\6\3\6\5\6"+
-    "\u0090\n\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6"+
-    "\3\6\3\6\3\6\3\6\3\6\6\6\u00a6\n\6\r\6\16\6\u00a7\5\6\u00aa\n\6\3\7\3"+
-    "\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\5\7\u00b8\n\7\3\7\3\7\3\7\5"+
-    "\7\u00bd\n\7\3\b\3\b\5\b\u00c1\n\b\3\t\3\t\7\t\u00c5\n\t\f\t\16\t\u00c8"+
-    "\13\t\3\t\5\t\u00cb\n\t\3\t\3\t\3\n\3\n\3\13\3\13\5\13\u00d3\n\13\3\f"+
-    "\3\f\3\r\3\r\3\r\3\r\7\r\u00db\n\r\f\r\16\r\u00de\13\r\3\16\3\16\3\16"+
-    "\7\16\u00e3\n\16\f\16\16\16\u00e6\13\16\3\17\3\17\3\17\5\17\u00eb\n\17"+
-    "\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
+    "\t!\4\"\t\"\4#\t#\3\2\7\2H\n\2\f\2\16\2K\13\2\3\2\7\2N\n\2\f\2\16\2Q\13"+
+    "\2\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\7\4a\n\4\f"+
+    "\4\16\4d\13\4\5\4f\n\4\3\4\3\4\3\5\3\5\3\5\3\5\5\5n\n\5\3\6\3\6\3\6\3"+
+    "\6\3\6\3\6\3\6\3\6\5\6x\n\6\3\6\3\6\3\6\3\6\3\6\3\6\5\6\u0080\n\6\3\6"+
+    "\3\6\3\6\5\6\u0085\n\6\3\6\3\6\5\6\u0089\n\6\3\6\3\6\5\6\u008d\n\6\3\6"+
+    "\3\6\3\6\5\6\u0092\n\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6"+
+    "\3\6\3\6\3\6\3\6\3\6\3\6\3\6\3\6\6\6\u00a8\n\6\r\6\16\6\u00a9\5\6\u00ac"+
+    "\n\6\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\5\7\u00ba\n\7\3\7"+
+    "\3\7\3\7\5\7\u00bf\n\7\3\b\3\b\5\b\u00c3\n\b\3\t\3\t\7\t\u00c7\n\t\f\t"+
+    "\16\t\u00ca\13\t\3\t\5\t\u00cd\n\t\3\t\3\t\3\n\3\n\3\13\3\13\5\13\u00d5"+
+    "\n\13\3\f\3\f\3\r\3\r\3\r\3\r\7\r\u00dd\n\r\f\r\16\r\u00e0\13\r\3\16\3"+
+    "\16\3\16\7\16\u00e5\n\16\f\16\16\16\u00e8\13\16\3\17\3\17\3\17\5\17\u00ed"+
+    "\n\17\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3\21"+
     "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
     "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21"+
-    "\3\21\3\21\7\21\u0127\n\21\f\21\16\21\u012a\13\21\3\22\3\22\3\22\3\22"+
-    "\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\5\22\u0139\n\22\3\23\3\23"+
-    "\7\23\u013d\n\23\f\23\16\23\u0140\13\23\3\23\3\23\3\23\7\23\u0145\n\23"+
-    "\f\23\16\23\u0148\13\23\3\23\5\23\u014b\n\23\3\24\3\24\3\24\3\24\3\24"+
-    "\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\3\24\5\24"+
-    "\u015f\n\24\3\25\3\25\3\25\5\25\u0164\n\25\3\26\3\26\5\26\u0168\n\26\3"+
-    "\27\3\27\3\27\3\27\3\30\3\30\3\30\3\31\3\31\3\31\3\31\3\32\3\32\3\32\3"+
-    "\32\3\32\3\32\6\32\u017b\n\32\r\32\16\32\u017c\3\32\3\32\7\32\u0181\n"+
-    "\32\f\32\16\32\u0184\13\32\5\32\u0186\n\32\3\32\3\32\3\32\3\32\3\32\3"+
-    "\32\3\32\3\32\7\32\u0190\n\32\f\32\16\32\u0193\13\32\5\32\u0195\n\32\3"+
-    "\32\3\32\7\32\u0199\n\32\f\32\16\32\u019c\13\32\5\32\u019e\n\32\3\33\3"+
-    "\33\3\33\3\33\7\33\u01a4\n\33\f\33\16\33\u01a7\13\33\3\33\3\33\3\33\3"+
-    "\33\5\33\u01ad\n\33\3\34\3\34\3\34\3\34\7\34\u01b3\n\34\f\34\16\34\u01b6"+
-    "\13\34\3\34\3\34\3\34\3\34\3\34\5\34\u01bd\n\34\3\35\3\35\3\35\3\35\3"+
-    "\36\3\36\3\36\3\36\7\36\u01c7\n\36\f\36\16\36\u01ca\13\36\5\36\u01cc\n"+
-    "\36\3\36\3\36\3\37\3\37\3\37\5\37\u01d3\n\37\3 \3 \3 \3 \3 \7 \u01da\n"+
-    " \f \16 \u01dd\13 \5 \u01df\n \3 \5 \u01e2\n \3 \3 \3 \5 \u01e7\n \3!"+
-    "\5!\u01ea\n!\3!\3!\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\"\3\""+
-    "\5\"\u01fb\n\"\3\"\2\3 #\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&("+
-    "*,.\60\62\64\668:<>@B\2\17\3\3\16\16\3\2 \"\3\2#$\3\2:;\3\2%\'\3\2(+\3"+
-    "\2,/\3\2>I\3\2<=\4\2\36\37#$\3\2JM\3\2\13\f\3\2UV\u0236\2G\3\2\2\2\4R"+
-    "\3\2\2\2\6W\3\2\2\2\bk\3\2\2\2\n\u00a9\3\2\2\2\f\u00bc\3\2\2\2\16\u00c0"+
-    "\3\2\2\2\20\u00c2\3\2\2\2\22\u00ce\3\2\2\2\24\u00d2\3\2\2\2\26\u00d4\3"+
-    "\2\2\2\30\u00d6\3\2\2\2\32\u00df\3\2\2\2\34\u00e7\3\2\2\2\36\u00ec\3\2"+
-    "\2\2 \u00f3\3\2\2\2\"\u0138\3\2\2\2$\u014a\3\2\2\2&\u015e\3\2\2\2(\u0163"+
-    "\3\2\2\2*\u0167\3\2\2\2,\u0169\3\2\2\2.\u016d\3\2\2\2\60\u0170\3\2\2\2"+
-    "\62\u019d\3\2\2\2\64\u01ac\3\2\2\2\66\u01bc\3\2\2\28\u01be\3\2\2\2:\u01c2"+
-    "\3\2\2\2<\u01d2\3\2\2\2>\u01e1\3\2\2\2@\u01e9\3\2\2\2B\u01fa\3\2\2\2D"+
-    "F\5\4\3\2ED\3\2\2\2FI\3\2\2\2GE\3\2\2\2GH\3\2\2\2HM\3\2\2\2IG\3\2\2\2"+
-    "JL\5\b\5\2KJ\3\2\2\2LO\3\2\2\2MK\3\2\2\2MN\3\2\2\2NP\3\2\2\2OM\3\2\2\2"+
-    "PQ\7\2\2\3Q\3\3\2\2\2RS\5\32\16\2ST\7T\2\2TU\5\6\4\2UV\5\20\t\2V\5\3\2"+
-    "\2\2Wc\7\t\2\2XY\5\32\16\2Y`\7T\2\2Z[\7\r\2\2[\\\5\32\16\2\\]\7T\2\2]"+
-    "_\3\2\2\2^Z\3\2\2\2_b\3\2\2\2`^\3\2\2\2`a\3\2\2\2ad\3\2\2\2b`\3\2\2\2"+
-    "cX\3\2\2\2cd\3\2\2\2de\3\2\2\2ef\7\n\2\2f\7\3\2\2\2gl\5\n\6\2hi\5\f\7"+
-    "\2ij\t\2\2\2jl\3\2\2\2kg\3\2\2\2kh\3\2\2\2l\t\3\2\2\2mn\7\17\2\2no\7\t"+
-    "\2\2op\5 \21\2pq\7\n\2\2qu\5\16\b\2rs\7\21\2\2sv\5\16\b\2tv\6\6\2\2ur"+
-    "\3\2\2\2ut\3\2\2\2v\u00aa\3\2\2\2wx\7\22\2\2xy\7\t\2\2yz\5 \21\2z}\7\n"+
-    "\2\2{~\5\16\b\2|~\5\22\n\2}{\3\2\2\2}|\3\2\2\2~\u00aa\3\2\2\2\177\u0080"+
-    "\7\24\2\2\u0080\u0082\7\t\2\2\u0081\u0083\5\24\13\2\u0082\u0081\3\2\2"+
-    "\2\u0082\u0083\3\2\2\2\u0083\u0084\3\2\2\2\u0084\u0086\7\16\2\2\u0085"+
-    "\u0087\5 \21\2\u0086\u0085\3\2\2\2\u0086\u0087\3\2\2\2\u0087\u0088\3\2"+
-    "\2\2\u0088\u008a\7\16\2\2\u0089\u008b\5\26\f\2\u008a\u0089\3\2\2\2\u008a"+
-    "\u008b\3\2\2\2\u008b\u008c\3\2\2\2\u008c\u008f\7\n\2\2\u008d\u0090\5\16"+
-    "\b\2\u008e\u0090\5\22\n\2\u008f\u008d\3\2\2\2\u008f\u008e\3\2\2\2\u0090"+
-    "\u00aa\3\2\2\2\u0091\u0092\7\24\2\2\u0092\u0093\7\t\2\2\u0093\u0094\5"+
-    "\32\16\2\u0094\u0095\7T\2\2\u0095\u0096\7\66\2\2\u0096\u0097\5 \21\2\u0097"+
-    "\u0098\7\n\2\2\u0098\u0099\5\16\b\2\u0099\u00aa\3\2\2\2\u009a\u009b\7"+
-    "\24\2\2\u009b\u009c\7\t\2\2\u009c\u009d\7T\2\2\u009d\u009e\7\20\2\2\u009e"+
-    "\u009f\5 \21\2\u009f\u00a0\7\n\2\2\u00a0\u00a1\5\16\b\2\u00a1\u00aa\3"+
-    "\2\2\2\u00a2\u00a3\7\31\2\2\u00a3\u00a5\5\20\t\2\u00a4\u00a6\5\36\20\2"+
-    "\u00a5\u00a4\3\2\2\2\u00a6\u00a7\3\2\2\2\u00a7\u00a5\3\2\2\2\u00a7\u00a8"+
-    "\3\2\2\2\u00a8\u00aa\3\2\2\2\u00a9m\3\2\2\2\u00a9w\3\2\2\2\u00a9\177\3"+
-    "\2\2\2\u00a9\u0091\3\2\2\2\u00a9\u009a\3\2\2\2\u00a9\u00a2\3\2\2\2\u00aa"+
-    "\13\3\2\2\2\u00ab\u00ac\7\23\2\2\u00ac\u00ad\5\20\t\2\u00ad\u00ae\7\22"+
-    "\2\2\u00ae\u00af\7\t\2\2\u00af\u00b0\5 \21\2\u00b0\u00b1\7\n\2\2\u00b1"+
-    "\u00bd\3\2\2\2\u00b2\u00bd\5\30\r\2\u00b3\u00bd\7\25\2\2\u00b4\u00bd\7"+
-    "\26\2\2\u00b5\u00b7\7\27\2\2\u00b6\u00b8\5 \21\2\u00b7\u00b6\3\2\2\2\u00b7"+
-    "\u00b8\3\2\2\2\u00b8\u00bd\3\2\2\2\u00b9\u00ba\7\33\2\2\u00ba\u00bd\5"+
-    " \21\2\u00bb\u00bd\5 \21\2\u00bc\u00ab\3\2\2\2\u00bc\u00b2\3\2\2\2\u00bc"+
-    "\u00b3\3\2\2\2\u00bc\u00b4\3\2\2\2\u00bc\u00b5\3\2\2\2\u00bc\u00b9\3\2"+
-    "\2\2\u00bc\u00bb\3\2\2\2\u00bd\r\3\2\2\2\u00be\u00c1\5\20\t\2\u00bf\u00c1"+
-    "\5\b\5\2\u00c0\u00be\3\2\2\2\u00c0\u00bf\3\2\2\2\u00c1\17\3\2\2\2\u00c2"+
-    "\u00c6\7\5\2\2\u00c3\u00c5\5\b\5\2\u00c4\u00c3\3\2\2\2\u00c5\u00c8\3\2"+
-    "\2\2\u00c6\u00c4\3\2\2\2\u00c6\u00c7\3\2\2\2\u00c7\u00ca\3\2\2\2\u00c8"+
-    "\u00c6\3\2\2\2\u00c9\u00cb\5\f\7\2\u00ca\u00c9\3\2\2\2\u00ca\u00cb\3\2"+
-    "\2\2\u00cb\u00cc\3\2\2\2\u00cc\u00cd\7\6\2\2\u00cd\21\3\2\2\2\u00ce\u00cf"+
-    "\7\16\2\2\u00cf\23\3\2\2\2\u00d0\u00d3\5\30\r\2\u00d1\u00d3\5 \21\2\u00d2"+
-    "\u00d0\3\2\2\2\u00d2\u00d1\3\2\2\2\u00d3\25\3\2\2\2\u00d4\u00d5\5 \21"+
-    "\2\u00d5\27\3\2\2\2\u00d6\u00d7\5\32\16\2\u00d7\u00dc\5\34\17\2\u00d8"+
-    "\u00d9\7\r\2\2\u00d9\u00db\5\34\17\2\u00da\u00d8\3\2\2\2\u00db\u00de\3"+
-    "\2\2\2\u00dc\u00da\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd\31\3\2\2\2\u00de"+
-    "\u00dc\3\2\2\2\u00df\u00e4\7S\2\2\u00e0\u00e1\7\7\2\2\u00e1\u00e3\7\b"+
-    "\2\2\u00e2\u00e0\3\2\2\2\u00e3\u00e6\3\2\2\2\u00e4\u00e2\3\2\2\2\u00e4"+
-    "\u00e5\3\2\2\2\u00e5\33\3\2\2\2\u00e6\u00e4\3\2\2\2\u00e7\u00ea\7T\2\2"+
-    "\u00e8\u00e9\7>\2\2\u00e9\u00eb\5 \21\2\u00ea\u00e8\3\2\2\2\u00ea\u00eb"+
-    "\3\2\2\2\u00eb\35\3\2\2\2\u00ec\u00ed\7\32\2\2\u00ed\u00ee\7\t\2\2\u00ee"+
-    "\u00ef\7S\2\2\u00ef\u00f0\7T\2\2\u00f0\u00f1\7\n\2\2\u00f1\u00f2\5\20"+
-    "\t\2\u00f2\37\3\2\2\2\u00f3\u00f4\b\21\1\2\u00f4\u00f5\5\"\22\2\u00f5"+
-    "\u0128\3\2\2\2\u00f6\u00f7\f\21\2\2\u00f7\u00f8\t\3\2\2\u00f8\u0127\5"+
-    " \21\22\u00f9\u00fa\f\20\2\2\u00fa\u00fb\t\4\2\2\u00fb\u0127\5 \21\21"+
-    "\u00fc\u00fd\f\17\2\2\u00fd\u00fe\t\5\2\2\u00fe\u0127\5 \21\20\u00ff\u0100"+
-    "\f\16\2\2\u0100\u0101\t\6\2\2\u0101\u0127\5 \21\17\u0102\u0103\f\r\2\2"+
-    "\u0103\u0104\t\7\2\2\u0104\u0127\5 \21\16\u0105\u0106\f\13\2\2\u0106\u0107"+
-    "\t\b\2\2\u0107\u0127\5 \21\f\u0108\u0109\f\n\2\2\u0109\u010a\7\60\2\2"+
-    "\u010a\u0127\5 \21\13\u010b\u010c\f\t\2\2\u010c\u010d\7\61\2\2\u010d\u0127"+
-    "\5 \21\n\u010e\u010f\f\b\2\2\u010f\u0110\7\62\2\2\u0110\u0127\5 \21\t"+
-    "\u0111\u0112\f\7\2\2\u0112\u0113\7\63\2\2\u0113\u0127\5 \21\b\u0114\u0115"+
-    "\f\6\2\2\u0115\u0116\7\64\2\2\u0116\u0127\5 \21\7\u0117\u0118\f\5\2\2"+
-    "\u0118\u0119\7\65\2\2\u0119\u011a\5 \21\2\u011a\u011b\7\66\2\2\u011b\u011c"+
-    "\5 \21\5\u011c\u0127\3\2\2\2\u011d\u011e\f\4\2\2\u011e\u011f\7\67\2\2"+
-    "\u011f\u0127\5 \21\4\u0120\u0121\f\3\2\2\u0121\u0122\t\t\2\2\u0122\u0127"+
-    "\5 \21\3\u0123\u0124\f\f\2\2\u0124\u0125\7\35\2\2\u0125\u0127\5\32\16"+
-    "\2\u0126\u00f6\3\2\2\2\u0126\u00f9\3\2\2\2\u0126\u00fc\3\2\2\2\u0126\u00ff"+
-    "\3\2\2\2\u0126\u0102\3\2\2\2\u0126\u0105\3\2\2\2\u0126\u0108\3\2\2\2\u0126"+
-    "\u010b\3\2\2\2\u0126\u010e\3\2\2\2\u0126\u0111\3\2\2\2\u0126\u0114\3\2"+
-    "\2\2\u0126\u0117\3\2\2\2\u0126\u011d\3\2\2\2\u0126\u0120\3\2\2\2\u0126"+
-    "\u0123\3\2\2\2\u0127\u012a\3\2\2\2\u0128\u0126\3\2\2\2\u0128\u0129\3\2"+
-    "\2\2\u0129!\3\2\2\2\u012a\u0128\3\2\2\2\u012b\u012c\t\n\2\2\u012c\u0139"+
-    "\5$\23\2\u012d\u012e\5$\23\2\u012e\u012f\t\n\2\2\u012f\u0139\3\2\2\2\u0130"+
-    "\u0139\5$\23\2\u0131\u0132\t\13\2\2\u0132\u0139\5\"\22\2\u0133\u0134\7"+
-    "\t\2\2\u0134\u0135\5\32\16\2\u0135\u0136\7\n\2\2\u0136\u0137\5\"\22\2"+
-    "\u0137\u0139\3\2\2\2\u0138\u012b\3\2\2\2\u0138\u012d\3\2\2\2\u0138\u0130"+
-    "\3\2\2\2\u0138\u0131\3\2\2\2\u0138\u0133\3\2\2\2\u0139#\3\2\2\2\u013a"+
-    "\u013e\5&\24\2\u013b\u013d\5(\25\2\u013c\u013b\3\2\2\2\u013d\u0140\3\2"+
-    "\2\2\u013e\u013c\3\2\2\2\u013e\u013f\3\2\2\2\u013f\u014b\3\2\2\2\u0140"+
-    "\u013e\3\2\2\2\u0141\u0142\5\32\16\2\u0142\u0146\5*\26\2\u0143\u0145\5"+
-    "(\25\2\u0144\u0143\3\2\2\2\u0145\u0148\3\2\2\2\u0146\u0144\3\2\2\2\u0146"+
-    "\u0147\3\2\2\2\u0147\u014b\3\2\2\2\u0148\u0146\3\2\2\2\u0149\u014b\5\62"+
-    "\32\2\u014a\u013a\3\2\2\2\u014a\u0141\3\2\2\2\u014a\u0149\3\2\2\2\u014b"+
-    "%\3\2\2\2\u014c\u014d\7\t\2\2\u014d\u014e\5 \21\2\u014e\u014f\7\n\2\2"+
-    "\u014f\u015f\3\2\2\2\u0150\u015f\t\f\2\2\u0151\u015f\7P\2\2\u0152\u015f"+
-    "\7Q\2\2\u0153\u015f\7R\2\2\u0154\u015f\7N\2\2\u0155\u015f\7O\2\2\u0156"+
-    "\u015f\5\64\33\2\u0157\u015f\5\66\34\2\u0158\u015f\7T\2\2\u0159\u015a"+
-    "\7T\2\2\u015a\u015f\5:\36\2\u015b\u015c\7\30\2\2\u015c\u015d\7S\2\2\u015d"+
-    "\u015f\5:\36\2\u015e\u014c\3\2\2\2\u015e\u0150\3\2\2\2\u015e\u0151\3\2"+
-    "\2\2\u015e\u0152\3\2\2\2\u015e\u0153\3\2\2\2\u015e\u0154\3\2\2\2\u015e"+
-    "\u0155\3\2\2\2\u015e\u0156\3\2\2\2\u015e\u0157\3\2\2\2\u015e\u0158\3\2"+
-    "\2\2\u015e\u0159\3\2\2\2\u015e\u015b\3\2\2\2\u015f\'\3\2\2\2\u0160\u0164"+
-    "\5,\27\2\u0161\u0164\5.\30\2\u0162\u0164\5\60\31\2\u0163\u0160\3\2\2\2"+
-    "\u0163\u0161\3\2\2\2\u0163\u0162\3\2\2\2\u0164)\3\2\2\2\u0165\u0168\5"+
-    ",\27\2\u0166\u0168\5.\30\2\u0167\u0165\3\2\2\2\u0167\u0166\3\2\2\2\u0168"+
-    "+\3\2\2\2\u0169\u016a\t\r\2\2\u016a\u016b\7V\2\2\u016b\u016c\5:\36\2\u016c"+
-    "-\3\2\2\2\u016d\u016e\t\r\2\2\u016e\u016f\t\16\2\2\u016f/\3\2\2\2\u0170"+
-    "\u0171\7\7\2\2\u0171\u0172\5 \21\2\u0172\u0173\7\b\2\2\u0173\61\3\2\2"+
-    "\2\u0174\u0175\7\30\2\2\u0175\u017a\7S\2\2\u0176\u0177\7\7\2\2\u0177\u0178"+
-    "\5 \21\2\u0178\u0179\7\b\2\2\u0179\u017b\3\2\2\2\u017a\u0176\3\2\2\2\u017b"+
-    "\u017c\3\2\2\2\u017c\u017a\3\2\2\2\u017c\u017d\3\2\2\2\u017d\u0185\3\2"+
-    "\2\2\u017e\u0182\5*\26\2\u017f\u0181\5(\25\2\u0180\u017f\3\2\2\2\u0181"+
-    "\u0184\3\2\2\2\u0182\u0180\3\2\2\2\u0182\u0183\3\2\2\2\u0183\u0186\3\2"+
-    "\2\2\u0184\u0182\3\2\2\2\u0185\u017e\3\2\2\2\u0185\u0186\3\2\2\2\u0186"+
-    "\u019e\3\2\2\2\u0187\u0188\7\30\2\2\u0188\u0189\7S\2\2\u0189\u018a\7\7"+
-    "\2\2\u018a\u018b\7\b\2\2\u018b\u0194\7\5\2\2\u018c\u0191\5 \21\2\u018d"+
-    "\u018e\7\r\2\2\u018e\u0190\5 \21\2\u018f\u018d\3\2\2\2\u0190\u0193\3\2"+
-    "\2\2\u0191\u018f\3\2\2\2\u0191\u0192\3\2\2\2\u0192\u0195\3\2\2\2\u0193"+
-    "\u0191\3\2\2\2\u0194\u018c\3\2\2\2\u0194\u0195\3\2\2\2\u0195\u0196\3\2"+
-    "\2\2\u0196\u019a\7\6\2\2\u0197\u0199\5(\25\2\u0198\u0197\3\2\2\2\u0199"+
-    "\u019c\3\2\2\2\u019a\u0198\3\2\2\2\u019a\u019b\3\2\2\2\u019b\u019e\3\2"+
-    "\2\2\u019c\u019a\3\2\2\2\u019d\u0174\3\2\2\2\u019d\u0187\3\2\2\2\u019e"+
-    "\63\3\2\2\2\u019f\u01a0\7\7\2\2\u01a0\u01a5\5 \21\2\u01a1\u01a2\7\r\2"+
-    "\2\u01a2\u01a4\5 \21\2\u01a3\u01a1\3\2\2\2\u01a4\u01a7\3\2\2\2\u01a5\u01a3"+
-    "\3\2\2\2\u01a5\u01a6\3\2\2\2\u01a6\u01a8\3\2\2\2\u01a7\u01a5\3\2\2\2\u01a8"+
-    "\u01a9\7\b\2\2\u01a9\u01ad\3\2\2\2\u01aa\u01ab\7\7\2\2\u01ab\u01ad\7\b"+
-    "\2\2\u01ac\u019f\3\2\2\2\u01ac\u01aa\3\2\2\2\u01ad\65\3\2\2\2\u01ae\u01af"+
-    "\7\7\2\2\u01af\u01b4\58\35\2\u01b0\u01b1\7\r\2\2\u01b1\u01b3\58\35\2\u01b2"+
-    "\u01b0\3\2\2\2\u01b3\u01b6\3\2\2\2\u01b4\u01b2\3\2\2\2\u01b4\u01b5\3\2"+
-    "\2\2\u01b5\u01b7\3\2\2\2\u01b6\u01b4\3\2\2\2\u01b7\u01b8\7\b\2\2\u01b8"+
-    "\u01bd\3\2\2\2\u01b9\u01ba\7\7\2\2\u01ba\u01bb\7\66\2\2\u01bb\u01bd\7"+
-    "\b\2\2\u01bc\u01ae\3\2\2\2\u01bc\u01b9\3\2\2\2\u01bd\67\3\2\2\2\u01be"+
-    "\u01bf\5 \21\2\u01bf\u01c0\7\66\2\2\u01c0\u01c1\5 \21\2\u01c19\3\2\2\2"+
-    "\u01c2\u01cb\7\t\2\2\u01c3\u01c8\5<\37\2\u01c4\u01c5\7\r\2\2\u01c5\u01c7"+
-    "\5<\37\2\u01c6\u01c4\3\2\2\2\u01c7\u01ca\3\2\2\2\u01c8\u01c6\3\2\2\2\u01c8"+
-    "\u01c9\3\2\2\2\u01c9\u01cc\3\2\2\2\u01ca\u01c8\3\2\2\2\u01cb\u01c3\3\2"+
-    "\2\2\u01cb\u01cc\3\2\2\2\u01cc\u01cd\3\2\2\2\u01cd\u01ce\7\n\2\2\u01ce"+
-    ";\3\2\2\2\u01cf\u01d3\5 \21\2\u01d0\u01d3\5> \2\u01d1\u01d3\5B\"\2\u01d2"+
-    "\u01cf\3\2\2\2\u01d2\u01d0\3\2\2\2\u01d2\u01d1\3\2\2\2\u01d3=\3\2\2\2"+
-    "\u01d4\u01e2\5@!\2\u01d5\u01de\7\t\2\2\u01d6\u01db\5@!\2\u01d7\u01d8\7"+
-    "\r\2\2\u01d8\u01da\5@!\2\u01d9\u01d7\3\2\2\2\u01da\u01dd\3\2\2\2\u01db"+
-    "\u01d9\3\2\2\2\u01db\u01dc\3\2\2\2\u01dc\u01df\3\2\2\2\u01dd\u01db\3\2"+
-    "\2\2\u01de\u01d6\3\2\2\2\u01de\u01df\3\2\2\2\u01df\u01e0\3\2\2\2\u01e0"+
-    "\u01e2\7\n\2\2\u01e1\u01d4\3\2\2\2\u01e1\u01d5\3\2\2\2\u01e2\u01e3\3\2"+
-    "\2\2\u01e3\u01e6\79\2\2\u01e4\u01e7\5\20\t\2\u01e5\u01e7\5 \21\2\u01e6"+
-    "\u01e4\3\2\2\2\u01e6\u01e5\3\2\2\2\u01e7?\3\2\2\2\u01e8\u01ea\5\32\16"+
-    "\2\u01e9\u01e8\3\2\2\2\u01e9\u01ea\3\2\2\2\u01ea\u01eb\3\2\2\2\u01eb\u01ec"+
-    "\7T\2\2\u01ecA\3\2\2\2\u01ed\u01ee\7S\2\2\u01ee\u01ef\78\2\2\u01ef\u01fb"+
-    "\7T\2\2\u01f0\u01f1\5\32\16\2\u01f1\u01f2\78\2\2\u01f2\u01f3\7\30\2\2"+
-    "\u01f3\u01fb\3\2\2\2\u01f4\u01f5\7T\2\2\u01f5\u01f6\78\2\2\u01f6\u01fb"+
-    "\7T\2\2\u01f7\u01f8\7\34\2\2\u01f8\u01f9\78\2\2\u01f9\u01fb\7T\2\2\u01fa"+
-    "\u01ed\3\2\2\2\u01fa\u01f0\3\2\2\2\u01fa\u01f4\3\2\2\2\u01fa\u01f7\3\2"+
-    "\2\2\u01fbC\3\2\2\2\65GM`cku}\u0082\u0086\u008a\u008f\u00a7\u00a9\u00b7"+
-    "\u00bc\u00c0\u00c6\u00ca\u00d2\u00dc\u00e4\u00ea\u0126\u0128\u0138\u013e"+
-    "\u0146\u014a\u015e\u0163\u0167\u017c\u0182\u0185\u0191\u0194\u019a\u019d"+
-    "\u01a5\u01ac\u01b4\u01bc\u01c8\u01cb\u01d2\u01db\u01de\u01e1\u01e6\u01e9"+
-    "\u01fa";
+    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\7\21\u0120\n\21\f\21\16\21\u0123"+
+    "\13\21\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\5\22\u0130"+
+    "\n\22\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23"+
+    "\5\23\u013f\n\23\3\24\3\24\7\24\u0143\n\24\f\24\16\24\u0146\13\24\3\24"+
+    "\3\24\3\24\7\24\u014b\n\24\f\24\16\24\u014e\13\24\3\24\5\24\u0151\n\24"+
+    "\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25"+
+    "\3\25\3\25\3\25\3\25\5\25\u0165\n\25\3\26\3\26\3\26\5\26\u016a\n\26\3"+
+    "\27\3\27\5\27\u016e\n\27\3\30\3\30\3\30\3\30\3\31\3\31\3\31\3\32\3\32"+
+    "\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\33\6\33\u0181\n\33\r\33\16\33\u0182"+
+    "\3\33\3\33\7\33\u0187\n\33\f\33\16\33\u018a\13\33\5\33\u018c\n\33\3\33"+
+    "\3\33\3\33\3\33\3\33\3\33\3\33\3\33\7\33\u0196\n\33\f\33\16\33\u0199\13"+
+    "\33\5\33\u019b\n\33\3\33\3\33\7\33\u019f\n\33\f\33\16\33\u01a2\13\33\5"+
+    "\33\u01a4\n\33\3\34\3\34\3\34\3\34\7\34\u01aa\n\34\f\34\16\34\u01ad\13"+
+    "\34\3\34\3\34\3\34\3\34\5\34\u01b3\n\34\3\35\3\35\3\35\3\35\7\35\u01b9"+
+    "\n\35\f\35\16\35\u01bc\13\35\3\35\3\35\3\35\3\35\3\35\5\35\u01c3\n\35"+
+    "\3\36\3\36\3\36\3\36\3\37\3\37\3\37\3\37\7\37\u01cd\n\37\f\37\16\37\u01d0"+
+    "\13\37\5\37\u01d2\n\37\3\37\3\37\3 \3 \3 \5 \u01d9\n \3!\3!\3!\3!\3!\7"+
+    "!\u01e0\n!\f!\16!\u01e3\13!\5!\u01e5\n!\3!\5!\u01e8\n!\3!\3!\3!\5!\u01ed"+
+    "\n!\3\"\5\"\u01f0\n\"\3\"\3\"\3#\3#\3#\3#\3#\3#\3#\3#\3#\3#\3#\3#\3#\5"+
+    "#\u0201\n#\3#\2\3 $\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60"+
+    "\62\64\668:<>@BD\2\17\3\3\16\16\3\2 \"\3\2#$\3\2:;\3\2%\'\3\2(+\3\2,/"+
+    "\3\2>I\3\2<=\4\2\36\37#$\3\2JM\3\2\13\f\3\2UV\u023b\2I\3\2\2\2\4T\3\2"+
+    "\2\2\6Y\3\2\2\2\bm\3\2\2\2\n\u00ab\3\2\2\2\f\u00be\3\2\2\2\16\u00c2\3"+
+    "\2\2\2\20\u00c4\3\2\2\2\22\u00d0\3\2\2\2\24\u00d4\3\2\2\2\26\u00d6\3\2"+
+    "\2\2\30\u00d8\3\2\2\2\32\u00e1\3\2\2\2\34\u00e9\3\2\2\2\36\u00ee\3\2\2"+
+    "\2 \u00f5\3\2\2\2\"\u012f\3\2\2\2$\u013e\3\2\2\2&\u0150\3\2\2\2(\u0164"+
+    "\3\2\2\2*\u0169\3\2\2\2,\u016d\3\2\2\2.\u016f\3\2\2\2\60\u0173\3\2\2\2"+
+    "\62\u0176\3\2\2\2\64\u01a3\3\2\2\2\66\u01b2\3\2\2\28\u01c2\3\2\2\2:\u01c4"+
+    "\3\2\2\2<\u01c8\3\2\2\2>\u01d8\3\2\2\2@\u01e7\3\2\2\2B\u01ef\3\2\2\2D"+
+    "\u0200\3\2\2\2FH\5\4\3\2GF\3\2\2\2HK\3\2\2\2IG\3\2\2\2IJ\3\2\2\2JO\3\2"+
+    "\2\2KI\3\2\2\2LN\5\b\5\2ML\3\2\2\2NQ\3\2\2\2OM\3\2\2\2OP\3\2\2\2PR\3\2"+
+    "\2\2QO\3\2\2\2RS\7\2\2\3S\3\3\2\2\2TU\5\32\16\2UV\7T\2\2VW\5\6\4\2WX\5"+
+    "\20\t\2X\5\3\2\2\2Ye\7\t\2\2Z[\5\32\16\2[b\7T\2\2\\]\7\r\2\2]^\5\32\16"+
+    "\2^_\7T\2\2_a\3\2\2\2`\\\3\2\2\2ad\3\2\2\2b`\3\2\2\2bc\3\2\2\2cf\3\2\2"+
+    "\2db\3\2\2\2eZ\3\2\2\2ef\3\2\2\2fg\3\2\2\2gh\7\n\2\2h\7\3\2\2\2in\5\n"+
+    "\6\2jk\5\f\7\2kl\t\2\2\2ln\3\2\2\2mi\3\2\2\2mj\3\2\2\2n\t\3\2\2\2op\7"+
+    "\17\2\2pq\7\t\2\2qr\5\"\22\2rs\7\n\2\2sw\5\16\b\2tu\7\21\2\2ux\5\16\b"+
+    "\2vx\6\6\2\2wt\3\2\2\2wv\3\2\2\2x\u00ac\3\2\2\2yz\7\22\2\2z{\7\t\2\2{"+
+    "|\5\"\22\2|\177\7\n\2\2}\u0080\5\16\b\2~\u0080\5\22\n\2\177}\3\2\2\2\177"+
+    "~\3\2\2\2\u0080\u00ac\3\2\2\2\u0081\u0082\7\24\2\2\u0082\u0084\7\t\2\2"+
+    "\u0083\u0085\5\24\13\2\u0084\u0083\3\2\2\2\u0084\u0085\3\2\2\2\u0085\u0086"+
+    "\3\2\2\2\u0086\u0088\7\16\2\2\u0087\u0089\5\"\22\2\u0088\u0087\3\2\2\2"+
+    "\u0088\u0089\3\2\2\2\u0089\u008a\3\2\2\2\u008a\u008c\7\16\2\2\u008b\u008d"+
+    "\5\26\f\2\u008c\u008b\3\2\2\2\u008c\u008d\3\2\2\2\u008d\u008e\3\2\2\2"+
+    "\u008e\u0091\7\n\2\2\u008f\u0092\5\16\b\2\u0090\u0092\5\22\n\2\u0091\u008f"+
+    "\3\2\2\2\u0091\u0090\3\2\2\2\u0092\u00ac\3\2\2\2\u0093\u0094\7\24\2\2"+
+    "\u0094\u0095\7\t\2\2\u0095\u0096\5\32\16\2\u0096\u0097\7T\2\2\u0097\u0098"+
+    "\7\66\2\2\u0098\u0099\5\"\22\2\u0099\u009a\7\n\2\2\u009a\u009b\5\16\b"+
+    "\2\u009b\u00ac\3\2\2\2\u009c\u009d\7\24\2\2\u009d\u009e\7\t\2\2\u009e"+
+    "\u009f\7T\2\2\u009f\u00a0\7\20\2\2\u00a0\u00a1\5\"\22\2\u00a1\u00a2\7"+
+    "\n\2\2\u00a2\u00a3\5\16\b\2\u00a3\u00ac\3\2\2\2\u00a4\u00a5\7\31\2\2\u00a5"+
+    "\u00a7\5\20\t\2\u00a6\u00a8\5\36\20\2\u00a7\u00a6\3\2\2\2\u00a8\u00a9"+
+    "\3\2\2\2\u00a9\u00a7\3\2\2\2\u00a9\u00aa\3\2\2\2\u00aa\u00ac\3\2\2\2\u00ab"+
+    "o\3\2\2\2\u00aby\3\2\2\2\u00ab\u0081\3\2\2\2\u00ab\u0093\3\2\2\2\u00ab"+
+    "\u009c\3\2\2\2\u00ab\u00a4\3\2\2\2\u00ac\13\3\2\2\2\u00ad\u00ae\7\23\2"+
+    "\2\u00ae\u00af\5\20\t\2\u00af\u00b0\7\22\2\2\u00b0\u00b1\7\t\2\2\u00b1"+
+    "\u00b2\5\"\22\2\u00b2\u00b3\7\n\2\2\u00b3\u00bf\3\2\2\2\u00b4\u00bf\5"+
+    "\30\r\2\u00b5\u00bf\7\25\2\2\u00b6\u00bf\7\26\2\2\u00b7\u00b9\7\27\2\2"+
+    "\u00b8\u00ba\5\"\22\2\u00b9\u00b8\3\2\2\2\u00b9\u00ba\3\2\2\2\u00ba\u00bf"+
+    "\3\2\2\2\u00bb\u00bc\7\33\2\2\u00bc\u00bf\5\"\22\2\u00bd\u00bf\5\"\22"+
+    "\2\u00be\u00ad\3\2\2\2\u00be\u00b4\3\2\2\2\u00be\u00b5\3\2\2\2\u00be\u00b6"+
+    "\3\2\2\2\u00be\u00b7\3\2\2\2\u00be\u00bb\3\2\2\2\u00be\u00bd\3\2\2\2\u00bf"+
+    "\r\3\2\2\2\u00c0\u00c3\5\20\t\2\u00c1\u00c3\5\b\5\2\u00c2\u00c0\3\2\2"+
+    "\2\u00c2\u00c1\3\2\2\2\u00c3\17\3\2\2\2\u00c4\u00c8\7\5\2\2\u00c5\u00c7"+
+    "\5\b\5\2\u00c6\u00c5\3\2\2\2\u00c7\u00ca\3\2\2\2\u00c8\u00c6\3\2\2\2\u00c8"+
+    "\u00c9\3\2\2\2\u00c9\u00cc\3\2\2\2\u00ca\u00c8\3\2\2\2\u00cb\u00cd\5\f"+
+    "\7\2\u00cc\u00cb\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\u00ce\3\2\2\2\u00ce"+
+    "\u00cf\7\6\2\2\u00cf\21\3\2\2\2\u00d0\u00d1\7\16\2\2\u00d1\23\3\2\2\2"+
+    "\u00d2\u00d5\5\30\r\2\u00d3\u00d5\5\"\22\2\u00d4\u00d2\3\2\2\2\u00d4\u00d3"+
+    "\3\2\2\2\u00d5\25\3\2\2\2\u00d6\u00d7\5\"\22\2\u00d7\27\3\2\2\2\u00d8"+
+    "\u00d9\5\32\16\2\u00d9\u00de\5\34\17\2\u00da\u00db\7\r\2\2\u00db\u00dd"+
+    "\5\34\17\2\u00dc\u00da\3\2\2\2\u00dd\u00e0\3\2\2\2\u00de\u00dc\3\2\2\2"+
+    "\u00de\u00df\3\2\2\2\u00df\31\3\2\2\2\u00e0\u00de\3\2\2\2\u00e1\u00e6"+
+    "\7S\2\2\u00e2\u00e3\7\7\2\2\u00e3\u00e5\7\b\2\2\u00e4\u00e2\3\2\2\2\u00e5"+
+    "\u00e8\3\2\2\2\u00e6\u00e4\3\2\2\2\u00e6\u00e7\3\2\2\2\u00e7\33\3\2\2"+
+    "\2\u00e8\u00e6\3\2\2\2\u00e9\u00ec\7T\2\2\u00ea\u00eb\7>\2\2\u00eb\u00ed"+
+    "\5\"\22\2\u00ec\u00ea\3\2\2\2\u00ec\u00ed\3\2\2\2\u00ed\35\3\2\2\2\u00ee"+
+    "\u00ef\7\32\2\2\u00ef\u00f0\7\t\2\2\u00f0\u00f1\7S\2\2\u00f1\u00f2\7T"+
+    "\2\2\u00f2\u00f3\7\n\2\2\u00f3\u00f4\5\20\t\2\u00f4\37\3\2\2\2\u00f5\u00f6"+
+    "\b\21\1\2\u00f6\u00f7\5$\23\2\u00f7\u0121\3\2\2\2\u00f8\u00f9\f\17\2\2"+
+    "\u00f9\u00fa\t\3\2\2\u00fa\u0120\5 \21\20\u00fb\u00fc\f\16\2\2\u00fc\u00fd"+
+    "\t\4\2\2\u00fd\u0120\5 \21\17\u00fe\u00ff\f\r\2\2\u00ff\u0100\t\5\2\2"+
+    "\u0100\u0120\5 \21\16\u0101\u0102\f\f\2\2\u0102\u0103\t\6\2\2\u0103\u0120"+
+    "\5 \21\r\u0104\u0105\f\13\2\2\u0105\u0106\t\7\2\2\u0106\u0120\5 \21\f"+
+    "\u0107\u0108\f\t\2\2\u0108\u0109\t\b\2\2\u0109\u0120\5 \21\n\u010a\u010b"+
+    "\f\b\2\2\u010b\u010c\7\60\2\2\u010c\u0120\5 \21\t\u010d\u010e\f\7\2\2"+
+    "\u010e\u010f\7\61\2\2\u010f\u0120\5 \21\b\u0110\u0111\f\6\2\2\u0111\u0112"+
+    "\7\62\2\2\u0112\u0120\5 \21\7\u0113\u0114\f\5\2\2\u0114\u0115\7\63\2\2"+
+    "\u0115\u0120\5 \21\6\u0116\u0117\f\4\2\2\u0117\u0118\7\64\2\2\u0118\u0120"+
+    "\5 \21\5\u0119\u011a\f\3\2\2\u011a\u011b\7\67\2\2\u011b\u0120\5 \21\3"+
+    "\u011c\u011d\f\n\2\2\u011d\u011e\7\35\2\2\u011e\u0120\5\32\16\2\u011f"+
+    "\u00f8\3\2\2\2\u011f\u00fb\3\2\2\2\u011f\u00fe\3\2\2\2\u011f\u0101\3\2"+
+    "\2\2\u011f\u0104\3\2\2\2\u011f\u0107\3\2\2\2\u011f\u010a\3\2\2\2\u011f"+
+    "\u010d\3\2\2\2\u011f\u0110\3\2\2\2\u011f\u0113\3\2\2\2\u011f\u0116\3\2"+
+    "\2\2\u011f\u0119\3\2\2\2\u011f\u011c\3\2\2\2\u0120\u0123\3\2\2\2\u0121"+
+    "\u011f\3\2\2\2\u0121\u0122\3\2\2\2\u0122!\3\2\2\2\u0123\u0121\3\2\2\2"+
+    "\u0124\u0130\5 \21\2\u0125\u0126\5 \21\2\u0126\u0127\7\65\2\2\u0127\u0128"+
+    "\5\"\22\2\u0128\u0129\7\66\2\2\u0129\u012a\5\"\22\2\u012a\u0130\3\2\2"+
+    "\2\u012b\u012c\5 \21\2\u012c\u012d\t\t\2\2\u012d\u012e\5\"\22\2\u012e"+
+    "\u0130\3\2\2\2\u012f\u0124\3\2\2\2\u012f\u0125\3\2\2\2\u012f\u012b\3\2"+
+    "\2\2\u0130#\3\2\2\2\u0131\u0132\t\n\2\2\u0132\u013f\5&\24\2\u0133\u0134"+
+    "\5&\24\2\u0134\u0135\t\n\2\2\u0135\u013f\3\2\2\2\u0136\u013f\5&\24\2\u0137"+
+    "\u0138\t\13\2\2\u0138\u013f\5$\23\2\u0139\u013a\7\t\2\2\u013a\u013b\5"+
+    "\32\16\2\u013b\u013c\7\n\2\2\u013c\u013d\5$\23\2\u013d\u013f\3\2\2\2\u013e"+
+    "\u0131\3\2\2\2\u013e\u0133\3\2\2\2\u013e\u0136\3\2\2\2\u013e\u0137\3\2"+
+    "\2\2\u013e\u0139\3\2\2\2\u013f%\3\2\2\2\u0140\u0144\5(\25\2\u0141\u0143"+
+    "\5*\26\2\u0142\u0141\3\2\2\2\u0143\u0146\3\2\2\2\u0144\u0142\3\2\2\2\u0144"+
+    "\u0145\3\2\2\2\u0145\u0151\3\2\2\2\u0146\u0144\3\2\2\2\u0147\u0148\5\32"+
+    "\16\2\u0148\u014c\5,\27\2\u0149\u014b\5*\26\2\u014a\u0149\3\2\2\2\u014b"+
+    "\u014e\3\2\2\2\u014c\u014a\3\2\2\2\u014c\u014d\3\2\2\2\u014d\u0151\3\2"+
+    "\2\2\u014e\u014c\3\2\2\2\u014f\u0151\5\64\33\2\u0150\u0140\3\2\2\2\u0150"+
+    "\u0147\3\2\2\2\u0150\u014f\3\2\2\2\u0151\'\3\2\2\2\u0152\u0153\7\t\2\2"+
+    "\u0153\u0154\5\"\22\2\u0154\u0155\7\n\2\2\u0155\u0165\3\2\2\2\u0156\u0165"+
+    "\t\f\2\2\u0157\u0165\7P\2\2\u0158\u0165\7Q\2\2\u0159\u0165\7R\2\2\u015a"+
+    "\u0165\7N\2\2\u015b\u0165\7O\2\2\u015c\u0165\5\66\34\2\u015d\u0165\58"+
+    "\35\2\u015e\u0165\7T\2\2\u015f\u0160\7T\2\2\u0160\u0165\5<\37\2\u0161"+
+    "\u0162\7\30\2\2\u0162\u0163\7S\2\2\u0163\u0165\5<\37\2\u0164\u0152\3\2"+
+    "\2\2\u0164\u0156\3\2\2\2\u0164\u0157\3\2\2\2\u0164\u0158\3\2\2\2\u0164"+
+    "\u0159\3\2\2\2\u0164\u015a\3\2\2\2\u0164\u015b\3\2\2\2\u0164\u015c\3\2"+
+    "\2\2\u0164\u015d\3\2\2\2\u0164\u015e\3\2\2\2\u0164\u015f\3\2\2\2\u0164"+
+    "\u0161\3\2\2\2\u0165)\3\2\2\2\u0166\u016a\5.\30\2\u0167\u016a\5\60\31"+
+    "\2\u0168\u016a\5\62\32\2\u0169\u0166\3\2\2\2\u0169\u0167\3\2\2\2\u0169"+
+    "\u0168\3\2\2\2\u016a+\3\2\2\2\u016b\u016e\5.\30\2\u016c\u016e\5\60\31"+
+    "\2\u016d\u016b\3\2\2\2\u016d\u016c\3\2\2\2\u016e-\3\2\2\2\u016f\u0170"+
+    "\t\r\2\2\u0170\u0171\7V\2\2\u0171\u0172\5<\37\2\u0172/\3\2\2\2\u0173\u0174"+
+    "\t\r\2\2\u0174\u0175\t\16\2\2\u0175\61\3\2\2\2\u0176\u0177\7\7\2\2\u0177"+
+    "\u0178\5\"\22\2\u0178\u0179\7\b\2\2\u0179\63\3\2\2\2\u017a\u017b\7\30"+
+    "\2\2\u017b\u0180\7S\2\2\u017c\u017d\7\7\2\2\u017d\u017e\5\"\22\2\u017e"+
+    "\u017f\7\b\2\2\u017f\u0181\3\2\2\2\u0180\u017c\3\2\2\2\u0181\u0182\3\2"+
+    "\2\2\u0182\u0180\3\2\2\2\u0182\u0183\3\2\2\2\u0183\u018b\3\2\2\2\u0184"+
+    "\u0188\5,\27\2\u0185\u0187\5*\26\2\u0186\u0185\3\2\2\2\u0187\u018a\3\2"+
+    "\2\2\u0188\u0186\3\2\2\2\u0188\u0189\3\2\2\2\u0189\u018c\3\2\2\2\u018a"+
+    "\u0188\3\2\2\2\u018b\u0184\3\2\2\2\u018b\u018c\3\2\2\2\u018c\u01a4\3\2"+
+    "\2\2\u018d\u018e\7\30\2\2\u018e\u018f\7S\2\2\u018f\u0190\7\7\2\2\u0190"+
+    "\u0191\7\b\2\2\u0191\u019a\7\5\2\2\u0192\u0197\5\"\22\2\u0193\u0194\7"+
+    "\r\2\2\u0194\u0196\5\"\22\2\u0195\u0193\3\2\2\2\u0196\u0199\3\2\2\2\u0197"+
+    "\u0195\3\2\2\2\u0197\u0198\3\2\2\2\u0198\u019b\3\2\2\2\u0199\u0197\3\2"+
+    "\2\2\u019a\u0192\3\2\2\2\u019a\u019b\3\2\2\2\u019b\u019c\3\2\2\2\u019c"+
+    "\u01a0\7\6\2\2\u019d\u019f\5*\26\2\u019e\u019d\3\2\2\2\u019f\u01a2\3\2"+
+    "\2\2\u01a0\u019e\3\2\2\2\u01a0\u01a1\3\2\2\2\u01a1\u01a4\3\2\2\2\u01a2"+
+    "\u01a0\3\2\2\2\u01a3\u017a\3\2\2\2\u01a3\u018d\3\2\2\2\u01a4\65\3\2\2"+
+    "\2\u01a5\u01a6\7\7\2\2\u01a6\u01ab\5\"\22\2\u01a7\u01a8\7\r\2\2\u01a8"+
+    "\u01aa\5\"\22\2\u01a9\u01a7\3\2\2\2\u01aa\u01ad\3\2\2\2\u01ab\u01a9\3"+
+    "\2\2\2\u01ab\u01ac\3\2\2\2\u01ac\u01ae\3\2\2\2\u01ad\u01ab\3\2\2\2\u01ae"+
+    "\u01af\7\b\2\2\u01af\u01b3\3\2\2\2\u01b0\u01b1\7\7\2\2\u01b1\u01b3\7\b"+
+    "\2\2\u01b2\u01a5\3\2\2\2\u01b2\u01b0\3\2\2\2\u01b3\67\3\2\2\2\u01b4\u01b5"+
+    "\7\7\2\2\u01b5\u01ba\5:\36\2\u01b6\u01b7\7\r\2\2\u01b7\u01b9\5:\36\2\u01b8"+
+    "\u01b6\3\2\2\2\u01b9\u01bc\3\2\2\2\u01ba\u01b8\3\2\2\2\u01ba\u01bb\3\2"+
+    "\2\2\u01bb\u01bd\3\2\2\2\u01bc\u01ba\3\2\2\2\u01bd\u01be\7\b\2\2\u01be"+
+    "\u01c3\3\2\2\2\u01bf\u01c0\7\7\2\2\u01c0\u01c1\7\66\2\2\u01c1\u01c3\7"+
+    "\b\2\2\u01c2\u01b4\3\2\2\2\u01c2\u01bf\3\2\2\2\u01c39\3\2\2\2\u01c4\u01c5"+
+    "\5\"\22\2\u01c5\u01c6\7\66\2\2\u01c6\u01c7\5\"\22\2\u01c7;\3\2\2\2\u01c8"+
+    "\u01d1\7\t\2\2\u01c9\u01ce\5> \2\u01ca\u01cb\7\r\2\2\u01cb\u01cd\5> \2"+
+    "\u01cc\u01ca\3\2\2\2\u01cd\u01d0\3\2\2\2\u01ce\u01cc\3\2\2\2\u01ce\u01cf"+
+    "\3\2\2\2\u01cf\u01d2\3\2\2\2\u01d0\u01ce\3\2\2\2\u01d1\u01c9\3\2\2\2\u01d1"+
+    "\u01d2\3\2\2\2\u01d2\u01d3\3\2\2\2\u01d3\u01d4\7\n\2\2\u01d4=\3\2\2\2"+
+    "\u01d5\u01d9\5\"\22\2\u01d6\u01d9\5@!\2\u01d7\u01d9\5D#\2\u01d8\u01d5"+
+    "\3\2\2\2\u01d8\u01d6\3\2\2\2\u01d8\u01d7\3\2\2\2\u01d9?\3\2\2\2\u01da"+
+    "\u01e8\5B\"\2\u01db\u01e4\7\t\2\2\u01dc\u01e1\5B\"\2\u01dd\u01de\7\r\2"+
+    "\2\u01de\u01e0\5B\"\2\u01df\u01dd\3\2\2\2\u01e0\u01e3\3\2\2\2\u01e1\u01df"+
+    "\3\2\2\2\u01e1\u01e2\3\2\2\2\u01e2\u01e5\3\2\2\2\u01e3\u01e1\3\2\2\2\u01e4"+
+    "\u01dc\3\2\2\2\u01e4\u01e5\3\2\2\2\u01e5\u01e6\3\2\2\2\u01e6\u01e8\7\n"+
+    "\2\2\u01e7\u01da\3\2\2\2\u01e7\u01db\3\2\2\2\u01e8\u01e9\3\2\2\2\u01e9"+
+    "\u01ec\79\2\2\u01ea\u01ed\5\20\t\2\u01eb\u01ed\5\"\22\2\u01ec\u01ea\3"+
+    "\2\2\2\u01ec\u01eb\3\2\2\2\u01edA\3\2\2\2\u01ee\u01f0\5\32\16\2\u01ef"+
+    "\u01ee\3\2\2\2\u01ef\u01f0\3\2\2\2\u01f0\u01f1\3\2\2\2\u01f1\u01f2\7T"+
+    "\2\2\u01f2C\3\2\2\2\u01f3\u01f4\7S\2\2\u01f4\u01f5\78\2\2\u01f5\u0201"+
+    "\7T\2\2\u01f6\u01f7\5\32\16\2\u01f7\u01f8\78\2\2\u01f8\u01f9\7\30\2\2"+
+    "\u01f9\u0201\3\2\2\2\u01fa\u01fb\7T\2\2\u01fb\u01fc\78\2\2\u01fc\u0201"+
+    "\7T\2\2\u01fd\u01fe\7\34\2\2\u01fe\u01ff\78\2\2\u01ff\u0201\7T\2\2\u0200"+
+    "\u01f3\3\2\2\2\u0200\u01f6\3\2\2\2\u0200\u01fa\3\2\2\2\u0200\u01fd\3\2"+
+    "\2\2\u0201E\3\2\2\2\66IObemw\177\u0084\u0088\u008c\u0091\u00a9\u00ab\u00b9"+
+    "\u00be\u00c2\u00c8\u00cc\u00d4\u00de\u00e6\u00ec\u011f\u0121\u012f\u013e"+
+    "\u0144\u014c\u0150\u0164\u0169\u016d\u0182\u0188\u018b\u0197\u019a\u01a0"+
+    "\u01a3\u01ab\u01b2\u01ba\u01c2\u01ce\u01d1\u01d8\u01e1\u01e4\u01e7\u01ec"+
+    "\u01ef\u0200";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserBaseVisitor.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserBaseVisitor.java
@@ -220,20 +220,6 @@ class PainlessParserBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
-  @Override public T visitConditional(PainlessParser.ConditionalContext ctx) { return visitChildren(ctx); }
-  /**
-   * {@inheritDoc}
-   *
-   * <p>The default implementation returns the result of calling
-   * {@link #visitChildren} on {@code ctx}.</p>
-   */
-  @Override public T visitAssignment(PainlessParser.AssignmentContext ctx) { return visitChildren(ctx); }
-  /**
-   * {@inheritDoc}
-   *
-   * <p>The default implementation returns the result of calling
-   * {@link #visitChildren} on {@code ctx}.</p>
-   */
   @Override public T visitBinary(PainlessParser.BinaryContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}
@@ -249,6 +235,27 @@ class PainlessParserBaseVisitor<T> extends AbstractParseTreeVisitor<T> implement
    * {@link #visitChildren} on {@code ctx}.</p>
    */
   @Override public T visitInstanceof(PainlessParser.InstanceofContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitNonconditional(PainlessParser.NonconditionalContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitConditional(PainlessParser.ConditionalContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitAssignment(PainlessParser.AssignmentContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}
    *

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserVisitor.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/PainlessParserVisitor.java
@@ -181,25 +181,53 @@ interface PainlessParserVisitor<T> extends ParseTreeVisitor<T> {
   T visitTrap(PainlessParser.TrapContext ctx);
   /**
    * Visit a parse tree produced by the {@code single}
-   * labeled alternative in {@link PainlessParser#expression}.
+   * labeled alternative in {@link PainlessParser#noncondexpression}.
    * @param ctx the parse tree
    * @return the visitor result
    */
   T visitSingle(PainlessParser.SingleContext ctx);
   /**
    * Visit a parse tree produced by the {@code comp}
-   * labeled alternative in {@link PainlessParser#expression}.
+   * labeled alternative in {@link PainlessParser#noncondexpression}.
    * @param ctx the parse tree
    * @return the visitor result
    */
   T visitComp(PainlessParser.CompContext ctx);
   /**
    * Visit a parse tree produced by the {@code bool}
-   * labeled alternative in {@link PainlessParser#expression}.
+   * labeled alternative in {@link PainlessParser#noncondexpression}.
    * @param ctx the parse tree
    * @return the visitor result
    */
   T visitBool(PainlessParser.BoolContext ctx);
+  /**
+   * Visit a parse tree produced by the {@code binary}
+   * labeled alternative in {@link PainlessParser#noncondexpression}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitBinary(PainlessParser.BinaryContext ctx);
+  /**
+   * Visit a parse tree produced by the {@code elvis}
+   * labeled alternative in {@link PainlessParser#noncondexpression}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitElvis(PainlessParser.ElvisContext ctx);
+  /**
+   * Visit a parse tree produced by the {@code instanceof}
+   * labeled alternative in {@link PainlessParser#noncondexpression}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitInstanceof(PainlessParser.InstanceofContext ctx);
+  /**
+   * Visit a parse tree produced by the {@code nonconditional}
+   * labeled alternative in {@link PainlessParser#expression}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitNonconditional(PainlessParser.NonconditionalContext ctx);
   /**
    * Visit a parse tree produced by the {@code conditional}
    * labeled alternative in {@link PainlessParser#expression}.
@@ -214,27 +242,6 @@ interface PainlessParserVisitor<T> extends ParseTreeVisitor<T> {
    * @return the visitor result
    */
   T visitAssignment(PainlessParser.AssignmentContext ctx);
-  /**
-   * Visit a parse tree produced by the {@code binary}
-   * labeled alternative in {@link PainlessParser#expression}.
-   * @param ctx the parse tree
-   * @return the visitor result
-   */
-  T visitBinary(PainlessParser.BinaryContext ctx);
-  /**
-   * Visit a parse tree produced by the {@code elvis}
-   * labeled alternative in {@link PainlessParser#expression}.
-   * @param ctx the parse tree
-   * @return the visitor result
-   */
-  T visitElvis(PainlessParser.ElvisContext ctx);
-  /**
-   * Visit a parse tree produced by the {@code instanceof}
-   * labeled alternative in {@link PainlessParser#expression}.
-   * @param ctx the parse tree
-   * @return the visitor result
-   */
-  T visitInstanceof(PainlessParser.InstanceofContext ctx);
   /**
    * Visit a parse tree produced by the {@code pre}
    * labeled alternative in {@link PainlessParser#unary}.

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -538,8 +538,8 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitBinary(BinaryContext ctx) {
-        AExpression left = (AExpression)visit(ctx.expression(0));
-        AExpression right = (AExpression)visit(ctx.expression(1));
+        AExpression left = (AExpression)visit(ctx.noncondexpression(0));
+        AExpression right = (AExpression)visit(ctx.noncondexpression(1));
         final Operation operation;
 
         if (ctx.MUL() != null) {
@@ -577,8 +577,8 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitComp(CompContext ctx) {
-        AExpression left = (AExpression)visit(ctx.expression(0));
-        AExpression right = (AExpression)visit(ctx.expression(1));
+        AExpression left = (AExpression)visit(ctx.noncondexpression(0));
+        AExpression right = (AExpression)visit(ctx.noncondexpression(1));
         final Operation operation;
 
         if (ctx.LT() != null) {
@@ -606,7 +606,7 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitInstanceof(InstanceofContext ctx) {
-        AExpression expr = (AExpression)visit(ctx.expression());
+        AExpression expr = (AExpression)visit(ctx.noncondexpression());
         String type = ctx.decltype().getText();
 
         return new EInstanceof(location(ctx), expr, type);
@@ -614,8 +614,8 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitBool(BoolContext ctx) {
-        AExpression left = (AExpression)visit(ctx.expression(0));
-        AExpression right = (AExpression)visit(ctx.expression(1));
+        AExpression left = (AExpression)visit(ctx.noncondexpression(0));
+        AExpression right = (AExpression)visit(ctx.noncondexpression(1));
         final Operation operation;
 
         if (ctx.BOOLAND() != null) {
@@ -631,25 +631,25 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
 
     @Override
     public ANode visitConditional(ConditionalContext ctx) {
-        AExpression condition = (AExpression)visit(ctx.expression(0));
-        AExpression left = (AExpression)visit(ctx.expression(1));
-        AExpression right = (AExpression)visit(ctx.expression(2));
+        AExpression condition = (AExpression)visit(ctx.noncondexpression());
+        AExpression left = (AExpression)visit(ctx.expression(0));
+        AExpression right = (AExpression)visit(ctx.expression(1));
 
         return new EConditional(location(ctx), condition, left, right);
     }
 
     @Override
     public ANode visitElvis(ElvisContext ctx) {
-        AExpression left = (AExpression)visit(ctx.expression(0));
-        AExpression right = (AExpression)visit(ctx.expression(1));
+        AExpression left = (AExpression)visit(ctx.noncondexpression(0));
+        AExpression right = (AExpression)visit(ctx.noncondexpression(1));
 
         return new EElvis(location(ctx), left, right);
     }
 
     @Override
     public ANode visitAssignment(AssignmentContext ctx) {
-        AExpression lhs = (AExpression)visit(ctx.expression(0));
-        AExpression rhs = (AExpression)visit(ctx.expression(1));
+        AExpression lhs = (AExpression)visit(ctx.noncondexpression());
+        AExpression rhs = (AExpression)visit(ctx.expression());
 
         final Operation operation;
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ConditionalTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ConditionalTests.java
@@ -21,6 +21,10 @@ package org.elasticsearch.painless;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.joining;
 
 public class ConditionalTests extends ScriptTestCase {
     public void testBasic() {
@@ -85,5 +89,17 @@ public class ConditionalTests extends ScriptTestCase {
         expectScriptThrows(ClassCastException.class, () -> {
             exec("boolean x = false; int y = 2; byte z = x ? y : 7; return z;");
         });
+    }
+
+    public void testNested() {
+        for (int i = 0; i < 100; i++) {
+            String scriptPart = IntStream.range(0, i).mapToObj(j -> "field == '" + j + "' ? '" + j + "' :").collect(joining("\n"));
+            assertEquals("z", exec("def field = params.a;\n" +
+                "\n" +
+                "return (\n" +
+                scriptPart +
+                "field == '' ? 'unknown' :\n" +
+                "field);", Map.of("a", "z"), true));
+        }
     }
 }


### PR DESCRIPTION
This PR changes how conditional expression is handled in `PainlessParser`
in a way that avoids the need for backtracking, which led to exponential
compilation times in case of nested conditionals.

The test was added ensures that we can compile deeply nested conditionals.