### PR TITLE
Capture stderr/stdout for closing before configuring logging

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -246,21 +246,10 @@ public class LogConfigurator {
         }
 
         // Redirect stdout/stderr to log4j. While we ensure Elasticsearch code does not write to those streams,
-        // third party libraries may do that
-        closeSysOut();
+        // third party libraries may do that. Note that we do NOT close the streams because other code may have
+        // grabbed a handle to the streams and intend to write to it, eg log4j for writing to the console
         System.setOut(new PrintStream(new LoggingOutputStream(LogManager.getLogger("stdout"), Level.INFO), false, StandardCharsets.UTF_8));
-        closeSysError();
         System.setErr(new PrintStream(new LoggingOutputStream(LogManager.getLogger("stderr"), Level.WARN), false, StandardCharsets.UTF_8));
-    }
-
-    @SuppressForbidden(reason = "System#out")
-    private static void closeSysOut() {
-        System.out.close();
-    }
-
-    @SuppressForbidden(reason = "System#err")
-    private static void closeSysError() {
-        System.err.close();
     }
 
     private static void configureStatusLogger() {

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -247,8 +247,20 @@ public class LogConfigurator {
 
         // Redirect stdout/stderr to log4j. While we ensure Elasticsearch code does not write to those streams,
         // third party libraries may do that
+        closeSysOut();
         System.setOut(new PrintStream(new LoggingOutputStream(LogManager.getLogger("stdout"), Level.INFO), false, StandardCharsets.UTF_8));
+        closeSysError();
         System.setErr(new PrintStream(new LoggingOutputStream(LogManager.getLogger("stderr"), Level.WARN), false, StandardCharsets.UTF_8));
+    }
+
+    @SuppressForbidden(reason = "System#out")
+    private static void closeSysOut() {
+        System.out.close();
+    }
+
+    @SuppressForbidden(reason = "System#err")
+    private static void closeSysError() {
+        System.err.close();
     }
 
     private static void configureStatusLogger() {


### PR DESCRIPTION
We replace the System.out and System.err objects with redirects to our
log file, but never ensure they are closed. This commit captures references to stderr and stdout before we configure logging, so that they may be closed when appropriate.