### PR TITLE
Clarified http.max_content_length description

### DIFF
--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -286,5 +286,5 @@ still be adjusted as desired using the cluster settings API.
 
 [float]
 ==== HTTP Max content length setting is no longer parsed leniently
-Previously, `http.max_content_length` would reset to `100mb` if the setting was greater than
-`Integer.MAX_VALUE`.  This leniency has been removed.
+Previously, `http.max_content_length` would reset to `100mb` if the setting was
+greater than `Integer.MAX_VALUE`.  This leniency has been removed.

--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -286,5 +286,5 @@ still be adjusted as desired using the cluster settings API.
 
 [float]
 ==== HTTP Max content length setting is no longer parsed leniently
-Previously, `http.max_content_length` would reset to `100mb` if the setting was
+Previously, `http.max_content_length` would reset to `100mb` if the setting was greater than
 `Integer.MAX_VALUE`.  This leniency has been removed.


### PR DESCRIPTION
Adding "greater than" based on discussion with @jasontedor for clarity.

This was in the 7.0 breaking changes section of the documentation.  Couldn't find this file in master so pointing this PR to 7.x.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
