### PR TITLE
Use thread local random for request id generation

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditUtil.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.security.audit;
 
 import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -64,7 +65,7 @@ public class AuditUtil {
                     + existing + "] already registered");
             }
         }
-        final String requestId = UUIDs.randomBase64UUID();
+        final String requestId = UUIDs.randomBase64UUID(Randomness.get());
         // Store as a header (not transient) so that it is passed over the network if this request requires execution on other nodes
         threadContext.putHeader(AUDIT_REQUEST_ID, requestId);
         return requestId;


### PR DESCRIPTION
Currently we used the secure random number generate when generating http
request ids in the security AuditUtil. We do not need to be using this
level of randomness for this use case. Additionally, this random number
generator involves locking that blocks the http worker threads at high
concurrency loads.

This commit modifies this randomness generator to use our reproducible
randomness generator for Elasticsearch. This generator will fall back to
thread local random when used in production.