### PR TITLE
Handle special characters and spaces in JAVA_HOME path in elasticsearch-service.bat

### DIFF
--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -123,7 +123,7 @@ rem   - fourth, ergonomic JVM options are applied
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 
 @setlocal
-for /F "usebackq delims=" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_PATH_CONF!" || echo jvm_options_parser_failed"`) do set ES_JAVA_OPTS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_PATH_CONF!" ^|^| echo jvm_options_parser_failed`) do set ES_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%ES_JAVA_OPTS%" & set ES_JAVA_OPTS=%ES_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (


### PR DESCRIPTION
I was unable to install elasticsearch service, due to the following issue
![error](https://user-images.githubusercontent.com/41253927/75094268-7a6db480-55ab-11ea-8e96-5f16cb40bb39.PNG)
The batch script was not able to parse the JAVA_HOME path correctly if there was a space in it, which is the case shown above as JAVA_HOME is set to C:\Program Files (x86)\jdk-12.0.2
