### PR TITLE
[DOCS] Adds deleting flag to the GET job stats API docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -135,6 +135,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=processed-record-count]
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
 
+`deleting`::
+(boolean)
+Indicates that the process of deleting the job is in progress but not yet 
+completed. It is only reported when `true`.
+
 [[forecastsstats]]`forecasts_stats`::
 (object) An object that provides statistical information about forecasts 
 belonging to this job. Some statistics are omitted if no forecasts have been 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1368,7 +1368,6 @@ force closed and then deleted. If the {dfeed} can be corrected, the job can be
 closed and then re-opened.
 * `opened`: The job is available to receive and process data.
 * `opening`: The job open action is in progress and has not yet completed.
-* `deleting`: The job deletion process is in progress but not yet completed.
 --
 end::state-anomaly-job[]
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1368,6 +1368,7 @@ force closed and then deleted. If the {dfeed} can be corrected, the job can be
 closed and then re-opened.
 * `opened`: The job is available to receive and process data.
 * `opening`: The job open action is in progress and has not yet completed.
+* `deleting`: The job deletion process is in progress but not yet completed.
 --
 end::state-anomaly-job[]
 


### PR DESCRIPTION
This PR adds the `deleting` flag to the list of the possible states of the anomaly detection jobs.

Preview: http://elasticsearch_53223.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-job-stats.html