### PR TITLE
Percentiles aggregation: disallow specifying same percentile values twice

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -11,6 +11,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 coming[8.0.0]
 
+* <<breaking_80_aggregations_changes>>
 * <<breaking_80_analysis_changes>>
 * <<breaking_80_allocation_changes>>
 * <<breaking_80_breaker_changes>>
@@ -63,6 +64,7 @@ is replaced with a new endpoint that does not contain `_xpack`. As an example,
 
 // end::notable-breaking-changes[]
 
+include::migrate_8_0/aggregations.asciidoc[]
 include::migrate_8_0/analysis.asciidoc[]
 include::migrate_8_0/allocation.asciidoc[]
 include::migrate_8_0/breaker.asciidoc[]

--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -1,0 +1,10 @@
+[float]
+[[breaking_80_aggregations_changes]]
+=== Analysis changes
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -1,10 +1,17 @@
 [float]
 [[breaking_80_aggregations_changes]]
-=== Analysis changes
+=== Aggregations changes
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[discrete]
+[[percentile-duplication]]
+==== Duplicate values no longer supported in percentiles aggregation
+
+If you specify the `percents` parameter with the
+<<search-aggregations-metrics-percentile-aggregation,percentiles aggregation>>,
+its values must be unique. Otherwise, an exception occurs.
 
 // end::notable-breaking-changes[]

--- a/docs/reference/release-notes/8.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-alpha1.asciidoc
@@ -4,5 +4,12 @@
 The changes listed below have been released for the first time in {es}
 8.0.0-alpha1.
 
+[[breaking-8.0.0-alpha1]]
+[float]
+=== Breaking changes
+
+Aggregations::
+* disallow specifying the same percentile multiple times in percentiles aggregation {pull}52257[#52257]
+
 coming[8.0.0]
 

--- a/docs/reference/release-notes/8.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-alpha1.asciidoc
@@ -9,7 +9,6 @@ The changes listed below have been released for the first time in {es}
 === Breaking changes
 
 Aggregations::
-* disallow specifying the same percentile multiple times in percentiles aggregation {pull}52257[#52257]
+* Disallow specifying the same percentile multiple times in percentiles aggregation {pull}52257[#52257]
 
 coming[8.0.0]
-

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
@@ -99,11 +99,17 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
             throw new IllegalArgumentException("[percents] must not be empty: [" + aggName + "]");
         }
         double[] sortedPercents = Arrays.copyOf(percents, percents.length);
+        double previousPercent = -1.0;
         Arrays.sort(sortedPercents);
         for (double percent : sortedPercents) {
             if (percent < 0.0 || percent > 100.0) {
                 throw new IllegalArgumentException("percent must be in [0,100], got [" + percent + "]: [" + aggName + "]");
             }
+
+            if (percent == previousPercent) {
+                throw new IllegalArgumentException("percent [" + percent + "] has been specified twice: [" + name + "]");
+            }
+            previousPercent = percent;
         }
         return sortedPercents;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregationBuilder.java
@@ -107,7 +107,7 @@ public class PercentilesAggregationBuilder extends AbstractPercentilesAggregatio
             }
 
             if (percent == previousPercent) {
-                throw new IllegalArgumentException("percent [" + percent + "] has been specified twice: [" + name + "]");
+                throw new IllegalArgumentException("percent [" + percent + "] has been specified twice: [" + aggName + "]");
             }
             previousPercent = percent;
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -78,6 +78,12 @@ public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggrega
         assertEquals("percent must be in [0,100], got [104.0]: [testAgg]", ex.getMessage());
     }
 
+    public void testDuplicatePercentilesThrows() throws IOException {
+        PercentilesAggregationBuilder builder = new PercentilesAggregationBuilder("testAgg");
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> builder.percentiles(5, 42, 10, 99, 42, 87));
+        assertEquals("percent [42.0] has been specified twice: [testAgg]", ex.getMessage());
+    }
+
     public void testExceptionMultipleMethods() throws IOException {
         final String illegalAgg = "{\n" +
             "       \"percentiles\": {\n" +


### PR DESCRIPTION
disallows specifying same percentile values twice and throws an exception.

Note: As this is a breaking change, it goes only into 8.0
Related: #51871