### PR TITLE
Fix Rollover handing of hidden aliases

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasAction;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.AliasOrIndex;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -114,7 +115,8 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         validate(metaData, rolloverRequest);
         final AliasOrIndex.Alias alias = (AliasOrIndex.Alias) metaData.getAliasAndIndexLookup().get(rolloverRequest.getAlias());
         final IndexMetaData indexMetaData = alias.getWriteIndex();
-        final boolean explicitWriteIndex = Boolean.TRUE.equals(indexMetaData.getAliases().get(alias.getAliasName()).writeIndex());
+        final AliasMetaData aliasMetaData = indexMetaData.getAliases().get(alias.getAliasName());
+        final boolean explicitWriteIndex = Boolean.TRUE.equals(aliasMetaData.writeIndex());
         final String sourceProvidedName = indexMetaData.getSettings().get(IndexMetaData.SETTING_INDEX_PROVIDED_NAME,
             indexMetaData.getIndex().getName());
         final String sourceIndexName = indexMetaData.getIndex().getName();
@@ -155,7 +157,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                                 ClusterState newState = createIndexService.applyCreateIndexRequest(currentState, createIndexRequest);
                                 newState = indexAliasesService.applyAliasActions(newState,
                                     rolloverAliasToNewIndex(sourceIndexName, rolloverIndexName, rolloverRequest, explicitWriteIndex,
-                                        alias.isHidden()));
+                                        aliasMetaData.isHidden()));
                                 RolloverInfo rolloverInfo = new RolloverInfo(rolloverRequest.getAlias(), metConditions,
                                     threadPool.absoluteTimeInMillis());
                                 return ClusterState.builder(newState)

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.CombinableMatcher.both;
 import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
@@ -430,5 +431,67 @@ public class RolloverIT extends ESIntegTestCase {
         assertTrue(rolloverResponse.isRolledOver());
         assertEquals(writeIndexPrefix + "000001", rolloverResponse.getOldIndex());
         assertEquals(writeIndexPrefix + "000002", rolloverResponse.getNewIndex());
+    }
+
+    public void testRolloverWithHiddenAliasesAndExplicitWriteIndex() {
+        long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
+        final String indexNamePrefix = "test_index_hidden-";
+        final String firstIndexName = indexNamePrefix + "000001";
+        final String secondIndexName = indexNamePrefix + "000002";
+
+        final String aliasName = "test_alias";
+        assertAcked(prepareCreate(firstIndexName).addAlias(new Alias(aliasName).writeIndex(true).isHidden(true)).get());
+        indexDoc(aliasName, "1", "field", "value");
+        refresh();
+        final RolloverResponse response = client().admin().indices().prepareRolloverIndex(aliasName).get();
+        assertThat(response.getOldIndex(), equalTo(firstIndexName));
+        assertThat(response.getNewIndex(), equalTo(secondIndexName));
+        assertThat(response.isDryRun(), equalTo(false));
+        assertThat(response.isRolledOver(), equalTo(true));
+        assertThat(response.getConditionStatus().size(), equalTo(0));
+        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final IndexMetaData oldIndex = state.metaData().index(firstIndexName);
+        assertTrue(oldIndex.getAliases().containsKey(aliasName));
+        assertTrue(oldIndex.getAliases().get(aliasName).isHidden());
+        assertFalse(oldIndex.getAliases().get(aliasName).writeIndex());
+        final IndexMetaData newIndex = state.metaData().index(secondIndexName);
+        assertTrue(newIndex.getAliases().containsKey(aliasName));
+        assertTrue(newIndex.getAliases().get(aliasName).isHidden());
+        assertTrue(newIndex.getAliases().get(aliasName).writeIndex());
+        assertThat(oldIndex.getRolloverInfos().size(), equalTo(1));
+        assertThat(oldIndex.getRolloverInfos().get(aliasName).getAlias(), equalTo(aliasName));
+        assertThat(oldIndex.getRolloverInfos().get(aliasName).getMetConditions(), is(empty()));
+        assertThat(oldIndex.getRolloverInfos().get(aliasName).getTime(),
+            is(both(greaterThanOrEqualTo(beforeTime)).and(lessThanOrEqualTo(client().threadPool().absoluteTimeInMillis() + 1000L))));
+    }
+
+    public void testRolloverWithHiddenAliasesAndImplicitWriteIndex() {
+        long beforeTime = client().threadPool().absoluteTimeInMillis() - 1000L;
+        final String indexNamePrefix = "test_index_hidden-";
+        final String firstIndexName = indexNamePrefix + "000001";
+        final String secondIndexName = indexNamePrefix + "000002";
+
+        final String aliasName = "test_alias";
+        assertAcked(prepareCreate(firstIndexName).addAlias(new Alias(aliasName).isHidden(true)).get());
+        indexDoc(aliasName, "1", "field", "value");
+        refresh();
+        final RolloverResponse response = client().admin().indices().prepareRolloverIndex(aliasName).get();
+        assertThat(response.getOldIndex(), equalTo(firstIndexName));
+        assertThat(response.getNewIndex(), equalTo(secondIndexName));
+        assertThat(response.isDryRun(), equalTo(false));
+        assertThat(response.isRolledOver(), equalTo(true));
+        assertThat(response.getConditionStatus().size(), equalTo(0));
+        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final IndexMetaData oldIndex = state.metaData().index(firstIndexName);
+        assertFalse(oldIndex.getAliases().containsKey(aliasName));
+        final IndexMetaData newIndex = state.metaData().index(secondIndexName);
+        assertTrue(newIndex.getAliases().containsKey(aliasName));
+        assertTrue(newIndex.getAliases().get(aliasName).isHidden());
+        assertThat(newIndex.getAliases().get(aliasName).writeIndex(), nullValue());
+        assertThat(oldIndex.getRolloverInfos().size(), equalTo(1));
+        assertThat(oldIndex.getRolloverInfos().get(aliasName).getAlias(), equalTo(aliasName));
+        assertThat(oldIndex.getRolloverInfos().get(aliasName).getMetConditions(), is(empty()));
+        assertThat(oldIndex.getRolloverInfos().get(aliasName).getTime(),
+            is(both(greaterThanOrEqualTo(beforeTime)).and(lessThanOrEqualTo(client().threadPool().absoluteTimeInMillis() + 1000L))));
     }
 }


### PR DESCRIPTION
Prior to this commit, rollover did not propagate the `is_hidden` alias
property when rollover over an index. This commit ensures that an alias
that's rolled over will remain hidden.

---

Labelled `non-issue` as hidden aliases have not yet shipped, so this bug isn't relevant to the release notes.