### PR TITLE
Add UTF-8 encoding to build.gradle in BuildSrc/.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -80,6 +80,9 @@ sourceSets {
 compileMinimumRuntimeJava {
   targetCompatibility = 8
   sourceCompatibility = 8
+  tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+  }
 }
 
 jar {


### PR DESCRIPTION
I build via `./gradlew assemble` on ubuntu 16.04. I get an "error: unmappable character (0xA4) for encoding US-ASCII". in BuildSrc/.

```
/usr/src/git/elasticsearch/buildSrc/src/test/java/org/elasticsearch/gradle/ConcatFilesTaskTests.java:76: error: unmappable character (0xE0) for encoding US-ASCII
        assertEquals(Arrays.asList("Hello", "??????????????????"), Files.readAllLines(concatFilesTask.getTarget().toPath(), StandardCharsets.UTF_8));
                                             ^
/usr/src/git/elasticsearch/buildSrc/src/test/java/org/elasticsearch/gradle/ConcatFilesTaskTests.java:76: error: unmappable character (0xA4) for encoding US-ASCII
        assertEquals(Arrays.asList("Hello", "??????????????????"), Files.readAllLines(concatFilesTask.getTarget().toPath(), StandardCharsets.UTF_8));
                                              ^
```

I add UTF-8 encoding in build.gradle, The error no longer appears.
