### PR TITLE
Simplify ml license checking with XpackLicenseState internals (#52684)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.license.License;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -234,21 +233,6 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
 
     public License.OperationMode getLicenseLevel() {
         return licenseLevel;
-    }
-
-    public boolean isAvailableWithLicense(XPackLicenseState licenseState) {
-        // Basic is always true
-        if (licenseLevel.equals(License.OperationMode.BASIC)) {
-            return true;
-        }
-
-        // The model license does not matter, Platinum license gets the same functions as the highest license
-        if (licenseState.isAllowedByLicense(License.OperationMode.PLATINUM)) {
-            return true;
-        }
-
-        // catch the rest, if the license is active and is at least the required model license
-        return licenseState.isAllowedByLicense(licenseLevel, true, false);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -79,8 +79,8 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
         } else {
             trainedModelProvider.getTrainedModel(request.getModelId(), false, ActionListener.wrap(
                 trainedModelConfig -> {
-                    responseBuilder.setLicensed(trainedModelConfig.isAvailableWithLicense(licenseState));
-                    if (trainedModelConfig.isAvailableWithLicense(licenseState) || request.isPreviouslyLicensed()) {
+                    responseBuilder.setLicensed(licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()));
+                    if (licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()) || request.isPreviouslyLicensed()) {
                         this.modelLoadingService.getModel(request.getModelId(), getModelListener);
                     } else {
                         listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));


### PR DESCRIPTION
This change removes TrainedModelConfig#isAvailableWithLicense method with calls to
XPackLicenseState#isAllowedByLicense.

Please note there are subtle changes to the code logic. But they are the right changes:
* Instead of Platinum license, Enterprise license nows guarantees availability.
* No explicit check when the license requirement is basic. Since basic license is always available, this check is unnecessary.
* Trial license is always allowed.