### PR TITLE
Disable duplicate project detection in Gradle 6.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
 options.forkOptions.memoryMaximumSize=2g
+
+# Disable duplicate project id detection
+# See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
+systemProp.org.gradle.dependency.duplicate.project.detection=false


### PR DESCRIPTION
Gradle 6.2 enforces that projects have unique publishing coordinates and fails otherwise: https://gradle-enterprise.elastic.co/s/klqf2th25y4ae/failure?openFailures=WzBd&openStackTraces=WzFd#top=0

I've opened #52528 to go back and address the root cause here, but for now this pull request simply reverts to the behavior in Gradle 6.1 which is to allow this scenario. In our case this is benign, since we explicitly publish only certain artifacts, which is handled by release-manager.

For details on this breaking change in Gradle 6.2 see: https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail