### PR TITLE
[DOCS] Adds link in datafeed indices_options

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -761,7 +761,9 @@ not be set to `false` on any {ml} nodes.
 end::indices[]
 
 tag::indices-options[]
-Object specifying index expansion options used during search.
+Specifies index expansion options that are used during search.
++
+--
 For example:
 ```
 {
@@ -771,6 +773,8 @@ For example:
    "ignore_throttled": true
 }
 ```
+For more information about these options, see <<multi-index>>.
+--
 end::indices-options[]
 
 tag::influencers[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/52793 and https://github.com/elastic/elasticsearch/pull/53063

This PR adds a link from the indices_option in create and update datafeed APIs to the list of index option definitions in https://www.elastic.co/guide/en/elasticsearch/reference/master/multi-index.html