### PR TITLE
[7.6] Switch to AtomicLong for "IngestCurrent" metric to prevent negative values

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetric.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetric.java
@@ -22,6 +22,8 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * <p>Metrics to measure ingest actions.
  * <p>This counts measure documents and timings for a given scope.
@@ -39,7 +41,7 @@ class IngestMetric {
      * The current count of things being measure. Should most likely ever be 0 or 1.
      * Useful when aggregating multiple metrics to see how many things are in flight.
      */
-    private final CounterMetric ingestCurrent = new CounterMetric();
+    private final AtomicLong ingestCurrent = new AtomicLong();
     /**
      * The ever increasing count of things being measured
      */
@@ -53,7 +55,7 @@ class IngestMetric {
      * Call this prior to the ingest action.
      */
     void preIngest() {
-        ingestCurrent.inc();
+        ingestCurrent.incrementAndGet();
     }
 
     /**
@@ -61,7 +63,7 @@ class IngestMetric {
      * @param ingestTimeInMillis The time it took to perform the action.
      */
     void postIngest(long ingestTimeInMillis) {
-        ingestCurrent.dec();
+        ingestCurrent.decrementAndGet();
         ingestTime.inc(ingestTimeInMillis);
         ingestCount.inc();
     }
@@ -90,6 +92,6 @@ class IngestMetric {
      * Creates a serializable representation for these metrics.
      */
     IngestStats.Stats createStats() {
-        return new IngestStats.Stats(ingestCount.count(), ingestTime.sum(), ingestCurrent.count(), ingestFailed.count());
+        return new IngestStats.Stats(ingestCount.count(), ingestTime.sum(), ingestCurrent.get(), ingestFailed.count());
     }
 }


### PR DESCRIPTION
For monotonically-increasing metrics, the tradeoff of `LongAdder`'s lower contention for non-atomic value reads tends not to cause problems. The "IngestCurrent" metric is more of a flag-type metric that should hover between zero and a small positive number with frequent increment and decrement operations. In that case, `LongAdder`'s non-atomic reads can result in negative values being returned due to out-of-order application of the increment and decrement operations. Those negative values both confuse users and fail during serialization. For that specific metric, `AtomicLong`'s guarantees are necessary.

Backport of https://github.com/elastic/elasticsearch/pull/52581