### PR TITLE
[DOCS] Links transforms in aggregation docs

### DIFF
--- a/docs/reference/aggregations/misc.asciidoc
+++ b/docs/reference/aggregations/misc.asciidoc
@@ -172,7 +172,7 @@ also contains information about the type of the targeted field: `lterms` (for a 
 [[indexing-aggregation-results]]
 == Indexing aggregation results with {transforms}
  
-{ref}/transforms.html[Transforms] enable you to convert existing {es} indices 
+<<transforms,{transforms-cap}>> enable you to convert existing {es} indices 
 into summarized indices, which provide opportunities for new insights and 
 analytics. You can use {transforms} to persistently index your aggregation 
 results into entity-centric indices.

--- a/docs/reference/aggregations/misc.asciidoc
+++ b/docs/reference/aggregations/misc.asciidoc
@@ -167,3 +167,12 @@ request. This is the case for Terms, Significant Terms and Percentiles aggregati
 also contains information about the type of the targeted field: `lterms` (for a terms aggregation on a Long field),
  `sigsterms` (for a significant terms aggregation on a String field), `tdigest_percentiles` (for a percentile
  aggregation based on the TDigest algorithm).
+ 
+
+ [[indexing-aggregation-results]]
+ == Indexing aggregation results with {transforms}
+ 
+ {ref}/transforms.html[Transforms] enable you to convert existing {es} indices 
+ into summarized indices, which provide opportunities for new insights and 
+ analytics. You can use {transforms} to persistently index your aggregation 
+ results into entity-centric indices.

--- a/docs/reference/aggregations/misc.asciidoc
+++ b/docs/reference/aggregations/misc.asciidoc
@@ -169,10 +169,10 @@ also contains information about the type of the targeted field: `lterms` (for a 
  aggregation based on the TDigest algorithm).
  
 
- [[indexing-aggregation-results]]
- == Indexing aggregation results with {transforms}
+[[indexing-aggregation-results]]
+== Indexing aggregation results with {transforms}
  
- {ref}/transforms.html[Transforms] enable you to convert existing {es} indices 
- into summarized indices, which provide opportunities for new insights and 
- analytics. You can use {transforms} to persistently index your aggregation 
- results into entity-centric indices.
+{ref}/transforms.html[Transforms] enable you to convert existing {es} indices 
+into summarized indices, which provide opportunities for new insights and 
+analytics. You can use {transforms} to persistently index your aggregation 
+results into entity-centric indices.


### PR DESCRIPTION
This PR adds a new section to the Misc aggregation docs called "Indexing aggregation results with transforms".

Preview:  http://elasticsearch_52563.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/indexing-aggregation-results.html