### PR TITLE
[DOCS] Update term vectors snippet to prevent CI failure

### DIFF
--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -216,7 +216,7 @@ PUT /twitter/_doc/1
   "text" : "twitter test test test "
 }
 
-PUT /twitter/_doc/2
+PUT /twitter/_doc/2?refresh=wait_for
 {
   "fullname" : "Jane Doe",
   "text" : "Another twitter test ..."


### PR DESCRIPTION
Adds the `?refresh=wait_for` query argument to an index API snippet in
the Term vectors API docs.

This should ensure the document is indexed and available before a
subsequent term vectors API request executes.

Fixes #52814.