### PR TITLE
Rename "username" to "name" in SetSecurityUserProcessor

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessor.java
@@ -66,7 +66,7 @@ public final class SetSecurityUserProcessor extends AbstractProcessor {
             switch (property) {
                 case USERNAME:
                     if (user.principal() != null) {
-                        userObject.put("username", user.principal());
+                        userObject.put("name", user.principal());
                     }
                     break;
                 case FULL_NAME:


### PR DESCRIPTION
Rename the "username" field of the user object to "name" in order to conform to the [ECS](https://www.elastic.co/guide/en/ecs/current/ecs-user.html#_user_field_details) [#51799](https://github.com/elastic/elasticsearch/issues/51799)

