### PR TITLE
[7.x] Make FreezeStep retryable (#52540)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/FreezeStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/FreezeStep.java
@@ -28,4 +28,9 @@ public class FreezeStep extends AsyncRetryDuringSnapshotActionStep {
             new FreezeRequest(indexMetaData.getIndex().getName()).masterNodeTimeout(getMasterTimeout(currentState)),
             ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure));
     }
+
+    @Override
+    public boolean isRetryable() {
+        return true;
+    }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make FreezeStep retryable (#52540)