### PR TITLE
Exclude MockRandomMergePolicy in testShouldPeriodicallyFlushAfterMerge

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4754,6 +4754,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testShouldPeriodicallyFlushAfterMerge() throws Exception {
         engine.close();
+        // Do not use MockRandomMergePolicy as it can cause a force merge performing two merges.
         engine = createEngine(copy(engine.config(), newMergePolicy(random(), false)));
         assertThat("Empty engine does not need flushing", engine.shouldPeriodicallyFlush(), equalTo(false));
         ParsedDocument doc =

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4753,6 +4753,8 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     public void testShouldPeriodicallyFlushAfterMerge() throws Exception {
+        engine.close();
+        engine = createEngine(copy(engine.config(), newMergePolicy(random(), false)));
         assertThat("Empty engine does not need flushing", engine.shouldPeriodicallyFlush(), equalTo(false));
         ParsedDocument doc =
             testParsedDocument(Integer.toString(0), null, testDocumentWithTextField(), SOURCE, null);


### PR DESCRIPTION
MockRandomMergePolicy randomly determines if a segment should use a [compound format](https://github.com/apache/lucene-solr/blob/c3e44e1fecc7295ace6bbc12d320581a90c41839/lucene/test-framework/src/java/org/apache/lucene/index/MockRandomMergePolicy.java#L134). This can cause a force merge performing two merges: (1) merging to a single segment, (2) [rewriting](https://github.com/apache/lucene-solr/blob/c3e44e1fecc7295ace6bbc12d320581a90c41839/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java#L584) the new segment using the compound format. If the second merge completes after we have flushed, then it can flip the flag `shouldPeriodicallyFlushAfterBigMerge` to true.

Closes #52205