### PR TITLE
Update skip after backport

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/280_rare_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/280_rare_terms.yml
@@ -316,8 +316,8 @@ setup:
 ---
 "sub aggs":
   - skip:
-      version: " - 7.99.99"
-      reason: Sub aggs fixed in 8.0 (to be backported to 7.6.1)
+      version: " - 7.6.1"
+      reason: Sub aggs fixed in 7.6.1
 
   - do:
       index:


### PR DESCRIPTION
Now that #51868 is fully backported we can run its tests in the
backwards compatibility tests.
