### PR TITLE
Rename "groups" to "roles"

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/idp/saml-service-provider-template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/idp/saml-service-provider-template.json
@@ -62,7 +62,7 @@
             "login": {
               "type": "keyword"
             },
-            "groups": {
+            "roles": {
               "type": "object",
               "dynamic": false
             }
@@ -80,7 +80,7 @@
             "name": {
               "type": "keyword"
             },
-            "groups": {
+            "roles": {
               "type": "keyword"
             }
           }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
@@ -26,8 +26,6 @@ import org.opensaml.saml.saml2.core.Response;
 
 import java.io.IOException;
 import java.time.Clock;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 public class TransportSamlInitiateSingleSignOnAction
@@ -84,7 +82,8 @@ public class TransportSamlInitiateSingleSignOnAction
 
     private UserServiceAuthentication buildUserFromAuthentication(Authentication authentication, SamlServiceProvider sp) {
         final User authenticatedUser = authentication.getUser();
-        final Set<String> groups = new HashSet<>(Arrays.asList(authenticatedUser.roles()));
-        return new UserServiceAuthentication(authenticatedUser.principal(), groups, sp);
+        // TODO : This needs to use UserPrivilegeResolver
+        final Set<String> roles = Set.of(authenticatedUser.roles());
+        return new UserServiceAuthentication(authenticatedUser.principal(), roles, sp);
     }
 }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ServiceProviderPrivileges.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/ServiceProviderPrivileges.java
