### PR TITLE
Fix ClusterDisruptionIT.testAckedIndexing

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -228,7 +228,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                 // is the super-connected node and recovery source and target are on opposite sides of the bridge
                 if (disruptionScheme instanceof NetworkDisruption &&
                     ((NetworkDisruption) disruptionScheme).getDisruptedLinks() instanceof Bridge) {
-                    assertAcked(client().admin().cluster().prepareReroute().setRetryFailed(true));
+                    assertBusy(() -> assertAcked(client().admin().cluster().prepareReroute().setRetryFailed(true)));
                 }
                 ensureGreen("test");
 


### PR DESCRIPTION
Use assertBusy when doing reroute after bridged disruption,
since it can return non-acked if a node is marked faulty
by follower check after disruption ended.

Closes #53064
