### PR TITLE
[7.x] Relax assertions on memory_estimation.* fields (#52452)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
@@ -125,8 +125,10 @@
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { memory_estimation.expected_memory_without_disk: "3kb" }
-  - match: { memory_estimation.expected_memory_with_disk: "3kb" }
+  - match:
+      memory_estimation.expected_memory_without_disk: / \dkb /
+  - match:
+      memory_estimation.expected_memory_with_disk: / \dkb /
   - length: { field_selection: 2 }
   - match: { field_selection.0.name: "x" }
   - match: { field_selection.0.mapping_types: ["float"] }
@@ -153,8 +155,10 @@
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { memory_estimation.expected_memory_without_disk: "4kb" }
-  - match: { memory_estimation.expected_memory_with_disk: "4kb" }
+  - match:
+      memory_estimation.expected_memory_without_disk: / \dkb /
+  - match:
+      memory_estimation.expected_memory_with_disk: / \dkb /
 
   - do:
       index:
@@ -168,8 +172,10 @@
         body:
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
-  - match: { memory_estimation.expected_memory_without_disk: "6kb" }
-  - match: { memory_estimation.expected_memory_with_disk: "5kb" }
+  - match:
+      memory_estimation.expected_memory_without_disk: / \dkb /
+  - match:
+      memory_estimation.expected_memory_with_disk: / \dkb /
 
 ---
 "Test field_selection given body":


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Relax assertions on memory_estimation.* fields  (#52452)