### PR TITLE
Disable ILM history in x-pack rest tests

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -99,6 +99,8 @@ testClusters.integTest {
   setting 'xpack.security.transport.ssl.verification_mode', 'certificate'
   setting 'xpack.security.audit.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
+  // disable ILM history, since it disturbs tests using _all
+  setting 'indices.lifecycle.history_index_enabled', 'false'
   keystore 'bootstrap.password', 'x-pack-test-password'
   keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
 


### PR DESCRIPTION
The ILM history index can be delayed created from one test into the
next, which can cause issues for tests using `_all`.

Closes #52209
