### PR TITLE
Add support for multipoint shape queries

### DIFF
--- a/docs/reference/mapping/types/shape.asciidoc
+++ b/docs/reference/mapping/types/shape.asciidoc
@@ -67,15 +67,8 @@ depends on the number of vertices that define the geometry.
 
 *IMPORTANT NOTES*
 
-The following features are not yet supported:
-
-* `shape` query with `MultiPoint` geometry types - Elasticsearch currently prevents searching
-   `shape` fields with a MultiPoint geometry type to avoid a brute force linear search
-   over each individual point. For now, if this is absolutely needed, this can be achieved
-   using a `bool` query with each individual point. (Note: this could be very costly)
-
-* `CONTAINS` relation query - `shape` queries with `relation` defined as `contains` are supported
-   for indices created with ElasticSearch 7.5.0 or higher.
+`CONTAINS` relation query - `shape` queries with `relation` defined as `contains` are supported
+for indices created with ElasticSearch 7.5.0 or higher.
 
 [float]
 ===== Example

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
@@ -81,11 +81,7 @@ public class ShapeQueryBuilderTests extends AbstractQueryTestCase<ShapeQueryBuil
     }
 
     protected ShapeQueryBuilder doCreateTestQueryBuilder(boolean indexedShape) {
-        Geometry shape;
-        // multipoint queries not (yet) supported
-        do {
-            shape = ShapeTestUtils.randomGeometry(false);
-        } while (shape.type() == ShapeType.MULTIPOINT || shape.type() == ShapeType.GEOMETRYCOLLECTION);
+        Geometry shape = ShapeTestUtils.randomGeometry(false);
 
         ShapeQueryBuilder builder;
         clearShapeFields();
@@ -110,10 +106,9 @@ public class ShapeQueryBuilderTests extends AbstractQueryTestCase<ShapeQueryBuil
         }
 
         if (shape.type() == ShapeType.LINESTRING || shape.type() == ShapeType.MULTILINESTRING) {
-            builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS));
+            builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS));
         } else {
-            // XYShape does not support CONTAINS:
-            builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN));
+            builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN, ShapeRelation.CONTAINS));
         }
 
         if (randomBoolean()) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
@@ -10,6 +10,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
@@ -105,10 +106,22 @@ public class ShapeQueryBuilderTests extends AbstractQueryTestCase<ShapeQueryBuil
             }
         }
 
-        if (shape.type() == ShapeType.LINESTRING || shape.type() == ShapeType.MULTILINESTRING) {
-            builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS));
-        } else {
-            builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN, ShapeRelation.CONTAINS));
+        if (randomBoolean()) {
+            QueryShardContext context = createShardContext();
+            if (context.indexVersionCreated().onOrAfter(Version.V_7_5_0)) { // CONTAINS is only supported from version 7.5
+                if (shape.type() == ShapeType.LINESTRING || shape.type() == ShapeType.MULTILINESTRING) {
+                    builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.CONTAINS));
+                } else {
+                    builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS,
+                        ShapeRelation.WITHIN, ShapeRelation.CONTAINS));
+                }
+            } else {
+                if (shape.type() == ShapeType.LINESTRING || shape.type() == ShapeType.MULTILINESTRING) {
+                    builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS));
+                } else {
+                    builder.relation(randomFrom(ShapeRelation.DISJOINT, ShapeRelation.INTERSECTS, ShapeRelation.WITHIN));
+                }
+            }
         }
 
         if (randomBoolean()) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.spatial.SpatialPlugin;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryBuilder;
 import org.elasticsearch.xpack.spatial.util.ShapeTestUtils;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.MultiPoint;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.builders.EnvelopeBuilder;
 import org.elasticsearch.common.geo.builders.GeometryCollectionBuilder;
+import org.elasticsearch.common.geo.builders.MultiPointBuilder;
 import org.elasticsearch.common.geo.builders.PointBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -28,6 +29,7 @@ import org.elasticsearch.xpack.spatial.SpatialPlugin;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryBuilder;
 import org.elasticsearch.xpack.spatial.util.ShapeTestUtils;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.MultiPoint;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -297,10 +299,10 @@ public class ShapeQueryTests extends ESSingleNodeTestCase {
             assertEquals(0, response.getHits().getTotalHits().value);
         }
         {
-            // A geometry collection that is partially within the indexed shape
-            GeometryCollectionBuilder builder = new GeometryCollectionBuilder();
-            builder.shape(new PointBuilder(1, 2));
-            builder.shape(new PointBuilder(20, 30));
+            // A geometry collection (as multi point) that is partially within the indexed shape
+            MultiPointBuilder builder = new MultiPointBuilder();
+            builder.coordinate(1, 2);
+            builder.coordinate(20, 30);
             SearchResponse response = client().prepareSearch("test_collections")
                 .setQuery(new ShapeQueryBuilder("geometry", builder.buildGeometry()).relation(ShapeRelation.CONTAINS))
                 .get();
@@ -317,8 +319,10 @@ public class ShapeQueryTests extends ESSingleNodeTestCase {
         {
             // A geometry collection that is disjoint with the indexed shape
             GeometryCollectionBuilder builder = new GeometryCollectionBuilder();
-            builder.shape(new PointBuilder(-20, -30));
-            builder.shape(new PointBuilder(20, 30));
+            MultiPointBuilder innerBuilder = new MultiPointBuilder();
+            innerBuilder.coordinate(-20, -30);
+            innerBuilder.coordinate(20, 30);
+            builder.shape(innerBuilder);
             SearchResponse response = client().prepareSearch("test_collections")
                 .setQuery(new ShapeQueryBuilder("geometry", builder.buildGeometry()).relation(ShapeRelation.CONTAINS))
                 .get();


### PR DESCRIPTION
Currently multi-point queries are not supported for shape queries. This PR removes this limitation.

relates to #52133