### PR TITLE
Enable parallel builds by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.warning.mode=none
-org.gradle.daemon=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Xss2m
 options.forkOptions.memoryMaximumSize=2g
 


### PR DESCRIPTION
Enable parallel builds by default. The time has come 🚀 

Also, no need to explicitly enable the Gradle daemon since it's been enabled by default since Gradle 3.0.

Closes #49181