### PR TITLE
[DOCS] Add admonition for apps using cat APIs

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -4,10 +4,18 @@
 ["float",id="intro"]
 === Introduction
 
-JSON is great... for computers.  Even if it's pretty-printed, trying
-to find relationships in the data is tedious.  Human eyes, especially
-when looking at a terminal, need compact and aligned text.  The cat API
-aims to meet this need.
+JSON is great... for computers. Even if it's pretty-printed, trying
+to find relationships in the data is tedious. Human eyes, especially
+when looking at a terminal, need compact and aligned text. The cat APIs
+aim to meet this need.
+
+[IMPORTANT]
+====
+cat APIs are only intended for human consumption using the
+{kibana-ref}/console-kibana.html[Kibana console] or command line. They are _not_
+intended for use by applications. For application consumption, we recommend
+using a corresponding JSON API.
+====
 
 All the cat commands accept a query string parameter `help` to see all
 the headers and info they provide, and the `/_cat` command alone lists all


### PR DESCRIPTION
Adds an explicit "important" admonition discouraging apps from using cat
APIs.

cat APIs are intended for human consumption via the command line or
Kibana console only. They are not intended for consumption by
applications.

Closes #51772.
