### PR TITLE
[DOCS] Update EQL default event category and timestamp values

### DIFF
--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -27,7 +27,7 @@ In {es}, EQL assumes each document in an index corresponds to an event.
 To search an index using EQL, each document in the index must contain the
 following field archetypes:
 
-Event type::
+Event category::
 A field containing the event classification, such as `process`, `file`, or
 `network`. This is typically mapped as a <<keyword,`keyword`>> field.
 

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -17,10 +17,14 @@ The following <<docs-bulk,bulk API>> request adds some example log data to the
 ----
 PUT sec_logs/_bulk?refresh
 {"index":{"_index" : "sec_logs", "_id" : "1"}}
-{ "@timestamp": "2020-12-07T11:06:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process" }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
+{ "@timestamp": "2020-12-06T11:04:05.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process" }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
 {"index":{"_index" : "sec_logs", "_id" : "2"}}
-{ "@timestamp": "2020-12-07T11:07:08.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file" }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
+{ "@timestamp": "2020-12-06T11:04:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file" }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
 {"index":{"_index" : "sec_logs", "_id" : "3"}}
+{ "@timestamp": "2020-12-07T11:06:07.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process" }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{"_index" : "sec_logs", "_id" : "4"}}
+{ "@timestamp": "2020-12-07T11:07:08.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "file" }, "file": { "accessed": "2020-12-07T11:07:08.000Z", "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe", "type": "file", "size": 16384 }, "process": { "name": "cmd.exe", "path": "C:\\Windows\\System32\\cmd.exe" } }
+{"index":{"_index" : "sec_logs", "_id" : "5"}}
 { "@timestamp": "2020-12-07T11:07:09.000Z", "agent": { "id": "8a4f500d" }, "event": { "category": "process" }, "process": { "name": "regsvr32.exe", "path": "C:\\Windows\\System32\\regsvr32.exe" } }
 ----
 // TESTSETUP
@@ -45,22 +49,45 @@ Because the `sec_log` index follows the ECS, you don't need to specify the
 required <<eql-required-fields,event category or timestamp>> fields. The request
 uses the `event.category` and `@timestamp` fields by default.
 
-The API returns the following response containing the matching event:
+The API returns the following response containing the matching events. Events
+in the response are sorted by timestamp, converted to milliseconds since the
+https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
 
 [source,console-result]
 ----
 {
-  "took": 3,
+  "took": 60,
   "timed_out": false,
   "hits": {
     "total": {
-      "value": 1,
+      "value": 2,
       "relation": "eq"
     },
     "events": [
       {
         "_index": "sec_logs",
         "_id": "1",
+        "_score": null,
+        "_source": {
+          "@timestamp": "2020-12-06T11:04:05.000Z",
+          "agent": {
+            "id": "8a4f500d"
+          },
+          "event": {
+            "category": "process"
+          },
+          "process": {
+            "name": "cmd.exe",
+            "path": "C:\\Windows\\System32\\cmd.exe"
+          }
+        },
+        "sort": [
+          1607252645000
+        ]
+      },
+      {
+        "_index": "sec_logs",
+        "_id": "3",
         "_score": null,
         "_source": {
           "@timestamp": "2020-12-07T11:06:07.000Z",
@@ -75,13 +102,15 @@ The API returns the following response containing the matching event:
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
         },
-        "sort" : [1607339167000]
+        "sort": [
+          1607339167000
+        ]
       }
     ]
   }
 }
 ----
-// TESTRESPONSE[s/"took": 3/"took": $body.took/]
+// TESTRESPONSE[s/"took": 60/"took": $body.took/]
 
 [discrete]
 [[eql-search-specify-event-category-field]]

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -35,8 +35,6 @@ specified in the `query` parameter. The EQL query matches events with an
 ----
 GET sec_logs/_eql/search
 {
-  "event_category_field": "event.category",
-  "timestamp_field": "@timestamp",
   "query": """
     process where process.name == "cmd.exe"
   """
@@ -44,7 +42,8 @@ GET sec_logs/_eql/search
 ----
 
 Because the `sec_log` index follows the ECS, you don't need to specify the
-timestamp field. The request uses the `@timestamp` field by default.
+required <<eql-required-fields,event category or timestamp>> fields. The request
+uses the `event.category` and `@timestamp` fields by default.
 
 The API returns the following response containing the matching event:
 
@@ -85,22 +84,21 @@ The API returns the following response containing the matching event:
 // TESTRESPONSE[s/"took": 3/"took": $body.took/]
 
 [discrete]
-[[eql-search-specify-event-type-field]]
-=== Specify an event type field
+[[eql-search-specify-event-category-field]]
+=== Specify an event category field
 
-The EQL search API uses `event.category` as the required <<eql-required-fields,event
-category field>> by default. You can use the `event_category_field` parameter to specify
-another event category field.
+The EQL search API uses `event.category` as the required
+<<eql-required-fields,event category field>> by default. You can use the
+`event_category_field` parameter to specify another event category field.
 
-For example, the following request specifies `file.type` as the event type
+For example, the following request specifies `file.type` as the event category
 field.
 
 [source,console]
 ----
 GET sec_logs/_eql/search
 {
-  "event_category_field": "file.type",
-  "timestamp_field": "@timestamp",
+   "event_category_field": "file.type",
   "query": """
     file where agent.id == "8a4f500d"
   """
@@ -123,7 +121,6 @@ timestamp field.
 GET sec_logs/_eql/search
 {
   "timestamp_field": "file.accessed",
-  "event_category_field": "event.category",
   "query": """
     file where (file.size > 1 and file.type == "file")
   """
@@ -147,8 +144,6 @@ filtered documents.
 ----
 GET sec_logs/_eql/search
 {
-  "event_category_field": "event.category",
-  "timestamp_field": "@timestamp",
   "filter": {
     "range" : {
       "file.size" : {


### PR DESCRIPTION
Updates the documented default `event_category_field` and `timestamp_field`
values for the EQL search API. Also updates related guidance in the
EQL requirement docs.

Relates to #53073.