### PR TITLE
Update Docker on linux exclusion list

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -7,9 +7,11 @@
 debian-8
 opensuse-15-1
 ol-7.7
-sles-12
+sles-12.3 # older version used in Vagrant image
+sles-12.4
+sles-15.1
 
-# These OSes are deprecated and filtered starting with 8.0.0, but need to be excluded 
+# These OSes are deprecated and filtered starting with 8.0.0, but need to be excluded
 # for PR checks
 centos-6
 ol-6.10

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/docker/DockerSupportService.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/docker/DockerSupportService.java
@@ -220,7 +220,7 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
             // remove optional leading and trailing quotes and whitespace
             final String value = parts[1].replaceAll("^['\"]?\\s*", "").replaceAll("\\s*['\"]?$", "");
 
-            values.put(key, value);
+            values.put(key, value.toLowerCase());
         });
 
         return values;

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/docker/DockerSupportServiceTests.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/docker/DockerSupportServiceTests.java
@@ -38,12 +38,12 @@ public class DockerSupportServiceTests extends GradleIntegrationTestCase {
         expected.put("CPE_NAME", "cpe:/o:oracle:linux:6:10:server");
         expected.put("HOME_URL" + "", "https://linux.oracle.com/");
         expected.put("ID", "ol");
-        expected.put("NAME", "Oracle Linux Server");
-        expected.put("ORACLE_BUGZILLA_PRODUCT" + "", "Oracle Linux 6");
+        expected.put("NAME", "oracle linux server");
+        expected.put("ORACLE_BUGZILLA_PRODUCT" + "", "oracle linux 6");
         expected.put("ORACLE_BUGZILLA_PRODUCT_VERSION", "6.10");
-        expected.put("ORACLE_SUPPORT_PRODUCT", "Oracle Linux");
+        expected.put("ORACLE_SUPPORT_PRODUCT", "oracle linux");
         expected.put("ORACLE_SUPPORT_PRODUCT_VERSION", "6.10");
-        expected.put("PRETTY_NAME", "Oracle Linux Server 6.10");
+        expected.put("PRETTY_NAME", "oracle linux server 6.10");
         expected.put("VERSION", "6.10");
         expected.put("VERSION_ID", "6.10");
 
@@ -58,7 +58,7 @@ public class DockerSupportServiceTests extends GradleIntegrationTestCase {
 
         final Map<String, String> results = parseOsRelease(lines);
 
-        final Map<String, String> expected = Map.of("NAME", "Oracle Linux Server");
+        final Map<String, String> expected = Map.of("NAME", "oracle linux server");
 
         assertThat(expected, equalTo(results));
     }
@@ -71,7 +71,7 @@ public class DockerSupportServiceTests extends GradleIntegrationTestCase {
 
         final Map<String, String> results = parseOsRelease(lines);
 
-        final Map<String, String> expected = Map.of("NAME", "Oracle Linux Server");
+        final Map<String, String> expected = Map.of("NAME", "oracle linux server");
 
         assertThat(expected, equalTo(results));
     }


### PR DESCRIPTION
This pull request updates our exclusion logic for slipping Docker-based build tasks on certain Linux distributions. We have been inadvertently running Docker tasks on SLES distributions because `/etc/os-release` reports and `ID` of `SLES` instead of `sles` and `VERSION` of `12.4` instead of `12`. This PR fixes the former issue by simply forcing all reported values to lower-case so we don't have to worry about any discrepancies there, as well as adding the explicit service-pack version to our exclusion list.

I've also added SLES 15 to the naughty list due to the continues occurrences of [this issue](https://github.com/elastic/elasticsearch/issues/48027) on that OS.