### PR TITLE
SQL: supplement input checks on received request parameters (#52229)

### DIFF
--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
@@ -39,4 +39,20 @@ public class RestSqlIT extends RestSqlTestCase {
             containsString("Cannot generate a query DSL for a special SQL command " +
                 "(e.g.: DESCRIBE, SHOW), sql statement: [SHOW FUNCTIONS]"));
     }
+
+    public void testErrorMessageForInvalidParamDataType() throws IOException {
+        expectBadRequest(() -> runTranslateSql(
+            "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"invalid\", \"value\":\"irrelevant\"}]}"
+            ),
+            containsString("Invalid parameter data type [invalid]")
+        );
+    }
+
+    public void testErrorMessageForInvalidParamSpec() throws IOException {
+        expectBadRequest(() -> runTranslateSql(
+            "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"SHAPE\", \"value\":false}]}"
+            ),
+            containsString("Cannot cast value [false] of type [BOOLEAN] to parameter type [SHAPE]")
+        );
+    }
 }

--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
@@ -44,7 +44,7 @@ public class RestSqlIT extends RestSqlTestCase {
         expectBadRequest(() -> runTranslateSql(
             "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"invalid\", \"value\":\"irrelevant\"}]}"
             ),
-            containsString("Invalid parameter data type [invalid]")
+            containsString("Cannot cast value [irrelevant] of type [KEYWORD] to parameter type [UNSUPPORTED]")
         );
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -128,8 +128,8 @@ import java.util.StringJoiner;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.canConvert;
-import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.converterFor;
+import static org.elasticsearch.xpack.sql.type.DataTypeConversion.canConvert;
+import static org.elasticsearch.xpack.sql.type.DataTypeConversion.conversionFor;
 import static org.elasticsearch.xpack.sql.util.DateUtils.asDateOnly;
 import static org.elasticsearch.xpack.sql.util.DateUtils.asTimeOnly;
 import static org.elasticsearch.xpack.sql.util.DateUtils.ofEscapedLiteral;
@@ -700,9 +700,6 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         SqlTypedParamValue param = param(ctx.PARAM());
         DataType dataType = DataType.fromTypeName(param.type);
         Source source = source(ctx);
-        if (dataType == null) {
-            throw new ParsingException(source, "Invalid parameter data type [{}]", param.type);
-        }
         if (param.value == null) {
             // no conversion is required for null values
             return new Literal(source, null, dataType);
@@ -724,8 +721,8 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
                 throw new ParsingException(source, "Cannot cast value [{}] of type [{}] to parameter type [{}]", param.value, sourceType,
                     dataType);
             }
-            return new Literal(source, converterFor(sourceType, dataType).convert(param.value), dataType);
-        } catch (QlIllegalArgumentException ex) {
+            return new Literal(source, conversionFor(sourceType, dataType).convert(param.value), dataType);
+        } catch (SqlIllegalArgumentException ex) {
             throw new ParsingException(ex, source, "Unexpected actual parameter type [{}] for type [{}]", sourceType, param.type);
         }
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/parser/ExpressionBuilder.java
@@ -128,7 +128,8 @@ import java.util.StringJoiner;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.xpack.sql.type.DataTypeConversion.conversionFor;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.canConvert;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypeConverter.converterFor;
 import static org.elasticsearch.xpack.sql.util.DateUtils.asDateOnly;
 import static org.elasticsearch.xpack.sql.util.DateUtils.asTimeOnly;
 import static org.elasticsearch.xpack.sql.util.DateUtils.ofEscapedLiteral;
@@ -699,6 +700,9 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         SqlTypedParamValue param = param(ctx.PARAM());
         DataType dataType = DataType.fromTypeName(param.type);
         Source source = source(ctx);
+        if (dataType == null) {
+            throw new ParsingException(source, "Invalid parameter data type [{}]", param.type);
+        }
         if (param.value == null) {
             // no conversion is required for null values
             return new Literal(source, null, dataType);
@@ -716,8 +720,12 @@ abstract class ExpressionBuilder extends IdentifierBuilder {
         }
         // otherwise we need to make sure that xcontent-serialized value is converted to the correct type
         try {
-            return new Literal(source, conversionFor(sourceType, dataType).convert(param.value), dataType);
-        } catch (SqlIllegalArgumentException ex) {
+            if (canConvert(sourceType, dataType) == false) {
+                throw new ParsingException(source, "Cannot cast value [{}] of type [{}] to parameter type [{}]", param.value, sourceType,
+                    dataType);
+            }
+            return new Literal(source, converterFor(sourceType, dataType).convert(param.value), dataType);
+        } catch (QlIllegalArgumentException ex) {
             throw new ParsingException(ex, source, "Unexpected actual parameter type [{}] for type [{}]", sourceType, param.type);
         }
     }


### PR DESCRIPTION
* Add more checks around parameter conversions

This commit adds two necessary verifications on received parameters:
- it checks the validity of the parameter's data type: if the declared
data type is resolved to an ES or Java type;
- it checks if the returned converter is non-null (i.e. a conversion is
possible) and generates an appropriate exception otherwise.

(cherry picked from commit eda30ac9c69383165324328c599ace39ac064342)
