### PR TITLE
[DOCS] "now" cannot be used at indexing time in date_range fields

### DIFF
--- a/docs/reference/mapping/types/range.asciidoc
+++ b/docs/reference/mapping/types/range.asciidoc
@@ -54,7 +54,7 @@ PUT range_index/_doc/1?refresh
 <1> `date_range` types accept the same field parameters defined by the <<date, `date`>> type.
 <2> Example indexing a meeting with 10 to 20 attendees.
 <3> Date ranges accept the same format as described in <<ranges-on-dates, date range queries>>.
-<4> Example date range using date time stamp. This also accepts <<date-math, date math>> formatting, or "now" for system time.
+<4> Example date range using date time stamp. This also accepts <<date-math, date math>> formatting. Note that "now" cannot be used at indexing time.
 
 The following is an example of a <<query-dsl-term-query, term query>> on the `integer_range` field named "expected_attendees".
 


### PR DESCRIPTION
According to https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java#L174, `date_range` fields do not accept `"now"` as a value of either bounds at indexing time, so the documentation should reflect that restriction.