### PR TITLE
Update IdP plugin security policy

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/identity-provider/src/main/plugin-metadata/plugin-security.policy
@@ -1,6 +1,9 @@
 grant {
   permission java.lang.RuntimePermission "setFactory";
 
+  // ApacheXMLSecurityInitializer
+  permission java.util.PropertyPermission "org.apache.xml.security.ignoreLineBreaks", "read,write";
+
   // needed because of SAML (cf. o.e.x.c.s.s.RestorableContextClassLoader)
   permission java.lang.RuntimePermission "getClassLoader";
   permission java.lang.RuntimePermission "setContextClassLoader";


### PR DESCRIPTION
ApacheXMLSecurityInitializer (a dependency of OpenSAML) attempts to
set the "org.apache.xml.security.ignoreLineBreaks" system property if
it doesn't exist
