### PR TITLE
Mute MixedCluster 180_locale_dependent_mapping

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/180_locale_dependent_mapping.yml
@@ -2,8 +2,8 @@
 "Test Index and Search locale dependent mappings / dates":
 
   - skip:
-      version: " - 6.8.4, 7.0.0 - 7.4.99"
-      reason: JDK9 only supports this with a special sysproperty added in 6.2.0 and java.time 8prefix fix is in 6.8.5, 7.5 and master
+      version: "all"
+      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/49719"
 
   - do:
       indices.create:


### PR DESCRIPTION
Muting this test as it has frequent failures.

Relates: #49719
Backport of: #52116
