### PR TITLE
Enable BWC test after backport

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -376,8 +376,8 @@ setup:
 ---
 "date_histogram with pre-epoch daylight savings time transition":
   - skip:
-      version: " - 7.99.99"
-      reason:  bug fixed in 8.0.0. will be backported to 7.6.1
+      version: " - 7.6.1"
+      reason:  bug fixed in 7.6.1.
 
   - do:
       bulk:


### PR DESCRIPTION
Now that we've backported #52016 we can run its tests when we're
performance backwards compatibility testing.
