### PR TITLE
Ignore test seed in third party test system property inputs

### DIFF
--- a/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
+++ b/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
@@ -103,7 +103,7 @@ task thirdPartyTest(type: Test) {
   include '**/GoogleCloudStorageThirdPartyTests.class'
   systemProperty 'tests.security.manager', false
   systemProperty 'test.google.bucket', gcsBucket
-  systemProperty 'test.google.base', gcsBasePath + "_third_party_tests_" + BuildParams.testSeed
+  nonInputProperties.systemProperty 'test.google.base', gcsBasePath + "_third_party_tests_" + BuildParams.testSeed
   nonInputProperties.systemProperty 'test.google.account', "${-> encodedCredentials.call()}"
 }
 

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -137,7 +137,7 @@ task thirdPartyTest(type: Test) {
   systemProperty 'test.s3.account', s3PermanentAccessKey
   systemProperty 'test.s3.key', s3PermanentSecretKey
   systemProperty 'test.s3.bucket', s3PermanentBucket
-  systemProperty 'test.s3.base', s3PermanentBasePath + "_third_party_tests_" + BuildParams.testSeed
+  nonInputProperties.systemProperty 'test.s3.base', s3PermanentBasePath + "_third_party_tests_" + BuildParams.testSeed
 }
 
 if (useFixture) {


### PR DESCRIPTION
Our GCS and S3 third-party tests are inadvertently embedding the test seed as an input to test tasks. This has the side effect of breaking cacheability for these tests. This change ignores this system property for the purposes of input snapshotting so that we can get better test avoidance.