### PR TITLE
[DOCS] Fix a syntax error in ingest-node doc

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -372,7 +372,7 @@ is not null safe alternative, so an explicit null check is needed.
 
 [[ingest-conditional-complex]]
 === Complex Conditionals
-The `if` condition can be more then a simple equality check.
+The `if` condition can be more complex than a simple equality check.
 The full power of the <<modules-scripting-painless, Painless Scripting Language>> is available and
 running in the {painless}/painless-ingest-processor-context.html[ingest processor context].
 


### PR DESCRIPTION
I think there is a syntax error in the ingest-node doc, and maybe the original meaning
 is `more complex than`.