### PR TITLE
Fix single newline in logging output stream buffer

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
@@ -98,6 +98,7 @@ class LoggingOutputStream extends OutputStream {
         }
         if (used == 0) {
             // only windows \r was in the buffer
+            buffer.used = 0;
             return;
         }
         log(new String(buffer.bytes, 0, used, StandardCharsets.UTF_8));

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
@@ -81,6 +81,7 @@ public class LoggingOutputStreamTests extends ESTestCase {
     // this test explicitly outputs the newlines instead of relying on println, to always test the unix behavior
     public void testFlushOnUnixNewline() {
         printStream.print("hello\n");
+        printStream.print("\n"); // newline by itself does not show up
         printStream.print("world\n");
         assertThat(loggingStream.lines, contains("hello", "world"));
     }
@@ -88,6 +89,7 @@ public class LoggingOutputStreamTests extends ESTestCase {
     // this test explicitly outputs the newlines instead of relying on println, to always test the windows behavior
     public void testFlushOnWindowsNewline() {
         printStream.print("hello\r\n");
+        printStream.print("\r\n"); // newline by itself does not show up
         printStream.print("world\r\n");
         assertThat(loggingStream.lines, contains("hello", "world"));
     }
@@ -102,7 +104,6 @@ public class LoggingOutputStreamTests extends ESTestCase {
         assertThat(loggingStream.threadLocal.get().bytes.length, equalTo(DEFAULT_BUFFER_LENGTH));
     }
 
-    @AwaitsFix( bugUrl = "https://github.com/elastic/elasticsearch/issues/51838")
     public void testMaxBuffer() {
         String longStr = randomAlphaOfLength(MAX_BUFFER_LENGTH);
         String extraLongStr = longStr + "OVERFLOW";


### PR DESCRIPTION
The buffer in LoggingOutputStream skips flushing when only a newline
appears. However, if a windows newline appeared, the buffer length was
not reset. This commit resets the length so the \r does not appear in
the next logging message.

closes #51838