### PR TITLE
Add support for source_path to the field caps API.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -1229,11 +1229,11 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         assertEquals(2, ratingResponse.size());
 
         FieldCapabilities expectedKeywordCapabilities = new FieldCapabilities(
-            "rating", "keyword", true, true, new String[]{"index2"}, null, null, Collections.emptyMap());
+            "rating", "keyword", true, true, new String[]{"index2"}, null, null, Collections.emptyMap(), Collections.emptyList());
         assertEquals(expectedKeywordCapabilities, ratingResponse.get("keyword"));
 
         FieldCapabilities expectedLongCapabilities = new FieldCapabilities(
-            "rating", "long", true, true, new String[]{"index1"}, null, null, Collections.emptyMap());
+            "rating", "long", true, true, new String[]{"index1"}, null, null, Collections.emptyMap(), Collections.emptyList());
         assertEquals(expectedLongCapabilities, ratingResponse.get("long"));
 
         // Check the capabilities for the 'field' field.
@@ -1242,7 +1242,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         assertEquals(1, fieldResponse.size());
 
         FieldCapabilities expectedTextCapabilities = new FieldCapabilities(
-            "field", "text", true, false, null, null, null, Collections.emptyMap());
+            "field", "text", true, false, null, null, null, Collections.emptyMap(), Collections.emptyList());
         assertEquals(expectedTextCapabilities, fieldResponse.get("text"));
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/30_source_path.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/30_source_path.yml
@@ -1,0 +1,76 @@
+---
+setup:
+  - skip:
+      version: " - 7.99.99"
+      reason: "source_path is currently only supported on 8.0."
+
+  - do:
+      indices.create:
+        index: index1
+        body:
+          mappings:
+            properties:
+              field:
+                type: text
+              new_field:
+                type: alias
+                path: field
+              copy_to_field1:
+                type: text
+                copy_to: field
+
+  - do:
+      indices.create:
+        index: index2
+        body:
+          mappings:
+            properties:
+              field:
+                type: text
+              new_field:
+                type: alias
+                path: field
+              copy_to_field2:
+                type: text
+                copy_to: field
+
+  - do:
+      indices.create:
+        index: index3
+        body:
+          mappings:
+            properties:
+              field:
+                type: text
+              new_field:
+                type: text
+              copy_to_field2:
+                type: text
+                copy_to: field
+
+---
+"Merge source path information across multiple indices":
+  - do:
+      field_caps:
+        index: index1
+        fields: ["field", "new_field"]
+
+  - match: {"fields.field.text.source_path.0.indices": ["index1"]}
+  - match: {"fields.field.text.source_path.0.paths":   ["copy_to_field1"]}
+
+  - match: {"fields.new_field.text.source_path.0.indices": ["index1"]}
+  - match: {"fields.new_field.text.source_path.0.paths":   ["field"]}
+
+  - do:
+      field_caps:
+        index: index1,index2,index3
+        fields: ["field", "new_field"]
+
+  - match: {"fields.field.text.source_path.0.indices": ["index1"]}
+  - match: {"fields.field.text.source_path.0.paths":   ["copy_to_field1"]}
+
+  - match: {"fields.field.text.source_path.1.indices": ["index2", "index3"]}
+  - match: {"fields.field.text.source_path.1.paths":   ["copy_to_field2"]}
+
+  - match: {"fields.new_field.text.source_path.0.indices": ["index1", "index2"]}
+  - match: {"fields.new_field.text.source_path.0.paths":   ["field"]}

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -176,7 +176,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             FieldCapabilities.Builder unmapped = new FieldCapabilities.Builder(field, "unmapped");
             typeMap.put("unmapped", unmapped);
             for (String index : unmappedIndices) {
-                unmapped.add(index, false, false, Collections.emptyMap());
+                unmapped.add(index, false, false, Collections.emptyMap(), Collections.emptySet());
             }
         }
     }
@@ -189,7 +189,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(field, f -> new HashMap<>());
             FieldCapabilities.Builder builder = typeMap.computeIfAbsent(fieldCap.getType(),
                 key -> new FieldCapabilities.Builder(field, key));
