### PR TITLE
Fix hardcoded version replacement in put-dfanalytics.asciidoc #51053

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -411,7 +411,7 @@ The API returns the following result:
 }
 ----
 // TESTRESPONSE[s/1562265491319/$body.$_path/]
-// TESTRESPONSE[s/"version": "7.6.0"/"version": $body.version/]
+// TESTRESPONSE[s/"version" : "7.6.0"/"version" : $body.version/]
 
 
 [[ml-put-dfanalytics-example-r]]


### PR DESCRIPTION
The version replacement for the code snippet should replace 7.6 with the current version,
but doesn't match because of a missing whitespace.

Backport of #51053, it has started failing on the 7.6 branch after the version bump to 7.6.1
