### PR TITLE
Check for query cancellation during rewrite

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -46,6 +46,7 @@ import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.Weight;
+import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.lucene.Lucene;
@@ -112,7 +113,8 @@ public class QueryPhase implements SearchPhase {
         final Runnable cancellation;
         if (context.lowLevelCancellation()) {
             cancellation = context.searcher().addQueryCancellation(() -> {
-                if (context.getTask().isCancelled()) {
+                SearchShardTask task = context.getTask();
+                if (task.isCancelled()) {
                     throw new TaskCancelledException("cancelled");
                 }
             });
@@ -281,7 +283,8 @@ public class QueryPhase implements SearchPhase {
 
             if (searchContext.lowLevelCancellation()) {
                 searcher.addQueryCancellation(() -> {
-                    if (searchContext.getTask().isCancelled()) {
+                    SearchShardTask task = searchContext.getTask();
+                    if (task.isCancelled()) {
                         throw new TaskCancelledException("cancelled");
                     }
                 });

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -112,8 +112,8 @@ public class QueryPhase implements SearchPhase {
     public void preProcess(SearchContext context) {
         final Runnable cancellation;
         if (context.lowLevelCancellation()) {
+            SearchShardTask task = context.getTask();
             cancellation = context.searcher().addQueryCancellation(() -> {
-                SearchShardTask task = context.getTask();
                 if (task.isCancelled()) {
                     throw new TaskCancelledException("cancelled");
                 }
@@ -282,8 +282,8 @@ public class QueryPhase implements SearchPhase {
             }
 
             if (searchContext.lowLevelCancellation()) {
+                SearchShardTask task = searchContext.getTask();
                 searcher.addQueryCancellation(() -> {
-                    SearchShardTask task = searchContext.getTask();
                     if (task.isCancelled()) {
                         throw new TaskCancelledException("cancelled");
                     }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -843,18 +843,17 @@ public class QueryPhaseTests extends IndexShardTestCase {
             w.flush();
             w.close();
 
-            IndexReader reader = DirectoryReader.open(dir);
-            TestSearchContext context = new TestSearchContextWithRewriteAndCancellation(
-                    null, indexShard, newContextSearcher(reader));
-            PrefixQuery prefixQuery = new PrefixQuery(new Term("foo", "a"));
-            prefixQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-            context.parsedQuery(new ParsedQuery(prefixQuery));
-            SearchShardTask task = mock(SearchShardTask.class);
-            when(task.isCancelled()).thenReturn(true);
-            context.setTask(task);
-            expectThrows(TaskCancelledException.class, () -> new QueryPhase().preProcess(context));
-
-            reader.close();
+            try (IndexReader reader = DirectoryReader.open(dir)) {
+                TestSearchContext context = new TestSearchContextWithRewriteAndCancellation(
+                        null, indexShard, newContextSearcher(reader));
+                PrefixQuery prefixQuery = new PrefixQuery(new Term("foo", "a"));
+                prefixQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+                context.parsedQuery(new ParsedQuery(prefixQuery));
+                SearchShardTask task = mock(SearchShardTask.class);
+                when(task.isCancelled()).thenReturn(true);
+                context.setTask(task);
+                expectThrows(TaskCancelledException.class, () -> new QueryPhase().preProcess(context));
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -53,6 +53,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
@@ -75,6 +77,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.search.ESToParentBlockJoinQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
@@ -83,6 +86,7 @@ import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortAndFormats;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.TestSearchContext;
 
 import java.io.IOException;
@@ -825,7 +829,55 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
         reader.close();
         dir.close();
+    }
 
+    public void testCancellationDuringPreprocess() throws IOException {
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir, newIndexWriterConfig())) {
+
+            for (int i = 0; i < 10; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("foo", "a".repeat(i), Store.NO));
+                w.addDocument(doc);
+            }
+            w.flush();
+            w.close();
+
+            IndexReader reader = DirectoryReader.open(dir);
+            TestSearchContext context = new TestSearchContextWithRewriteAndCancellation(
+                    null, indexShard, newContextSearcher(reader));
+            PrefixQuery prefixQuery = new PrefixQuery(new Term("foo", "a"));
+            prefixQuery.setRewriteMethod(MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+            context.parsedQuery(new ParsedQuery(prefixQuery));
+            SearchShardTask task = mock(SearchShardTask.class);
+            when(task.isCancelled()).thenReturn(true);
+            context.setTask(task);
+            expectThrows(TaskCancelledException.class, () -> new QueryPhase().preProcess(context));
+
+            reader.close();
+        }
+    }
+
+    private static class TestSearchContextWithRewriteAndCancellation extends TestSearchContext {
+
+        public TestSearchContextWithRewriteAndCancellation(QueryShardContext queryShardContext, IndexShard indexShard,
+                                                           ContextIndexSearcher searcher) {
+            super(queryShardContext, indexShard, searcher);
+        }
+
+        @Override
+        public void preProcess(boolean rewrite) {
+            try {
+                searcher().rewrite(query());
+            } catch (IOException e) {
+                fail("IOException shouldn't be thrown");
+            }
+        }
+
+        @Override
+        public boolean lowLevelCancellation() {
+            return true;
+        }
     }
 
     private static ContextIndexSearcher newContextSearcher(IndexReader reader) throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -860,8 +860,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
     private static class TestSearchContextWithRewriteAndCancellation extends TestSearchContext {
 
-        public TestSearchContextWithRewriteAndCancellation(QueryShardContext queryShardContext, IndexShard indexShard,
-                                                           ContextIndexSearcher searcher) {
+        private TestSearchContextWithRewriteAndCancellation(QueryShardContext queryShardContext,
+                                                            IndexShard indexShard,
+                                                            ContextIndexSearcher searcher) {
             super(queryShardContext, indexShard, searcher);
         }
 


### PR DESCRIPTION
With ExitableDirectoryReader in place, check for query cancellation
during QueryPhase#preProcess where the query rewriting takes place.

Follows: #52822
