### PR TITLE
Mute additional failing top_metrics test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -112,6 +112,9 @@
 
 ---
 "sort by scaled float field":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/52418"
   - do:
       indices.create:
         index: test


### PR DESCRIPTION
Most top_metrics tests were muted in #52468, but the scaled float can
also fail. This commit mutes that test as well.

relates #52418