### PR TITLE
 Add `allowed_warnings` to yaml tests (backport of #53139) 

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -198,6 +198,23 @@ header. The warnings must match exactly. Using it looks like this:
             id:        1
 ....
 
+If the arguments to `do` include `allowed_warnings` then matching `Warning`
+headers do not fail the request. Unlike the `warnings` argument, these aren't
+expected so much as "allowed". This usually comes up in backwards compatibility
+testing. Using it looks like this:
+
+....
+    - do:
+        allowed_warnings:
+            - some warning
+            - this argument is also always a list, never a single string
+            - no matter how many warnings you expect
+        get:
+            index:    test
+            type:    test
+            id:        1
+....
+
 If the arguments to `do` include `node_selector` then the request is only
 sent to nodes that match the `node_selector`. It looks like this:
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Features.java
@@ -49,8 +49,9 @@ public final class Features {
             "yaml",
             "contains",
             "transform_and_set",
-            "arbitrary_key"
-    ));
+            "arbitrary_key",
+            "allowed_warnings"));
+
     private static final String SPI_ON_CLASSPATH_SINCE_JDK_9 = "spi_on_classpath_jdk9";
 
     private Features() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -164,6 +164,14 @@ public class ClientYamlTestSuite {
                 "section can skip the test at line [" + section.getLocation().lineNumber + "]");
 
         errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)
+                .map(section -> (DoSection) section)
+                .filter(section -> false == section.getAllowedWarningHeaders().isEmpty())
+                .filter(section -> false == hasSkipFeature("allowed_warnings", testSection, setupSection, teardownSection))
+                .map(section -> "attempted to add a [do] with a [allowed_warnings] section " +
+                    "without a corresponding [\"skip\": \"features\": \"allowed_warnings\"] so runners that do not " +
+                    "support the [allowed_warnings] section can skip the test at line [" + section.getLocation().lineNumber + "]"));
+
+        errors = Stream.concat(errors, sections.stream().filter(section -> section instanceof DoSection)
             .map(section -> (DoSection) section)
             .filter(section -> NodeSelector.ANY != section.getApiCallSection().getNodeSelector())
             .filter(section -> false == hasSkipFeature("node_selector", testSection, setupSection, teardownSection))

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -50,10 +50,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.common.collect.Tuple.tuple;
 import static org.elasticsearch.common.logging.DeprecationLogger.WARNING_HEADER_PATTERN;
 import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
@@ -77,6 +78,9 @@ import static org.junit.Assert.fail;
  *          - Stuff is deprecated, yo
  *          - Don't use deprecated stuff
  *          - Please, stop. It hurts.
+ *      allowed_warnings:
+ *          - Maybe this warning shows up
+ *          - But it isn't actually required for the test to pass.
  *      update:
  *          index:  test_1
  *          type:   test
@@ -94,6 +98,7 @@ public class DoSection implements ExecutableSection {
         NodeSelector nodeSelector = NodeSelector.ANY;
         Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         List<String> expectedWarnings = new ArrayList<>();
+        List<String> allowedWarnings = new ArrayList<>();
 
         if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
             throw new IllegalArgumentException("expected [" + XContentParser.Token.START_OBJECT + "], " +
@@ -116,6 +121,14 @@ public class DoSection implements ExecutableSection {
                     }
                     if (token != XContentParser.Token.END_ARRAY) {
                         throw new ParsingException(parser.getTokenLocation(), "[warnings] must be a string array but saw [" + token + "]");
+                    }
+                } else if ("allowed_warnings".equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) == XContentParser.Token.VALUE_STRING) {
+                        allowedWarnings.add(parser.text());
+                    }
+                    if (token != XContentParser.Token.END_ARRAY) {
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "[allowed_warnings] must be a string array but saw [" + token + "]");
                     }
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "unknown array [" + currentFieldName + "]");
@@ -172,10 +185,16 @@ public class DoSection implements ExecutableSection {
             if (apiCallSection == null) {
                 throw new IllegalArgumentException("client call section is mandatory within a do section");
             }
+            for (String w : expectedWarnings) {
+                if (allowedWarnings.contains(w)) {
+                    throw new IllegalArgumentException("the warning [" + w + "] was both allowed and expected");
+                }
+            }
             apiCallSection.addHeaders(headers);
             apiCallSection.setNodeSelector(nodeSelector);
             doSection.setApiCallSection(apiCallSection);
             doSection.setExpectedWarningHeaders(unmodifiableList(expectedWarnings));
+            doSection.setAllowedWarningHeaders(unmodifiableList(allowedWarnings));
         } finally {
             parser.nextToken();
         }
