### PR TITLE
Fix input snapshotting error when using test clusters cliSetup

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyList.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyList.java
@@ -170,10 +170,22 @@ public class LazyPropertyList<T> extends AbstractLazyPropertyCollection implemen
     }
 
     @Override
-    public List<? extends Object> getNormalizedCollection() {
+    public List<? extends PropertyListEntry<T>> getNormalizedCollection() {
         return delegate.stream()
             .peek(this::validate)
             .filter(entry -> entry.getNormalization() != PropertyNormalization.IGNORE_VALUE)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Return a "flattened" collection. This should be used when the collection type is itself a complex type with properties
+     * annotated as Gradle inputs rather than a simple type like {@link String}.
+     *
+     * @return a flattened collection filtered according to normalization strategy
+     */
+    public List<? extends T> getFlatNormalizedCollection() {
+        return getNormalizedCollection().stream()
+            .map(PropertyListEntry::getValue)
             .collect(Collectors.toList());
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyList.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyList.java
@@ -184,9 +184,7 @@ public class LazyPropertyList<T> extends AbstractLazyPropertyCollection implemen
      * @return a flattened collection filtered according to normalization strategy
      */
     public List<? extends T> getFlatNormalizedCollection() {
-        return getNormalizedCollection().stream()
-            .map(PropertyListEntry::getValue)
-            .collect(Collectors.toList());
+        return getNormalizedCollection().stream().map(PropertyListEntry::getValue).collect(Collectors.toList());
     }
 
     private void validate(PropertyListEntry<T> entry) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1163,7 +1163,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     @Nested
     public List<?> getCliSetup() {
-        return cliSetup.getNormalizedCollection();
+        return cliSetup.getFlatNormalizedCollection();
     }
 
     @Nested


### PR DESCRIPTION
This PR fixes an error when attempting to use the `cliSetup` configuration option on a test cluster. The root cause was that our `LazyPropertyList` did not properly handle collection types that were themselves complex types with their own `@Input` annotations. This PR introduces a `getFlatNormalizedCollection()` method which allows Gradle's `@Nested` annotation to work properly.

Example error:
```
Unable to store input properties for task ':plugins:ingest-attachment:integTestRunner'. Property 'clusters.integTest$0.nodes.$0.cliSetup.$0.value' with value 'org.elasticsearch.gradle.testclusters.ElasticsearchNode$CliEntry@262bda8d' cannot be serialized.
> Could not serialize value of type ElasticsearchNode.CliEntry
  > org.elasticsearch.gradle.testclusters.ElasticsearchNode$CliEntry
```