### PR TITLE
Fix GCS Test testReadLargeBlobWithRetries

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -202,7 +202,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends ESTestCase {
 
     public void testReadLargeBlobWithRetries() throws Exception {
         final int maxRetries = randomIntBetween(2, 10);
-        final CountDown countDown = new CountDown(maxRetries);
+        final AtomicInteger countDown = new AtomicInteger(maxRetries);
 
         // SDK reads in 2 MB chunks so we use twice that to simulate 2 chunks
         final byte[] bytes = randomBytes(1 << 22);
@@ -214,7 +214,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends ESTestCase {
             final int end = Integer.parseInt(range[1]);
             final byte[] chunk = Arrays.copyOfRange(bytes, offset, Math.min(end + 1, bytes.length));
             exchange.sendResponseHeaders(RestStatus.OK.getStatus(), chunk.length);
-            if (randomBoolean() && countDown.countDown() == false) {
+            if (randomBoolean() && countDown.decrementAndGet() >= 0) {
                 exchange.getResponseBody().write(chunk, 0, chunk.length - 1);
                 exchange.close();
                 return;


### PR DESCRIPTION
The countdown didn't work well here because it only returns `true` once the countdown reaches `0`
but can on subsequent executions return `false` again if a countdown at `0` is counted down again,
leading to more than the expected number of simulated failures.

Closes #52607
