### PR TITLE
Add cluster:admin/analyze permission to Kibana system role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -113,7 +113,9 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 .put(KibanaUser.ROLE_NAME, new RoleDescriptor(KibanaUser.ROLE_NAME,
                         new String[] {
                             "monitor", "manage_index_templates", MonitoringBulkAction.NAME, "manage_saml", "manage_token", "manage_oidc",
-                            GetBuiltinPrivilegesAction.NAME, "delegate_pki", GetLifecycleAction.NAME,  PutLifecycleAction.NAME
+                            GetBuiltinPrivilegesAction.NAME, "delegate_pki", GetLifecycleAction.NAME,  PutLifecycleAction.NAME,
+                            // The symbolic constant for this one is in SecurityActionMapper, so not accessible from X-Pack core
+                            "cluster:admin/analyze"
                         },
                         new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder()


### PR DESCRIPTION
This is to support the ML categorization wizard.

Currently `cluster:admin/analyze` is only provided with the
`manage` cluster privilege, which is an excessive privilege
level to provide access to this single feature.  It means
that the ML categorization wizard only works for extremely
highly privileged users.

Following this change the Kibana system user will be
permitted to run the `_analyze` endpoint on supplied strings
(not on an index).  The ML UI will then call the `_analyze`
endpoint as the Kibana system user after first checking
that the logged-in user is permitted to create an ML job.
This will mean that users with the more reasonable
`manage_ml` cluster privilege will be permitted to use
the ML categorization wizard.

(This is also consistent with the way the ML UI will access
_all_ Elasticsearch functionality when the "ML in Spaces"
project is completed.)

Closes #51391
Relates elastic/kibana#57375