### PR TITLE
Remove unnecessary dirname command (#51968)

### DIFF
--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -38,7 +38,7 @@ fi
 unset KEYSTORE_PASSWORD
 KEYSTORE_PASSWORD=
 if [[ $CHECK_KEYSTORE = true ]] \
-    && "`dirname "$0"`"/elasticsearch-keystore has-passwd --silent
+    && bin/elasticsearch-keystore has-passwd --silent
 then
   if ! read -s -r -p "Elasticsearch keystore password: " KEYSTORE_PASSWORD ; then
     echo "Failed to read keystore password on console" 1>&2


### PR DESCRIPTION
The elasticsearch-env script changes the working directory to ES_HOME,
so we can just use bin/elasticsearch-keystore to invoke the keystore.