### PR TITLE
Add a simple random sampling query

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsQueryBuilders.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsQueryBuilders.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.analytics;
+
+import org.elasticsearch.xpack.analytics.randomsampling.RandomSamplingQueryBuilder;
+
+public class AnalyticsQueryBuilders {
+
+    /**
+     * Creates a random sampler query
+     *
+     * @param probability The probability that a document is randomly sampled
+     * @param seed  A seed to use with the random generator.  Null if you do not wish to provide a seed
+     */
+    public static RandomSamplingQueryBuilder randomSampleQuery(double probability, Integer seed) {
+        return new RandomSamplingQueryBuilder(probability, seed);
+    }
+}

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsUsage.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsUsage.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Tracks usage of the Analytics aggregations.
+ * Tracks usage of the Analytics features.
  */
 public class AnalyticsUsage {
     /**
@@ -25,7 +25,8 @@ public class AnalyticsUsage {
         BOXPLOT,
         CUMULATIVE_CARDINALITY,
         STRING_STATS,
-        TOP_METRICS;
+        TOP_METRICS,
+        RANDOM_SAMPLE;
     }
 
     private final Map<Item, AtomicLong> trackers = new EnumMap<>(Item.class);
@@ -54,6 +55,7 @@ public class AnalyticsUsage {
                 trackers.get(Item.BOXPLOT).get(),
                 trackers.get(Item.CUMULATIVE_CARDINALITY).get(),
                 trackers.get(Item.STRING_STATS).get(),
-                trackers.get(Item.TOP_METRICS).get());
+                trackers.get(Item.TOP_METRICS).get(),
+                trackers.get(Item.RANDOM_SAMPLE).get());
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/randomsampling/RandomSamplingQuery.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/randomsampling/RandomSamplingQuery.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.analytics.randomsampling;
+
+import com.carrotsearch.hppc.BitMixer;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A query that randomly matches documents with a user-provided probability.  May
+ * optionally include a seed so that matches are reproducible.
+ *
+ * This query uses two strategies depending on the size of the segment.
+ * For small segments, this uses simple random sampling per-document.  For larger
+ * segments, sampling is sped up by approximating the _gap_ between samples, then
+ * skipping forward that amount.
+ *
+ * Gap-sampling is based on the work of Jeffrey Vitter in "An Efficient Algorithm
+ * for Sequential Random Sampling" (http://www.ittc.ku.edu/~jsv/Papers/Vit87.RandomSampling.pdf),
+ * and more recently documented by Erik Erlandson
+ * (http://erikerlandson.github.io/blog/2014/09/11/faster-random-samples-with-gap-sampling/)
+ */
+public final class RandomSamplingQuery extends Query {
+
+    // Above this threshold, it is probably faster to just use simple random sampling
+    private static final double PROBABILITY_THRESHOLD = 0.5;
+    private static final float EPSILON = 1e-10f;
+
+    private final double p;
+    private final int seed;
+    private final boolean cacheable;
+
+    /**
+     * @param p         The sampling probability e.g. 0.05 == 5% probability a document will match
+     * @param seed      A seed to make the sample deterministic
+     * @param cacheable True if the seed is static (provided by the user) so that we can cache the query, false otherwise
+     */
+    RandomSamplingQuery(double p, int seed, boolean cacheable) {
+        if (p < 0.0 || p > 1.0) {
+            throw new IllegalArgumentException("RandomSampling probability must be between 0.0 and 1.0");
+        }
+
+        this.p = p;
+        this.seed = BitMixer.mix(seed);
+        this.cacheable = cacheable;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public Scorer scorer(LeafReaderContext context) {
+                int maxDoc = context.reader().maxDoc();
+
+                // For small doc sets, it's easier/more accurate to just sample directly
+                // instead of sampling gaps. Or, if the probability is high, faster to use SRS
+                if (maxDoc < 100 || p > PROBABILITY_THRESHOLD) {
+                    return new ConstantScoreScorer(this, score(), ScoreMode.COMPLETE, new RandomSamplingIterator(maxDoc, p, seed));
+                } else {
+                    return new ConstantScoreScorer(this, score(), ScoreMode.COMPLETE, new RandomGapIterator(maxDoc, p, seed));
+                }
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return cacheable;
+            }
+        };
+    }
+
+    /**
+     * A DocIDSetIter that samples on each document.  Empirically, this tends to
+     * be more accurate when the segment is small.  It may also be faster
+     * when the probability is high, since many docs are collected and gap approximation
+     * uses more expensive math
+     */
+    static class RandomSamplingIterator extends DocIdSetIterator {
+        private final int maxDoc;
+        private final double p;
+        private final int seed;
+        private int doc = -1;
+
+        RandomSamplingIterator(int maxDoc, double p, int seed) {
+            this.maxDoc = maxDoc;
+            this.p = p;
+            this.seed = seed;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) {
+            // Although this advances `doc` to `target`, the random value that decides which docs are returned
+            // is only dependent on maxDoc of segment, the docID and the seed.  So the same documents will be matched
+            // for a particular segment regardless of the order the iterator is consumed (although obviously not all
+            // will be returned depending on how `advance()` is invoked
+            doc = target;
+            while (doc < maxDoc) {
+                if (getRandomFloat(maxDoc, doc, seed) <= p) {
+                    return doc;
+                }
+                doc = doc + 1;
+            }
+            return NO_MORE_DOCS;
+        }
+
+        @Override
+        public long cost() {
+            return (long)(maxDoc * p);
+        }
+    }
+
+    /**
+     * A DocIDSetIter that approximates the gaps between sampled documents, and advances
+     * according to the gap.  This is more efficient for low probabilities
+     * because it can skip forward without having to consult the RNG on each document.
+     */
+    static class RandomGapIterator extends DocIdSetIterator {
+        private final int maxDoc;
+        private final double p;
+        private final int seed;
+        private final double logInverseP;
+        private int doc = -1;
+
+        RandomGapIterator(int maxDoc, double p, int seed) {
+            this.maxDoc = maxDoc;
+            this.p = p;
+            this.seed = seed;
+            this.logInverseP = (float)Math.log(1-p);
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) {
+            // Keep approximating gaps until we hit or surpass the target.  Although this can introduce
+            // more work if another iterator has moved us forward a lot, it is required so that the results
+            // returned by this iterator are consistent (e.g. always matches the same docs).
+            //
+            // If we set doc = target, the gaps generated would change depending on how `advance()` is invoked
+            while (doc <= target) {
+                doc += getGap(doc);
+            }
+            if (doc >= maxDoc) {
+                doc = NO_MORE_DOCS;
+            }
+            return doc;
+        }
+
+        @Override
+        public long cost() {
+            return (long)(maxDoc * p);
+        }
+
+        private int getGap(int doc) {
+            float u = Math.max(getRandomFloat(maxDoc, doc, seed), EPSILON);
+            return (int)(Math.log(u) / logInverseP) + 1;
+        }
+    }
+
+    private static float getRandomFloat(int maxDoc, int value, int seed) {
+        int hash = BitMixer.mix(value, seed + maxDoc);
+        return (hash & 0x00FFFFFF) / (float)(1 << 24); // only use the lower 24 bits to construct a float from 0.0-1.0
+    }
+
+    @Override
+    public String toString(String field) {
+        return "RandomSample[p=" + this.p + "](*:*)";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RandomSamplingQuery other = (RandomSamplingQuery)o;
+        return Objects.equals(this.p, other.p) &&
+            Objects.equals(this.seed, other.seed);
+    }
+
+    @Override
+    public int hashCode() {
+        return classHash();
+    }
+
+
+}

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/randomsampling/RandomSamplingQueryBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/randomsampling/RandomSamplingQueryBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.analytics.randomsampling;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A query that randomly matches documents with a user-provided probability.  May
+ * optionally include a seed so that matches are deterministic
+ */
+public class RandomSamplingQueryBuilder extends AbstractQueryBuilder<RandomSamplingQueryBuilder> {
+    public static final String NAME = "random_sample";
+    private static final ParseField PROBABILITY = new ParseField("probability");
+    private static final ParseField SEED = new ParseField("seed");
+
+    private double p = 0.5;
+    private Integer seed = null;
+
+    public RandomSamplingQueryBuilder(double probability) {
+        this(probability, null);
+    }
+
+    public RandomSamplingQueryBuilder(double probability, Integer seed) {
+        this.p = validateProbability(probability);
+        this.seed = seed;
+    }
+
+    private RandomSamplingQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public RandomSamplingQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        p = in.readDouble();
+        seed = in.readOptionalInt();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeDouble(p);
+        out.writeOptionalInt(seed);
+    }
+
+    public double getProbability() {
+        return p;
+    }
+
+    public void setProbability(double p) {
+        this.p = validateProbability(p);
+    }
+
+    public Integer getSeed() {
+        return seed;
+    }
+
+    public void setSeed(Integer seed) {
+        this.seed = seed;
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        printBoostAndQueryName(builder);
+        builder.field(PROBABILITY.getPreferredName(), p);
+        if (seed != null) {
+            builder.field(SEED.getPreferredName(), seed);
+        }
+        builder.endObject();
+    }
+
+    public static final ObjectParser<RandomSamplingQueryBuilder, Void> PARSER = new ObjectParser<>(NAME, RandomSamplingQueryBuilder::new);
+
+    static {
+        declareStandardFields(PARSER);
+        PARSER.declareDouble(RandomSamplingQueryBuilder::setProbability, PROBABILITY);
+        PARSER.declareInt(RandomSamplingQueryBuilder::setSeed, SEED);
+    }
+
+    @Override
+    protected final Query doToQuery(QueryShardContext context) {
+        return new RandomSamplingQuery(p, Objects.requireNonNullElseGet(seed, () -> Long.hashCode(context.nowInMillis())), seed == null);
+    }
+
+    @Override
+    protected boolean doEquals(RandomSamplingQueryBuilder other) {
+        return Objects.equals(p, other.p)
+            && Objects.equals(seed, other.seed);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(p, seed);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    private double validateProbability(double p) {
+        if (p <= 0.0) {
+            throw new IllegalArgumentException("[" + PROBABILITY.getPreferredName() + "] cannot be less than or equal to 0.0.");
+        }
+        if (p >= 1.0) {
+            throw new IllegalArgumentException("[" + PROBABILITY.getPreferredName() + "] cannot be greater than or equal to 1.0.");
+        }
+        return p;
+    }
+}

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/randomsampling/RandomDocIDSetIteratorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/randomsampling/RandomDocIDSetIteratorTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.analytics.randomsampling;
+
+import org.apache.lucene.search.DocIdSetIterator;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class RandomDocIDSetIteratorTests extends ESTestCase {
+
+    public void testRandomSampler() throws IOException {
+        int maxDoc = 10000;
+        int seed = randomInt();
+
+        for (int i = 1; i < 100; i++) {
+            double p = i / 100.0;
+            int count = 0;
+            RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, seed);
+            while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                count += 1;
+            }
+
+            double error = Math.abs((maxDoc * p)/count) / (maxDoc * p);
+            if (error > 0.05) {
+                fail("Hit count was [" + count + "], expected to be close to " + maxDoc * p
+                    + " (+/- 5% error). Error was " + error + ", p=" + p);
+            }
+        }
+    }
+
+    public void testRandomGapSampler() throws IOException {
+        int maxDoc = 10000;
+        int seed = randomInt();
+
+        for (int i = 1; i < 100; i++) {
+            double p = i / 100.0;
+            int count = 0;
+            RandomSamplingQuery.RandomGapIterator iter = new RandomSamplingQuery.RandomGapIterator(maxDoc, p, seed);
+            while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                count += 1;
+            }
+
+            double error = Math.abs((maxDoc * p)/count) / (maxDoc * p);
+            if (error > 0.05) {
+                fail("Hit count was [" + count + "], expected to be close to " + maxDoc * p
+                    + " (+/- 5% error). Error was " + error + ", p=" + p);
+            }
+        }
+    }
+}

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/randomsampling/RandomSamplingQueryBuilderTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/randomsampling/RandomSamplingQueryBuilderTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.analytics.randomsampling;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.license.License;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.AbstractQueryTestCase;
+import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class RandomSamplingQueryBuilderTests extends AbstractQueryTestCase<RandomSamplingQueryBuilder> {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(MockLicensedAnalyticsPlugin.class);
+    }
+
+    public static class MockLicensedAnalyticsPlugin extends AnalyticsPlugin {
+
+        public MockLicensedAnalyticsPlugin() {
+            super();
+        }
+
+        @Override
+        protected XPackLicenseState getLicenseState() {
+            return new XPackLicenseState(Settings.EMPTY) {
+                @Override
+                public boolean isAllowedByLicense(License.OperationMode minimumMode) {
+                    return minimumMode.equals(License.OperationMode.PLATINUM);
+                }
+            };
+        }
+    }
+
+    private boolean isCacheable = false;
+
+    @Override
+    protected RandomSamplingQueryBuilder doCreateTestQueryBuilder() {
+        double p = randomDoubleBetween(0.00001, 0.999999, true);
+        RandomSamplingQueryBuilder builder = new RandomSamplingQueryBuilder(p);
+        if (randomBoolean()) {
+            builder.setSeed(123);
+            isCacheable = true;
+        }
+        return builder;
+    }
+
+    @Override
+    protected boolean builderGeneratesCacheableQueries() {
+        return isCacheable;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(RandomSamplingQueryBuilder queryBuilder, Query query, QueryShardContext context) throws IOException {
+        assertThat(query, instanceOf(RandomSamplingQuery.class));
+    }
+
+    public void testIllegalArguments() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RandomSamplingQueryBuilder(0.0));
+        assertEquals("[probability] cannot be less than or equal to 0.0.", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> new RandomSamplingQueryBuilder(-5.0));
+        assertEquals("[probability] cannot be less than or equal to 0.0.", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> new RandomSamplingQueryBuilder(1.0));
+        assertEquals("[probability] cannot be greater than or equal to 1.0.", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> new RandomSamplingQueryBuilder(5.0));
+        assertEquals("[probability] cannot be greater than or equal to 1.0.", e.getMessage());
+    }
+
+
+    public void testFromJson() throws IOException {
+        String json =
+            "{\n" +
+                "  \"random_sample\" : {\n" +
+                "    \"boost\" : 1.0,\n" +
+                "    \"probability\" : 0.5\n" +
+                "  }\n" +
+                "}";
+        RandomSamplingQueryBuilder parsed = (RandomSamplingQueryBuilder) parseQuery(json);
+        checkGeneratedJson(json, parsed);
+        assertThat(parsed.getProbability(), equalTo(0.5));
+        assertThat(parsed.getSeed(), nullValue());
+
+        // try with seed
+        json =
+            "{\n" +
+                "  \"random_sample\" : {\n" +
+                "    \"boost\" : 1.0,\n" +
+                "    \"probability\" : 0.5,\n" +
+                "    \"seed\" : 123\n" +
+                "  }\n" +
+                "}";
+        parsed = (RandomSamplingQueryBuilder) parseQuery(json);
+        assertThat(parsed.getProbability(), equalTo(0.5));
+        assertThat(parsed.getSeed(), equalTo(123));
+
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
@@ -114,19 +114,22 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
         static final ParseField CUMULATIVE_CARDINALITY_USAGE = new ParseField("cumulative_cardinality_usage");
         static final ParseField STRING_STATS_USAGE = new ParseField("string_stats_usage");
         static final ParseField TOP_METRICS_USAGE = new ParseField("top_metrics_usage");
+        static final ParseField RANDOM_SAMPLE_QUERY_USAGE = new ParseField("random_sample_query_usage");
 
         private final long boxplotUsage;
         private final long cumulativeCardinalityUsage;
         private final long stringStatsUsage;
         private final long topMetricsUsage;
+        private final long randomSampleQueryUsage;
 
         public NodeResponse(DiscoveryNode node, long boxplotUsage, long cumulativeCardinalityUsage, long stringStatsUsage,
-                long topMetricsUsage) {
+                long topMetricsUsage, long randomSampleQueryUsage) {
             super(node);
             this.boxplotUsage = boxplotUsage;
             this.cumulativeCardinalityUsage = cumulativeCardinalityUsage;
             this.stringStatsUsage = stringStatsUsage;
             this.topMetricsUsage = topMetricsUsage;
+            this.randomSampleQueryUsage = randomSampleQueryUsage;
         }
 
         public NodeResponse(StreamInput in) throws IOException {
@@ -144,6 +147,11 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
                 stringStatsUsage = 0;
                 topMetricsUsage = 0;
             }
+            if (in.getVersion().onOrAfter((Version.V_7_7_0))) {
+                randomSampleQueryUsage = in.readVLong();
+            } else {
+                randomSampleQueryUsage = 0;
+            }
         }
 
         @Override
