### PR TITLE
Backport better ES startup checks for test040CreateKeystoreManually

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -156,9 +156,7 @@ public class DockerTests extends PackagingTestCase {
         // Move the auto-created one out of the way, or else the CLI prompts asks us to confirm
         sh.run("mv " + keystorePath + " " + keystorePathBackup);
 
-        waitForPathToExist(keystorePathBackup);
         sh.run(bin.keystoreTool + " create");
-        waitForPathToExist(keystorePath);
 
         final Result r = sh.run(bin.keystoreTool + " list");
         assertThat(r.stdout, containsString("keystore.seed"));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -149,13 +149,16 @@ public class DockerTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
 
         final Path keystorePath = installation.config("elasticsearch.keystore");
+        final Path keystorePathBackup = installation.config("elasticsearch.keystore.bak");
 
         waitForPathToExist(keystorePath);
 
         // Move the auto-created one out of the way, or else the CLI prompts asks us to confirm
-        sh.run("mv " + keystorePath + " " + keystorePath + ".bak");
+        sh.run("mv " + keystorePath + " " + keystorePathBackup);
 
+        waitForPathToExist(keystorePathBackup);
         sh.run(bin.keystoreTool + " create");
+        waitForPathToExist(keystorePath);
 
         final Result r = sh.run(bin.keystoreTool + " list");
         assertThat(r.stdout, containsString("keystore.seed"));

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -180,9 +180,9 @@ public class Docker {
                 // Give the container a chance to crash out
                 Thread.sleep(1000);
 
-                psOutput = dockerShell.run("ps -w ax").stdout;
+                psOutput = dockerShell.run("ps -ww ax").stdout;
 
-                if (psOutput.contains("/usr/share/elasticsearch/jdk/bin/java")) {
+                if (psOutput.contains("org.elasticsearch.bootstrap.Elasticsearch")) {
                     isElasticsearchRunning = true;
                     break;
                 }


### PR DESCRIPTION
This test got moved to `KeystoreManagementTests` and significantly restructured on the 7.x and master branches. It doesn't seem to be causing trouble there. Back here on 7.6, it's been failing unpredictably - see #51316 for details.

I looked at the difference between what's happening in 7.6 and what's happening on master, and the difference seems to be more waiting for files to be available, especially after we create a keystore: https://github.com/elastic/elasticsearch/blob/master/qa/os/src/test/java/org/elasticsearch/packaging/test/KeystoreManagementTests.java#L391

This PR brings 7.6 into line with the other branches, despite the different structure of the tests.