### PR TITLE
Use optionalVLong

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocument.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocument.java
@@ -262,7 +262,7 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         created = in.readInstant();
         lastModified = in.readInstant();
         nameIdFormats = in.readSet(StreamInput::readString);
-        authenticationExpiryMillis = in.readBoolean() ? in.readVLong() : null;
+        authenticationExpiryMillis = in.readOptionalVLong();
 
         privileges.application = in.readOptionalString();
         privileges.resource = in.readString();
@@ -289,12 +289,7 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         out.writeInstant(created);
         out.writeInstant(lastModified);
         out.writeCollection(nameIdFormats, StreamOutput::writeString);
-        if (authenticationExpiryMillis == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeVLong(authenticationExpiryMillis);
-        }
+        out.writeOptionalVLong(authenticationExpiryMillis);
 
         out.writeOptionalString(privileges.application);
         out.writeString(privileges.resource);


### PR DESCRIPTION
Updates SamlServiceProviderDocument to use the new
read/writeOptionalVLong methods from #53145
