### PR TITLE
Exclude indices with cache disabled from searchable snapshots stats

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponse.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponse.java
@@ -47,6 +47,7 @@ public class SearchableSnapshotsStatsResponse extends BroadcastResponse {
             .map(SearchableSnapshotShardStats::getShardRouting)
             .map(ShardRouting::index)
             .sorted(Comparator.comparing(Index::getName))
+            .distinct()
             .collect(toList());
 
         builder.startObject("indices");

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportSearchableSnapshotsStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportSearchableSnapshotsStatsAction.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
+import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotRepository.SNAPSHOT_CACHE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotRepository.SNAPSHOT_DIRECTORY_FACTORY_KEY;
 
 public class TransportSearchableSnapshotsStatsAction extends TransportBroadcastByNodeAction<SearchableSnapshotsStatsRequest,
@@ -94,7 +95,9 @@ public class TransportSearchableSnapshotsStatsAction extends TransportBroadcastB
             if (indexMetaData != null) {
                 Settings indexSettings = indexMetaData.getSettings();
                 if (INDEX_STORE_TYPE_SETTING.get(indexSettings).equals(SNAPSHOT_DIRECTORY_FACTORY_KEY)) {
-                    searchableSnapshotIndices.add(concreteIndex);
+                    if (SNAPSHOT_CACHE_ENABLED_SETTING.get(indexSettings)) {
+                        searchableSnapshotIndices.add(concreteIndex);
+                    }
                 }
             }
         }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -35,9 +35,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 
 public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTestCase {
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.searchablesnapshots;
 
 import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -15,6 +16,8 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -32,7 +35,9 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTestCase {
 
@@ -54,9 +59,11 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
             Settings.builder().put("delegate_type", repositoryType).put("readonly", true).put(repositorySettings).build());
 
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final int numberOfShards = randomIntBetween(1, 5);
+
         logger.info("creating index [{}]", indexName);
         createIndex(indexName, Settings.builder()
-            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5))
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, numberOfShards)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .build());
         ensureGreen(indexName);
@@ -130,6 +137,10 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
 
         logger.info("deleting snapshot [{}]", snapshot);
         deleteSnapshot(repository, snapshot, false);
+
+        final Map<String, Object> searchableSnapshotStats = searchableSnapshotStats(restoredIndexName);
+        assertThat("Expected searchable snapshots stats for " + numberOfShards + " shards but got " + searchableSnapshotStats,
+            searchableSnapshotStats.size(), equalTo(numberOfShards));
     }
 
     protected static void registerRepository(String repository, String type, boolean verify, Settings settings) throws IOException {
@@ -210,11 +221,27 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
         return responseAsMap;
     }
 
+    protected static Map<String, Object> searchableSnapshotStats(String index) throws IOException {
+        final Response response = client().performRequest(new Request(HttpGet.METHOD_NAME, '/' + index + "/_searchable_snapshots/stats"));
+        assertThat("Failed to retrieve searchable snapshots stats for on index [" + index + "]: " + response,
+            response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+
+        final Map<String, Object> responseAsMap = responseAsMap(response);
+        assertThat("Shard failures when retrieving searchable snapshots stats for index [" + index + "]: " + response,
+            extractValue(responseAsMap, "_shards.failed"), equalTo(0));
+        return extractValue(responseAsMap, "indices." + index + ".shards");
+    }
+
     protected static Map<String, Object> responseAsMap(Response response) throws IOException {
         final XContentType xContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
         assertThat("Unknown XContentType", xContentType, notNullValue());
-        try (InputStream responseBody = response.getEntity().getContent()) {
+
+        BytesReference bytesReference = Streams.readFully(response.getEntity().getContent());
+
+        try (InputStream responseBody = bytesReference.streamInput()) {
             return XContentHelper.convertToMap(xContentType.xContent(), responseBody, true);
+        } catch (Exception e) {
+            throw new IOException(bytesReference.utf8ToString(), e);
         }
     }
 


### PR DESCRIPTION
Searchable snapshots stats only make sense for indices with the setting `SNAPSHOT_CACHE_ENABLED_SETTING` enabled. This pull request prevents non-cached indices to be reported in searchable snapshots stats.