### PR TITLE
[ML] Adjust BWC version for categorization model size stats

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
@@ -200,8 +200,7 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
         totalPartitionFieldCount = in.readVLong();
         bucketAllocationFailuresCount = in.readVLong();
         memoryStatus = MemoryStatus.readFromStream(in);
-        // TODO change to 7.7.0 on backport
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             categorizedDocCount = in.readVLong();
             totalCategoryCount = in.readVLong();
             frequentCategoryCount = in.readVLong();
@@ -243,8 +242,7 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
         out.writeVLong(totalPartitionFieldCount);
         out.writeVLong(bucketAllocationFailuresCount);
         memoryStatus.writeTo(out);
-        // TODO change to 7.7.0 on backport
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeVLong(categorizedDocCount);
             out.writeVLong(totalCategoryCount);
             out.writeVLong(frequentCategoryCount);

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/30_ml_jobs_crud.yml
@@ -1,5 +1,8 @@
 ---
 "Test get old cluster job":
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_jobs:
         job_id: old-cluster-job
@@ -37,6 +40,9 @@
 
 ---
 "Test get old cluster job's timing stats":
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_job_stats:
         job_id: old-cluster-job-with-ts
@@ -51,6 +57,9 @@
 
 ---
 "Test get old cluster categorization job":
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_jobs:
         job_id: old-cluster-categorization-job
@@ -88,6 +97,9 @@
 
 ---
 "Create a job in the mixed cluster and write some data":
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.put_job:
         job_id: mixed-cluster-job
@@ -140,7 +152,9 @@
 
 ---
 "Test job with pre 6.4 rules":
-
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_jobs:
         job_id: job-with-old-rules

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/30_ml_jobs_crud.yml
@@ -8,6 +8,9 @@ setup:
 
 ---
 "Test open old jobs":
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.open_job:
         job_id: old-cluster-job
@@ -111,6 +114,9 @@ setup:
 
 ---
 "Test get old cluster job's timing stats":
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_job_stats:
         job_id: old-cluster-job-with-ts
@@ -135,7 +141,9 @@ setup:
 
 ---
 "Test job with pre 6.4 rules":
-
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_jobs:
         job_id: job-with-old-rules
@@ -145,7 +153,9 @@ setup:
 
 ---
 "Test get job with function shortcut should expand":
-
+  - skip:
+      version: "7.7.0 - "
+      reason: waiting merge of https://github.com/elastic/elasticsearch/pull/52009
   - do:
       ml.get_jobs:
         job_id: old-cluster-function-shortcut-expansion


### PR DESCRIPTION
The new stats will be available from 7.7.0, but the
BWC tests in master need disabling until the backport
PR is merged.

Relates #51879
Relates #52009