### PR TITLE
[7.x] Send the fields param in body instead of URL params

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -718,7 +718,6 @@ final class RequestConverters {
         Params params = new Params();
         params.withRouting(tvrequest.getRouting());
         params.withPreference(tvrequest.getPreference());
-        params.withFields(tvrequest.getFields());
         params.withRealtime(tvrequest.getRealtime());
         request.addParameters(params.asMap());
         request.setEntity(createEntity(tvrequest, REQUEST_BODY_CONTENT_TYPE));

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/TermVectorsRequest.java
@@ -258,6 +258,7 @@ public class TermVectorsRequest implements ToXContentObject, Validatable {
             builder.field("_type", type);
         }
         if (id != null) builder.field("_id", id);
+        if (fields != null) builder.field("fields", fields);
         // set values only when different from defaults
         if (requestPositions == false) builder.field("positions", false);
         if (requestPayloads == false) builder.field("payloads", false);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -1219,14 +1219,18 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 .build();
             String mappings = "\"properties\":{\"field\":{\"type\":\"text\"}, \"field2\":{\"type\":\"text\"}}";
             createIndex(sourceIndex, settings, mappings);
+            final Map<String, String> doc1 = new HashMap<>();
+            doc1.put("field", "value1");
+            doc1.put("field2", "hello world");
+            final Map<String, String> doc2 = new HashMap<>();
+            doc2.put("field", "value2");
+            doc2.put("field2", "foo var");
             assertEquals(
                 RestStatus.OK,
                 highLevelClient().bulk(
                     new BulkRequest()
-                        .add(new IndexRequest(sourceIndex).id("1")
-                            .source(Map.of("field", "value1", "field2", "hello world"), XContentType.JSON))
-                        .add(new IndexRequest(sourceIndex).id("2")
-                            .source(Map.of("field", "value2", "field2", "foo var"), XContentType.JSON))
+                        .add(new IndexRequest(sourceIndex).id("1").source(doc1, XContentType.JSON))
+                        .add(new IndexRequest(sourceIndex).id("2").source(doc2, XContentType.JSON))
                         .setRefreshPolicy(RefreshPolicy.IMMEDIATE),
                     RequestOptions.DEFAULT
                 ).status()
@@ -1288,7 +1292,13 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
             MultiTermVectorsResponse mtvResponse =
                 execute(mtvRequest, highLevelClient()::mtermvectors, highLevelClient()::mtermvectorsAsync);
-            List<List<String>> expectedRespFields = List.of(List.of("field"), List.of("field2"), List.of("field", "field2"));
+            final List<String> expectedFields = new ArrayList<>();
+            expectedFields.add("field");
+            expectedFields.add("field2");
+            List<List<String>> expectedRespFields = new ArrayList<>();
+            expectedRespFields.add(Collections.singletonList("field"));
+            expectedRespFields.add(Collections.singletonList("field2"));
+            expectedRespFields.add(expectedFields);
             List<TermVectorsResponse> responses = mtvResponse.getTermVectorsResponses();
             assertEquals(expectedRespFields.size(), responses.size());
             for (int i = 0; i < responses.size(); i++) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -76,6 +76,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.containsString;
@@ -1216,16 +1217,16 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 .put("number_of_shards", 1)
                 .put("number_of_replicas", 0)
                 .build();
-            String mappings = "\"properties\":{\"field\":{\"type\":\"text\"}}";
+            String mappings = "\"properties\":{\"field\":{\"type\":\"text\"}, \"field2\":{\"type\":\"text\"}}";
             createIndex(sourceIndex, settings, mappings);
             assertEquals(
                 RestStatus.OK,
                 highLevelClient().bulk(
                     new BulkRequest()
                         .add(new IndexRequest(sourceIndex).id("1")
-                            .source(Collections.singletonMap("field", "value1"), XContentType.JSON))
+                            .source(Map.of("field", "value1", "field2", "hello world"), XContentType.JSON))
                         .add(new IndexRequest(sourceIndex).id("2")
-                            .source(Collections.singletonMap("field", "value2"), XContentType.JSON))
+                            .source(Map.of("field", "value2", "field2", "foo var"), XContentType.JSON))
                         .setRefreshPolicy(RefreshPolicy.IMMEDIATE),
                     RequestOptions.DEFAULT
                 ).status()
@@ -1270,5 +1271,35 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             }
         }
 
+        {
+            // test the behavior of fields param
+            MultiTermVectorsRequest mtvRequest = new MultiTermVectorsRequest();
+            TermVectorsRequest tvRequest1 = new TermVectorsRequest(sourceIndex, "1");
+            tvRequest1.setFields("field");
+            mtvRequest.add(tvRequest1);
+
+            TermVectorsRequest tvRequest2 = new TermVectorsRequest(sourceIndex, "2");
+            tvRequest2.setFields("field2");
+            mtvRequest.add(tvRequest2);
+
+            TermVectorsRequest tvRequest3 = new TermVectorsRequest(sourceIndex, "2");
+            tvRequest3.setFields("field", "field2");
+            mtvRequest.add(tvRequest3);
+
+            MultiTermVectorsResponse mtvResponse =
+                execute(mtvRequest, highLevelClient()::mtermvectors, highLevelClient()::mtermvectorsAsync);
+            List<List<String>> expectedRespFields = List.of(List.of("field"), List.of("field2"), List.of("field", "field2"));
+            List<TermVectorsResponse> responses = mtvResponse.getTermVectorsResponses();
+            assertEquals(expectedRespFields.size(), responses.size());
+            for (int i = 0; i < responses.size(); i++) {
+                TermVectorsResponse tvResponse = responses.get(i);
+                assertThat(tvResponse.getIndex(), equalTo(sourceIndex));
+                assertTrue(tvResponse.getFound());
+                assertEquals(expectedRespFields.get(i).size(), tvResponse.getTermVectorsList().size());
+                assertEquals(
+                    expectedRespFields.get(i),
+                    tvResponse.getTermVectorsList().stream().map(tv -> tv.getFieldName()).collect(Collectors.toList()));
+            }
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1575,11 +1575,6 @@ public class RequestConvertersTests extends ESTestCase {
 
         assertEquals(HttpGet.METHOD_NAME, request.getMethod());
         assertEquals(endpoint.toString(), request.getEndpoint());
-        if (hasFields) {
-            assertThat(request.getParameters(), hasKey("fields"));
-            String[] requestFields = Strings.splitStringByCommaToArray(request.getParameters().get("fields"));
-            assertArrayEquals(tvRequest.getFields(), requestFields);
-        }
         for (Map.Entry<String, String> param : expectedParams.entrySet()) {
             assertThat(request.getParameters(), hasEntry(param.getKey(), param.getValue()));
         }


### PR DESCRIPTION
Fixes #42232.

Backport of https://github.com/elastic/elasticsearch/pull/48840.
