### PR TITLE
[7.x] Ensure only plugin REST tests are run for plugins (#53184)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestApiTask.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  * @see RestResourcesPlugin
  */
 public class CopyRestApiTask extends DefaultTask {
-    private static final String COPY_TO = "rest-api-spec/api";
+    private static final String REST_API_PREFIX = "rest-api-spec/api";
     final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
     final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
 
@@ -109,7 +109,7 @@ public class CopyRestApiTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(getTestSourceSet().getOutput().getResourcesDir(), COPY_TO);
+        return new File(getTestSourceSet().getOutput().getResourcesDir(), REST_API_PREFIX);
     }
 
     @TaskAction
@@ -132,7 +132,13 @@ public class CopyRestApiTask extends DefaultTask {
             project.copy(c -> {
                 c.from(project.zipTree(coreConfig.getSingleFile()));
                 c.into(getTestSourceSet().getOutput().getResourcesDir()); // this ends up as the same dir as outputDir
-                c.include(includeCore.get().stream().map(prefix -> COPY_TO + "/" + prefix + "*/**").collect(Collectors.toList()));
+                if (includeCore.get().isEmpty()) {
+                    c.include(REST_API_PREFIX + "/**");
+                } else {
+                    c.include(
+                        includeCore.get().stream().map(prefix -> REST_API_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
+                    );
+                }
             });
         }
         // only copy x-pack specs if explicitly instructed

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/CopyRestTestsTask.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  * @see RestResourcesPlugin
  */
 public class CopyRestTestsTask extends DefaultTask {
-    private static final String COPY_TO = "rest-api-spec/test";
+    private static final String REST_TEST_PREFIX = "rest-api-spec/test";
     final ListProperty<String> includeCore = getProject().getObjects().listProperty(String.class);
     final ListProperty<String> includeXpack = getProject().getObjects().listProperty(String.class);
 
@@ -103,7 +103,7 @@ public class CopyRestTestsTask extends DefaultTask {
 
     @OutputDirectory
     public File getOutputDir() {
-        return new File(getTestSourceSet().getOutput().getResourcesDir(), COPY_TO);
+        return new File(getTestSourceSet().getOutput().getResourcesDir(), REST_TEST_PREFIX);
     }
 
     @TaskAction
@@ -128,7 +128,9 @@ public class CopyRestTestsTask extends DefaultTask {
                 project.copy(c -> {
                     c.from(project.zipTree(coreConfig.getSingleFile()));
                     c.into(getTestSourceSet().getOutput().getResourcesDir()); // this ends up as the same dir as outputDir
-                    c.include(includeCore.get().stream().map(prefix -> COPY_TO + "/" + prefix + "*/**").collect(Collectors.toList()));
+                    c.include(
+                        includeCore.get().stream().map(prefix -> REST_TEST_PREFIX + "/" + prefix + "*/**").collect(Collectors.toList())
+                    );
                 });
             }
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Ensure only plugin REST tests are run for plugins (#53184)