### PR TITLE
Early return if no global checkpoint listeners

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
@@ -195,6 +195,11 @@ public class GlobalCheckpointListeners implements Closeable {
         assert Thread.holdsLock(this) : Thread.currentThread();
         assertNotification(globalCheckpoint, e);
 
+        // early return if there are no listeners
+        if (listeners.isEmpty()) {
+            return;
+        }
+
         final Map<GlobalCheckpointListener, Tuple<Long, ScheduledFuture<?>>> listenersToNotify;
         if (globalCheckpoint != UNASSIGNED_SEQ_NO) {
             listenersToNotify =


### PR DESCRIPTION
When notifying global checkpoint listeners, we have an opportunity to early return if there are not any registered listeners. This is important since it saves some allocations, and also saves forking some empty work to another thread. This commit adds an early return from notifying listeners if there are not any registered.
