### PR TITLE
Create SAML Responses for secondary authN

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
@@ -11,13 +11,12 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
-import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
+import org.elasticsearch.xpack.core.security.authc.support.SecondaryAuthentication;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.idp.saml.authn.SuccessfulAuthenticationResponseMessageBuilder;
 import org.elasticsearch.xpack.idp.saml.authn.UserServiceAuthentication;
@@ -37,29 +36,25 @@ import java.util.Set;
 public class TransportSamlInitiateSingleSignOnAction
     extends HandledTransportAction<SamlInitiateSingleSignOnRequest, SamlInitiateSingleSignOnResponse> {
 
-    private final ThreadPool threadPool;
+    private final SecurityContext securityContext;
     private final Environment env;
     private final Logger logger = LogManager.getLogger(TransportSamlInitiateSingleSignOnAction.class);
 
     @Inject
-    public TransportSamlInitiateSingleSignOnAction(ThreadPool threadPool, TransportService transportService,
-                                                   ActionFilters actionFilters, Environment environment) {
+    public TransportSamlInitiateSingleSignOnAction(TransportService transportService,
+                                                   SecurityContext securityContext, ActionFilters actionFilters, Environment environment) {
         super(SamlInitiateSingleSignOnAction.NAME, transportService, actionFilters, SamlInitiateSingleSignOnRequest::new);
-        this.threadPool = threadPool;
+        this.securityContext = securityContext;
         this.env = environment;
     }
 
     @Override
     protected void doExecute(Task task, SamlInitiateSingleSignOnRequest request,
                              ActionListener<SamlInitiateSingleSignOnResponse> listener) {
-        final ThreadContext threadContext = threadPool.getThreadContext();
         final SamlFactory samlFactory = new SamlFactory();
         final SamlIdentityProvider idp = new CloudIdp(env, env.settings());
         try {
-            // TODO: Adjust this once secondary auth code is merged in master and use the authentication object of the user
-            // Authentication authentication = authenticationService.getSecondaryAuth();
-            Authentication serviceAccountAuthentication = new AuthenticationContextSerializer().readFromContext(threadContext);
-            SamlServiceProvider sp = idp.getRegisteredServiceProvider(request.getSpEntityId());
+            final SamlServiceProvider sp = idp.getRegisteredServiceProvider(request.getSpEntityId());
             if (null == sp) {
                 final String message =
                     "Service Provider with Entity ID [" + request.getSpEntityId() + "] is not registered with this Identity Provider";
@@ -67,7 +62,12 @@ public class TransportSamlInitiateSingleSignOnAction
                 listener.onFailure(new IllegalArgumentException(message));
                 return;
             }
-            final UserServiceAuthentication user = buildUserFromAuthentication(serviceAccountAuthentication, sp);
+            final SecondaryAuthentication secondaryAuthentication = SecondaryAuthentication.readFromContext(securityContext);
+            if (secondaryAuthentication == null) {
+                listener.onFailure(new IllegalStateException("Request is missing secondary authentication"));
+                return;
+            }
+            final UserServiceAuthentication user = buildUserFromAuthentication(secondaryAuthentication.getAuthentication(), sp);
             final SuccessfulAuthenticationResponseMessageBuilder builder = new SuccessfulAuthenticationResponseMessageBuilder(samlFactory,
                 Clock.systemUTC(), idp);
             final Response response = builder.build(user, null);
@@ -81,7 +81,6 @@ public class TransportSamlInitiateSingleSignOnAction
 
     private UserServiceAuthentication buildUserFromAuthentication(Authentication authentication, SamlServiceProvider sp) {
         final User authenticatedUser = authentication.getUser();
-        //TBD Where we will be sourcing the information from, use roles for easier testing now
         final Set<String> groups = new HashSet<>(Arrays.asList(authenticatedUser.roles()));
         return new UserServiceAuthentication(authenticatedUser.principal(), groups, sp);
     }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnRequestTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnRequestTests.java
@@ -16,9 +16,10 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.support.SecondaryAuthentication;
 import org.elasticsearch.xpack.core.security.user.User;
-import org.junit.Before;
 
 import java.util.Collections;
 
@@ -29,10 +30,46 @@ import static org.mockito.Mockito.when;
 
 public class TransportSamlInitiateSingleSignOnRequestTests extends ESTestCase {
 
-    private TransportSamlInitiateSingleSignOnAction action;
+    public void testGetResponseForRegisteredSp() throws Exception {
+        final SamlInitiateSingleSignOnRequest request = new SamlInitiateSingleSignOnRequest();
+        request.setSpEntityId("https://sp.some.org");
 
-    @Before
-    public void setup() throws Exception {
+        final PlainActionFuture<SamlInitiateSingleSignOnResponse> future = new PlainActionFuture<>();
+        final TransportSamlInitiateSingleSignOnAction action = setupTransportAction(true);
+        action.doExecute(mock(Task.class), request, future);
+
+        final SamlInitiateSingleSignOnResponse response = future.get();
+        assertThat(response.getSpEntityId(), equalTo("https://sp.some.org"));
+        assertThat(response.getRedirectUrl(), equalTo("https://sp.some.org/api/security/v1/saml"));
+        assertThat(response.getResponseBody(), containsString("saml_enduser"));
+    }
+
+    public void testGetResponseWithoutSecondaryAuthentication() throws Exception {
+        final SamlInitiateSingleSignOnRequest request = new SamlInitiateSingleSignOnRequest();
+        request.setSpEntityId("https://sp.some.org");
+
+        final PlainActionFuture<SamlInitiateSingleSignOnResponse> future = new PlainActionFuture<>();
+        final TransportSamlInitiateSingleSignOnAction action = setupTransportAction(false);
+        action.doExecute(mock(Task.class), request, future);
+
+        Exception e = expectThrows(Exception.class, () -> future.get());
+        assertThat(e.getCause().getMessage(), containsString("Request is missing secondary authentication"));
+    }
+
+    public void testGetResponseForNotRegisteredSp() throws Exception {
+        final SamlInitiateSingleSignOnRequest request = new SamlInitiateSingleSignOnRequest();
+        request.setSpEntityId("https://sp2.other.org");
+
+        final PlainActionFuture<SamlInitiateSingleSignOnResponse> future = new PlainActionFuture<>();
+        final TransportSamlInitiateSingleSignOnAction action = setupTransportAction(true);
+        action.doExecute(mock(Task.class), request, future);
+
+        Exception e = expectThrows(Exception.class, () -> future.get());
+        assertThat(e.getCause().getMessage(), containsString("https://sp2.other.org"));
+        assertThat(e.getCause().getMessage(), containsString("is not registered with this Identity Provider"));
+    }
+
+    private TransportSamlInitiateSingleSignOnAction setupTransportAction(boolean withSecondaryAuth) throws Exception {
         final Settings settings = Settings.builder()
             .put("path.home", createTempDir())
             .put("xpack.idp.enabled", true)
@@ -41,40 +78,23 @@ public class TransportSamlInitiateSingleSignOnRequestTests extends ESTestCase {
             .build();
         final ThreadContext threadContext = new ThreadContext(settings);
         final ThreadPool threadPool = mock(ThreadPool.class);
+        final SecurityContext securityContext = new SecurityContext(settings, threadContext);
         final TransportService transportService = new TransportService(Settings.EMPTY, mock(Transport.class), null,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR, x -> null, null, Collections.emptySet());
         final ActionFilters actionFilters = mock(ActionFilters.class);
         final Environment env = TestEnvironment.newEnvironment(settings);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-        new Authentication(new User("test_saml_user", "saml_idp_role"),
-            new Authentication.RealmRef("_es_api_key", "_es_api_key", "node_name"),
-            new Authentication.RealmRef("_es_api_key", "_es_api_key", "node_name"))
+        new Authentication(new User("saml_service_account", "saml_service_role"),
+            new Authentication.RealmRef("default_native", "native", "node_name"),
+            new Authentication.RealmRef("default_native", "native", "node_name"))
             .writeToContext(threadContext);
-        action = new TransportSamlInitiateSingleSignOnAction(threadPool, transportService, actionFilters, env);
-    }
-
-    public void testGetResponseForRegisteredSp() throws Exception {
-        final SamlInitiateSingleSignOnRequest request = new SamlInitiateSingleSignOnRequest();
-        request.setSpEntityId("https://sp.some.org");
-
-        final PlainActionFuture<SamlInitiateSingleSignOnResponse> future = new PlainActionFuture<>();
-        action.doExecute(mock(Task.class), request, future);
-
-        final SamlInitiateSingleSignOnResponse response = future.get();
-        assertThat(response.getSpEntityId(), equalTo("https://sp.some.org"));
-        assertThat(response.getRedirectUrl(), equalTo("https://sp.some.org/api/security/v1/saml"));
-        assertThat(response.getResponseBody(), containsString("test_saml_user"));
-    }
-
-    public void testGetResponseForNotRegisteredSp() throws Exception {
-        final SamlInitiateSingleSignOnRequest request = new SamlInitiateSingleSignOnRequest();
-        request.setSpEntityId("https://sp2.other.org");
-
-        final PlainActionFuture<SamlInitiateSingleSignOnResponse> future = new PlainActionFuture<>();
-        action.doExecute(mock(Task.class), request, future);
-
-        Exception e = expectThrows(Exception.class, () -> future.get());
-        assertThat(e.getCause().getMessage(), containsString("https://sp2.other.org"));
-        assertThat(e.getCause().getMessage(), containsString("is not registered with this Identity Provider"));
+        if (withSecondaryAuth) {
+            new SecondaryAuthentication(securityContext,
+                new Authentication(new User("saml_enduser", "saml_enduser_role"),
+                    new Authentication.RealmRef("_es_api_key", "_es_api_key", "node_name"),
+                    new Authentication.RealmRef("_es_api_key", "_es_api_key", "node_name")))
+                .writeToContext(threadContext);
+        }
+        return new TransportSamlInitiateSingleSignOnAction(transportService, securityContext, actionFilters, env);
     }
 }


### PR DESCRIPTION
Create the SAML responses for the principal that we should. The
credentials of this user need to have been passed in the
es-secondary-authorization header.