### PR TITLE
Fix GCS Mock Range Downloads

### DIFF
--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/FakeOAuth2HttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/FakeOAuth2HttpHandler.java
@@ -35,11 +35,11 @@ public class FakeOAuth2HttpHandler implements HttpHandler {
     @Override
     public void handle(final HttpExchange exchange) throws IOException {
         try {
+            while (exchange.getRequestBody().read(BUFFER) >= 0) ;
             byte[] response = ("{\"access_token\":\"foo\",\"token_type\":\"Bearer\",\"expires_in\":3600}").getBytes(UTF_8);
             exchange.getResponseHeaders().add("Content-Type", "application/json");
             exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
             exchange.getResponseBody().write(response);
-            while (exchange.getRequestBody().read(BUFFER) >= 0) ;
         } finally {
             int read = exchange.getRequestBody().read();
             assert read == -1 : "Request body should have been fully read here but saw [" + read + "]";


### PR DESCRIPTION
We were not correctly respecting the download range which lead
to the GCS SDK client closing the connection at times.

Closes #51446
