### PR TITLE
Add file existence matchers in packaging tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -34,6 +34,8 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.cp;
 import static org.elasticsearch.packaging.util.FileUtils.getTempDir;
@@ -286,7 +288,7 @@ public class ArchiveTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
 
         if (distribution().isDefault()) {
-            assertTrue(Files.exists(installation.lib.resolve("tools").resolve("security-cli")));
+            assertThat(installation.lib.resolve("tools").resolve("security-cli"), fileExists());
             final Platforms.PlatformAction action = () -> {
                 Result result = sh.run(bin.certutilTool + " --help");
                 assertThat(result.stdout, containsString("Simplifies certificate creation for use with the Elastic Stack"));
@@ -299,7 +301,7 @@ public class ArchiveTests extends PackagingTestCase {
             Platforms.onLinux(action);
             Platforms.onWindows(action);
         } else {
-            assertFalse(Files.exists(installation.lib.resolve("tools").resolve("security-cli")));
+            assertThat(installation.lib.resolve("tools").resolve("security-cli"), fileDoesNotExist());
         }
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -22,9 +22,9 @@ package org.elasticsearch.packaging.test;
 import org.elasticsearch.packaging.util.Distribution;
 import org.junit.BeforeClass;
 
-import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
 import static org.elasticsearch.packaging.util.Packages.SYSVINIT_SCRIPT;
@@ -89,10 +89,10 @@ public class DebPreservationTests extends PackagingTestCase {
         );
 
         // sysvinit service file was not removed
-        assertTrue(Files.exists(SYSVINIT_SCRIPT));
+        assertThat(SYSVINIT_SCRIPT, fileExists());
 
         // defaults file was not removed
-        assertTrue(Files.exists(installation.envFile));
+        assertThat(installation.envFile, fileExists());
     }
 
     public void test30Purge() throws Exception {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -35,6 +35,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
@@ -212,7 +214,7 @@ public class PackageTests extends PackagingTestCase {
             installation.pidDir
         );
 
-        assertFalse(Files.exists(SYSTEMD_SERVICE));
+        assertThat(SYSTEMD_SERVICE, fileDoesNotExist());
     }
 
     public void test60Reinstall() throws Exception {
@@ -279,7 +281,7 @@ public class PackageTests extends PackagingTestCase {
 
         final Path pidFile = installation.pidDir.resolve("elasticsearch.pid");
 
-        assertTrue(Files.exists(pidFile));
+        assertThat(pidFile, fileExists());
 
         stopElasticsearch();
     }
@@ -320,7 +322,7 @@ public class PackageTests extends PackagingTestCase {
         startElasticsearch();
 
         final Path pidFile = installation.pidDir.resolve("elasticsearch.pid");
-        assertTrue(Files.exists(pidFile));
+        assertThat(pidFile, fileExists());
         String pid = slurp(pidFile).trim();
         String maxFileSize = sh.run("cat /proc/%s/limits | grep \"Max file size\" | awk '{ print $4 }'", pid).stdout.trim();
         assertThat(maxFileSize, equalTo("unlimited"));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
 import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
@@ -59,13 +61,13 @@ public class RpmPreservationTests extends PackagingTestCase {
         remove(distribution());
 
         // config was removed
-        assertFalse(Files.exists(installation.config));
+        assertThat(installation.config, fileDoesNotExist());
 
         // sysvinit service file was removed
-        assertFalse(Files.exists(SYSVINIT_SCRIPT));
+        assertThat(SYSVINIT_SCRIPT, fileDoesNotExist());
 
         // defaults file was removed
-        assertFalse(Files.exists(installation.envFile));
+        assertThat(installation.envFile, fileDoesNotExist());
     }
 
     public void test30PreserveConfig() throws Exception {
@@ -113,8 +115,8 @@ public class RpmPreservationTests extends PackagingTestCase {
             SYSTEMD_SERVICE
         );
 
-        assertTrue(Files.exists(installation.config));
-        assertTrue(Files.exists(installation.config("elasticsearch.keystore")));
+        assertThat(installation.config, fileExists());
+        assertThat(installation.config("elasticsearch.keystore"), fileExists());
 
         Stream.of(
             "elasticsearch.yml",

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileExistenceMatchers.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileExistenceMatchers.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.packaging.util;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class FileExistenceMatchers {
+
+    private static class FileExistsMatcher extends TypeSafeMatcher<Path> {
+
+        @Override
+        protected boolean matchesSafely(final Path path) {
+            return Files.exists(path);
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            description.appendText("expected path to exist");
+        }
+
+        @Override
+        protected void describeMismatchSafely(final Path path, final Description mismatchDescription) {
+            mismatchDescription.appendText("path " + path + " does not exist");
+        }
+
+    }
+
+    public static FileExistsMatcher fileExists() {
+        return new FileExistsMatcher();
+    }
+
+    private static class FileDoesNotExistMatcher extends TypeSafeMatcher<Path> {
+
+        @Override
+        protected boolean matchesSafely(final Path path) {
+            return Files.exists(path) == false;
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            description.appendText("expected path to not exist");
+        }
+
+        @Override
+        protected void describeMismatchSafely(final Path path, final Description mismatchDescription) {
+            if (Files.isDirectory(path)) {
+                mismatchDescription.appendText("path " + path + " is a directory with contents\n");
+                try {
+                    Files.walkFileTree(path, new SimpleFileVisitor<>() {
+
+                        @Override
+                        public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                            mismatchDescription.appendValue(path.relativize(file)).appendText("\n");
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                    });
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            } else {
+                mismatchDescription.appendText("path " + path + " exists");
+            }
+        }
+
+    }
+
+    public static FileDoesNotExistMatcher fileDoesNotExist() {
+        return new FileDoesNotExistMatcher();
+    }
+
+}


### PR DESCRIPTION
The packaging tests like to assert that files exist or do not exist. We do this with assertFalse and assertTrue which leads to useless assertion messages, especially when asserting a file does not exist, but it does and it is a directory. This commit helps with this situation by adding dedicated matchers.
