### PR TITLE
Serialize NodesInfoRequest as a set of strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,8 +219,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/53140" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -35,43 +35,51 @@ import java.util.stream.Collectors;
  */
 public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
-    private Set<String> infoSections = new TreeSet<>(Metrics.allMetrics());
+    private Set<String> requestedMetrics = new TreeSet<>(Metrics.allMetrics());
 
+    /**
+     * Create a new NodeInfoRequest from a {@link StreamInput} object.
+     *
+     * @param in A stream input object.
+     * @throws IOException if the stream cannot be deserialized.
+     */
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
-        infoSections.clear();
+        requestedMetrics.clear();
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            infoSections.addAll(Arrays.asList(in.readStringArray()));
+            requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
         } else {
+            // prior to version 8.x, a NodesInfoRequest was serialized as a list
+            // of booleans in a fixed order
             if (in.readBoolean()) {
-                infoSections.add(Metrics.SETTINGS.metricName());
+                requestedMetrics.add(Metrics.SETTINGS.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.OS.metricName());
+                requestedMetrics.add(Metrics.OS.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.PROCESS.metricName());
+                requestedMetrics.add(Metrics.PROCESS.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.JVM.metricName());
+                requestedMetrics.add(Metrics.JVM.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.THREAD_POOL.metricName());
+                requestedMetrics.add(Metrics.THREAD_POOL.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.TRANSPORT.metricName());
+                requestedMetrics.add(Metrics.TRANSPORT.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.HTTP.metricName());
+                requestedMetrics.add(Metrics.HTTP.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.PLUGINS.metricName());
+                requestedMetrics.add(Metrics.PLUGINS.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.INGEST.metricName());
+                requestedMetrics.add(Metrics.INGEST.metricName());
             }
             if (in.readBoolean()) {
-                infoSections.add(Metrics.INDICES.metricName());
+                requestedMetrics.add(Metrics.INDICES.metricName());
             }
         }
     }
@@ -89,7 +97,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Clears all info flags.
      */
     public NodesInfoRequest clear() {
-        infoSections.clear();
+        requestedMetrics.clear();
         return this;
     }
 
@@ -97,7 +105,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Sets to return all the data.
      */
     public NodesInfoRequest all() {
-        infoSections.addAll(Arrays.stream(Metrics.values()).map(Metrics::metricName).collect(Collectors.toSet()));
+        requestedMetrics.addAll(Arrays.stream(Metrics.values()).map(Metrics::metricName).collect(Collectors.toSet()));
         return this;
     }
 
