### PR TITLE
Reinstate params in rest api specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -41,6 +41,10 @@
       ]
     },
     "params":{
+      "analyzer": {
+        "type" : "string",
+        "description" : "The analyzer to use for the query string"
+      },
       "analyze_wildcard": {
         "type" : "boolean",
         "description" : "Specify whether wildcard and prefix queries should be analyzed (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -70,6 +70,11 @@
         "type" : "boolean",
         "description" : "Indicates whether hits.total should be rendered as an integer or an object in the rest search response",
         "default" : false
+      },
+      "ccs_minimize_roundtrips": {
+        "type" : "boolean",
+        "description" : "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
+        "default" : "true"
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -109,6 +109,11 @@
         "type":"boolean",
         "description":"Indicates whether hits.total should be rendered as an integer or an object in the rest search response",
         "default":false
+      },
+      "ccs_minimize_roundtrips": {
+        "type" : "boolean",
+        "description" : "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
+        "default" : "true"
       }
     },
     "body":{


### PR DESCRIPTION
This commit reinstates the following params in the rest specs:

1. "analyzer" in delete_by_query
2. "ccs_minimize_roundtrips" in msearch_template
3. "ccs_minimize_roundtrips" in search_template

All appear to be valid options that seem to have been inadvertantly removed
between 7.3 and 7.4.

Fixes elastic/elasticsearch#47768