### PR TITLE
Enable bw tests with 7.x for #49713

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
@@ -1,7 +1,7 @@
 setup:
 
   - skip:
-      version: " - 7.99.99" # TODO: make it 7.6.99 after backport
+      version: " - 7.6.99"
       reason: "constant_keyword was added in 7.7"
 
   - do:


### PR DESCRIPTION
These tests can be enabled now that the change has been backported.
