### PR TITLE
Test modifications for FIPS 140 mode

### DIFF
--- a/buildSrc/src/main/resources/fips_java.security
+++ b/buildSrc/src/main/resources/fips_java.security
@@ -1,6 +1,7 @@
 security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
 security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
 security.provider.3=SUN
+security.provider.4=SunJGSS
 securerandom.source=file:/dev/urandom
 securerandom.strongAlgorithms=NativePRNGBlocking:SUN,DRBG:SUN
 securerandom.drbg.config=

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -88,8 +88,11 @@ thirdPartyAudit {
   ignoreMissingClasses()
 }
 
-jarHell.onlyIf {
+if (BuildParams.inFipsJvm) {
   // FIPS JVM includes many classes from bouncycastle which count as jar hell for the third party audit,
   // rather than provide a long list of exclusions, disable the check on FIPS.
-  BuildParams.inFipsJvm == false
+  jarHell.enabled = false
+  test.enabled = false
+  integTest.enabled = false;
+  testingConventions.enabled = false;
 }

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -18,6 +18,7 @@
  */
 
 import org.elasticsearch.gradle.MavenFilteringHack
+import org.elasticsearch.gradle.info.BuildParams
 
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'

--- a/qa/smoke-test-plugins/build.gradle
+++ b/qa/smoke-test-plugins/build.gradle
@@ -27,6 +27,10 @@ int pluginsCount = 0
 
 testClusters.integTest {
   project(':plugins').getChildProjects().each { pluginName, pluginProject ->
+    if (BuildParams.inFipsJvm && pluginName == "ingest-attachment"){
+      //Do not attempt to install ingest-attachment in FIPS 140 as it is not supported (it depends on non-FIPS BouncyCastle
+      return
+    }
     plugin file(pluginProject.tasks.bundlePlugin.archiveFile)
     tasks.integTest.dependsOn pluginProject.tasks.bundlePlugin
     pluginsCount += 1


### PR DESCRIPTION
- Enable SunJGSS provider for Kerberos tests
- Disable tests, jarHell, testingConventions for ingest attachment
plugin. We don't support this plugin (and document this) in FIPS
mode.
- Don't attempt to install ingest-attachment in smoke-test-plugins

Backport of #51832 