### PR TITLE
[DOCS] Correct guidance for `index_options` mapping parm

### DIFF
--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -2,36 +2,33 @@
 === `index_options`
 
 The `index_options` parameter controls what information is added to the
-inverted index, for search and highlighting purposes.  It accepts the
-following settings:
+inverted index for search and highlighting purposes.
 
-[horizontal]
+[WARNING]
+====
+The `index_options` parameter is intended for use with <<text,`text`>> fields
+only. Avoid using `index_options` with other field datatypes.
+====
+
+It accepts the following values:
+
 `docs`::
-
-    Only the doc number is indexed.  Can answer the question _Does this term
-    exist in this field?_
+Only the doc number is indexed.  Can answer the question _Does this term
+exist in this field?_
 
 `freqs`::
+Doc number and term frequencies are indexed.  Term frequencies are used to
+score repeated terms higher than single terms.
 
-    Doc number and term frequencies are indexed.  Term frequencies are used to
-    score repeated terms higher than single terms.
-
-`positions`::
-
-    Doc number, term frequencies, and term positions (or order) are indexed.
-    Positions can be used for
-    <<query-dsl-match-query-phrase,proximity or phrase queries>>.
+`positions` (default)::
+Doc number, term frequencies, and term positions (or order) are indexed.
+Positions can be used for
+<<query-dsl-match-query-phrase,proximity or phrase queries>>.
 
 `offsets`::
-
-    Doc number, term frequencies, positions, and start and end character
-    offsets (which map the term back to the original string) are indexed.
-    Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
-
-NOTE: <<number,Numeric fields>> don't support the `index_options` parameter any longer.
-
-<<text,`text`>> fields use `positions` as the default, and all other fields use
-`docs` as the default.
+Doc number, term frequencies, positions, and start and end character
+offsets (which map the term back to the original string) are indexed.
+Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Adds a warning admonition stating that the `index_options` mapping
parameter is intended only for `text` fields.

Removes an outdated statement regarding default values for numeric
and other datatypes.

Closes #52777.