### PR TITLE
Correct description for mget API request URI index

### DIFF
--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -51,7 +51,9 @@ See <<shard-failures, Shard failures>> for more information.
 [[docs-multi-get-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+`<index>`::
+(Optional, string) Name of the index to retrieve documents from when `ids` are specified,
+or when a document in the `docs` array does not specify an index.
 
 [[docs-multi-get-api-query-params]]
 ==== {api-query-parms-title}


### PR DESCRIPTION
This PR corrects the description for the request URI index for the Multi Get (mget) API.
The index can only be a single index name (multiple or wildcard expressions not supported),
and acts as the index to use when "ids" are specified, or a document in the "docs" array does
not specify an index.