### PR TITLE
Permit autoscaling feature flag in release builds

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -45,8 +45,11 @@ testClusters.integTest {
   if (singleNode().testDistribution == DEFAULT) {
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'indices.lifecycle.history_index_enabled', 'false'
+    if (BuildParams.isSnapshotBuild() == false) {
+      systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+    }
+    setting 'xpack.autoscaling.enabled', 'true'
     if (BuildParams.isSnapshotBuild()) {
-      setting 'xpack.autoscaling.enabled', 'true'
       setting 'xpack.eql.enabled', 'true'
     }
   }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
  */
 public class Autoscaling extends Plugin implements ActionPlugin {
 
-    private static boolean AUTOSCALING_FEATURE_FLAG_REGISTERED;
+    private static final boolean AUTOSCALING_FEATURE_FLAG_REGISTERED;
 
     static {
         final String property = System.getProperty("es.autoscaling_feature_flag_registered");

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/Autoscaling.java
@@ -32,6 +32,24 @@ import java.util.function.Supplier;
  */
 public class Autoscaling extends Plugin implements ActionPlugin {
 
+    private static boolean AUTOSCALING_FEATURE_FLAG_REGISTERED;
+
+    static {
+        final String property = System.getProperty("es.autoscaling_feature_flag_registered");
+        if (Build.CURRENT.isSnapshot() && property != null) {
+            throw new IllegalArgumentException("es.autoscaling_feature_flag_registered is only supported in non-snapshot builds");
+        }
+        if ("true".equals(property)) {
+            AUTOSCALING_FEATURE_FLAG_REGISTERED = true;
+        } else if ("false".equals(property) || property == null) {
+            AUTOSCALING_FEATURE_FLAG_REGISTERED = false;
+        } else {
+            throw new IllegalArgumentException(
+                "expected es.autoscaling_feature_flag_registered to be unset or [true|false] but was [" + property + "]"
+            );
+        }
+    }
+
     public static final Setting<Boolean> AUTOSCALING_ENABLED_SETTING = Setting.boolSetting(
         "xpack.autoscaling.enabled",
         false,
@@ -51,7 +69,7 @@ public class Autoscaling extends Plugin implements ActionPlugin {
      */
     @Override
     public List<Setting<?>> getSettings() {
-        if (isSnapshot()) {
+        if (isSnapshot() || AUTOSCALING_FEATURE_FLAG_REGISTERED) {
             return List.of(AUTOSCALING_ENABLED_SETTING);
         } else {
             return List.of();


### PR DESCRIPTION
This commit provides a path to set register the autoscaling feature flag in release builds, and therefore enabling autoscaling in release builds. The primary reason that we add this is so that our release docs tests can pass. Our release docs tests do not have infrastructure in place to only register snippets from included portions of the docs, they instead include all docs snippets. Since autoscaling can not be enabled in release builds, this meant that the autoscaling snippets would fail in the release docs tests. To address then, we need the ability to enable autoscaling in the release docs tests which we can now do with the system property added here. This system property will be removed when autoscaling is ready for release.

Closes #52050
