### PR TITLE
Evaluate inactive replica size by current primary shard in DiskThresh…

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -465,6 +465,10 @@ public class DiskThresholdDecider extends AllocationDecider {
                 }
             }
             return targetShardSize == 0 ? defaultValue : targetShardSize;
+        } else if (shard.primary() == false && shard.active() == false) {
+            // if current shard is an inactive replica, evaluate shard size by primary shard.
+            ShardRouting primaryShard = routingTable.shardRoutingTable(shard.shardId()).primaryShard();
+            return clusterInfo.getShardSize(primaryShard, clusterInfo.getShardSize(shard, defaultValue));
         } else {
             return clusterInfo.getShardSize(shard, defaultValue);
         }


### PR DESCRIPTION
Evaluate inactive replica size by current primary shard in DiskThresholdDecider as discussed in [another PR comment](https://github.com/elastic/elasticsearch/pull/50374#issuecomment-586280202)

Relates #49972

