### PR TITLE
Remove TODOs from MetaStateService

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetaStateService.java
@@ -120,8 +120,6 @@ public class MetaStateService {
         if (globalMetaData != null) {
             metaDataBuilder = MetaData.builder(globalMetaData);
             indexGraveyard = globalMetaData.custom(IndexGraveyard.TYPE);
-            // TODO https://github.com/elastic/elasticsearch/issues/38556
-            // assert Version.CURRENT.major < 8 : "failed to find manifest file, which is mandatory staring with Elasticsearch version 8.0";
         } else {
             metaDataBuilder = MetaData.builder();
             indexGraveyard = IndexGraveyard.builder().build();
@@ -131,8 +129,6 @@ public class MetaStateService {
             Tuple<IndexMetaData, Long> indexMetaDataAndGeneration =
                     INDEX_META_DATA_FORMAT.loadLatestStateWithGeneration(logger, namedXContentRegistry,
                             nodeEnv.resolveIndexFolder(indexFolderName));
-            // TODO https://github.com/elastic/elasticsearch/issues/38556
-            // assert Version.CURRENT.major < 8 : "failed to find manifest file, which is mandatory staring with Elasticsearch version 8.0";
             IndexMetaData indexMetaData = indexMetaDataAndGeneration.v1();
             long generation = indexMetaDataAndGeneration.v2();
             if (indexMetaData != null) {


### PR DESCRIPTION
7.x nodes permit the on-disk cluster metadata to omit the manifest file in
order to support upgrades from 6.x. We are similarly lenient in `master`, i.e.
8.x, but there is no need to be since we must be upgrading from a 7.x node
which ensures that the manifest file is written.

We prefer to keep this lenience (see #52412) so this commit removes the
commented-out indications that it should be removed. The new metadata format
introduced in #50907 means that this whole subsystem will be removed in v9
anyway.

Relates #38556