### PR TITLE
Fix synchronization in ByteSizeCachingDirectory

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java
@@ -160,7 +160,7 @@ final class ByteSizeCachingDirectory extends FilterDirectory {
                 try {
                     super.close();
                 } finally {
-                    synchronized (this) {
+                    synchronized (ByteSizeCachingDirectory.this) {
                         numOpenOutputs--;
                         modCount++;
                     }


### PR DESCRIPTION
One particular code place was synchronizing on the wrong object.