### PR TITLE
Ignore absolute path to Gradle distribution from test execution task inputs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -732,8 +732,7 @@ class BuildPlugin implements Plugin<Project> {
                     test.jvmArgs '-ea', '-esa'
                 }
 
-                test.systemProperties 'gradle.dist.lib': new File(project.class.location.toURI()).parent,
-                        'java.awt.headless': 'true',
+                test.systemProperties 'java.awt.headless': 'true',
                         'tests.gradle': 'true',
                         'tests.artifact': project.name,
                         'tests.task': test.path,
@@ -748,6 +747,7 @@ class BuildPlugin implements Plugin<Project> {
                 }
 
                 // don't track these as inputs since they contain absolute paths and break cache relocatability
+                nonInputProperties.systemProperty('gradle.dist.lib', new File(project.class.location.toURI()).parent)
                 nonInputProperties.systemProperty('gradle.worker.jar', "${project.gradle.getGradleUserHomeDir()}/caches/${project.gradle.gradleVersion}/workerMain/gradle-worker.jar")
                 nonInputProperties.systemProperty('gradle.user.home', project.gradle.getGradleUserHomeDir())
                 // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/45521 originally fixed this issue but somehow the change got reverted in the `7.x` branch. This PR reapplies that fix such that we don't mistakenly track the absolute path to the current Gradle distribution directory as a task input, which would cause unnecessary cache misses.