### PR TITLE
Refresh .ml-state* indices in the BWC test's setup phase

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/30_ml_jobs_crud.yml
@@ -8,9 +8,8 @@ setup:
           }
 
   - do:
-      cluster.health:
-        index: [".ml-state"]
-        wait_for_status: green
+      indices.refresh:
+        index: .ml-state*
 
 ---
 "Put job on the old cluster and post some data":


### PR DESCRIPTION
This PR aims at fixing BWC test timeout issue.