### PR TITLE
Add autoscaling feature flag in release REST tests

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/build.gradle
+++ b/x-pack/plugin/autoscaling/qa/rest/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
@@ -14,6 +15,9 @@ task restTest(type: RestIntegTestTask) {
 
 testClusters.restTest {
   testDistribution = 'DEFAULT'
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+  }
   setting 'xpack.autoscaling.enabled', 'true'
   setting 'xpack.security.enabled', 'true'
   extraConfigFile 'roles.yml', file('autoscaling-roles.yml')


### PR DESCRIPTION
The REST tests for autoscaling either need to be skipped in a non-snapshot build, or alternatively, the feature flag registered so that autoscaling can be enabled. We prefer the latter approach, as it allows us to also test autoscaling in non-snapshot builds incrementally, instead of at the end of development as autoscaling prepares for release. This commit registers the autoscaling feature flag in REST tests for non-snapshot builds.

Relates #52088
