### PR TITLE
Tiered allocation deciders

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -185,11 +185,11 @@ public class ClusterModule extends AbstractModule {
         addAllocationDecider(deciders, new SnapshotInProgressAllocationDecider());
         addAllocationDecider(deciders, new RestoreInProgressAllocationDecider());
         addAllocationDecider(deciders, new FilterAllocationDecider(settings, clusterSettings));
-        addAllocationDecider(deciders, new SameShardAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new DiskThresholdDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new ThrottlingAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new ShardsLimitAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new AwarenessAllocationDecider(settings, clusterSettings));
+        addAllocationDecider(deciders, new SameShardAllocationDecider(settings, clusterSettings));
 
         clusterPlugins.stream()
             .flatMap(p -> p.createAllocationDeciders(settings, clusterSettings).stream())

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -27,24 +27,35 @@ import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * A composite {@link AllocationDecider} combining the "decision" of multiple
  * {@link AllocationDecider} implementations into a single allocation decision.
  */
-public class AllocationDeciders extends AllocationDecider {
+public class AllocationDeciders /*extends AllocationDecider*/ {
 
     private static final Logger logger = LogManager.getLogger(AllocationDeciders.class);
 
-    private final Collection<AllocationDecider> allocations;
+    private final List<AllocationDecider> allocations;
 
+    /**
+     * Create deciders based on an ordered collection of deciders.
+     */
     public AllocationDeciders(Collection<AllocationDecider> allocations) {
-        this.allocations = Collections.unmodifiableCollection(allocations);
+        this.allocations = Collections.unmodifiableList(new ArrayList<>(allocations));
     }
 
-    @Override
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
@@ -63,63 +74,15 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    @Override
+    // todo: remove canAllocate and canRemain from here? Can lead to performance issues if using these unqualified.
     public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        if (allocation.shouldIgnoreShardForNode(shardRouting.shardId(), node.nodeId())) {
-            return Decision.NO;
-        }
-        Decision.Multi ret = new Decision.Multi();
-        for (AllocationDecider allocationDecider : allocations) {
-            Decision decision = allocationDecider.canAllocate(shardRouting, node, allocation);
-            // short track if a NO is returned.
-            if (decision == Decision.NO) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Can not allocate [{}] on node [{}] due to [{}]",
-                        shardRouting, node.node(), allocationDecider.getClass().getSimpleName());
-                }
-                // short circuit only if debugging is not enabled
-                if (!allocation.debugDecision()) {
-                    return decision;
-                } else {
-                    ret.add(decision);
-                }
-            } else {
-                addDecision(ret, decision, allocation);
-            }
-        }
-        return ret;
+        return shardDecisions(shardRouting, allocation).canAllocate(node);
     }
 
-    @Override
     public Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        if (allocation.shouldIgnoreShardForNode(shardRouting.shardId(), node.nodeId())) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Shard [{}] should be ignored for node [{}]", shardRouting, node.nodeId());
-            }
-            return Decision.NO;
-        }
-        Decision.Multi ret = new Decision.Multi();
-        for (AllocationDecider allocationDecider : allocations) {
-            Decision decision = allocationDecider.canRemain(shardRouting, node, allocation);
-            // short track if a NO is returned.
-            if (decision == Decision.NO) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Shard [{}] can not remain on node [{}] due to [{}]",
-                        shardRouting, node.nodeId(), allocationDecider.getClass().getSimpleName());
-                }
-                if (!allocation.debugDecision()) {
-                    return decision;
-                } else {
-                    ret.add(decision);
-                }
-            } else {
-                addDecision(ret, decision, allocation);
-            }
-        }
-        return ret;
+        return shardDecisions(shardRouting, allocation).canRemain(node);
     }
 
