### PR TITLE
Remove TODO in MaxSizeCondition

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxAgeCondition.java
@@ -57,7 +57,7 @@ public class MaxAgeCondition extends Condition<TimeValue> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        // While we technically could serialize this would out.writeTimeValue(...), that would
+        // While we technically could serialize this with out.writeTimeValue(...), that would
         // require doing the song and dance around backwards compatibility for this value. Since
         // in this case the deserialized version is not displayed to a user, it's okay to simply use
         // milliseconds. It's possible to lose precision if someone were to say, specify 50

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxSizeCondition.java
@@ -57,7 +57,10 @@ public class MaxSizeCondition extends Condition<ByteSizeValue> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        //TODO here we should just use ByteSizeValue#writeTo and same for de-serialization in the constructor
+        // While we technically could serialize this with value.writeTo(...), that would
+        // require doing the song and dance around backwards compatibility for this value. Since
+        // in this case the deserialized version is not displayed to a user, it's okay to simply use
+        // bytes.
         out.writeVLong(value.getBytes());
     }
 


### PR DESCRIPTION
Similar to what we did in #52794, this removes the TODO.

Relates again to #52505
