### PR TITLE
EQL: Make 'where' optional

### DIFF
--- a/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
+++ b/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
@@ -63,7 +63,7 @@ subquery
     ;
 
 eventQuery
-    : event=identifier WHERE expression
+    : (event=identifier WHERE)? expression
     ;
 
 expression

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
@@ -312,7 +312,17 @@ class EqlBaseParser extends Parser {
         join();
         }
         break;
+      case FALSE:
+      case NOT:
+      case NULL:
+      case TRUE:
+      case PLUS:
+      case MINUS:
+      case LP:
       case ESCAPED_IDENTIFIER:
+      case STRING:
+      case INTEGER_VALUE:
+      case DECIMAL_VALUE:
       case IDENTIFIER:
         enterOuterAlt(_localctx, 3);
         {
@@ -947,10 +957,10 @@ class EqlBaseParser extends Parser {
 
   public static class EventQueryContext extends ParserRuleContext {
     public IdentifierContext event;
-    public TerminalNode WHERE() { return getToken(EqlBaseParser.WHERE, 0); }
     public ExpressionContext expression() {
       return getRuleContext(ExpressionContext.class,0);
     }
+    public TerminalNode WHERE() { return getToken(EqlBaseParser.WHERE, 0); }
     public IdentifierContext identifier() {
       return getRuleContext(IdentifierContext.class,0);
     }
@@ -979,11 +989,19 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(152);
-      ((EventQueryContext)_localctx).event = identifier();
-      setState(153);
-      match(WHERE);
-      setState(154);
+      setState(155);
+      _errHandler.sync(this);
+      switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
+      case 1:
+        {
+        setState(152);
+        ((EventQueryContext)_localctx).event = identifier();
+        setState(153);
+        match(WHERE);
+        }
+        break;
+      }
+      setState(157);
       expression();
       }
     }
@@ -1027,7 +1045,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(156);
+      setState(159);
       booleanExpression(0);
       }
     }
@@ -1157,18 +1175,18 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(165);
+      setState(168);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,17,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
       case 1:
         {
         _localctx = new LogicalNotContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(159);
+        setState(162);
         match(NOT);
-        setState(160);
+        setState(163);
         booleanExpression(5);
         }
         break;
@@ -1177,11 +1195,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ProcessCheckContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(161);
+        setState(164);
         ((ProcessCheckContext)_localctx).relationship = match(IDENTIFIER);
-        setState(162);
+        setState(165);
         match(OF);
-        setState(163);
+        setState(166);
         subquery();
         }
         break;
@@ -1190,33 +1208,33 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanDefaultContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(164);
+        setState(167);
         valueExpression(0);
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(175);
+      setState(178);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,19,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,20,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(173);
+          setState(176);
           _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,18,_ctx) ) {
+          switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
           case 1:
             {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(167);
+            setState(170);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(168);
+            setState(171);
             ((LogicalBinaryContext)_localctx).operator = match(AND);
-            setState(169);
+            setState(172);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(3);
             }
             break;
@@ -1225,20 +1243,20 @@ class EqlBaseParser extends Parser {
             _localctx = new LogicalBinaryContext(new BooleanExpressionContext(_parentctx, _parentState));
             ((LogicalBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_booleanExpression);
-            setState(170);
+            setState(173);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(171);
+            setState(174);
             ((LogicalBinaryContext)_localctx).operator = match(OR);
-            setState(172);
+            setState(175);
             ((LogicalBinaryContext)_localctx).right = booleanExpression(2);
             }
             break;
           }
           } 
         }
-        setState(177);
+        setState(180);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,19,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,20,_ctx);
       }
       }
     }
@@ -1382,7 +1400,7 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(185);
+      setState(188);
       switch (_input.LA(1)) {
       case FALSE:
       case NULL:
@@ -1398,14 +1416,14 @@ class EqlBaseParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(179);
+        setState(182);
         primaryExpression();
-        setState(181);
+        setState(184);
         _errHandler.sync(this);
-        switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
+        switch ( getInterpreter().adaptivePredict(_input,21,_ctx) ) {
         case 1:
           {
-          setState(180);
+          setState(183);
           predicate();
           }
           break;
@@ -1418,7 +1436,7 @@ class EqlBaseParser extends Parser {
         _localctx = new ArithmeticUnaryContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(183);
+        setState(186);
         ((ArithmeticUnaryContext)_localctx).operator = _input.LT(1);
         _la = _input.LA(1);
         if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1426,7 +1444,7 @@ class EqlBaseParser extends Parser {
         } else {
           consume();
         }
-        setState(184);
+        setState(187);
         valueExpression(4);
         }
         break;
@@ -1434,25 +1452,25 @@ class EqlBaseParser extends Parser {
         throw new NoViableAltException(this);
       }
       _ctx.stop = _input.LT(-1);
-      setState(199);
+      setState(202);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(197);
+          setState(200);
           _errHandler.sync(this);
-          switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
+          switch ( getInterpreter().adaptivePredict(_input,23,_ctx) ) {
           case 1:
             {
             _localctx = new ArithmeticBinaryContext(new ValueExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_valueExpression);
-            setState(187);
+            setState(190);
             if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-            setState(188);
+            setState(191);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ASTERISK) | (1L << SLASH) | (1L << PERCENT))) != 0)) ) {
@@ -1460,7 +1478,7 @@ class EqlBaseParser extends Parser {
             } else {
               consume();
             }
-            setState(189);
+            setState(192);
             ((ArithmeticBinaryContext)_localctx).right = valueExpression(4);
             }
             break;
