### PR TITLE
Autoformat :qa:os and :benchmarks

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/fs/AvailableIndexFoldersBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/fs/AvailableIndexFoldersBenchmark.java
@@ -55,13 +55,14 @@ public class AvailableIndexFoldersBenchmark {
     @Setup
     public void setup() throws IOException {
         Path path = Files.createTempDirectory("test");
-        String[] paths = new String[] {path.toString()};
+        String[] paths = new String[] { path.toString() };
         nodePath = new NodeEnvironment.NodePath(path);
 
         LogConfigurator.setNodeName("test");
         Settings settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), path)
-            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths)
+            .build();
         nodeEnv = new NodeEnvironment(settings, new Environment(settings, null));
 
         Files.createDirectories(nodePath.indicesPath);
@@ -79,7 +80,6 @@ public class AvailableIndexFoldersBenchmark {
             throw new IllegalStateException("bad size");
         }
     }
-
 
     @Benchmark
     public Set<String> availableIndexFolderNaive() throws IOException {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/indices/breaker/MemoryStatsBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/indices/breaker/MemoryStatsBenchmark.java
@@ -41,11 +41,11 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class MemoryStatsBenchmark {
     private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
 
-    @Param({"0", "16", "256", "4096"})
+    @Param({ "0", "16", "256", "4096" })
     private int tokens;
 
     @Benchmark
@@ -102,4 +102,3 @@ public class MemoryStatsBenchmark {
         return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
     }
 }
-

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class AllocationBenchmark {
     // Do NOT make any field final (even if it is not annotated with @Param)! See also
     // http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_10_ConstantFold.java
@@ -106,8 +106,7 @@ public class AllocationBenchmark {
         "       10|     10|        2|    50",
         "      100|      1|        2|    50",
         "      100|      3|        2|    50",
-        "      100|     10|        2|    50"
-    })
+        "      100|     10|        2|    50" })
     public String indicesShardsReplicasNodes = "10|1|0|1";
 
     public int numTags = 2;
