### PR TITLE
[DOCS] Clarifies description of num_top_feature_importance_values

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -152,7 +152,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=randomize-seed]
 (Optional, integer)
 Advanced configuration option. Specifies the maximum number of
 {ml-docs}/dfa-classification.html#dfa-classification-feature-importance[feature
-importance] values to return. By default, it is zero and no feature importance
+importance] values per document to return. By default, it is zero and no feature importance
 calculation occurs.
 
 `analysis`.`classification`.`training_percent`::::

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -150,10 +150,10 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=randomize-seed]
 
 `analysis`.`classification`.`num_top_feature_importance_values`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=num-top-feature-importance-values]
-+
-See
-{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[Feature importance in {classification}].
+Advanced configuration option. Specifies the maximum number of
+{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[feature
+importance] values to return. By default, it is zero and no feature importance
+calculation occurs.
 
 `analysis`.`classification`.`training_percent`::::
 (Optional, integer)
@@ -236,9 +236,10 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
 
 `analysis`.`regression`.`num_top_feature_importance_values`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=num-top-feature-importance-values]
-+
-See {ml-docs}/dfa-regression.html#dfa-regression-feature-importance[Feature importance in {regression}].
+Advanced configuration option. Specifies the maximum number of
+{ml-docs}/dfa-regression.html#dfa-regression-feature-importance[feature importance] 
+values to return. By default, it is zero and no feature importance calculation
+occurs.
 
 `analysis`.`regression`.`training_percent`::::
 (Optional, integer)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -151,6 +151,9 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=randomize-seed]
 `analysis`.`classification`.`num_top_feature_importance_values`::::
 (Optional, integer)
 include::{docdir}/ml/ml-shared.asciidoc[tag=num-top-feature-importance-values]
++
+See
+{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[Feature importance in {classification}].
 
 `analysis`.`classification`.`training_percent`::::
 (Optional, integer)
@@ -234,6 +237,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
 `analysis`.`regression`.`num_top_feature_importance_values`::::
 (Optional, integer)
 include::{docdir}/ml/ml-shared.asciidoc[tag=num-top-feature-importance-values]
++
+See {ml-docs}/dfa-regression.html#dfa-regression-feature-importance[Feature importance in {regression}].
 
 `analysis`.`regression`.`training_percent`::::
 (Optional, integer)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -238,7 +238,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
 (Optional, integer)
 Advanced configuration option. Specifies the maximum number of
 {ml-docs}/dfa-regression.html#dfa-regression-feature-importance[feature importance] 
-values to return. By default, it is zero and no feature importance calculation
+values per document to return. By default, it is zero and no feature importance calculation
 occurs.
 
 `analysis`.`regression`.`training_percent`::::

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -906,13 +906,6 @@ total number of categories (in the {version} version of the {stack}, it's two)
 to predict then we will report all category probabilities. Defaults to 2.
 end::num-top-classes[]
 
-tag::num-top-feature-importance-values[]
-Advanced configuration option. If set, feature importance for the top
-most important features will be computed. Importance is calculated
-using the SHAP (SHapley Additive exPlanations) method as described in
-https://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf[Lundberg, S. M., & Lee, S.-I. A Unified Approach to Interpreting Model Predictions. In NeurIPS 2017.].
-end::num-top-feature-importance-values[]
-
 tag::over-field-name[]
 The field used to split the data. In particular, this property is used for 
 analyzing the splits with respect to the history of all splits. It is used for 


### PR DESCRIPTION
This PR clarifies the descriptions for analysis.classification.num_top_feature_importance_values and analysis.regression.num_top_feature_importance_values in the create data frame analytics job API.

Preview: http://elasticsearch_52246.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html