### PR TITLE
[DOCS] Fix several Asciidoctor double arrow replacements

### DIFF
--- a/docs/painless/painless-lang-spec/painless-operators-general.asciidoc
+++ b/docs/painless/painless-lang-spec/painless-operators-general.asciidoc
@@ -265,7 +265,7 @@ value of the variable/field and can result in data loss.
 |Remainder|%=
 |Addition|+=
 |Subtraction|-=
-|Left Shift|<<=
+|Left Shift|+++<<=+++
 |Right Shift|>>=
 |Unsigned Right Shift|>>>=
 |Bitwise And|&=

--- a/docs/painless/painless-lang-spec/painless-operators.asciidoc
+++ b/docs/painless/painless-lang-spec/painless-operators.asciidoc
@@ -45,7 +45,7 @@ is evaluated.  The following table lists all available operators:
 | <<greater-than-operator, Greater Than>>                   | <<painless-operators-boolean, Boolean>>     | >           | 7            | left -> right
 | <<greater-than-or-equal-operator, Greater Than Or Equal>> | <<painless-operators-boolean, Boolean>>     | >=          | 7            | left -> right
 | <<less-than-operator, Less Than>>                         | <<painless-operators-boolean, Boolean>>     | <           | 7            | left -> right
-| <<less-than-or-equal-operator, Less Than Or Equal>>       | <<painless-operators-boolean, Boolean>>     | <=          | 7            | left -> right
+| <<less-than-or-equal-operator, Less Than Or Equal>>       | <<painless-operators-boolean, Boolean>>     | +++<=+++    | 7            | left -> right
 | <<instanceof-operator, Instanceof>>                       | <<painless-operators-boolean, Boolean>>     | instanceof  | 8            | left -> right
 | <<equality-equals-operator, Equality Equals>>             | <<painless-operators-boolean, Boolean>>     | ==          | 9            | left -> right
 | <<equality-not-equals-operator, Equality Not Equals>>     | <<painless-operators-boolean, Boolean>>     | !=          | 9            | left -> right

--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -88,7 +88,7 @@ PUT /test_index
 --------------------------------------------------
 
 With the above request the word `bar` gets skipped but a mapping `foo => baz` is still added. However, if the mapping
-being added was "foo, baz => bar" nothing would get added to the synonym list. This is because the target word for the
+being added was `foo, baz => bar` nothing would get added to the synonym list. This is because the target word for the
 mapping is itself eliminated because it was a stop word. Similarly, if the mapping was "bar, foo, baz" and `expand` was
 set to `false` no mapping would get added as when `expand=false` the target mapping is the first word. However, if
 `expand=true` then the mappings added would be equivalent to `foo, baz => foo, baz` i.e, all mappings other than the

--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -78,7 +78,7 @@ PUT /test_index
 --------------------------------------------------
 
 With the above request the word `bar` gets skipped but a mapping `foo => baz` is still added. However, if the mapping
-being added was "foo, baz => bar" nothing would get added to the synonym list. This is because the target word for the
+being added was `foo, baz => bar` nothing would get added to the synonym list. This is because the target word for the
 mapping is itself eliminated because it was a stop word. Similarly, if the mapping was "bar, foo, baz" and `expand` was
 set to `false` no mapping would get added as when `expand=false` the target mapping is the first word. However, if
 `expand=true` then the mappings added would be equivalent to `foo, baz => foo, baz` i.e, all mappings other than the

--- a/docs/reference/analysis/tokenfilters/word-delimiter-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/word-delimiter-graph-tokenfilter.asciidoc
@@ -32,23 +32,23 @@ Parameters include:
 
 `generate_word_parts`::
     If `true` causes parts of words to be
-    generated: "PowerShot" => "Power" "Shot". Defaults to `true`.
+    generated: "PowerShot" -> "Power" "Shot". Defaults to `true`.
 
 `generate_number_parts`::
     If `true` causes number subwords to be
-    generated: "500-42" => "500" "42". Defaults to `true`.
+    generated: "500-42" -> "500" "42". Defaults to `true`.
 
 `catenate_words`::
     If `true` causes maximum runs of word parts to be
-    catenated: "wi-fi" => "wifi". Defaults to `false`.
+    catenated: "wi-fi" -> "wifi". Defaults to `false`.
 
 `catenate_numbers`::
     If `true` causes maximum runs of number parts to
-    be catenated: "500-42" => "50042". Defaults to `false`.
+    be catenated: "500-42" -> "50042". Defaults to `false`.
 
 `catenate_all`::
     If `true` causes all subword parts to be catenated:
