### PR TITLE
Test percolate queries using `NOW` and sorting

### DIFF
--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -956,6 +956,11 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             BytesReference.bytes(jsonBuilder().startObject().field("d", "2020-02-01T15:00:00.000+11:00").endObject()),
             XContentType.JSON)).get();
         assertEquals(1, response.getHits().getTotalHits().value);
+        
+        response = client().prepareSearch("test").setQuery(new PercolateQueryBuilder("q",
+            BytesReference.bytes(jsonBuilder().startObject().field("d", "2020-02-01T15:00:00.000+11:00").endObject()),
+            XContentType.JSON)).addSort("_doc", SortOrder.ASC).get();
+        assertEquals(1, response.getHits().getTotalHits().value);
 
         response = client().prepareSearch("test").setQuery(constantScoreQuery(new PercolateQueryBuilder("q",
             BytesReference.bytes(jsonBuilder().startObject().field("d", "2020-02-01T15:00:00.000+11:00").endObject()),


### PR DESCRIPTION
Commit #52748 fixed a bug where percolate queries wrapped in a constant score
could report incorrect matches.  This commit adds a test to check that it also fixes
the case where a percolate query is sorted by something other than score.

Closes #52618 