-            builder.add(indexName, fieldCap.isSearchable(), fieldCap.isAggregatable(), fieldCap.meta());
+            builder.add(indexName, fieldCap.isSearchable(), fieldCap.isAggregatable(), fieldCap.meta(), fieldCap.sourcePath());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesIndexAction.java
@@ -90,8 +90,9 @@ public class TransportFieldCapabilitiesIndexAction extends TransportSingleShardA
             if (ft != null) {
                 if (indicesService.isMetaDataField(mapperService.getIndexSettings().getIndexVersionCreated(), field)
                         || fieldPredicate.test(ft.name())) {
+                    Set<String> sourcePath = mapperService.sourcePath(field);
                     IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(field, ft.typeName(),
-                        ft.isSearchable(), ft.isAggregatable(), ft.meta());
+                        ft.isSearchable(), ft.isAggregatable(), ft.meta(), sourcePath);
                     responseMap.put(field, fieldCap);
                 } else {
                     continue;
@@ -110,7 +111,7 @@ public class TransportFieldCapabilitiesIndexAction extends TransportSingleShardA
                         ObjectMapper mapper = mapperService.getObjectMapper(parentField);
                         String type = mapper.nested().isNested() ? "nested" : "object";
                         IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(parentField, type,
-                            false, false, Collections.emptyMap());
+                            false, false, Collections.emptyMap(), Collections.emptySet());
                         responseMap.put(parentField, fieldCap);
                     }
                     dotIndex = parentField.lastIndexOf('.');

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -602,6 +602,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return fieldTypes.simpleMatchToFullName(pattern);
     }
 
+    public Set<String> sourcePath(String fullName) {
+        return fieldTypes.sourcePath(fullName);
+    }
+
     /**
      * Returns all mapped field types.
      */

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 
@@ -74,8 +75,10 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
                 break;
         }
 
