### PR TITLE
Replace assertFalse/assertTrue for file existence

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -117,7 +117,7 @@ public class ArchiveTests extends PackagingTestCase {
             throw e;
         }
 
-        assertTrue("gc logs exist", Files.exists(installation.logs.resolve("gc.log")));
+        assertThat(installation.logs.resolve("gc.log"), fileExists());
         ServerUtils.runElasticsearchTests();
 
         stopElasticsearch();

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -25,7 +25,7 @@ import org.junit.BeforeClass;
 import java.nio.file.Paths;
 
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
-import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
+import static org.elasticsearch.packaging.util.FileUtils.assertPathsDoNotExist;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
 import static org.elasticsearch.packaging.util.Packages.SYSVINIT_SCRIPT;
 import static org.elasticsearch.packaging.util.Packages.assertInstalled;
@@ -76,14 +76,14 @@ public class DebPreservationTests extends PackagingTestCase {
 
         // keystore was removed
 
-        assertPathsDontExist(
+        assertPathsDoNotExist(
             installation.config("elasticsearch.keystore"),
             installation.config(".elasticsearch.keystore.initial_md5sum")
         );
 
         // doc files were removed
 
-        assertPathsDontExist(
+        assertPathsDoNotExist(
             Paths.get("/usr/share/doc/" + distribution().flavor.name),
             Paths.get("/usr/share/doc/" + distribution().flavor.name + "/copyright")
         );
@@ -100,7 +100,7 @@ public class DebPreservationTests extends PackagingTestCase {
 
         assertRemoved(distribution());
 
-        assertPathsDontExist(
+        assertPathsDoNotExist(
             installation.config,
             installation.envFile,
             SYSVINIT_SCRIPT

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -38,7 +38,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.append;
-import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
+import static org.elasticsearch.packaging.util.FileUtils.assertPathsDoNotExist;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
 import static org.elasticsearch.packaging.util.FileUtils.cp;
 import static org.elasticsearch.packaging.util.FileUtils.fileWithGlobExist;
@@ -205,7 +205,7 @@ public class PackageTests extends PackagingTestCase {
 
         }
 
-        assertPathsDontExist(
+        assertPathsDoNotExist(
             installation.bin,
             installation.lib,
             installation.modules,

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -56,6 +56,7 @@ import java.util.List;
 import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
 import static org.elasticsearch.packaging.util.Docker.ensureImageIsLoaded;
 import static org.elasticsearch.packaging.util.Docker.removeContainer;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -326,7 +327,7 @@ public abstract class PackagingTestCase extends Assert {
 
             // If log file exists, then we have bootstrapped our logging and the
             // error should be in the logs
-            assertTrue("log file exists", Files.exists(installation.logs.resolve("elasticsearch.log")));
+            assertThat(installation.logs.resolve("elasticsearch.log"), fileExists());
             String logfile = FileUtils.slurp(installation.logs.resolve("elasticsearch.log"));
 
             assertThat(logfile, anyOf(stringMatchers));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -57,9 +57,9 @@ import static org.elasticsearch.packaging.util.Cleanup.cleanEverything;
 import static org.elasticsearch.packaging.util.Docker.ensureImageIsLoaded;
 import static org.elasticsearch.packaging.util.Docker.removeContainer;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.packaging.util.Distribution;
 import org.elasticsearch.packaging.util.Shell;
 import org.junit.BeforeClass;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.append;
-import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
+import static org.elasticsearch.packaging.util.FileUtils.assertPathsDoNotExist;
 import static org.elasticsearch.packaging.util.Packages.SYSTEMD_SERVICE;
 import static org.elasticsearch.packaging.util.Packages.SYSVINIT_SCRIPT;
 import static org.elasticsearch.packaging.util.Packages.assertInstalled;
@@ -103,7 +103,7 @@ public class RpmPreservationTests extends PackagingTestCase {
             assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode, is(1));
         }
 
-        assertPathsDontExist(
+        assertPathsDoNotExist(
             installation.bin,
             installation.lib,
             installation.modules,
@@ -137,7 +137,7 @@ public class RpmPreservationTests extends PackagingTestCase {
     private void assertConfFilePreserved(String configFile) {
         final Path original = installation.config(configFile);
         final Path saved = installation.config(configFile + ".rpmsave");
-        assertFalse(original + " should not exist", Files.exists(original));
-        assertTrue(saved + " should exist", Files.exists(saved));
+        assertThat(original, fileDoesNotExist());
+        assertThat(saved, fileExists());
     }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/SysVInitTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/SysVInitTests.java
@@ -24,8 +24,6 @@ import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
 import org.junit.BeforeClass;
 
-import java.nio.file.Files;
-
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
 import static org.hamcrest.CoreMatchers.anyOf;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/SysVInitTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/SysVInitTests.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 
 import java.nio.file.Files;
 
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -59,7 +60,7 @@ public class SysVInitTests extends PackagingTestCase {
 
     public void test20Start() throws Exception {
         startElasticsearch();
-        assertTrue("gc logs exist", Files.exists(installation.logs.resolve("gc.log")));
+        assertThat(installation.logs.resolve("gc.log"), fileExists());
         ServerUtils.runElasticsearchTests();
         sh.run("service elasticsearch status"); // returns 0 exit status when ok
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.Directory;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.File;
 import static org.elasticsearch.packaging.util.FileMatcher.file;
@@ -268,7 +270,7 @@ public class Archives {
     public static Shell.Result runElasticsearchStartCommand(Installation installation, Shell sh, String keystorePassword) {
         final Path pidFile = installation.home.resolve("elasticsearch.pid");
 
-        assertFalse("Pid file doesn't exist when starting Elasticsearch", Files.exists(pidFile));
+        assertThat(pidFile, fileDoesNotExist());
 
         final Installation.Executables bin = installation.executables();
 
@@ -338,14 +340,14 @@ public class Archives {
         final Path pidFile = installation.home.resolve("elasticsearch.pid");
         ServerUtils.waitForElasticsearch(installation);
 
-        assertTrue("Starting Elasticsearch produced a pid file at " + pidFile, Files.exists(pidFile));
+        assertThat("Starting Elasticsearch produced a pid file at " + pidFile, pidFile, fileExists());
         String pid = slurp(pidFile).trim();
         assertThat(pid, is(not(emptyOrNullString())));
     }
 
     public static void stopElasticsearch(Installation installation) throws Exception {
         Path pidFile = installation.home.resolve("elasticsearch.pid");
-        assertTrue("pid file should exist", Files.exists(pidFile));
+        assertThat(pidFile, fileExists());
         String pid = slurp(pidFile).trim();
         assertThat(pid, is(not(emptyOrNullString())));
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -50,8 +50,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Installation and verification logic for archive distributions

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.fluent.Request;
 import org.elasticsearch.common.CheckedRunnable;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributes;
@@ -39,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.nio.file.attribute.PosixFilePermissions.fromString;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileMatcher.p644;
 import static org.elasticsearch.packaging.util.FileMatcher.p660;
 import static org.elasticsearch.packaging.util.FileMatcher.p755;
@@ -156,7 +156,7 @@ public class Docker {
         // Bind-mount any volumes
         if (volumes != null) {
             volumes.forEach((localPath, containerPath) -> {
-                assertTrue(localPath + " doesn't exist", Files.exists(localPath));
+                assertThat(localPath, fileExists());
 
                 if (Platforms.WINDOWS == false && System.getProperty("user.name").equals("root")) {
                     // The tests are running as root, but the process in the Docker container runs as `elasticsearch` (UID 1000),

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -52,10 +52,11 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipException;
 
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 /**
  * Wrappers and convenience methods for common filesystem operations
@@ -308,8 +309,8 @@ public class FileUtils {
         return distribution.path;
     }
 
-    public static void assertPathsExist(Path... paths) {
-        Arrays.stream(paths).forEach(path -> assertTrue(path + " should exist", Files.exists(path)));
+    public static void assertPathsExist(final Path... paths) {
+        Arrays.stream(paths).forEach(path -> assertThat(path, fileExists()));
     }
 
     public static Matcher<Path> fileWithGlobExist(String glob) throws IOException {
@@ -326,8 +327,8 @@ public class FileUtils {
         };
     }
 
-    public static void assertPathsDontExist(Path... paths) {
-        Arrays.stream(paths).forEach(path -> assertFalse(path + " should not exist", Files.exists(path)));
+    public static void assertPathsDoNotExist(final Path... paths) {
+        Arrays.stream(paths).forEach(path -> assertThat(path, fileDoesNotExist()));
     }
 
     public static void deleteIfExists(Path path) {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -33,7 +33,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
-import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.Directory;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.File;
 import static org.elasticsearch.packaging.util.FileMatcher.file;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -32,6 +32,8 @@ import java.nio.file.StandardOpenOption;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
+import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileExists;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.Directory;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.File;
 import static org.elasticsearch.packaging.util.FileMatcher.file;
@@ -164,7 +166,7 @@ public class Packages {
 
         final Result passwdResult = sh.run("getent passwd elasticsearch");
         final Path homeDir = Paths.get(passwdResult.stdout.trim().split(":")[5]);
-        assertFalse("elasticsearch user home directory must not exist", Files.exists(homeDir));
+        assertThat("elasticsearch user home directory must not exist", homeDir, fileDoesNotExist());
 
         Stream.of(
             es.home,


### PR DESCRIPTION
In the packaging tests, we added convenience methods for asserting file existence and file non-existence. This commit replaces the remaining uses of assertFalse/assertTrue in favor of these dedicated matchers.

Relates #52090
