### PR TITLE
Document how CCR may be used to speed up indexing.

### DIFF
--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -132,10 +132,10 @@ two shards that are heavily indexing.
 === Use {ccr} to prevent searching from stealing resources from indexing
 
 With a single cluster, indexing and searching typically compete for resources.
-By setting up two clusters, configuring {ccr} to replicate data from one cluster
-to the other one, and routing all searches to the cluster that has the follower
-indices, search activity will no longer steal resources from indexing on the
-cluster that hosts the leader indices.
+By setting up two clusters, configuring <<xpack-ccr,{ccr}>> to replicate data
+from one cluster to the other one, and routing all searches to the cluster that
+has the follower indices, search activity will no longer steal resources from
+indexing on the cluster that hosts the leader indices.
 
 [float]
 === Additional optimizations

--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -131,10 +131,10 @@ two shards that are heavily indexing.
 [float]
 === Use {ccr} to prevent searching from stealing resources from indexing
 
-With a single cluster, indexing and searching typically compete for resources.
-By setting up two clusters, configuring <<xpack-ccr,{ccr}>> to replicate data
-from one cluster to the other one, and routing all searches to the cluster that
-has the follower indices, search activity will no longer steal resources from
+Within a single cluster, indexing and searching can compete for resources. By
+setting up two clusters, configuring <<xpack-ccr,{ccr}>> to replicate data from
+one cluster to the other one, and routing all searches to the cluster that has
+the follower indices, search activity will no longer steal resources from
 indexing on the cluster that hosts the leader indices.
 
 [float]

--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -129,6 +129,15 @@ The default is `10%` which is often plenty: for example, if you give the JVM
 two shards that are heavily indexing.
 
 [float]
+=== Use {ccr} to prevent searching from stealing resources from indexing
+
+With a single cluster, indexing and searching typically compete for resources.
+By setting up two clusters, configuring {ccr} to replicate data from one cluster
+to the other one, and routing all searches to the cluster that has the follower
+indices, search activity will no longer steal resources from indexing on the
+cluster that hosts the leader indices.
+
+[float]
 === Additional optimizations
 
 Many of the strategies outlined in <<tune-for-disk-usage>> also


### PR DESCRIPTION
One architecture that we have recommended to several users to speed up
indexing involved using CCR to prevent searching from stealing resources
from indexing.