@@ -188,6 +207,7 @@ public class DoSection implements ExecutableSection {
     private String catchParam;
     private ApiCallSection apiCallSection;
     private List<String> expectedWarningHeaders = emptyList();
+    private List<String> allowedWarningHeaders = emptyList();
 
     public DoSection(XContentLocation location) {
         this.location = location;
@@ -223,6 +243,22 @@ public class DoSection implements ExecutableSection {
      */
     void setExpectedWarningHeaders(List<String> expectedWarningHeaders) {
         this.expectedWarningHeaders = expectedWarningHeaders;
+    }
+
+    /**
+     * Warning headers that we allow from this response. These warning
+     * headers don't cause the test to fail. Defaults to emptyList.
+     */
+    List<String> getAllowedWarningHeaders() {
+        return allowedWarningHeaders;
+    }
+
+    /**
+     * Set the warning headers that we expect from this response. These
+     * warning headers don't cause the test to fail. Defaults to emptyList.
+     */
+    void setAllowedWarningHeaders(List<String> allowedWarningHeaders) {
+        this.allowedWarningHeaders = allowedWarningHeaders;
     }
 
     @Override
@@ -284,15 +320,18 @@ public class DoSection implements ExecutableSection {
         final List<String> unexpected = new ArrayList<>();
         final List<String> unmatched = new ArrayList<>();
         final List<String> missing = new ArrayList<>();
+        Set<String> allowed = allowedWarningHeaders.stream()
+                .map(DeprecationLogger::escapeAndEncode)
+                .collect(toSet());
         // LinkedHashSet so that missing expected warnings come back in a predictable order which is nice for testing
-        final Set<String> expected =
-                new LinkedHashSet<>(expectedWarningHeaders.stream().map(DeprecationLogger::escapeAndEncode).collect(Collectors.toList()));
+        final Set<String> expected = expectedWarningHeaders.stream()
+                .map(DeprecationLogger::escapeAndEncode)
+                .collect(toCollection(LinkedHashSet::new));
         for (final String header : warningHeaders) {
             final Matcher matcher = WARNING_HEADER_PATTERN.matcher(header);
             final boolean matches = matcher.matches();
             if (matches) {
                 final String message = matcher.group(1);
-                // noinspection StatementWithEmptyBody
                 if (masterVersion.before(Version.V_7_0_0)
                         && message.equals("the default number of shards will change from [5] to [1] in 7.0.0; "
                         + "if you wish to continue using the default of [5] shards, "
@@ -301,15 +340,19 @@ public class DoSection implements ExecutableSection {
                      * This warning header will come back in the vast majority of our tests that create an index when running against an
                      * older master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
                      */
-                } else // noinspection StatementWithEmptyBody
-                    if (message.startsWith("[types removal]") || message.startsWith("[_data_frame/transforms/] is deprecated")) {
-                    /*
-                     * We skip warnings related to types deprecation and transform rename so that we can continue to run the many
-                     * mixed-version tests that used typed APIs.
-                     */
-                } else if (expected.remove(message) == false) {
-                    unexpected.add(header);
+                    continue;
                 }
+                if (message.startsWith("[types removal]")) {
+                    // We skip warnings related to types deprecation because they are *everywhere*.
+                    continue;
+                }
+                if (allowed.contains(message)) {
+                    continue;
+                }
+                if (expected.remove(message)) {
+                    continue;
+                }
+                unexpected.add(header);
             } else {
                 unmatched.add(header);
             }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -411,6 +411,19 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
             "at line [" + lineNumber + "]"));
     }
 
+    public void testAddingDoWithAllowedWarningWithoutSkipAllowedWarnings() {
+        int lineNumber = between(1, 10000);
+        DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
+        doSection.setAllowedWarningHeaders(singletonList("foo"));
+        doSection.setApiCallSection(new ApiCallSection("test"));
+        ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
+        Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
+        assertThat(e.getMessage(), containsString("api/name:\nattempted to add a [do] with a [allowed_warnings] " +
+            "section without a corresponding [\"skip\": \"features\": \"allowed_warnings\"] so runners that do not " +
+            "support the [allowed_warnings] section can skip the test at line [" + lineNumber + "]"));
+    }
+
+
     public void testAddingDoWithHeaderWithoutSkipHeaders() {
         int lineNumber = between(1, 10000);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -126,6 +126,15 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                             "did not get expected warning headers [\n\tanother\n\tsome more\n]\n",
                     e.getMessage());
         }
+
+        // "allowed" warnings are fine
+        {
+            final DoSection section = new DoSection(new XContentLocation(1, 1));
+            section.setAllowedWarningHeaders(singletonList("test"));
+            section.checkWarningHeaders(singletonList(testHeader), Version.CURRENT);
+            // and don't throw exceptions if we don't receive them
+            section.checkWarningHeaders(emptyList(), Version.CURRENT);
+        }
     }
 
     public void testIgnoreTypesWarnings() {
@@ -465,6 +474,54 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
         assertThat(doSection.getApiCallSection(), notNullValue());
         assertThat(doSection.getExpectedWarningHeaders(), equalTo(singletonList(
                 "just one entry this time")));
+    }
+
+    public void testParseDoSectionAllowedWarnings() throws Exception {
+        parser = createParser(YamlXContent.yamlXContent,
+                "indices.get_field_mapping:\n" +
+                "        index: test_index\n" +
+                "        type: test_type\n" +
+                "allowed_warnings:\n" +
+                "    - some test warning they are typically pretty long\n" +
+                "    - some other test warning sometimes they have [in] them"
+        );
+
+        DoSection doSection = DoSection.parse(parser);
+        assertThat(doSection.getCatch(), nullValue());
+        assertThat(doSection.getApiCallSection(), notNullValue());
+        assertThat(doSection.getApiCallSection().getApi(), equalTo("indices.get_field_mapping"));
+        assertThat(doSection.getApiCallSection().getParams().size(), equalTo(2));
+        assertThat(doSection.getApiCallSection().getParams().get("index"), equalTo("test_index"));
+        assertThat(doSection.getApiCallSection().getParams().get("type"), equalTo("test_type"));
+        assertThat(doSection.getApiCallSection().hasBody(), equalTo(false));
+        assertThat(doSection.getApiCallSection().getBodies().size(), equalTo(0));
+        assertThat(doSection.getAllowedWarningHeaders(), equalTo(Arrays.asList(
+                "some test warning they are typically pretty long",
+                "some other test warning sometimes they have [in] them")));
+
+        parser = createParser(YamlXContent.yamlXContent,
+                "indices.get_field_mapping:\n" +
+                "        index: test_index\n" +
+                "allowed_warnings:\n" +
+                "    - just one entry this time"
+        );
+
+        doSection = DoSection.parse(parser);
+        assertThat(doSection.getCatch(), nullValue());
+        assertThat(doSection.getApiCallSection(), notNullValue());
+        assertThat(doSection.getAllowedWarningHeaders(), equalTo(singletonList(
+                "just one entry this time")));
+
+        parser = createParser(YamlXContent.yamlXContent,
+                "indices.get_field_mapping:\n" +
+                "        index: test_index\n" +
+                "warnings:\n" +
+                "    - foo\n" +
+                "allowed_warnings:\n" +
+                "    - foo"
+        );
+        Exception e = expectThrows(IllegalArgumentException.class, () -> DoSection.parse(parser));
+        assertThat(e.getMessage(), equalTo("the warning [foo] was both allowed and expected"));
     }
 
     public void testNodeSelectorByVersion() throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
@@ -1,5 +1,8 @@
 ---
 "Test put batch transform on mixed cluster":
+  - skip:
+      features: allowed_warnings
+
   - do:
       cluster.health:
         index: "transform-airline-data"
@@ -7,6 +10,8 @@
         timeout: 70s
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.put_transform:
         transform_id: "mixed-simple-transform"
         body: >
@@ -21,10 +26,14 @@
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "mixed-simple-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
@@ -34,12 +43,16 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "mixed-simple-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-transform"
   - match: { count: 1 }
@@ -49,6 +62,8 @@
   #- match: { transforms.0.state: "stopped" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.put_transform:
         transform_id: "mixed-complex-transform"
         body: >
@@ -76,16 +91,22 @@
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-complex-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "mixed-complex-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
@@ -95,12 +116,16 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "mixed-complex-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-complex-transform"
   - match: { count: 1 }
@@ -111,6 +136,9 @@
 
 ---
 "Test put continuous transform on mixed cluster":
+  - skip:
+      features: allowed_warnings
+
   - do:
       cluster.health:
         index: "transform-airline-data-cont"
@@ -118,6 +146,8 @@
         timeout: 70s
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.put_transform:
         transform_id: "mixed-simple-continuous-transform"
         body: >
@@ -138,6 +168,8 @@
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
@@ -148,10 +180,14 @@
   - is_true: transforms.0.create_time
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "mixed-simple-continuous-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
@@ -161,12 +197,16 @@
   #- match: { transforms.0.state: "/started|indexing/" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "mixed-simple-continuous-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "mixed-simple-continuous-transform"
   - match: { count: 1 }
@@ -177,6 +217,9 @@
 
 ---
 "Test GET, start, and stop old cluster batch transforms":
+  - skip:
+      features: allowed_warnings
+
   - do:
       cluster.health:
         index: "transform-airline-data"
@@ -184,6 +227,8 @@
         timeout: 70s
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
@@ -194,10 +239,14 @@
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
@@ -207,11 +256,15 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
@@ -221,6 +274,8 @@
   #- match: { transforms.0.state: "stopped" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
@@ -233,10 +288,14 @@
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "old-complex-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
@@ -246,11 +305,15 @@
   #- match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "old-complex-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
@@ -261,6 +324,9 @@
 
 ---
 "Test GET, stop, start, old continuous transforms":
+  - skip:
+      features: allowed_warnings
+
   - do:
       cluster.health:
         index: "transform-airline-data-cont"
@@ -268,6 +334,8 @@
         timeout: 70s
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
@@ -278,10 +346,14 @@
   - is_true: transforms.0.create_time
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
@@ -291,12 +363,16 @@
   #- match: { transforms.0.state: "/started|indexing/" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-continuous-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_transform_jobs_crud.yml
@@ -23,6 +23,8 @@
         timeout: 70s
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.put_transform:
         transform_id: "old-simple-transform"
         body: >

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_transform_jobs_crud.yml
@@ -1,5 +1,7 @@
 ---
 "Test put batch transform on old cluster":
+  - skip:
+      features: allowed_warnings
   - do:
       indices.create:
         index: transform-airline-data
@@ -35,34 +37,46 @@
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.put_transform:
         transform_id: "old-complex-transform"
         body: >
@@ -90,28 +104,38 @@
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "old-complex-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-complex-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "old-complex-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-complex-transform"
   - match: { count: 1 }
@@ -119,6 +143,9 @@
 
 ---
 "Test put continuous transform on old cluster":
+  - skip:
+      features: allowed_warnings
+
   - do:
       indices.create:
         index: transform-airline-data-cont
@@ -140,6 +167,8 @@
         timeout: 70s
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.put_transform:
         transform_id: "old-simple-continuous-transform"
         body: >
@@ -160,6 +189,8 @@
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
@@ -170,22 +201,30 @@
   - is_true: transforms.0.create_time
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.start_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { acknowledged: true }
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.stop_transform:
         transform_id: "old-simple-continuous-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - '[_data_frame/transforms/] is deprecated, use [_transform/] in the future.'
       data_frame_transform_deprecated.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
   - match: { count: 1 }


### PR DESCRIPTION
When we test backwards compatibility we often end up in a situation
where we *sometimes* get a warning, and sometimes don't. Like, we won't
get the warning if we're testing against an older version, but we will
in a newer one. Or we won't get the warning if the request randomly
lands on a node with an old version of the code. But we wouldn't if it
randomed into a node with newer code.

This adds `allowed_warnings` to our yaml test runner for those cases:
warnings declared this way are "allowed" but not "required".

Blocks #52959