### PR TITLE
SQL: Issue a different error message in case an index doesn't have a mapping

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -289,7 +289,7 @@ public class IndexResolver {
     public static IndexResolution mergedMappings(DataTypeRegistry typeRegistry, String indexPattern, String[] indexNames,
             Map<String, Map<String, FieldCapabilities>> fieldCaps) {
 
-        if (fieldCaps == null || fieldCaps.isEmpty()) {
+        if (indexNames.length == 0) {
             return IndexResolution.notFound(indexPattern);
         }
 

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/ErrorsTestCase.java
@@ -13,7 +13,9 @@ package org.elasticsearch.xpack.sql.qa;
 public interface ErrorsTestCase {
     void testSelectInvalidSql() throws Exception;
     void testSelectFromMissingIndex() throws Exception;
-    void testSelectFromIndexWithoutTypes() throws Exception;
+    void testSelectColumnFromMissingIndex() throws Exception;
+    void testSelectFromEmptyIndex() throws Exception;
+    void testSelectColumnFromEmptyIndex() throws Exception;
     void testSelectMissingField() throws Exception;
     void testSelectMissingFunction() throws Exception;
     void testSelectProjectScoreInAggContext() throws Exception;

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/cli/ErrorsTestCase.java
@@ -37,15 +37,30 @@ public abstract class ErrorsTestCase extends CliIntegrationTestCase implements o
     }
 
     @Override
-    public void testSelectFromIndexWithoutTypes() throws Exception {
+    public void testSelectColumnFromMissingIndex() throws Exception {
+        assertFoundOneProblem(command("SELECT abc FROM test"));
+        assertEquals("line 1:17: Unknown index [test]" + END, readLine());
+    }
+
+    @Override
+    public void testSelectFromEmptyIndex() throws Exception {
         // Create an index without any types
         Request request = new Request("PUT", "/test");
         request.setJsonEntity("{}");
         client().performRequest(request);
 
         assertFoundOneProblem(command("SELECT * FROM test"));
-        //assertEquals("line 1:15: [test] doesn't have any types so it is incompatible with sql" + END, readLine());
-        assertEquals("line 1:15: Unknown index [test]" + END, readLine());
+        assertEquals("line 1:8: Cannot determine columns for [*]" + END, readLine());
+    }
+
+    @Override
+    public void testSelectColumnFromEmptyIndex() throws Exception {
+        Request request = new Request("PUT", "/test");
+        request.setJsonEntity("{}");
+        client().performRequest(request);
+        
+        assertFoundOneProblem(command("SELECT abc FROM test"));
+        assertEquals("line 1:8: Unknown column [abc]" + END, readLine());
     }
 
     @Override

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -317,16 +317,28 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
     }
 
     @Override
-    public void testSelectFromIndexWithoutTypes() throws Exception {
+    public void testSelectColumnFromMissingIndex() throws Exception {
+        String mode = randomFrom("jdbc", "plain");
+        expectBadRequest(() -> runSql(mode, "SELECT abc FROM missing"), containsString("1:17: Unknown index [missing]"));
+    }
+
+    @Override
+    public void testSelectFromEmptyIndex() throws Exception {
         // Create an index without any types
         Request request = new Request("PUT", "/test");
         request.setJsonEntity("{}");
         client().performRequest(request);
         String mode = randomFrom("jdbc", "plain");
-        expectBadRequest(() -> runSql(mode, "SELECT * FROM test"),
-                // see https://github.com/elastic/elasticsearch/issues/34719
-            //containsString("1:15: [test] doesn't have any types so it is incompatible with sql"));
-            containsString("1:15: Unknown index [test]"));
+        expectBadRequest(() -> runSql(mode, "SELECT * FROM test"), containsString("1:8: Cannot determine columns for [*]"));
+    }
+
+    @Override
+    public void testSelectColumnFromEmptyIndex() throws Exception {
+        Request request = new Request("PUT", "/test");
+        request.setJsonEntity("{}");
+        client().performRequest(request);
+        String mode = randomFrom("jdbc", "plain");
+        expectBadRequest(() -> runSql(mode, "SELECT abc FROM test"), containsString("1:8: Unknown column [abc]"));
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/52967