### PR TITLE
Mute LoggingOutputStreamTests.testMaxBuffer

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
@@ -102,6 +102,7 @@ public class LoggingOutputStreamTests extends ESTestCase {
         assertThat(loggingStream.threadLocal.get().bytes.length, equalTo(DEFAULT_BUFFER_LENGTH));
     }
 
+    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/51838")
     public void testMaxBuffer() {
         String longStr = randomAlphaOfLength(MAX_BUFFER_LENGTH);
         String extraLongStr = longStr + "OVERFLOW";


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/51838

