### PR TITLE
Backport: simplify watcher indexing listener.

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -114,18 +114,20 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         verifyZeroInteractions(parser);
     }
 
-    public void testPreIndex() throws Exception {
+    public void testPostIndex() throws Exception {
         when(operation.id()).thenReturn(randomAlphaOfLength(10));
         when(operation.source()).thenReturn(BytesArray.EMPTY);
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
+        List<Engine.Result.Type> types = new ArrayList<>(Arrays.asList(Engine.Result.Type.values()));
+        types.remove(Engine.Result.Type.FAILURE);
+        when(result.getResultType()).thenReturn(randomFrom(types));
 
         boolean watchActive = randomBoolean();
         boolean isNewWatch = randomBoolean();
         Watch watch = mockWatch("_id", watchActive, isNewWatch);
         when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong())).thenReturn(watch);
 
-        Engine.Index returnedOperation = listener.preIndex(shardId, operation);
-        assertThat(returnedOperation, is(operation));
+        listener.postIndex(shardId, operation, result);
         ZonedDateTime now = DateUtils.nowWithMillisResolution(clock);
         verify(parser).parseWithSecrets(eq(operation.id()), eq(true), eq(BytesArray.EMPTY), eq(now), anyObject(), anyLong(), anyLong());
 
@@ -140,12 +142,13 @@ public class WatcherIndexingListenerTests extends ESTestCase {
 
     // this test emulates an index with 10 shards, and ensures that triggering only happens on a
     // single shard
-    public void testPreIndexWatchGetsOnlyTriggeredOnceAcrossAllShards() throws Exception {
+    public void testPostIndexWatchGetsOnlyTriggeredOnceAcrossAllShards() throws Exception {
         String id = randomAlphaOfLength(10);
         int totalShardCount = randomIntBetween(1, 10);
         boolean watchActive = randomBoolean();
         boolean isNewWatch = randomBoolean();
         Watch watch = mockWatch(id, watchActive, isNewWatch);
+        when(result.getResultType()).thenReturn(Engine.Result.Type.SUCCESS);
 
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
         when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong())).thenReturn(watch);
@@ -155,7 +158,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
             localShards.put(shardId, new ShardAllocationConfiguration(idx, totalShardCount, Collections.emptyList()));
             Configuration configuration = new Configuration(Watch.INDEX, localShards);
             listener.setConfiguration(configuration);
-            listener.preIndex(shardId, operation);
+            listener.postIndex(shardId, operation, result);
         }
 
         // no matter how many shards we had, this should have been only called once
@@ -187,16 +190,17 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         return watch;
     }
 
-    public void testPreIndexCheckParsingException() throws Exception {
+    public void testPostIndexCheckParsingException() throws Exception {
         String id = randomAlphaOfLength(10);
         when(operation.id()).thenReturn(id);
         when(operation.source()).thenReturn(BytesArray.EMPTY);
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
         when(parser.parseWithSecrets(anyObject(), eq(true), anyObject(), anyObject(), anyObject(), anyLong(), anyLong()))
                 .thenThrow(new IOException("self thrown"));
+        when(result.getResultType()).thenReturn(Engine.Result.Type.SUCCESS);
 
         ElasticsearchParseException exc = expectThrows(ElasticsearchParseException.class,
-                () -> listener.preIndex(shardId, operation));
+                () -> listener.postIndex(shardId, operation, result));
         assertThat(exc.getMessage(), containsString("Could not parse watch"));
         assertThat(exc.getMessage(), containsString(id));
     }
@@ -204,19 +208,6 @@ public class WatcherIndexingListenerTests extends ESTestCase {
     public void testPostIndexRemoveTriggerOnDocumentRelatedException() throws Exception {
         when(operation.id()).thenReturn("_id");
         when(result.getResultType()).thenReturn(Engine.Result.Type.FAILURE);
-        when(result.getFailure()).thenReturn(new RuntimeException());
-        when(shardId.getIndexName()).thenReturn(Watch.INDEX);
-
-        listener.postIndex(shardId, operation, result);
-        verify(triggerService).remove(eq("_id"));
-    }
-
-    public void testPostIndexRemoveTriggerOnDocumentRelatedException_ignoreOtherEngineResultTypes() throws Exception {
-        List<Engine.Result.Type> types = new ArrayList<>(Arrays.asList(Engine.Result.Type.values()));
-        types.remove(Engine.Result.Type.FAILURE);
-
-        when(operation.id()).thenReturn("_id");
-        when(result.getResultType()).thenReturn(randomFrom(types));
         when(result.getFailure()).thenReturn(new RuntimeException());
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
 
@@ -239,7 +230,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
         when(shardId.getIndexName()).thenReturn(Watch.INDEX);
 
         listener.postIndex(shardId, operation, new ElasticsearchParseException("whatever"));
-        verify(triggerService).remove(eq("_id"));
+        verifyZeroInteractions(triggerService);
     }
 
     public void testPostIndexRemoveTriggerOnEngineLevelException_ignoreNonWatcherDocument() throws Exception {


### PR DESCRIPTION
Backport: #52627

Add watcher to trigger server after index operation has succeeded,
instead of adding a watch to trigger service before
the actual index operation has performed on the shard level.

This logic is simpler to reason about in the case that a failure
does occur during the execution of an index operation on
the shard level.

Relates to #52453, but I think doesn't fix it, but makes it easier
to debug.