-    "wi-fi-4000" => "wifi4000". Defaults to `false`.
+    "wi-fi-4000" -> "wifi4000". Defaults to `false`.
 
 `split_on_case_change`::
     If `true` causes "PowerShot" to be two tokens;
@@ -56,7 +56,7 @@ Parameters include:
 
 `preserve_original`::
     If `true` includes original words in subwords:
-    "500-42" => "500-42" "500" "42". Defaults to `false`.
+    "500-42" -> "500-42" "500" "42". Defaults to `false`.
 
 `split_on_numerics`::
     If `true` causes "j2se" to be three tokens; "j"
@@ -64,7 +64,7 @@ Parameters include:
 
 `stem_english_possessive`::
     If `true` causes trailing "'s" to be
-    removed for each subword: "O'Neil's" => "O", "Neil". Defaults to `true`.
+    removed for each subword: "O'Neil's" -> "O", "Neil". Defaults to `true`.
 
 Advance settings include:
 

--- a/docs/reference/analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc
@@ -20,23 +20,23 @@ Parameters include:
 
 `generate_word_parts`::
     If `true` causes parts of words to be
-    generated: "Power-Shot", "(Power,Shot)" => "Power" "Shot". Defaults to `true`.
+    generated: "Power-Shot", "(Power,Shot)" -> "Power" "Shot". Defaults to `true`.
 
 `generate_number_parts`::
     If `true` causes number subwords to be
-    generated: "500-42" => "500" "42". Defaults to `true`.
+    generated: "500-42" -> "500" "42". Defaults to `true`.
 
 `catenate_words`::
     If `true` causes maximum runs of word parts to be
-    catenated: "wi-fi" => "wifi". Defaults to `false`.
+    catenated: "wi-fi" -> "wifi". Defaults to `false`.
 
 `catenate_numbers`::
     If `true` causes maximum runs of number parts to
-    be catenated: "500-42" => "50042". Defaults to `false`.
+    be catenated: "500-42" -> "50042". Defaults to `false`.
 
 `catenate_all`::
     If `true` causes all subword parts to be catenated:
-    "wi-fi-4000" => "wifi4000". Defaults to `false`.
+    "wi-fi-4000" -> "wifi4000". Defaults to `false`.
 
 `split_on_case_change`::
     If `true` causes "PowerShot" to be two tokens;
@@ -44,7 +44,7 @@ Parameters include:
 
 `preserve_original`::
     If `true` includes original words in subwords:
-    "500-42" => "500-42" "500" "42". Defaults to `false`.
+    "500-42" -> "500-42" "500" "42". Defaults to `false`.
 
 `split_on_numerics`::
     If `true` causes "j2se" to be three tokens; "j"
@@ -52,7 +52,7 @@ Parameters include:
 
 `stem_english_possessive`::
     If `true` causes trailing "'s" to be
-    removed for each subword: "O'Neil's" => "O", "Neil". Defaults to `true`.
+    removed for each subword: "O'Neil's" -> "O", "Neil". Defaults to `true`.
 
 Advance settings include:
 

--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -151,7 +151,7 @@ within the document (`my_parent`, `my_child`, ...).
 It also creates one field per parent/child relation.
 The name of this field is the name of the `join` field followed by `#` and the
 name of the parent in the relation.
-So for instance for the `my_parent` => [`my_child`, `another_child`] relation,
+So for instance for the `my_parent` -> [`my_child`, `another_child`] relation,
 the `join` field creates an additional field named `my_join_field#my_parent`.
 
 This field contains the parent `_id` that the document links to

--- a/docs/reference/sql/language/syntax/lexic/index.asciidoc
+++ b/docs/reference/sql/language/syntax/lexic/index.asciidoc
@@ -183,7 +183,7 @@ s|Description
 |
 |range containment, string matching
 
-|< > <= >= = <=> <> !=
+|+++< > <= >= = <=> <> !=+++
 |
 |comparison
 


### PR DESCRIPTION
Per the [Asciidoctor docs][0], Asciidoctor replaces the following
syntax with double arrows in the rendered HTML:

* => renders as ⇒
* <= renders as ⇐

This escapes several unintended replacements, such as in the Painless
docs.

Where appropriate, it also replaces some double arrow instances with
single arrows for consistency.

Closes #52609

[0]: https://asciidoctor.org/docs/user-manual/#replacements


### Previews

- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/painless/master/painless-operators-general.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/painless/master/painless-operators.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/analysis-synonym-graph-tokenfilter.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/analysis-synonym-tokenfilter.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/analysis-word-delimiter-graph-tokenfilter.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/analysis-word-delimiter-tokenfilter.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/parent-join.html
- http://elasticsearch_52827.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/sql-lexical-structure.html