### PR TITLE
Fix testPrepareIndexForPeerRecovery

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -177,11 +177,13 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         Optional<SequenceNumbers.CommitInfo> safeCommit = shard.store().findSafeIndexCommit(globalCheckpoint);
         assertTrue(safeCommit.isPresent());
         int expectedTotalLocal = 0;
-        try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint + 1, globalCheckpoint)) {
-            Translog.Operation op;
-            while ((op = snapshot.next()) != null) {
-                if (op.seqNo() <= globalCheckpoint) {
-                    expectedTotalLocal++;
+        if (safeCommit.get().localCheckpoint < globalCheckpoint) {
+            try (Translog.Snapshot snapshot = getTranslog(shard).newSnapshot(safeCommit.get().localCheckpoint + 1, globalCheckpoint)) {
+                Translog.Operation op;
+                while ((op = snapshot.next()) != null) {
+                    if (op.seqNo() <= globalCheckpoint) {
+                        expectedTotalLocal++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Since #51905, we skip translog recovery if the local checkpoint of the safe commit equals to the global checkpoint. This change adjusts the test not to create a new snapshot in that case.

Closes #52221
Relates #51905