### PR TITLE
Fix test failures with the new `constant_keyword` field.

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
@@ -8,6 +8,8 @@ setup:
       indices.create:
         index:  test1
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               foo:
@@ -18,6 +20,8 @@ setup:
       indices.create:
         index:  test2
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               foo:
@@ -62,9 +66,6 @@ setup:
 
 ---
 "Term query":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/53131"
 
   - do:
       search:
@@ -94,9 +95,6 @@ setup:
 
 ---
 "Terms query":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/53131"
 
   - do:
       search:
@@ -113,9 +111,6 @@ setup:
 
 ---
 "Prefix query":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/53131"
 
   - do:
       search:
@@ -143,9 +138,6 @@ setup:
 
 ---
 "Wildcard query":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/53131"
 
   - do:
       search:


### PR DESCRIPTION
This test failed because YAML tests randomly install an index template
that updates the default number of shards to 2.

Closes #53131
