### PR TITLE
IndexWriterConfig used in InMemoryNoOpCommitDirectory should support soft-deletes

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotRepository.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotRepository.java
@@ -7,11 +7,13 @@ package org.elasticsearch.xpack.searchablesnapshots;
 
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
@@ -93,7 +95,11 @@ public class SearchableSnapshotRepository extends FilterRepository {
         }
         directory = new InMemoryNoOpCommitDirectory(directory);
 
-        try (IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig())) {
+        final IndexWriterConfig indexWriterConfig = new IndexWriterConfig(null)
+            .setSoftDeletesField(Lucene.SOFT_DELETES_FIELD)
+            .setMergePolicy(NoMergePolicy.INSTANCE);
+
+        try (IndexWriter indexWriter = new IndexWriter(directory, indexWriterConfig)) {
             final Map<String, String> userData = new HashMap<>();
             indexWriter.getLiveCommitData().forEach(e -> userData.put(e.getKey(), e.getValue()));
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -66,7 +66,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
 
         final StringBuilder bulkBody = new StringBuilder();
         for (int i = 0; i < numDocs; i++) {
-            bulkBody.append("{\"index\":{}}\n");
+            bulkBody.append("{\"index\":{\"_id\":\"").append(i).append("\"}}\n");
             bulkBody.append("{\"field\":").append(i).append(",\"text\":\"Document number ").append(i).append("\"}\n");
         }
 
@@ -75,8 +75,21 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
         documents.setJsonEntity(bulkBody.toString());
         assertOK(client().performRequest(documents));
 
+        if (randomBoolean()) {
+            final StringBuilder bulkUpdateBody = new StringBuilder();
+            for (int i = 0; i < randomIntBetween(1, numDocs); i++) {
+                bulkUpdateBody.append("{\"update\":{\"_id\":\"").append(i).append("\"}}\n");
+                bulkUpdateBody.append("{\"doc\":{").append("\"text\":\"Updated document number ").append(i).append("\"}}\n");
+            }
+
+            final Request bulkUpdate = new Request(HttpPost.METHOD_NAME, '/' + indexName + "/_bulk");
+            bulkUpdate.addParameter("refresh", Boolean.TRUE.toString());
+            bulkUpdate.setJsonEntity(bulkUpdateBody.toString());
+            assertOK(client().performRequest(bulkUpdate));
+        }
+
         logger.info("force merging index [{}]", indexName);
-        forceMerge(indexName, true, true);
+        forceMerge(indexName, randomBoolean(), randomBoolean());
 
         final String snapshot = "searchable-snapshot";
 


### PR DESCRIPTION
Today we use the default `IndexWriterConfig` during the initialization of searchable snapshots `Directory` instances. This `IndexWriterConfig` is used when opening an `IndexWriter` that is later committed in order to associate an empty translog with the Lucene index built from the snapshot.

Since the snapshot might contain soft deletes, the `IndexWriterConfig` should also declares a soft delete field otherwise it might just fail opening some Lucene files.