### PR TITLE
Fix searchable snapshot stats fwd/bwd seeking counters

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/IndexInputStats.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/IndexInputStats.java
@@ -156,7 +156,7 @@ public class IndexInputStats {
     }
 
     @SuppressForbidden(reason = "Handles Long.MIN_VALUE before using Math.abs()")
-    private boolean isLargeSeek(long delta) {
+    boolean isLargeSeek(long delta) {
         return delta != Long.MIN_VALUE && Math.abs(delta) > seekingThreshold;
     }
 


### PR DESCRIPTION
This pull request fixes the backward/forward seeking counters in searchable snapshot statistics. These counters use the current file pointer position and the new seeking position to compute the seeking stats, but at the time the stat is computed the current file pointer position is already updated to the new position, making the delta always equals to `0`.

Sadly, no tests were able to catch this.