### PR TITLE
[7.x] Avoid clash between source field and header field in CsvProcessorTests (#51962)

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/CsvProcessorTests.java
@@ -287,8 +287,9 @@ public class CsvProcessorTests extends ESTestCase {
     private IngestDocument processDocument(String[] headers, String csv, boolean trim, Object emptyValue) {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         Arrays.stream(headers).filter(ingestDocument::hasField).forEach(ingestDocument::removeField);
+        String fieldName = randomAlphaOfLength(11);
+        ingestDocument.setFieldValue(fieldName, csv);
 
-        String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, csv);
         char quoteChar = quote.isEmpty() ? '"' : quote.charAt(0);
         CsvProcessor processor = new CsvProcessor(randomAlphaOfLength(5), fieldName, headers, trim, separator, quoteChar, false,
             emptyValue);


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Avoid clash between source field and header field in CsvProcessorTests (#51962)