### PR TITLE
Autoformat :qa:os and :benchmarks

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/fs/AvailableIndexFoldersBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/fs/AvailableIndexFoldersBenchmark.java
@@ -55,13 +55,14 @@ public class AvailableIndexFoldersBenchmark {
     @Setup
     public void setup() throws IOException {
         Path path = Files.createTempDirectory("test");
-        String[] paths = new String[] {path.toString()};
+        String[] paths = new String[] { path.toString() };
         nodePath = new NodeEnvironment.NodePath(path);
 
         LogConfigurator.setNodeName("test");
         Settings settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), path)
-            .putList(Environment.PATH_DATA_SETTING.getKey(), paths).build();
+            .putList(Environment.PATH_DATA_SETTING.getKey(), paths)
+            .build();
         nodeEnv = new NodeEnvironment(settings, new Environment(settings, null));
 
         Files.createDirectories(nodePath.indicesPath);
@@ -79,7 +80,6 @@ public class AvailableIndexFoldersBenchmark {
             throw new IllegalStateException("bad size");
         }
     }
-
 
     @Benchmark
     public Set<String> availableIndexFolderNaive() throws IOException {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/indices/breaker/MemoryStatsBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/indices/breaker/MemoryStatsBenchmark.java
@@ -41,11 +41,11 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class MemoryStatsBenchmark {
     private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
 
-    @Param({"0", "16", "256", "4096"})
+    @Param({ "0", "16", "256", "4096" })
     private int tokens;
 
     @Benchmark
@@ -102,4 +102,3 @@ public class MemoryStatsBenchmark {
         return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
     }
 }
-

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class AllocationBenchmark {
     // Do NOT make any field final (even if it is not annotated with @Param)! See also
     // http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_10_ConstantFold.java
@@ -106,8 +106,7 @@ public class AllocationBenchmark {
         "       10|     10|        2|    50",
         "      100|      1|        2|    50",
         "      100|      3|        2|    50",
-        "      100|     10|        2|    50"
-    })
+        "      100|     10|        2|    50" })
     public String indicesShardsReplicasNodes = "10|1|0|1";
 
     public int numTags = 2;
