### PR TITLE
SQL: supplement input checks on received request parameters (#52229)

### DIFF
--- a/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
+++ b/x-pack/plugin/sql/qa/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/RestSqlIT.java
@@ -39,4 +39,20 @@ public class RestSqlIT extends RestSqlTestCase {
             containsString("Cannot generate a query DSL for a special SQL command " +
                 "(e.g.: DESCRIBE, SHOW), sql statement: [SHOW FUNCTIONS]"));
     }
+
+    public void testErrorMessageForInvalidParamDataType() throws IOException {
+        expectBadRequest(() -> runTranslateSql(
+            "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"invalid\", \"value\":\"irrelevant\"}]}"
+            ),
+            containsString("Invalid parameter data type [invalid]")
+        );
+    }
+
+    public void testErrorMessageForInvalidParamSpec() throws IOException {
+        expectBadRequest(() -> runTranslateSql(
+            "{\"query\":\"SELECT null WHERE 0 = ? \", \"mode\": \"odbc\", \"params\":[{\"type\":\"SHAPE\", \"value\":false}]}"
+            ),
+            containsString("Cannot cast value [false] of type [BOOLEAN] to parameter type [SHAPE]")
+        );
+    }
 }


### PR DESCRIPTION
* Add more checks around parameter conversions

This commit adds two necessary verifications on received parameters:
- it checks the validity of the parameter's data type: if the declared
data type is resolved to an ES or Java type;
- it checks if the returned converter is non-null (i.e. a conversion is
possible) and generates an appropriate exception otherwise.

(cherry picked from commit eda30ac9c69383165324328c599ace39ac064342)