@@ -124,13 +123,14 @@ public class AllocationBenchmark {
         int numReplicas = toInt(params[2]);
         int numNodes = toInt(params[3]);
 
-        strategy = Allocators.createAllocationService(Settings.builder()
-                .put("cluster.routing.allocation.awareness.attributes", "tag")
-                .build());
+        strategy = Allocators.createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.awareness.attributes", "tag").build()
+        );
 
         MetaData.Builder mb = MetaData.builder();
         for (int i = 1; i <= numIndices; i++) {
-            mb.put(IndexMetaData.builder("test_" + i)
+            mb.put(
+                IndexMetaData.builder("test_" + i)
                     .settings(Settings.builder().put("index.version.created", Version.CURRENT))
                     .numberOfShards(numShards)
                     .numberOfReplicas(numReplicas)
@@ -147,8 +147,10 @@ public class AllocationBenchmark {
             nb.add(Allocators.newNode("node" + i, Collections.singletonMap("tag", "tag_" + (i % numTags))));
         }
         initialClusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metaData(metaData).routingTable(routingTable).nodes
-                (nb).build();
+            .metaData(metaData)
+            .routingTable(routingTable)
+            .nodes(nb)
+            .build();
     }
 
     private int toInt(String v) {
@@ -159,8 +161,10 @@ public class AllocationBenchmark {
     public ClusterState measureAllocation() {
         ClusterState clusterState = initialClusterState;
         while (clusterState.getRoutingNodes().hasUnassignedShards()) {
-            clusterState = strategy.applyStartedShards(clusterState, clusterState.getRoutingNodes()
-                    .shardsWithState(ShardRoutingState.INITIALIZING));
+            clusterState = strategy.applyStartedShards(
+                clusterState,
+                clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING)
+            );
             clusterState = strategy.reroute(clusterState, "reroute");
         }
         return clusterState;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/Allocators.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/Allocators.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.gateway.GatewayAllocator;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -67,33 +66,34 @@ public final class Allocators {
         throw new AssertionError("Do not instantiate");
     }
 
-
-    public static AllocationService createAllocationService(Settings settings) throws NoSuchMethodException, InstantiationException,
-        IllegalAccessException, InvocationTargetException {
-        return createAllocationService(settings, new ClusterSettings(Settings.EMPTY, ClusterSettings
-            .BUILT_IN_CLUSTER_SETTINGS));
+    public static AllocationService createAllocationService(Settings settings) {
+        return createAllocationService(settings, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
     }
 
-    public static AllocationService createAllocationService(Settings settings, ClusterSettings clusterSettings) throws
-        InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    public static AllocationService createAllocationService(Settings settings, ClusterSettings clusterSettings) {
         return new AllocationService(
             defaultAllocationDeciders(settings, clusterSettings),
-            NoopGatewayAllocator.INSTANCE, new BalancedShardsAllocator(settings), EmptyClusterInfoService.INSTANCE);
+            NoopGatewayAllocator.INSTANCE,
+            new BalancedShardsAllocator(settings),
+            EmptyClusterInfoService.INSTANCE
+        );
     }
 
-    public static AllocationDeciders defaultAllocationDeciders(Settings settings, ClusterSettings clusterSettings) throws
-        IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
-        Collection<AllocationDecider> deciders =
-            ClusterModule.createAllocationDeciders(settings, clusterSettings, Collections.emptyList());
+    public static AllocationDeciders defaultAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
+        Collection<AllocationDecider> deciders = ClusterModule.createAllocationDeciders(settings, clusterSettings, Collections.emptyList());
         return new AllocationDeciders(deciders);
-
     }
 
     private static final AtomicInteger portGenerator = new AtomicInteger();
 
     public static DiscoveryNode newNode(String nodeId, Map<String, String> attributes) {
-        return new DiscoveryNode("", nodeId, new TransportAddress(TransportAddress.META_ADDRESS,
-            portGenerator.incrementAndGet()), attributes, Sets.newHashSet(DiscoveryNodeRole.MASTER_ROLE,
-            DiscoveryNodeRole.DATA_ROLE), Version.CURRENT);
+        return new DiscoveryNode(
+            "",
+            nodeId,
+            new TransportAddress(TransportAddress.META_ADDRESS, portGenerator.incrementAndGet()),
+            attributes,
+            Sets.newHashSet(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE),
+            Version.CURRENT
+        );
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterBenchmark.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class DateFormatterBenchmark {
 
     private final DateFormatter javaFormatter = DateFormatter.forPattern("8year_month_day||ordinal_date||epoch_millis");

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterFromBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterFromBenchmark.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class DateFormatterFromBenchmark {
 
     private final TemporalAccessor accessor = DateFormatter.forPattern("epoch_millis").parse("1234567890");

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/time/RoundingBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/time/RoundingBenchmark.java
@@ -48,7 +48,7 @@ import static org.elasticsearch.common.Rounding.DateTimeUnit.YEAR_OF_CENTURY;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class RoundingBenchmark {
 
     private final ZoneId zoneId = ZoneId.of("Europe/Amsterdam");
@@ -56,10 +56,10 @@ public class RoundingBenchmark {
 
     private long timestamp = 1548879021354L;
 
-    private final org.elasticsearch.common.rounding.Rounding jodaRounding =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(timeZone).build();
-    private final Rounding javaRounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY)
-        .timeZone(zoneId).build();
+    private final org.elasticsearch.common.rounding.Rounding jodaRounding = org.elasticsearch.common.rounding.Rounding.builder(
+        DateTimeUnit.HOUR_OF_DAY
+    ).timeZone(timeZone).build();
+    private final Rounding javaRounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).timeZone(zoneId).build();
 
     @Benchmark
     public long timeRoundingDateTimeUnitJoda() {
@@ -71,10 +71,10 @@ public class RoundingBenchmark {
         return javaRounding.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding jodaDayOfMonthRounding =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(timeZone).build();
-    private final Rounding javaDayOfMonthRounding = Rounding.builder(DAY_OF_MONTH)
-        .timeZone(zoneId).build();
+    private final org.elasticsearch.common.rounding.Rounding jodaDayOfMonthRounding = org.elasticsearch.common.rounding.Rounding.builder(
+        DateTimeUnit.DAY_OF_MONTH
+    ).timeZone(timeZone).build();
+    private final Rounding javaDayOfMonthRounding = Rounding.builder(DAY_OF_MONTH).timeZone(zoneId).build();
 
     @Benchmark
     public long timeRoundingDateTimeUnitDayOfMonthJoda() {
@@ -86,10 +86,10 @@ public class RoundingBenchmark {
         return javaDayOfMonthRounding.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding timeIntervalRoundingJoda =
-        org.elasticsearch.common.rounding.Rounding.builder(TimeValue.timeValueMinutes(60)).timeZone(timeZone).build();
-    private final Rounding timeIntervalRoundingJava = Rounding.builder(TimeValue.timeValueMinutes(60))
-        .timeZone(zoneId).build();
+    private final org.elasticsearch.common.rounding.Rounding timeIntervalRoundingJoda = org.elasticsearch.common.rounding.Rounding.builder(
+        TimeValue.timeValueMinutes(60)
+    ).timeZone(timeZone).build();
+    private final Rounding timeIntervalRoundingJava = Rounding.builder(TimeValue.timeValueMinutes(60)).timeZone(zoneId).build();
 
     @Benchmark
     public long timeIntervalRoundingJava() {
@@ -101,10 +101,11 @@ public class RoundingBenchmark {
         return timeIntervalRoundingJoda.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcDayOfMonthJoda =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcDayOfMonthJava = Rounding.builder(DAY_OF_MONTH)
-        .timeZone(ZoneOffset.UTC).build();
+    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcDayOfMonthJoda = org.elasticsearch.common.rounding.Rounding
+        .builder(DateTimeUnit.DAY_OF_MONTH)
+        .timeZone(DateTimeZone.UTC)
+        .build();
+    private final Rounding timeUnitRoundingUtcDayOfMonthJava = Rounding.builder(DAY_OF_MONTH).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcDayOfMonthJava() {
@@ -118,8 +119,7 @@ public class RoundingBenchmark {
 
     private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcQuarterOfYearJoda =
         org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.QUARTER).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcQuarterOfYearJava = Rounding.builder(QUARTER_OF_YEAR)
-        .timeZone(ZoneOffset.UTC).build();
+    private final Rounding timeUnitRoundingUtcQuarterOfYearJava = Rounding.builder(QUARTER_OF_YEAR).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcQuarterOfYearJava() {
@@ -131,10 +131,11 @@ public class RoundingBenchmark {
         return timeUnitRoundingUtcQuarterOfYearJoda.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcMonthOfYearJoda =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcMonthOfYearJava = Rounding.builder(MONTH_OF_YEAR)
-        .timeZone(ZoneOffset.UTC).build();
+    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcMonthOfYearJoda = org.elasticsearch.common.rounding.Rounding
+        .builder(DateTimeUnit.MONTH_OF_YEAR)
+        .timeZone(DateTimeZone.UTC)
+        .build();
+    private final Rounding timeUnitRoundingUtcMonthOfYearJava = Rounding.builder(MONTH_OF_YEAR).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcMonthOfYearJava() {
@@ -146,11 +147,9 @@ public class RoundingBenchmark {
         return timeUnitRoundingUtcMonthOfYearJoda.round(timestamp);
     }
 
-
     private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcYearOfCenturyJoda =
         org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcYearOfCenturyJava = Rounding.builder(YEAR_OF_CENTURY)
-        .timeZone(ZoneOffset.UTC).build();
+    private final Rounding timeUnitRoundingUtcYearOfCenturyJava = Rounding.builder(YEAR_OF_CENTURY).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcYearOfCenturyJava() {

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ subprojects {
     // is greater than the number of unformatted projects, this can be
     // switched to an exclude list, and eventualy removed completely.
     def projectPathsToFormat = [
+      ':benchmarks',
       ':build-tools',
       ':distribution:tools:java-version-checker',
       ':distribution:tools:launchers',

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ subprojects {
       ':distribution:tools:java-version-checker',
       ':distribution:tools:launchers',
       ':distribution:tools:plugin-cli',
+      ':qa:os',
       ':x-pack:plugin:autoscaling',
       ':x-pack:plugin:enrich'
     ]

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -79,10 +79,7 @@ public class DebPreservationTests extends PackagingTestCase {
 
         // keystore was removed
 
-        assertPathsDoNotExist(
-            installation.config("elasticsearch.keystore"),
-            installation.config(".elasticsearch.keystore.initial_md5sum")
-        );
+        assertPathsDoNotExist(installation.config("elasticsearch.keystore"), installation.config(".elasticsearch.keystore.initial_md5sum"));
 
         // doc files were removed
 
@@ -105,11 +102,7 @@ public class DebPreservationTests extends PackagingTestCase {
 
         assertRemoved(distribution());
 
-        assertPathsDoNotExist(
-            installation.config,
-            installation.envFile,
-            SYSVINIT_SCRIPT
-        );
+        assertPathsDoNotExist(installation.config, installation.envFile, SYSVINIT_SCRIPT);
 
         assertThat(packageStatus(distribution()).exitCode, is(1));
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java
@@ -30,15 +30,16 @@ import org.elasticsearch.packaging.util.Shell;
 import org.junit.Ignore;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.packaging.util.Archives.ARCHIVE_OWNER;
 import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
@@ -82,8 +83,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
         Shell.Result r = sh.runIgnoreExitCode(bin.keystoreTool.toString() + " has-passwd");
         assertFalse("has-passwd should fail", r.isSuccess());
-        assertThat("has-passwd should indicate missing keystore",
-            r.stderr, containsString(ERROR_KEYSTORE_NOT_FOUND));
+        assertThat("has-passwd should indicate missing keystore", r.stderr, containsString(ERROR_KEYSTORE_NOT_FOUND));
     }
 
     /** Test initial package state */
@@ -98,8 +98,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
         Shell.Result r = sh.runIgnoreExitCode(bin.keystoreTool.toString() + " has-passwd");
         assertFalse("has-passwd should fail", r.isSuccess());
-        assertThat("has-passwd should indicate unprotected keystore",
-            r.stderr, containsString(ERROR_KEYSTORE_NOT_PASSWORD_PROTECTED));
+        assertThat("has-passwd should indicate unprotected keystore", r.stderr, containsString(ERROR_KEYSTORE_NOT_PASSWORD_PROTECTED));
         Shell.Result r2 = bin.keystoreTool.run("list");
         assertThat(r2.stdout, containsString("keystore.seed"));
     }
@@ -119,8 +118,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
         Shell.Result r = sh.runIgnoreExitCode(bin.keystoreTool.toString() + " has-passwd");
         assertFalse("has-passwd should fail", r.isSuccess());
-        assertThat("has-passwd should indicate unprotected keystore",
-            r.stdout, containsString(ERROR_KEYSTORE_NOT_PASSWORD_PROTECTED));
+        assertThat("has-passwd should indicate unprotected keystore", r.stdout, containsString(ERROR_KEYSTORE_NOT_PASSWORD_PROTECTED));
         Shell.Result r2 = bin.keystoreTool.run("list");
         assertThat(r2.stdout, containsString("keystore.seed"));
     }
@@ -153,8 +151,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
     }
 
     public void test40KeystorePasswordOnStandardInput() throws Exception {
-        assumeTrue("packages will use systemd, which doesn't handle stdin",
-            distribution.isArchive());
+        assumeTrue("packages will use systemd, which doesn't handle stdin", distribution.isArchive());
         assumeThat(installation, is(notNullValue()));
 
         String password = "^|<>\\&exit"; // code insertion on Windows if special characters are not escaped
@@ -171,8 +168,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
     }
 
     public void test41WrongKeystorePasswordOnStandardInput() {
-        assumeTrue("packages will use systemd, which doesn't handle stdin",
-            distribution.isArchive());
+        assumeTrue("packages will use systemd, which doesn't handle stdin", distribution.isArchive());
         assumeThat(installation, is(notNullValue()));
 
         assertPasswordProtectedKeystore();
@@ -183,10 +179,8 @@ public class KeystoreManagementTests extends PackagingTestCase {
 
     @Ignore /* Ignored for feature branch, awaits fix: https://github.com/elastic/elasticsearch/issues/49340 */
     public void test42KeystorePasswordOnTty() throws Exception {
-        assumeTrue("expect command isn't on Windows",
-            distribution.platform != Distribution.Platform.WINDOWS);
-        assumeTrue("packages will use systemd, which doesn't handle stdin",
-            distribution.isArchive());
+        assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);
+        assumeTrue("packages will use systemd, which doesn't handle stdin", distribution.isArchive());
         assumeThat(installation, is(notNullValue()));
 
         String password = "keystorepass";
@@ -204,10 +198,8 @@ public class KeystoreManagementTests extends PackagingTestCase {
 
     @Ignore /* Ignored for feature branch, awaits fix: https://github.com/elastic/elasticsearch/issues/49340 */
     public void test43WrongKeystorePasswordOnTty() throws Exception {
-        assumeTrue("expect command isn't on Windows",
-            distribution.platform != Distribution.Platform.WINDOWS);
-        assumeTrue("packages will use systemd, which doesn't handle stdin",
-            distribution.isArchive());
+        assumeTrue("expect command isn't on Windows", distribution.platform != Distribution.Platform.WINDOWS);
+        assumeTrue("packages will use systemd, which doesn't handle stdin", distribution.isArchive());
         assumeThat(installation, is(notNullValue()));
 
         assertPasswordProtectedKeystore();
@@ -222,8 +214,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
      * view help information.
      */
     public void test44EncryptedKeystoreAllowsHelpMessage() throws Exception {
-        assumeTrue("users call elasticsearch directly in archive case",
-            distribution.isArchive());
+        assumeTrue("users call elasticsearch directly in archive case", distribution.isArchive());
 
         String password = "keystorepass";
 
@@ -251,9 +242,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
             sh.run("sudo systemctl set-environment ES_KEYSTORE_PASSPHRASE_FILE=" + esKeystorePassphraseFile);
 
             Files.createFile(esKeystorePassphraseFile);
-            Files.write(esKeystorePassphraseFile,
-                (password + System.lineSeparator()).getBytes(StandardCharsets.UTF_8),
-                StandardOpenOption.WRITE);
+            Files.write(esKeystorePassphraseFile, singletonList(password));
 
             startElasticsearch();
             ServerUtils.runElasticsearchTests();
@@ -277,9 +266,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
             }
 
             Files.createFile(esKeystorePassphraseFile);
-            Files.write(esKeystorePassphraseFile,
-                ("wrongpassword" + System.lineSeparator()).getBytes(StandardCharsets.UTF_8),
-                StandardOpenOption.WRITE);
+            Files.write(esKeystorePassphraseFile, singletonList("wrongpassword"));
 
             Packages.JournaldWrapper journaldWrapper = new Packages.JournaldWrapper(sh);
             Shell.Result result = runElasticsearchStartCommand();
@@ -323,7 +310,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
 
             String password = "password";
             String passwordFilename = "password.txt";
-            Files.write(tempDir.resolve(passwordFilename), (password + "\n").getBytes(StandardCharsets.UTF_8));
+            Files.write(tempDir.resolve(passwordFilename), singletonList(password));
             Files.setPosixFilePermissions(tempDir.resolve(passwordFilename), p600);
 
             Path dockerKeystore = installation.config("elasticsearch.keystore");
@@ -342,8 +329,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
 
             waitForElasticsearch(installation);
             ServerUtils.runElasticsearchTests();
-        }
-        finally {
+        } finally {
             if (tempDir != null) {
                 rm(tempDir);
             }
@@ -387,9 +373,12 @@ public class KeystoreManagementTests extends PackagingTestCase {
         // It's very tricky to properly quote a pipeline that you're passing to
         // a docker exec command, so we're just going to put a small script in the
         // temp folder.
-        String setPasswordScript = "echo \"" + password + "\n" + password
-            + "\n\" | " + installation.executables().keystoreTool.toString() + " passwd";
-        Files.write(tempDirectory.resolve("set-pass.sh"), setPasswordScript.getBytes(StandardCharsets.UTF_8));
+        List<String> setPasswordScript = new ArrayList<>();
+        setPasswordScript.add("echo \"" + password);
+        setPasswordScript.add(password);
+        setPasswordScript.add("\" | " + installation.executables().keystoreTool.toString() + " passwd");
+
+        Files.write(tempDirectory.resolve("set-pass.sh"), setPasswordScript);
 
         runContainer(distribution(), volumes, null);
         try {
@@ -420,9 +409,7 @@ public class KeystoreManagementTests extends PackagingTestCase {
         // the keystore ends up being owned by the Administrators group, so we manually set it to be owned by the vagrant user here.
         // from the server's perspective the permissions aren't really different, this is just to reflect what we'd expect in the tests.
         // when we run these commands as a role user we won't have to do this
-        Platforms.onWindows(() -> {
-            sh.chown(keystore);
-        });
+        Platforms.onWindows(() -> sh.chown(keystore));
 
         if (distribution().isDocker()) {
             try {
@@ -455,14 +442,11 @@ public class KeystoreManagementTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
 
         // set the password by passing it to stdin twice
-        Platforms.onLinux(() -> {
-            bin.keystoreTool.run("passwd", password + "\n" + password + "\n");
-        });
+        Platforms.onLinux(() -> bin.keystoreTool.run("passwd", password + "\n" + password + "\n"));
 
-        Platforms.onWindows(() -> {
-            sh.run("Invoke-Command -ScriptBlock {echo \'" + password + "\'; echo \'" + password + "\'} | "
-                + bin.keystoreTool + " passwd");
-        });
+        Platforms.onWindows(
+            () -> sh.run("Invoke-Command -ScriptBlock {echo '" + password + "'; echo '" + password + "'} | " + bin.keystoreTool + " passwd")
+        );
     }
 
     private void assertPasswordProtectedKeystore() {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -67,14 +67,12 @@ import static org.junit.Assume.assumeTrue;
  * Class that all packaging test cases should inherit from
  */
 @RunWith(RandomizedRunner.class)
-@TestMethodProviders({
-    JUnit3MethodProvider.class
-})
+@TestMethodProviders({ JUnit3MethodProvider.class })
 @Timeout(millis = 20 * 60 * 1000) // 20 min
 @TestCaseOrdering(TestCaseOrdering.AlphabeticOrder.class)
 public abstract class PackagingTestCase extends Assert {
 
-    protected final Logger logger =  LogManager.getLogger(getClass());
+    protected final Logger logger = LogManager.getLogger(getClass());
 
     // the distribution being tested
     protected static final Distribution distribution;
@@ -142,19 +140,14 @@ public abstract class PackagingTestCase extends Assert {
         }
     }
 
-
     @Before
     public void setup() throws Exception {
         assumeFalse(failed); // skip rest of tests once one fails
 
         sh.reset();
         if (distribution().hasJdk == false) {
-            Platforms.onLinux(() -> {
-                sh.getEnv().put("JAVA_HOME", systemJavaHome);
-            });
-            Platforms.onWindows(() -> {
-                sh.getEnv().put("JAVA_HOME", systemJavaHome);
-            });
+            Platforms.onLinux(() -> sh.getEnv().put("JAVA_HOME", systemJavaHome));
+            Platforms.onWindows(() -> sh.getEnv().put("JAVA_HOME", systemJavaHome));
         }
     }
 
@@ -208,15 +201,14 @@ public abstract class PackagingTestCase extends Assert {
     protected void assertWhileRunning(Platforms.PlatformAction assertions) throws Exception {
         try {
             awaitElasticsearchStartup(runElasticsearchStartCommand());
-        } catch (Exception e ){
+        } catch (Exception e) {
             if (Files.exists(installation.home.resolve("elasticsearch.pid"))) {
                 String pid = FileUtils.slurp(installation.home.resolve("elasticsearch.pid")).trim();
                 logger.info("Dumping jstack of elasticsearch processb ({}) that failed to start", pid);
                 sh.runIgnoreExitCode("jstack " + pid);
             }
             if (Files.exists(installation.logs.resolve("elasticsearch.log"))) {
-                logger.warn("Elasticsearch log:\n" +
-                    FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
+                logger.warn("Elasticsearch log:\n" + FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
             }
             if (Files.exists(installation.logs.resolve("output.out"))) {
                 logger.warn("Stdout:\n" + FileUtils.slurpTxtorGz(installation.logs.resolve("output.out")));
@@ -230,8 +222,7 @@ public abstract class PackagingTestCase extends Assert {
         try {
             assertions.run();
         } catch (Exception e) {
-            logger.warn("Elasticsearch log:\n" +
-                FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
+            logger.warn("Elasticsearch log:\n" + FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
             throw e;
         }
         stopElasticsearch();
@@ -345,9 +336,11 @@ public abstract class PackagingTestCase extends Assert {
             // in the background
             String wrapperPid = result.stdout.trim();
             sh.runIgnoreExitCode("Wait-Process -Timeout " + Archives.ES_STARTUP_SLEEP_TIME_SECONDS + " -Id " + wrapperPid);
-            sh.runIgnoreExitCode("Get-EventSubscriber | " +
-                "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |" +
-                "Unregister-EventSubscriber -Force");
+            sh.runIgnoreExitCode(
+                "Get-EventSubscriber | "
+                    + "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |"
+                    + "Unregister-EventSubscriber -Force"
+            );
             assertThat(FileUtils.slurp(Archives.getPowershellErrorPath(installation)), anyOf(stringMatchers));
 
         } else {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
@@ -28,13 +28,15 @@ import org.junit.Before;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assume.assumeTrue;
@@ -52,9 +54,12 @@ public class PasswordToolsTests extends PackagingTestCase {
 
     public void test010Install() throws Exception {
         install();
-        append(installation.config("elasticsearch.yml"),
-            "xpack.license.self_generated.type: trial\n" +
-            "xpack.security.enabled: true");
+
+        List<String> lines = new ArrayList<>();
+        lines.add("xpack.license.self_generated.type: trial");
+        lines.add("xpack.security.enabled: true");
+
+        Files.write(installation.config("elasticsearch.yml"), lines, StandardOpenOption.APPEND);
     }
 
     public void test20GeneratePasswords() throws Exception {
@@ -63,7 +68,11 @@ public class PasswordToolsTests extends PackagingTestCase {
             Map<String, String> userpasses = parseUsersAndPasswords(result.stdout);
             for (Map.Entry<String, String> userpass : userpasses.entrySet()) {
                 String response = ServerUtils.makeRequest(
-                    Request.Get("http://localhost:9200"), userpass.getKey(), userpass.getValue(), null);
+                    Request.Get("http://localhost:9200"),
+                    userpass.getKey(),
+                    userpass.getValue(),
+                    null
+                );
                 assertThat(response, containsString("You Know, for Search"));
             }
         });
@@ -112,7 +121,10 @@ public class PasswordToolsTests extends PackagingTestCase {
         assertWhileRunning(() -> {
             String response = ServerUtils.makeRequest(
                 Request.Get("http://localhost:9200/_cluster/health?wait_for_status=green&timeout=180s"),
-                "elastic", BOOTSTRAP_PASSWORD, null);
+                "elastic",
+                BOOTSTRAP_PASSWORD,
+                null
+            );
             assertThat(response, containsString("\"status\":\"green\""));
         });
     }
@@ -125,7 +137,11 @@ public class PasswordToolsTests extends PackagingTestCase {
             assertThat(userpasses, hasKey("elastic"));
             for (Map.Entry<String, String> userpass : userpasses.entrySet()) {
                 String response = ServerUtils.makeRequest(
-                    Request.Get("http://localhost:9200"), userpass.getKey(), userpass.getValue(), null);
+                    Request.Get("http://localhost:9200"),
+                    userpass.getKey(),
+                    userpass.getValue(),
+                    null
+                );
                 assertThat(response, containsString("You Know, for Search"));
             }
         });

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -78,21 +78,12 @@ public class RpmPreservationTests extends PackagingTestCase {
         verifyPackageInstallation(installation, distribution(), sh);
 
         sh.run("echo foobar | " + installation.executables().keystoreTool + " add --stdin foo.bar");
-        Stream.of(
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        )
+        Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties")
             .map(each -> installation.config(each))
             .forEach(path -> append(path, "# foo"));
         append(installation.config(Paths.get("jvm.options.d", "heap.options")), "# foo");
         if (distribution().isDefault()) {
-            Stream.of(
-                "role_mapping.yml",
-                "roles.yml",
-                "users",
-                "users_roles"
-            )
+            Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles")
                 .map(each -> installation.config(each))
                 .forEach(path -> append(path, "# foo"));
         }
@@ -119,27 +110,18 @@ public class RpmPreservationTests extends PackagingTestCase {
         assertThat(installation.config, fileExists());
         assertThat(installation.config("elasticsearch.keystore"), fileExists());
 
-        Stream.of(
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        ).forEach(this::assertConfFilePreserved);
+        Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties").forEach(this::assertConfFilePreserved);
         assertThat(installation.config(Paths.get("jvm.options.d", "heap.options")), fileExists());
 
         if (distribution().isDefault()) {
-            Stream.of(
-                "role_mapping.yml",
-                "roles.yml",
-                "users",
-                "users_roles"
-            ).forEach(this::assertConfFilePreserved);
+            Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles").forEach(this::assertConfFilePreserved);
         }
     }
 
     private void assertConfFilePreserved(String configFile) {
         final Path original = installation.config(configFile);
         final Path saved = installation.config(configFile + ".rpmsave");
-        assertConfFilePreserved(original ,saved);
+        assertConfFilePreserved(original, saved);
     }
 
     private void assertConfFilePreserved(final Path original, final Path saved) {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/SysVInitTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/SysVInitTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.packaging.test;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ServerUtils;
 import org.elasticsearch.packaging.util.Shell;
-import org.junit.BeforeClass;   
+import org.junit.BeforeClass;
 
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
 import static org.elasticsearch.packaging.util.FileUtils.fileWithGlobExist;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
@@ -56,12 +57,10 @@ import static org.hamcrest.core.IsNot.not;
  */
 public class Archives {
 
-    protected static final Logger logger =  LogManager.getLogger(Archives.class);
+    protected static final Logger logger = LogManager.getLogger(Archives.class);
 
     // in the future we'll run as a role user on Windows
-    public static final String ARCHIVE_OWNER = Platforms.WINDOWS
-        ? System.getenv("username")
-        : "elasticsearch";
+    public static final String ARCHIVE_OWNER = Platforms.WINDOWS ? System.getenv("username") : "elasticsearch";
 
     /** This is an arbitrarily chosen value that gives Elasticsearch time to log Bootstrap
      *  errors to the console if they occur before the logging framework is initialized. */
@@ -91,9 +90,12 @@ public class Archives {
             if (Platforms.WINDOWS == false) {
                 throw new IllegalStateException("Distribution " + distribution + " is not supported on linux");
             }
-            installCommand =
-                "Add-Type -AssemblyName 'System.IO.Compression.Filesystem'; " +
-                "[IO.Compression.ZipFile]::ExtractToDirectory('" + distributionFile + "', '" + baseInstallPath + "')";
+            installCommand = String.format(
+                Locale.ROOT,
+                "Add-Type -AssemblyName 'System.IO.Compression.Filesystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s', '%s')",
+                distributionFile,
+                baseInstallPath
+            );
 
         } else {
             throw new RuntimeException("Distribution " + distribution + " is not a known archive type");
@@ -129,22 +131,26 @@ public class Archives {
 
         if (sh.runIgnoreExitCode("id elasticsearch").isSuccess() == false) {
             if (isDPKG()) {
-                sh.run("adduser " +
-                    "--quiet " +
-                    "--system " +
-                    "--no-create-home " +
-                    "--ingroup elasticsearch " +
-                    "--disabled-password " +
-                    "--shell /bin/false " +
-                    "elasticsearch");
+                sh.run(
+                    "adduser "
+                        + "--quiet "
+                        + "--system "
+                        + "--no-create-home "
+                        + "--ingroup elasticsearch "
+                        + "--disabled-password "
+                        + "--shell /bin/false "
+                        + "elasticsearch"
+                );
             } else {
-                sh.run("useradd " +
-                    "--system " +
-                    "-M " +
-                    "--gid elasticsearch " +
-                    "--shell /sbin/nologin " +
-                    "--comment 'elasticsearch user' " +
-                    "elasticsearch");
+                sh.run(
+                    "useradd "
+                        + "--system "
+                        + "-M "
+                        + "--gid elasticsearch "
+                        + "--shell /sbin/nologin "
+                        + "--comment 'elasticsearch user' "
+                        + "elasticsearch"
+                );
             }
         }
     }
@@ -157,13 +163,7 @@ public class Archives {
     }
 
     private static void verifyOssInstallation(Installation es, Distribution distribution, String owner) {
-        Stream.of(
-            es.home,
-            es.config,
-            es.plugins,
-            es.modules,
-            es.logs
-        ).forEach(dir -> assertThat(dir, file(Directory, owner, owner, p755)));
+        Stream.of(es.home, es.config, es.plugins, es.modules, es.logs).forEach(dir -> assertThat(dir, file(Directory, owner, owner, p755)));
 
         assertThat(Files.exists(es.data), is(false));
 
@@ -188,24 +188,15 @@ public class Archives {
         });
 
         if (distribution.packaging == Distribution.Packaging.ZIP) {
-            Stream.of(
-                "elasticsearch-service.bat",
-                "elasticsearch-service-mgr.exe",
-                "elasticsearch-service-x64.exe"
-            ).forEach(executable -> assertThat(es.bin(executable), file(File, owner)));
+            Stream.of("elasticsearch-service.bat", "elasticsearch-service-mgr.exe", "elasticsearch-service-x64.exe")
+                .forEach(executable -> assertThat(es.bin(executable), file(File, owner)));
         }
 
-        Stream.of(
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        ).forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
+        Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties")
+            .forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
 
-        Stream.of(
-            "NOTICE.txt",
-            "LICENSE.txt",
-            "README.asciidoc"
-        ).forEach(doc -> assertThat(es.home.resolve(doc), file(File, owner, owner, p644)));
+        Stream.of("NOTICE.txt", "LICENSE.txt", "README.asciidoc")
+            .forEach(doc -> assertThat(es.home.resolve(doc), file(File, owner, owner, p644)));
     }
 
     private static void verifyDefaultInstallation(Installation es, Distribution distribution, String owner) {
@@ -236,13 +227,8 @@ public class Archives {
         // the version through here
         assertThat(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), file(File, owner, owner, p755));
 
-        Stream.of(
-            "users",
-            "users_roles",
-            "roles.yml",
-            "role_mapping.yml",
-            "log4j2.properties"
-        ).forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
+        Stream.of("users", "users_roles", "roles.yml", "role_mapping.yml", "log4j2.properties")
+            .forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
     }
 
     public static Shell.Result startElasticsearch(Installation installation, Shell sh) {
@@ -254,13 +240,20 @@ public class Archives {
         final Installation.Executables bin = installation.executables();
 
         // requires the "expect" utility to be installed
-        String script = "expect -c \"$(cat<<EXPECT\n" +
-            "spawn -ignore HUP sudo -E -u " + ARCHIVE_OWNER + " " + bin.elasticsearch + " -d -p " + pidFile + "\n" +
-            "expect \"Elasticsearch keystore password:\"\n" +
-            "send \"" + keystorePassword + "\\r\"\n" +
-            "expect eof\n" +
-            "EXPECT\n" +
-            ")\"";
+        String script = String.format(
+            Locale.ROOT,
+            "expect -c \"$(cat<<EXPECT\n"
+                + "spawn -ignore HUP sudo -E -u %s %s -d -p %s \n"
+                + "expect \"Elasticsearch keystore password:\"\n"
+                + "send \"%s\\r\"\n"
+                + "expect eof\n"
+                + "EXPECT\n"
+                + ")\"",
+            ARCHIVE_OWNER,
+            bin.elasticsearch,
+            pidFile,
+            keystorePassword
+        );
 
         sh.getEnv().put("ES_STARTUP_SLEEP_TIME", ES_STARTUP_SLEEP_TIME_SECONDS);
         return sh.runIgnoreExitCode(script);
@@ -283,8 +276,9 @@ public class Archives {
 
             // We need to give Elasticsearch enough time to print failures to stderr before exiting
             sh.getEnv().put("ES_STARTUP_SLEEP_TIME", ES_STARTUP_SLEEP_TIME_SECONDS);
-            return sh.runIgnoreExitCode("sudo -E -u " + ARCHIVE_OWNER + " " + bin.elasticsearch + " -d -p " + pidFile +
-                " <<<'" + keystorePassword + "'");
+            return sh.runIgnoreExitCode(
+                "sudo -E -u " + ARCHIVE_OWNER + " " + bin.elasticsearch + " -d -p " + pidFile + " <<<'" + keystorePassword + "'"
+            );
         }
         final Path stdout = getPowershellOutputPath(installation);
         final Path stderr = getPowershellErrorPath(installation);
@@ -294,45 +288,59 @@ public class Archives {
             // the tests will run as Administrator in vagrant.
             // we don't want to run the server as Administrator, so we provide the current user's
             // username and password to the process which has the effect of starting it not as Administrator.
-            powerShellProcessUserSetup =
-                "$password = ConvertTo-SecureString 'vagrant' -AsPlainText -Force; " +
-                "$processInfo.Username = 'vagrant'; " +
-                "$processInfo.Password = $password; ";
+            powerShellProcessUserSetup = "$password = ConvertTo-SecureString 'vagrant' -AsPlainText -Force; "
+                + "$processInfo.Username = 'vagrant'; "
+                + "$processInfo.Password = $password; ";
         } else {
             powerShellProcessUserSetup = "";
         }
 
         // this starts the server in the background. the -d flag is unsupported on windows
         return sh.run(
-            "$processInfo = New-Object System.Diagnostics.ProcessStartInfo; " +
-                "$processInfo.FileName = '" + bin.elasticsearch + "'; " +
-                "$processInfo.Arguments = '-p " + installation.home.resolve("elasticsearch.pid") + "'; " +
-                powerShellProcessUserSetup +
-                "$processInfo.RedirectStandardOutput = $true; " +
-                "$processInfo.RedirectStandardError = $true; " +
-                "$processInfo.RedirectStandardInput = $true; " +
-                sh.env.entrySet().stream()
+            "$processInfo = New-Object System.Diagnostics.ProcessStartInfo; "
+                + "$processInfo.FileName = '"
+                + bin.elasticsearch
+                + "'; "
+                + "$processInfo.Arguments = '-p "
+                + installation.home.resolve("elasticsearch.pid")
+                + "'; "
+                + powerShellProcessUserSetup
+                + "$processInfo.RedirectStandardOutput = $true; "
+                + "$processInfo.RedirectStandardError = $true; "
+                + "$processInfo.RedirectStandardInput = $true; "
+                + sh.env.entrySet()
+                    .stream()
                     .map(entry -> "$processInfo.Environment.Add('" + entry.getKey() + "', '" + entry.getValue() + "'); ")
-                    .collect(joining()) +
-                "$processInfo.UseShellExecute = $false; " +
-                "$process = New-Object System.Diagnostics.Process; " +
-                "$process.StartInfo = $processInfo; " +
+                    .collect(joining())
+                + "$processInfo.UseShellExecute = $false; "
+                + "$process = New-Object System.Diagnostics.Process; "
+                + "$process.StartInfo = $processInfo; "
+                +
 
                 // set up some asynchronous output handlers
-                "$outScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '" + stdout + "' }; " +
-                "$errScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '" + stderr + "' }; " +
-                "$stdOutEvent = Register-ObjectEvent -InputObject $process " +
-                "-Action $outScript -EventName 'OutputDataReceived'; " +
-                "$stdErrEvent = Register-ObjectEvent -InputObject $process " +
-                "-Action $errScript -EventName 'ErrorDataReceived'; " +
+                "$outScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '"
+                + stdout
+                + "' }; "
+                + "$errScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '"
+                + stderr
+                + "' }; "
+                + "$stdOutEvent = Register-ObjectEvent -InputObject $process "
+                + "-Action $outScript -EventName 'OutputDataReceived'; "
+                + "$stdErrEvent = Register-ObjectEvent -InputObject $process "
+                + "-Action $errScript -EventName 'ErrorDataReceived'; "
+                +
 
-                "$process.Start() | Out-Null; " +
-                "$process.BeginOutputReadLine(); " +
-                "$process.BeginErrorReadLine(); " +
-                "$process.StandardInput.WriteLine('" + keystorePassword + "'); " +
-                "Wait-Process -Timeout " + ES_STARTUP_SLEEP_TIME_SECONDS + " -Id $process.Id; " +
-                "$process.Id;"
-            );
+                "$process.Start() | Out-Null; "
+                + "$process.BeginOutputReadLine(); "
+                + "$process.BeginErrorReadLine(); "
+                + "$process.StandardInput.WriteLine('"
+                + keystorePassword
+                + "'); "
+                + "Wait-Process -Timeout "
+                + ES_STARTUP_SLEEP_TIME_SECONDS
+                + " -Id $process.Id; "
+                + "$process.Id;"
+        );
     }
 
     public static void assertElasticsearchStarted(Installation installation) throws Exception {
@@ -356,9 +364,11 @@ public class Archives {
             sh.run("Get-Process -Id " + pid + " | Stop-Process -Force; Wait-Process -Id " + pid);
 
             // Clear the asynchronous event handlers
-            sh.runIgnoreExitCode("Get-EventSubscriber | " +
-                "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |" +
-                "Unregister-EventSubscriber -Force");
+            sh.runIgnoreExitCode(
+                "Get-EventSubscriber | "
+                    + "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |"
+                    + "Unregister-EventSubscriber -Force"
+            );
         });
         if (Files.exists(pidFile)) {
             Files.delete(pidFile);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -62,14 +62,16 @@ public class Cleanup {
             sh.runIgnoreExitCode("ps aux | grep -i 'org.elasticsearch.bootstrap.Elasticsearch' | awk {'print $2'} | xargs kill -9");
         });
 
-        Platforms.onWindows(() -> {
-            // the view of processes returned by Get-Process doesn't expose command line arguments, so we use WMI here
-            sh.runIgnoreExitCode(
-                "Get-WmiObject Win32_Process | " +
-                "Where-Object { $_.CommandLine -Match 'org.elasticsearch.bootstrap.Elasticsearch' } | " +
-                "ForEach-Object { $_.Terminate() }"
-            );
-        });
+        Platforms.onWindows(
+            () -> {
+                // the view of processes returned by Get-Process doesn't expose command line arguments, so we use WMI here
+                sh.runIgnoreExitCode(
+                    "Get-WmiObject Win32_Process | "
+                        + "Where-Object { $_.CommandLine -Match 'org.elasticsearch.bootstrap.Elasticsearch' } | "
+                        + "ForEach-Object { $_.Terminate() }"
+                );
+            }
+        );
 
         Platforms.onLinux(Cleanup::purgePackagesLinux);
 
@@ -85,10 +87,7 @@ public class Cleanup {
         final List<String> filesToDelete = Platforms.WINDOWS ? ELASTICSEARCH_FILES_WINDOWS : ELASTICSEARCH_FILES_LINUX;
         // windows needs leniency due to asinine releasing of file locking async from a process exiting
         Consumer<? super Path> rm = Platforms.WINDOWS ? FileUtils::rmWithRetries : FileUtils::rm;
-        filesToDelete.stream()
-            .map(Paths::get)
-            .filter(Files::exists)
-            .forEach(rm);
+        filesToDelete.stream().map(Paths::get).filter(Files::exists).forEach(rm);
 
         // disable elasticsearch service
         // todo add this for windows when adding tests for service intallation

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -79,10 +79,7 @@ public class Docker {
     public static void ensureImageIsLoaded(Distribution distribution) {
         Shell.Result result = sh.run("docker image ls --format '{{.Repository}}' " + distribution.flavor.name);
 
-        final long count = Arrays.stream(result.stdout.split("\n"))
-            .map(String::trim)
-            .filter(s -> s.isEmpty() == false)
-            .count();
+        final long count = Arrays.stream(result.stdout.split("\n")).map(String::trim).filter(s -> s.isEmpty() == false).count();
 
         if (count != 0) {
             return;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileMatcher.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileMatcher.java
@@ -43,7 +43,10 @@ import static org.elasticsearch.packaging.util.FileUtils.getPosixFileAttributes;
  */
 public class FileMatcher extends TypeSafeMatcher<Path> {
 
-    public enum Fileness { File, Directory }
+    public enum Fileness {
+        File,
+        Directory
+    }
 
     public static final Set<PosixFilePermission> p775 = fromString("rwxrwxr-x");
     public static final Set<PosixFilePermission> p770 = fromString("rwxrwx---");
@@ -126,10 +129,14 @@ public class FileMatcher extends TypeSafeMatcher<Path> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendValue("file/directory: ").appendValue(fileness)
-            .appendText(" with owner ").appendValue(owner)
-            .appendText(" with group ").appendValue(group)
-            .appendText(" with posix permissions ").appendValueList("[", ",", "]", posixPermissions);
+        description.appendValue("file/directory: ")
+            .appendValue(fileness)
+            .appendText(" with owner ")
+            .appendValue(owner)
+            .appendText(" with group ")
+            .appendValue(group)
+            .appendText(" with posix permissions ")
+            .appendValueList("[", ",", "]", posixPermissions);
     }
 
     public static FileMatcher file(Fileness fileness, String owner) {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -111,22 +112,21 @@ public class FileUtils {
 
     public static Path mktempDir(Path path) {
         try {
-            return Files.createTempDirectory(path,"tmp");
+            return Files.createTempDirectory(path, "tmp");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-
     public static Path mkdir(Path path) {
         try {
             return Files.createDirectories(path);
-         } catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
-         }
-     }
+        }
+    }
 
-     public static Path cp(Path source, Path target) {
+    public static Path cp(Path source, Path target) {
         try {
             return Files.copy(source, target);
         } catch (IOException e) {
@@ -142,9 +142,22 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Creates or appends to the specified file, and writes the supplied string to it.
+     * No newline is written - if a trailing newline is required, it should be present
+     * in <code>text</code>, or use {@link Files#write(Path, Iterable, OpenOption...)}.
+     * @param file the file to create or append
+     * @param text the string to write
+     */
     public static void append(Path file, String text) {
-        try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8,
-            StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+        try (
+            BufferedWriter writer = Files.newBufferedWriter(
+                file,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND
+            )
+        ) {
 
             writer.write(text);
         } catch (IOException e) {
@@ -204,7 +217,7 @@ public class FileUtils {
             for (Path rotatedLogFile : FileUtils.lsGlob(logPath, rotatedLogFilesGlob)) {
                 logFileJoiner.add(FileUtils.slurpTxtorGz(rotatedLogFile));
             }
-            return(logFileJoiner.toString());
+            return (logFileJoiner.toString());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -221,14 +234,14 @@ public class FileUtils {
                 // gc logs are verbose and not useful in this context
                 .filter(file -> file.getFileName().toString().startsWith("gc.log") == false)
                 .forEach(file -> {
-                logger.info("=== Contents of `{}` ({}) ===", file, file.toAbsolutePath());
-                try (Stream<String> stream = Files.lines(file)) {
-                    stream.forEach(logger::info);
-                } catch (IOException e) {
-                    logger.error("Can't show contents", e);
-                }
-                logger.info("=== End of contents of `{}`===", file);
-            });
+                    logger.info("=== Contents of `{}` ({}) ===", file, file.toAbsolutePath());
+                    try (Stream<String> stream = Files.lines(file)) {
+                        stream.forEach(logger::info);
+                    } catch (IOException e) {
+                        logger.error("Can't show contents", e);
+                    }
+                    logger.info("=== End of contents of `{}`===", file);
+                });
         } catch (IOException e) {
             logger.error("Can't list log files", e);
         }
@@ -284,7 +297,6 @@ public class FileUtils {
         return numericPathOwnership;
     }
 
-
     // vagrant creates /tmp for us in windows so we use that to avoid long paths
     public static Path getTempDir() {
         return Paths.get("/tmp").toAbsolutePath();
@@ -295,6 +307,7 @@ public class FileUtils {
     }
 
     private static final Pattern VERSION_REGEX = Pattern.compile("(\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?)");
+
     public static String getCurrentVersion() {
         // TODO: just load this once
         String distroFile = System.getProperty("tests.distribution");
@@ -314,12 +327,12 @@ public class FileUtils {
     }
 
     public static Matcher<Path> fileWithGlobExist(String glob) throws IOException {
-        return new FeatureMatcher<Path,Iterable<Path>>(not(emptyIterable()),"File with pattern exist", "file with pattern"){
+        return new FeatureMatcher<Path, Iterable<Path>>(not(emptyIterable()), "File with pattern exist", "file with pattern") {
 
             @Override
             protected Iterable<Path> featureValueOf(Path actual) {
                 try {
-                    return Files.newDirectoryStream(actual,glob);
+                    return Files.newDirectoryStream(actual, glob);
                 } catch (IOException e) {
                     return Collections.emptyList();
                 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Installation.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Installation.java
@@ -28,9 +28,7 @@ import java.nio.file.Paths;
 public class Installation {
 
     // in the future we'll run as a role user on Windows
-    public static final String ARCHIVE_OWNER = Platforms.WINDOWS
-        ? System.getenv("username")
-        : "elasticsearch";
+    public static final String ARCHIVE_OWNER = Platforms.WINDOWS ? System.getenv("username") : "elasticsearch";
 
     private final Shell sh;
     public final Distribution distribution;
@@ -46,8 +44,18 @@ public class Installation {
     public final Path pidDir;
     public final Path envFile;
 
-    private Installation(Shell sh, Distribution distribution, Path home, Path config, Path data, Path logs,
-                         Path plugins, Path modules, Path pidDir, Path envFile) {
+    private Installation(
+        Shell sh,
+        Distribution distribution,
+        Path home,
+        Path config,
+        Path data,
+        Path logs,
+        Path plugins,
+        Path modules,
+        Path pidDir,
+        Path envFile
+    ) {
         this.sh = sh;
         this.distribution = distribution;
         this.home = home;
@@ -147,9 +155,7 @@ public class Installation {
         public final Path path;
 
         private Executable(String name) {
-            final String platformExecutableName = Platforms.WINDOWS
-                ? name + ".bat"
-                : name;
+            final String platformExecutableName = Platforms.WINDOWS ? name + ".bat" : name;
             this.path = bin(platformExecutableName);
         }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.packaging.util.Shell.Result;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +31,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.packaging.util.FileExistenceMatchers.fileDoesNotExist;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.Directory;
 import static org.elasticsearch.packaging.util.FileMatcher.Fileness.File;
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 
 public class Packages {
 
-    private static final Logger logger =  LogManager.getLogger(Packages.class);
+    private static final Logger logger = LogManager.getLogger(Packages.class);
 
     public static final Path SYSVINIT_SCRIPT = Paths.get("/etc/init.d/elasticsearch");
     public static final Path SYSTEMD_SERVICE = Paths.get("/usr/lib/systemd/system/elasticsearch.service");
@@ -73,9 +73,10 @@ public class Packages {
         Platforms.onDPKG(() -> {
             assertThat(status.exitCode, anyOf(is(0), is(1)));
             if (status.exitCode == 0) {
-                assertTrue("an uninstalled status should be indicated: " + status.stdout,
-                    Pattern.compile("(?m)^Status:.+deinstall ok").matcher(status.stdout).find() ||
-                    Pattern.compile("(?m)^Status:.+ok not-installed").matcher(status.stdout).find()
+                assertTrue(
+                    "an uninstalled status should be indicated: " + status.stdout,
+                    Pattern.compile("(?m)^Status:.+deinstall ok").matcher(status.stdout).find()
+                        || Pattern.compile("(?m)^Status:.+ok not-installed").matcher(status.stdout).find()
                 );
             }
         });
@@ -108,8 +109,7 @@ public class Packages {
         Installation installation = Installation.ofPackage(sh, distribution);
 
         if (distribution.hasJdk == false) {
-            Files.write(installation.envFile, ("JAVA_HOME=" + systemJavaHome + "\n").getBytes(StandardCharsets.UTF_8),
-                StandardOpenOption.APPEND);
+            Files.write(installation.envFile, singletonList("JAVA_HOME=" + systemJavaHome), StandardOpenOption.APPEND);
         }
         return installation;
     }
@@ -124,9 +124,7 @@ public class Packages {
             if (r.exitCode != 0) {
                 Result lockOF = sh.runIgnoreExitCode("lsof /var/lib/dpkg/lock");
                 if (lockOF.exitCode == 0) {
-                    throw new RuntimeException(
-                            "dpkg failed and the lockfile still exists. "
-                            + "Failure:\n" + r + "\nLockfile:\n" + lockOF);
+                    throw new RuntimeException("dpkg failed and the lockfile still exists. " + "Failure:\n" + r + "\nLockfile:\n" + lockOF);
                 }
             }
             return r;
@@ -157,7 +155,6 @@ public class Packages {
         }
     }
 
-
     private static void verifyOssInstallation(Installation es, Distribution distribution, Shell sh) {
 
         sh.run("id elasticsearch");
@@ -167,16 +164,9 @@ public class Packages {
         final Path homeDir = Paths.get(passwdResult.stdout.trim().split(":")[5]);
         assertThat("elasticsearch user home directory must not exist", homeDir, fileDoesNotExist());
 
-        Stream.of(
-            es.home,
-            es.plugins,
-            es.modules
-        ).forEach(dir -> assertThat(dir, file(Directory, "root", "root", p755)));
+        Stream.of(es.home, es.plugins, es.modules).forEach(dir -> assertThat(dir, file(Directory, "root", "root", p755)));
 
-        Stream.of(
-            es.data,
-            es.logs
-        ).forEach(dir -> assertThat(dir, file(Directory, "elasticsearch", "elasticsearch", p750)));
+        Stream.of(es.data, es.logs).forEach(dir -> assertThat(dir, file(Directory, "elasticsearch", "elasticsearch", p750)));
 
         // we shell out here because java's posix file permission view doesn't support special modes
         assertThat(es.config, file(Directory, "root", "elasticsearch", p750));
@@ -186,33 +176,18 @@ public class Packages {
         assertThat(jvmOptionsDirectory, file(Directory, "root", "elasticsearch", p750));
         assertThat(sh.run("find \"" + jvmOptionsDirectory + "\" -maxdepth 0 -printf \"%m\"").stdout, containsString("2750"));
 
-        Stream.of(
-            "elasticsearch.keystore",
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        ).forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));
+        Stream.of("elasticsearch.keystore", "elasticsearch.yml", "jvm.options", "log4j2.properties")
+            .forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));
         assertThat(es.config(".elasticsearch.keystore.initial_md5sum"), file(File, "root", "elasticsearch", p644));
 
         assertThat(sh.run("sudo -u elasticsearch " + es.bin("elasticsearch-keystore") + " list").stdout, containsString("keystore.seed"));
 
-        Stream.of(
-            es.bin,
-            es.lib
-        ).forEach(dir -> assertThat(dir, file(Directory, "root", "root", p755)));
+        Stream.of(es.bin, es.lib).forEach(dir -> assertThat(dir, file(Directory, "root", "root", p755)));
 
-        Stream.of(
-            "elasticsearch",
-            "elasticsearch-plugin",
-            "elasticsearch-keystore",
-            "elasticsearch-shard",
-            "elasticsearch-node"
-        ).forEach(executable -> assertThat(es.bin(executable), file(File, "root", "root", p755)));
+        Stream.of("elasticsearch", "elasticsearch-plugin", "elasticsearch-keystore", "elasticsearch-shard", "elasticsearch-node")
+            .forEach(executable -> assertThat(es.bin(executable), file(File, "root", "root", p755)));
 
-        Stream.of(
-            "NOTICE.txt",
-            "README.asciidoc"
-        ).forEach(doc -> assertThat(es.home.resolve(doc), file(File, "root", "root", p644)));
+        Stream.of("NOTICE.txt", "README.asciidoc").forEach(doc -> assertThat(es.home.resolve(doc), file(File, "root", "root", p644)));
 
         assertThat(es.envFile, file(File, "root", "elasticsearch", p660));
 
@@ -231,9 +206,7 @@ public class Packages {
                 Paths.get("/usr/lib/sysctl.d/elasticsearch.conf")
             ).forEach(confFile -> assertThat(confFile, file(File, "root", "root", p644)));
 
-            final String sysctlExecutable = (distribution.packaging == Distribution.Packaging.RPM)
-                ? "/usr/sbin/sysctl"
-                : "/sbin/sysctl";
+            final String sysctlExecutable = (distribution.packaging == Distribution.Packaging.RPM) ? "/usr/sbin/sysctl" : "/sbin/sysctl";
             assertThat(sh.run(sysctlExecutable + " vm.max_map_count").stdout, containsString("vm.max_map_count = 262144"));
         }
 
@@ -263,13 +236,8 @@ public class Packages {
         // the version through here
         assertThat(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), file(File, "root", "root", p755));
 
-        Stream.of(
-            "users",
-            "users_roles",
-            "roles.yml",
-            "role_mapping.yml",
-            "log4j2.properties"
-        ).forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));
+        Stream.of("users", "users_roles", "roles.yml", "role_mapping.yml", "log4j2.properties")
+            .forEach(configFile -> assertThat(es.config(configFile), file(File, "root", "elasticsearch", p660)));
     }
 
     /**
@@ -337,8 +305,8 @@ public class Packages {
          * for Elasticsearch logs and storing it in class state.
          */
         public void clear() {
-            cursor = sh.run("sudo journalctl --unit=elasticsearch.service --lines=0 --show-cursor -o cat" +
-                " | sed -e 's/-- cursor: //'").stdout.trim();
+            final String script = "sudo journalctl --unit=elasticsearch.service --lines=0 --show-cursor -o cat | sed -e 's/-- cursor: //'";
+            cursor = sh.run(script).stdout.trim();
         }
 
         /**

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -58,12 +58,12 @@ import static org.hamcrest.Matchers.containsString;
 
 public class ServerUtils {
 
-    private static final Logger logger =  LogManager.getLogger(ServerUtils.class);
+    private static final Logger logger = LogManager.getLogger(ServerUtils.class);
 
     private static String SECURITY_ENABLED = "xpack.security.enabled: true";
     private static String SSL_ENABLED = "xpack.security.http.ssl.enabled: true";
 
-    // generous timeout  as nested virtualization can be quite slow ...
+    // generous timeout as nested virtualization can be quite slow ...
     private static final long waitTime = TimeUnit.MINUTES.toMillis(3);
     private static final long timeoutLength = TimeUnit.SECONDS.toMillis(30);
     private static final long requestInterval = TimeUnit.SECONDS.toMillis(5);
@@ -124,9 +124,7 @@ public class ServerUtils {
                 connectionManager.setDefaultMaxPerRoute(100);
                 connectionManager.setMaxTotal(200);
                 connectionManager.setValidateAfterInactivity(1000);
-                executor = Executor.newInstance(HttpClientBuilder.create()
-                    .setConnectionManager(connectionManager)
-                    .build());
+                executor = Executor.newInstance(HttpClientBuilder.create().setConnectionManager(connectionManager).build());
             }
         } else {
             executor = Executor.newInstance();
@@ -159,13 +157,8 @@ public class ServerUtils {
         throw new RuntimeException("Elasticsearch (with x-pack) did not start");
     }
 
-    public static void waitForElasticsearch(
-        String status,
-        String index,
-        Installation installation,
-        String username,
-        String password
-    ) throws Exception {
+    public static void waitForElasticsearch(String status, String index, Installation installation, String username, String password)
+        throws Exception {
 
         Objects.requireNonNull(status);
 
@@ -186,8 +179,7 @@ public class ServerUtils {
                 try {
 
                     final HttpResponse response = execute(
-                        Request
-                            .Get("http://localhost:9200/_cluster/health")
+                        Request.Get("http://localhost:9200/_cluster/health")
                             .connectTimeout((int) timeoutLength)
                             .socketTimeout((int) timeoutLength),
                         username,
@@ -239,11 +231,13 @@ public class ServerUtils {
     public static void runElasticsearchTests() throws Exception {
         makeRequest(
             Request.Post("http://localhost:9200/library/book/1?refresh=true&pretty")
-                .bodyString("{ \"title\": \"Book #1\", \"pages\": 123 }", ContentType.APPLICATION_JSON));
+                .bodyString("{ \"title\": \"Book #1\", \"pages\": 123 }", ContentType.APPLICATION_JSON)
+        );
 
         makeRequest(
             Request.Post("http://localhost:9200/library/book/2?refresh=true&pretty")
-                .bodyString("{ \"title\": \"Book #2\", \"pages\": 456 }", ContentType.APPLICATION_JSON));
+                .bodyString("{ \"title\": \"Book #2\", \"pages\": 456 }", ContentType.APPLICATION_JSON)
+        );
 
         String count = makeRequest(Request.Get("http://localhost:9200/_count?pretty"));
         assertThat(count, containsString("\"count\" : 2"));


### PR DESCRIPTION
Backport of #52756 and #52750.

Add `:qa:os` and `:benchmarks` to the list of automatically formatted
projects, and apply some manual fix-ups to polish them up.

In particular, I noticed that `Files.write(...)` when passed a list will
automaticaly apply a UTF-8 encoding and write a newline after each line,
making it easier to use than FileUtils.append. It's even available from
1.8.

In `:benchmarks` in the Allocators class, a number of methods declared
thrown exceptions that IntelliJ reported were never thrown, and as far as I
could see this is true, so I removed the exceptions.