### PR TITLE
Fix windows empty line in logging capture

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
@@ -96,6 +96,10 @@ class LoggingOutputStream extends OutputStream {
             // windows case: remove the first part of newlines there too
             --used;
         }
+        if (used == 0) {
+            // only windows \r was in the buffer
+            return;
+        }
         log(new String(buffer.bytes, 0, used, StandardCharsets.UTF_8));
         if (buffer.bytes.length != DEFAULT_BUFFER_LENGTH) {
             threadLocal.set(new Buffer()); // reset size

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
@@ -58,9 +58,15 @@ public class LoggingOutputStreamTests extends ESTestCase {
         printStream = new PrintStream(loggingStream, false, StandardCharsets.UTF_8);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/51838")
-    public void testEmptyLine() {
-        printStream.println("");
+    public void testEmptyLineUnix() {
+        printStream.print("\n");
+        assertTrue(loggingStream.lines.isEmpty());
+        printStream.flush();
+        assertTrue(loggingStream.lines.isEmpty());
+    }
+
+    public void testEmptyLineWindows() {
+        printStream.print("\r\n");
         assertTrue(loggingStream.lines.isEmpty());
         printStream.flush();
         assertTrue(loggingStream.lines.isEmpty());
@@ -96,7 +102,6 @@ public class LoggingOutputStreamTests extends ESTestCase {
         assertThat(loggingStream.threadLocal.get().bytes.length, equalTo(DEFAULT_BUFFER_LENGTH));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/51838")
     public void testMaxBuffer() {
         String longStr = randomAlphaOfLength(MAX_BUFFER_LENGTH);
         String extraLongStr = longStr + "OVERFLOW";


### PR DESCRIPTION
This commit fixes another edge case in handling windows newlines in our
capture of stdout/stderr to log4j. The case is that the \r appears at
the beginning of the buffer when flushing, which would unintentionally
be emitted as an empty string. This commit skips the flush if only a \r
was found.

closes #51838