### PR TITLE
[DOCS] Display feature flag docs on  master, 7.x only

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -59,6 +59,21 @@ endif::[]
 :javadoc-watcher: {rest-high-level-client-javadoc}/org/elasticsearch/protocol/xpack/watcher
 
 ///////
+Permanently unreleased branches (master, n.X)
+///////
+ifeval::["{release-state}"=="unreleased"]
+
+ifeval::["{source_branch}"=="master"]
+:permanently-unreleased-branch:
+endif::[]
+
+ifeval::["{source_branch}"=="{major-version}"]
+:permanently-unreleased-branch:
+endif::[]
+
+endif::[]
+
+///////
 Shared attribute values are pulled from elastic/docs
 ///////
 

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -40,7 +40,7 @@ include::ingest.asciidoc[]
 
 include::ilm/index.asciidoc[]
 
-ifeval::["{release-state}"=="unreleased"]
+ifdef::permanently-unreleased-branch[]
 
 include::autoscaling/index.asciidoc[]
 


### PR DESCRIPTION
This is a reattempt at #51743. I added some additional logic to target only non-release docs.

<hr>

Adds the ability to display docs on permanently unreleased branches,
such as `master` and `7.x`.

Also updates how the autoscaling and EQL docs are included. Currently,
these feature-flag docs would display on any unreleased branches that
contain the changes, such as 7.7.