### PR TITLE
[7.x] Update persistent state document in the index the document belongs to (#51751)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
@@ -8,12 +8,13 @@ package org.elasticsearch.xpack.ml.process;
 import com.carrotsearch.randomizedtesting.annotations.Timeout;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.mock.orig.Mockito;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 import org.junit.After;
@@ -22,15 +23,23 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -39,6 +48,7 @@ import static org.mockito.Mockito.when;
 public class IndexingStateProcessorTests extends ESTestCase {
 
     private static final String STATE_SAMPLE = ""
+            + "        \n"
             + "{\"index\": {\"_index\": \"test\", \"_id\": \"1\"}}\n"
             + "{ \"field\" : \"value1\" }\n"
             + "\0"
@@ -56,34 +66,54 @@ public class IndexingStateProcessorTests extends ESTestCase {
 
     private IndexingStateProcessor stateProcessor;
     private ResultsPersisterService resultsPersisterService;
+    private SearchResponse searchResponse;
 
     @Before
     public void initialize() {
+        searchResponse = mock(SearchResponse.class);
+        when(searchResponse.status()).thenReturn(RestStatus.OK);
         resultsPersisterService = mock(ResultsPersisterService.class);
+        doReturn(searchResponse).when(resultsPersisterService).searchWithRetry(any(SearchRequest.class), any(), any(), any());
+        doReturn(mock(BulkResponse.class)).when(resultsPersisterService).bulkIndexWithRetry(any(BulkRequest.class), any(), any(), any());
         AnomalyDetectionAuditor auditor = mock(AnomalyDetectionAuditor.class);
         stateProcessor = spy(new IndexingStateProcessor(JOB_ID, resultsPersisterService, auditor));
-        when(resultsPersisterService.bulkIndexWithRetry(any(BulkRequest.class), any(), any(), any())).thenReturn(mock(BulkResponse.class));
-        ThreadPool threadPool = mock(ThreadPool.class);
-        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
     }
 
     @After
     public void verifyNoMoreClientInteractions() {
-        Mockito.verifyNoMoreInteractions(resultsPersisterService);
+        verifyNoMoreInteractions(resultsPersisterService);
     }
 
-    public void testStateRead() throws IOException {
+    public void testExtractDocId() throws IOException {
+        assertThat(IndexingStateProcessor.extractDocId("{ \"index\": {\"_index\": \"test\", \"_id\": \"1\" } }\n"), equalTo("1"));
+        assertThat(IndexingStateProcessor.extractDocId("{ \"index\": {\"_id\": \"2\" } }\n"), equalTo("2"));
+    }
+
+    private void testStateRead(SearchHits searchHits, String expectedIndexOrAlias) throws IOException {
+        when(searchResponse.getHits()).thenReturn(searchHits);
+
         ByteArrayInputStream stream = new ByteArrayInputStream(STATE_SAMPLE.getBytes(StandardCharsets.UTF_8));
         stateProcessor.process(stream);
         ArgumentCaptor<BytesReference> bytesRefCaptor = ArgumentCaptor.forClass(BytesReference.class);
-        verify(stateProcessor, times(3)).persist(bytesRefCaptor.capture());
+        verify(stateProcessor, times(3)).persist(eq(expectedIndexOrAlias), bytesRefCaptor.capture());
 
         String[] threeStates = STATE_SAMPLE.split("\0");
         List<BytesReference> capturedBytes = bytesRefCaptor.getAllValues();
         assertEquals(threeStates[0], capturedBytes.get(0).utf8ToString());
         assertEquals(threeStates[1], capturedBytes.get(1).utf8ToString());
         assertEquals(threeStates[2], capturedBytes.get(2).utf8ToString());
+        verify(resultsPersisterService, times(3)).searchWithRetry(any(SearchRequest.class), any(), any(), any());
         verify(resultsPersisterService, times(3)).bulkIndexWithRetry(any(BulkRequest.class), any(), any(), any());
+    }
+
+    public void testStateRead_StateDocumentCreated() throws IOException {
+        testStateRead(SearchHits.empty(), ".ml-state-write");
+    }
+
+    public void testStateRead_StateDocumentUpdated() throws IOException {
+        testStateRead(
+            new SearchHits(new SearchHit[]{ SearchHit.createFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f),
+            ".ml-state-dummy");
     }
 
     public void testStateReadGivenConsecutiveZeroBytes() throws IOException {
@@ -92,18 +122,43 @@ public class IndexingStateProcessorTests extends ESTestCase {
 
         stateProcessor.process(stream);
 
-        verify(stateProcessor, never()).persist(any());
-        Mockito.verifyNoMoreInteractions(resultsPersisterService);
+        verify(stateProcessor, never()).persist(any(), any());
     }
 
-    public void testStateReadGivenConsecutiveSpacesFollowedByZeroByte() throws IOException {
-        String zeroBytes = "        \n\0";
-        ByteArrayInputStream stream = new ByteArrayInputStream(zeroBytes.getBytes(StandardCharsets.UTF_8));
+    public void testStateReadGivenSpacesAndNewLineCharactersFollowedByZeroByte() throws IOException {
+        Function<String, InputStream> stringToInputStream = s -> new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
 
-        stateProcessor.process(stream);
+        stateProcessor.process(stringToInputStream.apply("\0"));
+        stateProcessor.process(stringToInputStream.apply(" \0"));
+        stateProcessor.process(stringToInputStream.apply("\n\0"));
+        stateProcessor.process(stringToInputStream.apply("            \0"));
+        stateProcessor.process(stringToInputStream.apply("        \n  \0"));
+        stateProcessor.process(stringToInputStream.apply("      \n\n  \0"));
+        stateProcessor.process(stringToInputStream.apply("    \n  \n  \0"));
+        stateProcessor.process(stringToInputStream.apply("  \n    \n  \0"));
+        stateProcessor.process(stringToInputStream.apply("\n      \n  \0"));
 
-        verify(stateProcessor, times(1)).persist(any());
-        Mockito.verifyNoMoreInteractions(resultsPersisterService);
+        verify(stateProcessor, never()).persist(any(), any());
+    }
+
+    public void testStateReadGivenNoIndexField() throws IOException {
+        String bytes = "  \n    \n  \n \n\n   {}\0";
+        ByteArrayInputStream stream = new ByteArrayInputStream(bytes.getBytes(StandardCharsets.UTF_8));
+
+        Exception e = expectThrows(IllegalStateException.class, () -> stateProcessor.process(stream));
+        assertThat(e.getMessage(), containsString("Could not extract \"index\" field"));
+
+        verify(stateProcessor, never()).persist(any(), any());
+    }
+
+    public void testStateReadGivenNoIdField() throws IOException {
+        String bytes = "  \n \n    \n   {\"index\": {}}\0";
+        ByteArrayInputStream stream = new ByteArrayInputStream(bytes.getBytes(StandardCharsets.UTF_8));
+
+        Exception e = expectThrows(IllegalStateException.class, () -> stateProcessor.process(stream));
+        assertThat(e.getMessage(), containsString("Could not extract \"index._id\" field"));
+
+        verify(stateProcessor, never()).persist(any(), any());
     }
 
     /**
@@ -113,9 +168,11 @@ public class IndexingStateProcessorTests extends ESTestCase {
      */
     @Timeout(millis = 10 * 1000)
     public void testLargeStateRead() throws Exception {
+        when(searchResponse.getHits()).thenReturn(SearchHits.empty());
+
         StringBuilder builder = new StringBuilder(NUM_LARGE_DOCS * (LARGE_DOC_SIZE + 10)); // 10 for header and separators
         for (int docNum = 1; docNum <= NUM_LARGE_DOCS; ++docNum) {
-            builder.append("{\"index\":{\"_index\":\"header").append(docNum).append("\"}}\n");
+            builder.append("{\"index\":{\"_index\":\"header").append(docNum).append("\",\"_id\":\"doc").append(docNum).append("\"}}\n");
             for (int count = 0; count < (LARGE_DOC_SIZE / "data".length()); ++count) {
                 builder.append("data");
             }
@@ -124,7 +181,8 @@ public class IndexingStateProcessorTests extends ESTestCase {
 
         ByteArrayInputStream stream = new ByteArrayInputStream(builder.toString().getBytes(StandardCharsets.UTF_8));
         stateProcessor.process(stream);
-        verify(stateProcessor, times(NUM_LARGE_DOCS)).persist(any());
+        verify(stateProcessor, times(NUM_LARGE_DOCS)).persist(eq(".ml-state-write"), any());
+        verify(resultsPersisterService, times(NUM_LARGE_DOCS)).searchWithRetry(any(SearchRequest.class), any(), any(), any());
         verify(resultsPersisterService, times(NUM_LARGE_DOCS)).bulkIndexWithRetry(any(BulkRequest.class), any(), any(), any());
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
@@ -25,8 +25,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
@@ -112,7 +112,7 @@ public class IndexingStateProcessorTests extends ESTestCase {
 
     public void testStateRead_StateDocumentUpdated() throws IOException {
         testStateRead(
-            new SearchHits(new SearchHit[]{ SearchHit.createFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f),
+            new SearchHits(new SearchHit[]{ SearchHit.createFromMap(Collections.singletonMap("_index", ".ml-state-dummy")) }, null, 0.0f),
             ".ml-state-dummy");
     }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update persistent state document in the index the document belongs to  (#51751)