### PR TITLE
Increase timeout testFollowIndexMaxOperationSizeInBytes

### DIFF
--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/IndexFollowingIT.java
@@ -605,7 +605,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
         }
 
         PutFollowAction.Request followRequest = putFollow("index1", "index2");
-        followRequest.getParameters().setMaxReadRequestSize(new ByteSizeValue(1, ByteSizeUnit.BYTES));
+        followRequest.getParameters().setMaxReadRequestSize(new ByteSizeValue(randomIntBetween(1, 1024), ByteSizeUnit.BYTES));
         followerClient().execute(PutFollowAction.INSTANCE, followRequest).get();
 
         final Map<ShardId, Long> firstBatchNumDocsPerShard = new HashMap<>();
@@ -618,7 +618,7 @@ public class IndexFollowingIT extends CcrIntegTestCase {
             }
         }
 
-        assertBusy(assertTask(1, firstBatchNumDocsPerShard));
+        assertBusy(assertTask(1, firstBatchNumDocsPerShard), 60, TimeUnit.SECONDS);
         for (int i = 0; i < numDocs; i++) {
             assertBusy(assertExpectedDocumentRunnable(i));
         }


### PR DESCRIPTION
```
max_read_request_size":"1b",
    Expected: <998L>
         but: was <625L>
```

Replicating 998 documents one by one (as we cap the request size at 1 byte) can take more than 10 seconds on a slow CI.

Closes #52812