### PR TITLE
Fix cacheability of repository-hdfs integ tests

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -153,7 +153,7 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
       onlyIf { BuildParams.inFipsJvm == false }
       if (integTestTaskName.contains("Ha")) {
         Path portsFile
-        File portsFileDir = file("${workingDir}/ports")
+        File portsFileDir = file("${workingDir}/hdfsFixture")
         if (integTestTaskName.contains("Secure")) {
           portsFile = buildDir.toPath()
             .resolve("fixtures")

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -79,7 +79,7 @@ normalization {
     // ignore generated keytab files for the purposes of build avoidance
     ignore '*.keytab'
     // ignore fixture ports file which is on the classpath primarily to pacify the security manager
-    ignore '*HdfsFixture/**'
+    ignore 'ports'
   }
 }
 
@@ -152,20 +152,29 @@ for (String integTestTaskName : ['integTestHa', 'integTestSecure', 'integTestSec
     runner {
       onlyIf { BuildParams.inFipsJvm == false }
       if (integTestTaskName.contains("Ha")) {
+        Path portsFile
+        File portsFileDir = file("${workingDir}/ports")
         if (integTestTaskName.contains("Secure")) {
-          Path path = buildDir.toPath()
+          portsFile = buildDir.toPath()
             .resolve("fixtures")
             .resolve("secureHaHdfsFixture")
             .resolve("ports")
-          nonInputProperties.systemProperty "test.hdfs-fixture.ports", path
         } else {
-          Path path = buildDir.toPath()
+          portsFile = buildDir.toPath()
             .resolve("fixtures")
             .resolve("haHdfsFixture")
             .resolve("ports")
-          nonInputProperties.systemProperty "test.hdfs-fixture.ports", path
         }
-        classpath += files("$buildDir/fixtures")
+        nonInputProperties.systemProperty "test.hdfs-fixture.ports", file("$portsFileDir/ports")
+        classpath += files(portsFileDir)
+        // Copy ports file to separate location which is placed on the test classpath
+        doFirst {
+          mkdir(portsFileDir)
+          copy {
+            from portsFile
+            into portsFileDir
+          }
+        }
       }
 
       if (integTestTaskName.contains("Secure")) {


### PR DESCRIPTION
Several of the `:plugins:repository-hdfs` integration test tasks are not being pulled from the cache due to changes in test fixture data directories. These directories really shouldn't be on the classpath as the only thing we need is the ports file. Due to some particularities in classpath input filtering, we can't just add the ports file itself and subsequently ignore it for the purposes if input snapshotting. So instead we copy the file to its own directory, and add the directory to the classpath. This allows us to ignore the ports file so changes won't affect the cache key.