-    @Override
     public Decision canAllocate(IndexMetaData indexMetaData, RoutingNode node, RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
@@ -138,7 +101,6 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    @Override
     public Decision shouldAutoExpandToNode(IndexMetaData indexMetaData, DiscoveryNode node, RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
@@ -157,7 +119,6 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    @Override
     public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
@@ -176,7 +137,6 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    @Override
     public Decision canAllocate(RoutingNode node, RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
@@ -195,7 +155,6 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    @Override
     public Decision canRebalance(RoutingAllocation allocation) {
         Decision.Multi ret = new Decision.Multi();
         for (AllocationDecider allocationDecider : allocations) {
@@ -214,7 +173,6 @@ public class AllocationDeciders extends AllocationDecider {
         return ret;
     }
 
-    @Override
     public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard routing " + shardRouting;
 
@@ -243,10 +201,181 @@ public class AllocationDeciders extends AllocationDecider {
     }
 
     private void addDecision(Decision.Multi ret, Decision decision, RoutingAllocation allocation) {
-        // We never add ALWAYS decisions and only add YES decisions when requested by debug mode (since Multi default is YES).
-        if (decision != Decision.ALWAYS
-            && (allocation.getDebugMode() == RoutingAllocation.DebugMode.ON || decision.type() != Decision.Type.YES)) {
+        if (shouldAddDecision(decision, allocation)) {
             ret.add(decision);
+        }
+    }
+
+    private boolean shouldAddDecision(Decision decision, RoutingAllocation allocation) {
+        // We never add ALWAYS decisions and only add YES decisions when requested by debug mode (since Multi default is YES).
+        return decision != Decision.ALWAYS
+            && (allocation.getDebugMode() == RoutingAllocation.DebugMode.ON || decision.type() != Decision.Type.YES);
+    }
+
+    public ShardDecisions shardDecisions(ShardRouting shardRouting, RoutingAllocation allocation) {
+        class LazyShardDecisions implements ShardDecisions {
+            private ShardDecisions cached;
+
+            public ShardDecisions get() {
+                if (cached == null) {
+                    this.cached = calculateDecisions(shardRouting, allocation);
+                }
+                return cached;
+            }
+
+            @Override
+            public Decision canAllocate(RoutingNode node) {
+                // we do this here, since we do not want this to affect tiered allocation like awareness.
+                if (allocation.shouldIgnoreShardForNode(shardRouting.shardId(), node.nodeId())) {
+                    return Decision.NO;
+                }
+
+                return get().canAllocate(node);
+            }
+
+            @Override
+            public Decision canRemain(RoutingNode node) {
+                if (allocation.shouldIgnoreShardForNode(shardRouting.shardId(), node.nodeId())) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Shard [{}] should be ignored for node [{}]", shardRouting, node.nodeId());
+                    }
+                    return Decision.NO;
+                }
+                return get().canRemain(node);
+            }
+        }
+        return new LazyShardDecisions();
+    }
+
+    private ShardDecisions calculateDecisions(ShardRouting shardRouting, RoutingAllocation allocation) {
+        // todo: make this evaluation more lazy, possibly by keeping the decision for every node for tiered
+        //  deciders.
+        Set<RoutingNode> candidates = StreamSupport.stream(allocation.routingNodes().spliterator(), false)
+            .collect(Collectors.toSet());
+        Map<RoutingNode, Decision> decisions = candidates.stream().collect(Collectors.toMap(Function.identity(), k -> Decision.ALWAYS));
+        Decision remainDecision = Decision.ALWAYS;
+        RoutingNode currentNode = shardRouting.assignedToNode()
+            ? allocation.routingNodes().node(shardRouting.currentNodeId())
+            : null;
+
+        BiFunction<Decision, Decision, Decision> decisionMerger = (oldDecision, newDecision) -> mergeDecision(oldDecision, newDecision,
+            allocation);
+        TieredAllocationDecider.LowerTierDecider lowerTierDecider = new TieredAllocationDecider.LowerTierDecider() {
+            @Override
+            public Set<RoutingNode> candidates() {
+                return candidates;
+            }
+
+            @Override
+            public Decision decisionFor(RoutingNode node) {
+                return decisions.getOrDefault(node, Decision.YES);
+            }
+        };
+
+        for (AllocationDecider decider : allocations) {
+            boolean tiered = decider instanceof TieredAllocationDecider;
+            Map<RoutingNode, Decision> newDecisions = new HashMap<>();
+            Set<RoutingNode> nodesToCheck = allocation.debugDecision() ? decisions.keySet() : candidates;
+            for (RoutingNode node : nodesToCheck) {
+                Decision decision = tiered
+                    ? ((TieredAllocationDecider) decider).canAllocate(shardRouting, node, allocation, lowerTierDecider)
+                    : decider.canAllocate(shardRouting, node, allocation);
+                if (decision == Decision.NO && logger.isTraceEnabled()) {
+                    logger.trace("Can not allocate [{}] on node [{}] due to [{}]: [{}]",
+                        shardRouting, node.node(), decider.getClass().getSimpleName(), decision);
+                }
+
+                newDecisions.put(node, decision);
+            }
+            if (currentNode != null && (remainDecision.type() != Decision.Type.NO || allocation.debugDecision())) {
+                Decision decision = tiered
+                    ? ((TieredAllocationDecider) decider).canRemain(shardRouting, currentNode, allocation, lowerTierDecider)
+                    : decider.canRemain(shardRouting, currentNode, allocation);
+                if (decision == Decision.NO && logger.isTraceEnabled()) {
+                    logger.trace("Can not remain [{}] on node [{}] due to [{}]: [{}]",
+                        shardRouting, currentNode.node(), decider.getClass().getSimpleName(), decision);
+                }
+
+                remainDecision = decisionMerger.apply(remainDecision, decision);
+            }
+
+            candidates.removeIf(n -> newDecisions.get(n) == Decision.NO);
+            newDecisions.forEach((n, d) -> decisions.merge(n, d, decisionMerger));
+        }
+
+        final Decision finalRemainDecision = remainDecision;
+        return new ShardDecisions() {
+            @Override
+            public Decision canAllocate(RoutingNode node) {
+                return toMulti(decisions.get(node), allocation);
+            }
+
+            @Override
+            public Decision canRemain(RoutingNode node) {
+                if (shardRouting.currentNodeId().equals(node.nodeId()) == false) {
+                    throw new IllegalArgumentException("Shard [" + shardRouting + "] is not allocated on node: [" + node.nodeId() + "]");
+                }
+
+                return toMulti(finalRemainDecision, allocation);
+            }
+        };
+    }
+
+    private Decision toMulti(Decision decision, RoutingAllocation allocation) {
+        // todo: we can likely remove this compatibility.
+        if (decision instanceof Decision.Single) {
+            Decision.Multi result = new Decision.Multi();
+            if (shouldAddDecision(decision, allocation)) {
+                result.add(decision);
+            }
+            decision = result;
+        }
+        return decision;
+    }
+
+    /**
+     * Get a decisions object for the allocation. Returned object is only valid until the allocation/routing nodes changes.
+     */
+    public Decisions decisions(RoutingAllocation allocation) {
+        Map<ShardRouting, ShardDecisions> cache = new HashMap<>();
+        return shardRouting -> cache.computeIfAbsent(shardRouting, s -> shardDecisions(s, allocation));
+    }
+
+    /**
+     * A representation of canAllocate and canRemain decisions at shard level.
+     * Notice that this might be lazy evaluated and should not be used after RoutingNodes have changed.
+     */
+    public interface ShardDecisions {
+        Decision canAllocate(RoutingNode node);
+
+        Decision canRemain(RoutingNode node);
+    }
+
+    /**
+     * A representation of canAllocate and canRemain decisions across shards.
+     * Notice that this might be lazy evaluated and should not be used after RoutingNodes have changed.
+     */
+    public interface Decisions {
+        ShardDecisions shard(ShardRouting shardRouting);
+    }
+
+    private Decision mergeDecision(Decision oldDecision, Decision newDecision, RoutingAllocation allocation) {
+        if (shouldAddDecision(newDecision, allocation) == false) {
+            return oldDecision;
+        } else if (oldDecision == Decision.ALWAYS) {
+            return newDecision;
+        } else if (allocation.debugDecision() == false) {
+            // higherThan means yes > throttle > no
+            if (oldDecision.type().higherThan(newDecision.type())) {
+                return newDecision;
+            } else {
+                return oldDecision;
+            }
+        } else {
+            Decision.Multi ret = new Decision.Multi();
+            oldDecision.getDecisions().forEach(ret::add);
+            ret.add(newDecision);
+            return ret;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -66,7 +66,7 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
     public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
         return canRebalance(allocation);
     }
-    
+
     @Override
     public Decision canRebalance(RoutingAllocation allocation) {
         if (clusterConcurrentRebalance == -1) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/TieredAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/TieredAllocationDecider.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.decider;
+
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * {@link TieredAllocationDecider} is an abstract base class that allows to make
+ * dynamic cluster- or index-wide shard allocation decisions on a per-node
+ * basis based on the decisions of lower tiered allocation deciders.
+ */
+public abstract class TieredAllocationDecider extends AllocationDecider {
+
+    public abstract Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation,
+                                 LowerTierDecider lowerTierDecider);
+
+    public abstract Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation,
+                              LowerTierDecider lowerTierDecider);
+
+    @Override
+    public final Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final Decision canRemain(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        assert shardRouting.primary() : "must not call canForceAllocatePrimary on a non-primary shard " + shardRouting;
+        assert shardRouting.unassigned() : "must not call canForceAllocatePrimary on an assigned shard " + shardRouting;
+        Decision decision = canAllocate(shardRouting, node, allocation, new LowerTierDecider() {
+            @Override
+            public Set<RoutingNode> candidates() {
+                return StreamSupport.stream(allocation.routingNodes().spliterator(), false).collect(Collectors.toSet());
+            }
+
+            @Override
+            public Decision decisionFor(RoutingNode node) {
+                return Decision.YES;
+            }
+        });
+        if (decision.type() == Decision.Type.NO) {
+            // On a NO decision, by default, we allow force allocating the primary.
+            return allocation.decision(Decision.YES,
+                decision.label(),
+                "primary shard [%s] allowed to force allocate on node [%s]",
+                shardRouting.shardId(), node.nodeId());
+        } else {
+            // On a THROTTLE/YES decision, we use the same decision instead of forcing allocation
+            return decision;
+        }
+    }
+
+    public interface LowerTierDecider {
+        Set<RoutingNode> candidates();
+        Decision decisionFor(RoutingNode node);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/BaseGatewayShardAllocator.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 
 import java.util.ArrayList;
@@ -94,9 +95,10 @@ public abstract class BaseGatewayShardAllocator {
      * allocation decisions for each node, while still waiting to allocate the shard (e.g. due to fetching shard data).
      */
     protected static List<NodeAllocationResult> buildDecisionsForAllNodes(ShardRouting shard, RoutingAllocation allocation) {
+        AllocationDeciders.ShardDecisions decisions = allocation.deciders().shardDecisions(shard, allocation);
         List<NodeAllocationResult> results = new ArrayList<>();
         for (RoutingNode node : allocation.routingNodes()) {
-            Decision decision = allocation.deciders().canAllocate(shard, node, allocation);
+            Decision decision = decisions.canAllocate(node);
             results.add(new NodeAllocationResult(node.node(), null, decision));
         }
         return results;

--- a/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult.ShardStoreInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.env.ShardLockObtainFailedException;
@@ -304,6 +305,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
         List<DecidedNode> yesNodeShards = new ArrayList<>();
         List<DecidedNode> throttledNodeShards = new ArrayList<>();
         List<DecidedNode> noNodeShards = new ArrayList<>();
+        AllocationDeciders.ShardDecisions decisions = allocation.deciders().shardDecisions(shardRouting, allocation);
         for (NodeGatewayStartedShards nodeShardState : nodeShardStates) {
             RoutingNode node = allocation.routingNodes().node(nodeShardState.getNode().getId());
             if (node == null) {
@@ -311,7 +313,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
             }
 
             Decision decision = forceAllocate ? allocation.deciders().canForceAllocatePrimary(shardRouting, node, allocation) :
-                                                allocation.deciders().canAllocate(shardRouting, node, allocation);
+                                                decisions.canAllocate(node);
             DecidedNode decidedNode = new DecidedNode(nodeShardState, decision);
             if (decision.type() == Type.THROTTLE) {
                 throttledNodeShards.add(decidedNode);

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -184,11 +184,11 @@ public class ClusterModuleTests extends ModuleTestCase {
             SnapshotInProgressAllocationDecider.class,
             RestoreInProgressAllocationDecider.class,
             FilterAllocationDecider.class,
-            SameShardAllocationDecider.class,
             DiskThresholdDecider.class,
             ThrottlingAllocationDecider.class,
             ShardsLimitAllocationDecider.class,
-            AwarenessAllocationDecider.class);
+            AwarenessAllocationDecider.class,
+            SameShardAllocationDecider.class);
         Collection<AllocationDecider> deciders = ClusterModule.createAllocationDeciders(Settings.EMPTY,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), Collections.emptyList());
         Iterator<AllocationDecider> iter = deciders.iterator();

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -89,7 +89,7 @@ public abstract class ESAllocationTestCase extends ESTestCase {
     public static AllocationDeciders randomAllocationDeciders(Settings settings, ClusterSettings clusterSettings, Random random) {
         List<AllocationDecider> deciders = new ArrayList<>(
             ClusterModule.createAllocationDeciders(settings, clusterSettings, Collections.emptyList()));
-        Collections.shuffle(deciders, random);
+//        Collections.shuffle(deciders, random);
         return new AllocationDeciders(deciders);
     }
 


### PR DESCRIPTION
This commit changes allocation deciders to be evaluated in order,
forming tiers of deciders where a subsequent tier can rely on the
evaluation of the previous tier.

This is used here to ensure that allocation awareness is made aware of
the decisions of other deciders making the cluster stay green when
possible even when a zone cannot be used due to filtering. This is
useful for instance when decommissioning the last node in a zone.

The intention is to add a another tiered decider that ensures that
the target of a write alias is forced spread across as many nodes as
possible while still respecting all other rules setup (i.e. not go yellow).
This should provide an automatic and better experience than using
`total_shards_per_node`.

This is WIP, but should be ready for feedback on whether this can be considered a viable idea?

At least following needs resolving before this can be considered done:

- [ ] Documentation
- [ ] BWC: we probably want this to be opt-in for the awareness decider in 7.x
- [ ] Lazy evaluation and performance study.
- [ ] An integration test
- [ ] More unittests
