### PR TITLE
Simplify ml license checking with XpackLicenseState internals

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -237,18 +237,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
     }
 
     public boolean isAvailableWithLicense(XPackLicenseState licenseState) {
-        // Basic is always true
-        if (licenseLevel.equals(License.OperationMode.BASIC)) {
-            return true;
-        }
-
-        // The model license does not matter, Platinum license gets the same functions as the highest license
-        if (licenseState.isAllowedByLicense(License.OperationMode.PLATINUM)) {
-            return true;
-        }
-
-        // catch the rest, if the license is active and is at least the required model license
-        return licenseState.isAllowedByLicense(licenseLevel, true, false);
+        return licenseState.isAllowedByLicense(licenseLevel);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.license.License;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -234,10 +233,6 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
 
     public License.OperationMode getLicenseLevel() {
         return licenseLevel;
-    }
-
-    public boolean isAvailableWithLicense(XPackLicenseState licenseState) {
-        return licenseState.isAllowedByLicense(licenseLevel);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.license.License;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -44,9 +43,6 @@ import static org.elasticsearch.xpack.core.ml.utils.ToXContentParams.FOR_INTERNA
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class TrainedModelConfigTests extends AbstractSerializingTestCase<TrainedModelConfig> {
 
@@ -305,13 +301,4 @@ public class TrainedModelConfigTests extends AbstractSerializingTestCase<Trained
             .assertToXContentEquivalence(true)
             .test();
     }
-
-    public void testIsAvailableWithLicenseWillDelegate() {
-        TrainedModelConfig.Builder builder = createTestInstance(randomAlphaOfLength(10));
-        XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        final License.OperationMode operationMode = randomFrom(License.OperationMode.values());
-        builder.setLicenseLevel(operationMode.description()).build().isAvailableWithLicense(licenseState);
-        verify(licenseState, times(1)).isAllowedByLicense(operationMode);
-    }
-
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -79,8 +79,8 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
         } else {
             trainedModelProvider.getTrainedModel(request.getModelId(), false, ActionListener.wrap(
                 trainedModelConfig -> {
-                    responseBuilder.setLicensed(trainedModelConfig.isAvailableWithLicense(licenseState));
-                    if (trainedModelConfig.isAvailableWithLicense(licenseState) || request.isPreviouslyLicensed()) {
+                    responseBuilder.setLicensed(licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()));
+                    if (licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()) || request.isPreviouslyLicensed()) {
                         this.modelLoadingService.getModel(request.getModelId(), getModelListener);
                     } else {
                         listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));


### PR DESCRIPTION
This change reduces `TrainedModelConfig#isAvailableWithLicense` method to a single call to `XPackLicenseState#isAllowedByLicense`. It is made possible by the [recent](https://github.com/elastic/elasticsearch/pull/52115) [enhancements](https://github.com/elastic/elasticsearch/pull/52118) to license checking logic. 

Please note there are subtle change to the code logic. But they seem to be the right changes:
1. Trial license is always allowed.
2. Platinum license no longer guarantees availability since there is now a dedicated [Enterprise license](#52115).
3. No explicit check when the license requirement is basic. Since basic license is always available, this check is unnecessary.