### PR TITLE
Removed link to wikipedia as it is incorrect

### DIFF
--- a/docs/reference/sql/functions/aggs.asciidoc
+++ b/docs/reference/sql/functions/aggs.asciidoc
@@ -542,7 +542,7 @@ SUM_OF_SQUARES(field_name) <1>
 
 *Description*:
 
-Returns the https://en.wikipedia.org/wiki/Total_sum_of_squares[sum of squares] of input values in the field `field_name`.
+Returns the sum of squares of input values in the field `field_name`.
 
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------


### PR DESCRIPTION
Removed the link to Wikipedia as the function is not calculating the sum of squares in this way. More can be found here at this issue:

https://github.com/elastic/elasticsearch/issues/50416

