### PR TITLE
Fix sql cli sourcing of x-pack-env

### DIFF
--- a/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli
+++ b/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli
@@ -6,9 +6,9 @@
 
 source "`dirname "$0"`"/elasticsearch-env
 
-source "`dirname "$0"`"/x-pack-env
+source "$ES_HOME"/bin/x-pack-env
 
-CLI_JAR=$(ls $ES_HOME/bin/elasticsearch-sql-cli-*.jar)
+CLI_JAR=$(ls "$ES_HOME"/bin/elasticsearch-sql-cli-*.jar)
 
 exec \
   "$JAVA" \

--- a/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli.bat
+++ b/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli.bat
@@ -9,7 +9,7 @@ setlocal enableextensions
 
 call "%~dp0elasticsearch-env.bat" || exit /b 1
 
-call "%~dp0x-pack-env.bat" || exit /b 1
+call "%ES_HOME%/bin/x-pack-env.bat" || exit /b 1
 
 set CLI_JAR=%ES_HOME%/bin/*
 


### PR DESCRIPTION
The sql-cli script sources x-pack-env, but it does so assuming the
current directory is ES_HOME. This commit alters the source command to
use ES_HOME which is available after running elasticsearch-env.

closes #47803