### PR TITLE
Disable AwsSdkMetrics in S3 Repo Plugin

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.repositories.s3;
 
+import com.amazonaws.metrics.AwsSdkMetrics;
 import com.amazonaws.util.json.Jackson;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
@@ -58,6 +59,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             } catch (final ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
+            AwsSdkMetrics.disableMetrics();
             return null;
         });
     }

--- a/plugins/repository-s3/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-s3/src/main/plugin-metadata/plugin-security.policy
@@ -39,6 +39,7 @@ grant {
   // s3 client opens socket connections for to access repository
   permission java.net.SocketPermission "*", "connect";
 
+  // s3 SDK needs these so it can disable its internal metrics collection
   permission javax.management.MBeanServerPermission "findMBeanServer";
   permission javax.management.MBeanServerPermission "createMBeanServer";
   permission javax.management.MBeanTrustPermission "register";

--- a/plugins/repository-s3/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-s3/src/main/plugin-metadata/plugin-security.policy
@@ -39,5 +39,8 @@ grant {
   // s3 client opens socket connections for to access repository
   permission java.net.SocketPermission "*", "connect";
 
-
+  permission javax.management.MBeanServerPermission "findMBeanServer";
+  permission javax.management.MBeanServerPermission "createMBeanServer";
+  permission javax.management.MBeanTrustPermission "register";
+  permission javax.management.MBeanPermission "*", "registerMBean";
 };


### PR DESCRIPTION
We have a lot of logging about failing to set the metrics mbean in S3 test logs since we don't
give the relevant permissions to set the mbean.
This commit disables `AwsSdkMetrics` since it never worked anyway and quiets down this logging.
The new permissions in the policy are necessary so the metrics disable call works.

Example warning log that this fixes:

```
1> [2020-02-10T09:18:15,990][WARN ][c.a.j.SdkMBeanRegistrySupport] [node_sm0] 
  1> java.security.AccessControlException: access denied ("javax.management.MBeanServerPermission" "findMBeanServer")
  1> 	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:?]
  1> 	at java.security.AccessController.checkPermission(AccessController.java:1036) ~[?:?]
  1> 	at java.lang.SecurityManager.checkPermission(SecurityManager.java:408) ~[?:?]
  1> 	at javax.management.MBeanServerFactory.checkPermission(MBeanServerFactory.java:413) ~[?:?]
  1> 	at javax.management.MBeanServerFactory.findMBeanServer(MBeanServerFactory.java:361) ~[?:?]
  1> 	at com.amazonaws.jmx.MBeans.getMBeanServer(MBeans.java:111) ~[aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.jmx.MBeans.registerMBean(MBeans.java:50) ~[aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.jmx.SdkMBeanRegistrySupport.registerMetricAdminMBean(SdkMBeanRegistrySupport.java:27) [aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.metrics.AwsSdkMetrics.registerMetricAdminMBean(AwsSdkMetrics.java:398) [aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.metrics.AwsSdkMetrics.<clinit>(AwsSdkMetrics.java:359) [aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3Client.<clinit>(AmazonS3Client.java:406) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3Builder$1.apply(AmazonS3Builder.java:35) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3Builder$1.apply(AmazonS3Builder.java:32) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3ClientBuilder.build(AmazonS3ClientBuilder.java:64) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3ClientBuilder.build(AmazonS3ClientBuilder.java:28) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.client.builder.AwsSyncClientBuilder.build(AwsSyncClientBuilder.java:46) [aws-java-sdk-core-1.11.636.jar:?]
  1> 	at org.elasticsearch.repositories.s3.S3Service.buildClient(S3Service.java:162) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3Service.client(S3Service.java:95) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobStore.clientReference(S3BlobStore.java:68) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.executeSingleUpload(S3BlobContainer.java:318) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.lambda$writeBlob$0(S3BlobContainer.java:97) [main/:?]
  1> 	at java.security.AccessController.doPrivileged(AccessController.java:554) [?:?]
  1> 	at org.elasticsearch.repositories.s3.SocketAccess.doPrivilegedIOException(SocketAccess.java:48) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.writeBlob(S3BlobContainer.java:95) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.writeBlobAtomic(S3BlobContainer.java:112) [main/:?]
  1> 	at org.elasticsearch.repositories.blobstore.BlobStoreRepository.startVerification(BlobStoreRepository.java:1023) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at org.elasticsearch.repositories.RepositoriesService$3.doRun(RepositoriesService.java:246) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:688) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
  1> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
  1> 	at java.lang.Thread.run(Thread.java:832) [?:?]
  1> [2020-02-10T09:18:16,003][WARN ][c.a.m.AwsSdkMetrics      ] [node_sm0] 
  1> java.security.AccessControlException: access denied ("javax.management.MBeanServerPermission" "findMBeanServer")
  1> 	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:?]
  1> 	at java.security.AccessController.checkPermission(AccessController.java:1036) ~[?:?]
  1> 	at java.lang.SecurityManager.checkPermission(SecurityManager.java:408) ~[?:?]
  1> 	at javax.management.MBeanServerFactory.checkPermission(MBeanServerFactory.java:413) ~[?:?]
  1> 	at javax.management.MBeanServerFactory.findMBeanServer(MBeanServerFactory.java:361) ~[?:?]
  1> 	at com.amazonaws.jmx.MBeans.getMBeanServer(MBeans.java:111) ~[aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.jmx.MBeans.isRegistered(MBeans.java:98) ~[aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.jmx.SdkMBeanRegistrySupport.isMBeanRegistered(SdkMBeanRegistrySupport.java:46) ~[aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.metrics.AwsSdkMetrics.registerMetricAdminMBean(AwsSdkMetrics.java:404) ~[aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.metrics.AwsSdkMetrics.<clinit>(AwsSdkMetrics.java:359) [aws-java-sdk-core-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3Client.<clinit>(AmazonS3Client.java:406) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3Builder$1.apply(AmazonS3Builder.java:35) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3Builder$1.apply(AmazonS3Builder.java:32) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3ClientBuilder.build(AmazonS3ClientBuilder.java:64) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.services.s3.AmazonS3ClientBuilder.build(AmazonS3ClientBuilder.java:28) [aws-java-sdk-s3-1.11.636.jar:?]
  1> 	at com.amazonaws.client.builder.AwsSyncClientBuilder.build(AwsSyncClientBuilder.java:46) [aws-java-sdk-core-1.11.636.jar:?]
  1> 	at org.elasticsearch.repositories.s3.S3Service.buildClient(S3Service.java:162) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3Service.client(S3Service.java:95) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobStore.clientReference(S3BlobStore.java:68) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.executeSingleUpload(S3BlobContainer.java:318) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.lambda$writeBlob$0(S3BlobContainer.java:97) [main/:?]
  1> 	at java.security.AccessController.doPrivileged(AccessController.java:554) [?:?]
  1> 	at org.elasticsearch.repositories.s3.SocketAccess.doPrivilegedIOException(SocketAccess.java:48) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.writeBlob(S3BlobContainer.java:95) [main/:?]
  1> 	at org.elasticsearch.repositories.s3.S3BlobContainer.writeBlobAtomic(S3BlobContainer.java:112) [main/:?]
  1> 	at org.elasticsearch.repositories.blobstore.BlobStoreRepository.startVerification(BlobStoreRepository.java:1023) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at org.elasticsearch.repositories.RepositoriesService$3.doRun(RepositoriesService.java:246) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:688) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-8.0.0-SNAPSHOT.jar:8.0.0-SNAPSHOT]
  1> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) [?:?]
  1> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) [?:?]
  1> 	at java.lang.Thread.run(Thread.java:832) [?:?]
```