### PR TITLE
Update to ASM 7.1 in logger usage check

### DIFF
--- a/test/logger-usage/build.gradle
+++ b/test/logger-usage/build.gradle
@@ -18,7 +18,9 @@
  */
 
 dependencies {
-  compile 'org.ow2.asm:asm-debug-all:5.0.4' // use asm-debug-all as asm-all is broken
+  compile 'org.ow2.asm:asm:7.1'
+  compile 'org.ow2.asm:asm-tree:7.1'
+  compile 'org.ow2.asm:asm-analysis:7.1'
   compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   testCompile project(":test:framework")
 }

--- a/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
+++ b/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
@@ -188,7 +188,7 @@ public class ESLoggerUsageChecker {
         private final Predicate<String> methodsToCheck;
 
         ClassChecker(Consumer<WrongLoggerUsage> wrongUsageCallback, Predicate<String> methodsToCheck) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             this.wrongUsageCallback = wrongUsageCallback;
             this.methodsToCheck = methodsToCheck;
         }
@@ -222,7 +222,7 @@ public class ESLoggerUsageChecker {
         private boolean ignoreChecks;
 
         MethodChecker(String className, int access, String name, String desc, Consumer<WrongLoggerUsage> wrongUsageCallback) {
-            super(Opcodes.ASM5, new MethodNode(access, name, desc, null, null));
+            super(Opcodes.ASM7, new MethodNode(access, name, desc, null, null));
             this.className = className;
             this.wrongUsageCallback = wrongUsageCallback;
         }
@@ -503,6 +503,10 @@ public class ESLoggerUsageChecker {
     }
 
     private static final class PlaceHolderStringInterpreter extends BasicInterpreter {
+        PlaceHolderStringInterpreter() {
+            super(Opcodes.ASM7);
+        }
+
         @Override
         public BasicValue newOperation(AbstractInsnNode insnNode) throws AnalyzerException {
             if (insnNode.getOpcode() == Opcodes.LDC) {
@@ -527,6 +531,10 @@ public class ESLoggerUsageChecker {
     }
 
     private static final class ArraySizeInterpreter extends BasicInterpreter {
+        ArraySizeInterpreter() {
+            super(Opcodes.ASM7);
+        }
+
         @Override
         public BasicValue newOperation(AbstractInsnNode insnNode) throws AnalyzerException {
             switch (insnNode.getOpcode()) {


### PR DESCRIPTION
The logger usage check uses its own version of ASM to inspect class
files for logging usages. Master was updated to support java 11
compilation in #40754. However, 7.x still used ASM 5, which could not
read newer java bytecode versions. This commit bumps ASM in 7.x used in
the logger usage check.

closes #52408