### PR TITLE
Allow dynamic updates for index.hidden setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -262,7 +262,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
      * normal wildcard searches unless explicitly allowed
      */
     public static final Setting<Boolean> INDEX_HIDDEN_SETTING =
-        Setting.boolSetting(SETTING_INDEX_HIDDEN, false, Property.IndexScope, Property.Final);
+        Setting.boolSetting(SETTING_INDEX_HIDDEN, false, Property.Dynamic, Property.IndexScope);
 
     /**
      * an internal index format description, allowing us to find out if this index is upgraded or needs upgrading

--- a/server/src/test/java/org/elasticsearch/index/HiddenIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/index/HiddenIndexIT.java
@@ -77,6 +77,15 @@ public class HiddenIndexIT extends ESIntegTestCase {
             .get();
         matchedHidden = Arrays.stream(searchResponse.getHits().getHits()).anyMatch(hit -> ".hidden-index".equals(hit.getIndex()));
         assertTrue(matchedHidden);
+
+        // make index not hidden
+        assertAcked(client().admin().indices().prepareUpdateSettings("hidden-index")
+            .setSettings(Settings.builder().put("index.hidden", false).build())
+            .get());
+        searchResponse =
+            client().prepareSearch(randomFrom("*", "_all", "h*", "*index")).setSize(1000).setQuery(QueryBuilders.matchAllQuery()).get();
+        matchedHidden = Arrays.stream(searchResponse.getHits().getHits()).anyMatch(hit -> "hidden-index".equals(hit.getIndex()));
+        assertTrue(matchedHidden);
     }
 
     public void testGlobalTemplatesDoNotApply() {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -364,6 +364,7 @@ public class TransportResumeFollowAction extends TransportMasterNodeAction<Resum
             IndexMetaData.INDEX_BLOCKS_READ_ONLY_ALLOW_DELETE_SETTING,
             IndexMetaData.INDEX_PRIORITY_SETTING,
             IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS,
+            IndexMetaData.INDEX_HIDDEN_SETTING,
             EnableAllocationDecider.INDEX_ROUTING_REBALANCE_ENABLE_SETTING,
             EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING,
             ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,


### PR DESCRIPTION
This commit changes the `index.hidden` setting from being final to a
dynamic setting. While the setting being final allows for easier
reasoning about an index, making this setting updateable has more
benefits in that we can upgrade existing indices to be hidden and it
will enable future features that would dynamically make indices hidden.