### PR TITLE
Ensure test temporary directory exists

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -655,6 +655,7 @@ class BuildPlugin implements Plugin<Project> {
                     project.mkdir(testOutputDir)
                     project.mkdir(heapdumpDir)
                     project.mkdir(test.workingDir)
+                    project.mkdir(test.workingDir.toPath().resolve('temp'))
 
                     //TODO remove once jvm.options are added to test system properties
                     test.systemProperty ('java.locale.providers','SPI,COMPAT')


### PR DESCRIPTION
Today we we set the test temporary directory explicitly by controling java.io.tmpdir. Yet, we do not guarantee this directory exists, instead relying on a test base class (LuceneTestCase) to create this directory when it initializes. However, some of our tests do not rely on our test frameowkr, and thus do not have access to LuceneTestCase, instead relying on RandomizedRunner directly. We should not be relying on the temporary directory being implicitly created, instead guaranteeing that it exists before test execution starts. This commit does that by creating the test temporary before the test task executes (via a doFirst).

Relates #52176