### PR TITLE
Fix put index template bug

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -178,7 +178,7 @@ public class MetaDataIndexTemplateService {
 
                 for (Alias alias : request.aliases) {
                     AliasMetaData aliasMetaData = AliasMetaData.builder(alias.name()).filter(alias.filter())
-                        .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
+                        .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).writeIndex(alias.writeIndex()).build();
                     templateBuilder.putAlias(aliasMetaData);
                 }
                 IndexTemplateMetaData template = templateBuilder.build();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -136,7 +137,16 @@ public class PutIndexTemplateRequestTests extends ESTestCase {
                 .endObject()
             .endObject()
             .startObject("aliases")
-                .startObject("my-alias").endObject()
+                .startObject("my-alias")
+                    .field("is_write_index", true)
+                    .field("index_routing", "1")
+                    .field("search_routing", "2")
+                    .startObject("filter")
+                        .startObject("term")
+                            .field("user", "kimchy")
+                        .endObject()
+                    .endObject()
+                .endObject()
             .endObject()
         .endObject();
 
@@ -155,7 +165,8 @@ public class PutIndexTemplateRequestTests extends ESTestCase {
 
         assertThat(request.mappings(), containsString("field"));
 
-        Alias alias = new Alias("my-alias");
+        Alias alias = new Alias("my-alias").writeIndex(true).indexRouting("1").searchRouting("2")
+            .filter(QueryBuilders.termQuery("user", "kimchy"));
         assertThat(request.aliases().size(), equalTo(1));
         assertThat(request.aliases().iterator().next(), equalTo(alias));
     }


### PR DESCRIPTION


The changes are:

1. Fix the bug for  the parameter `is_write_index` in a alias is ignored when putting index template.
2. Test parsing the parameters of a alias.