### PR TITLE
add explicit tests for geo_shape with doc values on old indices

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -30,20 +30,14 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.geo.CentroidCalculator;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.GeoShapeCoordinateEncoder;
-import org.elasticsearch.common.geo.GeoTestUtils;
-import org.elasticsearch.common.geo.TriangleTreeReader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.geometry.MultiPoint;
-import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.geometry.Line;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
-import org.elasticsearch.index.fielddata.MultiGeoValues;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
@@ -78,7 +72,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
     protected static int numUniqueGeoPoints;
     protected static GeoPoint[] singleValues, multiValues;
     protected static GeoPoint singleTopLeft, singleBottomRight, multiTopLeft, multiBottomRight,
-        singleCentroid, singleShapeCentroid, multiCentroid, unmappedCentroid, singleShapeTopLeft, singleShapeBottomRight;
+        singleCentroid, singleShapeCentroid, multiCentroid, unmappedCentroid;
     protected static ObjectIntMap<String> expectedDocCountsForGeoHash = null;
     protected static ObjectObjectMap<String, GeoPoint> expectedCentroidsForGeoHash = null;
     protected static final double GEOHASH_TOLERANCE = 1E-5D;
@@ -101,8 +95,6 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
 
         singleTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         singleBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
-        singleShapeTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
-        singleShapeBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
         multiTopLeft = new GeoPoint(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         multiBottomRight = new GeoPoint(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
         singleCentroid = new GeoPoint(0, 0);
@@ -121,16 +113,6 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
             updateBoundsTopLeft(singleValues[i], singleTopLeft);
             updateBoundsBottomRight(singleValues[i], singleBottomRight);
         }
-
-        // update geo_shape geo_bounds value
-        List<Point> points = new ArrayList<>();
-        for (int i = 0; i < singleValues.length; i++) {
-            points.add(new Point(singleValues[i].lon(), singleValues[i].lat()));
-        }
-        TriangleTreeReader reader = GeoTestUtils.triangleTreeReader(new MultiPoint(points), GeoShapeCoordinateEncoder.INSTANCE);
-        MultiGeoValues.BoundingBox box = new MultiGeoValues.GeoShapeValue(reader).boundingBox();
-        singleShapeTopLeft = new GeoPoint(box.maxY(), box.minX());
-        singleShapeBottomRight = new GeoPoint(box.minY(), box.maxX());
 
         multiValues = new GeoPoint[numUniqueGeoPoints];
         for (int i = 0 ; i < multiValues.length; i++)

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
@@ -66,17 +66,16 @@ public class GeoBoundsIT extends AbstractGeoTestCase {
 
     public void test7xIndexWith8Index() {
         SearchResponse response = client().prepareSearch(IDX_NAME_7x, IDX_NAME)
-            .addAggregation(geoBounds(geoShapeAggName).field(SINGLE_VALUED_GEOSHAPE_FIELD_NAME))
-            .get();
+            .addAggregation(geoBounds(geoShapeAggName).field(SINGLE_VALUED_GEOSHAPE_FIELD_NAME).wrapLongitude(false)).get();
         assertThat(response.status(), equalTo(RestStatus.OK));
         assertThat(response.getSuccessfulShards(), lessThan(response.getTotalShards()));
         GeoBounds geoBounds = response.getAggregations().get(geoShapeAggName);
         GeoPoint topLeft = geoBounds.topLeft();
         GeoPoint bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.lat(), closeTo(singleShapeTopLeft.lat(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.lon(), closeTo(singleShapeTopLeft.lon(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.lat(), closeTo(singleShapeBottomRight.lat(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.lon(), closeTo(singleShapeBottomRight.lon(), GEOHASH_TOLERANCE));
+        assertThat(topLeft.lat(), closeTo(singleTopLeft.lat(), GEOHASH_TOLERANCE));
+        assertThat(topLeft.lon(), closeTo(singleTopLeft.lon(), GEOHASH_TOLERANCE));
+        assertThat(bottomRight.lat(), closeTo(singleBottomRight.lat(), GEOHASH_TOLERANCE));
+        assertThat(bottomRight.lon(), closeTo(singleBottomRight.lon(), GEOHASH_TOLERANCE));
     }
 
     public void testSingleValuedField() throws Exception {


### PR DESCRIPTION
This PR adds tests to verify behavior of geo-aggregations on indices that have 
doc-values disabled by default due to an old index version.

the version bounds to 7.x can be updated after merge of `geoshape-doc-values` into master