### PR TITLE
Update skip for backported fix

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -786,8 +786,8 @@ setup:
 ---
 "date_histogram with time_zone":
   - skip:
-      version: " - 7.99.99"
-      reason: This will fail against 7.whatever until we backport the fix
+      version: " - 7.6.0"
+      reason: Fixed in 7.6.0
   - do:
       index:
         index:   test


### PR DESCRIPTION
Now that #51172 is fully backported we can fix the `skip` clause in the
bwc tests for it.
