### PR TITLE
[ML] Unwrap cause from remote ActionTransportExceptions

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.transform.transforms;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
@@ -267,9 +268,10 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         ActionListener<Void> templateCheckListener = ActionListener.wrap(
             aVoid -> transformServices.getConfigManager().getTransformConfiguration(transformId, getTransformConfigListener),
             error -> {
+                Throwable cause = ExceptionsHelper.unwrapCause(error);
                 String msg = "Failed to create internal index mappings";
-                logger.error(msg, error);
-                markAsFailed(buildTask, msg);
+                logger.error(msg, cause);
+                markAsFailed(buildTask, msg + "[" + cause + "]");
             }
         );
 


### PR DESCRIPTION
Mostly changes to DataFrameAnalyticsManager to unwrap remote exceptions and a small change in transforms. 

The rule of thumb I'm using is that if the action does not run on the same node then the error should be unwrapped. Mostly this means master node actions that are not called from the master node. Put Template called by `TransformPersistentTasksExecutor` is a master node action.

For https://github.com/elastic/elasticsearch/issues/52654#issuecomment-591562301

