### PR TITLE
Add note to CONTRIBUTING.md about REST URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,22 @@ Some tests related to locale testing also require the flag
 IntelliJ or Eclipse like describe above to use
 `-Djava.locale.providers=SPI,COMPAT`.
 
+### REST Endpoint Conventions
+
+Elasticsearch typically uses singular nouns rather than plurals in URLs.
+For example:
+
+    /_ingest/pipline
+    /_ingest/pipline/{id}
+
+but not:
+
+    /_ingest/piplines
+    /_ingest/piplines/{id}
+
+You may find counterexamples, but new endpoints should use the singular
+form.
+
 ### Java Language Formatting Guidelines
 
 Java files in the Elasticsearch codebase are formatted with the Eclipse JDT


### PR DESCRIPTION
Add a note that describes the convention for REST URLs, per [this email](https://github.com/elastic/elasticsearch/pull/28368#issuecomment-373518427).