### PR TITLE
Mute failing top_metrics tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -1,5 +1,8 @@
 ---
 "sort by long field":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/52418"
   - do:
       bulk:
         index: test
@@ -56,6 +59,9 @@
 
 ---
 "sort by double field":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/52418"
   - do:
       indices.create:
         index: test
@@ -156,6 +162,9 @@
 
 ---
 "sort by keyword field fails":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/52409"
   - do:
       bulk:
         index: test
@@ -179,6 +188,9 @@
 
 ---
 "sort by score":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/52409"
   - do:
       bulk:
         index: test
@@ -236,6 +248,9 @@
 
 ---
 "sort by string script fails":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/52409"
   - do:
       bulk:
         index: test


### PR DESCRIPTION
These tests fails when the global template is added, which changes
number_of_shards to 2.

Relates #52409 and #52418
