### PR TITLE
Update test after backport of #52662

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -447,7 +447,7 @@
                   field: v
                 sort:
                   s: desc
-  - match: { error.root_cause.0.reason: "error building sort for field [s.keyword] of type [keyword] in index [test]: only supported on numeric fields" }
+  - match: { error.root_cause.0.reason: "[top_metrics.size] must not be more than [10] but was [100]. This limit can be set by changing the [index.top_metrics_max_size] index level setting." }
 
   - do:
       indices.put_settings:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -1,9 +1,5 @@
 ---
 "sort by long field":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.0.0 pending"
-
   - do:
       bulk:
         index: test
@@ -60,10 +56,6 @@
 
 ---
 "sort by double field":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.0.0 pending"
-
   - do:
       indices.create:
         index: test
@@ -114,10 +106,6 @@
 
 ---
 "sort by scaled float field":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.0.0 pending"
-
   - do:
       indices.create:
         index: test
@@ -168,10 +156,6 @@
 
 ---
 "sort by keyword field fails":
-  - skip:
-      version: " - 8.0.0"
-      reason: backport to 7.7.0 pending
-
   - do:
       indices.create:
         index: test
@@ -203,10 +187,6 @@
 
 ---
 "sort by score":
-  - skip:
-      version: " - 8.0.0"
-      reason: backport to 7.7.0 pending
-
   - do:
       indices.create:
         index: test
@@ -244,10 +224,6 @@
 
 ---
 "sort by numeric script":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.7.0 pending"
-
   - do:
       bulk:
         index: test
@@ -275,10 +251,6 @@
 
 ---
 "sort by string script fails":
-  - skip:
-      version: " - 8.0.0"
-      reason: backport to 7.7.0 pending
-
   - do:
       indices.create:
         index: test
@@ -314,10 +286,6 @@
 
 ---
 "sort by geo_distance":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.7.0 pending"
-
   - do:
       indices.create:
         index: test
@@ -375,10 +343,6 @@
 
 ---
 "inside terms":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.7.0 pending"
-
   - do:
       indices.create:
         index: test
@@ -451,10 +415,6 @@
 
 ---
 "size is index setting":
-  - skip:
-      version: " - 8.0.0"
-      reason: "backport to 7.0.0 pending"
-
   - do:
       indices.create:
         index: test


### PR DESCRIPTION
Now that #52662 is backported to 7.x we can run the backwards
compatibility tests for top_metrics again.