@@ -124,13 +123,14 @@ public class AllocationBenchmark {
         int numReplicas = toInt(params[2]);
         int numNodes = toInt(params[3]);
 
-        strategy = Allocators.createAllocationService(Settings.builder()
-                .put("cluster.routing.allocation.awareness.attributes", "tag")
-                .build());
+        strategy = Allocators.createAllocationService(
+            Settings.builder().put("cluster.routing.allocation.awareness.attributes", "tag").build()
+        );
 
         MetaData.Builder mb = MetaData.builder();
         for (int i = 1; i <= numIndices; i++) {
-            mb.put(IndexMetaData.builder("test_" + i)
+            mb.put(
+                IndexMetaData.builder("test_" + i)
                     .settings(Settings.builder().put("index.version.created", Version.CURRENT))
                     .numberOfShards(numShards)
                     .numberOfReplicas(numReplicas)
@@ -147,8 +147,10 @@ public class AllocationBenchmark {
             nb.add(Allocators.newNode("node" + i, Collections.singletonMap("tag", "tag_" + (i % numTags))));
         }
         initialClusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metaData(metaData).routingTable(routingTable).nodes
-                (nb).build();
+            .metaData(metaData)
+            .routingTable(routingTable)
+            .nodes(nb)
+            .build();
     }
 
     private int toInt(String v) {
@@ -159,8 +161,10 @@ public class AllocationBenchmark {
     public ClusterState measureAllocation() {
         ClusterState clusterState = initialClusterState;
         while (clusterState.getRoutingNodes().hasUnassignedShards()) {
-            clusterState = strategy.applyStartedShards(clusterState, clusterState.getRoutingNodes()
-                    .shardsWithState(ShardRoutingState.INITIALIZING));
+            clusterState = strategy.applyStartedShards(
+                clusterState,
+                clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING)
+            );
             clusterState = strategy.reroute(clusterState, "reroute");
         }
         return clusterState;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/Allocators.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/Allocators.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.gateway.GatewayAllocator;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -67,33 +66,34 @@ public final class Allocators {
         throw new AssertionError("Do not instantiate");
     }
 
-
-    public static AllocationService createAllocationService(Settings settings) throws NoSuchMethodException, InstantiationException,
-        IllegalAccessException, InvocationTargetException {
-        return createAllocationService(settings, new ClusterSettings(Settings.EMPTY, ClusterSettings
-            .BUILT_IN_CLUSTER_SETTINGS));
+    public static AllocationService createAllocationService(Settings settings) {
+        return createAllocationService(settings, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
     }
 
-    public static AllocationService createAllocationService(Settings settings, ClusterSettings clusterSettings) throws
-        InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    public static AllocationService createAllocationService(Settings settings, ClusterSettings clusterSettings) {
         return new AllocationService(
             defaultAllocationDeciders(settings, clusterSettings),
-            NoopGatewayAllocator.INSTANCE, new BalancedShardsAllocator(settings), EmptyClusterInfoService.INSTANCE);
+            NoopGatewayAllocator.INSTANCE,
+            new BalancedShardsAllocator(settings),
+            EmptyClusterInfoService.INSTANCE
+        );
     }
 
-    public static AllocationDeciders defaultAllocationDeciders(Settings settings, ClusterSettings clusterSettings) throws
-        IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
-        Collection<AllocationDecider> deciders =
-            ClusterModule.createAllocationDeciders(settings, clusterSettings, Collections.emptyList());
+    public static AllocationDeciders defaultAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
+        Collection<AllocationDecider> deciders = ClusterModule.createAllocationDeciders(settings, clusterSettings, Collections.emptyList());
         return new AllocationDeciders(deciders);
-
     }
 
     private static final AtomicInteger portGenerator = new AtomicInteger();
 
     public static DiscoveryNode newNode(String nodeId, Map<String, String> attributes) {
-        return new DiscoveryNode("", nodeId, new TransportAddress(TransportAddress.META_ADDRESS,
-            portGenerator.incrementAndGet()), attributes, Sets.newHashSet(DiscoveryNodeRole.MASTER_ROLE,
-            DiscoveryNodeRole.DATA_ROLE), Version.CURRENT);
+        return new DiscoveryNode(
+            "",
+            nodeId,
+            new TransportAddress(TransportAddress.META_ADDRESS, portGenerator.incrementAndGet()),
+            attributes,
+            Sets.newHashSet(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE),
+            Version.CURRENT
+        );
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterBenchmark.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class DateFormatterBenchmark {
 
     private final DateFormatter javaFormatter = DateFormatter.forPattern("8year_month_day||ordinal_date||epoch_millis");

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterFromBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/time/DateFormatterFromBenchmark.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class DateFormatterFromBenchmark {
 
     private final TemporalAccessor accessor = DateFormatter.forPattern("epoch_millis").parse("1234567890");

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/time/RoundingBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/time/RoundingBenchmark.java
@@ -48,7 +48,7 @@ import static org.elasticsearch.common.Rounding.DateTimeUnit.YEAR_OF_CENTURY;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("unused") //invoked by benchmarking framework
+@SuppressWarnings("unused") // invoked by benchmarking framework
 public class RoundingBenchmark {
 
     private final ZoneId zoneId = ZoneId.of("Europe/Amsterdam");
@@ -56,10 +56,10 @@ public class RoundingBenchmark {
 
     private long timestamp = 1548879021354L;
 
-    private final org.elasticsearch.common.rounding.Rounding jodaRounding =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.HOUR_OF_DAY).timeZone(timeZone).build();
-    private final Rounding javaRounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY)
-        .timeZone(zoneId).build();
+    private final org.elasticsearch.common.rounding.Rounding jodaRounding = org.elasticsearch.common.rounding.Rounding.builder(
+        DateTimeUnit.HOUR_OF_DAY
+    ).timeZone(timeZone).build();
+    private final Rounding javaRounding = Rounding.builder(Rounding.DateTimeUnit.HOUR_OF_DAY).timeZone(zoneId).build();
 
     @Benchmark
     public long timeRoundingDateTimeUnitJoda() {
@@ -71,10 +71,10 @@ public class RoundingBenchmark {
         return javaRounding.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding jodaDayOfMonthRounding =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(timeZone).build();
-    private final Rounding javaDayOfMonthRounding = Rounding.builder(DAY_OF_MONTH)
-        .timeZone(zoneId).build();
+    private final org.elasticsearch.common.rounding.Rounding jodaDayOfMonthRounding = org.elasticsearch.common.rounding.Rounding.builder(
+        DateTimeUnit.DAY_OF_MONTH
+    ).timeZone(timeZone).build();
+    private final Rounding javaDayOfMonthRounding = Rounding.builder(DAY_OF_MONTH).timeZone(zoneId).build();
 
     @Benchmark
     public long timeRoundingDateTimeUnitDayOfMonthJoda() {
@@ -86,10 +86,10 @@ public class RoundingBenchmark {
         return javaDayOfMonthRounding.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding timeIntervalRoundingJoda =
-        org.elasticsearch.common.rounding.Rounding.builder(TimeValue.timeValueMinutes(60)).timeZone(timeZone).build();
-    private final Rounding timeIntervalRoundingJava = Rounding.builder(TimeValue.timeValueMinutes(60))
-        .timeZone(zoneId).build();
+    private final org.elasticsearch.common.rounding.Rounding timeIntervalRoundingJoda = org.elasticsearch.common.rounding.Rounding.builder(
+        TimeValue.timeValueMinutes(60)
+    ).timeZone(timeZone).build();
+    private final Rounding timeIntervalRoundingJava = Rounding.builder(TimeValue.timeValueMinutes(60)).timeZone(zoneId).build();
 
     @Benchmark
     public long timeIntervalRoundingJava() {
@@ -101,10 +101,11 @@ public class RoundingBenchmark {
         return timeIntervalRoundingJoda.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcDayOfMonthJoda =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.DAY_OF_MONTH).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcDayOfMonthJava = Rounding.builder(DAY_OF_MONTH)
-        .timeZone(ZoneOffset.UTC).build();
+    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcDayOfMonthJoda = org.elasticsearch.common.rounding.Rounding
+        .builder(DateTimeUnit.DAY_OF_MONTH)
+        .timeZone(DateTimeZone.UTC)
+        .build();
+    private final Rounding timeUnitRoundingUtcDayOfMonthJava = Rounding.builder(DAY_OF_MONTH).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcDayOfMonthJava() {
@@ -118,8 +119,7 @@ public class RoundingBenchmark {
 
     private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcQuarterOfYearJoda =
         org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.QUARTER).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcQuarterOfYearJava = Rounding.builder(QUARTER_OF_YEAR)
-        .timeZone(ZoneOffset.UTC).build();
+    private final Rounding timeUnitRoundingUtcQuarterOfYearJava = Rounding.builder(QUARTER_OF_YEAR).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcQuarterOfYearJava() {
@@ -131,10 +131,11 @@ public class RoundingBenchmark {
         return timeUnitRoundingUtcQuarterOfYearJoda.round(timestamp);
     }
 
-    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcMonthOfYearJoda =
-        org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.MONTH_OF_YEAR).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcMonthOfYearJava = Rounding.builder(MONTH_OF_YEAR)
-        .timeZone(ZoneOffset.UTC).build();
+    private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcMonthOfYearJoda = org.elasticsearch.common.rounding.Rounding
+        .builder(DateTimeUnit.MONTH_OF_YEAR)
+        .timeZone(DateTimeZone.UTC)
+        .build();
+    private final Rounding timeUnitRoundingUtcMonthOfYearJava = Rounding.builder(MONTH_OF_YEAR).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcMonthOfYearJava() {
@@ -146,11 +147,9 @@ public class RoundingBenchmark {
         return timeUnitRoundingUtcMonthOfYearJoda.round(timestamp);
     }
 
-
     private final org.elasticsearch.common.rounding.Rounding timeUnitRoundingUtcYearOfCenturyJoda =
         org.elasticsearch.common.rounding.Rounding.builder(DateTimeUnit.YEAR_OF_CENTURY).timeZone(DateTimeZone.UTC).build();
-    private final Rounding timeUnitRoundingUtcYearOfCenturyJava = Rounding.builder(YEAR_OF_CENTURY)
-        .timeZone(ZoneOffset.UTC).build();
+    private final Rounding timeUnitRoundingUtcYearOfCenturyJava = Rounding.builder(YEAR_OF_CENTURY).timeZone(ZoneOffset.UTC).build();
 
     @Benchmark
     public long timeUnitRoundingUtcYearOfCenturyJava() {

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ subprojects {
       ':distribution:tools:java-version-checker',
       ':distribution:tools:launchers',
       ':distribution:tools:plugin-cli',
+      ':qa:os',
       ':x-pack:plugin:enrich'
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,7 @@ subprojects {
     // is greater than the number of unformatted projects, this can be
     // switched to an exclude list, and eventualy removed completely.
     def projectPathsToFormat = [
+      ':benchmarks',
       ':build-tools',
       ':distribution:tools:java-version-checker',
       ':distribution:tools:launchers',

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -31,8 +31,12 @@ import org.junit.BeforeClass;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
 import static org.elasticsearch.packaging.util.Archives.ARCHIVE_OWNER;
 import static org.elasticsearch.packaging.util.Archives.installArchive;
 import static org.elasticsearch.packaging.util.Archives.verifyArchiveInstallation;
@@ -142,7 +146,7 @@ public class ArchiveTests extends PackagingTestCase {
 
         try {
             startElasticsearch();
-        } catch (Exception e ){
+        } catch (Exception e) {
             if (Files.exists(installation.home.resolve("elasticsearch.pid"))) {
                 String pid = FileUtils.slurp(installation.home.resolve("elasticsearch.pid")).trim();
                 logger.info("Dumping jstack of elasticsearch processb ({}) that failed to start", pid);
@@ -151,9 +155,7 @@ public class ArchiveTests extends PackagingTestCase {
             throw e;
         }
 
-        final String gcLogName = Platforms.LINUX && distribution().hasJdk == false
-            ? "gc.log.0.current"
-            : "gc.log";
+        final String gcLogName = Platforms.LINUX && distribution().hasJdk == false ? "gc.log.0.current" : "gc.log";
 
         assertTrue("gc logs exist", Files.exists(installation.logs.resolve(gcLogName)));
         ServerUtils.runElasticsearchTests();
@@ -176,8 +178,7 @@ public class ArchiveTests extends PackagingTestCase {
         stopElasticsearch();
 
         String systemJavaHome1 = sh.getEnv().get("JAVA_HOME");
-        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"),
-            containsString(systemJavaHome1));
+        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(systemJavaHome1));
     }
 
     public void test52BundledJdkRemoved() throws Exception {
@@ -200,8 +201,7 @@ public class ArchiveTests extends PackagingTestCase {
             stopElasticsearch();
 
             String systemJavaHome1 = sh.getEnv().get("JAVA_HOME");
-            assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"),
-                containsString(systemJavaHome1));
+            assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(systemJavaHome1));
         } finally {
             mv(relocatedJdk, installation.bundledJdk);
         }
@@ -216,7 +216,7 @@ public class ArchiveTests extends PackagingTestCase {
 
                 sh.getEnv().put("JAVA_HOME", "C:\\Program Files (x86)\\java");
 
-                //verify ES can start, stop and run plugin list
+                // verify ES can start, stop and run plugin list
                 startElasticsearch();
 
                 stopElasticsearch();
@@ -226,7 +226,7 @@ public class ArchiveTests extends PackagingTestCase {
                 assertThat(result.exitCode, equalTo(0));
 
             } finally {
-                //clean up sym link
+                // clean up sym link
                 if (Files.exists(Paths.get(javaPath))) {
                     sh.run("cmd /c rmdir '" + javaPath + "' ");
                 }
@@ -241,7 +241,7 @@ public class ArchiveTests extends PackagingTestCase {
                 sh.run("ln -s \"" + systemJavaHome + "\" \"" + testJavaHome + "\"");
                 sh.getEnv().put("JAVA_HOME", testJavaHome);
 
-                //verify ES can start, stop and run plugin list
+                // verify ES can start, stop and run plugin list
                 startElasticsearch();
 
                 stopElasticsearch();
@@ -283,11 +283,11 @@ public class ArchiveTests extends PackagingTestCase {
             // we have to disable Log4j from using JMX lest it will hit a security
             // manager exception before we have configured logging; this will fail
             // startup since we detect usages of logging before it is configured
-            final String jvmOptions =
-                "-Xms512m\n" +
-                "-Xmx512m\n" +
-                "-Dlog4j2.disable.jmx=true\n";
-            append(tempConf.resolve("jvm.options"), jvmOptions);
+            final List<String> jvmOptions = new ArrayList<>();
+            jvmOptions.add("-Xms512m");
+            jvmOptions.add("-Xmx512m");
+            jvmOptions.add("-Dlog4j2.disable.jmx=true");
+            Files.write(tempConf.resolve("jvm.options"), jvmOptions, CREATE, APPEND);
 
             sh.chown(tempConf);
 
@@ -314,11 +314,8 @@ public class ArchiveTests extends PackagingTestCase {
 
         try {
             mkdir(tempConf);
-            Stream.of(
-                "elasticsearch.yml",
-                "log4j2.properties",
-                "jvm.options"
-            ).forEach(file -> cp(installation.config(file), tempConf.resolve(file)));
+            Stream.of("elasticsearch.yml", "log4j2.properties", "jvm.options")
+                .forEach(file -> cp(installation.config(file), tempConf.resolve(file)));
 
             append(tempConf.resolve("elasticsearch.yml"), "node.name: relative");
 
@@ -379,8 +376,7 @@ public class ArchiveTests extends PackagingTestCase {
 
         Platforms.PlatformAction action = () -> {
             final Result result = sh.run(bin.nodeTool + " -h");
-            assertThat(result.stdout,
-                    containsString("A CLI tool to do unsafe cluster and index manipulations on current node"));
+            assertThat(result.stdout, containsString("A CLI tool to do unsafe cluster and index manipulations on current node"));
         };
 
         // TODO: this should be checked on all distributions
@@ -410,17 +406,13 @@ public class ArchiveTests extends PackagingTestCase {
 
         Platforms.PlatformAction action = () -> {
             Result result = sh.run(bin.certutilTool + " -h");
-            assertThat(result.stdout,
-                containsString("Simplifies certificate creation for use with the Elastic Stack"));
+            assertThat(result.stdout, containsString("Simplifies certificate creation for use with the Elastic Stack"));
             result = sh.run(bin.syskeygenTool + " -h");
-            assertThat(result.stdout,
-                containsString("system key tool"));
+            assertThat(result.stdout, containsString("system key tool"));
             result = sh.run(bin.setupPasswordsTool + " -h");
-            assertThat(result.stdout,
-                containsString("Sets the passwords for reserved users"));
+            assertThat(result.stdout, containsString("Sets the passwords for reserved users"));
             result = sh.run(bin.usersTool + " -h");
-            assertThat(result.stdout,
-                containsString("Manages elasticsearch file users"));
+            assertThat(result.stdout, containsString("Manages elasticsearch file users"));
         };
 
         // TODO: this should be checked on all distributions

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -76,10 +76,7 @@ public class DebPreservationTests extends PackagingTestCase {
 
         // keystore was removed
 
-        assertPathsDontExist(
-            installation.config("elasticsearch.keystore"),
-            installation.config(".elasticsearch.keystore.initial_md5sum")
-        );
+        assertPathsDontExist(installation.config("elasticsearch.keystore"), installation.config(".elasticsearch.keystore.initial_md5sum"));
 
         // doc files were removed
 
@@ -100,11 +97,7 @@ public class DebPreservationTests extends PackagingTestCase {
 
         assertRemoved(distribution());
 
-        assertPathsDontExist(
-            installation.config,
-            installation.envFile,
-            SYSVINIT_SCRIPT
-        );
+        assertPathsDontExist(installation.config, installation.envFile, SYSVINIT_SCRIPT);
 
         assertThat(packageStatus(distribution()).exitCode, is(1));
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -26,15 +26,15 @@ import org.elasticsearch.packaging.util.Packages;
 import org.elasticsearch.packaging.util.Shell.Result;
 import org.junit.BeforeClass;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.getRandom;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsDontExist;
 import static org.elasticsearch.packaging.util.FileUtils.assertPathsExist;
@@ -96,8 +96,7 @@ public class PackageTests extends PackagingTestCase {
     private void assertRunsWithJavaHome() throws Exception {
         byte[] originalEnvFile = Files.readAllBytes(installation.envFile);
         try {
-            Files.write(installation.envFile, ("JAVA_HOME=" + systemJavaHome + "\n").getBytes(StandardCharsets.UTF_8),
-                StandardOpenOption.APPEND);
+            Files.write(installation.envFile, singletonList("JAVA_HOME=" + systemJavaHome), APPEND);
             startElasticsearch();
             runElasticsearchTests();
             stopElasticsearch();
@@ -105,8 +104,7 @@ public class PackageTests extends PackagingTestCase {
             Files.write(installation.envFile, originalEnvFile);
         }
 
-        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"),
-            containsString(systemJavaHome));
+        assertThat(FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"), containsString(systemJavaHome));
     }
 
     public void test32JavaHomeOverride() throws Exception {
@@ -152,9 +150,12 @@ public class PackageTests extends PackagingTestCase {
         String start = sh.runIgnoreExitCode("date ").stdout.trim();
         startElasticsearch();
 
-        String journalEntries = sh.runIgnoreExitCode("journalctl _SYSTEMD_UNIT=elasticsearch.service " +
-            "--since \"" + start + "\" --output cat | grep -v \"future versions of Elasticsearch will require Java 11\" | wc -l")
-            .stdout.trim();
+        String journalEntries = sh.runIgnoreExitCode(
+            "journalctl _SYSTEMD_UNIT=elasticsearch.service "
+                + "--since \""
+                + start
+                + "\" --output cat | grep -v \"future versions of Elasticsearch will require Java 11\" | wc -l"
+        ).stdout.trim();
         assertThat(journalEntries, equalTo("0"));
 
         assertPathsExist(installation.pidDir.resolve("elasticsearch.pid"));
@@ -193,9 +194,7 @@ public class PackageTests extends PackagingTestCase {
                 matcher.find();
                 final int version = Integer.parseInt(matcher.group(1));
 
-                statusExitCode = version < 231
-                    ? 3
-                    : 4;
+                statusExitCode = version < 231 ? 3 : 4;
             }
 
             assertThat(sh.runIgnoreExitCode("systemctl status elasticsearch.service").exitCode, is(statusExitCode));
@@ -238,7 +237,6 @@ public class PackageTests extends PackagingTestCase {
         }
     }
 
-
     public void test72TestRuntimeDirectory() throws Exception {
         try {
             install();
@@ -260,7 +258,6 @@ public class PackageTests extends PackagingTestCase {
     }
 
     // TEST CASES FOR SYSTEMD ONLY
-
 
     /**
      * # Simulates the behavior of a system restart:

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -56,14 +56,12 @@ import static org.junit.Assume.assumeTrue;
  * Class that all packaging test cases should inherit from
  */
 @RunWith(RandomizedRunner.class)
-@TestMethodProviders({
-    JUnit3MethodProvider.class
-})
+@TestMethodProviders({ JUnit3MethodProvider.class })
 @Timeout(millis = 20 * 60 * 1000) // 20 min
 @TestCaseOrdering(TestCaseOrdering.AlphabeticOrder.class)
 public abstract class PackagingTestCase extends Assert {
 
-    protected final Logger logger =  LogManager.getLogger(getClass());
+    protected final Logger logger = LogManager.getLogger(getClass());
 
     // the distribution being tested
     protected static final Distribution distribution;
@@ -124,12 +122,8 @@ public abstract class PackagingTestCase extends Assert {
 
         sh.reset();
         if (distribution().hasJdk == false) {
-            Platforms.onLinux(() -> {
-                sh.getEnv().put("JAVA_HOME", systemJavaHome);
-            });
-            Platforms.onWindows(() -> {
-                sh.getEnv().put("JAVA_HOME", systemJavaHome);
-            });
+            Platforms.onLinux(() -> sh.getEnv().put("JAVA_HOME", systemJavaHome));
+            Platforms.onWindows(() -> sh.getEnv().put("JAVA_HOME", systemJavaHome));
         }
     }
 
@@ -165,15 +159,14 @@ public abstract class PackagingTestCase extends Assert {
     protected void assertWhileRunning(Platforms.PlatformAction assertions) throws Exception {
         try {
             awaitElasticsearchStartup(runElasticsearchStartCommand());
-        } catch (Exception e ){
+        } catch (Exception e) {
             if (Files.exists(installation.home.resolve("elasticsearch.pid"))) {
                 String pid = FileUtils.slurp(installation.home.resolve("elasticsearch.pid")).trim();
                 logger.info("Dumping jstack of elasticsearch processb ({}) that failed to start", pid);
                 sh.runIgnoreExitCode("jstack " + pid);
             }
             if (Files.exists(installation.logs.resolve("elasticsearch.log"))) {
-                logger.warn("Elasticsearch log:\n" +
-                    FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
+                logger.warn("Elasticsearch log:\n" + FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
             }
             if (Files.exists(installation.logs.resolve("output.out"))) {
                 logger.warn("Stdout:\n" + FileUtils.slurpTxtorGz(installation.logs.resolve("output.out")));
@@ -187,8 +180,7 @@ public abstract class PackagingTestCase extends Assert {
         try {
             assertions.run();
         } catch (Exception e) {
-            logger.warn("Elasticsearch log:\n" +
-                FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
+            logger.warn("Elasticsearch log:\n" + FileUtils.slurpAllLogs(installation.logs, "elasticsearch.log", "*.log.gz"));
             throw e;
         }
         stopElasticsearch();
@@ -286,9 +278,11 @@ public abstract class PackagingTestCase extends Assert {
             // in the background
             String wrapperPid = result.stdout.trim();
             sh.runIgnoreExitCode("Wait-Process -Timeout " + Archives.ES_STARTUP_SLEEP_TIME_SECONDS + " -Id " + wrapperPid);
-            sh.runIgnoreExitCode("Get-EventSubscriber | " +
-                "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |" +
-                "Unregister-EventSubscriber -Force");
+            sh.runIgnoreExitCode(
+                "Get-EventSubscriber | "
+                    + "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |"
+                    + "Unregister-EventSubscriber -Force"
+            );
             assertThat(FileUtils.slurp(Archives.getPowershellErrorPath(installation)), containsString(expectedMessage));
 
         } else {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PasswordToolsTests.java
@@ -28,13 +28,15 @@ import org.junit.Before;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.packaging.util.FileUtils.append;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assume.assumeTrue;
@@ -52,9 +54,12 @@ public class PasswordToolsTests extends PackagingTestCase {
 
     public void test010Install() throws Exception {
         install();
-        append(installation.config("elasticsearch.yml"),
-            "xpack.license.self_generated.type: trial\n" +
-            "xpack.security.enabled: true");
+
+        List<String> lines = new ArrayList<>();
+        lines.add("xpack.license.self_generated.type: trial");
+        lines.add("xpack.security.enabled: true");
+
+        Files.write(installation.config("elasticsearch.yml"), lines, StandardOpenOption.APPEND);
     }
 
     public void test20GeneratePasswords() throws Exception {
@@ -63,7 +68,11 @@ public class PasswordToolsTests extends PackagingTestCase {
             Map<String, String> userpasses = parseUsersAndPasswords(result.stdout);
             for (Map.Entry<String, String> userpass : userpasses.entrySet()) {
                 String response = ServerUtils.makeRequest(
-                    Request.Get("http://localhost:9200"), userpass.getKey(), userpass.getValue(), null);
+                    Request.Get("http://localhost:9200"),
+                    userpass.getKey(),
+                    userpass.getValue(),
+                    null
+                );
                 assertThat(response, containsString("You Know, for Search"));
             }
         });
@@ -112,7 +121,10 @@ public class PasswordToolsTests extends PackagingTestCase {
         assertWhileRunning(() -> {
             String response = ServerUtils.makeRequest(
                 Request.Get("http://localhost:9200/_cluster/health?wait_for_status=green&timeout=180s"),
-                "elastic", BOOTSTRAP_PASSWORD, null);
+                "elastic",
+                BOOTSTRAP_PASSWORD,
+                null
+            );
             assertThat(response, containsString("\"status\":\"green\""));
         });
     }
@@ -125,7 +137,11 @@ public class PasswordToolsTests extends PackagingTestCase {
             assertThat(userpasses, hasKey("elastic"));
             for (Map.Entry<String, String> userpass : userpasses.entrySet()) {
                 String response = ServerUtils.makeRequest(
-                    Request.Get("http://localhost:9200"), userpass.getKey(), userpass.getValue(), null);
+                    Request.Get("http://localhost:9200"),
+                    userpass.getKey(),
+                    userpass.getValue(),
+                    null
+                );
                 assertThat(response, containsString("You Know, for Search"));
             }
         });

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -76,20 +76,11 @@ public class RpmPreservationTests extends PackagingTestCase {
         verifyPackageInstallation(installation, distribution(), sh);
 
         sh.run("echo foobar | " + installation.executables().keystoreTool + " add --stdin foo.bar");
-        Stream.of(
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        )
+        Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties")
             .map(each -> installation.config(each))
             .forEach(path -> append(path, "# foo"));
         if (distribution().isDefault()) {
-            Stream.of(
-                "role_mapping.yml",
-                "roles.yml",
-                "users",
-                "users_roles"
-            )
+            Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles")
                 .map(each -> installation.config(each))
                 .forEach(path -> append(path, "# foo"));
         }
@@ -116,19 +107,10 @@ public class RpmPreservationTests extends PackagingTestCase {
         assertTrue(Files.exists(installation.config));
         assertTrue(Files.exists(installation.config("elasticsearch.keystore")));
 
-        Stream.of(
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        ).forEach(this::assertConfFilePreserved);
+        Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties").forEach(this::assertConfFilePreserved);
 
         if (distribution().isDefault()) {
-            Stream.of(
-                "role_mapping.yml",
-                "roles.yml",
-                "users",
-                "users_roles"
-            ).forEach(this::assertConfFilePreserved);
+            Stream.of("role_mapping.yml", "roles.yml", "users", "users_roles").forEach(this::assertConfFilePreserved);
         }
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
@@ -56,12 +57,10 @@ import static org.junit.Assert.assertTrue;
  */
 public class Archives {
 
-    protected static final Logger logger =  LogManager.getLogger(Archives.class);
+    protected static final Logger logger = LogManager.getLogger(Archives.class);
 
     // in the future we'll run as a role user on Windows
-    public static final String ARCHIVE_OWNER = Platforms.WINDOWS
-        ? System.getenv("username")
-        : "elasticsearch";
+    public static final String ARCHIVE_OWNER = Platforms.WINDOWS ? System.getenv("username") : "elasticsearch";
 
     /** This is an arbitrarily chosen value that gives Elasticsearch time to log Bootstrap
      *  errors to the console if they occur before the logging framework is initialized. */
@@ -91,9 +90,12 @@ public class Archives {
             if (Platforms.WINDOWS == false) {
                 throw new IllegalStateException("Distribution " + distribution + " is not supported on linux");
             }
-            installCommand =
-                "Add-Type -AssemblyName 'System.IO.Compression.Filesystem'; " +
-                "[IO.Compression.ZipFile]::ExtractToDirectory('" + distributionFile + "', '" + baseInstallPath + "')";
+            installCommand = String.format(
+                Locale.ROOT,
+                "Add-Type -AssemblyName 'System.IO.Compression.Filesystem'; [IO.Compression.ZipFile]::ExtractToDirectory('%s', '%s')",
+                distributionFile,
+                baseInstallPath
+            );
 
         } else {
             throw new RuntimeException("Distribution " + distribution + " is not a known archive type");
@@ -129,22 +131,26 @@ public class Archives {
 
         if (sh.runIgnoreExitCode("id elasticsearch").isSuccess() == false) {
             if (isDPKG()) {
-                sh.run("adduser " +
-                    "--quiet " +
-                    "--system " +
-                    "--no-create-home " +
-                    "--ingroup elasticsearch " +
-                    "--disabled-password " +
-                    "--shell /bin/false " +
-                    "elasticsearch");
+                sh.run(
+                    "adduser "
+                        + "--quiet "
+                        + "--system "
+                        + "--no-create-home "
+                        + "--ingroup elasticsearch "
+                        + "--disabled-password "
+                        + "--shell /bin/false "
+                        + "elasticsearch"
+                );
             } else {
-                sh.run("useradd " +
-                    "--system " +
-                    "-M " +
-                    "--gid elasticsearch " +
-                    "--shell /sbin/nologin " +
-                    "--comment 'elasticsearch user' " +
-                    "elasticsearch");
+                sh.run(
+                    "useradd "
+                        + "--system "
+                        + "-M "
+                        + "--gid elasticsearch "
+                        + "--shell /sbin/nologin "
+                        + "--comment 'elasticsearch user' "
+                        + "elasticsearch"
+                );
             }
         }
     }
@@ -157,13 +163,7 @@ public class Archives {
     }
 
     private static void verifyOssInstallation(Installation es, Distribution distribution, String owner) {
-        Stream.of(
-            es.home,
-            es.config,
-            es.plugins,
-            es.modules,
-            es.logs
-        ).forEach(dir -> assertThat(dir, file(Directory, owner, owner, p755)));
+        Stream.of(es.home, es.config, es.plugins, es.modules, es.logs).forEach(dir -> assertThat(dir, file(Directory, owner, owner, p755)));
 
         assertThat(Files.exists(es.data), is(false));
 
@@ -188,24 +188,15 @@ public class Archives {
         });
 
         if (distribution.packaging == Distribution.Packaging.ZIP) {
-            Stream.of(
-                "elasticsearch-service.bat",
-                "elasticsearch-service-mgr.exe",
-                "elasticsearch-service-x64.exe"
-            ).forEach(executable -> assertThat(es.bin(executable), file(File, owner)));
+            Stream.of("elasticsearch-service.bat", "elasticsearch-service-mgr.exe", "elasticsearch-service-x64.exe")
+                .forEach(executable -> assertThat(es.bin(executable), file(File, owner)));
         }
 
-        Stream.of(
-            "elasticsearch.yml",
-            "jvm.options",
-            "log4j2.properties"
-        ).forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
+        Stream.of("elasticsearch.yml", "jvm.options", "log4j2.properties")
+            .forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
 
-        Stream.of(
-            "NOTICE.txt",
-            "LICENSE.txt",
-            "README.asciidoc"
-        ).forEach(doc -> assertThat(es.home.resolve(doc), file(File, owner, owner, p644)));
+        Stream.of("NOTICE.txt", "LICENSE.txt", "README.asciidoc")
+            .forEach(doc -> assertThat(es.home.resolve(doc), file(File, owner, owner, p644)));
     }
 
     private static void verifyDefaultInstallation(Installation es, Distribution distribution, String owner) {
@@ -236,13 +227,8 @@ public class Archives {
         // the version through here
         assertThat(es.bin("elasticsearch-sql-cli-" + getCurrentVersion() + ".jar"), file(File, owner, owner, p755));
 
-        Stream.of(
-            "users",
-            "users_roles",
-            "roles.yml",
-            "role_mapping.yml",
-            "log4j2.properties"
-        ).forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
+        Stream.of("users", "users_roles", "roles.yml", "role_mapping.yml", "log4j2.properties")
+            .forEach(configFile -> assertThat(es.config(configFile), file(File, owner, owner, p660)));
     }
 
     public static Shell.Result runElasticsearchStartCommand(Installation installation, Shell sh) {
@@ -272,44 +258,56 @@ public class Archives {
             // the tests will run as Administrator in vagrant.
             // we don't want to run the server as Administrator, so we provide the current user's
             // username and password to the process which has the effect of starting it not as Administrator.
-            powerShellProcessUserSetup =
-                "$password = ConvertTo-SecureString 'vagrant' -AsPlainText -Force; " +
-                "$processInfo.Username = 'vagrant'; " +
-                "$processInfo.Password = $password; ";
+            powerShellProcessUserSetup = "$password = ConvertTo-SecureString 'vagrant' -AsPlainText -Force; "
+                + "$processInfo.Username = 'vagrant'; "
+                + "$processInfo.Password = $password; ";
         } else {
             powerShellProcessUserSetup = "";
         }
 
         // this starts the server in the background. the -d flag is unsupported on windows
         return sh.run(
-            "$processInfo = New-Object System.Diagnostics.ProcessStartInfo; " +
-                "$processInfo.FileName = '" + bin.elasticsearch + "'; " +
-                "$processInfo.Arguments = '-p " + installation.home.resolve("elasticsearch.pid") + "'; " +
-                powerShellProcessUserSetup +
-                "$processInfo.RedirectStandardOutput = $true; " +
-                "$processInfo.RedirectStandardError = $true; " +
-                "$processInfo.RedirectStandardInput = $true; " +
-                sh.env.entrySet().stream()
+            "$processInfo = New-Object System.Diagnostics.ProcessStartInfo; "
+                + "$processInfo.FileName = '"
+                + bin.elasticsearch
+                + "'; "
+                + "$processInfo.Arguments = '-p "
+                + installation.home.resolve("elasticsearch.pid")
+                + "'; "
+                + powerShellProcessUserSetup
+                + "$processInfo.RedirectStandardOutput = $true; "
+                + "$processInfo.RedirectStandardError = $true; "
+                + "$processInfo.RedirectStandardInput = $true; "
+                + sh.env.entrySet()
+                    .stream()
                     .map(entry -> "$processInfo.Environment.Add('" + entry.getKey() + "', '" + entry.getValue() + "'); ")
-                    .collect(joining()) +
-                "$processInfo.UseShellExecute = $false; " +
-                "$process = New-Object System.Diagnostics.Process; " +
-                "$process.StartInfo = $processInfo; " +
+                    .collect(joining())
+                + "$processInfo.UseShellExecute = $false; "
+                + "$process = New-Object System.Diagnostics.Process; "
+                + "$process.StartInfo = $processInfo; "
+                +
 
                 // set up some asynchronous output handlers
-                "$outScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '" + stdout + "' }; " +
-                "$errScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '" + stderr + "' }; " +
-                "$stdOutEvent = Register-ObjectEvent -InputObject $process " +
-                "-Action $outScript -EventName 'OutputDataReceived'; " +
-                "$stdErrEvent = Register-ObjectEvent -InputObject $process " +
-                "-Action $errScript -EventName 'ErrorDataReceived'; " +
+                "$outScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '"
+                + stdout
+                + "' }; "
+                + "$errScript = { $EventArgs.Data | Out-File -Encoding UTF8 -Append '"
+                + stderr
+                + "' }; "
+                + "$stdOutEvent = Register-ObjectEvent -InputObject $process "
+                + "-Action $outScript -EventName 'OutputDataReceived'; "
+                + "$stdErrEvent = Register-ObjectEvent -InputObject $process "
+                + "-Action $errScript -EventName 'ErrorDataReceived'; "
+                +
 
-                "$process.Start() | Out-Null; " +
-                "$process.BeginOutputReadLine(); " +
-                "$process.BeginErrorReadLine(); " +
-                "Wait-Process -Timeout " + ES_STARTUP_SLEEP_TIME_SECONDS + " -Id $process.Id; " +
-                "$process.Id;"
-            );
+                "$process.Start() | Out-Null; "
+                + "$process.BeginOutputReadLine(); "
+                + "$process.BeginErrorReadLine(); "
+                + "Wait-Process -Timeout "
+                + ES_STARTUP_SLEEP_TIME_SECONDS
+                + " -Id $process.Id; "
+                + "$process.Id;"
+        );
     }
 
     public static void assertElasticsearchStarted(Installation installation) throws Exception {
@@ -333,9 +331,11 @@ public class Archives {
             sh.run("Get-Process -Id " + pid + " | Stop-Process -Force; Wait-Process -Id " + pid);
 
             // Clear the asynchronous event handlers
-            sh.runIgnoreExitCode("Get-EventSubscriber | " +
-                "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |" +
-                "Unregister-EventSubscriber -Force");
+            sh.runIgnoreExitCode(
+                "Get-EventSubscriber | "
+                    + "where {($_.EventName -eq 'OutputDataReceived' -Or $_.EventName -eq 'ErrorDataReceived' |"
+                    + "Unregister-EventSubscriber -Force"
+            );
         });
         if (Files.exists(pidFile)) {
             Files.delete(pidFile);

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -61,14 +61,16 @@ public class Cleanup {
             sh.runIgnoreExitCode("ps aux | grep -i 'org.elasticsearch.bootstrap.Elasticsearch' | awk {'print $2'} | xargs kill -9");
         });
 
-        Platforms.onWindows(() -> {
-            // the view of processes returned by Get-Process doesn't expose command line arguments, so we use WMI here
-            sh.runIgnoreExitCode(
-                "Get-WmiObject Win32_Process | " +
-                "Where-Object { $_.CommandLine -Match 'org.elasticsearch.bootstrap.Elasticsearch' } | " +
-                "ForEach-Object { $_.Terminate() }"
-            );
-        });
+        Platforms.onWindows(
+            () -> {
+                // the view of processes returned by Get-Process doesn't expose command line arguments, so we use WMI here
+                sh.runIgnoreExitCode(
+                    "Get-WmiObject Win32_Process | "
+                        + "Where-Object { $_.CommandLine -Match 'org.elasticsearch.bootstrap.Elasticsearch' } | "
+                        + "ForEach-Object { $_.Terminate() }"
+                );
+            }
+        );
 
         Platforms.onLinux(Cleanup::purgePackagesLinux);
 
@@ -84,10 +86,7 @@ public class Cleanup {
         final List<String> filesToDelete = Platforms.WINDOWS ? ELASTICSEARCH_FILES_WINDOWS : ELASTICSEARCH_FILES_LINUX;
         // windows needs leniency due to asinine releasing of file locking async from a process exiting
         Consumer<? super Path> rm = Platforms.WINDOWS ? FileUtils::rmWithRetries : FileUtils::rm;
-        filesToDelete.stream()
-            .map(Paths::get)
-            .filter(Files::exists)
-            .forEach(rm);
+        filesToDelete.stream().map(Paths::get).filter(Files::exists).forEach(rm);
 
         // disable elasticsearch service
         // todo add this for windows when adding tests for service intallation

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -77,10 +77,7 @@ public class Docker {
     public static void ensureImageIsLoaded(Distribution distribution) {
         Shell.Result result = sh.run("docker image ls --format '{{.Repository}}' " + distribution.flavor.name);
 
-        final long count = Arrays.stream(result.stdout.split("\n"))
-            .map(String::trim)
-            .filter(s -> s.isEmpty() == false)
-            .count();
+        final long count = Arrays.stream(result.stdout.split("\n")).map(String::trim).filter(s -> s.isEmpty() == false).count();
 
         if (count != 0) {
             return;

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileMatcher.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileMatcher.java
@@ -43,7 +43,10 @@ import static org.elasticsearch.packaging.util.FileUtils.getPosixFileAttributes;
  */
 public class FileMatcher extends TypeSafeMatcher<Path> {
 
-    public enum Fileness { File, Directory }
+    public enum Fileness {
+        File,
+        Directory
+    }
 
     public static final Set<PosixFilePermission> p775 = fromString("rwxrwxr-x");
     public static final Set<PosixFilePermission> p770 = fromString("rwxrwx---");
@@ -126,10 +129,14 @@ public class FileMatcher extends TypeSafeMatcher<Path> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendValue("file/directory: ").appendValue(fileness)
-            .appendText(" with owner ").appendValue(owner)
-            .appendText(" with group ").appendValue(group)
-            .appendText(" with posix permissions ").appendValueList("[", ",", "]", posixPermissions);
+        description.appendValue("file/directory: ")
+            .appendValue(fileness)
+            .appendText(" with owner ")
+            .appendValue(owner)
+            .appendText(" with group ")
+            .appendValue(group)
+            .appendText(" with posix permissions ")
+            .appendValueList("[", ",", "]", posixPermissions);
     }
 
     public static FileMatcher file(Fileness fileness, String owner) {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/FileUtils.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -110,22 +111,21 @@ public class FileUtils {
 
     public static Path mktempDir(Path path) {
         try {
-            return Files.createTempDirectory(path,"tmp");
+            return Files.createTempDirectory(path, "tmp");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-
     public static Path mkdir(Path path) {
         try {
             return Files.createDirectories(path);
-         } catch (IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
-         }
-     }
+        }
+    }
 
-     public static Path cp(Path source, Path target) {
+    public static Path cp(Path source, Path target) {
         try {
             return Files.copy(source, target);
         } catch (IOException e) {
@@ -141,9 +141,22 @@ public class FileUtils {
         }
     }
 
+    /**
+     * Creates or appends to the specified file, and writes the supplied string to it.
+     * No newline is written - if a trailing newline is required, it should be present
+     * in <code>text</code>, or use {@link Files#write(Path, Iterable, OpenOption...)}.
+     * @param file the file to create or append
+     * @param text the string to write
+     */
     public static void append(Path file, String text) {
-        try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8,
-            StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+        try (
+            BufferedWriter writer = Files.newBufferedWriter(
+                file,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND
+            )
+        ) {
 
             writer.write(text);
         } catch (IOException e) {
@@ -203,7 +216,7 @@ public class FileUtils {
             for (Path rotatedLogFile : FileUtils.lsGlob(logPath, rotatedLogFilesGlob)) {
                 logFileJoiner.add(FileUtils.slurpTxtorGz(rotatedLogFile));
             }
-            return(logFileJoiner.toString());
+            return (logFileJoiner.toString());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -220,14 +233,14 @@ public class FileUtils {
                 // gc logs are verbose and not useful in this context
                 .filter(file -> file.getFileName().toString().startsWith("gc.log") == false)
                 .forEach(file -> {
-                logger.info("=== Contents of `{}` ({}) ===", file, file.toAbsolutePath());
-                try (Stream<String> stream = Files.lines(file)) {
-                    stream.forEach(logger::info);
-                } catch (IOException e) {
-                    logger.error("Can't show contents", e);
-                }
-                logger.info("=== End of contents of `{}`===", file);
-            });
+                    logger.info("=== Contents of `{}` ({}) ===", file, file.toAbsolutePath());
+                    try (Stream<String> stream = Files.lines(file)) {
+                        stream.forEach(logger::info);
+                    } catch (IOException e) {
+                        logger.error("Can't show contents", e);
+                    }
+                    logger.info("=== End of contents of `{}`===", file);
+                });
         } catch (IOException e) {
             logger.error("Can't list log files", e);
         }
@@ -283,7 +296,6 @@ public class FileUtils {
         return numericPathOwnership;
     }
 
-
     // vagrant creates /tmp for us in windows so we use that to avoid long paths
     public static Path getTempDir() {
         return Paths.get("/tmp").toAbsolutePath();
@@ -294,6 +306,7 @@ public class FileUtils {
     }
 
     private static final Pattern VERSION_REGEX = Pattern.compile("(\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?)");
+
     public static String getCurrentVersion() {
         // TODO: just load this once
         String distroFile = System.getProperty("tests.distribution");
@@ -313,12 +326,12 @@ public class FileUtils {
     }
 
     public static Matcher<Path> fileWithGlobExist(String glob) throws IOException {
-        return new FeatureMatcher<Path,Iterable<Path>>(not(emptyIterable()),"File with pattern exist", "file with pattern"){
+        return new FeatureMatcher<Path, Iterable<Path>>(not(emptyIterable()), "File with pattern exist", "file with pattern") {
 
             @Override
             protected Iterable<Path> featureValueOf(Path actual) {
                 try {
-                    return Files.newDirectoryStream(actual,glob);
+                    return Files.newDirectoryStream(actual, glob);
                 } catch (IOException e) {
                     return Collections.emptyList();
                 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Installation.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Installation.java
@@ -28,9 +28,7 @@ import java.nio.file.Paths;
 public class Installation {
 
     // in the future we'll run as a role user on Windows
-    public static final String ARCHIVE_OWNER = Platforms.WINDOWS
-        ? System.getenv("username")
-        : "elasticsearch";
+    public static final String ARCHIVE_OWNER = Platforms.WINDOWS ? System.getenv("username") : "elasticsearch";
 
     private final Shell sh;
     public final Distribution distribution;
@@ -46,8 +44,18 @@ public class Installation {
     public final Path pidDir;
     public final Path envFile;
 
-    private Installation(Shell sh, Distribution distribution, Path home, Path config, Path data, Path logs,
-                         Path plugins, Path modules, Path pidDir, Path envFile) {
+    private Installation(
+        Shell sh,
+        Distribution distribution,
+        Path home,
+        Path config,
+        Path data,
+        Path logs,
+        Path plugins,
+        Path modules,
+        Path pidDir,
+        Path envFile
+    ) {
         this.sh = sh;
         this.distribution = distribution;
         this.home = home;
@@ -143,9 +151,7 @@ public class Installation {
         public final Path path;
 
         private Executable(String name) {
-            final String platformExecutableName = Platforms.WINDOWS
-                ? name + ".bat"
-                : name;
+            final String platformExecutableName = Platforms.WINDOWS ? name + ".bat" : name;
             this.path = bin(platformExecutableName);
         }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -58,12 +58,12 @@ import static org.hamcrest.Matchers.containsString;
 
 public class ServerUtils {
 
-    private static final Logger logger =  LogManager.getLogger(ServerUtils.class);
+    private static final Logger logger = LogManager.getLogger(ServerUtils.class);
 
     private static String SECURITY_ENABLED = "xpack.security.enabled: true";
     private static String SSL_ENABLED = "xpack.security.http.ssl.enabled: true";
 
-    // generous timeout  as nested virtualization can be quite slow ...
+    // generous timeout as nested virtualization can be quite slow ...
     private static final long waitTime = TimeUnit.MINUTES.toMillis(3);
     private static final long timeoutLength = TimeUnit.SECONDS.toMillis(30);
     private static final long requestInterval = TimeUnit.SECONDS.toMillis(5);
@@ -124,9 +124,7 @@ public class ServerUtils {
                 connectionManager.setDefaultMaxPerRoute(100);
                 connectionManager.setMaxTotal(200);
                 connectionManager.setValidateAfterInactivity(1000);
-                executor = Executor.newInstance(HttpClientBuilder.create()
-                    .setConnectionManager(connectionManager)
-                    .build());
+                executor = Executor.newInstance(HttpClientBuilder.create().setConnectionManager(connectionManager).build());
             }
         } else {
             executor = Executor.newInstance();
@@ -159,13 +157,8 @@ public class ServerUtils {
         throw new RuntimeException("Elasticsearch (with x-pack) did not start");
     }
 
-    public static void waitForElasticsearch(
-        String status,
-        String index,
-        Installation installation,
-        String username,
-        String password
-    ) throws Exception {
+    public static void waitForElasticsearch(String status, String index, Installation installation, String username, String password)
+        throws Exception {
 
         Objects.requireNonNull(status);
 
@@ -186,8 +179,7 @@ public class ServerUtils {
                 try {
 
                     final HttpResponse response = execute(
-                        Request
-                            .Get("http://localhost:9200/_cluster/health")
+                        Request.Get("http://localhost:9200/_cluster/health")
                             .connectTimeout((int) timeoutLength)
                             .socketTimeout((int) timeoutLength),
                         username,
@@ -239,11 +231,13 @@ public class ServerUtils {
     public static void runElasticsearchTests() throws Exception {
         makeRequest(
             Request.Post("http://localhost:9200/library/book/1?refresh=true&pretty")
-                .bodyString("{ \"title\": \"Book #1\", \"pages\": 123 }", ContentType.APPLICATION_JSON));
+                .bodyString("{ \"title\": \"Book #1\", \"pages\": 123 }", ContentType.APPLICATION_JSON)
+        );
 
         makeRequest(
             Request.Post("http://localhost:9200/library/book/2?refresh=true&pretty")
-                .bodyString("{ \"title\": \"Book #2\", \"pages\": 456 }", ContentType.APPLICATION_JSON));
+                .bodyString("{ \"title\": \"Book #2\", \"pages\": 456 }", ContentType.APPLICATION_JSON)
+        );
 
         String count = makeRequest(Request.Get("http://localhost:9200/_count?pretty"));
         assertThat(count, containsString("\"count\" : 2"));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Shell.java
@@ -42,9 +42,8 @@ import java.util.stream.Stream;
  */
 public class Shell {
 
-    public static final int TAIL_WHEN_TOO_MUCH_OUTPUT = 1000;
-    public static final Result NO_OP = new Shell.Result(0, "","");
-    protected final Logger logger =  LogManager.getLogger(getClass());
+    public static final Result NO_OP = new Shell.Result(0, "", "");
+    protected final Logger logger = LogManager.getLogger(getClass());
 
     final Map<String, String> env = new HashMap<>();
     Path workingDirectory;
@@ -86,20 +85,28 @@ public class Shell {
 
     public void chown(Path path) throws Exception {
         Platforms.onLinux(() -> run("chown -R elasticsearch:elasticsearch " + path));
-        Platforms.onWindows(() -> run(
-            "$account = New-Object System.Security.Principal.NTAccount '" + System.getenv("username")  + "'; " +
-                "$pathInfo = Get-Item '" + path + "'; " +
-                "$toChown = @(); " +
-                "if ($pathInfo.PSIsContainer) { " +
-                "  $toChown += Get-ChildItem '" + path + "' -Recurse; " +
-                "}" +
-                "$toChown += $pathInfo; " +
-                "$toChown | ForEach-Object { " +
-                "$acl = Get-Acl $_.FullName; " +
-                "$acl.SetOwner($account); " +
-                "Set-Acl $_.FullName $acl " +
-                "}"
-        ));
+        Platforms.onWindows(
+            () -> run(
+                String.format(
+                    Locale.ROOT,
+                    "$account = New-Object System.Security.Principal.NTAccount '%s'; "
+                        + "$pathInfo = Get-Item '%s'; "
+                        + "$toChown = @(); "
+                        + "if ($pathInfo.PSIsContainer) { "
+                        + "  $toChown += Get-ChildItem '%s' -Recurse; "
+                        + "}"
+                        + "$toChown += $pathInfo; "
+                        + "$toChown | ForEach-Object { "
+                        + "  $acl = Get-Acl $_.FullName; "
+                        + "  $acl.SetOwner($account); "
+                        + "  Set-Acl $_.FullName $acl "
+                        + "}",
+                    System.getenv("username"),
+                    path,
+                    path
+                )
+            )
+        );
     }
 
     public void extractZip(Path zipPath, Path destinationDir) throws Exception {
@@ -165,22 +172,11 @@ public class Shell {
                 if (process.isAlive()) {
                     process.destroyForcibly();
                 }
-                Result result = new Result(
-                    -1,
-                    readFileIfExists(stdOut),
-                    readFileIfExists(stdErr)
-                );
-                throw new IllegalStateException(
-                    "Timed out running shell command: " + command + "\n" +
-                    "Result:\n" + result
-                );
+                Result result = new Result(-1, readFileIfExists(stdOut), readFileIfExists(stdErr));
+                throw new IllegalStateException("Timed out running shell command: " + command + "\n" + "Result:\n" + result);
             }
 
-            Result result = new Result(
-                process.exitValue(),
-                readFileIfExists(stdOut),
-                readFileIfExists(stdErr)
-            );
+            Result result = new Result(process.exitValue(), readFileIfExists(stdOut), readFileIfExists(stdErr));
             logger.info("Ran: {} {}", Arrays.toString(command), result);
             return result;
 
@@ -203,7 +199,7 @@ public class Shell {
         if (Files.exists(path)) {
             long size = Files.size(path);
             if (size > 100 * 1024) {
-                return "<<Too large to read: " + size  + " bytes>>";
+                return "<<Too large to read: " + size + " bytes>>";
             }
             try (Stream<String> lines = Files.lines(path, StandardCharsets.UTF_8)) {
                 return lines.collect(Collectors.joining("\n"));
@@ -225,15 +221,7 @@ public class Shell {
     }
 
     public String toString() {
-        return new StringBuilder()
-            .append(" ")
-            .append("env = [")
-            .append(env)
-            .append("]")
-            .append("workingDirectory = [")
-            .append(workingDirectory)
-            .append("]")
-            .toString();
+        return String.format(Locale.ROOT, " env = [%s] workingDirectory = [%s]", env, workingDirectory);
     }
 
     public static class Result {
@@ -252,17 +240,7 @@ public class Shell {
         }
 
         public String toString() {
-            return new StringBuilder()
-                .append("exitCode = [")
-                .append(exitCode)
-                .append("] ")
-                .append("stdout = [")
-                .append(stdout.trim())
-                .append("] ")
-                .append("stderr = [")
-                .append(stderr.trim())
-                .append("]")
-                .toString();
+            return String.format(Locale.ROOT, "exitCode = [%d] stdout = [%s] stderr = [%s]", exitCode, stdout.trim(), stderr.trim());
         }
     }
 


### PR DESCRIPTION
Backport of #52756 and #52750.

Add `:qa:os` and `:benchmarks` to the list of automatically formatted
projects, and apply some manual fix-ups to polish them up.

In particular, I noticed that `Files.write(...)` when passed a list will
automaticaly apply a UTF-8 encoding and write a newline after each line,
making it easier to use than FileUtils.append. It's even available from
1.8.

In `:benchmarks` in the Allocators class, a number of methods declared
thrown exceptions that IntelliJ reported were never thrown, and as far as I
could see this is true, so I removed the exceptions.