### PR TITLE
Exclude generated source from benchmarks formatting

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -64,3 +64,12 @@ thirdPartyAudit.ignoreViolations(
   'org.openjdk.jmh.profile.HotspotRuntimeProfiler',
   'org.openjdk.jmh.util.Utils'
 )
+
+spotless {
+  java {
+    // IDEs can sometimes run annotation processors that leave files in
+    // here, causing Spotless to complain. Even though this path ought not
+    // to exist, exclude it anyway in order to avoid spurious failures.
+    targetExclude 'src/main/generated/**/*.java'
+  }
+}


### PR DESCRIPTION
IDEs can sometimes run annotation processors that leave files in
`src/main/generated/**/*.java`, causing Spotless to complain. Even
though this path ought not to exist, exclude it anyway in order to avoid
spurious failures.