### PR TITLE
[DOCS] Monospace request routes

### DIFF
--- a/docs/reference/ingest/apis/simulate-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/simulate-pipeline.asciidoc
@@ -54,13 +54,13 @@ POST /_ingest/pipeline/my-pipeline-id/_simulate
 [[simulate-pipeline-api-request]]
 ==== {api-request-title}
 
-POST /_ingest/pipeline/<pipeline>/_simulate
+`POST /_ingest/pipeline/<pipeline>/_simulate`
 
-GET /_ingest/pipeline/<pipeline>/_simulate
+`GET /_ingest/pipeline/<pipeline>/_simulate`
 
-POST /_ingest/pipeline/_simulate
+`POST /_ingest/pipeline/_simulate`
 
-GET /_ingest/pipeline/_simulate
+`GET /_ingest/pipeline/_simulate`
 
 
 [[simulate-pipeline-api-desc]]


### PR DESCRIPTION
The lack of backticks resulted in them being rendered without the usual monospaced font:

<img width="359" alt="Screenshot 2020-02-25 at 12 45 08" src="https://user-images.githubusercontent.com/809707/75244780-b3d13a80-57cc-11ea-8b0b-e452c1e66ae9.png">
