### PR TITLE
[DOCS] Fixes monitoring links

### DIFF
--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -103,7 +103,7 @@ monitoring cluster.
 
 ** <<configuring-metricbeat,Use {metricbeat}>>.
 
-** <<configuring-monitoring,Use HTTP exporters>>.
+** <<configuring-monitoring-data,Use HTTP exporters>>.
 
 . (Optional)
 {logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster].

--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -103,7 +103,7 @@ monitoring cluster.
 
 ** <<configuring-metricbeat,Use {metricbeat}>>.
 
-** <<configuring-monitoring-data,Use HTTP exporters>>.
+** <<collecting-monitoring-data,Use HTTP exporters>>.
 
 . (Optional)
 {logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster].

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -91,16 +91,6 @@ See <<transform-resource>>.
 
 See <<transform-resource>>.
 
-[role="exclude",id="configuring-monitoring"]
-=== Configuring monitoring
-
-See <<monitoring-overview>>.
-
-[role="exclude",id="es-monitoring"]
-=== Monitoring {es}
-
-See <<monitor-elasticsearch-cluster>>.
-
 [role="exclude",id="docker-cli-run"]
 === Docker Run
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -91,6 +91,11 @@ See <<transform-resource>>.
 
 See <<transform-resource>>.
 
+[role="exclude",id="es-monitoring"]
+=== Monitoring {es}
+
+See <<monitor-elasticsearch-cluster>>.
+
 [role="exclude",id="docker-cli-run"]
 === Docker Run
 

--- a/x-pack/docs/en/security/ccs-clients-integrations/monitoring.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/monitoring.asciidoc
@@ -17,7 +17,7 @@ with the monitoring cluster.
 
 For more information, see:
 
-* <<configuring-monitoring>>
+* <<monitoring-production>>
 * {kibana-ref}/monitoring-xpack-kibana.html[Configuring monitoring in {kib}]
 * {logstash-ref}/configuring-logstash.html[Configuring monitoring for Logstash nodes]
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
@@ -1,7 +1,7 @@
 {
   "monitoring.bulk":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/es-monitoring.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/monitor-elasticsearch-cluster.html"
     },
     "stability":"experimental",
     "url":{


### PR DESCRIPTION
This PR fixes an out-dated link in the second step of the "Monitoring in a production environment" page (https://www.elastic.co/guide/en/elasticsearch/reference/master/monitoring-production.html).

It also removes other out-dated monitoring links that lingered as redirects.