### PR TITLE
Add BlobStoreRepository#writeSnapshotIndexLatestBlob method

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1400,14 +1400,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             writeAtomic(indexBlob,
                 BytesReference.bytes(filteredRepositoryData.snapshotsToXContent(XContentFactory.jsonBuilder(), writeShardGens)), true);
             // write the current generation to the index-latest file
-            final BytesReference genBytes;
-            try (BytesStreamOutput bStream = new BytesStreamOutput()) {
-                bStream.writeLong(newGen);
-                genBytes = bStream.bytes();
-            }
             logger.debug("Repository [{}] updating index.latest with generation [{}]", metadata.name(), newGen);
-
-            writeAtomic(INDEX_LATEST_BLOB, genBytes, false);
+            writeSnapshotIndexLatestBlob(newGen);
 
             // Step 3: Update CS to reflect new repository generation.
             clusterService.submitStateUpdateTask("set safe repository generation [" + metadata.name() + "][" + newGen + "]",
@@ -1499,9 +1493,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
-    // package private for testing
-    long readSnapshotIndexLatestBlob() throws IOException {
+    protected long readSnapshotIndexLatestBlob() throws IOException {
         return Numbers.bytesToLong(Streams.readFully(blobContainer().readBlob(INDEX_LATEST_BLOB)).toBytesRef());
+    }
+
+    protected void writeSnapshotIndexLatestBlob(long newGen) throws IOException {
+        final BytesReference genBytes;
+        try (BytesStreamOutput baos = new BytesStreamOutput()) {
+            baos.writeLong(newGen);
+            genBytes = baos.bytes();
+        }
+        writeAtomic(INDEX_LATEST_BLOB, genBytes, false);
     }
 
     private long listBlobsToGetLatestIndexId() throws IOException {


### PR DESCRIPTION
This commit creates a new protected method to access (write) the `index.latest` blob; there exists already to opposite method to read the said blob. This change permits `BlobStoreRepository` implementations to have a different access behavior, compared to the other blobs, for the special `index.latest` blob.

_NB: This change might not be REQUIRED for the encrypted repository, given the latest developments https://github.com/elastic/elasticsearch/pull/50846#issuecomment-594063727 , but it seems to me like a good-to-have option._
