### PR TITLE
Fix translog stats on closed indices yaml test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -108,6 +108,10 @@
   - match: { indices.test.primaries.translog.operations: 1 }
   - match: { indices.test.primaries.translog.uncommitted_operations: 1 }
   - do:
+      cluster.health:
+        wait_for_no_initializing_shards: true
+        wait_for_events: languid
+  - do:
       indices.close:
         index: test
         wait_for_active_shards: 1


### PR DESCRIPTION
We need to wait for no initializing shards before closing; otherwise, we might fail to close some recovering replicas.

Closes #52701 