### PR TITLE
[DOCS] Correct important note for xpack.transform.enabled

### DIFF
--- a/docs/reference/settings/data-frames-settings.asciidoc
+++ b/docs/reference/settings/data-frames-settings.asciidoc
@@ -28,8 +28,8 @@ Therefore the node cannot start or administrate {transform} or receive transport
 communication requests related to {transform} APIs.
 +
 IMPORTANT: If you want to use {transform} features in your cluster, you must have
-`xpack.transform.enabled` set to `true` on all master-eligible nodes. This is the
-default behavior.
+`xpack.transform.enabled` set to `true` on all master-eligible nodes and all data nodes.
+This is the default behavior.
 
 `xpack.transform.num_transform_failure_retries` (<<cluster-update-settings,Dynamic>>)::
 The number of times that a {transform} retries when it experiences a

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -48,6 +48,16 @@ list.
 
 
 [float]
+[[transform-node-assignment-limitations]]
+==== {transforms-cap} node assignment not configurable
+
+{transforms-cap} persistent tasks are assigned to the data node running
+fewest persistent tasks at the time of assignment. This cannot be customized.
+It means that if {transforms} are being used then `xpack.transform.enabled`
+must be set to `true` (which is the default) on every data node in the cluster.
+
+
+[float]
 [[transform-aggresponse-limitations]]
 ==== Aggregation responses may be incompatible with destination index mappings
 


### PR DESCRIPTION
Because transforms get assigned to an arbitrary data node it
is important that the transforms plugin is enabled on every
data node.