@@ -1469,9 +1487,9 @@ class EqlBaseParser extends Parser {
             _localctx = new ArithmeticBinaryContext(new ValueExpressionContext(_parentctx, _parentState));
             ((ArithmeticBinaryContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_valueExpression);
-            setState(190);
+            setState(193);
             if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(191);
+            setState(194);
             ((ArithmeticBinaryContext)_localctx).operator = _input.LT(1);
             _la = _input.LA(1);
             if ( !(_la==PLUS || _la==MINUS) ) {
@@ -1479,7 +1497,7 @@ class EqlBaseParser extends Parser {
             } else {
               consume();
             }
-            setState(192);
+            setState(195);
             ((ArithmeticBinaryContext)_localctx).right = valueExpression(3);
             }
             break;
@@ -1488,20 +1506,20 @@ class EqlBaseParser extends Parser {
             _localctx = new ComparisonContext(new ValueExpressionContext(_parentctx, _parentState));
             ((ComparisonContext)_localctx).left = _prevctx;
             pushNewRecursionContext(_localctx, _startState, RULE_valueExpression);
-            setState(193);
+            setState(196);
             if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-            setState(194);
+            setState(197);
             comparisonOperator();
-            setState(195);
+            setState(198);
             ((ComparisonContext)_localctx).right = valueExpression(2);
             }
             break;
           }
           } 
         }
-        setState(201);
+        setState(204);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,24,_ctx);
       }
       }
     }
@@ -1558,38 +1576,38 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(203);
+      setState(206);
       _la = _input.LA(1);
       if (_la==NOT) {
         {
-        setState(202);
+        setState(205);
         match(NOT);
         }
       }
 
-      setState(205);
+      setState(208);
       ((PredicateContext)_localctx).kind = match(IN);
-      setState(206);
+      setState(209);
       match(LP);
-      setState(207);
+      setState(210);
       expression();
-      setState(212);
+      setState(215);
       _errHandler.sync(this);
       _la = _input.LA(1);
       while (_la==COMMA) {
         {
         {
-        setState(208);
+        setState(211);
         match(COMMA);
-        setState(209);
+        setState(212);
         expression();
         }
         }
-        setState(214);
+        setState(217);
         _errHandler.sync(this);
         _la = _input.LA(1);
       }
-      setState(215);
+      setState(218);
       match(RP);
       }
     }
@@ -1698,14 +1716,14 @@ class EqlBaseParser extends Parser {
     PrimaryExpressionContext _localctx = new PrimaryExpressionContext(_ctx, getState());
     enterRule(_localctx, 34, RULE_primaryExpression);
     try {
-      setState(224);
+      setState(227);
       _errHandler.sync(this);
-      switch ( getInterpreter().adaptivePredict(_input,26,_ctx) ) {
+      switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
       case 1:
         _localctx = new ConstantDefaultContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(217);
+        setState(220);
         constant();
         }
         break;
@@ -1713,7 +1731,7 @@ class EqlBaseParser extends Parser {
         _localctx = new FunctionContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(218);
+        setState(221);
         functionExpression();
         }
         break;
@@ -1721,7 +1739,7 @@ class EqlBaseParser extends Parser {
         _localctx = new DereferenceContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(219);
+        setState(222);
         qualifiedName();
         }
         break;
@@ -1729,11 +1747,11 @@ class EqlBaseParser extends Parser {
         _localctx = new ParenthesizedExpressionContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(220);
+        setState(223);
         match(LP);
-        setState(221);
+        setState(224);
         expression();
-        setState(222);
+        setState(225);
         match(RP);
         }
         break;
@@ -1791,36 +1809,36 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(226);
+      setState(229);
       ((FunctionExpressionContext)_localctx).name = match(IDENTIFIER);
-      setState(227);
+      setState(230);
       match(LP);
-      setState(236);
+      setState(239);
       _la = _input.LA(1);
       if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << FALSE) | (1L << NOT) | (1L << NULL) | (1L << TRUE) | (1L << PLUS) | (1L << MINUS) | (1L << LP) | (1L << ESCAPED_IDENTIFIER) | (1L << STRING) | (1L << INTEGER_VALUE) | (1L << DECIMAL_VALUE) | (1L << IDENTIFIER))) != 0)) {
         {
-        setState(228);
+        setState(231);
         expression();
-        setState(233);
+        setState(236);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(229);
+          setState(232);
           match(COMMA);
-          setState(230);
+          setState(233);
           expression();
           }
           }
-          setState(235);
+          setState(238);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
       }
 
-      setState(238);
+      setState(241);
       match(RP);
       }
     }
