### PR TITLE
Permit EQL feature flag in release builds

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -47,11 +47,10 @@ testClusters.integTest {
     setting 'indices.lifecycle.history_index_enabled', 'false'
     if (BuildParams.isSnapshotBuild() == false) {
       systemProperty 'es.autoscaling_feature_flag_registered', 'true'
+      systemProperty 'es.eql_feature_flag_registered', 'true'
     }
     setting 'xpack.autoscaling.enabled', 'true'
-    if (BuildParams.isSnapshotBuild()) {
-      setting 'xpack.eql.enabled', 'true'
-    }
+    setting 'xpack.eql.enabled', 'true'
   }
 
   // enable regexes in painless so our tests don't complain about example snippets that use them

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/EqlPlugin.java
@@ -45,6 +45,24 @@ import java.util.function.Supplier;
 
 public class EqlPlugin extends Plugin implements ActionPlugin {
 
+    private static final boolean EQL_FEATURE_FLAG_REGISTERED;
+
+    static {
+        final String property = System.getProperty("es.eql_feature_flag_registered");
+        if (Build.CURRENT.isSnapshot() && property != null) {
+            throw new IllegalArgumentException("es.eql_feature_flag_registered is only supported in non-snapshot builds");
+        }
+        if ("true".equals(property)) {
+            EQL_FEATURE_FLAG_REGISTERED = true;
+        } else if ("false".equals(property) || property == null) {
+            EQL_FEATURE_FLAG_REGISTERED = false;
+        } else {
+            throw new IllegalArgumentException(
+                "expected es.eql_feature_flag_registered to be unset or [true|false] but was [" + property + "]"
+            );
+        }
+    }
+
     public static final Setting<Boolean> EQL_ENABLED_SETTING = Setting.boolSetting(
         "xpack.eql.enabled",
         false,
@@ -83,7 +101,7 @@ public class EqlPlugin extends Plugin implements ActionPlugin {
      */
     @Override
     public List<Setting<?>> getSettings() {
-        if (isSnapshot()) {
+        if (isSnapshot() || EQL_FEATURE_FLAG_REGISTERED) {
             return List.of(EQL_ENABLED_SETTING);
         } else {
             return List.of();


### PR DESCRIPTION
Provides a path to set register the EQL feature flag in release builds.
This enables EQL in release builds so that release docs tests pass.

Release docs tests do not have infrastructure in place to only register
snippets from included portions of the docs, they instead include all
docs snippets.

Since EQL can not be enabled in release builds, this meant that the EQL
snippets fail in the release docs tests.

This adds the ability to enable EQL in the release docs tests. This
system property will be removed when EQL is ready for release.

Based on #52088, which solved #52050. EQL will encounter similar issues once we include API snippets in our docs.