### PR TITLE
Always set default ES_PATH_CONF for package scriptlets (#51827)

### DIFF
--- a/distribution/packages/src/common/env/elasticsearch
+++ b/distribution/packages/src/common/env/elasticsearch
@@ -9,6 +9,7 @@
 #JAVA_HOME=
 
 # Elasticsearch configuration directory
+# Note: this setting will be shared with command-line tools
 ES_PATH_CONF=${path.conf}
 
 # Elasticsearch PID directory

--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -11,9 +11,9 @@
 # source the default env file
 if [ -f "${path.env}" ]; then
     . "${path.env}"
-else
-  ES_PATH_CONF="${path.conf}"
 fi
+
+export ES_PATH_CONF=${ES_PATH_CONF:-${path.conf}}
 
 IS_UPGRADE=false
 

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -12,9 +12,9 @@
 # source the default env file
 if [ -f "${path.env}" ]; then
     . "${path.env}"
-else
-  ES_PATH_CONF="${path.conf}"
 fi
+
+export ES_PATH_CONF=${ES_PATH_CONF:-${path.conf}}
 
 REMOVE_DIRS=false
 REMOVE_JVM_OPTIONS_DIRECTORY=false

--- a/distribution/packages/src/common/scripts/posttrans
+++ b/distribution/packages/src/common/scripts/posttrans
@@ -1,9 +1,9 @@
 # source the default env file
 if [ -f "${path.env}" ]; then
     . "${path.env}"
-else
-  ES_PATH_CONF="${path.conf}"
 fi
+
+export ES_PATH_CONF=${ES_PATH_CONF:-${path.conf}}
 
 if [ ! -f "${ES_PATH_CONF}"/elasticsearch.keystore ]; then
     /usr/share/elasticsearch/bin/elasticsearch-keystore create

--- a/distribution/packages/src/common/scripts/preinst
+++ b/distribution/packages/src/common/scripts/preinst
@@ -18,9 +18,9 @@ err_exit() {
 # source the default env file
 if [ -f "${path.env}" ]; then
     . "${path.env}"
-else
-  ES_PATH_CONF="${path.conf}"
 fi
+
+export ES_PATH_CONF=${ES_PATH_CONF:-${path.conf}}
 
 case "$1" in
 

--- a/distribution/packages/src/common/scripts/prerm
+++ b/distribution/packages/src/common/scripts/prerm
@@ -12,9 +12,9 @@
 # source the default env file
 if [ -f "${path.env}" ]; then
     . "${path.env}"
-else
-  ES_PATH_CONF="${path.conf}"
 fi
+
+export ES_PATH_CONF=${ES_PATH_CONF:-${path.conf}}
 
 STOP_REQUIRED=false
 REMOVE_SERVICE=false


### PR DESCRIPTION
* Set default ES_PATH_CONF for package scriptlets

Our packages use scriptlets to create or update the Elasticsearch
keystore as necessary when installing or upgrading an Elasticsearch
package. If these scriptlets don't work as expected, Elasticsearch may
try and fail to create or upgrade the keystore at startup time. This
will prevent Elasticsearch from starting up at all.

These scriptlets use the Elasticsearch keystore command-line tools. Like
most of our command-line tools, the keystore tools will by default get
their value for ES_PATH_CONF from a system configuration file:
/etc/sysconfig/elasticsearch for RPMs, /etc/default/elasticsearch for
debian packages. Previously, if the user removed ES_PATH_CONF from that
system configuration file (perhaps thinking that it is obsolete when
the same variables is also defined in the systemd unit file), the
keystore command-line tools would fail. Scriptlet errors do not seem to
cause the installation to fail, and for RPMs the error message is easy
to miss in command output.

This commit adds a line of bash to scriptlets that will set ES_PATH_CONF
to a default when ES_PATH_CONF is unset, rather than only when the
system configuration file is missing.