@@ -1925,13 +1943,13 @@ class EqlBaseParser extends Parser {
     ConstantContext _localctx = new ConstantContext(_ctx, getState());
     enterRule(_localctx, 38, RULE_constant);
     try {
-      setState(244);
+      setState(247);
       switch (_input.LA(1)) {
       case NULL:
         _localctx = new NullLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(240);
+        setState(243);
         match(NULL);
         }
         break;
@@ -1940,7 +1958,7 @@ class EqlBaseParser extends Parser {
         _localctx = new NumericLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(241);
+        setState(244);
         number();
         }
         break;
@@ -1949,7 +1967,7 @@ class EqlBaseParser extends Parser {
         _localctx = new BooleanLiteralContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(242);
+        setState(245);
         booleanValue();
         }
         break;
@@ -1957,7 +1975,7 @@ class EqlBaseParser extends Parser {
         _localctx = new StringLiteralContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(243);
+        setState(246);
         string();
         }
         break;
@@ -2009,7 +2027,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(246);
+      setState(249);
       _la = _input.LA(1);
       if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << NEQ) | (1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
       _errHandler.recoverInline(this);
@@ -2058,7 +2076,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(248);
+      setState(251);
       _la = _input.LA(1);
       if ( !(_la==FALSE || _la==TRUE) ) {
       _errHandler.recoverInline(this);
@@ -2128,43 +2146,43 @@ class EqlBaseParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(250);
+      setState(253);
       identifier();
-      setState(262);
+      setState(265);
       _errHandler.sync(this);
-      _alt = getInterpreter().adaptivePredict(_input,32,_ctx);
+      _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
-          setState(260);
+          setState(263);
           switch (_input.LA(1)) {
           case DOT:
             {
-            setState(251);
+            setState(254);
             match(DOT);
-            setState(252);
+            setState(255);
             identifier();
             }
             break;
           case LB:
             {
-            setState(253);
+            setState(256);
             match(LB);
-            setState(255); 
+            setState(258); 
             _errHandler.sync(this);
             _la = _input.LA(1);
             do {
               {
               {
-              setState(254);
+              setState(257);
               match(INTEGER_VALUE);
               }
               }
-              setState(257); 
+              setState(260); 
               _errHandler.sync(this);
               _la = _input.LA(1);
             } while ( _la==INTEGER_VALUE );
-            setState(259);
+            setState(262);
             match(RB);
             }
             break;
@@ -2173,9 +2191,9 @@ class EqlBaseParser extends Parser {
           }
           } 
         }
-        setState(264);
+        setState(267);
         _errHandler.sync(this);
-        _alt = getInterpreter().adaptivePredict(_input,32,_ctx);
+        _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
       }
       }
     }
