### PR TITLE
Skip 'setupPorts' tasks when Docker is unavailable

### DIFF
--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -15,7 +15,7 @@ testFixtures.useFixture ":x-pack:test:idp-fixture", "oidc-provider"
 String ephemeralPort;
 task setupPorts {
   // Don't attempt to get ephemeral ports when Docker is not available
-  onlyIf { idpFixtureProject.postProcessFixture.enabled }
+  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
   dependsOn idpFixtureProject.postProcessFixture
   doLast {
     ephemeralPort = idpFixtureProject.postProcessFixture.ext."test.fixtures.oidc-provider.tcp.8080"

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -22,7 +22,7 @@ project.sourceSets.test.output.dir(outputDir, builtBy: copyIdpFiles)
 task setupPorts {
   dependsOn copyIdpFiles, idpFixtureProject.postProcessFixture
   // Don't attempt to get ephemeral ports when Docker is not available
-  onlyIf { idpFixtureProject.postProcessFixture.enabled }
+  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
   doLast {
     String portString = idpFixtureProject.postProcessFixture.ext."test.fixtures.shibboleth-idp.tcp.4443"
     int ephemeralPort = Integer.valueOf(portString)


### PR DESCRIPTION
Another fix for some fallout of #52548.

Closes #52678 