### PR TITLE
[7.x] Make DeleteStep retryable (#52494)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteStep.java
@@ -32,4 +32,9 @@ public class DeleteStep extends AsyncRetryDuringSnapshotActionStep {
     public boolean indexSurvives() {
         return false;
     }
+
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make DeleteStep retryable (#52494)