@@ -2219,7 +2237,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(265);
+      setState(268);
       _la = _input.LA(1);
       if ( !(_la==ESCAPED_IDENTIFIER || _la==IDENTIFIER) ) {
       _errHandler.recoverInline(this);
@@ -2271,13 +2289,13 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(267);
+      setState(270);
       number();
-      setState(269);
+      setState(272);
       _la = _input.LA(1);
       if (_la==IDENTIFIER) {
         {
-        setState(268);
+        setState(271);
         ((TimeUnitContext)_localctx).unit = match(IDENTIFIER);
         }
       }
@@ -2345,13 +2363,13 @@ class EqlBaseParser extends Parser {
     NumberContext _localctx = new NumberContext(_ctx, getState());
     enterRule(_localctx, 50, RULE_number);
     try {
-      setState(273);
+      setState(276);
       switch (_input.LA(1)) {
       case DECIMAL_VALUE:
         _localctx = new DecimalLiteralContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(271);
+        setState(274);
         match(DECIMAL_VALUE);
         }
         break;
@@ -2359,7 +2377,7 @@ class EqlBaseParser extends Parser {
         _localctx = new IntegerLiteralContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(272);
+        setState(275);
         match(INTEGER_VALUE);
         }
         break;
@@ -2405,7 +2423,7 @@ class EqlBaseParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(275);
+      setState(278);
       match(STRING);
       }
     }
@@ -2451,7 +2469,7 @@ class EqlBaseParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3,\u0118\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3,\u011b\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -2462,90 +2480,92 @@ class EqlBaseParser extends Parser {
     "\3\t\3\t\3\t\3\t\3\t\7\tx\n\t\f\t\16\t{\13\t\5\t}\n\t\3\n\3\n\3\n\3\n"+
     "\7\n\u0083\n\n\f\n\16\n\u0086\13\n\3\13\3\13\5\13\u008a\n\13\3\f\3\f\3"+
     "\f\3\f\5\f\u0090\n\f\5\f\u0092\n\f\3\f\5\f\u0095\n\f\3\r\3\r\3\r\3\r\3"+
-    "\16\3\16\3\16\3\16\3\17\3\17\3\20\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u00a8"+
-    "\n\20\3\20\3\20\3\20\3\20\3\20\3\20\7\20\u00b0\n\20\f\20\16\20\u00b3\13"+
-    "\20\3\21\3\21\3\21\5\21\u00b8\n\21\3\21\3\21\5\21\u00bc\n\21\3\21\3\21"+
-    "\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\7\21\u00c8\n\21\f\21\16\21\u00cb"+
-    "\13\21\3\22\5\22\u00ce\n\22\3\22\3\22\3\22\3\22\3\22\7\22\u00d5\n\22\f"+
-    "\22\16\22\u00d8\13\22\3\22\3\22\3\23\3\23\3\23\3\23\3\23\3\23\3\23\5\23"+
-    "\u00e3\n\23\3\24\3\24\3\24\3\24\3\24\7\24\u00ea\n\24\f\24\16\24\u00ed"+
-    "\13\24\5\24\u00ef\n\24\3\24\3\24\3\25\3\25\3\25\3\25\5\25\u00f7\n\25\3"+
-    "\26\3\26\3\27\3\27\3\30\3\30\3\30\3\30\3\30\6\30\u0102\n\30\r\30\16\30"+
-    "\u0103\3\30\7\30\u0107\n\30\f\30\16\30\u010a\13\30\3\31\3\31\3\32\3\32"+
-    "\5\32\u0110\n\32\3\33\3\33\5\33\u0114\n\33\3\34\3\34\3\34\2\4\36 \35\2"+
-    "\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\66\2\7\3\2\31"+
-    "\32\3\2\33\35\3\2\23\30\4\2\5\5\17\17\4\2%%))\u0127\28\3\2\2\2\4;\3\2"+
-    "\2\2\6>\3\2\2\2\bH\3\2\2\2\nJ\3\2\2\2\fO\3\2\2\2\16d\3\2\2\2\20r\3\2\2"+
-    "\2\22~\3\2\2\2\24\u0087\3\2\2\2\26\u008b\3\2\2\2\30\u0096\3\2\2\2\32\u009a"+
-    "\3\2\2\2\34\u009e\3\2\2\2\36\u00a7\3\2\2\2 \u00bb\3\2\2\2\"\u00cd\3\2"+
-    "\2\2$\u00e2\3\2\2\2&\u00e4\3\2\2\2(\u00f6\3\2\2\2*\u00f8\3\2\2\2,\u00fa"+
-    "\3\2\2\2.\u00fc\3\2\2\2\60\u010b\3\2\2\2\62\u010d\3\2\2\2\64\u0113\3\2"+
-    "\2\2\66\u0115\3\2\2\289\5\6\4\29:\7\2\2\3:\3\3\2\2\2;<\5\34\17\2<=\7\2"+
-    "\2\3=\5\3\2\2\2>B\5\b\5\2?A\5\20\t\2@?\3\2\2\2AD\3\2\2\2B@\3\2\2\2BC\3"+
-    "\2\2\2C\7\3\2\2\2DB\3\2\2\2EI\5\f\7\2FI\5\16\b\2GI\5\32\16\2HE\3\2\2\2"+
-    "HF\3\2\2\2HG\3\2\2\2I\t\3\2\2\2JK\7\22\2\2KL\7\t\2\2LM\7\23\2\2MN\5\62"+
-    "\32\2N\13\3\2\2\2OX\7\16\2\2PR\5\22\n\2QS\5\n\6\2RQ\3\2\2\2RS\3\2\2\2"+
-    "SY\3\2\2\2TV\5\n\6\2UW\5\22\n\2VU\3\2\2\2VW\3\2\2\2WY\3\2\2\2XP\3\2\2"+
-    "\2XT\3\2\2\2XY\3\2\2\2YZ\3\2\2\2Z\\\5\26\f\2[]\5\26\f\2\\[\3\2\2\2]^\3"+
-    "\2\2\2^\\\3\2\2\2^_\3\2\2\2_b\3\2\2\2`a\7\20\2\2ac\5\26\f\2b`\3\2\2\2"+
-    "bc\3\2\2\2c\r\3\2\2\2df\7\b\2\2eg\5\22\n\2fe\3\2\2\2fg\3\2\2\2gh\3\2\2"+
-    "\2hj\5\24\13\2ik\5\24\13\2ji\3\2\2\2kl\3\2\2\2lj\3\2\2\2lm\3\2\2\2mp\3"+
-    "\2\2\2no\7\20\2\2oq\5\24\13\2pn\3\2\2\2pq\3\2\2\2q\17\3\2\2\2rs\7$\2\2"+
-    "s|\7)\2\2ty\5\36\20\2uv\7\37\2\2vx\5\36\20\2wu\3\2\2\2x{\3\2\2\2yw\3\2"+
-    "\2\2yz\3\2\2\2z}\3\2\2\2{y\3\2\2\2|t\3\2\2\2|}\3\2\2\2}\21\3\2\2\2~\177"+
-    "\7\4\2\2\177\u0084\5\34\17\2\u0080\u0081\7\37\2\2\u0081\u0083\5\34\17"+
-    "\2\u0082\u0080\3\2\2\2\u0083\u0086\3\2\2\2\u0084\u0082\3\2\2\2\u0084\u0085"+
-    "\3\2\2\2\u0085\23\3\2\2\2\u0086\u0084\3\2\2\2\u0087\u0089\5\30\r\2\u0088"+
-    "\u008a\5\22\n\2\u0089\u0088\3\2\2\2\u0089\u008a\3\2\2\2\u008a\25\3\2\2"+
-    "\2\u008b\u0091\5\30\r\2\u008c\u008f\7\6\2\2\u008d\u008e\7\23\2\2\u008e"+
-    "\u0090\5,\27\2\u008f\u008d\3\2\2\2\u008f\u0090\3\2\2\2\u0090\u0092\3\2"+
-    "\2\2\u0091\u008c\3\2\2\2\u0091\u0092\3\2\2\2\u0092\u0094\3\2\2\2\u0093"+
-    "\u0095\5\22\n\2\u0094\u0093\3\2\2\2\u0094\u0095\3\2\2\2\u0095\27\3\2\2"+
-    "\2\u0096\u0097\7 \2\2\u0097\u0098\5\32\16\2\u0098\u0099\7!\2\2\u0099\31"+
-    "\3\2\2\2\u009a\u009b\5\60\31\2\u009b\u009c\7\21\2\2\u009c\u009d\5\34\17"+
-    "\2\u009d\33\3\2\2\2\u009e\u009f\5\36\20\2\u009f\35\3\2\2\2\u00a0\u00a1"+
-    "\b\20\1\2\u00a1\u00a2\7\n\2\2\u00a2\u00a8\5\36\20\7\u00a3\u00a4\7)\2\2"+
-    "\u00a4\u00a5\7\f\2\2\u00a5\u00a8\5\30\r\2\u00a6\u00a8\5 \21\2\u00a7\u00a0"+
-    "\3\2\2\2\u00a7\u00a3\3\2\2\2\u00a7\u00a6\3\2\2\2\u00a8\u00b1\3\2\2\2\u00a9"+
-    "\u00aa\f\4\2\2\u00aa\u00ab\7\3\2\2\u00ab\u00b0\5\36\20\5\u00ac\u00ad\f"+
-    "\3\2\2\u00ad\u00ae\7\r\2\2\u00ae\u00b0\5\36\20\4\u00af\u00a9\3\2\2\2\u00af"+
-    "\u00ac\3\2\2\2\u00b0\u00b3\3\2\2\2\u00b1\u00af\3\2\2\2\u00b1\u00b2\3\2"+
-    "\2\2\u00b2\37\3\2\2\2\u00b3\u00b1\3\2\2\2\u00b4\u00b5\b\21\1\2\u00b5\u00b7"+
-    "\5$\23\2\u00b6\u00b8\5\"\22\2\u00b7\u00b6\3\2\2\2\u00b7\u00b8\3\2\2\2"+
-    "\u00b8\u00bc\3\2\2\2\u00b9\u00ba\t\2\2\2\u00ba\u00bc\5 \21\6\u00bb\u00b4"+
-    "\3\2\2\2\u00bb\u00b9\3\2\2\2\u00bc\u00c9\3\2\2\2\u00bd\u00be\f\5\2\2\u00be"+
-    "\u00bf\t\3\2\2\u00bf\u00c8\5 \21\6\u00c0\u00c1\f\4\2\2\u00c1\u00c2\t\2"+
-    "\2\2\u00c2\u00c8\5 \21\5\u00c3\u00c4\f\3\2\2\u00c4\u00c5\5*\26\2\u00c5"+
-    "\u00c6\5 \21\4\u00c6\u00c8\3\2\2\2\u00c7\u00bd\3\2\2\2\u00c7\u00c0\3\2"+
-    "\2\2\u00c7\u00c3\3\2\2\2\u00c8\u00cb\3\2\2\2\u00c9\u00c7\3\2\2\2\u00c9"+
-    "\u00ca\3\2\2\2\u00ca!\3\2\2\2\u00cb\u00c9\3\2\2\2\u00cc\u00ce\7\n\2\2"+
-    "\u00cd\u00cc\3\2\2\2\u00cd\u00ce\3\2\2\2\u00ce\u00cf\3\2\2\2\u00cf\u00d0"+
-    "\7\7\2\2\u00d0\u00d1\7\"\2\2\u00d1\u00d6\5\34\17\2\u00d2\u00d3\7\37\2"+
-    "\2\u00d3\u00d5\5\34\17\2\u00d4\u00d2\3\2\2\2\u00d5\u00d8\3\2\2\2\u00d6"+
-    "\u00d4\3\2\2\2\u00d6\u00d7\3\2\2\2\u00d7\u00d9\3\2\2\2\u00d8\u00d6\3\2"+
-    "\2\2\u00d9\u00da\7#\2\2\u00da#\3\2\2\2\u00db\u00e3\5(\25\2\u00dc\u00e3"+
-    "\5&\24\2\u00dd\u00e3\5.\30\2\u00de\u00df\7\"\2\2\u00df\u00e0\5\34\17\2"+
-    "\u00e0\u00e1\7#\2\2\u00e1\u00e3\3\2\2\2\u00e2\u00db\3\2\2\2\u00e2\u00dc"+
-    "\3\2\2\2\u00e2\u00dd\3\2\2\2\u00e2\u00de\3\2\2\2\u00e3%\3\2\2\2\u00e4"+
-    "\u00e5\7)\2\2\u00e5\u00ee\7\"\2\2\u00e6\u00eb\5\34\17\2\u00e7\u00e8\7"+
-    "\37\2\2\u00e8\u00ea\5\34\17\2\u00e9\u00e7\3\2\2\2\u00ea\u00ed\3\2\2\2"+
-    "\u00eb\u00e9\3\2\2\2\u00eb\u00ec\3\2\2\2\u00ec\u00ef\3\2\2\2\u00ed\u00eb"+
-    "\3\2\2\2\u00ee\u00e6\3\2\2\2\u00ee\u00ef\3\2\2\2\u00ef\u00f0\3\2\2\2\u00f0"+
-    "\u00f1\7#\2\2\u00f1\'\3\2\2\2\u00f2\u00f7\7\13\2\2\u00f3\u00f7\5\64\33"+
-    "\2\u00f4\u00f7\5,\27\2\u00f5\u00f7\5\66\34\2\u00f6\u00f2\3\2\2\2\u00f6"+
-    "\u00f3\3\2\2\2\u00f6\u00f4\3\2\2\2\u00f6\u00f5\3\2\2\2\u00f7)\3\2\2\2"+
-    "\u00f8\u00f9\t\4\2\2\u00f9+\3\2\2\2\u00fa\u00fb\t\5\2\2\u00fb-\3\2\2\2"+
-    "\u00fc\u0108\5\60\31\2\u00fd\u00fe\7\36\2\2\u00fe\u0107\5\60\31\2\u00ff"+
-    "\u0101\7 \2\2\u0100\u0102\7\'\2\2\u0101\u0100\3\2\2\2\u0102\u0103\3\2"+
-    "\2\2\u0103\u0101\3\2\2\2\u0103\u0104\3\2\2\2\u0104\u0105\3\2\2\2\u0105"+
-    "\u0107\7!\2\2\u0106\u00fd\3\2\2\2\u0106\u00ff\3\2\2\2\u0107\u010a\3\2"+
-    "\2\2\u0108\u0106\3\2\2\2\u0108\u0109\3\2\2\2\u0109/\3\2\2\2\u010a\u0108"+
-    "\3\2\2\2\u010b\u010c\t\6\2\2\u010c\61\3\2\2\2\u010d\u010f\5\64\33\2\u010e"+
-    "\u0110\7)\2\2\u010f\u010e\3\2\2\2\u010f\u0110\3\2\2\2\u0110\63\3\2\2\2"+
-    "\u0111\u0114\7(\2\2\u0112\u0114\7\'\2\2\u0113\u0111\3\2\2\2\u0113\u0112"+
-    "\3\2\2\2\u0114\65\3\2\2\2\u0115\u0116\7&\2\2\u0116\67\3\2\2\2%BHRVX^b"+
-    "flpy|\u0084\u0089\u008f\u0091\u0094\u00a7\u00af\u00b1\u00b7\u00bb\u00c7"+
-    "\u00c9\u00cd\u00d6\u00e2\u00eb\u00ee\u00f6\u0103\u0106\u0108\u010f\u0113";
+    "\16\3\16\3\16\5\16\u009e\n\16\3\16\3\16\3\17\3\17\3\20\3\20\3\20\3\20"+
+    "\3\20\3\20\3\20\5\20\u00ab\n\20\3\20\3\20\3\20\3\20\3\20\3\20\7\20\u00b3"+
+    "\n\20\f\20\16\20\u00b6\13\20\3\21\3\21\3\21\5\21\u00bb\n\21\3\21\3\21"+
+    "\5\21\u00bf\n\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\3\21\7\21"+
+    "\u00cb\n\21\f\21\16\21\u00ce\13\21\3\22\5\22\u00d1\n\22\3\22\3\22\3\22"+
+    "\3\22\3\22\7\22\u00d8\n\22\f\22\16\22\u00db\13\22\3\22\3\22\3\23\3\23"+
+    "\3\23\3\23\3\23\3\23\3\23\5\23\u00e6\n\23\3\24\3\24\3\24\3\24\3\24\7\24"+
+    "\u00ed\n\24\f\24\16\24\u00f0\13\24\5\24\u00f2\n\24\3\24\3\24\3\25\3\25"+
+    "\3\25\3\25\5\25\u00fa\n\25\3\26\3\26\3\27\3\27\3\30\3\30\3\30\3\30\3\30"+
+    "\6\30\u0105\n\30\r\30\16\30\u0106\3\30\7\30\u010a\n\30\f\30\16\30\u010d"+
+    "\13\30\3\31\3\31\3\32\3\32\5\32\u0113\n\32\3\33\3\33\5\33\u0117\n\33\3"+
+    "\34\3\34\3\34\2\4\36 \35\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&("+
+    "*,.\60\62\64\66\2\7\3\2\31\32\3\2\33\35\3\2\23\30\4\2\5\5\17\17\4\2%%"+
+    "))\u012b\28\3\2\2\2\4;\3\2\2\2\6>\3\2\2\2\bH\3\2\2\2\nJ\3\2\2\2\fO\3\2"+
+    "\2\2\16d\3\2\2\2\20r\3\2\2\2\22~\3\2\2\2\24\u0087\3\2\2\2\26\u008b\3\2"+
+    "\2\2\30\u0096\3\2\2\2\32\u009d\3\2\2\2\34\u00a1\3\2\2\2\36\u00aa\3\2\2"+
+    "\2 \u00be\3\2\2\2\"\u00d0\3\2\2\2$\u00e5\3\2\2\2&\u00e7\3\2\2\2(\u00f9"+
+    "\3\2\2\2*\u00fb\3\2\2\2,\u00fd\3\2\2\2.\u00ff\3\2\2\2\60\u010e\3\2\2\2"+
+    "\62\u0110\3\2\2\2\64\u0116\3\2\2\2\66\u0118\3\2\2\289\5\6\4\29:\7\2\2"+
+    "\3:\3\3\2\2\2;<\5\34\17\2<=\7\2\2\3=\5\3\2\2\2>B\5\b\5\2?A\5\20\t\2@?"+
+    "\3\2\2\2AD\3\2\2\2B@\3\2\2\2BC\3\2\2\2C\7\3\2\2\2DB\3\2\2\2EI\5\f\7\2"+
+    "FI\5\16\b\2GI\5\32\16\2HE\3\2\2\2HF\3\2\2\2HG\3\2\2\2I\t\3\2\2\2JK\7\22"+
+    "\2\2KL\7\t\2\2LM\7\23\2\2MN\5\62\32\2N\13\3\2\2\2OX\7\16\2\2PR\5\22\n"+
+    "\2QS\5\n\6\2RQ\3\2\2\2RS\3\2\2\2SY\3\2\2\2TV\5\n\6\2UW\5\22\n\2VU\3\2"+
+    "\2\2VW\3\2\2\2WY\3\2\2\2XP\3\2\2\2XT\3\2\2\2XY\3\2\2\2YZ\3\2\2\2Z\\\5"+
+    "\26\f\2[]\5\26\f\2\\[\3\2\2\2]^\3\2\2\2^\\\3\2\2\2^_\3\2\2\2_b\3\2\2\2"+
+    "`a\7\20\2\2ac\5\26\f\2b`\3\2\2\2bc\3\2\2\2c\r\3\2\2\2df\7\b\2\2eg\5\22"+
+    "\n\2fe\3\2\2\2fg\3\2\2\2gh\3\2\2\2hj\5\24\13\2ik\5\24\13\2ji\3\2\2\2k"+
+    "l\3\2\2\2lj\3\2\2\2lm\3\2\2\2mp\3\2\2\2no\7\20\2\2oq\5\24\13\2pn\3\2\2"+
+    "\2pq\3\2\2\2q\17\3\2\2\2rs\7$\2\2s|\7)\2\2ty\5\36\20\2uv\7\37\2\2vx\5"+
+    "\36\20\2wu\3\2\2\2x{\3\2\2\2yw\3\2\2\2yz\3\2\2\2z}\3\2\2\2{y\3\2\2\2|"+
+    "t\3\2\2\2|}\3\2\2\2}\21\3\2\2\2~\177\7\4\2\2\177\u0084\5\34\17\2\u0080"+
+    "\u0081\7\37\2\2\u0081\u0083\5\34\17\2\u0082\u0080\3\2\2\2\u0083\u0086"+
+    "\3\2\2\2\u0084\u0082\3\2\2\2\u0084\u0085\3\2\2\2\u0085\23\3\2\2\2\u0086"+
+    "\u0084\3\2\2\2\u0087\u0089\5\30\r\2\u0088\u008a\5\22\n\2\u0089\u0088\3"+
+    "\2\2\2\u0089\u008a\3\2\2\2\u008a\25\3\2\2\2\u008b\u0091\5\30\r\2\u008c"+
+    "\u008f\7\6\2\2\u008d\u008e\7\23\2\2\u008e\u0090\5,\27\2\u008f\u008d\3"+
+    "\2\2\2\u008f\u0090\3\2\2\2\u0090\u0092\3\2\2\2\u0091\u008c\3\2\2\2\u0091"+
+    "\u0092\3\2\2\2\u0092\u0094\3\2\2\2\u0093\u0095\5\22\n\2\u0094\u0093\3"+
+    "\2\2\2\u0094\u0095\3\2\2\2\u0095\27\3\2\2\2\u0096\u0097\7 \2\2\u0097\u0098"+
+    "\5\32\16\2\u0098\u0099\7!\2\2\u0099\31\3\2\2\2\u009a\u009b\5\60\31\2\u009b"+
+    "\u009c\7\21\2\2\u009c\u009e\3\2\2\2\u009d\u009a\3\2\2\2\u009d\u009e\3"+
+    "\2\2\2\u009e\u009f\3\2\2\2\u009f\u00a0\5\34\17\2\u00a0\33\3\2\2\2\u00a1"+
+    "\u00a2\5\36\20\2\u00a2\35\3\2\2\2\u00a3\u00a4\b\20\1\2\u00a4\u00a5\7\n"+
+    "\2\2\u00a5\u00ab\5\36\20\7\u00a6\u00a7\7)\2\2\u00a7\u00a8\7\f\2\2\u00a8"+
+    "\u00ab\5\30\r\2\u00a9\u00ab\5 \21\2\u00aa\u00a3\3\2\2\2\u00aa\u00a6\3"+
+    "\2\2\2\u00aa\u00a9\3\2\2\2\u00ab\u00b4\3\2\2\2\u00ac\u00ad\f\4\2\2\u00ad"+
+    "\u00ae\7\3\2\2\u00ae\u00b3\5\36\20\5\u00af\u00b0\f\3\2\2\u00b0\u00b1\7"+
+    "\r\2\2\u00b1\u00b3\5\36\20\4\u00b2\u00ac\3\2\2\2\u00b2\u00af\3\2\2\2\u00b3"+
+    "\u00b6\3\2\2\2\u00b4\u00b2\3\2\2\2\u00b4\u00b5\3\2\2\2\u00b5\37\3\2\2"+
+    "\2\u00b6\u00b4\3\2\2\2\u00b7\u00b8\b\21\1\2\u00b8\u00ba\5$\23\2\u00b9"+
+    "\u00bb\5\"\22\2\u00ba\u00b9\3\2\2\2\u00ba\u00bb\3\2\2\2\u00bb\u00bf\3"+
+    "\2\2\2\u00bc\u00bd\t\2\2\2\u00bd\u00bf\5 \21\6\u00be\u00b7\3\2\2\2\u00be"+
+    "\u00bc\3\2\2\2\u00bf\u00cc\3\2\2\2\u00c0\u00c1\f\5\2\2\u00c1\u00c2\t\3"+
+    "\2\2\u00c2\u00cb\5 \21\6\u00c3\u00c4\f\4\2\2\u00c4\u00c5\t\2\2\2\u00c5"+
+    "\u00cb\5 \21\5\u00c6\u00c7\f\3\2\2\u00c7\u00c8\5*\26\2\u00c8\u00c9\5 "+
+    "\21\4\u00c9\u00cb\3\2\2\2\u00ca\u00c0\3\2\2\2\u00ca\u00c3\3\2\2\2\u00ca"+
+    "\u00c6\3\2\2\2\u00cb\u00ce\3\2\2\2\u00cc\u00ca\3\2\2\2\u00cc\u00cd\3\2"+
+    "\2\2\u00cd!\3\2\2\2\u00ce\u00cc\3\2\2\2\u00cf\u00d1\7\n\2\2\u00d0\u00cf"+
+    "\3\2\2\2\u00d0\u00d1\3\2\2\2\u00d1\u00d2\3\2\2\2\u00d2\u00d3\7\7\2\2\u00d3"+
+    "\u00d4\7\"\2\2\u00d4\u00d9\5\34\17\2\u00d5\u00d6\7\37\2\2\u00d6\u00d8"+
+    "\5\34\17\2\u00d7\u00d5\3\2\2\2\u00d8\u00db\3\2\2\2\u00d9\u00d7\3\2\2\2"+
+    "\u00d9\u00da\3\2\2\2\u00da\u00dc\3\2\2\2\u00db\u00d9\3\2\2\2\u00dc\u00dd"+
+    "\7#\2\2\u00dd#\3\2\2\2\u00de\u00e6\5(\25\2\u00df\u00e6\5&\24\2\u00e0\u00e6"+
+    "\5.\30\2\u00e1\u00e2\7\"\2\2\u00e2\u00e3\5\34\17\2\u00e3\u00e4\7#\2\2"+
+    "\u00e4\u00e6\3\2\2\2\u00e5\u00de\3\2\2\2\u00e5\u00df\3\2\2\2\u00e5\u00e0"+
+    "\3\2\2\2\u00e5\u00e1\3\2\2\2\u00e6%\3\2\2\2\u00e7\u00e8\7)\2\2\u00e8\u00f1"+
+    "\7\"\2\2\u00e9\u00ee\5\34\17\2\u00ea\u00eb\7\37\2\2\u00eb\u00ed\5\34\17"+
+    "\2\u00ec\u00ea\3\2\2\2\u00ed\u00f0\3\2\2\2\u00ee\u00ec\3\2\2\2\u00ee\u00ef"+
+    "\3\2\2\2\u00ef\u00f2\3\2\2\2\u00f0\u00ee\3\2\2\2\u00f1\u00e9\3\2\2\2\u00f1"+
+    "\u00f2\3\2\2\2\u00f2\u00f3\3\2\2\2\u00f3\u00f4\7#\2\2\u00f4\'\3\2\2\2"+
+    "\u00f5\u00fa\7\13\2\2\u00f6\u00fa\5\64\33\2\u00f7\u00fa\5,\27\2\u00f8"+
+    "\u00fa\5\66\34\2\u00f9\u00f5\3\2\2\2\u00f9\u00f6\3\2\2\2\u00f9\u00f7\3"+
+    "\2\2\2\u00f9\u00f8\3\2\2\2\u00fa)\3\2\2\2\u00fb\u00fc\t\4\2\2\u00fc+\3"+
+    "\2\2\2\u00fd\u00fe\t\5\2\2\u00fe-\3\2\2\2\u00ff\u010b\5\60\31\2\u0100"+
+    "\u0101\7\36\2\2\u0101\u010a\5\60\31\2\u0102\u0104\7 \2\2\u0103\u0105\7"+
+    "\'\2\2\u0104\u0103\3\2\2\2\u0105\u0106\3\2\2\2\u0106\u0104\3\2\2\2\u0106"+
+    "\u0107\3\2\2\2\u0107\u0108\3\2\2\2\u0108\u010a\7!\2\2\u0109\u0100\3\2"+
+    "\2\2\u0109\u0102\3\2\2\2\u010a\u010d\3\2\2\2\u010b\u0109\3\2\2\2\u010b"+
+    "\u010c\3\2\2\2\u010c/\3\2\2\2\u010d\u010b\3\2\2\2\u010e\u010f\t\6\2\2"+
+    "\u010f\61\3\2\2\2\u0110\u0112\5\64\33\2\u0111\u0113\7)\2\2\u0112\u0111"+
+    "\3\2\2\2\u0112\u0113\3\2\2\2\u0113\63\3\2\2\2\u0114\u0117\7(\2\2\u0115"+
+    "\u0117\7\'\2\2\u0116\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117\65\3\2\2"+
+    "\2\u0118\u0119\7&\2\2\u0119\67\3\2\2\2&BHRVX^bflpy|\u0084\u0089\u008f"+
+    "\u0091\u0094\u009d\u00aa\u00b2\u00b4\u00ba\u00be\u00ca\u00cc\u00d0\u00d9"+
+    "\u00e5\u00ee\u00f1\u00f9\u0106\u0109\u010b\u0112\u0116";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/LogicalPlanTests.java
@@ -28,6 +28,13 @@ public class LogicalPlanTests extends ESTestCase {
         assertEquals(fullQuery, new Filter(Source.EMPTY, new UnresolvedRelation(Source.EMPTY, null, "", false, ""), fullExpression));
     }
 
+    public void testEventQueryWithoutWhere() {
+        LogicalPlan fullQuery = parser.createStatement("process_name == 'net.exe'");
+        Expression fullExpression = expr("process_name == 'net.exe'");
+
+        assertEquals(fullQuery, new Filter(Source.EMPTY, new UnresolvedRelation(Source.EMPTY, null, "", false, ""), fullExpression));
+    }
+
     public void testParameterizedEventQuery() {
         ParserParams params = new ParserParams().fieldEventType("myCustomEvent");
         LogicalPlan fullQuery = parser.createStatement("process where process_name == 'net.exe'", params);


### PR DESCRIPTION
Closes #52168 
Closes #51853  

Most of the work was already in place, but this makes `eventType where ...` optional, and indirectly closes #51853, since that could be solved with `event.category = 42` instead of `42 where ...` 