### PR TITLE
SQL: [Docs] Add limitation for sorting on aggs

### DIFF
--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -118,6 +118,22 @@ SELECT * FROM test GROUP BY age ORDER BY COUNT(*) LIMIT 100;
 It is possible to run the same queries without a `LIMIT` however in that case if the maximum size (*10000*) is passed,
 an exception will be returned as {es-sql} is unable to track (and sort) all the results returned.
 
+Moreover, if there are aggregation(s) in the `ORDER BY`, they must be the exact the same exact aggregation
+expressions(s), as used in the `SELECT` clause. The same applies for the fields that are defined the `GROUP BY` clause:
+they must be the exact same expressions in the `ORDER BY` as in the `GROUP BY`. No operators or scalar functions can be
+used on top or removed from those expressions. Here are some examples of queries that are not allowed:
+
+[source, sql]
+--------------------------------------------------
+SELECT age, MAX(salary) FROM test GROUP BY gender ORDER BY age % 10, MAX(salary);
+
+SELECT age, MAX(salary) FROM test GROUP BY gender ORDER BY age, CAST(MAX(salary) AS FLOAT);
+
+SELECT age % 10, MAX(salary) FROM test GROUP BY gender ORDER BY age, MAX(salary);
+
+SELECT age, MAX(salary) / 12 AS max_salary FROM test GROUP BY ORDER BY age, MAX(salary);
+--------------------------------------------------
+
 [float]
 === Using aggregation functions on top of scalar functions
 

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -118,20 +118,15 @@ SELECT * FROM test GROUP BY age ORDER BY COUNT(*) LIMIT 100;
 It is possible to run the same queries without a `LIMIT` however in that case if the maximum size (*10000*) is passed,
 an exception will be returned as {es-sql} is unable to track (and sort) all the results returned.
 
-Moreover, if there are aggregation(s) in the `ORDER BY`, they must be the exact the same exact aggregation
-expressions(s), as used in the `SELECT` clause. The same applies for the fields that are defined the `GROUP BY` clause:
-they must be the exact same expressions in the `ORDER BY` as in the `GROUP BY`. No operators or scalar functions can be
-used on top or removed from those expressions. Here are some examples of queries that are not allowed:
+Moreover, the aggregation(s) used in the `ORDER BY`, must be only plain aggregate functions. No scalar
+functions or operators can be used, and therefore no complex columns that combine two ore more aggregate
+functions can be used for ordering. Here are some examples of queries that are *not allowed*:
 
 [source, sql]
 --------------------------------------------------
-SELECT age, MAX(salary) FROM test GROUP BY gender ORDER BY age % 10, MAX(salary);
+SELECT age, ROUND(AVG(salary)) AS avg FROM test GROUP BY gender ORDER BY avg;
 
-SELECT age, MAX(salary) FROM test GROUP BY gender ORDER BY age, CAST(MAX(salary) AS FLOAT);
-
-SELECT age % 10, MAX(salary) FROM test GROUP BY gender ORDER BY age, MAX(salary);
-
-SELECT age, MAX(salary) / 12 AS max_salary FROM test GROUP BY ORDER BY age, MAX(salary);
+SELECT age, MAX(salary) - MIN(salary) AS diff FROM test GROUP BY gender ORDER BY diff;
 --------------------------------------------------
 
 [float]

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -118,7 +118,7 @@ SELECT * FROM test GROUP BY age ORDER BY COUNT(*) LIMIT 100;
 It is possible to run the same queries without a `LIMIT` however in that case if the maximum size (*10000*) is passed,
 an exception will be returned as {es-sql} is unable to track (and sort) all the results returned.
 
-Moreover, the aggregation(s) used in the `ORDER BY`, must be only plain aggregate functions. No scalar
+Moreover, the aggregation(s) used in the `ORDER BY must be only plain aggregate functions. No scalar
 functions or operators can be used, and therefore no complex columns that combine two ore more aggregate
 functions can be used for ordering. Here are some examples of queries that are *not allowed*:
 

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -124,9 +124,9 @@ functions can be used for ordering. Here are some examples of queries that are *
 
 [source, sql]
 --------------------------------------------------
-SELECT age, ROUND(AVG(salary)) AS avg FROM test GROUP BY gender ORDER BY avg;
+SELECT age, ROUND(AVG(salary)) AS avg FROM test GROUP BY age ORDER BY avg;
 
-SELECT age, MAX(salary) - MIN(salary) AS diff FROM test GROUP BY gender ORDER BY diff;
+SELECT age, MAX(salary) - MIN(salary) AS diff FROM test GROUP BY age ORDER BY diff;
 --------------------------------------------------
 
 [float]


### PR DESCRIPTION
Add a section to point out that when ordering by an aggregate
only plain aggregate functions are allowed, no scalars/operators
can be used on top of them.

Fixes: #52204
