### PR TITLE
Introduce compound query

### DIFF
--- a/docs/java-rest/high-level/query-builders.asciidoc
+++ b/docs/java-rest/high-level/query-builders.asciidoc
@@ -52,6 +52,7 @@ This page lists all the available search queries with their corresponding `Query
 | {ref}/query-dsl-dis-max-query.html[Dis Max]                         | {query-ref}/DisMaxQueryBuilder.html[DisMaxQueryBuilder]                             | {query-ref}/QueryBuilders.html#disMaxQuery--[QueryBuilders.disMaxQuery()]
 | {ref}/query-dsl-function-score-query.html[Function Score]           | {query-ref}/functionscore/FunctionScoreQueryBuilder.html[FunctionScoreQueryBuilder] | {query-ref}/QueryBuilders.html#functionScoreQuery-org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder.FilterFunctionBuilder:A-[QueryBuilders.functionScoreQuery()]
 | {ref}/query-dsl-boosting-query.html[Boosting]                       | {query-ref}/BoostingQueryBuilder.html[BoostingQueryBuilder]                         | {query-ref}/QueryBuilders.html#boostingQuery-org.elasticsearch.index.query.QueryBuilder-org.elasticsearch.index.query.QueryBuilder-[QueryBuilders.boostingQuery()]
+| {ref}/query-dsl-compound-query.html[Compound]                       | {query-ref}/CompoundQueryBuilder.html[CompoundQueryBuilder]                         | {query-ref}/QueryBuilders.html#compoundQuery-org.elasticsearch.index.query.QueryBuilder-org.elasticsearch.index.query.QueryBuilder-[QueryBuilders.compoundQuery()]
 |======
 
 ==== Joining queries

--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -19,7 +19,8 @@ Compound query clauses::
 
 Compound query clauses wrap other leaf *or* compound queries and are used to combine
 multiple queries in a logical fashion (such as the
-<<query-dsl-bool-query,`bool`>> or <<query-dsl-dis-max-query,`dis_max`>> query),
+<<query-dsl-bool-query,`bool`>>, <<query-dsl-dis-max-query,`dis_max`>> query
+or <<query-dsl-compound-query,`compound`>>),
 or to alter their behaviour (such as the
 <<query-dsl-constant-score-query,`constant_score`>> query).
 

--- a/docs/reference/query-dsl/compound-query.asciidoc
+++ b/docs/reference/query-dsl/compound-query.asciidoc
@@ -1,0 +1,182 @@
+[[query-dsl-compound-query]]
+=== Compound query
+++++
+<titleabbrev>Compound</titleabbrev>
+++++
+
+Returns documents matching any of wrapped queries and computes
+the documents' scores by combining scores from the queries.
+
+Similarly to <<query-dsl-bool-query, `bool`
+query's>> `should` option, `compound` query returns the union of all documents
+matching any of the provided queries. Unlike,  <<query-dsl-bool-query, `bool`
+query's>> `should` option that always sums the scores from the queries
+to compute the final documents' scores, `compound` query allows to define
+`combine_mode` -- how the queries' scores should be combined: summing,
+multiplying, taking an average, maximum, minimum, or taking the score from
+the first matching query.
+
+`compound` query best suits for situations when
+you want to combine scores produced by script queries.
+
+NOTE: Use <<query-dsl-bool-query, `bool` query's>> `should` option,
+if you want to sum up scores from queries.
+Use <<query-dsl-dis-max-query, `dis_max` query>> if you want get
+a max score from queries. `bool` and `dis_max` queries use optimizations
+and are more performant.
+
+
+[[query-dsl-compound-request]]
+==== Example request
+
+[[compound-index-setup]]
+===== Index setup
+. Create an `job_applicants` index with the following field mapping:
++
+--
+[source,console]
+----
+PUT /items
+{
+  "mappings": {
+    "properties": {
+      "skills": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+----
+// TESTSETUP
+--
+
+. Index several documents to this index.
++
+--
+[source,console]
+----
+PUT /job_applicants/_doc/1?refresh
+{
+  "skills" : "Java"
+}
+
+PUT /job_applicants/_doc/2?refresh
+{
+  "skills" : "Scalla"
+}
+
+
+PUT /job_applicants/_doc/3?refresh
+{
+  "skills" : ["Java", "Scalla"]
+}
+----
+--
+
+
+[[compound-query-ex-query]]
+===== Example query
+The following request scores documents by the first matching query:
+[source,console]
+----
+GET /job_applicants/_search
+{
+    "query": {
+      "compound": {
+        "combine_mode": "first",
+        "queries": [
+          {
+            "script_score": {
+              "query": {
+                "match": {
+                  "skills": "Java"
+                }
+              },
+              "script": { "source": "10.0"}
+            }
+          },
+          {
+            "script_score": {
+              "query": {
+                "match": {
+                  "skills": "Scalla"
+                }
+              },
+              "script": {"source": "5.0"}
+            }
+          }
+        ]
+      }
+    }
+}
+----
+
+This returns the following response:
+
+[source,console-result]
+--------------------------------------------------
+{
+    ...,
+    "hits" : {
+        "total" : {
+            "value": 3,
+            "relation": "eq"
+        },
+        "max_score": 10.0,
+        "hits": [
+            {
+                "_index": "test-index",
+                "_id": "1",
+                "_score": 10.0,
+                "_source": {
+                    "skills": "Java"
+                }
+            },
+            {
+                "_index": "test-index",
+                "_id": "3",
+                "_score": 10.0,
+                "_source": {
+                    "skills": [
+                        "Java",
+                        "Scalla"
+                    ]
+                }
+            },
+            {
+                "_index": "test-index",
+                "_id": "2",
+                "_score": 5.0,
+                "_source": {
+                    "skills": "Scalla"
+                }
+            }
+        ]
+    }
+}
+--------------------------------------------------
+
+[[query-dsl-compound-query-top-level-params]]
+==== Top-level parameters for `compound`
+
+`queries`::
+(Required, array of query objects) Contains one or more query clauses. Returned
+documents **must match one or more** of these queries. If a document matches
+multiple queries, {es} combines scores from the queries according the
+`combine_mode`
+
+`combine_mode`::
++
+--
+(Required, string) If a document matches  multiple queries,
+instructs how scores from the multiple queries should be combined.
+Can take one of the following options:
+
+[horizontal]
+`multiply`::    scores are multiplied
+`sum`::         scores are summed
+`avg`::         scores are averaged
+`first`::       score from the the first matching query is applied
+`max`::         maximum score is used
+`min`::         minimum score is used
+--

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/110_compound_query.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/110_compound_query.yml
@@ -1,0 +1,352 @@
+setup:
+  - do:
+      indices.create:
+        index: job_applicants
+        body:
+          settings:
+            number_of_replicas: 0
+            number_of_shards: 1
+          mappings:
+            properties:
+              skills:
+                type: keyword
+              years_work_experience:
+                type: integer
+              expected_salary:
+                type: integer
+
+  - do:
+      bulk:
+        index: job_applicants
+        refresh: true
+        body:
+          - '{"index": {"_id": "1"}}'
+          - '{"skills": "Java"}'
+          - '{"index": {"_id": "2"}}'
+          - '{"skills": "Scalla"}'
+          - '{"index": {"_id": "3"}}'
+          - '{"skills": ["Java", "Scalla"]}'
+
+---
+"Test first combine_mode 1":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "first",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": { "source": "10.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": {"source": "5.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "1" }
+  - match: { hits.hits.0._score: 10 }
+  - match: { hits.hits.1._id : "3" }
+  - match: { hits.hits.1._score: 10 } #3rd doc that has both "Java" and "Scalla" gets a score from the 1st query
+  - match: { hits.hits.2._id : "2" }
+  - match: { hits.hits.2._score: 5 }
+
+
+---
+"Test first combine_mode 2":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "first",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": { "source": "5.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": {"source": "10.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "1" }
+  - match: { hits.hits.0._score: 10 }
+  - match: { hits.hits.1._id : "2" }
+  - match: { hits.hits.1._score: 5 }
+  - match: { hits.hits.2._id : "3" }
+  - match: { hits.hits.2._score: 5 }  #3rd doc that has both "Java" and "Scalla" gets a score from the 1st query
+
+---
+"Test sum combine_mode":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "sum",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": { "source": "10.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": {"source": "5.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "3" }
+  - match: { hits.hits.0._score: 15 }
+  - match: { hits.hits.1._id : "1" }
+  - match: { hits.hits.1._score: 10 }
+  - match: { hits.hits.2._id : "2" }
+  - match: { hits.hits.2._score: 5 }
+
+---
+"Test multiply combine_mode":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "multiply",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": { "source": "10.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": {"source": "5.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "3" }
+  - match: { hits.hits.0._score: 50 }
+  - match: { hits.hits.1._id : "1" }
+  - match: { hits.hits.1._score: 10 }
+  - match: { hits.hits.2._id : "2" }
+  - match: { hits.hits.2._score: 5 }
+
+---
+"Test avg combine_mode":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "avg",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": { "source": "10.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": {"source": "5.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "1" }
+  - match: { hits.hits.0._score: 10 }
+  - match: { hits.hits.1._id : "3" }
+  - match: { hits.hits.1._score: 7.5 }
+  - match: { hits.hits.2._id : "2" }
+  - match: { hits.hits.2._score: 5 }
+
+---
+"Test max combine_mode":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "max",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": { "source": "10.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": {"source": "5.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "1" }
+  - match: { hits.hits.0._score: 10 }
+  - match: { hits.hits.1._id : "3" }
+  - match: { hits.hits.1._score: 10 }
+  - match: { hits.hits.2._id : "2" }
+  - match: { hits.hits.2._score: 5 }
+
+
+---
+"Test min combine_mode":
+  - skip:
+      version: " - 7.9.99"
+      reason: "Compound query was added from 8.0"
+  - do:
+      search:
+        index: job_applicants
+        body:  >
+          {
+            "query": {
+              "compound": {
+                "combine_mode": "min",
+                "queries": [
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Java"
+                        }
+                      },
+                      "script": { "source": "10.0"}
+                    }
+                  },
+                  {
+                    "script_score": {
+                      "query": {
+                        "match": {
+                          "skills": "Scalla"
+                        }
+                      },
+                      "script": {"source": "5.0"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+  - match: { hits.total.value: 3 }
+  - match: { hits.hits.0._id : "1" }
+  - match: { hits.hits.0._score: 10 }
+  - match: { hits.hits.1._id : "2" }
+  - match: { hits.hits.1._score: 5 }
+  - match: { hits.hits.2._id : "3" }
+  - match: { hits.hits.2._score: 5 }

--- a/server/src/main/java/org/elasticsearch/index/query/CompoundQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CompoundQueryBuilder.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.compound.CompoundQuery;
+import org.elasticsearch.index.query.compound.CompoundQuery.CombineMode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+/**
+ * Compound query that allows to combine scores from queries in a  more flexible way than bool query
+ */
+public class CompoundQueryBuilder extends AbstractQueryBuilder<CompoundQueryBuilder> {
+    public static final String NAME = "compound";
+    public static int maxClauseCount = 1024;
+
+    private static final ParseField QUERIES_FIELD = new ParseField("queries");
+    private static final ParseField COMBINE_MODE_FIELD = new ParseField("combine_mode");
+    private List<QueryBuilder> queryBuilders;
+    private CombineMode combineMode;
+
+    private static final ConstructingObjectParser<CompoundQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME, false,
+        args -> {
+            CompoundQueryBuilder cQueryBuilder = new CompoundQueryBuilder(
+                    (List<QueryBuilder>) args[0], CombineMode.fromString((String) args[1]));
+            if (args[2] != null) cQueryBuilder.boost((Float) args[2]);
+            if (args[3] != null) cQueryBuilder.queryName((String) args[3]);
+            return cQueryBuilder;
+        });
+
+    static {
+        PARSER.declareObjectArray(constructorArg(), (p,c) -> parseInnerQueryBuilder(p), QUERIES_FIELD);
+        PARSER.declareString(constructorArg(), COMBINE_MODE_FIELD);
+        PARSER.declareFloat(optionalConstructorArg(), AbstractQueryBuilder.BOOST_FIELD);
+        PARSER.declareString(optionalConstructorArg(), AbstractQueryBuilder.NAME_FIELD);
+    }
+
+    public static CompoundQueryBuilder fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    /**
+     * Create a new {@link CompoundQueryBuilder}
+     *
+     * @param queryBuilders a list of queries to combine
+     * @param combineMode combination mode
+     */
+    public CompoundQueryBuilder(List<QueryBuilder> queryBuilders, CombineMode combineMode) {
+        if (queryBuilders == null) {
+            throw new IllegalArgumentException("[queries] cannot be null.");
+        }
+        if (queryBuilders.size() > maxClauseCount) {
+            throw new IllegalArgumentException("Too many clauses! Should be less or equal [" +  maxClauseCount + "]!");
+        }
+        if (combineMode == null) {
+            throw new IllegalArgumentException("[combine_mode] cannot be null.");
+        }
+        this.queryBuilders = queryBuilders;
+        this.combineMode = combineMode;
+    }
+
+    /**
+     * Set the maximum number of clauses permitted per CompoundQuery.
+     */
+    public static void setMaxClauseCount(int maxClauseCount) {
+        if (maxClauseCount < 1) {
+            throw new IllegalArgumentException("maxClauseCount must be >= 1");
+        }
+        CompoundQueryBuilder.maxClauseCount = maxClauseCount;
+    }
+
+    public List<QueryBuilder> getQueryBuilders() {
+        return queryBuilders;
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.startArray(QUERIES_FIELD.getPreferredName());
+        for (QueryBuilder clause : queryBuilders) {
+            clause.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.field(COMBINE_MODE_FIELD.getPreferredName(), combineMode.name().toLowerCase(Locale.ROOT));
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    public CompoundQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        queryBuilders = readQueries(in);
+        combineMode = CombineMode.readFromStream(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        writeQueries(out, queryBuilders);
+        combineMode.writeTo(out);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        Query[] queries = new Query[queryBuilders.size()];
+        for (int i = 0; i < queryBuilders.size(); i++) {
+            queries[i] = queryBuilders.get(i).toQuery(context);
+        }
+        return new CompoundQuery(queries, combineMode);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(queryBuilders, combineMode);
+    }
+
+    @Override
+    protected boolean doEquals(CompoundQueryBuilder other) {
+        return Objects.equals(queryBuilders, other.queryBuilders) && Objects.equals(combineMode, other.combineMode) ;
+    }
+
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        if (queryBuilders.size() == 0) {
+            return new MatchAllQueryBuilder().boost(boost()).queryName(queryName());
+        }
+        boolean rewritten = false;
+        List<QueryBuilder> rqueryBuilders = new ArrayList<>();
+        for (QueryBuilder queryBuilder : queryBuilders) {
+            QueryBuilder rqueryBuilder = queryBuilder.rewrite(queryRewriteContext);
+            rqueryBuilders.add(rqueryBuilder);
+            if (queryBuilder != rqueryBuilder) {
+                rewritten = true;
+            }
+        }
+        // early termination when all clauses are returning MatchNoneQueryBuilder
+        if(rqueryBuilders.stream().allMatch(b -> b instanceof MatchNoneQueryBuilder)) {
+            return new MatchNoneQueryBuilder();
+        }
+        if (rewritten) {
+            CompoundQueryBuilder newCompoundQueryBuilder = new CompoundQueryBuilder(rqueryBuilders, combineMode);
+            newCompoundQueryBuilder.boost(boost());
+            newCompoundQueryBuilder.queryName(queryName());
+            return newCompoundQueryBuilder;
+        };
+        return this;
+    }
+
+    @Override
+    protected void extractInnerHitBuilders(Map<String, InnerHitContextBuilder> innerHits) {
+        List<QueryBuilder> clauses = new ArrayList<>();
+        clauses.addAll(queryBuilders);
+        for (QueryBuilder clause : clauses) {
+            InnerHitContextBuilder.extractInnerHits(clause, innerHits);
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.query.DistanceFeatureQueryBuilder.Origin;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder.Item;
+import org.elasticsearch.index.query.compound.CompoundQuery;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.ScriptScoreQueryBuilder;
@@ -437,6 +438,16 @@ public final class QueryBuilders {
      */
     public static ScriptScoreQueryBuilder scriptScoreQuery(QueryBuilder queryBuilder, Script script) {
         return new ScriptScoreQueryBuilder(queryBuilder, script);
+    }
+
+    /**
+     * A query that combines scores from different queries
+     *
+     * @param queryBuilders Queries which scores need to be combined
+     * @param combineMode  combination mode
+     */
+    public static CompoundQueryBuilder compoundQuery(List<QueryBuilder> queryBuilders, CompoundQuery.CombineMode combineMode) {
+        return new CompoundQueryBuilder(queryBuilders, combineMode);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/index/query/compound/CompoundQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/query/compound/CompoundQuery.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.query.compound;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.Matches;
+import org.apache.lucene.search.MatchesUtils;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Scorer;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Set;
+
+
+public class CompoundQuery extends Query {
+    private final Query[] queries;
+    private final CombineMode combineMode;
+
+    public CompoundQuery(Query[] queries, CombineMode combineMode) {
+        this.queries = queries;
+        this.combineMode = combineMode;
+    }
+
+    public Query[] getQueries() {
+        return queries;
+    }
+
+    @Override
+    public Query rewrite(IndexReader reader) throws IOException {
+        if (queries.length == 1) {
+            return queries[0];
+        }
+        Query[] rewrittenQueries = new Query[queries.length];
+        boolean rewritten = false;
+        for (int i = 0; i < queries.length; i++) {
+            Query rewrittenQuery = queries[i].rewrite(reader);
+            if (queries[i] != rewrittenQuery) {
+                rewritten = true;
+                rewrittenQueries[i] = rewrittenQuery;
+            } else {
+                rewrittenQueries[i] = queries[i];
+            }
+        }
+        if (rewritten) {
+            return new CompoundQuery(queries, combineMode);
+        }
+        return super.rewrite(reader);
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        QueryVisitor v = visitor.getSubVisitor(BooleanClause.Occur.SHOULD, this);
+        for (Query q : queries) {
+            q.visit(v);
+        }
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new CompoundWeight(this, combineMode, searcher, scoreMode, boost);
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("compound (combine_mode:" + combineMode.toString());
+        sb.append(", queries: [");
+        for (Query query : queries) {
+            sb.append("{" + query.toString(field) + "}");
+        }
+        sb.append("])");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CompoundQuery other = (CompoundQuery) o;
+        return Arrays.equals(this.queries, other.queries) && Objects.equals(this.combineMode, other.combineMode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(queries), combineMode);
+    }
+
+    public enum CombineMode implements Writeable {
+        FIRST, AVG, MAX, SUM, MIN, MULTIPLY;
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeEnum(this);
+        }
+
+        public static CombineMode readFromStream(StreamInput in) throws IOException {
+            return in.readEnum(CombineMode.class);
+        }
+
+        public static CombineMode fromString(String combineMode) {
+            return valueOf(combineMode.toUpperCase(Locale.ROOT));
+        }
+    }
+
+    static final class CompoundWeight extends Weight {
+        private final Weight[] queryWeights;
+        private final ScoreMode scoreMode;
+        private final CombineMode combineMode;
+
+        CompoundWeight(CompoundQuery compoundQuery, CombineMode combineMode, IndexSearcher searcher,
+                ScoreMode scoreMode, float boost) throws IOException {
+            super(compoundQuery);
+            Query[] queries = compoundQuery.getQueries();
+            this.queryWeights = new Weight[queries.length];
+            this.combineMode = combineMode;
+            this.scoreMode = scoreMode;
+            for (int i = 0; i < queries.length; i++) {
+                queryWeights[i] = searcher.createWeight(searcher.rewrite(queries[i]), scoreMode, boost);
+            }
+        }
+
+        @Override
+        public void extractTerms(Set<Term> terms) {
+            for (Weight w: queryWeights) {
+                w.extractTerms(terms);
+            }
+        }
+
+        @Override
+        public Matches matches(LeafReaderContext context, int doc) throws IOException {
+            List<Matches> matches = new ArrayList<>();
+            for (Weight w: queryWeights) {
+                Matches m = w.matches(context, doc);
+                if (m != null) {
+                    matches.add(m);
+                    if (combineMode == CombineMode.FIRST) break;
+                }
+            }
+            return MatchesUtils.fromSubMatches(matches);
+        }
+
+        @Override
+        public Scorer scorer(LeafReaderContext context) throws IOException {
+            ScorerSupplier scorerSupplier = scorerSupplier(context);
+            if (scorerSupplier == null) {
+                return null;
+            }
+            return scorerSupplier.get(Long.MAX_VALUE);
+        }
+
+        @Override
+        public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+            List<ScorerSupplier> scorerSuppliers = new ArrayList<>();
+            for (Weight w: queryWeights) {
+                ScorerSupplier scorerSupplier = w.scorerSupplier(context);
+                if (scorerSupplier != null) {
+                    scorerSuppliers.add(scorerSupplier);
+                }
+            }
+            return new CompoundScorerSupplier(this, scoreMode, scorerSuppliers, combineMode);
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext ctx) {
+            for (Weight w: queryWeights) {
+                if (w.isCacheable(ctx) == false) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+            boolean match = false;
+            List<Explanation> subExplanations = new ArrayList<>();
+            for (Weight w : queryWeights) {
+                Explanation e = w.explain(context, doc);
+                if (e.isMatch()) {
+                    match = true;
+                    subExplanations.add(e);
+                    if (combineMode == CombineMode.FIRST) break;
+                }
+            }
+            if (match) {
+                Scorer scorer = scorer(context);
+                int advanced = scorer.iterator().advance(doc);
+                assert advanced == doc;
+                String desc;
+                switch (combineMode) {
+                    case FIRST:
+                        desc = "first of:";
+                        break;
+                    case MAX:
+                        desc = "max of:";
+                        break;
+                    case MIN:
+                        desc = "min of:";
+                        break;
+                    case MULTIPLY:
+                        desc = "multiplication of:";
+                        break;
+                    case SUM:
+                        desc = "sum of:";
+                        break;
+                    default: //average
+                        desc = "average of";
+                }
+                return Explanation.match(scorer.score(), desc, subExplanations);
+            } else {
+                return Explanation.noMatch("No matching clause");
+            }
+        }
+    }
+
+    static final class CompoundScorerSupplier extends ScorerSupplier {
+        private final Weight weight;
+        private final ScoreMode scoreMode;
+        private final List<ScorerSupplier> scorerSuppliers;
+        private final CombineMode combineMode;
+        private long cost = -1;
+
+        CompoundScorerSupplier(Weight weight, ScoreMode scoreMode, List<ScorerSupplier> scorerSuppliers, CombineMode combineMode) {
+            this.weight = weight;
+            this.scoreMode = scoreMode;
+            this.scorerSuppliers = scorerSuppliers;
+            this.combineMode = combineMode;
+        }
+
+        @Override
+        public long cost() {
+            if (cost == -1) {
+                cost = scorerSuppliers.stream().mapToLong(ScorerSupplier::cost).sum();
+            }
+            return cost;
+        }
+
+        @Override
+        public Scorer get(long leadCost) throws IOException {
+            leadCost = Math.min(leadCost, cost());
+            final List<Scorer> scorers = new ArrayList<>();
+            for (ScorerSupplier scorerSupplier : scorerSuppliers) {
+                scorers.add(scorerSupplier.get(leadCost));
+            };
+            return new DisjunctionCombineScorer(weight, scorers, combineMode, scoreMode);
+        }
+    }
+}
+
+

--- a/server/src/main/java/org/elasticsearch/index/query/compound/DisiOrderedWrapper.java
+++ b/server/src/main/java/org/elasticsearch/index/query/compound/DisiOrderedWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.compound;
+
+import org.apache.lucene.search.DisiWrapper;
+import org.apache.lucene.search.Scorer;
+
+/*
+ * DisiWrapper that also stores its insertion order
+ */
+public class DisiOrderedWrapper extends DisiWrapper {
+    final int order;
+
+    DisiOrderedWrapper(Scorer scorer, int order) {
+        super(scorer);
+        this.order = order;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/query/compound/DisjunctionCombineScorer.java
+++ b/server/src/main/java/org/elasticsearch/index/query/compound/DisjunctionCombineScorer.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query.compound;
+
+import org.apache.lucene.search.DisiPriorityQueue;
+import org.apache.lucene.search.DisiWrapper;
+import org.apache.lucene.search.DisjunctionDISIApproximation;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.index.query.compound.CompoundQuery.CombineMode;
+
+/*
+ *  Based on org.apache.lucene.search.DisjunctionScorer
+ */
+class DisjunctionCombineScorer extends Scorer {
+
+    private final DisiPriorityQueue subScorers;
+    private final DocIdSetIterator approximation;
+    private final CombineMode combineMode;
+    protected DisjunctionCombineScorer(Weight weight, List<Scorer> subScorers, CombineMode combineMode, ScoreMode scoreMode)
+            throws IOException {
+        super(weight);
+        if (subScorers.size() <= 1) {
+            throw new IllegalArgumentException("There must be at least 2 subScorers");
+        }
+        this.combineMode = combineMode;
+        this.subScorers = new DisiPriorityQueue(subScorers.size());
+        for (int i = 0; i < subScorers.size(); i++) {
+            final DisiOrderedWrapper w = new DisiOrderedWrapper(subScorers.get(i), i);
+            this.subScorers.add(w);
+        }
+        this.approximation = new DisjunctionDISIApproximation(this.subScorers);
+    }
+
+    @Override
+    public DocIdSetIterator iterator() {
+        return approximation;
+    }
+
+    @Override
+    public final int docID() {
+        return subScorers.top().doc;
+    }
+
+    DisiWrapper getSubMatches() {
+        return subScorers.topList();
+    }
+
+    @Override
+    public final float score() throws IOException {
+        return score(getSubMatches());
+    }
+
+    private float score(DisiWrapper topList) throws IOException {
+        float score;
+        switch(combineMode) {
+            case FIRST:
+                Scorer scorer = null;
+                int minOrder = Integer.MAX_VALUE;
+                for (DisiOrderedWrapper w = (DisiOrderedWrapper) topList; w != null; w = (DisiOrderedWrapper) w.next) {
+                    if (w.order < minOrder) {
+                        minOrder = w.order;
+                        scorer = w.scorer;
+                    }
+                }
+                score = scorer.score();
+                break;
+            case MAX:
+                score = 0;
+                for (DisiWrapper w = topList; w != null; w = w.next) {
+                    float curScore = w.scorer.score();
+                    if (curScore > score) {
+                        score = curScore;
+                    }
+                }
+                break;
+            case MIN:
+                score = Float.MAX_VALUE;
+                for (DisiWrapper w = topList; w != null; w = w.next) {
+                    float curScore = w.scorer.score();
+                    if (curScore < score) {
+                        score = curScore;
+                    }
+                }
+                break;
+            case MULTIPLY:
+                score = 1;
+                for (DisiWrapper w = topList; w != null; w = w.next) {
+                    score *= w.scorer.score();
+                }
+                break;
+            default: // SUM or AVG
+                score = 0;
+                int scorersCount = 0;
+                for (DisiWrapper w = topList; w != null; w = w.next) {
+                    score += w.scorer.score();
+                    scorersCount++;
+                }
+                if (combineMode == CombineMode.AVG) {
+                    score = score / scorersCount;
+                }
+        }
+        return score;
+    }
+
+    @Override
+    public float getMaxScore(int upTo) {
+        return Float.MAX_VALUE;
+    }
+
+    @Override
+    public final Collection<ChildScorable> getChildren() {
+        ArrayList<ChildScorable> children = new ArrayList<>();
+        for (DisiWrapper scorer = getSubMatches(); scorer != null; scorer = scorer.next) {
+            children.add(new ChildScorable(scorer.scorer, "SHOULD"));
+        }
+        return children;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
+import org.elasticsearch.index.query.CompoundQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.DisMaxQueryBuilder;
 import org.elasticsearch.index.query.DistanceFeatureQueryBuilder;
@@ -762,6 +763,8 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(FunctionScoreQueryBuilder.NAME, FunctionScoreQueryBuilder::new,
                 FunctionScoreQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(ScriptScoreQueryBuilder.NAME, ScriptScoreQueryBuilder::new, ScriptScoreQueryBuilder::fromXContent));
+        CompoundQueryBuilder.setMaxClauseCount(INDICES_MAX_CLAUSE_COUNT_SETTING.get(settings));
+        registerQuery(new QuerySpec<>(CompoundQueryBuilder.NAME, CompoundQueryBuilder::new, CompoundQueryBuilder::fromXContent));
         registerQuery(
                 new QuerySpec<>(SimpleQueryStringBuilder.NAME, SimpleQueryStringBuilder::new, SimpleQueryStringBuilder::fromXContent));
         registerQuery(new QuerySpec<>(ScriptQueryBuilder.NAME, ScriptQueryBuilder::new, ScriptQueryBuilder::fromXContent));

--- a/server/src/test/java/org/elasticsearch/index/query/CompoundQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/CompoundQueryBuilderTests.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.compound.CompoundQuery;
+import org.elasticsearch.test.AbstractQueryTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.elasticsearch.index.query.compound.CompoundQuery.CombineMode;
+
+public class CompoundQueryBuilderTests extends AbstractQueryTestCase<CompoundQueryBuilder> {
+
+    @Override
+    protected CompoundQueryBuilder doCreateTestQueryBuilder() {
+        int numClauses = randomIntBetween(0, 5);
+        List<QueryBuilder> queryBuilders = new ArrayList<>(numClauses);
+        for (int i = 0; i < numClauses; i++) {
+            queryBuilders.add(RandomQueryBuilder.createQuery(random()));
+        }
+        int combineModeIndex = randomIntBetween(0, CombineMode.values().length - 1);
+        CombineMode combineMode = CombineMode.values()[combineModeIndex];
+        CompoundQueryBuilder queryBuilder = new CompoundQueryBuilder(queryBuilders, combineMode);
+        return queryBuilder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(CompoundQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        if (queryBuilder.getQueryBuilders().size() == 0) {
+            assertThat(query, instanceOf(MatchAllDocsQuery.class));
+        } else {
+            assertThat(query, instanceOf(CompoundQuery.class));
+            CompoundQuery compoundQuery = (CompoundQuery) query;
+            assertEquals(queryBuilder.getQueryBuilders().size(), compoundQuery.getQueries().length);
+        }
+    }
+
+    public void testFromJson() throws IOException {
+        String query =
+            "{" +
+                "\"compound\" : {" +
+                "  \"queries\" : [ {" +
+                "    \"term\" : {" +
+                "      \"tag\" : {" +
+                "        \"value\" : \"white\"," +
+                "        \"boost\" : 1.0" +
+                "      }" +
+                "    }" +
+                "  }, {" +
+                "    \"term\" : {" +
+                "      \"tag\" : {" +
+                "        \"value\" : \"elephant\"," +
+                "        \"boost\" : 1.0" +
+                "      }" +
+                "    }" +
+                "  } ]," +
+                "  \"combine_mode\" : \"sum\"," +
+                "  \"boost\" : 42.0" +
+                "}" +
+            "}";
+
+        CompoundQueryBuilder queryBuilder = (CompoundQueryBuilder) parseQuery(query);
+        checkGeneratedJson(query, queryBuilder);
+        assertEquals(query, 42, queryBuilder.boost, 0.00001);
+    }
+
+    public void testRewrite() throws IOException {
+        QueryBuilder queryBuilder = new WrapperQueryBuilder(new TermsQueryBuilder("field", "elephant").toString());
+        List<QueryBuilder> queryBuilders = new ArrayList<>(Arrays.asList(queryBuilder));
+        CompoundQueryBuilder compoundQueryBuilder = new CompoundQueryBuilder(queryBuilders, CombineMode.SUM);
+        CompoundQueryBuilder rewritten = (CompoundQueryBuilder) compoundQueryBuilder.rewrite(createShardContext());
+        assertNotSame(rewritten, compoundQueryBuilder);
+        assertEquals(new TermsQueryBuilder("field", "elephant"), rewritten.getQueryBuilders().get(0));
+    }
+}


### PR DESCRIPTION
This introduces compound query that allows to combine
scores from wrapped queries in a number of ways:

```js
{
  "query": {
    "compound": {
      "queries": [
        {
          "match": {"message": "elasticsearch"}
        },
        {
         "match": {"author": "kibana"}
        }
      ],
      "combine_mode": "sum"
    }
  }
}
```

Options for combine_mode:

combine_mode | definition
-- | --
sum | scores are summed (default)
multiply | scores are multiplied 
avg | scores are averaged
first | the first function that has a matching filter is applied
max | maximum score is used
min | minimum score is used

compound query allows to deprecate function_score query.

closes #51967