### PR TITLE
Bubble up exception in follow task in ccr tests

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -126,6 +126,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                         equalTo(leaderGroup.getPrimary().getLastKnownGlobalCheckpoint()));
                     followerGroup.assertAllEqual(indexedDocIds.size() - deleteDocIds.size());
                 });
+                assertNull(shardFollowTask.getStatus().getFatalException());
                 shardFollowTask.markAsCompleted();
                 assertConsistentHistoryBetweenLeaderAndFollower(leaderGroup, followerGroup, true);
             }
@@ -170,6 +171,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                 assertThat(shardFollowTask.getFailure(), nullValue());
                 int expectedDoc = docCount;
                 assertBusy(() -> followerGroup.assertAllEqual(expectedDoc));
+                assertNull(shardFollowTask.getStatus().getFatalException());
                 shardFollowTask.markAsCompleted();
                 assertConsistentHistoryBetweenLeaderAndFollower(leaderGroup, followerGroup, hasPromotion == false);
             }
@@ -325,6 +327,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                             equalTo(leadingPrimary.getLastKnownGlobalCheckpoint()));
                         assertConsistentHistoryBetweenLeaderAndFollower(leaderGroup, followerGroup, true);
                     });
+                    assertNull(shardFollowTask.getStatus().getFatalException());
                 } finally {
                     shardFollowTask.markAsCompleted();
                 }
@@ -397,6 +400,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     follower.recoverReplica(follower.addReplica());
                 }
                 assertBusy(() -> assertConsistentHistoryBetweenLeaderAndFollower(leader, follower, false));
+                assertNull(followTask.getStatus().getFatalException());
                 followTask.markAsCompleted();
             }
         }
@@ -675,7 +679,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     request.getOperations(), request.getMaxSeqNoOfUpdatesOrDeletes(), primary, logger);
                 TransportWriteActionTestHelper.performPostWriteActions(primary, request, ccrResult.location, logger);
             } catch (InterruptedException | ExecutionException | IOException e) {
-                throw new AssertionError(e);
+                throw new RuntimeException(e);
             }
             listener.onResponse(new PrimaryResult(ccrResult.replicaRequest(), ccrResult.finalResponseIfSuccessful));
         }


### PR DESCRIPTION
It's perfectly fine if a bulk request on the follower hits `IndexShardClosedException` in some CCR tests because we sometimes close some follower shards while the follow-task is replicating operations. Instead of failing the test immediately, this commit bubbles up that failure to the shard follow task.

Closes #52052