### PR TITLE
Fix testRestoreLocalHistoryFromTranslog

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4207,7 +4207,6 @@ public class InternalEngineTests extends EngineTestCase {
             final EngineConfig engineConfig;
             final SeqNoStats prevSeqNoStats;
             final List<DocIdSeqNoAndSource> prevDocs;
-            final List<Translog.Operation> existingTranslog;
             try (InternalEngine engine = createEngine(store, createTempDir(), globalCheckpoint::get)) {
                 engineConfig = engine.config();
                 for (final long seqNo : seqNos) {
@@ -4226,24 +4225,17 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.syncTranslog();
                 prevSeqNoStats = engine.getSeqNoStats(globalCheckpoint.get());
                 prevDocs = getDocIds(engine, true);
-                try (Translog.Snapshot snapshot = engine.getTranslog().newSnapshot()) {
-                    existingTranslog = TestTranslog.drainSnapshot(snapshot, false);
-                }
             }
             try (InternalEngine engine = new InternalEngine(engineConfig)) {
-                final Translog.TranslogGeneration currrentTranslogGeneration = new Translog.TranslogGeneration(
-                    engine.getTranslog().getTranslogUUID(), engine.getTranslog().currentFileGeneration());
+                final long currentTranslogGeneration = engine.getTranslog().currentFileGeneration();
                 engine.recoverFromTranslog(translogHandler, globalCheckpoint.get());
                 engine.restoreLocalHistoryFromTranslog(translogHandler);
                 assertThat(getDocIds(engine, true), equalTo(prevDocs));
                 SeqNoStats seqNoStats = engine.getSeqNoStats(globalCheckpoint.get());
                 assertThat(seqNoStats.getLocalCheckpoint(), equalTo(prevSeqNoStats.getLocalCheckpoint()));
                 assertThat(seqNoStats.getMaxSeqNo(), equalTo(prevSeqNoStats.getMaxSeqNo()));
-                try (Translog.Snapshot snapshot = engine.getTranslog().newSnapshot()) {
-                    assertThat("restore from local translog must not add operations to translog",
-                        snapshot.totalOperations(), equalTo(existingTranslog.size()));
-                    assertThat(TestTranslog.drainSnapshot(snapshot, false), equalTo(existingTranslog));
-                }
+                assertThat("restore from local translog must not add operations to translog",
+                    engine.getTranslog().totalOperationsByMinGen(currentTranslogGeneration), equalTo(0));
             }
             assertConsistentHistoryBetweenTranslogAndLuceneIndex(engine, createMapperService());
         }


### PR DESCRIPTION
Asserts that no new operations are made into the translog since we re-opened the engine.

Relates #51905 
Closes #52410