### PR TITLE
remove usage of Lucene's GeoRelationUtils

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/MultiGeoValues.java
@@ -20,7 +20,6 @@ package org.elasticsearch.index.fielddata;
 
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.spatial.util.GeoRelationUtils;
 import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.CentroidCalculator;
@@ -111,8 +110,8 @@ public abstract class MultiGeoValues {
 
         @Override
         public GeoRelation relate(Rectangle rectangle) {
-            if (GeoRelationUtils.pointInRectPrecise(geoPoint.lat(), geoPoint.lon(),
-                rectangle.getMinLat(), rectangle.getMaxLat(), rectangle.getMinLon(), rectangle.getMaxLon())) {
+            if (geoPoint.lat() >= rectangle.getMinLat() && geoPoint.lat() <= rectangle.getMaxLat()
+                    && geoPoint.lon() >= rectangle.getMinLon() && geoPoint.lon() <= rectangle.getMaxLon()) {
                 return GeoRelation.QUERY_CROSSES;
             }
             return GeoRelation.QUERY_DISJOINT;


### PR DESCRIPTION
Lucene removed GeoRelationUtils[1], and so this commit
inlines ES's usage of this utility class.

[1] https://github.com/apache/lucene-solr/pull/1173