### PR TITLE
Dump container logs on shell command failure

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -291,6 +291,22 @@ public class Docker {
 
             return super.getScriptCommand("docker exec --user elasticsearch:root --tty " + containerId + " " + script);
         }
+
+        @Override
+        public Result run(String script) {
+            try {
+                return super.run(script);
+            } catch (ShellException e) {
+                try {
+                    final Shell.Result dockerLogs = getContainerLogs();
+                    throw new ShellException(
+                        e.getMessage() + "\n\nContainer stdout: " + dockerLogs.stdout + "\n\nContainer stderr: " + dockerLogs.stderr
+                    );
+                } catch (ShellException logsException) {
+                    throw new ShellException("Command failed, and couldn't get docker logs", logsException);
+                }
+            }
+        }
     }
 
     /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -132,7 +132,7 @@ public class Shell {
         logger.warn("Running command with env: " + env);
         Result result = runScriptIgnoreExitCode(command);
         if (result.isSuccess() == false) {
-            throw new RuntimeException("Command was not successful: [" + String.join(" ", command) + "]\n   result: " + result.toString());
+            throw new ShellException("Command was not successful: [" + String.join(" ", command) + "]\n   result: " + result.toString());
         }
         return result;
     }
@@ -266,4 +266,17 @@ public class Shell {
         }
     }
 
+    /**
+     * An exception to model failures to run a shell command. This exists so that calling code can differentiate between
+     * shell / command errors, and other runtime errors.
+     */
+    public static class ShellException extends RuntimeException {
+        public ShellException(String message) {
+            super(message);
+        }
+
+        public ShellException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
 }


### PR DESCRIPTION
The Docker tests framework captures container logs when Elasticsearch
fails to start. However, it doesn't do this if a later shell command
fails. Amend the `DockerShell` wrapper to capture the container logs if
a command fails when it should succeed.