### PR TITLE
Add comment explaining priority of JVM options

### DIFF
--- a/distribution/src/bin/elasticsearch
+++ b/distribution/src/bin/elasticsearch
@@ -8,8 +8,7 @@
 #   ES_PATH_CONF -- Path to config directory
 #   ES_JAVA_OPTS -- External Java Opts on top of the defaults set
 #
-# Optionally, exact memory values can be set using the `ES_JAVA_OPTS`. Note that
-# the Xms and Xmx lines in the JVM options file must be commented out. Example
+# Optionally, exact memory values can be set using the `ES_JAVA_OPTS`. Example
 # values are "512m", and "10g".
 #
 #   ES_JAVA_OPTS="-Xms8g -Xmx8g" ./bin/elasticsearch
@@ -46,6 +45,13 @@ then
   fi
 fi
 
+# The JVM options parser produces the final JVM options to start Elasticsearch.
+# It does this by incorporating JVM options in the following way:
+#   - first, system JVM options are applied (these are hardcoded options in the
+#     parser)
+#   - second, JVM options are read from jvm.options and jvm.options.d/*.options
+#   - third, JVM options from ES_JAVA_OPTS are applied
+#   - fourth, ergonomic JVM options are applied
 ES_JAVA_OPTS=`export ES_TMPDIR; "$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.launchers.JvmOptionsParser "$ES_PATH_CONF"`
 
 # manual parsing to find out, if process should be detached

--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -110,7 +110,14 @@ if not defined ES_TMPDIR (
   for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set ES_TMPDIR=%%a
 )
 
-set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
+rem the JVM options parser produces the final JVM options to start Elasticsearch
+rem it does this by incorporating JVM options in the following way:
+rem   - first, system JVM options are applied (these are hardcoded options in
+rem     the parser)
+rem   - second, JVM options are read from jvm.options and
+rem     jvm.options.d/*.options
+rem   - third, JVM options from ES_JAVA_OPTS are applied
+rem   - fourth, ergonomic JVM options are applied
 
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 

--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -110,8 +110,9 @@ if not defined ES_TMPDIR (
   for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set ES_TMPDIR=%%a
 )
 
-rem the JVM options parser produces the final JVM options to start Elasticsearch
-rem it does this by incorporating JVM options in the following way:
+rem The JVM options parser produces the final JVM options to start
+rem Elasticsearch. It does this by incorporating JVM options in the following
+rem way:
 rem   - first, system JVM options are applied (these are hardcoded options in
 rem     the parser)
 rem   - second, JVM options are read from jvm.options and

--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -72,6 +72,14 @@ if not defined ES_TMPDIR (
   for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set  ES_TMPDIR=%%a
 )
 
+rem the JVM options parser produces the final JVM options to start Elasticsearch
+rem it does this by incorporating JVM options in the following way:
+rem   - first, system JVM options are applied (these are hardcoded options in
+rem     the parser)
+rem   - second, JVM options are read from jvm.options and
+rem     jvm.options.d/*.options
+rem   - third, JVM options from ES_JAVA_OPTS are applied
+rem   - fourth, ergonomic JVM options are applied
 @setlocal
 for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_PATH_CONF!" ^|^| echo jvm_options_parser_failed`) do set ES_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%ES_JAVA_OPTS%" & set ES_JAVA_OPTS=%ES_JAVA_OPTS%

--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -72,8 +72,9 @@ if not defined ES_TMPDIR (
   for /f "tokens=* usebackq" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.TempDirectory"`) do set  ES_TMPDIR=%%a
 )
 
-rem the JVM options parser produces the final JVM options to start Elasticsearch
-rem it does this by incorporating JVM options in the following way:
+rem The JVM options parser produces the final JVM options to start
+rem Elasticsearch. It does this by incorporating JVM options in the following
+rem way:
 rem   - first, system JVM options are applied (these are hardcoded options in
 rem     the parser)
 rem   - second, JVM options are read from jvm.options and


### PR DESCRIPTION
Reading the startup scripts does not elucidate how JVM options are applied. Instead, the reader must consult the source for the JVM options parser. This commit adds some transparency around this process so that it easier to understand reading the startup scripts how the final JVM options to start Elasticsearch are constructed.
