### PR TITLE
Revert randomizedtesting version to 2.7.4

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -31,7 +31,7 @@ joda              = 2.10.4
 #  - x-pack/plugin/security
 bouncycastle=1.64
 # test dependencies
-randomizedrunner  = 2.7.6
+randomizedrunner  = 2.7.4
 junit             = 4.12
 httpclient        = 4.5.10
 httpcore          = 4.4.12


### PR DESCRIPTION
Use older version of randomizedtesting library since the latest version
introduces a bug in test filtering which makese reproducing certain test
case scenarios difficult.

See: https://github.com/randomizedtesting/randomizedtesting/issues/283

Closes #52383

