### PR TITLE
Fix IndexShardIT#testMaybeFlush

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -315,11 +315,6 @@ public abstract class TransportWriteAction<
                     maybeFinish();
                 });
             }
-            try {
-                Thread.sleep(5_000);
-            } catch (InterruptedException e) {
-                throw new AssertionError(e);
-            }
             if (sync) {
                 assert pendingOps.get() > 0;
                 indexShard.sync(location, (ex) -> {

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -315,6 +315,11 @@ public abstract class TransportWriteAction<
                     maybeFinish();
                 });
             }
+            try {
+                Thread.sleep(5_000);
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
             if (sync) {
                 assert pendingOps.get() > 0;
                 indexShard.sync(location, (ex) -> {

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -349,8 +349,8 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             assertFalse(shard.shouldPeriodicallyFlush());
             assertThat(shard.flushStats().getPeriodic(), greaterThan(0L));
         });
+        shard.sync();
         assertEquals(0, translog.stats().getUncommittedOperations());
-        translog.sync();
         long size = Math.max(translog.stats().getUncommittedSizeInBytes(), Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1);
         logger.info("--> current translog size: [{}] num_ops [{}] generation [{}]",
             translog.stats().getUncommittedSizeInBytes(), translog.stats().getUncommittedOperations(), translog.getGeneration());
@@ -369,6 +369,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
                 commitStats.getUserData(), flushStats.getPeriodic(), flushStats.getTotal());
             assertFalse(shard.shouldPeriodicallyFlush());
         });
+        shard.sync();
         assertEquals(0, translog.stats().getUncommittedOperations());
     }
 


### PR DESCRIPTION
Since #51905, we use the local checkpoint of the safe commit to calculate the number of uncommitted operations of a translog stats. If a periodic flush triggered by afterWriteOperation completes before we sync translog, then the last commit is not safe. We also need to sync translog from Engine instead of the translog so that we can advance the safe commit.

Relates #51905 
Closes #52223