@@ -157,6 +165,9 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
                 out.writeVLong(stringStatsUsage);
                 out.writeVLong(topMetricsUsage);
             }
+            if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
+                out.writeVLong(randomSampleQueryUsage);
+            }
         }
 
         @Override
@@ -166,6 +177,7 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
             builder.field(CUMULATIVE_CARDINALITY_USAGE.getPreferredName(), cumulativeCardinalityUsage);
             builder.field(STRING_STATS_USAGE.getPreferredName(), stringStatsUsage);
             builder.field(TOP_METRICS_USAGE.getPreferredName(), topMetricsUsage);
+            builder.field(RANDOM_SAMPLE_QUERY_USAGE.getPreferredName(), randomSampleQueryUsage);
             builder.endObject();
             return builder;
         }
@@ -184,6 +196,10 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
 
         public long getTopMetricsUsage() {
             return topMetricsUsage;
+        }
+
+        public long getRandomSampleQueryUsage() {
+            return randomSampleQueryUsage;
         }
     }
 }


### PR DESCRIPTION
WIP:  Putting up for some eyeballs.  If we like it, it needs more tests, documentation, cleanup, etc

This is a reboot of https://github.com/elastic/elasticsearch/pull/25561.  It adds a `random_sample` query which randomly matches documents according to the user-defined probability.  Note this is a pure random sampler: if `p=0.05`, each document has a 5% chance of being included.  This is not a reservoir sampler where 5% of the documents are selected (although I believe we can use the same gap sampling technique to later build a reservoir sampler)