+        Set<String> sourcePath = randomBoolean() ? Collections.emptySet() : Set.of("field1", "field2");
+
         return new IndexFieldCapabilities(fieldName, randomAlphaOfLengthBetween(5, 20),
-            randomBoolean(), randomBoolean(), meta);
+            randomBoolean(), randomBoolean(), meta, sourcePath);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/MergedFieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/MergedFieldCapabilitiesResponseTests.java
@@ -152,19 +152,20 @@ public class MergedFieldCapabilitiesResponseTests extends AbstractSerializingTes
 
     private static FieldCapabilitiesResponse createSimpleResponse() {
         Map<String, FieldCapabilities> titleCapabilities = new HashMap<>();
-        titleCapabilities.put("text", new FieldCapabilities("title", "text", true, false, null, null, null, Collections.emptyMap()));
+        titleCapabilities.put("text", new FieldCapabilities("title", "text", true, false, null, null, null,
+            Collections.emptyMap(), Collections.emptyList()));
 
         Map<String, FieldCapabilities> ratingCapabilities = new HashMap<>();
         ratingCapabilities.put("long", new FieldCapabilities("rating", "long",
             true, false,
             new String[]{"index1", "index2"},
             null,
-            new String[]{"index1"}, Collections.emptyMap()));
+            new String[]{"index1"}, Collections.emptyMap(), Collections.emptyList()));
         ratingCapabilities.put("keyword", new FieldCapabilities("rating", "keyword",
             false, true,
             new String[]{"index3", "index4"},
             new String[]{"index4"},
-            null, Collections.emptyMap()));
+            null, Collections.emptyMap(), Collections.emptyList()));
 
         Map<String, Map<String, FieldCapabilities>> responses = new HashMap<>();
         responses.put("title", titleCapabilities);

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 
@@ -148,6 +149,72 @@ public class FieldTypeLookupTests extends ESTestCase {
 
         assertTrue(names.contains("bar"));
         assertTrue(names.contains("barometer"));
+    }
+
+    public void testSourcePathsWithMultiFields() {
+        MappedFieldType ft = new MockFieldMapper.FakeFieldType();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(
+            MockFieldMapper.dummySettings, new ContentPath());
+
+        MockFieldMapper field = new MockFieldMapper.Builder("field", ft, ft)
+            .addMultiField(new MockFieldMapper.Builder("field.subfield1", ft, ft))
+            .addMultiField(new MockFieldMapper.Builder("field.subfield2", ft, ft))
+            .build(context);
+
+        FieldTypeLookup lookup = new FieldTypeLookup();
+        lookup = lookup.copyAndAddAll(newList(field), emptyList());
+
+        assertTrue(lookup.sourcePath("field").isEmpty());
+        assertEquals(Set.of("field"), lookup.sourcePath("field.subfield1"));
+        assertEquals(Set.of("field"), lookup.sourcePath("field.subfield2"));
+    }
+
+    public void testSourcePathsWithCopyTo() {
+        MappedFieldType ft = new MockFieldMapper.FakeFieldType();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(
+            MockFieldMapper.dummySettings, new ContentPath());
+
+        MockFieldMapper field = new MockFieldMapper.Builder("field", ft, ft)
+            .addMultiField(new MockFieldMapper.Builder("field.subfield1", ft, ft))
+            .build(context);
+
+        MockFieldMapper otherField = new MockFieldMapper.Builder("other_field", ft, ft)
+            .copyTo(new FieldMapper.CopyTo.Builder()
+                .add("field")
+                .add("field.subfield1")
+                .build())
+            .build(context);
+
+        MockFieldMapper anotherField = new MockFieldMapper.Builder("another_field", ft, ft)
+            .copyTo(new FieldMapper.CopyTo.Builder()
+                .add("field")
+                .build())
+            .build(context);
+
+        FieldTypeLookup lookup = new FieldTypeLookup();
+        lookup = lookup.copyAndAddAll(newList(field, otherField, anotherField), emptyList());
+
+        assertEquals(Set.of("other_field", "another_field"), lookup.sourcePath("field"));
+        assertEquals(Set.of("field"), lookup.sourcePath("field.subfield1"));
+    }
+
+    public void testSourcePathsWithAliases() {
+        MappedFieldType ft = new MockFieldMapper.FakeFieldType();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(
+            MockFieldMapper.dummySettings, new ContentPath());
+
+        MockFieldMapper field = new MockFieldMapper.Builder("field", ft, ft)
+            .addMultiField(new MockFieldMapper.Builder("field.subfield", ft, ft))
+            .build(context);
+
+        FieldAliasMapper alias1 = new FieldAliasMapper("alias1", "alias1", "field");
+        FieldAliasMapper alias2 = new FieldAliasMapper("alias2", "alias2", "field.subfield");
+
+        FieldTypeLookup lookup = new FieldTypeLookup();
+        lookup = lookup.copyAndAddAll(newList(field), newList(alias1, alias2));
+
+        assertEquals(Set.of("field"), lookup.sourcePath("alias1"));
+        assertEquals(Set.of("field.subfield"), lookup.sourcePath("alias2"));
     }
 
     public void testIteratorImmutable() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -44,6 +44,14 @@ public class MockFieldMapper extends FieldMapper {
             MultiFields.empty(), new CopyTo.Builder().build());
     }
 
+    public MockFieldMapper(String fullName,
+                           MappedFieldType fieldType,
+                           MultiFields multifields,
+                           CopyTo copyTo) {
+        super(findSimpleName(fullName), setName(fullName, fieldType), setName(fullName, fieldType), dummySettings,
+            multifields, copyTo);
+    }
+
     static MappedFieldType setName(String fullName, MappedFieldType fieldType) {
         fieldType.setName(fullName);
         return fieldType;
@@ -89,5 +97,18 @@ public class MockFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List list) throws IOException {
+    }
+
+    public static class Builder extends FieldMapper.Builder<MockFieldMapper.Builder, MockFieldMapper> {
+        protected Builder(String name, MappedFieldType fieldType, MappedFieldType defaultFieldType) {
+            super(name, fieldType, defaultFieldType);
+            builder = this;
+        }
+
+        @Override
+        public MockFieldMapper build(BuilderContext context) {
+            MultiFields multiFields = multiFieldsBuilder.build(this, context);
+            return new MockFieldMapper(name(), fieldType, multiFields, copyTo);
+        }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -968,7 +968,8 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         private MockFieldCapsResponseBuilder addField(String field, boolean isAggregatable, String... types) {
             Map<String, FieldCapabilities> caps = new HashMap<>();
             for (String type : types) {
-                caps.put(type, new FieldCapabilities(field, type, true, isAggregatable, null, null, null, Collections.emptyMap()));
+                caps.put(type, new FieldCapabilities(field, type, true, isAggregatable, null, null, null,
+                    Collections.emptyMap(), Collections.emptyList()));
             }
             fieldCaps.put(field, caps);
             return this;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -244,9 +244,9 @@ public class IndexResolverTests extends ESTestCase {
 
         Map<String, FieldCapabilities> multi = new HashMap<>();
         multi.put("long", new FieldCapabilities(fieldName, "long", true, true, new String[] { "one-index" }, null, null,
-                Collections.emptyMap()));
+                Collections.emptyMap(), Collections.emptyList()));
         multi.put("text", new FieldCapabilities(fieldName, "text", true, false, new String[] { "another-index" }, null, null,
-                Collections.emptyMap()));
+                Collections.emptyMap(), Collections.emptyList()));
         fieldCaps.put(fieldName, multi);
 
 