@@ -17,13 +17,13 @@ public class ServiceProviderPrivileges {
     private final String applicationName;
     private final String resource;
     private final String loginAction;
-    private final Map<String, String> groups;
+    private final Map<String, String> roles;
 
-    public ServiceProviderPrivileges(String applicationName, String resource, String loginAction, Map<String, String> groups) {
+    public ServiceProviderPrivileges(String applicationName, String resource, String loginAction, Map<String, String> roles) {
         this.applicationName = Objects.requireNonNull(applicationName, "Application name cannot be null");
         this.resource = Objects.requireNonNull(resource, "Resource cannot be null");
         this.loginAction = Objects.requireNonNull(loginAction, "Login action cannot be null");
-        this.groups = Map.copyOf(groups);
+        this.roles = Map.copyOf(roles);
     }
 
     /**
@@ -51,12 +51,15 @@ public class ServiceProviderPrivileges {
     }
 
     /**
-     * Returns a mapping from "group name" (key) to "{@link ApplicationPrivilegeDescriptor#getActions() action name}" (value)
-     * that represents the groups that should be exposed to this Service Provider.
-     * The "group name" (but not the action name) will be provided to the service provider.
+     * Returns a mapping from "role name" (key) to "{@link ApplicationPrivilegeDescriptor#getActions() action name}" (value)
+     * that represents the roles that should be exposed to this Service Provider.
+     * The "role name" (but not the action name) will be provided to the service provider.
+     * These roles have no semantic meaning within the IdP, they are simply metadata that we pass to the Service Provider. They may not
+     * have any relationship to the roles that the user has in this cluster, and the service provider may refer to them using a different
+     * terminology (e.g. "groups").
      * The actions will be resolved as application privileges from the IdP's security cluster.
      */
-    public Map<String, String> getGroupActions() {
-        return groups;
+    public Map<String, String> getRoleActions() {
+        return roles;
     }
 }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolver.java
@@ -32,15 +32,15 @@ public class UserPrivilegeResolver {
     public static class UserPrivileges {
         public final String principal;
         public final boolean hasAccess;
-        public final Set<String> groups;
+        public final Set<String> roles;
 
-        public UserPrivileges(String principal, boolean hasAccess, Set<String> groups) {
+        public UserPrivileges(String principal, boolean hasAccess, Set<String> roles) {
             this.principal = Objects.requireNonNull(principal, "principal may not be null");
-            if (hasAccess == false && groups.isEmpty() == false) {
-                throw new IllegalArgumentException("a user without access ([" + hasAccess + "]) may not have groups ([" + groups + "])");
+            if (hasAccess == false && roles.isEmpty() == false) {
+                throw new IllegalArgumentException("a user without access ([" + hasAccess + "]) may not have roles ([" + roles + "])");
             }
             this.hasAccess = hasAccess;
-            this.groups = Set.copyOf(Objects.requireNonNull(groups, "groups may not be null"));
+            this.roles = Set.copyOf(Objects.requireNonNull(roles, "roles may not be null"));
         }
 
         @Override
@@ -52,7 +52,7 @@ public class UserPrivilegeResolver {
                 .append(", ")
                 .append(hasAccess);
             if (hasAccess) {
-                str.append(", ").append(groups);
+                str.append(", ").append(roles);
             }
             str.append("}");
             return str.toString();
@@ -102,11 +102,11 @@ public class UserPrivilegeResolver {
         if (hasAccess == false) {
             return UserPrivileges.noAccess(response.getUsername());
         }
-        final Set<String> groups = service.getGroupActions().entrySet().stream()
+        final Set<String> roles = service.getRoleActions().entrySet().stream()
             .filter(entry -> checkAccess(appPrivileges, entry.getValue(), service.getResource()))
             .map(Map.Entry::getKey)
             .collect(Collectors.toUnmodifiableSet());
-        return new UserPrivileges(response.getUsername(), hasAccess, groups);
+        return new UserPrivileges(response.getUsername(), hasAccess, roles);
     }
 
     private boolean checkAccess(Set<ResourcePrivileges> userPrivileges, String action, String resource) {
@@ -122,9 +122,9 @@ public class UserPrivilegeResolver {
         final RoleDescriptor.ApplicationResourcePrivileges.Builder builder = RoleDescriptor.ApplicationResourcePrivileges.builder();
         builder.application(service.getApplicationName());
         builder.resources(service.getResource());
-        Set<String> actions = new HashSet<>(1 + service.getGroupActions().size());
+        Set<String> actions = new HashSet<>(1 + service.getRoleActions().size());
         actions.add(service.getLoginAction());
-        actions.addAll(service.getGroupActions().values());
+        actions.addAll(service.getRoleActions().values());
         builder.privileges(actions);
         return builder.build();
     }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilder.java
@@ -174,9 +174,9 @@ public class SuccessfulAuthenticationResponseMessageBuilder {
         final SamlServiceProvider serviceProvider = user.getServiceProvider();
         final AttributeStatement statement = samlFactory.object(AttributeStatement.class, AttributeStatement.DEFAULT_ELEMENT_NAME);
         // TODO Add principal, email, name
-        final Attribute groups = buildAttribute(serviceProvider.getAttributeNames().groups, "groups", user.getGroups());
-        if (groups != null) {
-            statement.getAttributes().add(groups);
+        final Attribute roles = buildAttribute(serviceProvider.getAttributeNames().roles, "roles", user.getRoles());
+        if (roles != null) {
+            statement.getAttributes().add(roles);
         }
         if (statement.getAttributes().isEmpty()) {
             return null;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/UserServiceAuthentication.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/UserServiceAuthentication.java
@@ -17,30 +17,30 @@ import java.util.Set;
  */
 public class UserServiceAuthentication {
     private final String principal;
-    private final Set<String> groups;
+    private final Set<String> roles;
     private final SamlServiceProvider serviceProvider;
     private final Set<AuthenticationMethod> authenticationMethods;
     private final Set<NetworkControl> networkControls;
 
-    public UserServiceAuthentication(String principal, Set<String> groups, SamlServiceProvider serviceProvider,
+    public UserServiceAuthentication(String principal, Set<String> roles, SamlServiceProvider serviceProvider,
                                      Set<AuthenticationMethod> authenticationMethods, Set<NetworkControl> networkControls) {
         this.principal = principal;
-        this.groups = groups;
+        this.roles = roles;
         this.serviceProvider = serviceProvider;
         this.authenticationMethods = authenticationMethods;
         this.networkControls = networkControls;
     }
 
-    public UserServiceAuthentication(String principal, Set<String> groups, SamlServiceProvider serviceProvider) {
-        this(principal, groups, serviceProvider, Set.of(AuthenticationMethod.PASSWORD), Set.of(NetworkControl.TLS));
+    public UserServiceAuthentication(String principal, Set<String> roles, SamlServiceProvider serviceProvider) {
+        this(principal, roles, serviceProvider, Set.of(AuthenticationMethod.PASSWORD), Set.of(NetworkControl.TLS));
     }
 
     public String getPrincipal() {
         return principal;
     }
 
-    public Set<String> getGroups() {
-        return groups;
+    public Set<String> getRoles() {
+        return roles;
     }
 
     public SamlServiceProvider getServiceProvider() {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
@@ -122,7 +122,7 @@ public class SamlIdentityProvider {
                         "https://saml.elasticsearch.org/attributes/principal",
                         "https://saml.elasticsearch.org/attributes/name",
                         "https://saml.elasticsearch.org/attributes/email",
-                        "https://saml.elasticsearch.org/attributes/groups"),
+                        "https://saml.elasticsearch.org/attributes/roles"),
                     null, false, false));
         } catch (MalformedURLException e) {
             throw new UncheckedIOException(e);

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProvider.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProvider.java
@@ -29,13 +29,13 @@ public interface SamlServiceProvider {
         public final String principal;
         public final String name;
         public final String email;
-        public final String groups;
+        public final String roles;
 
-        public AttributeNames(String principal, String name, String email, String groups) {
+        public AttributeNames(String principal, String name, String email, String roles) {
             this.principal = principal;
             this.name = name;
             this.email = email;
-            this.groups = groups;
+            this.roles = roles;
         }
     }
 

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocument.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocument.java
@@ -57,7 +57,7 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         public String resource;
         @Nullable
         public String loginAction;
-        public Map<String, String> groupActions = Map.of();
+        public Map<String, String> roleActions = Map.of();
 
         public void setApplication(String application) {
             this.application = application;
@@ -71,8 +71,8 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
             this.loginAction = loginAction;
         }
 
-        public void setGroupActions(Map<String, String> groupActions) {
-            this.groupActions = groupActions;
+        public void setRoleActions(Map<String, String> roleActions) {
+            this.roleActions = roleActions;
         }
 
         @Override
@@ -83,12 +83,12 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
             return Objects.equals(application, that.application) &&
                 Objects.equals(resource, that.resource) &&
                 Objects.equals(loginAction, that.loginAction) &&
-                Objects.equals(groupActions, that.groupActions);
+                Objects.equals(roleActions, that.roleActions);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(application, resource, loginAction, groupActions);
+            return Objects.hash(application, resource, loginAction, roleActions);
         }
     }
 
@@ -99,7 +99,7 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         @Nullable
         public String name;
         @Nullable
-        public String groups;
+        public String roles;
 
         public void setPrincipal(String principal) {
             this.principal = principal;
@@ -113,8 +113,8 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
             this.name = name;
         }
 
-        public void setGroups(String groups) {
-            this.groups = groups;
+        public void setRoles(String roles) {
+            this.roles = roles;
         }
 
         @Override
@@ -125,12 +125,12 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
             return Objects.equals(principal, that.principal) &&
                 Objects.equals(email, that.email) &&
                 Objects.equals(name, that.name) &&
-                Objects.equals(groups, that.groups);
+                Objects.equals(roles, that.roles);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(principal, email, name, groups);
+            return Objects.hash(principal, email, name, roles);
         }
     }
 
@@ -273,12 +273,12 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         privileges.application = in.readOptionalString();
         privileges.resource = in.readString();
         privileges.loginAction = in.readOptionalString();
-        privileges.groupActions = in.readMap(StreamInput::readString, StreamInput::readString);
+        privileges.roleActions = in.readMap(StreamInput::readString, StreamInput::readString);
 
         attributeNames.principal = in.readString();
         attributeNames.email = in.readOptionalString();
         attributeNames.name = in.readOptionalString();
-        attributeNames.groups = in.readOptionalString();
+        attributeNames.roles = in.readOptionalString();
 
         certificates.serviceProviderSigning = in.readStringList();
         certificates.identityProviderSigning = in.readStringList();
@@ -305,13 +305,13 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         out.writeOptionalString(privileges.application);
         out.writeString(privileges.resource);
         out.writeOptionalString(privileges.loginAction);
-        out.writeMap(privileges.groupActions == null ? Map.of() : privileges.groupActions,
+        out.writeMap(privileges.roleActions == null ? Map.of() : privileges.roleActions,
             StreamOutput::writeString, StreamOutput::writeString);
 
         out.writeString(attributeNames.principal);
         out.writeOptionalString(attributeNames.email);
         out.writeOptionalString(attributeNames.name);
-        out.writeOptionalString(attributeNames.groups);
+        out.writeOptionalString(attributeNames.roles);
 
         out.writeStringCollection(certificates.serviceProviderSigning);
         out.writeStringCollection(certificates.identityProviderSigning);
@@ -425,15 +425,15 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         PRIVILEGES_PARSER.declareStringOrNull(Privileges::setApplication, Fields.Privileges.APPLICATION);
         PRIVILEGES_PARSER.declareString(Privileges::setResource, Fields.Privileges.RESOURCE);
         PRIVILEGES_PARSER.declareStringOrNull(Privileges::setLoginAction, Fields.Privileges.LOGIN_ACTION);
-        PRIVILEGES_PARSER.declareField(Privileges::setGroupActions,
+        PRIVILEGES_PARSER.declareField(Privileges::setRoleActions,
             (parser, ignore) -> parser.currentToken() == XContentParser.Token.VALUE_NULL ? null : parser.mapStrings(),
-            Fields.Privileges.GROUPS, ObjectParser.ValueType.OBJECT_OR_NULL);
+            Fields.Privileges.ROLES, ObjectParser.ValueType.OBJECT_OR_NULL);
 
         DOC_PARSER.declareObject(NULL_CONSUMER, (p, doc) -> ATTRIBUTES_PARSER.parse(p, doc.attributeNames, null), Fields.ATTRIBUTES);
         ATTRIBUTES_PARSER.declareString(AttributeNames::setPrincipal, Fields.Attributes.PRINCIPAL);
         ATTRIBUTES_PARSER.declareStringOrNull(AttributeNames::setEmail, Fields.Attributes.EMAIL);
         ATTRIBUTES_PARSER.declareStringOrNull(AttributeNames::setName, Fields.Attributes.NAME);
-        ATTRIBUTES_PARSER.declareStringOrNull(AttributeNames::setGroups, Fields.Attributes.GROUPS);
+        ATTRIBUTES_PARSER.declareStringOrNull(AttributeNames::setRoles, Fields.Attributes.ROLES);
 
         DOC_PARSER.declareObject(NULL_CONSUMER, (p, doc) -> CERTIFICATES_PARSER.parse(p, doc.certificates, null), Fields.CERTIFICATES);
         CERTIFICATES_PARSER.declareStringArray(Certificates::setServiceProviderSigning, Fields.Certificates.SP_SIGNING);
@@ -503,14 +503,14 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
         builder.field(Fields.Privileges.APPLICATION.getPreferredName(), privileges.application);
         builder.field(Fields.Privileges.RESOURCE.getPreferredName(), privileges.resource);
         builder.field(Fields.Privileges.LOGIN_ACTION.getPreferredName(), privileges.loginAction);
-        builder.field(Fields.Privileges.GROUPS.getPreferredName(), privileges.groupActions);
+        builder.field(Fields.Privileges.ROLES.getPreferredName(), privileges.roleActions);
         builder.endObject();
 
         builder.startObject(Fields.ATTRIBUTES.getPreferredName());
         builder.field(Fields.Attributes.PRINCIPAL.getPreferredName(), attributeNames.principal);
         builder.field(Fields.Attributes.EMAIL.getPreferredName(), attributeNames.email);
         builder.field(Fields.Attributes.NAME.getPreferredName(), attributeNames.name);
-        builder.field(Fields.Attributes.GROUPS.getPreferredName(), attributeNames.groups);
+        builder.field(Fields.Attributes.ROLES.getPreferredName(), attributeNames.roles);
         builder.endObject();
 
         builder.startObject(Fields.CERTIFICATES.getPreferredName());
@@ -542,14 +542,14 @@ public class SamlServiceProviderDocument implements ToXContentObject, Writeable 
             ParseField APPLICATION = new ParseField("application");
             ParseField RESOURCE = new ParseField("resource");
             ParseField LOGIN_ACTION = new ParseField("login");
-            ParseField GROUPS = new ParseField("groups");
+            ParseField ROLES = new ParseField("roles");
         }
 
         interface Attributes {
             ParseField PRINCIPAL = new ParseField("principal");
             ParseField EMAIL = new ParseField("email");
             ParseField NAME = new ParseField("name");
-            ParseField GROUPS = new ParseField("groups");
+            ParseField ROLES = new ParseField("roles");
         }
 
         interface Certificates {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderResolver.java
@@ -96,7 +96,7 @@ public class SamlServiceProviderResolver {
     private SamlServiceProvider buildServiceProvider(SamlServiceProviderDocument document) {
         final ServiceProviderPrivileges privileges = buildPrivileges(document.privileges);
         final SamlServiceProvider.AttributeNames attributes = new SamlServiceProvider.AttributeNames(
-            document.attributeNames.principal, document.attributeNames.name, document.attributeNames.email, document.attributeNames.groups
+            document.attributeNames.principal, document.attributeNames.name, document.attributeNames.email, document.attributeNames.roles
         );
         final Set<X509Credential> credentials = document.certificates.getServiceProviderX509SigningCertificates()
             .stream()
@@ -125,8 +125,8 @@ public class SamlServiceProviderResolver {
         final String resource = configuredPrivileges.resource;
         final String loginAction = Optional.ofNullable(configuredPrivileges.loginAction)
             .orElse(identityProvider.getServiceProviderDefaults().loginAction);
-        final Map<String, String> groups = Optional.ofNullable(configuredPrivileges.groupActions).orElse(Map.of());
-        return new ServiceProviderPrivileges(applicationName, resource, loginAction, groups);
+        final Map<String, String> roles = Optional.ofNullable(configuredPrivileges.roleActions).orElse(Map.of());
+        return new ServiceProviderPrivileges(applicationName, resource, loginAction, roles);
     }
 
     private URL parseUrl(SamlServiceProviderDocument document) {

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/PutSamlServiceProviderRequestTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/PutSamlServiceProviderRequestTests.java
@@ -94,12 +94,12 @@ public class PutSamlServiceProviderRequestTests extends ESTestCase {
             "principal", "urn:oid:0.1." + randomLongBetween(1, 1000),
             "email", "urn:oid:0.2." + randomLongBetween(1001, 2000),
             "name", "urn:oid:0.3." + randomLongBetween(2001, 3000),
-            "groups", "urn:oid:0.4." + randomLongBetween(3001, 4000)
+            "roles", "urn:oid:0.4." + randomLongBetween(3001, 4000)
         ));
         fields.put("privileges", Map.of(
             "resource", "ece:deployment:" + randomLongBetween(1_000_000, 999_999_999),
             "login", "action:" + randomAlphaOfLengthBetween(3, 12),
-            "groups", Map.of("group_name", "role:" + randomAlphaOfLengthBetween(4, 8))
+            "roles", Map.of("role_name", "role:" + randomAlphaOfLengthBetween(4, 8))
         ));
         fields.put("certificates", Map.of());
         final String entityId = "https://www." + randomAlphaOfLengthBetween(5, 12) + ".app/";
@@ -111,12 +111,12 @@ public class PutSamlServiceProviderRequestTests extends ESTestCase {
         assertThat(request.getDocument().privileges.application, nullValue());
         assertThat(request.getDocument().privileges.resource, notNullValue());
         assertThat(request.getDocument().privileges.loginAction, notNullValue());
-        assertThat(request.getDocument().privileges.groupActions, aMapWithSize(1));
-        assertThat(request.getDocument().privileges.groupActions.keySet(), contains("group_name"));
+        assertThat(request.getDocument().privileges.roleActions, aMapWithSize(1));
+        assertThat(request.getDocument().privileges.roleActions.keySet(), contains("role_name"));
         assertThat(request.getDocument().attributeNames.principal, startsWith("urn:oid:0.1"));
         assertThat(request.getDocument().attributeNames.email, startsWith("urn:oid:0.2"));
         assertThat(request.getDocument().attributeNames.name, startsWith("urn:oid:0.3"));
-        assertThat(request.getDocument().attributeNames.groups, startsWith("urn:oid:0.4"));
+        assertThat(request.getDocument().attributeNames.roles, startsWith("urn:oid:0.4"));
         assertThat(request.getDocument().certificates.serviceProviderSigning, emptyIterable());
         assertThat(request.getDocument().certificates.identityProviderSigning, emptyIterable());
         assertThat(request.getDocument().certificates.identityProviderMetadataSigning, emptyIterable());

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolverTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolverTests.java
@@ -60,10 +60,10 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final UserPrivilegeResolver.UserPrivileges privileges = future.get();
         assertThat(privileges.principal, equalTo(username));
         assertThat(privileges.hasAccess, equalTo(false));
-        assertThat(privileges.groups, emptyIterable());
+        assertThat(privileges.roles, emptyIterable());
     }
 
-    public void testResolveSsoWithNoGroupsDefined() throws Exception {
+    public void testResolveSsoWithNoRolesDefined() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
         final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
@@ -77,10 +77,10 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final UserPrivilegeResolver.UserPrivileges privileges = future.get();
         assertThat(privileges.principal, equalTo(username));
         assertThat(privileges.hasAccess, equalTo(true));
-        assertThat(privileges.groups, emptyIterable());
+        assertThat(privileges.roles, emptyIterable());
     }
 
-    public void testResolveSsoWithNoGroupAccess() throws Exception {
+    public void testResolveSsoWithNoRoleAccess() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
         final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
@@ -97,10 +97,10 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final UserPrivilegeResolver.UserPrivileges privileges = future.get();
         assertThat(privileges.principal, equalTo(username));
         assertThat(privileges.hasAccess, equalTo(true));
-        assertThat(privileges.groups, emptyIterable());
+        assertThat(privileges.roles, emptyIterable());
     }
 
-    public void testResolveSsoWithSingleGroup() throws Exception {
+    public void testResolveSsoWithSingleRole() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
         final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
@@ -117,10 +117,10 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final UserPrivilegeResolver.UserPrivileges privileges = future.get();
         assertThat(privileges.principal, equalTo(username));
         assertThat(privileges.hasAccess, equalTo(true));
-        assertThat(privileges.groups, containsInAnyOrder("viewer"));
+        assertThat(privileges.roles, containsInAnyOrder("viewer"));
     }
 
-    public void testResolveSsoWithMultipleGroup() throws Exception {
+    public void testResolveSsoWithMultipleRoles() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
         final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
@@ -146,10 +146,10 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final UserPrivilegeResolver.UserPrivileges privileges = future.get();
         assertThat(privileges.principal, equalTo(username));
         assertThat(privileges.hasAccess, equalTo(true));
-        assertThat(privileges.groups, containsInAnyOrder("operator", "monitor"));
+        assertThat(privileges.roles, containsInAnyOrder("operator", "monitor"));
     }
 
-    public void testResolveWithNoSsoPrivilegeReturnsEmptyGroupAccess() throws Exception {
+    public void testResolveWithNoSsoPrivilegeReturnsEmptyRoleAccess() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
         final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
@@ -166,11 +166,11 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final UserPrivilegeResolver.UserPrivileges privileges = future.get();
         assertThat(privileges.principal, equalTo(username));
         assertThat(privileges.hasAccess, equalTo(false));
-        assertThat(privileges.groups, emptyIterable());
+        assertThat(privileges.roles, emptyIterable());
     }
 
-    private ServiceProviderPrivileges service(String appName, String resource, String loginAction, Map<String, String> groups) {
-        return new ServiceProviderPrivileges(appName, resource, loginAction, groups);
+    private ServiceProviderPrivileges service(String appName, String resource, String loginAction, Map<String, String> roles) {
+        return new ServiceProviderPrivileges(appName, resource, loginAction, roles);
     }
 
     private HasPrivilegesResponse setupHasPrivileges(String username, String appName,

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilderTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilderTests.java
@@ -75,7 +75,7 @@ public class SuccessfulAuthenticationResponseMessageBuilderTests extends IdpSaml
 
         final UserServiceAuthentication user = mock(UserServiceAuthentication.class);
         when(user.getPrincipal()).thenReturn(randomAlphaOfLengthBetween(4, 12));
-        when(user.getGroups()).thenReturn(Set.of(randomArray(1, 5, String[]::new, () -> randomAlphaOfLengthBetween(4, 12))));
+        when(user.getRoles()).thenReturn(Set.of(randomArray(1, 5, String[]::new, () -> randomAlphaOfLengthBetween(4, 12))));
         when(user.getServiceProvider()).thenReturn(sp);
 
         final SuccessfulAuthenticationResponseMessageBuilder builder =

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocumentTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocumentTests.java
@@ -109,16 +109,16 @@ public class SamlServiceProviderDocumentTests extends IdpSamlTestCase {
         doc1.privileges.setApplication(randomAlphaOfLengthBetween(6, 24));
         doc1.privileges.setResource("service:" + randomAlphaOfLength(12) + ":" + randomAlphaOfLength(12));
         doc1.privileges.setLoginAction(randomAlphaOfLength(6) + ":" + randomAlphaOfLength(6));
-        final Map<String, String> groupActions = new HashMap<>();
+        final Map<String, String> roleActions = new HashMap<>();
         for (int i = randomIntBetween(1, 6); i > 0; i--) {
-            groupActions.put(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLength(6) + ":" + randomAlphaOfLength(6));
+            roleActions.put(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLength(6) + ":" + randomAlphaOfLength(6));
         }
-        doc1.privileges.setGroupActions(groupActions);
+        doc1.privileges.setRoleActions(roleActions);
 
         doc1.attributeNames.setPrincipal("urn:" + randomAlphaOfLengthBetween(4, 8) + "." + randomAlphaOfLengthBetween(4, 8));
         doc1.attributeNames.setEmail("urn:" + randomAlphaOfLengthBetween(4, 8) + "." + randomAlphaOfLengthBetween(4, 8));
         doc1.attributeNames.setName("urn:" + randomAlphaOfLengthBetween(4, 8) + "." + randomAlphaOfLengthBetween(4, 8));
-        doc1.attributeNames.setGroups("urn:" + randomAlphaOfLengthBetween(4, 8) + "." + randomAlphaOfLengthBetween(4, 8));
+        doc1.attributeNames.setRoles("urn:" + randomAlphaOfLengthBetween(4, 8) + "." + randomAlphaOfLengthBetween(4, 8));
         return doc1;
     }
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -246,12 +246,12 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         if (randomBoolean()) {
             document.privileges.setLoginAction(randomAlphaOfLengthBetween(3, 6) + ":" + randomAlphaOfLengthBetween(3, 6));
         }
-        final int groupCount = randomIntBetween(0, 4);
-        final Map<String, String> groups = new HashMap<>();
-        for (int i = 0; i < groupCount; i++) {
-            groups.put(randomAlphaOfLengthBetween(4, 8), randomAlphaOfLengthBetween(3, 6) + ":" + randomAlphaOfLengthBetween(3, 6));
+        final int roleCount = randomIntBetween(0, 4);
+        final Map<String, String> roles = new HashMap<>();
+        for (int i = 0; i < roleCount; i++) {
+            roles.put(randomAlphaOfLengthBetween(4, 8), randomAlphaOfLengthBetween(3, 6) + ":" + randomAlphaOfLengthBetween(3, 6));
         }
-        document.privileges.setGroupActions(groups);
+        document.privileges.setRoleActions(roles);
 
         document.attributeNames.setPrincipal(randomUri());
         if (randomBoolean()) {
@@ -260,8 +260,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         if (randomBoolean()) {
             document.attributeNames.setEmail(randomUri());
         }
-        if (groups.isEmpty() == false) {
-            document.attributeNames.setGroups(randomUri());
+        if (roles.isEmpty() == false) {
+            document.attributeNames.setRoles(randomUri());
         }
 
         assertThat(document.validate(), nullValue());

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderResolverTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderResolverTests.java
@@ -55,10 +55,10 @@ public class SamlServiceProviderResolverTests extends ESTestCase {
         final URL acs = new URL(entityId + "saml/acs");
 
         final String principalAttribute = randomAlphaOfLengthBetween(6, 36);
-        final String groupsAttribute = randomAlphaOfLengthBetween(6, 36);
+        final String rolesAttribute = randomAlphaOfLengthBetween(6, 36);
         final String resource = "ece:" + randomAlphaOfLengthBetween(6, 12);
         final String spLoginAction = "action:" + randomAlphaOfLengthBetween(6, 12);
-        final Map<String, String> groupPrivileges = Map.of(randomAlphaOfLengthBetween(3, 6), "role:" + randomAlphaOfLengthBetween(4, 8));
+        final Map<String, String> rolePrivileges = Map.of(randomAlphaOfLengthBetween(3, 6), "role:" + randomAlphaOfLengthBetween(4, 8));
 
         final DocumentVersion docVersion = new DocumentVersion(
             randomAlphaOfLength(12), randomNonNegativeLong(), randomNonNegativeLong());
@@ -68,9 +68,9 @@ public class SamlServiceProviderResolverTests extends ESTestCase {
         document.setAcs(acs.toString());
         document.privileges.setResource(resource);
         document.privileges.setLoginAction(spLoginAction);
-        document.privileges.setGroupActions(groupPrivileges);
+        document.privileges.setRoleActions(rolePrivileges);
         document.attributeNames.setPrincipal(principalAttribute);
-        document.attributeNames.setGroups(groupsAttribute);
+        document.attributeNames.setRoles(rolesAttribute);
 
         mockDocument(entityId, docVersion, document);
 
@@ -87,13 +87,13 @@ public class SamlServiceProviderResolverTests extends ESTestCase {
         assertThat(serviceProvider.getAttributeNames().principal, equalTo(principalAttribute));
         assertThat(serviceProvider.getAttributeNames().name, nullValue());
         assertThat(serviceProvider.getAttributeNames().email, nullValue());
-        assertThat(serviceProvider.getAttributeNames().groups, equalTo(groupsAttribute));
+        assertThat(serviceProvider.getAttributeNames().roles, equalTo(rolesAttribute));
 
         assertThat(serviceProvider.getPrivileges(), notNullValue());
         assertThat(serviceProvider.getPrivileges().getApplicationName(), equalTo(defaults.applicationName));
         assertThat(serviceProvider.getPrivileges().getResource(), equalTo(resource));
         assertThat(serviceProvider.getPrivileges().getLoginAction(), equalTo(spLoginAction));
-        assertThat(serviceProvider.getPrivileges().getGroupActions(), equalTo(groupPrivileges));
+        assertThat(serviceProvider.getPrivileges().getRoleActions(), equalTo(rolePrivileges));
     }
 
     public void testResolveReturnsCachedObject() throws Exception {
@@ -136,7 +136,7 @@ public class SamlServiceProviderResolverTests extends ESTestCase {
         assertThat(serviceProvider2.getAttributeNames().principal, equalTo(document2.attributeNames.principal));
         assertThat(serviceProvider2.getAttributeNames().name, equalTo(document2.attributeNames.name));
         assertThat(serviceProvider2.getAttributeNames().email, equalTo(document2.attributeNames.email));
-        assertThat(serviceProvider2.getAttributeNames().groups, equalTo(document2.attributeNames.groups));
+        assertThat(serviceProvider2.getAttributeNames().roles, equalTo(document2.attributeNames.roles));
         assertThat(serviceProvider2.getPrivileges().getResource(), equalTo(document2.privileges.resource));
     }
 


### PR DESCRIPTION
The Identity Provider has a feature to release a standard set of
attributes to a Service Provider. One of those attributes is intended
to represent the groups or roles to which the user belongs.

From an Identity Provider point of view, there is no concrete
definition of what these attributes represent or should be used for -
the Service Provider may treat them as "groups" (a named collection of
users) or "roles" (a named representation of the user's access
rights).

Terminology across IdPs varies, but we have decided that within the ES
IdP, we will refer to them as "roles". This change replaces any use of
the term "groups" with "roles".
