### PR TITLE
SQL: Allow intervals to be passed as request parameters

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/Interval.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/Interval.java
@@ -26,7 +26,8 @@ import java.util.Objects;
  * Unfortunately because the SQL interval type is not preserved accurately by the JDK TemporalAmount class
  * in both cases, the data type needs to be carried around as it cannot be inferred.
  */
-public abstract class Interval<I extends TemporalAmount> implements ConstantNamedWriteable, ToXContentObject, IntervalScripting {
+public abstract class Interval<I extends TemporalAmount> implements ConstantNamedWriteable, ToXContentObject, IntervalScripting,
+        Comparable<Interval<I>> {
 
     private final I interval;
     private final DataType intervalType;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/IntervalDayTime.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/IntervalDayTime.java
@@ -33,6 +33,15 @@ public class IntervalDayTime extends Interval<Duration> {
         super(duration(in), SqlDataTypes.fromTypeName(in.readString()));
     }
 
+    public static IntervalDayTime from(String value, DataType intervalType) {
+        return new IntervalDayTime(Duration.parse(value), intervalType);
+    }
+
+    @Override
+    public int compareTo(Interval<Duration> o) {
+        return interval().compareTo(o.interval());
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(interval().getSeconds());

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/IntervalYearMonth.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/IntervalYearMonth.java
@@ -34,6 +34,15 @@ public class IntervalYearMonth extends Interval<Period> {
         super(period(in), SqlDataTypes.fromTypeName(in.readString()));
     }
 
+    public static IntervalYearMonth from(String value, DataType intervalType) {
+        return new IntervalYearMonth(Period.parse(value), intervalType);
+    }
+
+    @Override
+    public int compareTo(Interval<Period> o) {
+        return Long.valueOf(interval().toTotalMonths()).compareTo(o.interval().toTotalMonths());
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         Period p = interval();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/Intervals.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/literal/interval/Intervals.java
@@ -97,6 +97,16 @@ public final class Intervals {
         }
     }
 
+    public static Interval<?> from(String isoValue, DataType dataType) {
+        if (isYearMonthInterval(dataType)) {
+            return IntervalYearMonth.from(isoValue, dataType);
+        }
+        if (isDayTimeInterval(dataType)) {
+            return IntervalDayTime.from(isoValue, dataType);
+        }
+        return null;
+    }
+
     public static DataType intervalType(Source source, TimeUnit leading, TimeUnit trailing) {
         if (trailing == null) {
             switch (leading) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -724,10 +724,8 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
             Object literalValue;
             // The interval types are handled "directly", as they must not be exposed through the SQL types converter, which would then in
             // turn expose the "protocol" interval types (i.e. "interval_year" & co.) to, for instance, SQL scalars (like CAST) a.s.o.
-            if (SqlDataTypes.isYearMonthInterval(dataType)) {
-                literalValue = IntervalYearMonth.from(param.value.toString(), dataType);
-            } else if (SqlDataTypes.isDayTimeInterval(dataType)) {
-                literalValue = IntervalDayTime.from(param.value.toString(), dataType);
+            if (SqlDataTypes.isInterval(dataType)) {
+                literalValue = Intervals.from(param.value.toString(), dataType);
             } else if (canConvert(sourceType, dataType)) {
                 literalValue = converterFor(sourceType, dataType).convert(param.value);
             } else {


### PR DESCRIPTION
This PR adds the possibility for intervals to be passed as request
parameters. This functionality is only strictly required by the drivers.

The PR also changes the way the protocol tests are executed,
allowing to check not only that values of the SQL type are correctly
returned, but also that parameters of those types are correctly received
by the server.

Closes #45915