### PR TITLE
add index name for the source of the cluster put-mapping task

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -326,7 +326,7 @@ public class MetaDataMappingService {
     }
 
     public void putMapping(final PutMappingClusterStateUpdateRequest request, final ActionListener<ClusterStateUpdateResponse> listener) {
-        clusterService.submitStateUpdateTask("put-mapping",
+        clusterService.submitStateUpdateTask("put-mapping " + getRequestIndex(request),
                 request,
                 ClusterStateTaskConfig.build(Priority.HIGH, request.masterNodeTimeout()),
                 putMappingExecutor,
@@ -358,4 +358,19 @@ public class MetaDataMappingService {
                     }
                 });
     }
+
+    public String getRequestIndex(PutMappingClusterStateUpdateRequest request) {
+        Index[] indices = request.indices();
+
+        if (indices == null) {
+            return "";
+        }
+
+        List<String> indexList = new ArrayList<>(indices.length);
+        for (Index index : indices) {
+            indexList.add(index.toString());
+        }
+        return String.join(",", indexList);
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataMappingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataMappingServiceTests.java
@@ -52,16 +52,16 @@ public class MetaDataMappingServiceTests extends ESSingleNodeTestCase {
         // TODO - it will be nice to get a random mapping generator
         final PutMappingClusterStateUpdateRequest request
             = new PutMappingClusterStateUpdateRequest("{ \"properties\": { \"field\": { \"type\": \"text\" }}}");
-        request.indices(new Index[] {indexService.index()});
+        request.indices(new Index[]{indexService.index()});
         final ClusterStateTaskExecutor.ClusterTasksResult<PutMappingClusterStateUpdateRequest> result =
-                mappingService.putMappingExecutor.execute(clusterService.state(), Collections.singletonList(request));
+            mappingService.putMappingExecutor.execute(clusterService.state(), Collections.singletonList(request));
         // the task completed successfully
         assertThat(result.executionResults.size(), equalTo(1));
         assertTrue(result.executionResults.values().iterator().next().isSuccess());
         // the task really was a mapping update
         assertThat(
-                indexService.mapperService().documentMapper().mappingSource(),
-                not(equalTo(result.resultingState.metaData().index("test").mapping().source())));
+            indexService.mapperService().documentMapper().mappingSource(),
+            not(equalTo(result.resultingState.metaData().index("test").mapping().source())));
         // since we never committed the cluster state update, the in-memory state is unchanged
         assertThat(indexService.mapperService().documentMapper().mappingSource(), equalTo(currentMapping));
     }
@@ -91,9 +91,9 @@ public class MetaDataMappingServiceTests extends ESSingleNodeTestCase {
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         final PutMappingClusterStateUpdateRequest request
             = new PutMappingClusterStateUpdateRequest("{ \"properties\": { \"field\": { \"type\": \"text\" }}}");
-        request.indices(new Index[] {indexService.index()});
+        request.indices(new Index[]{indexService.index()});
         final ClusterStateTaskExecutor.ClusterTasksResult<PutMappingClusterStateUpdateRequest> result =
-                mappingService.putMappingExecutor.execute(clusterService.state(), Collections.singletonList(request));
+            mappingService.putMappingExecutor.execute(clusterService.state(), Collections.singletonList(request));
         assertThat(result.executionResults.size(), equalTo(1));
         assertTrue(result.executionResults.values().iterator().next().isSuccess());
         assertThat(result.resultingState.metaData().index("test").getMappingVersion(), equalTo(1 + previousVersion));
@@ -105,12 +105,26 @@ public class MetaDataMappingServiceTests extends ESSingleNodeTestCase {
         final MetaDataMappingService mappingService = getInstanceFromNode(MetaDataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("{ \"properties\": {}}");
-        request.indices(new Index[] {indexService.index()});
+        request.indices(new Index[]{indexService.index()});
         final ClusterStateTaskExecutor.ClusterTasksResult<PutMappingClusterStateUpdateRequest> result =
-                mappingService.putMappingExecutor.execute(clusterService.state(), Collections.singletonList(request));
+            mappingService.putMappingExecutor.execute(clusterService.state(), Collections.singletonList(request));
         assertThat(result.executionResults.size(), equalTo(1));
         assertTrue(result.executionResults.values().iterator().next().isSuccess());
         assertThat(result.resultingState.metaData().index("test").getMappingVersion(), equalTo(previousVersion));
     }
+
+    public void testGetRequestIndex() {
+        String source = "{\"properties\":{\"id\":{\"type\":\"long\"}}}";
+        String indexName = "test";
+        final IndexService indexService = createIndex(indexName, client().admin().indices().prepareCreate(indexName));
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest(source);
+        request.indices(new Index[]{indexService.index()});
+
+        final MetaDataMappingService mappingService = getInstanceFromNode(MetaDataMappingService.class);
+
+        String requestIndex = mappingService.getRequestIndex(request);
+        assertEquals(indexService.index().toString(), requestIndex);
+    }
+
 
 }


### PR DESCRIPTION
When there are a lot of pending tasks with put-mapping in the cluster, it is too simple to obtain the task information returned by the _cat/pending_tasks API, such as "put-mapping", so it is impossible to quickly know which index is put-mapping.
When obtaining the pending task, the description of each task is taken from the 'source' field of the task, so when submitting the put-mapping task, add index name after the 'source' of the task to facilitate the quick locating of the index when the pending task appears