### PR TITLE
Use newIndexSearcher() to avoid incompatible readers in AggregatorTestCase#testSupportedFieldTypes

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -605,7 +605,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
      *
      * Exception types/messages are not currently checked, just presence/absence of an exception.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/52681")
     public void testSupportedFieldTypes() throws IOException {
         MapperRegistry mapperRegistry = new IndicesModule(Collections.emptyList()).getMapperRegistry();
         Settings settings = Settings.builder().put("index.version.created", Version.CURRENT.id).build();
@@ -647,7 +646,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 indexWriter.close();
 
                 try (IndexReader indexReader = DirectoryReader.open(directory)) {
-                    IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
+                    IndexSearcher indexSearcher = newIndexSearcher(indexReader);
                     AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, fieldName);
 
                     // TODO in the future we can make this more explicit with expectThrows(), when the exceptions are standardized


### PR DESCRIPTION
Lucene's `newSearcher()` can generate readers like ParallelCompositeReader which we can't use.  We need to instead use our helper `newIndexSearcher()`.

Fixes https://github.com/elastic/elasticsearch/issues/52681
