### PR TITLE
Remove unnecessary method in JvmOptionsParser

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmOptionsParser.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmOptionsParser.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -95,8 +94,7 @@ final class JvmOptionsParser {
 
         try {
             final List<String> jvmOptions = parser.jvmOptions(Paths.get(args[0]), System.getenv("ES_JAVA_OPTS"), substitutions);
-            final String spaceDelimitedJvmOptions = spaceDelimitJvmOptions(jvmOptions);
-            Launchers.outPrintln(spaceDelimitedJvmOptions);
+            Launchers.outPrintln(String.join(" ", jvmOptions));
         } catch (final JvmOptionsFileParserException e) {
             final String errorMessage = String.format(
                 Locale.ROOT,
@@ -338,24 +336,6 @@ final class JvmOptionsParser {
                 invalidLineConsumer.accept(lineNumber, line);
             }
         }
-    }
-
-    /**
-     * Delimits the specified JVM options by spaces.
-     *
-     * @param jvmOptions the JVM options
-     * @return a single-line string containing the specified JVM options in the order they appear delimited by spaces
-     */
-    static String spaceDelimitJvmOptions(final List<String> jvmOptions) {
-        final StringBuilder spaceDelimitedJvmOptionsBuilder = new StringBuilder();
-        final Iterator<String> it = jvmOptions.iterator();
-        while (it.hasNext()) {
-            spaceDelimitedJvmOptionsBuilder.append(it.next());
-            if (it.hasNext()) {
-                spaceDelimitedJvmOptionsBuilder.append(" ");
-            }
-        }
-        return spaceDelimitedJvmOptionsBuilder.toString();
     }
 
 }

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmOptionsParserTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/JvmOptionsParserTests.java
@@ -246,13 +246,4 @@ public class JvmOptionsParserTests extends LaunchersTestCase {
         assertThat(seenInvalidLines, equalTo(invalidLines));
     }
 
-    public void testSpaceDelimitedJvmOptions() {
-        assertThat(JvmOptionsParser.spaceDelimitJvmOptions(Collections.singletonList("-Xms1g")), equalTo("-Xms1g"));
-        assertThat(JvmOptionsParser.spaceDelimitJvmOptions(Arrays.asList("-Xms1g", "-Xmx1g")), equalTo("-Xms1g -Xmx1g"));
-        assertThat(
-            JvmOptionsParser.spaceDelimitJvmOptions(Arrays.asList("-Xms1g", "-Xmx1g", "-XX:+UseG1GC")),
-            equalTo("-Xms1g -Xmx1g -XX:+UseG1GC")
-        );
-    }
-
 }


### PR DESCRIPTION
Back when the distribution launchers were compiled to target JDK 7, we did not have access to the String#join method to space-delimit JVM options. Since the launchers now target the same minimum JDK as Elasticsearch itself, we now have access to this method and can replace the use of spaceDelimitJvmOptions with String#join. This commit does that.
