### PR TITLE
[DOCS]Remove extra heading in update alias API doc

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -135,7 +135,6 @@ for the alias's indexing operations.
 See <<aliases-routing>> for an example.
 
 `search_routing`::
-`index_routing`::
 (Optional, string)
 Custom <<mapping-routing-field, routing value>> used
 for the alias's search operations.


### PR DESCRIPTION
There is an extra heading in update alias API doc, which is useless I think.