### PR TITLE
Fix Non-Verbose Snapshot List Missing Empty Snapshots (#52433)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -180,10 +180,9 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 }
             }
         }
-        for (Map.Entry<SnapshotId, List<String>> entry : snapshotsToIndices.entrySet()) {
-            final List<String> indices = entry.getValue();
+        for (SnapshotId snapshotId : toResolve) {
+            final List<String> indices = snapshotsToIndices.getOrDefault(snapshotId, Collections.emptyList());
             CollectionUtil.timSort(indices);
-            final SnapshotId snapshotId = entry.getKey();
             snapshotInfos.add(new SnapshotInfo(snapshotId, indices, repositoryData.getSnapshotState(snapshotId)));
         }
         CollectionUtil.timSort(snapshotInfos);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -41,6 +41,8 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
@@ -166,5 +168,27 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         expectThrows(SnapshotMissingException.class, () -> client().admin().cluster()
             .prepareSnapshotStatus("test-repo").setSnapshots("test-snap").execute().actionGet());
+    }
+
+    public void testGetSnapshotsWithoutIndices() {
+        logger.info("--> creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository("test-repo").setType("fs").setSettings(
+            Settings.builder().put("location", randomRepoPath()).build()));
+
+        logger.info("--> snapshot");
+        final SnapshotInfo snapshotInfo =
+            client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
+                .setIndices().setWaitForCompletion(true).get().getSnapshotInfo();
+
+        assertThat(snapshotInfo.state(), is(SnapshotState.SUCCESS));
+        assertThat(snapshotInfo.totalShards(), is(0));
+
+        logger.info("--> verify that snapshot without index shows up in non-verbose listing");
+        final List<SnapshotInfo> snapshotInfos =
+            client().admin().cluster().prepareGetSnapshots("test-repo").setVerbose(false).get().getSnapshots();
+        assertThat(snapshotInfos, hasSize(1));
+        final SnapshotInfo found = snapshotInfos.get(0);
+        assertThat(found.snapshotId(), is(snapshotInfo.snapshotId()));
+        assertThat(found.state(), is(SnapshotState.SUCCESS));
     }
 }


### PR DESCRIPTION
We were not including snapshots without indices in the non-verbose
listing because we used the snapshot -> indices mapping to get the
snapshots.

backport of #52433 