### PR TITLE
Fix Failure to Drain Stream in GCS Repo Tests

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -323,7 +323,6 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends ESTestCase {
         logger.debug("starting with resumable upload id [{}]", sessionUploadId.get());
 
         httpServer.createContext("/upload/storage/v1/b/bucket/o", safeHandler(exchange -> {
-            // read all the request body, otherwise the SDK client throws a non-retryable StorageException
             final BytesReference requestBody = Streams.readFully(exchange.getRequestBody());
 
             final Map<String, String> params = new HashMap<>();


### PR DESCRIPTION
Same as #51933 but for the custom handler just used in this test.

Closes #52430