Some notable points:

- Without a user-defined seed, this uses `context.nowInMillis()` and is not eligible for caching.  If the user provides a seed, I'm allowing it to cache
- With a seed, this is deterministic as long as the segments do not change.  It uses the `docID`, `maxDoc` and `seed` to run the random generator.  Segment merging will changeup `maxDoc`/`docID` so the rng will change.

    I personally think this is acceptable given the nature of the query.  If we wanted to make it deterministic, we could seed it off a value from the document... but this means A) visiting every document instead of gap sampling and B) touching the field's DV for each document.  My gut says this would remove the performance benefit

   Should also note that the `random` function in `function_score` has the same behavior if a seed and field are not supplied.

- If the requested probability is < 50%, we use gap sampling.  If it's greater than 50%, we check the rng on each document.  This is a rough heuristic right now... if the approach looks acceptable I'd like to do more benchmarking on where this line is.

## Performance
I need to run more benchmarks to get a better sense of how it behaves, but with simple tests it is encouraging :)

As a test, I included a bunch of nested terms/date_histo aggs (to slow the query down) and an overall average at the top (to get a sense for sampling error).  Index was ~20m docs

| Test  | Took | Hits | Avg value
| ------------- | ------------- | ------------- | ------------- |
| MatchAll  | 2819ms | 20535000 | 19224.137132261993
| 5% Sampling  | 235ms  | 1025388 | 18677.448469262366

So 91.6% faster and 2.8% error on the overall avg metric.

This kind of simple sampling is obviously very use-case dependent (min/max are likely to be skewed, anything relying on rare strata are likely to be under-represented, etc).  But for a whole class of queries this could provide a very fast, approximate answer while a more accurate response is calculated.