### PR TITLE
[ML] Use event.timezone in ingest pipeline from find_file_structure

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/find-file-structure.asciidoc
@@ -315,7 +315,7 @@ If the request does not encounter errors, you receive the following result:
       {
         "date" : {
           "field" : "release_date",
-          "timezone" : "{{ beat.timezone }}",
+          "timezone" : "{{ event.timezone }}",
           "formats" : [
             "ISO8601"
           ]
@@ -702,7 +702,7 @@ If the request does not encounter errors, you receive the following result:
       {
         "date" : {
           "field" : "tpep_pickup_datetime",
-          "timezone" : "{{ beat.timezone }}",
+          "timezone" : "{{ event.timezone }}",
           "formats" : [
             "yyyy-MM-dd HH:mm:ss"
           ]
@@ -1577,7 +1577,7 @@ this:
       {
         "date" : {
           "field" : "timestamp",
-          "timezone" : "{{ beat.timezone }}",
+          "timezone" : "{{ event.timezone }}",
           "formats" : [
             "ISO8601"
           ]
@@ -1743,7 +1743,7 @@ this:
       {
         "date" : {
           "field" : "timestamp",
-          "timezone" : "{{ beat.timezone }}",
+          "timezone" : "{{ event.timezone }}",
           "formats" : [
             "ISO8601"
           ]

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/FileStructureUtils.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/FileStructureUtils.java
@@ -43,7 +43,7 @@ public final class FileStructureUtils {
     private static final int KEYWORD_MAX_LEN = 256;
     private static final int KEYWORD_MAX_SPACES = 5;
 
-    private static final String BEAT_TIMEZONE_FIELD = "beat.timezone";
+    private static final String BEAT_TIMEZONE_FIELD = "event.timezone";
 
     private FileStructureUtils() {
     }


### PR DESCRIPTION
This is because beat.timezone was renamed to event.timezone in
elastic/beats#9458