@@ -105,14 +113,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node settings be returned.
      */
     public boolean settings() {
-        return infoSections.contains(Metrics.SETTINGS.metricName());
+        return Metrics.SETTINGS.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node settings be returned.
      */
     public NodesInfoRequest settings(boolean settings) {
-        setSection(settings, Metrics.SETTINGS.metricName());
+        addOrRemoveMetric(settings, Metrics.SETTINGS.metricName());
         return this;
     }
 
@@ -120,14 +128,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node OS be returned.
      */
     public boolean os() {
-        return infoSections.contains(Metrics.OS.metricName());
+        return Metrics.OS.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node OS be returned.
      */
     public NodesInfoRequest os(boolean os) {
-        setSection(os, Metrics.OS.metricName());
+        addOrRemoveMetric(os, Metrics.OS.metricName());
         return this;
     }
 
@@ -135,14 +143,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node Process be returned.
      */
     public boolean process() {
-        return infoSections.contains(Metrics.PROCESS.metricName());
+        return Metrics.PROCESS.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node Process be returned.
      */
     public NodesInfoRequest process(boolean process) {
-        setSection(process, Metrics.PROCESS.metricName());
+        addOrRemoveMetric(process, Metrics.PROCESS.metricName());
         return this;
     }
 
@@ -150,14 +158,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node JVM be returned.
      */
     public boolean jvm() {
-        return infoSections.contains(Metrics.JVM.metricName());
+        return Metrics.JVM.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node JVM be returned.
      */
     public NodesInfoRequest jvm(boolean jvm) {
-        setSection(jvm, Metrics.JVM.metricName());
+        addOrRemoveMetric(jvm, Metrics.JVM.metricName());
         return this;
     }
 
@@ -165,14 +173,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node Thread Pool info be returned.
      */
     public boolean threadPool() {
-        return infoSections.contains(Metrics.THREAD_POOL.metricName());
+        return Metrics.THREAD_POOL.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node Thread Pool info be returned.
      */
     public NodesInfoRequest threadPool(boolean threadPool) {
-        setSection(threadPool, Metrics.THREAD_POOL.metricName());
+        addOrRemoveMetric(threadPool, Metrics.THREAD_POOL.metricName());
         return this;
     }
 
@@ -180,14 +188,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node Transport be returned.
      */
     public boolean transport() {
-        return infoSections.contains(Metrics.TRANSPORT.metricName());
+        return Metrics.TRANSPORT.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node Transport be returned.
      */
     public NodesInfoRequest transport(boolean transport) {
-        setSection(transport, Metrics.TRANSPORT.metricName());
+        addOrRemoveMetric(transport, Metrics.TRANSPORT.metricName());
         return this;
     }
 
@@ -195,14 +203,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node HTTP be returned.
      */
     public boolean http() {
-        return infoSections.contains(Metrics.HTTP.metricName());
+        return Metrics.HTTP.containedIn(requestedMetrics);
     }
 
     /**
      * Should the node HTTP be returned.
      */
     public NodesInfoRequest http(boolean http) {
-        setSection(http, Metrics.HTTP.metricName());
+        addOrRemoveMetric(http, Metrics.HTTP.metricName());
         return this;
     }
 
@@ -212,7 +220,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return The request
      */
     public NodesInfoRequest plugins(boolean plugins) {
-        setSection(plugins, Metrics.PLUGINS.metricName());
+        addOrRemoveMetric(plugins, Metrics.PLUGINS.metricName());
         return this;
     }
 
@@ -220,7 +228,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return true if information about plugins is requested
      */
     public boolean plugins() {
-        return infoSections.contains(Metrics.PLUGINS.metricName());
+        return Metrics.PLUGINS.containedIn(requestedMetrics);
     }
 
     /**
@@ -228,7 +236,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @param ingest true if you want info
      */
     public NodesInfoRequest ingest(boolean ingest) {
-        setSection(ingest, Metrics.INGEST.metricName());
+        addOrRemoveMetric(ingest, Metrics.INGEST.metricName());
         return this;
     }
 
@@ -236,7 +244,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return true if information about ingest is requested
      */
     public boolean ingest() {
-        return infoSections.contains(Metrics.INGEST.metricName());
+        return Metrics.INGEST.containedIn(requestedMetrics);
     }
 
     /**
@@ -244,7 +252,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @param indices true if you want info
      */
     public NodesInfoRequest indices(boolean indices) {
-        setSection(indices, Metrics.INDICES.metricName());
+        addOrRemoveMetric(indices, Metrics.INDICES.metricName());
         return this;
     }
 
@@ -252,14 +260,19 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return true if information about indices (currently just indexing buffers)
      */
     public boolean indices() {
-        return infoSections.contains(Metrics.INDICES.metricName());
+        return Metrics.INDICES.containedIn(requestedMetrics);
     }
 
-    private void setSection(boolean includeSection, String sectionName) {
-        if (includeSection) {
-            infoSections.add(sectionName);
+    /**
+     * Helper method for adding and removing metrics.
+     * @param includeMetric Whether or not to include a metric.
+     * @param metricName Name of the metric to include or remove.
+     */
+    private void addOrRemoveMetric(boolean includeMetric, String metricName) {
+        if (includeMetric) {
+            requestedMetrics.add(metricName);
         } else {
-            infoSections.remove(sectionName);
+            requestedMetrics.remove(metricName);
         }
     }
 
@@ -267,21 +280,28 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeStringArray(infoSections.toArray(String[]::new));
+            out.writeStringArray(requestedMetrics.toArray(String[]::new));
         } else {
-            out.writeBoolean(infoSections.contains(Metrics.SETTINGS.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.OS.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.PROCESS.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.JVM.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.THREAD_POOL.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.TRANSPORT.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.HTTP.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.PLUGINS.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.INGEST.metricName()));
-            out.writeBoolean(infoSections.contains(Metrics.INDICES.metricName()));
+            // prior to version 8.x, a NodesInfoRequest was serialized as a list
+            // of booleans in a fixed order
+            out.writeBoolean(requestedMetrics.contains(Metrics.SETTINGS.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.OS.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.PROCESS.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.JVM.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.THREAD_POOL.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.TRANSPORT.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.HTTP.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.PLUGINS.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.INGEST.metricName()));
+            out.writeBoolean(requestedMetrics.contains(Metrics.INDICES.metricName()));
         }
     }
 
+    /**
+     * An enumeration of the "core" sections of metrics that may be requested
+     * from the nodes information endpoint. Eventually this list list will be
+     * pluggable.
+     */
     enum Metrics {
         SETTINGS("settings"),
         OS("os"),
@@ -302,6 +322,10 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
         String metricName() {
             return this.metricName;
+        }
+
+        boolean containedIn(Set<String> metricNames) {
+            return metricNames.contains(this.metricName());
         }
 
         static Set<String> allMetrics() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -34,10 +34,11 @@ import java.util.stream.Collectors;
  */
 public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
-    private Set<String> infoSections = new TreeSet<>();
+    private Set<String> infoSections = new TreeSet<>(Metrics.allMetrics());
 
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
+        infoSections.clear();
         infoSections.addAll(Arrays.asList(in.readStringArray()));
     }
 
@@ -47,6 +48,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      */
     public NodesInfoRequest(String... nodesIds) {
         super(nodesIds);
+        all();
     }
 
     /**
@@ -253,6 +255,10 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
         String metricName() {
             return this.metricName;
+        }
+
+        static Set<String> allMetrics() {
+            return Arrays.stream(values()).map(Metrics::metricName).collect(Collectors.toSet());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -45,7 +45,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
         requestedMetrics.clear();
-        if (in.getVersion().before(Version.V_8_0_0)){
+        if (in.getVersion().before(Version.V_7_7_0)){
             // prior to version 8.x, a NodesInfoRequest was serialized as a list
             // of booleans in a fixed order
             addOrRemoveMetric(in.readBoolean(), Metrics.SETTINGS.metricName());
@@ -258,7 +258,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_8_0_0)){
+        if (out.getVersion().before(Version.V_7_7_0)){
             // prior to version 8.x, a NodesInfoRequest was serialized as a list
             // of booleans in a fixed order
             out.writeBoolean(Metrics.SETTINGS.containedIn(requestedMetrics));

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -46,9 +46,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
         requestedMetrics.clear();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
-        } else {
+        if (in.getVersion().before(Version.V_8_0_0)){
             // prior to version 8.x, a NodesInfoRequest was serialized as a list
             // of booleans in a fixed order
             if (in.readBoolean()) {
@@ -81,6 +79,8 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
             if (in.readBoolean()) {
                 requestedMetrics.add(Metrics.INDICES.metricName());
             }
+        } else {
+            requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
         }
     }
 
@@ -279,9 +279,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeStringArray(requestedMetrics.toArray(String[]::new));
-        } else {
+        if (out.getVersion().before(Version.V_8_0_0)){
             // prior to version 8.x, a NodesInfoRequest was serialized as a list
             // of booleans in a fixed order
             out.writeBoolean(requestedMetrics.contains(Metrics.SETTINGS.metricName()));
@@ -294,6 +292,8 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
             out.writeBoolean(requestedMetrics.contains(Metrics.PLUGINS.metricName()));
             out.writeBoolean(requestedMetrics.contains(Metrics.INGEST.metricName()));
             out.writeBoolean(requestedMetrics.contains(Metrics.INDICES.metricName()));
+        } else {
+            out.writeStringArray(requestedMetrics.toArray(String[]::new));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -35,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
-    private Set<String> requestedMetrics = new TreeSet<>(Metrics.allMetrics());
+    private Set<String> requestedMetrics = Metrics.allMetrics();
 
     /**
      * Create a new NodeInfoRequest from a {@link StreamInput} object.
@@ -49,36 +48,16 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
         if (in.getVersion().before(Version.V_8_0_0)){
             // prior to version 8.x, a NodesInfoRequest was serialized as a list
             // of booleans in a fixed order
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.SETTINGS.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.OS.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.PROCESS.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.JVM.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.THREAD_POOL.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.TRANSPORT.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.HTTP.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.PLUGINS.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.INGEST.metricName());
-            }
-            if (in.readBoolean()) {
-                requestedMetrics.add(Metrics.INDICES.metricName());
-            }
+            addOrRemoveMetric(in.readBoolean(), Metrics.SETTINGS.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.OS.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.PROCESS.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.JVM.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.THREAD_POOL.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.TRANSPORT.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.HTTP.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.PLUGINS.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.INGEST.metricName());
+            addOrRemoveMetric(in.readBoolean(), Metrics.INDICES.metricName());
         } else {
             requestedMetrics.addAll(Arrays.asList(in.readStringArray()));
         }
@@ -105,7 +84,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Sets to return all the data.
      */
     public NodesInfoRequest all() {
-        requestedMetrics.addAll(Arrays.stream(Metrics.values()).map(Metrics::metricName).collect(Collectors.toSet()));
+        requestedMetrics.addAll(Metrics.allMetrics());
         return this;
     }
 
@@ -282,16 +261,16 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
         if (out.getVersion().before(Version.V_8_0_0)){
             // prior to version 8.x, a NodesInfoRequest was serialized as a list
             // of booleans in a fixed order
-            out.writeBoolean(requestedMetrics.contains(Metrics.SETTINGS.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.OS.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.PROCESS.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.JVM.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.THREAD_POOL.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.TRANSPORT.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.HTTP.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.PLUGINS.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.INGEST.metricName()));
-            out.writeBoolean(requestedMetrics.contains(Metrics.INDICES.metricName()));
+            out.writeBoolean(Metrics.SETTINGS.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.OS.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.PROCESS.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.JVM.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.THREAD_POOL.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.TRANSPORT.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.HTTP.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.PLUGINS.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.INGEST.containedIn(requestedMetrics));
+            out.writeBoolean(Metrics.INDICES.containedIn(requestedMetrics));
         } else {
             out.writeStringArray(requestedMetrics.toArray(String[]::new));
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -24,35 +24,21 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * A request to get node (cluster) level information.
  */
 public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
-    private boolean settings = true;
-    private boolean os = true;
-    private boolean process = true;
-    private boolean jvm = true;
-    private boolean threadPool = true;
-    private boolean transport = true;
-    private boolean http = true;
-    private boolean plugins = true;
-    private boolean ingest = true;
-    private boolean indices = true;
+    private Set<String> infoSections = new TreeSet<>();
 
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
-        settings = in.readBoolean();
-        os = in.readBoolean();
-        process = in.readBoolean();
-        jvm = in.readBoolean();
-        threadPool = in.readBoolean();
-        transport = in.readBoolean();
-        http = in.readBoolean();
-        plugins = in.readBoolean();
-        ingest = in.readBoolean();
-        indices = in.readBoolean();
+        infoSections.addAll(Arrays.asList(in.readStringArray()));
     }
 
     /**
@@ -67,16 +53,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Clears all info flags.
      */
     public NodesInfoRequest clear() {
-        settings = false;
-        os = false;
-        process = false;
-        jvm = false;
-        threadPool = false;
-        transport = false;
-        http = false;
-        plugins = false;
-        ingest = false;
-        indices = false;
+        infoSections.clear();
         return this;
     }
 
@@ -84,16 +61,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Sets to return all the data.
      */
     public NodesInfoRequest all() {
-        settings = true;
-        os = true;
-        process = true;
-        jvm = true;
-        threadPool = true;
-        transport = true;
-        http = true;
-        plugins = true;
-        ingest = true;
-        indices = true;
+        infoSections.addAll(Arrays.stream(Metrics.values()).map(Metrics::metricName).collect(Collectors.toSet()));
         return this;
     }
 
@@ -101,14 +69,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node settings be returned.
      */
     public boolean settings() {
-        return this.settings;
+        return infoSections.contains(Metrics.SETTINGS.metricName());
     }
 
     /**
      * Should the node settings be returned.
      */
     public NodesInfoRequest settings(boolean settings) {
-        this.settings = settings;
+        setSection(settings, Metrics.SETTINGS.metricName());
         return this;
     }
 
@@ -116,14 +84,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node OS be returned.
      */
     public boolean os() {
-        return this.os;
+        return infoSections.contains(Metrics.OS.metricName());
     }
 
     /**
      * Should the node OS be returned.
      */
     public NodesInfoRequest os(boolean os) {
-        this.os = os;
+        setSection(os, Metrics.OS.metricName());
         return this;
     }
 
@@ -131,14 +99,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node Process be returned.
      */
     public boolean process() {
-        return this.process;
+        return infoSections.contains(Metrics.PROCESS.metricName());
     }
 
     /**
      * Should the node Process be returned.
      */
     public NodesInfoRequest process(boolean process) {
-        this.process = process;
+        setSection(process, Metrics.PROCESS.metricName());
         return this;
     }
 
@@ -146,14 +114,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node JVM be returned.
      */
     public boolean jvm() {
-        return this.jvm;
+        return infoSections.contains(Metrics.JVM.metricName());
     }
 
     /**
      * Should the node JVM be returned.
      */
     public NodesInfoRequest jvm(boolean jvm) {
-        this.jvm = jvm;
+        setSection(jvm, Metrics.JVM.metricName());
         return this;
     }
 
@@ -161,14 +129,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node Thread Pool info be returned.
      */
     public boolean threadPool() {
-        return this.threadPool;
+        return infoSections.contains(Metrics.THREAD_POOL.metricName());
     }
 
     /**
      * Should the node Thread Pool info be returned.
      */
     public NodesInfoRequest threadPool(boolean threadPool) {
-        this.threadPool = threadPool;
+        setSection(threadPool, Metrics.THREAD_POOL.metricName());
         return this;
     }
 
@@ -176,14 +144,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node Transport be returned.
      */
     public boolean transport() {
-        return this.transport;
+        return infoSections.contains(Metrics.TRANSPORT.metricName());
     }
 
     /**
      * Should the node Transport be returned.
      */
     public NodesInfoRequest transport(boolean transport) {
-        this.transport = transport;
+        setSection(transport, Metrics.TRANSPORT.metricName());
         return this;
     }
 
@@ -191,14 +159,14 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Should the node HTTP be returned.
      */
     public boolean http() {
-        return this.http;
+        return infoSections.contains(Metrics.HTTP.metricName());
     }
 
     /**
      * Should the node HTTP be returned.
      */
     public NodesInfoRequest http(boolean http) {
-        this.http = http;
+        setSection(http, Metrics.HTTP.metricName());
         return this;
     }
 
@@ -208,7 +176,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return The request
      */
     public NodesInfoRequest plugins(boolean plugins) {
-        this.plugins = plugins;
+        setSection(plugins, Metrics.PLUGINS.metricName());
         return this;
     }
 
@@ -216,7 +184,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return true if information about plugins is requested
      */
     public boolean plugins() {
-        return plugins;
+        return infoSections.contains(Metrics.PLUGINS.metricName());
     }
 
     /**
@@ -224,7 +192,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @param ingest true if you want info
      */
     public NodesInfoRequest ingest(boolean ingest) {
-        this.ingest = ingest;
+        setSection(ingest, Metrics.INGEST.metricName());
         return this;
     }
 
@@ -232,7 +200,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return true if information about ingest is requested
      */
     public boolean ingest() {
-        return ingest;
+        return infoSections.contains(Metrics.INGEST.metricName());
     }
 
     /**
@@ -240,7 +208,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @param indices true if you want info
      */
     public NodesInfoRequest indices(boolean indices) {
-        this.indices = indices;
+        setSection(indices, Metrics.INDICES.metricName());
         return this;
     }
 
@@ -248,21 +216,43 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * @return true if information about indices (currently just indexing buffers)
      */
     public boolean indices() {
-        return indices;
+        return infoSections.contains(Metrics.INDICES.metricName());
+    }
+
+    private void setSection(boolean includeSection, String sectionName) {
+        if (includeSection) {
+            infoSections.add(sectionName);
+        } else {
+            infoSections.remove(sectionName);
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeBoolean(settings);
-        out.writeBoolean(os);
-        out.writeBoolean(process);
-        out.writeBoolean(jvm);
-        out.writeBoolean(threadPool);
-        out.writeBoolean(transport);
-        out.writeBoolean(http);
-        out.writeBoolean(plugins);
-        out.writeBoolean(ingest);
-        out.writeBoolean(indices);
+        out.writeStringArray(infoSections.toArray(String[]::new));
+    }
+
+    enum Metrics {
+        SETTINGS("settings"),
+        OS("os"),
+        PROCESS("process"),
+        JVM("jvm"),
+        THREAD_POOL("threadPool"),
+        TRANSPORT("transport"),
+        HTTP("http"),
+        PLUGINS("plugins"),
+        INGEST("ingest"),
+        INDICES("indices");
+
+        private String metricName;
+
+        Metrics(String name) {
+            this.metricName = name;
+        }
+
+        String metricName() {
+            return this.metricName;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,7 +40,40 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     public NodesInfoRequest(StreamInput in) throws IOException {
         super(in);
         infoSections.clear();
-        infoSections.addAll(Arrays.asList(in.readStringArray()));
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            infoSections.addAll(Arrays.asList(in.readStringArray()));
+        } else {
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.SETTINGS.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.OS.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.PROCESS.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.JVM.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.THREAD_POOL.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.TRANSPORT.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.HTTP.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.PLUGINS.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.INGEST.metricName());
+            }
+            if (in.readBoolean()) {
+                infoSections.add(Metrics.INDICES.metricName());
+            }
+        }
     }
 
     /**
@@ -232,7 +266,20 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeStringArray(infoSections.toArray(String[]::new));
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeStringArray(infoSections.toArray(String[]::new));
+        } else {
+            out.writeBoolean(infoSections.contains(Metrics.SETTINGS.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.OS.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.PROCESS.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.JVM.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.THREAD_POOL.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.TRANSPORT.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.HTTP.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.PLUGINS.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.INGEST.metricName()));
+            out.writeBoolean(infoSections.contains(Metrics.INDICES.metricName()));
+        }
     }
 
     enum Metrics {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTest.java
@@ -1,0 +1,198 @@
+package org.elasticsearch.action.admin.cluster.node.info;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class NodesInfoRequestTest {
+
+    @Test
+    public void testNodesInfoRequestSettings() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.settings(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.settings(), equalTo(roundTrippedRequest.settings()));
+
+        request.settings(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.settings(), equalTo(roundTrippedRequest.settings()));
+    }
+
+    @Test
+    public void testNodesInfoRequestOs() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.os(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.os(), equalTo(roundTrippedRequest.os()));
+
+        request.os(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.os(), equalTo(roundTrippedRequest.os()));
+    }
+
+    @Test
+    public void testNodesInfoRequestProcess() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.process(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.process(), equalTo(roundTrippedRequest.process()));
+
+        request.process(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.process(), equalTo(roundTrippedRequest.process()));
+    }
+
+    @Test
+    public void testNodesInfoRequestJvm() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.jvm(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.jvm(), equalTo(roundTrippedRequest.jvm()));
+
+        request.jvm(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.jvm(), equalTo(roundTrippedRequest.jvm()));
+    }
+
+    @Test
+    public void testNodesInfoRequestThreadPool() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.threadPool(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.threadPool(), equalTo(roundTrippedRequest.threadPool()));
+
+        request.threadPool(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.threadPool(), equalTo(roundTrippedRequest.threadPool()));
+    }
+
+    @Test
+    public void testNodesInfoRequestTransport() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.transport(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.transport(), equalTo(roundTrippedRequest.transport()));
+
+        request.transport(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.transport(), equalTo(roundTrippedRequest.transport()));
+    }
+
+    @Test
+    public void testNodesInfoRequestHttp() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.http(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.http(), equalTo(roundTrippedRequest.http()));
+
+        request.http(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.http(), equalTo(roundTrippedRequest.http()));
+    }
+
+    @Test
+    public void testNodesInfoRequestPlugins() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.plugins(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.plugins(), equalTo(roundTrippedRequest.plugins()));
+
+        request.plugins(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.plugins(), equalTo(roundTrippedRequest.plugins()));
+    }
+
+    @Test
+    public void testNodesInfoRequestIngest() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.ingest(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.ingest(), equalTo(roundTrippedRequest.ingest()));
+
+        request.ingest(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.ingest(), equalTo(roundTrippedRequest.ingest()));
+    }
+
+    @Test
+    public void testNodesInfoRequestIndices() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.indices(true);
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.indices(), equalTo(roundTrippedRequest.indices()));
+
+        request.indices(false);
+        roundTrippedRequest = roundTripRequest(request);
+        assertThat(request.indices(), equalTo(roundTrippedRequest.indices()));
+    }
+
+    @Test
+    public void testNodesInfoRequestAll() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.all();
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+
+        assertTrue(request.settings());
+        assertTrue(roundTrippedRequest.settings());
+        assertTrue(request.os());
+        assertTrue(roundTrippedRequest.os());
+        assertTrue(request.process());
+        assertTrue(roundTrippedRequest.process());
+        assertTrue(request.jvm());
+        assertTrue(roundTrippedRequest.jvm());
+        assertTrue(request.threadPool());
+        assertTrue(roundTrippedRequest.threadPool());
+        assertTrue(request.transport());
+        assertTrue(roundTrippedRequest.transport());
+        assertTrue(request.http());
+        assertTrue(roundTrippedRequest.http());
+        assertTrue(request.plugins());
+        assertTrue(roundTrippedRequest.plugins());
+        assertTrue(request.ingest());
+        assertTrue(roundTrippedRequest.ingest());
+        assertTrue(request.indices());
+        assertTrue(roundTrippedRequest.indices());
+    }
+
+    @Test
+    public void testNodesInfoRequestClear() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest("node");
+        request.clear();
+        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
+
+        assertFalse(request.settings());
+        assertFalse(roundTrippedRequest.settings());
+        assertFalse(request.os());
+        assertFalse(roundTrippedRequest.os());
+        assertFalse(request.process());
+        assertFalse(roundTrippedRequest.process());
+        assertFalse(request.jvm());
+        assertFalse(roundTrippedRequest.jvm());
+        assertFalse(request.threadPool());
+        assertFalse(roundTrippedRequest.threadPool());
+        assertFalse(request.transport());
+        assertFalse(roundTrippedRequest.transport());
+        assertFalse(request.http());
+        assertFalse(roundTrippedRequest.http());
+        assertFalse(request.plugins());
+        assertFalse(roundTrippedRequest.plugins());
+        assertFalse(request.ingest());
+        assertFalse(roundTrippedRequest.ingest());
+        assertFalse(request.indices());
+        assertFalse(roundTrippedRequest.indices());
+    }
+
+    private NodesInfoRequest roundTripRequest(NodesInfoRequest request) throws Exception {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                return new NodesInfoRequest(in);
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -1,17 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.action.admin.cluster.node.info;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.junit.Test;
+import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
-public class NodesInfoRequestTest {
+public class NodesInfoRequestTests extends ESTestCase {
 
-    @Test
     public void testNodesInfoRequestSettings() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.settings(true);
@@ -23,7 +38,6 @@ public class NodesInfoRequestTest {
         assertThat(request.settings(), equalTo(roundTrippedRequest.settings()));
     }
 
-    @Test
     public void testNodesInfoRequestOs() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.os(true);
@@ -35,7 +49,6 @@ public class NodesInfoRequestTest {
         assertThat(request.os(), equalTo(roundTrippedRequest.os()));
     }
 
-    @Test
     public void testNodesInfoRequestProcess() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.process(true);
@@ -47,7 +60,6 @@ public class NodesInfoRequestTest {
         assertThat(request.process(), equalTo(roundTrippedRequest.process()));
     }
 
-    @Test
     public void testNodesInfoRequestJvm() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.jvm(true);
@@ -59,7 +71,6 @@ public class NodesInfoRequestTest {
         assertThat(request.jvm(), equalTo(roundTrippedRequest.jvm()));
     }
 
-    @Test
     public void testNodesInfoRequestThreadPool() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.threadPool(true);
@@ -71,7 +82,6 @@ public class NodesInfoRequestTest {
         assertThat(request.threadPool(), equalTo(roundTrippedRequest.threadPool()));
     }
 
-    @Test
     public void testNodesInfoRequestTransport() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.transport(true);
@@ -83,7 +93,6 @@ public class NodesInfoRequestTest {
         assertThat(request.transport(), equalTo(roundTrippedRequest.transport()));
     }
 
-    @Test
     public void testNodesInfoRequestHttp() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.http(true);
@@ -95,7 +104,6 @@ public class NodesInfoRequestTest {
         assertThat(request.http(), equalTo(roundTrippedRequest.http()));
     }
 
-    @Test
     public void testNodesInfoRequestPlugins() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.plugins(true);
@@ -107,7 +115,6 @@ public class NodesInfoRequestTest {
         assertThat(request.plugins(), equalTo(roundTrippedRequest.plugins()));
     }
 
-    @Test
     public void testNodesInfoRequestIngest() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.ingest(true);
@@ -119,7 +126,6 @@ public class NodesInfoRequestTest {
         assertThat(request.ingest(), equalTo(roundTrippedRequest.ingest()));
     }
 
-    @Test
     public void testNodesInfoRequestIndices() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.indices(true);
@@ -131,7 +137,6 @@ public class NodesInfoRequestTest {
         assertThat(request.indices(), equalTo(roundTrippedRequest.indices()));
     }
 
-    @Test
     public void testNodesInfoRequestAll() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.all();
@@ -159,7 +164,6 @@ public class NodesInfoRequestTest {
         assertTrue(roundTrippedRequest.indices());
     }
 
-    @Test
     public void testNodesInfoRequestClear() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.clear();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -25,6 +25,10 @@ import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
 
+/**
+ * Granular tests for the {@link NodesInfoRequest} class. Higher-level tests
+ * can be found in {@link org.elasticsearch.rest.action.admin.cluster.RestNodesInfoActionTests}.
+ */
 public class NodesInfoRequestTests extends ESTestCase {
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -34,6 +34,9 @@ public class NodesInfoRequestTests extends ESTestCase {
     /**
      * Make sure that we can set, serialize, and deserialize arbitrary sets
      * of metrics.
+     *
+     * TODO: Once we can set values by string, use a collection rather than
+     *   checking each and every setter in the public API
      */
     public void testMetricsSetters() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest(randomAlphaOfLength(8));
@@ -48,7 +51,7 @@ public class NodesInfoRequestTests extends ESTestCase {
         request.ingest(randomBoolean());
         request.indices(randomBoolean());
         NodesInfoRequest deserializedRequest = roundTripRequest(request);
-        assertThat(request.settings(), equalTo(deserializedRequest.settings()));
+        assertRequestsEqual(request, deserializedRequest);
     }
 
     /**
@@ -66,6 +69,9 @@ public class NodesInfoRequestTests extends ESTestCase {
     /**
      * Test that the {@link NodesInfoRequest#all()} method sets all of the
      * metrics to {@code true}.
+     *
+     * TODO: Once we can check values by string, use a collection rather than
+     *   checking each and every getter in the public API
      */
     public void testNodesInfoRequestAll() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
@@ -86,6 +92,9 @@ public class NodesInfoRequestTests extends ESTestCase {
     /**
      * Test that the {@link NodesInfoRequest#clear()} method sets all of the
      * metrics to {@code false}.
+     *
+     * TODO: Once we can check values by string, use a collection rather than
+     *   checking each and every getter in the public API
      */
     public void testNodesInfoRequestClear() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
@@ -118,6 +127,9 @@ public class NodesInfoRequestTests extends ESTestCase {
     }
 
     private static void assertRequestsEqual(NodesInfoRequest request1, NodesInfoRequest request2) {
+
+        // TODO: Once we can check values by string, use a collection rather than
+        //   checking each and every getter in the public API
         assertThat(request1.settings(), equalTo(request2.settings()));
         assertThat(request1.os(), equalTo(request2.os()));
         assertThat(request1.process(), equalTo(request2.process()));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -27,6 +27,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class NodesInfoRequestTests extends ESTestCase {
 
+    /**
+     * Make sure that we can set, serialize, and deserialize arbitrary sets
+     * of metrics.
+     */
     public void testMetricsSetters() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest(randomAlphaOfLength(8));
         request.settings(randomBoolean());
@@ -39,17 +43,26 @@ public class NodesInfoRequestTests extends ESTestCase {
         request.plugins(randomBoolean());
         request.ingest(randomBoolean());
         request.indices(randomBoolean());
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.settings(), equalTo(roundTrippedRequest.settings()));
+        NodesInfoRequest deserializedRequest = roundTripRequest(request);
+        assertThat(request.settings(), equalTo(deserializedRequest.settings()));
     }
 
+    /**
+     * Test that a newly constructed NodesInfoRequestObject requests all of the
+     * possible metrics defined in {@link NodesInfoRequest.Metrics}.
+     */
     public void testNodesInfoRequestDefaults() {
         NodesInfoRequest defaultNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
         NodesInfoRequest allMetricsNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
+        allMetricsNodesInfoRequest.all();
 
         assertRequestsEqual(defaultNodesInfoRequest, allMetricsNodesInfoRequest);
     }
 
+    /**
+     * Test that the {@link NodesInfoRequest#all()} method sets all of the
+     * metrics to {@code true}.
+     */
     public void testNodesInfoRequestAll() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.all();
@@ -66,6 +79,10 @@ public class NodesInfoRequestTests extends ESTestCase {
         assertTrue(request.indices());
     }
 
+    /**
+     * Test that the {@link NodesInfoRequest#clear()} method sets all of the
+     * metrics to {@code false}.
+     */
     public void testNodesInfoRequestClear() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.clear();
@@ -82,6 +99,11 @@ public class NodesInfoRequestTests extends ESTestCase {
         assertFalse(request.indices());
     }
 
+    /**
+     * Serialize and deserialize a request.
+     * @param request A request to serialize.
+     * @return The deserialized, "round-tripped" request.
+     */
     private static NodesInfoRequest roundTripRequest(NodesInfoRequest request) throws Exception {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request.writeTo(out);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestTests.java
@@ -27,176 +27,80 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class NodesInfoRequestTests extends ESTestCase {
 
-    public void testNodesInfoRequestSettings() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.settings(true);
+    public void testMetricsSetters() throws Exception {
+        NodesInfoRequest request = new NodesInfoRequest(randomAlphaOfLength(8));
+        request.settings(randomBoolean());
+        request.os(randomBoolean());
+        request.process(randomBoolean());
+        request.jvm(randomBoolean());
+        request.threadPool(randomBoolean());
+        request.transport(randomBoolean());
+        request.http(randomBoolean());
+        request.plugins(randomBoolean());
+        request.ingest(randomBoolean());
+        request.indices(randomBoolean());
         NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
         assertThat(request.settings(), equalTo(roundTrippedRequest.settings()));
-
-        request.settings(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.settings(), equalTo(roundTrippedRequest.settings()));
     }
 
-    public void testNodesInfoRequestOs() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.os(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.os(), equalTo(roundTrippedRequest.os()));
+    public void testNodesInfoRequestDefaults() {
+        NodesInfoRequest defaultNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
+        NodesInfoRequest allMetricsNodesInfoRequest = new NodesInfoRequest(randomAlphaOfLength(8));
 
-        request.os(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.os(), equalTo(roundTrippedRequest.os()));
-    }
-
-    public void testNodesInfoRequestProcess() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.process(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.process(), equalTo(roundTrippedRequest.process()));
-
-        request.process(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.process(), equalTo(roundTrippedRequest.process()));
-    }
-
-    public void testNodesInfoRequestJvm() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.jvm(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.jvm(), equalTo(roundTrippedRequest.jvm()));
-
-        request.jvm(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.jvm(), equalTo(roundTrippedRequest.jvm()));
-    }
-
-    public void testNodesInfoRequestThreadPool() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.threadPool(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.threadPool(), equalTo(roundTrippedRequest.threadPool()));
-
-        request.threadPool(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.threadPool(), equalTo(roundTrippedRequest.threadPool()));
-    }
-
-    public void testNodesInfoRequestTransport() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.transport(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.transport(), equalTo(roundTrippedRequest.transport()));
-
-        request.transport(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.transport(), equalTo(roundTrippedRequest.transport()));
-    }
-
-    public void testNodesInfoRequestHttp() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.http(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.http(), equalTo(roundTrippedRequest.http()));
-
-        request.http(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.http(), equalTo(roundTrippedRequest.http()));
-    }
-
-    public void testNodesInfoRequestPlugins() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.plugins(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.plugins(), equalTo(roundTrippedRequest.plugins()));
-
-        request.plugins(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.plugins(), equalTo(roundTrippedRequest.plugins()));
-    }
-
-    public void testNodesInfoRequestIngest() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.ingest(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.ingest(), equalTo(roundTrippedRequest.ingest()));
-
-        request.ingest(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.ingest(), equalTo(roundTrippedRequest.ingest()));
-    }
-
-    public void testNodesInfoRequestIndices() throws Exception {
-        NodesInfoRequest request = new NodesInfoRequest("node");
-        request.indices(true);
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.indices(), equalTo(roundTrippedRequest.indices()));
-
-        request.indices(false);
-        roundTrippedRequest = roundTripRequest(request);
-        assertThat(request.indices(), equalTo(roundTrippedRequest.indices()));
+        assertRequestsEqual(defaultNodesInfoRequest, allMetricsNodesInfoRequest);
     }
 
     public void testNodesInfoRequestAll() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.all();
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
 
         assertTrue(request.settings());
-        assertTrue(roundTrippedRequest.settings());
         assertTrue(request.os());
-        assertTrue(roundTrippedRequest.os());
         assertTrue(request.process());
-        assertTrue(roundTrippedRequest.process());
         assertTrue(request.jvm());
-        assertTrue(roundTrippedRequest.jvm());
         assertTrue(request.threadPool());
-        assertTrue(roundTrippedRequest.threadPool());
         assertTrue(request.transport());
-        assertTrue(roundTrippedRequest.transport());
         assertTrue(request.http());
-        assertTrue(roundTrippedRequest.http());
         assertTrue(request.plugins());
-        assertTrue(roundTrippedRequest.plugins());
         assertTrue(request.ingest());
-        assertTrue(roundTrippedRequest.ingest());
         assertTrue(request.indices());
-        assertTrue(roundTrippedRequest.indices());
     }
 
     public void testNodesInfoRequestClear() throws Exception {
         NodesInfoRequest request = new NodesInfoRequest("node");
         request.clear();
-        NodesInfoRequest roundTrippedRequest = roundTripRequest(request);
 
         assertFalse(request.settings());
-        assertFalse(roundTrippedRequest.settings());
         assertFalse(request.os());
-        assertFalse(roundTrippedRequest.os());
         assertFalse(request.process());
-        assertFalse(roundTrippedRequest.process());
         assertFalse(request.jvm());
-        assertFalse(roundTrippedRequest.jvm());
         assertFalse(request.threadPool());
-        assertFalse(roundTrippedRequest.threadPool());
         assertFalse(request.transport());
-        assertFalse(roundTrippedRequest.transport());
         assertFalse(request.http());
-        assertFalse(roundTrippedRequest.http());
         assertFalse(request.plugins());
-        assertFalse(roundTrippedRequest.plugins());
         assertFalse(request.ingest());
-        assertFalse(roundTrippedRequest.ingest());
         assertFalse(request.indices());
-        assertFalse(roundTrippedRequest.indices());
     }
 
-    private NodesInfoRequest roundTripRequest(NodesInfoRequest request) throws Exception {
+    private static NodesInfoRequest roundTripRequest(NodesInfoRequest request) throws Exception {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request.writeTo(out);
             try (StreamInput in = out.bytes().streamInput()) {
                 return new NodesInfoRequest(in);
             }
         }
+    }
+
+    private static void assertRequestsEqual(NodesInfoRequest request1, NodesInfoRequest request2) {
+        assertThat(request1.settings(), equalTo(request2.settings()));
+        assertThat(request1.os(), equalTo(request2.os()));
+        assertThat(request1.process(), equalTo(request2.process()));
+        assertThat(request1.jvm(), equalTo(request2.jvm()));
+        assertThat(request1.threadPool(), equalTo(request2.threadPool()));
+        assertThat(request1.transport(), equalTo(request2.transport()));
+        assertThat(request1.http(), equalTo(request2.http()));
+        assertThat(request1.plugins(), equalTo(request2.plugins()));
+        assertThat(request1.ingest(), equalTo(request2.ingest()));
+        assertThat(request1.indices(), equalTo(request2.indices()));
     }
 }


### PR DESCRIPTION
If the nodes info endpoint is going to be pluggable, the `NodesInfoRequest` class needs to support flexible lists of metrics rather than a fixed group of boolean flags. This PR refactors the `NodesInfoRequest` class so that its serialization will be capable of carrying such lists.

It does not change the external API of the `NodesInfoRequest` class. This will be done in a follow-up PR. I want to keep this PR as small as I can in case I have misunderstood anything important about backwards compatibility for the transport protocol.

This PR also adds some granular unit tests that I used to make sure that the class's behavior didn't change.

Relates #52975 