@@ -317,7 +317,7 @@ public class IndexResolverTests extends ESTestCase {
     public void testIndexWithNoMapping() {
         Map<String, Map<String, FieldCapabilities>> versionFC = singletonMap("_version",
                 singletonMap("_index", new FieldCapabilities("_version", "_version", false, false,
-                        null, null, null, Collections.emptyMap())));
+                        null, null, null, Collections.emptyMap(), Collections.emptyList())));
         assertTrue(mergedMappings("*", new String[] { "empty" }, versionFC).isValid());
     }
 
@@ -392,7 +392,7 @@ public class IndexResolverTests extends ESTestCase {
         List<String> nonAggregatableIndices = new ArrayList<>();
 
         UpdateableFieldCapabilities(String name, String type, boolean isSearchable, boolean isAggregatable) {
-            super(name, type, isSearchable, isAggregatable, null, null, null, Collections.emptyMap());
+            super(name, type, isSearchable, isAggregatable, null, null, null, Collections.emptyMap(), Collections.emptyList());
         }
 
         @Override
@@ -426,7 +426,8 @@ public class IndexResolverTests extends ESTestCase {
     private void addFieldCaps(Map<String, Map<String, FieldCapabilities>> fieldCaps, String name, String type, boolean isSearchable,
             boolean isAggregatable) {
         Map<String, FieldCapabilities> cap = new HashMap<>();
-        cap.put(type, new FieldCapabilities(name, type, isSearchable, isAggregatable, null, null, null, Collections.emptyMap()));
+        cap.put(type, new FieldCapabilities(name, type, isSearchable, isAggregatable, null, null, null,
+            Collections.emptyMap(), Collections.emptyList()));
         fieldCaps.put(name, cap);
     }
     


### PR DESCRIPTION
This PR contains a draft of adding `_source` path information to the field caps API. It implements the API addition described in https://github.com/elastic/elasticsearch/issues/49264#issuecomment-564270080. This addition focuses on the SQL and ML use case of looking up values through `_source`. (Kibana may also want to use source path information to better support field aliases --  we're still working on defining their use case + requirements.)

Some notes on the design:
* To keep the field caps output fairly streamlined, we never include the field itself in the source path. When looking up values, clients should always assume that the source path could include the field itself.
* There is no special handling for meta fields, clients need to understand that they are not returned in `_source`.
* In addition to field alias targets and parent fields (for multi-fields), the source path includes fields whose contents were copied to the field through `copy_to`.
* Looking up the source paths for a field is currently not transitive. For example, if a field alias had a multi-field as its target, then we would just return the name of that multi-field (and not trace the source path to its parent). My intuition is that lookup **should** be transitive -- that way a client wouldn’t have to make multiple calls to field caps to find the actual source paths.

It would be great to get feedback on these notes. I’m curious if/ how we currently handle `copy_to` when looking up fields in SQL and ML, and if the current design is a good fit. Supporting `copy_to` did make the API + implementation a bit more complex, since each field can have multiple source paths.

Other implementation notes:
* The main functionality is exposed through `MapperService#sourcePath`. Tracking source path information within `MapperService` lets us avoid scanning over all the mappings on each call to field caps, and also makes the information available to other search components (maybe it could be useful to highlighting?)
* Some TODOs remain, like cleaning up tests and adding Javadoc.

Addresses #49264.