### PR TITLE
Fix LocalIndicesCleanerTests with hidden index

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/local/LocalIndicesCleanerTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/local/LocalIndicesCleanerTests.java
@@ -57,12 +57,11 @@ public class LocalIndicesCleanerTests extends AbstractIndicesCleanerTestCase {
             //so when es core gets the request with the explicit index name, it throws an index not found exception as that index
             //doesn't exist anymore. If we ignore unavailable instead no error will be thrown.
             GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings()
-                    .setIndicesOptions(IndicesOptions.fromOptions(true, true, true, true)).get();
+                    .setIndicesOptions(IndicesOptions.fromOptions(true, true, true, true, true)).get();
             assertThat(getSettingsResponse.getIndexToSettings().size(), equalTo(count));
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/53025")
     public void testHandlesWatcherHistory() throws Exception {
         internalCluster().startNode();
 


### PR DESCRIPTION
The LocalIndicesCleanerTests#testHandlesWatcherHistory creates random
watch history indices with a version of 1-20. When the version is 11,
this matches the existing watch history template that has the
index.hidden setting set to true and the check for indices in this test
did not include hidden indices. The change here updates the indices
options to include hidden indices.

Closes #53025