### PR TITLE
Add ObjectParser.declareNamedObject (singular) method

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/AbstractObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/AbstractObjectParser.java
@@ -48,6 +48,31 @@ public abstract class AbstractObjectParser<Value, Context>
             ValueType type);
 
     /**
+     * Declares a single named object.
+     *
+     * <pre>
+     * <code>
+     * {
+     *   "object_name": {
+     *     "instance_name": { "field1": "value1", ... }
+     *     }
+     *   }
+     * }
+     * </code>
+     * </pre>
+     *
+     * @param consumer
+     *            sets the value once it has been parsed
+     * @param namedObjectParser
+     *            parses the named object
+     * @param parseField
+     *            the field to parse
+     */
+    public abstract <T> void declareNamedObject(BiConsumer<Value, T> consumer, NamedObjectParser<T, Context> namedObjectParser,
+                                                 ParseField parseField);
+
+
+    /**
      * Declares named objects in the style of aggregations. These are named
      * inside and object like this:
      *


### PR DESCRIPTION
Add the method `AbstractObjectParser.declareNamedObject` (singular) to complement the existing `declareNamedObjects` (plural). This is a convenience to avoid hacking around with `declareNamedObject*s*`.

Also a small refactoring to avoid duplicated code in `ConstructingObjectParser.declareNamedObject..` methods.