### PR TITLE
Always create search context for scroll queries

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -610,7 +610,8 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         // if we already received a search result we can inform the shard that it
         // can return a null response if the request rewrites to match none rather
         // than creating an empty response in the search thread pool.
-        shardRequest.canReturnNullResponseIfMatchNoDocs(hasShardResponse.get());
+        // Note that, we have to disable this shortcut for scroll queries.
+        shardRequest.canReturnNullResponseIfMatchNoDocs(hasShardResponse.get() && request.scroll() == null);
         return shardRequest;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -372,6 +372,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     if (rewritten.canReturnNullResponseIfMatchNoDocs()
                             && canRewriteToMatchNone(rewritten.source())
                             && rewritten.source().query() instanceof MatchNoneQueryBuilder) {
+                        assert request.scroll() == null : "must always create search context for scroll requests";
                         onMatchNoDocs(context, listener);
                     } else {
                         // fork the execution in the search thread pool and wraps the searcher


### PR DESCRIPTION
We need to either exclude null responses from the scroll search response or always create a search context for every target shards, although that scroll query can be written to match_no_docs. Otherwise, we won't find search_context for subsequent scroll requests.

This commit implements the latter option as it's less error-prone.

I labelled this non-issue for an unreleased bug.

Relates #51708