### PR TITLE
Fix incorrect date nanos docs example

### DIFF
--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -61,7 +61,7 @@ GET my_index/_search
     "my_field" : {
       "script" : {
         "lang" : "painless",
-        "source" : "doc['date'].date.nanos" <6>
+        "source" : "doc['date'].value.nano" <6>
       }
     }
   }


### PR DESCRIPTION
The example of how to access the nano value of a date_nanos field has
been broken since it was created. This commit fixes it to use the
correct scripting methods.

closes #51931