### PR TITLE
Remove Xlint exclusions from gradle files

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -41,7 +41,6 @@ dependencies {
   runtime 'org.apache.commons:commons-math3:3.2'
 }
 
-compileJava.options.compilerArgs << "-Xlint:-cast,-rawtypes,-unchecked,-processing"
 // enable the JMH's BenchmarkProcessor to generate the final benchmark classes
 // needs to be added separately otherwise Gradle will quote it and javac will fail
 compileJava.options.compilerArgs.addAll(["-processor", "org.openjdk.jmh.generators.BenchmarkProcessor"])

--- a/client/client-benchmark-noop-api-plugin/build.gradle
+++ b/client/client-benchmark-noop-api-plugin/build.gradle
@@ -33,8 +33,6 @@ assemble.enabled = false
 dependencyLicenses.enabled = false
 dependenciesInfo.enabled = false
 
-compileJava.options.compilerArgs << "-Xlint:-cast,-rawtypes,-unchecked"
-
 // no unit tests
 test.enabled = false
 integTest.enabled = false

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -32,8 +32,6 @@ esplugin {
   classname 'org.elasticsearch.transport.Netty4Plugin'
 }
 
-compileTestJava.options.compilerArgs << "-Xlint:-cast,-rawtypes,-unchecked"
-
 dependencies {
   // network stack
   compile "io.netty:netty-buffer:${versions.netty}"

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -102,8 +102,7 @@ class Netty4HttpClient implements Closeable {
         return sendRequests(remoteAddress, requests);
     }
 
-    @SafeVarargs // Safe not because it doesn't do anything with the type parameters but because it won't leak them into other methods.
-    public final Collection<FullHttpResponse> post(SocketAddress remoteAddress, Tuple<String, CharSequence>... urisAndBodies)
+    public final Collection<FullHttpResponse> post(SocketAddress remoteAddress, List<Tuple<String, CharSequence>> urisAndBodies)
         throws InterruptedException {
         return processRequestsWithBody(HttpMethod.POST, remoteAddress, urisAndBodies);
     }
@@ -114,15 +113,14 @@ class Netty4HttpClient implements Closeable {
         return responses.iterator().next();
     }
 
-    @SafeVarargs // Safe not because it doesn't do anything with the type parameters but because it won't leak them into other methods.
-    public final Collection<FullHttpResponse> put(SocketAddress remoteAddress, Tuple<String, CharSequence>... urisAndBodies)
+    public final Collection<FullHttpResponse> put(SocketAddress remoteAddress, List<Tuple<String, CharSequence>> urisAndBodies)
         throws InterruptedException {
         return processRequestsWithBody(HttpMethod.PUT, remoteAddress, urisAndBodies);
     }
 
-    private Collection<FullHttpResponse> processRequestsWithBody(HttpMethod method, SocketAddress remoteAddress, Tuple<String,
-        CharSequence>... urisAndBodies) throws InterruptedException {
-        Collection<HttpRequest> requests = new ArrayList<>(urisAndBodies.length);
+    private Collection<FullHttpResponse> processRequestsWithBody(HttpMethod method, SocketAddress remoteAddress, List<Tuple<String,
+        CharSequence>> urisAndBodies) throws InterruptedException {
+        Collection<HttpRequest> requests = new ArrayList<>(urisAndBodies.size());
         for (Tuple<String, CharSequence> uriAndBody : urisAndBodies) {
             ByteBuf content = Unpooled.copiedBuffer(uriAndBody.v2(), StandardCharsets.UTF_8);
             HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriAndBody.v1(), content);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -35,6 +35,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -78,7 +79,7 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
             bulkRequest.append(System.lineSeparator());
         }
 
-        ArrayList<Tuple<String, CharSequence>> requests = new ArrayList<Tuple<String,CharSequence>>();
+        List<Tuple<String, CharSequence>> requests = new ArrayList<>();
         for (int i = 0; i < 150; i++) {
             requests.add(Tuple.tuple("/index/_bulk", bulkRequest));
         }
@@ -108,7 +109,7 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
     public void testDoesNotLimitExcludedRequests() throws Exception {
         ensureGreen();
 
-        ArrayList<Tuple<String, CharSequence>> requestUris = new ArrayList<Tuple<String, CharSequence>>();
+        List<Tuple<String, CharSequence>> requestUris = new ArrayList<>();
         for (int i = 0; i < 1500; i++) {
             requestUris.add(Tuple.tuple("/_cluster/settings",
                 "{ \"transient\": {\"search.default_search_timeout\": \"40s\" } }"));

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpRequestSizeLimitIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -77,25 +78,23 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
             bulkRequest.append(System.lineSeparator());
         }
 
-        @SuppressWarnings("unchecked")
-        Tuple<String, CharSequence>[] requests = new Tuple[150];
-        for (int i = 0; i < requests.length; i++) {
-            requests[i] = Tuple.tuple("/index/_bulk", bulkRequest);
+        ArrayList<Tuple<String, CharSequence>> requests = new ArrayList<Tuple<String,CharSequence>>();
+        for (int i = 0; i < 150; i++) {
+            requests.add(Tuple.tuple("/index/_bulk", bulkRequest));
         }
 
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
-        TransportAddress transportAddress = (TransportAddress) randomFrom(httpServerTransport.boundAddress
-            ().boundAddresses());
+        TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 
         try (Netty4HttpClient nettyHttpClient = new Netty4HttpClient()) {
-            Collection<FullHttpResponse> singleResponse = nettyHttpClient.post(transportAddress.address(), requests[0]);
+            Collection<FullHttpResponse> singleResponse = nettyHttpClient.post(transportAddress.address(), requests.subList(0, 1));
             try {
                 assertThat(singleResponse, hasSize(1));
                 assertAtLeastOnceExpectedStatus(singleResponse, HttpResponseStatus.OK);
 
                 Collection<FullHttpResponse> multipleResponses = nettyHttpClient.post(transportAddress.address(), requests);
                 try {
-                    assertThat(multipleResponses, hasSize(requests.length));
+                    assertThat(multipleResponses, hasSize(requests.size()));
                     assertAtLeastOnceExpectedStatus(multipleResponses, HttpResponseStatus.TOO_MANY_REQUESTS);
                 } finally {
                     multipleResponses.forEach(ReferenceCounted::release);
@@ -109,21 +108,19 @@ public class Netty4HttpRequestSizeLimitIT extends ESNetty4IntegTestCase {
     public void testDoesNotLimitExcludedRequests() throws Exception {
         ensureGreen();
 
-        @SuppressWarnings("unchecked")
-        Tuple<String, CharSequence>[] requestUris = new Tuple[1500];
-        for (int i = 0; i < requestUris.length; i++) {
-            requestUris[i] = Tuple.tuple("/_cluster/settings",
-                "{ \"transient\": {\"search.default_search_timeout\": \"40s\" } }");
+        ArrayList<Tuple<String, CharSequence>> requestUris = new ArrayList<Tuple<String, CharSequence>>();
+        for (int i = 0; i < 1500; i++) {
+            requestUris.add(Tuple.tuple("/_cluster/settings",
+                "{ \"transient\": {\"search.default_search_timeout\": \"40s\" } }"));
         }
 
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
-        TransportAddress transportAddress = (TransportAddress) randomFrom(httpServerTransport.boundAddress
-            ().boundAddresses());
+        TransportAddress transportAddress = randomFrom(httpServerTransport.boundAddress().boundAddresses());
 
         try (Netty4HttpClient nettyHttpClient = new Netty4HttpClient()) {
             Collection<FullHttpResponse> responses = nettyHttpClient.put(transportAddress.address(), requestUris);
             try {
-                assertThat(responses, hasSize(requestUris.length));
+                assertThat(responses, hasSize(requestUris.size()));
                 assertAllInExpectedStatus(responses, HttpResponseStatus.OK);
             } finally {
                 responses.forEach(ReferenceCounted::release);

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4TransportPublishAddressIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/Netty4TransportPublishAddressIT.java
@@ -76,7 +76,7 @@ public class Netty4TransportPublishAddressIT extends ESNetty4IntegTestCase {
                 assertThat(boundTransportAddress.boundAddresses().length, greaterThan(1));
                 for (TransportAddress boundAddress : boundTransportAddress.boundAddresses()) {
                     assertThat(boundAddress, instanceOf(TransportAddress.class));
-                    TransportAddress inetBoundAddress = (TransportAddress) boundAddress;
+                    TransportAddress inetBoundAddress = boundAddress;
                     if (inetBoundAddress.address().getAddress() instanceof Inet4Address) {
                         // IPv4 address is preferred publish address for _local_
                         assertThat(inetBoundAddress.getPort(), equalTo(boundTransportAddress.publishAddress().getPort()));

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -10,8 +10,6 @@ dependencies {
   testCompile project(':client:rest-high-level')
 }
 
-compileTestJava.options.compilerArgs << "-Xlint:-cast,-rawtypes,-unchecked"
-
 forbiddenPatterns {
   exclude '**/system_key'
 }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -299,6 +299,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private Map<Version, RestClient> getRestClientByVersion() throws IOException {
         Response response = client().performRequest(new Request("GET", "_nodes"));
         assertOK(response);
@@ -342,6 +343,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         assertOK(indexResponse1);
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> retrieveStoredTokens(RestClient client, int tokenIdx) throws IOException {
         Request getRequest = new Request("GET", "token_backwards_compatibility_it/_doc/old_cluster_token" + tokenIdx);
         Response getResponse = client().performRequest(getRequest);

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -13,8 +13,6 @@ processTestResources {
   from(project(xpackModule('security')).sourceSets.test.resources.srcDirs)
 }
 
-compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
-
 // we have to repeat these patterns because the security test resources are effectively in the src of this p
 forbiddenPatterns {
   exclude '**/*.key'


### PR DESCRIPTION
This commit is part of issue #40366 to remove disabled Xlint warnings
from gradle files. In particular, it removes the Xlint exclusions from
the following files:

- benchmarks/build.gradle
- client/client-benchmark-noop-api-plugin/build.gradle
- x-pack/qa/rolling-upgrade/build.gradle
- x-pack/qa/third-party/active-directory/build.gradle
- modules/transport-netty4/build.gradle

For the first three files no code adjustments were needed. For
x-pack/qa/third-party/active-directory move the suppression at the code
level. For transport-netty4 replace the variable arguments with
ArrayLists and remove any redundant casts.