### PR TITLE
Use actual current commit id for build scan custom value

### DIFF
--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -79,12 +79,6 @@ buildScan {
       }
       value 'Git Commit ID', BuildParams.gitRevision
       link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
-      if (System.getenv('GIT_PREVIOUS_COMMIT')) {
-        background {
-          def changes = "git diff --name-only ${System.getenv('GIT_PREVIOUS_COMMIT')}..${System.getenv('GIT_COMMIT')}".execute().text.trim()
-          value 'Git Changes', changes
-        }
-      }
     }
   } else {
     tag 'LOCAL'

--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.OS
+import org.elasticsearch.gradle.info.BuildParams
 import org.gradle.initialization.BuildRequestMetaData
 
 import java.util.concurrent.TimeUnit
@@ -76,9 +77,9 @@ buildScan {
         value 'Git Branch', branch
         tag branch
       }
-      if (System.getenv('GIT_COMMIT')) {
-        value 'Git Commit ID', System.getenv('GIT_COMMIT')
-        link 'Source', "https://github.com/elastic/elasticsearch/tree/${System.getenv('GIT_COMMIT')}"
+      value 'Git Commit ID', BuildParams.gitRevision
+      link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
+      if (System.getenv('GIT_PREVIOUS_COMMIT')) {
         background {
           def changes = "git diff --name-only ${System.getenv('GIT_PREVIOUS_COMMIT')}..${System.getenv('GIT_COMMIT')}".execute().text.trim()
           value 'Git Changes', changes


### PR DESCRIPTION
When using runbld with `--last-good-commit` the commit id reported by Jenkins via build environment variables is not guaranteed to be correct, and in most cases, it isn't. This is because runbld performs a second checkout during the build execution of the "last good commit".

This pull request changes the commit id reported in build scans to the real commit, and not what Jenkins is incorrectly reporting.