### PR TITLE
Ensure only plugin REST tests are run for plugins

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
@@ -135,7 +135,9 @@ public class CopyRestApiTask extends DefaultTask {
                 if (includeCore.get().isEmpty()) {
                     c.include(REST_API_PREFIX + "/**");
                 } else {
-                    c.include(includeCore.get().stream().map(prefix -> REST_API_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList()));
+                    c.include(
+                        includeCore.get().stream().map(prefix -> REST_API_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
+                    );
                 }
             });
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
@@ -132,7 +132,11 @@ public class CopyRestApiTask extends DefaultTask {
             project.copy(c -> {
                 c.from(project.zipTree(coreConfig.getSingleFile()));
                 c.into(getTestSourceSet().getOutput().getResourcesDir()); // this ends up as the same dir as outputDir
-                c.include(includeCore.get().stream().map(prefix -> COPY_TO + "/" + prefix + "*/**").collect(Collectors.toList()));
+                if (includeCore.get().isEmpty()) {
+                    c.include(COPY_TO + "/**");
+                } else {
+                    c.include(includeCore.get().stream().map(prefix -> COPY_TO + "/" + prefix + "*/**").collect(Collectors.toList()));
+                }
             });
         }
         // only copy x-pack specs if explicitly instructed

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  * @see RestResourcesPlugin
  */
 public class CopyRestApiTask extends DefaultTask {
-    private static final String COPY_TO = "rest-api-spec/api";
+    private static final String REST_API_PREFIX = "rest-api-spec/api";
     final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
     final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
 
@@ -109,7 +109,7 @@ public class CopyRestApiTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(getTestSourceSet().getOutput().getResourcesDir(), COPY_TO);
+        return new File(getTestSourceSet().getOutput().getResourcesDir(), REST_API_PREFIX);
     }
 
     @TaskAction
@@ -133,9 +133,9 @@ public class CopyRestApiTask extends DefaultTask {
                 c.from(project.zipTree(coreConfig.getSingleFile()));
                 c.into(getTestSourceSet().getOutput().getResourcesDir()); // this ends up as the same dir as outputDir
                 if (includeCore.get().isEmpty()) {
-                    c.include(COPY_TO + "/**");
+                    c.include(REST_API_PREFIX + "/**");
                 } else {
-                    c.include(includeCore.get().stream().map(prefix -> COPY_TO + "/" + prefix + "*/**").collect(Collectors.toList()));
+                    c.include(includeCore.get().stream().map(prefix -> REST_API_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList()));
                 }
             });
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  * @see RestResourcesPlugin
  */
 public class CopyRestTestsTask extends DefaultTask {
-    private static final String COPY_TO = "rest-api-spec/test";
+    private static final String REST_TEST_PREFIX = "rest-api-spec/test";
     final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
     final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
 
@@ -103,7 +103,7 @@ public class CopyRestTestsTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(getTestSourceSet().getOutput().getResourcesDir(), COPY_TO);
+        return new File(getTestSourceSet().getOutput().getResourcesDir(), REST_TEST_PREFIX);
     }
 
     @TaskAction
@@ -128,7 +128,7 @@ public class CopyRestTestsTask extends DefaultTask {
                 project.copy(c -> {
                     c.from(project.zipTree(coreConfig.getSingleFile()));
                     c.into(getTestSourceSet().getOutput().getResourcesDir()); // this ends up as the same dir as outputDir
-                    c.include(includeCore.get().stream().map(prefix -> COPY_TO + "/" + prefix + "*/**").collect(Collectors.toList()));
+                    c.include(includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList()));
                 });
             }
         }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -128,7 +128,9 @@ public class CopyRestTestsTask extends DefaultTask {
                 project.copy(c -> {
                     c.from(project.zipTree(coreConfig.getSingleFile()));
                     c.into(getTestSourceSet().getOutput().getResourcesDir()); // this ends up as the same dir as outputDir
-                    c.include(includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList()));
+                    c.include(
+                        includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
+                    );
                 });
             }
         }


### PR DESCRIPTION
This commit fixes ensures that for external builds
(e.g. plugin development) that the REST tests that are
copied are properly filtered to only include the API
by default.

The code prior to this change resulted in including both
the API and tests since the copy.include resulted as an
empty list by default since the stream is empty unless
explictly configured.

related #52114
fixes #53183

----------

Note - this is how I tested

```
# from elasticsearch directory
./gradlew :build-tools:publishToMavenLocal

./gradlew :rest-api-spec:publishToMavenLocal :test:framework:publishToMavenLocal :server:publishToMavenLocal :libs:elasticsearch-core:publishToMavenLocal :libs:elasticsearch-x-content:publishToMavenLocal :libs:elasticsearch-cli:publishToMavenLocal :libs:elasticsearch-nio:publishToMavenLocal :libs:elasticsearch-geo:publishToMavenLocal :libs:elasticsearch-secure-sm:publishToMavenLocal :distribution:archives:integ-test-zip:publishToMavenLocal :client:rest:publishToMavenLocal :client:sniffer:publishToMavenLocal :test:logger-usage:publishToMavenLocal


```

We can use [@spinscale 's cookie cutter](https://github.com/spinscale/cookiecutter-elasticsearch-ingest-processor) to help create a test project
```
# requires python3
pip3 install cookiecutter
cookiecutter gh:spinscale/cookiecutter-elasticsearch-ingest-processor
# Add the master version when it asks: elasticsearch_version [7.6.1]: 8.0.0-SNAPSHOT
cd ingest-awesome
# Add to the build.gradle
repositories {
   mavenLocal()
}
./gradlew check 
```