### PR TITLE
Correct the name of the search timeout parameter.

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -707,7 +707,7 @@ Defaults to 100.
 end::scroll_size[]
 
 tag::search_timeout[]
-`search_timeout`::
+`timeout`::
 (Optional, <<time-units, time units>>)
 Explicit timeout for each search request.
 Defaults to no timeout.


### PR DESCRIPTION
The request body parameter is called 'timeout', not 'search_timeout'.
