### PR TITLE
Handle special chars in JAVA_HOME in elasticsearch-service.bat (#52676) (#53057)

### DIFF
--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -115,7 +115,7 @@ set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 
 @setlocal
-for /F "usebackq delims=" %%a in (`"%JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" || echo jvm_options_parser_failed"`) do set ES_JAVA_OPTS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_PATH_CONF!" ^|^| echo jvm_options_parser_failed`) do set ES_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%ES_JAVA_OPTS%" & set ES_JAVA_OPTS=%ES_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (

--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -115,7 +115,7 @@ set ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 
 @setlocal
-for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_PATH_CONF!" ^|^| echo jvm_options_parser_failed`) do set ES_JAVA_OPTS=%%a
+for /F "usebackq delims=" %%a in (`CALL %JAVA% -cp "!ES_CLASSPATH!" "org.elasticsearch.tools.launchers.JvmOptionsParser" "!ES_JVM_OPTIONS!" ^|^| echo jvm_options_parser_failed`) do set ES_JAVA_OPTS=%%a
 @endlocal & set "MAYBE_JVM_OPTIONS_PARSER_FAILED=%ES_JAVA_OPTS%" & set ES_JAVA_OPTS=%ES_JAVA_OPTS%
 
 if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -55,6 +55,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
@@ -107,10 +108,27 @@ public class ArchiveTests extends PackagingTestCase {
         sh.getEnv().put("JAVA_HOME", "doesnotexist");
 
         // ask for elasticsearch version to quickly exit if java is actually found (ie test failure)
-        final Result runResult = sh.runIgnoreExitCode(bin.elasticsearch.toString() + " -v");
+        final Result runResult = sh.runIgnoreExitCode(bin.elasticsearch.toString() + " -V");
         assertThat(runResult.exitCode, is(1));
         assertThat(runResult.stderr, containsString("could not find java in JAVA_HOME"));
 
+    }
+
+    public void test32SpecialCharactersInJdkPath() throws Exception {
+        final Installation.Executables bin = installation.executables();
+        assumeTrue("Only run this test when we know where the JDK is.", distribution().hasJdk);
+
+        final Path relocatedJdk = installation.bundledJdk.getParent().resolve("a (special) path");
+        sh.getEnv().put("JAVA_HOME", relocatedJdk.toString());
+
+        try {
+            mv(installation.bundledJdk, relocatedJdk);
+            // ask for elasticsearch version to avoid starting the app
+            final Result runResult = sh.run(bin.elasticsearch.toString() + " -V");
+            assertThat(runResult.stdout, startsWith("Version: "));
+        } finally {
+            mv(relocatedJdk, installation.bundledJdk);
+        }
     }
 
     public void test40CreateKeystoreManually() throws Exception {

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/WindowsServiceTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/WindowsServiceTests.java
@@ -146,6 +146,21 @@ public class WindowsServiceTests extends PackagingTestCase {
         assertThat(result.stdout, containsString("Failed removing '" + DEFAULT_ID + "' service"));
     }
 
+    public void test16InstallSpecialCharactersInJdkPath() throws IOException {
+        assumeTrue("Only run this test when we know where the JDK is.", distribution().hasJdk);
+        final Path relocatedJdk = installation.bundledJdk.getParent().resolve("a (special) jdk");
+        sh.getEnv().put("JAVA_HOME", relocatedJdk.toString());
+
+        try {
+            mv(installation.bundledJdk, relocatedJdk);
+            Result result = sh.run(serviceScript + " install");
+            assertThat(result.stdout, containsString("The service 'elasticsearch-service-x64' has been installed."));
+        } finally {
+            sh.runIgnoreExitCode(serviceScript + " remove");
+            mv(relocatedJdk, installation.bundledJdk);
+        }
+    }
+
     public void test20CustomizeServiceId() {
         String serviceId = "my-es-service";
         String displayName = DEFAULT_DISPLAY_NAME.replace(DEFAULT_ID, serviceId);


### PR DESCRIPTION
* Handle special chars in JAVA_HOME in elasticsearch-service.bat (#52676)

* Test case for windows service where JAVA_HOME path contains spaces (#53028)

Co-authored-by: Muhammad Shaheer Akram <41253927+shaheerakr@users.noreply.github.com>