### PR TITLE
Mute DocumentSubsetBitsetCacheTests.testCacheUnderConcurrentAccess

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -337,6 +337,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             cache.verifyInternalConsistency();
         });
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/51914")
     public void testCacheUnderConcurrentAccess() throws Exception {
         // This value is based on the internal implementation details of lucene's FixedBitSet
         // If the implementation changes, this can be safely updated to match the new ram usage for a single bitset


### PR DESCRIPTION
Test does not always complete in expected time.

Relates: #51914
