### PR TITLE
[DOCS] Document CCS-supported APIs

### DIFF
--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -9,6 +9,17 @@ filter and analyze log data stored on clusters in different data centers.
 IMPORTANT: {ccs-cap} requires <<modules-remote-clusters, remote clusters>>.
 
 [float]
+[[ccs-supported-apis]]
+== Supported APIs
+
+The following APIs support {ccs}:
+
+* <<search-search,Search>>
+* <<search-multi-search,Multi search>>
+* <<search-template,Search template>>
+* <<multi-search-template,Multi search template>>
+
+[float]
 [[ccs-example]]
 == {ccs-cap} examples
 
@@ -55,7 +66,7 @@ PUT _cluster/settings
 [[ccs-search-remote-cluster]]
 === Search a single remote cluster
 
-The following <<search,search>> API request searches the
+The following <<search-search,search>> API request searches the
 `twitter` index on a single remote cluster, `cluster_one`.
 
 [source,console]
@@ -280,13 +291,12 @@ including a <<request-body-search-scroll, scroll>> or
 +
 See <<ccs-min-roundtrips>> to learn how this option works.
 
-<<ccs-unmin-roundtrips, Don't minimize network roundtrips>>::
-For search requests that include a scroll or inner hits, {es} sends multiple
-outgoing and ingoing requests to each remote cluster. You can also choose this
-option by setting the <<search,search>> API's
-<<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> parameter to `false`.
-While typically slower, this approach may work well for networks with low
-latency.
+<<ccs-unmin-roundtrips, Don't minimize network roundtrips>>:: For search
+requests that include a scroll or inner hits, {es} sends multiple outgoing and
+ingoing requests to each remote cluster. You can also choose this option by
+setting the <<ccs-minimize-roundtrips,`ccs_minimize_roundtrips`>> parameter to
+`false`. While typically slower, this approach may work well for networks with
+low latency.
 +
 See <<ccs-unmin-roundtrips>> to learn how this option works.
 


### PR DESCRIPTION
Explicitly notes the Elasticsearch API endpoints that support CCS.

This should deter users from attempting to use CCS with other 
unsupported API endpoints, such as `GET <index>/_doc/<_id>`.

Closes #52023