### PR TITLE
[DOCS] Correct the policy name in ilm doc

### DIFF
--- a/docs/reference/ilm/ilm-with-existing-indices.asciidoc
+++ b/docs/reference/ilm/ilm-with-existing-indices.asciidoc
@@ -253,7 +253,7 @@ phases required. For simplicity, we'll just use rollover:
 
 [source,console]
 -----------------------
-PUT _ilm/policy/sample_policy
+PUT _ilm/policy/mylogs_condensed_policy
 {
   "policy": {
     "phases": {


### PR DESCRIPTION
The policy name should be `mylogs_condensed_policy` which is used in the putting index template operation below.