### PR TITLE
Adjust the order of slowlog'x-opaque-id to avoid being truncated

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -213,16 +213,18 @@ public final class SearchSlowLog implements SearchOperationListener {
             }
             sb.append("search_type[").append(context.searchType()).append("], total_shards[")
                 .append(context.numberOfShards()).append("], ");
-            if (context.request().source() != null) {
-                sb.append("source[").append(context.request().source().toString(FORMAT_PARAMS)).append("], ");
-            } else {
-                sb.append("source[], ");
-            }
             if (context.getTask().getHeader(Task.X_OPAQUE_ID) != null) {
                 sb.append("id[").append(context.getTask().getHeader(Task.X_OPAQUE_ID)).append("], ");
             } else {
                 sb.append("id[], ");
             }
+            if (context.request().source() != null) {
+                sb.append("source[").append(context.request().source().toString(FORMAT_PARAMS)).append("], ");
+            } else {
+                sb.append("source[], ");
+            }
+            // Any field added in the future should add before `source`
+            // to avoid being truncated when the query source body is too long
             return sb.toString();
         }
 


### PR DESCRIPTION
[Pr#21609](https://github.com/elastic/elasticsearch/pull/21609) modified the slowlog pattern layout trunactes from the end. And the later [Pr#31539](https://github.com/elastic/elasticsearch/pull/31539) adds a useful field `x-opaque-id` after `source`. When the query body is long than 10kB, `x-opaque-id` will be trunacted. Adjust the order of `x-opaque-id` to avoid being truncated. And any field added in the future should add before `source` to avoid being truncated.