### PR TITLE
Disable BWC tests for backport of #52385

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,8 +219,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/52385" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
The system index module for Kibana has been merged to master in #52385
and is being backported to 7.x in #53035, which requires changes to the
serialization version. In order to avoid build failures, this commit
disables bwc tests. A subsequent commit will re-enable these tests.