### PR TITLE
Adapt searchable snapshots code to latest master changes

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotIndexInput.java
@@ -272,7 +272,8 @@ public class SearchableSnapshotIndexInput extends BufferedIndexInput {
                 }
             }
             if ((pos < 0L) || (length < 0L) || (pos + length > data.bytes.length)) {
-                throw new IllegalArgumentException("Invalid arguments (pos=" + pos + ", length=" + length + ") for hash content");
+                throw new IllegalArgumentException("Invalid arguments (pos=" + pos + ", length=" + length
+                    + ") for hash content (length=" + data.bytes.length + ')');
             }
             stream = new ByteArrayInputStream(data.bytes, Math.toIntExact(pos), Math.toIntExact(length));
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotIndexInput.java
@@ -7,11 +7,13 @@ package org.elasticsearch.index.store;
 
 import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
@@ -119,8 +121,7 @@ public class SearchableSnapshotIndexInput extends BufferedIndexInput {
 
         if (optimizedReadSize < length) {
             // we did not read everything in an optimized fashion, so read the remainder directly
-            try (InputStream inputStream
-                     = blobContainer.readBlob(fileInfo.partName(part), pos + optimizedReadSize, length - optimizedReadSize)) {
+            try (InputStream inputStream = openBlobStream(part, pos + optimizedReadSize, length - optimizedReadSize)) {
                 final int directReadSize = inputStream.read(b, offset + optimizedReadSize, length - optimizedReadSize);
                 assert optimizedReadSize + directReadSize == length : optimizedReadSize + " and " + directReadSize + " vs " + length;
                 position += directReadSize;
@@ -192,7 +193,7 @@ public class SearchableSnapshotIndexInput extends BufferedIndexInput {
 
         // if we open a stream of length streamLength then it will not be completely consumed by this read, so it is worthwhile to open
         // it and keep it open for future reads
-        final InputStream inputStream = blobContainer.readBlob(fileInfo.partName(part), pos, streamLength);
+        final InputStream inputStream = openBlobStream(part, pos, streamLength);
         streamForSequentialReads = new StreamForSequentialReads(inputStream, part, pos, streamLength);
 
         final int read = streamForSequentialReads.read(b, offset, length);
@@ -255,6 +256,27 @@ public class SearchableSnapshotIndexInput extends BufferedIndexInput {
             ", length=" + length +
             ", position=" + position +
             '}';
+    }
+
+    private InputStream openBlobStream(int part, long pos, long length) throws IOException {
+        final InputStream stream;
+        if (fileInfo.metadata().hashEqualsContents() == false) {
+            stream = blobContainer.readBlob(fileInfo.partName(part), pos, length);
+        } else {
+            // extract blob content from metadata hash
+            final BytesRef data = fileInfo.metadata().hash();
+            if (part > 0) {
+                assert fileInfo.numberOfParts() >= part;
+                for (int i = 0; i < part; i++) {
+                    pos += fileInfo.partBytes(i);
+                }
+            }
+            if ((pos < 0L) || (length < 0L) || (pos + length > data.bytes.length)) {
+                throw new IllegalArgumentException("Invalid arguments (pos=" + pos + ", length=" + length + ") for hash content");
+            }
+            stream = new ByteArrayInputStream(data.bytes, Math.toIntExact(pos), Math.toIntExact(length));
+        }
+        return stream;
     }
 
     private static class StreamForSequentialReads implements Closeable {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -131,7 +131,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Rep
                                              IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter,
                                              IndexNameExpressionResolver indexNameExpressionResolver,
                                              Supplier<DiscoveryNodes> nodesInCluster) {
-        return List.of(new RestSearchableSnapshotsStatsAction(restController));
+        return List.of(new RestSearchableSnapshotsStatsAction());
     }
 }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/rest/RestSearchableSnapshotsStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/rest/RestSearchableSnapshotsStatsAction.java
@@ -8,17 +8,21 @@ package org.elasticsearch.xpack.searchablesnapshots.rest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsAction;
 import org.elasticsearch.xpack.searchablesnapshots.action.SearchableSnapshotsStatsRequest;
 
+import java.util.List;
+
 public class RestSearchableSnapshotsStatsAction extends BaseRestHandler {
 
-    public RestSearchableSnapshotsStatsAction(final RestController controller) {
-        controller.registerHandler(RestRequest.Method.GET, "/_searchable_snapshots/stats", this);
-        controller.registerHandler(RestRequest.Method.GET, "/{index}/_searchable_snapshots/stats", this);
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(RestRequest.Method.GET, "/_searchable_snapshots/stats"),
+            new Route(RestRequest.Method.GET, "/{index}/_searchable_snapshots/stats")
+        );
     }
 
     @Override


### PR DESCRIPTION
This pull request adapts searchable snapshots to the latest changes from `master`.

The REST handlers declare their routes differently since #51950 and `SearchableSnapshotIndexInput` need to account for segment infos files that are stored in shard snapshot metadata hash and not uploaded to the blob store anymore since #51729.