### PR TITLE
Remove TODO in MaxAgeCondition serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
@@ -58,8 +58,8 @@ public class MaxAgeCondition extends Condition<TimeValue> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         // While we technically could serialize this would out.writeTimeValue(...), that would
-        // doing the song and dance around backwards compatibility for this value. Since in this
-        // case the deserialized version is not displayed to a user, it's okay to simply use
+        // required doing the song and dance around backwards compatibility for this value. Since
+        // in this case the deserialized version is not displayed to a user, it's okay to simply use
         // milliseconds. It's possible to lose precision if someone were to say, specify 50
         // nanoseconds, however, in that case, their max age is indistinguishable from 0
         // milliseconds regardless.

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
@@ -58,7 +58,7 @@ public class MaxAgeCondition extends Condition<TimeValue> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         // While we technically could serialize this would out.writeTimeValue(...), that would
-        // required doing the song and dance around backwards compatibility for this value. Since
+        // require doing the song and dance around backwards compatibility for this value. Since
         // in this case the deserialized version is not displayed to a user, it's okay to simply use
         // milliseconds. It's possible to lose precision if someone were to say, specify 50
         // nanoseconds, however, in that case, their max age is indistinguishable from 0

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
@@ -57,7 +57,12 @@ public class MaxAgeCondition extends Condition<TimeValue> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        //TODO here we should just use TimeValue#writeTo and same for de-serialization in the constructor, we lose information this way
+        // While we technically could serialize this would out.writeTimeValue(...), that would
+        // doing the song and dance around backwards compatibility for this value. Since in this
+        // case the deserialized version is not displayed to a user, it's okay to simply use
+        // milliseconds. It's possible to lose precision if someone were to say, specify 50
+        // nanoseconds, however, in that case, their max age is indistinguishable from 0
+        // milliseconds regardless.
         out.writeLong(value.getMillis());
     }
 


### PR DESCRIPTION
This removes the TODO with a message for any future readers regarding the code in question.

Resolves #52505
