### PR TITLE
Use absolute path for temporary directory in tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -686,8 +686,8 @@ class BuildPlugin implements Plugin<Project> {
                     test.jvmArgs '-ea', '-esa'
                 }
 
-                // we use './temp' since this is per JVM and tests are forbidden from writing to CWD
-                test.systemProperties 'java.io.tmpdir': './temp',
+                // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD
+                test.systemProperties 'java.io.tmpdir': test.workingDir.toPath().resolve('temp'),
                         'java.awt.headless': 'true',
                         'tests.gradle': 'true',
                         'tests.artifact': project.name,

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -686,15 +686,12 @@ class BuildPlugin implements Plugin<Project> {
                     test.jvmArgs '-ea', '-esa'
                 }
 
-                // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD
-                test.systemProperties 'java.io.tmpdir': test.workingDir.toPath().resolve('temp'),
-                        'java.awt.headless': 'true',
+                test.systemProperties 'java.awt.headless': 'true',
                         'tests.gradle': 'true',
                         'tests.artifact': project.name,
                         'tests.task': test.path,
                         'tests.security.manager': 'true',
                         'jna.nosys': 'true'
-
 
                 // ignore changing test seed when build is passed -Dignore.tests.seed for cacheability experimentation
                 if (System.getProperty('ignore.tests.seed') != null) {
@@ -707,6 +704,8 @@ class BuildPlugin implements Plugin<Project> {
                 nonInputProperties.systemProperty('gradle.dist.lib', new File(project.class.location.toURI()).parent)
                 nonInputProperties.systemProperty('gradle.worker.jar', "${project.gradle.getGradleUserHomeDir()}/caches/${project.gradle.gradleVersion}/workerMain/gradle-worker.jar")
                 nonInputProperties.systemProperty('gradle.user.home', project.gradle.getGradleUserHomeDir())
+                // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD
+                nonInputProperties.systemProperty('java.io.tmpdir', test.workingDir.toPath().resolve('temp'))
 
                 nonInputProperties.systemProperty('compiler.java', "${-> BuildParams.compilerJavaVersion.majorVersion}")
 


### PR DESCRIPTION
We explicitly set the path for the temporary directory to use in test tasks, but today this path is a relative path, relative to the current working directory of the test task. The fact that we are using a relative path here appears to be legacy, simply leftover from the days of the Maven build. An absolute path is preferred here, since it's explicit and we do not have to rely on everyone resolving the path properly relative to the working directory.

Relates #52176
