### PR TITLE
handle endsession endpoints with existing URL parameters

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -374,7 +374,17 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
             final State state = new State();
             final LogoutRequest logoutRequest = new LogoutRequest(opConfiguration.getEndsessionEndpoint(), idTokenHint,
                 rpConfiguration.getPostLogoutRedirectUri(), state);
-            return new OpenIdConnectLogoutResponse(logoutRequest.toURI().toString());
+
+            //#48409: this checks for existence of two `?` in the URL coming from LogoutRequest and changes the second
+            //to an `&`
+            String logoutRequestURI = logoutRequest.toURI().toString();
+            if (logoutRequestURI.indexOf("?") != logoutRequestURI.lastIndexOf("?")) {
+                StringBuilder fixedLogoutRequestURI = new StringBuilder(logoutRequestURI);
+                fixedLogoutRequestURI.setCharAt(logoutRequestURI.lastIndexOf("?"), '&');
+                logoutRequestURI = fixedLogoutRequestURI.toString();
+            }
+
+            return new OpenIdConnectLogoutResponse(logoutRequestURI);
         } else {
             return new OpenIdConnectLogoutResponse((String) null);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -375,8 +375,7 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
             final LogoutRequest logoutRequest = new LogoutRequest(opConfiguration.getEndsessionEndpoint(), idTokenHint,
                 rpConfiguration.getPostLogoutRedirectUri(), state);
 
-            //#48409: this checks for existence of two `?` in the URL coming from LogoutRequest and changes the second
-            //to an `&`
+            //#48409: this checks for existence of two `?` in the URL coming from LogoutRequest and changes the second to an `&`
             String logoutRequestURI = logoutRequest.toURI().toString();
             if (logoutRequestURI.indexOf("?") != logoutRequestURI.lastIndexOf("?")) {
                 StringBuilder fixedLogoutRequestURI = new StringBuilder(logoutRequestURI);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
@@ -259,6 +259,20 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
             containsString("&post_logout_redirect_uri=https%3A%2F%2Frp.elastic.co%2Fsucc_logout&state="));
     }
 
+    public void testBuildLogoutResponseFromEndsessionEndpointWithExistingParameters() throws Exception {
+        final Settings.Builder realmSettingsWithFunkyEndpoint = getBasicRealmSettings();
+        realmSettingsWithFunkyEndpoint.put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ENDSESSION_ENDPOINT), "https://op.example.org/logout?parameter=123");
+        final OpenIdConnectRealm realm = new OpenIdConnectRealm(buildConfig(realmSettingsWithFunkyEndpoint.build(), threadContext), null,
+            null);
+
+        // Random strings, as we will not validate the token here
+        final JWT idToken = generateIdToken(randomAlphaOfLength(8), randomAlphaOfLength(8), randomAlphaOfLength(8));
+        final OpenIdConnectLogoutResponse logoutResponse = realm.buildLogoutResponse(idToken);
+        assertThat(logoutResponse.getEndSessionUrl(), containsString("https://op.example.org/logout?parameter=123&id_token_hint="));
+        assertThat(logoutResponse.getEndSessionUrl(),
+            containsString("&post_logout_redirect_uri=https%3A%2F%2Frp.elastic.co%2Fsucc_logout&state="));
+    }
+
     public void testBuildingAuthenticationRequestWithExistingStateAndNonce() {
         final Settings.Builder settingsBuilder = Settings.builder()
             .put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_AUTHORIZATION_ENDPOINT), "https://op.example.com/login")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
@@ -261,7 +261,8 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
 
     public void testBuildLogoutResponseFromEndsessionEndpointWithExistingParameters() throws Exception {
         final Settings.Builder realmSettingsWithFunkyEndpoint = getBasicRealmSettings();
-        realmSettingsWithFunkyEndpoint.put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ENDSESSION_ENDPOINT), "https://op.example.org/logout?parameter=123");
+        realmSettingsWithFunkyEndpoint.put(getFullSettingKey(REALM_NAME, OpenIdConnectRealmSettings.OP_ENDSESSION_ENDPOINT),
+            "https://op.example.org/logout?parameter=123");
         final OpenIdConnectRealm realm = new OpenIdConnectRealm(buildConfig(realmSettingsWithFunkyEndpoint.build(), threadContext), null,
             null);
 


### PR DESCRIPTION
addresses https://github.com/elastic/elasticsearch/issues/48409

This PR adds a check and handling logic for endsession endpoints that have existing URL parameters, as well as a test case.

If/when the underlying OIDC library, oauth2-oidc-sdk, changes its behavior, this check and test can be removed. There is an [open issue](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/issues/285/logoutrequest-creates-invalid-uris-when). 

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
N/A
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
Yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
Yes
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
Yes
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
Yes
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
