### PR TITLE
Enrich documents with inference results at Fetch

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -123,6 +123,21 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
     }
 
     @Override
+    public Map<String, Object> writeResultToMap() {
+        Map<String, Object> results = new HashMap<>();
+        results.put(resultsField, valueAsString());
+        if (topClasses.size() > 0) {
+            results.put(topNumClassesField, topClasses.stream().map(TopClassEntry::asValueMap).collect(Collectors.toList()));
+        }
+        if (getFeatureImportance().size() > 0) {
+            results.put("feature_importance", getFeatureImportance());
+        }
+
+        return results;
+    }
+
+
+    @Override
     public String getWriteableName() {
         return NAME;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -123,8 +123,11 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
     }
 
     @Override
-    public Map<String, Object> writeResultToMap() {
+    public Map<String, Object> writeResultToMap(String parentResultField) {
+        Map<String, Object> parentField = new HashMap<>();
         Map<String, Object> results = new HashMap<>();
+        parentField.put(parentResultField, results);
+
         results.put(resultsField, valueAsString());
         if (topClasses.size() > 0) {
             results.put(topNumClassesField, topClasses.stream().map(TopClassEntry::asValueMap).collect(Collectors.toList()));
@@ -133,7 +136,7 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
             results.put("feature_importance", getFeatureImportance());
         }
 
-        return results;
+        return parentField;
     }
 
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
@@ -14,5 +14,5 @@ public interface InferenceResults extends NamedWriteable {
 
     void writeResult(IngestDocument document, String parentResultField);
 
-    Map<String, Object> writeResultToMap();
+    Map<String, Object> writeResultToMap(String parentResultField);
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/InferenceResults.java
@@ -8,8 +8,11 @@ package org.elasticsearch.xpack.core.ml.inference.results;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.ingest.IngestDocument;
 
+import java.util.Map;
+
 public interface InferenceResults extends NamedWriteable {
 
     void writeResult(IngestDocument document, String parentResultField);
 
+    Map<String, Object> writeResultToMap();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
@@ -58,6 +58,11 @@ public class RawInferenceResults implements InferenceResults {
     }
 
     @Override
+    public Map<String, Object> writeResultToMap() {
+        throw new UnsupportedOperationException("[raw] does not support writing inference results");
+    }
+
+    @Override
     public String getWriteableName() {
         return NAME;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RawInferenceResults.java
@@ -58,7 +58,7 @@ public class RawInferenceResults implements InferenceResults {
     }
 
     @Override
-    public Map<String, Object> writeResultToMap() {
+    public Map<String, Object> writeResultToMap(String parentResultField) {
         throw new UnsupportedOperationException("[raw] does not support writing inference results");
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
@@ -76,13 +76,17 @@ public class RegressionInferenceResults extends SingleValueInferenceResults {
     }
 
     @Override
-    public Map<String, Object> writeResultToMap() {
+    public Map<String, Object> writeResultToMap(String parentResultField) {
+        Map<String, Object> parentResult = new HashMap<>();
         Map<String, Object> result = new HashMap<>();
+        parentResult.put(parentResultField, result);
+
         result.put(resultsField, value());
         if (getFeatureImportance().size() > 0) {
             result.put("feature_importance", getFeatureImportance());
         }
-        return result;
+
+        return parentResult;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResults.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -72,6 +73,16 @@ public class RegressionInferenceResults extends SingleValueInferenceResults {
         if (getFeatureImportance().size() > 0) {
             document.setFieldValue(parentResultField + ".feature_importance", getFeatureImportance());
         }
+    }
+
+    @Override
+    public Map<String, Object> writeResultToMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put(resultsField, value());
+        if (getFeatureImportance().size() > 0) {
+            result.put("feature_importance", getFeatureImportance());
+        }
+        return result;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
@@ -61,8 +61,8 @@ public class WarningInferenceResults implements InferenceResults {
     }
 
     @Override
-    public Map<String, Object> writeResultToMap() {
-        return Collections.singletonMap(NAME, warning);
+    public Map<String, Object> writeResultToMap(String parentResultField) {
+        return Collections.singletonMap(parentResultField, Collections.singletonMap(NAME, warning));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResults.java
@@ -12,12 +12,14 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 public class WarningInferenceResults implements InferenceResults {
 
     public static final String NAME = "warning";
-    public static final ParseField WARNING = new ParseField("warning");
+    public static final ParseField WARNING = new ParseField(NAME);
 
     private final String warning;
 
@@ -55,7 +57,12 @@ public class WarningInferenceResults implements InferenceResults {
     public void writeResult(IngestDocument document, String parentResultField) {
         ExceptionsHelper.requireNonNull(document, "document");
         ExceptionsHelper.requireNonNull(parentResultField, "resultField");
-        document.setFieldValue(parentResultField + "." + "warning", warning);
+        document.setFieldValue(parentResultField + "." + NAME, warning);
+    }
+
+    @Override
+    public Map<String, Object> writeResultToMap() {
+        return Collections.singletonMap(NAME, warning);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
@@ -108,6 +108,7 @@ public class ClassificationConfig implements InferenceConfig {
         return topClassesResultsField;
     }
 
+    @Override
     public String getResultsField() {
         return resultsField;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfig.java
@@ -22,4 +22,6 @@ public interface InferenceConfig extends NamedXContentObject, NamedWriteable {
     default boolean requestingImportance() {
         return false;
     }
+
+    String getResultsField();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NullInferenceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NullInferenceConfig.java
@@ -24,6 +24,11 @@ public class NullInferenceConfig implements InferenceConfig {
     }
 
     @Override
+    public String getResultsField() {
+        return null;
+    }
+
+    @Override
     public boolean isTargetTypeSupported(TargetType targetType) {
         return true;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfig.java
@@ -82,6 +82,7 @@ public class RegressionConfig implements InferenceConfig {
         return numTopFeatureImportanceValues;
     }
 
+    @Override
     public String getResultsField() {
         return resultsField;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigTests;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,15 +92,18 @@ public class ClassificationInferenceResultsTests extends AbstractWireSerializing
                 "foo",
                 entries,
                 new ClassificationConfig(3, "my_results", "bar"));
-        Map<String, Object> resultsDoc = result.writeResultToMap();
+        Map<String, Object> resultsDoc = result.writeResultToMap("result_field");
 
-        List<?> list = (List<?>)resultsDoc.get("bar");
+        List<?> list = (List<?>) MapHelper.dig("result_field.bar", resultsDoc);
         assertThat(list.size(), equalTo(3));
 
         for(int i = 0; i < 3; i++) {
             Map<String, Object> map = (Map<String, Object>)list.get(i);
             assertThat(map, equalTo(entries.get(i).asValueMap()));
         }
+
+        Object value = MapHelper.dig("result_field.my_results", resultsDoc);
+        assertThat(value, equalTo("foo"));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResultsTests.java
@@ -81,6 +81,27 @@ public class ClassificationInferenceResultsTests extends AbstractWireSerializing
         assertThat(document.getFieldValue("result_field.my_results", String.class), equalTo("foo"));
     }
 
+    @SuppressWarnings("unchecked")
+    public void testWriteResultsToMapWithTopClasses() {
+        List<ClassificationInferenceResults.TopClassEntry> entries = Arrays.asList(
+                new ClassificationInferenceResults.TopClassEntry("foo", 0.7),
+                new ClassificationInferenceResults.TopClassEntry("bar", 0.2),
+                new ClassificationInferenceResults.TopClassEntry("baz", 0.1));
+        ClassificationInferenceResults result = new ClassificationInferenceResults(1.0,
+                "foo",
+                entries,
+                new ClassificationConfig(3, "my_results", "bar"));
+        Map<String, Object> resultsDoc = result.writeResultToMap();
+
+        List<?> list = (List<?>)resultsDoc.get("bar");
+        assertThat(list.size(), equalTo(3));
+
+        for(int i = 0; i < 3; i++) {
+            Map<String, Object> map = (Map<String, Object>)list.get(i);
+            assertThat(map, equalTo(entries.get(i).asValueMap()));
+        }
+    }
+
     @Override
     protected ClassificationInferenceResults createTestInstance() {
         return createRandomResults();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
@@ -8,11 +8,11 @@ package org.elasticsearch.xpack.core.ml.inference.results;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -29,6 +29,13 @@ public class RegressionInferenceResultsTests extends AbstractWireSerializingTest
         result.writeResult(document, "result_field");
 
         assertThat(document.getFieldValue("result_field.predicted_value", Double.class), equalTo(0.3));
+    }
+
+    public void testWriteResultsToMap() {
+        RegressionInferenceResults result = new RegressionInferenceResults(0.3, RegressionConfig.EMPTY_PARAMS);
+        Map<String, Object> doc = result.writeResultToMap();
+
+        assertThat(doc.get("predicted_value"), equalTo(0.3));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/RegressionInferenceResultsTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,9 +34,10 @@ public class RegressionInferenceResultsTests extends AbstractWireSerializingTest
 
     public void testWriteResultsToMap() {
         RegressionInferenceResults result = new RegressionInferenceResults(0.3, RegressionConfig.EMPTY_PARAMS);
-        Map<String, Object> doc = result.writeResultToMap();
+        Map<String, Object> doc = result.writeResultToMap("result_field");
 
-        assertThat(doc.get("predicted_value"), equalTo(0.3));
+        Object value = MapHelper.dig("result_field.predicted_value", doc);
+        assertThat(value, equalTo(0.3));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.inference.results;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,9 +31,10 @@ public class WarningInferenceResultsTests extends AbstractWireSerializingTestCas
 
     public void testWriteResultToMap() {
         WarningInferenceResults result = new WarningInferenceResults("foo");
-        Map<String, Object> doc = result.writeResultToMap();
+        Map<String, Object> doc = result.writeResultToMap("result_field");
 
-        assertThat(doc.get("result_field.warning"), equalTo("foo"));
+        Object field = MapHelper.dig("result_field.warning", doc);
+        assertThat(field, equalTo("foo"));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/WarningInferenceResultsTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -25,6 +26,13 @@ public class WarningInferenceResultsTests extends AbstractWireSerializingTestCas
         result.writeResult(document, "result_field");
 
         assertThat(document.getFieldValue("result_field.warning", String.class), equalTo("foo"));
+    }
+
+    public void testWriteResultToMap() {
+        WarningInferenceResults result = new WarningInferenceResults("foo");
+        Map<String, Object> doc = result.writeResultToMap();
+
+        assertThat(doc.get("result_field.warning"), equalTo("foo"));
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -123,6 +123,8 @@ integTest.runner {
     'ml/delete_model_snapshot/Test delete snapshot missing snapshotId',
     'ml/delete_model_snapshot/Test delete snapshot missing job_id',
     'ml/delete_model_snapshot/Test delete with in-use model',
+    'ml/fetch_inference/Test fetch regression',
+    'ml/fetch_inference/Test fetch classification',
     'ml/filter_crud/Test create filter api with mismatching body ID',
     'ml/filter_crud/Test create filter given invalid filter_id',
     'ml/filter_crud/Test get filter API with bad ID',

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -899,7 +899,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
         // TODO: is the full inference config really needed?
         String modelId = "model-id";
         InferenceConfig config = new RegressionConfig("ignored");
-        return List.of(new InferencePhase(modelId, config, this.modelLoadingService.get()));
+        return List.of(new InferencePhase(modelId, config, this.modelLoadingService));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -903,6 +903,11 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
     }
 
     @Override
+    public List<SearchExtSpec<?>> getSearchExts() {
+        return emptyList();
+    }
+
+    @Override
     public UnaryOperator<Map<String, IndexTemplateMetaData>> getIndexTemplateMetaDataUpgrader() {
         return UnaryOperator.identity();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -131,8 +131,6 @@ import org.elasticsearch.xpack.core.ml.dataframe.analyses.MlDataFrameAnalysisNam
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
@@ -212,10 +210,11 @@ import org.elasticsearch.xpack.ml.dataframe.process.NativeAnalyticsProcessFactor
 import org.elasticsearch.xpack.ml.dataframe.process.NativeMemoryUsageEstimationProcessFactory;
 import org.elasticsearch.xpack.ml.dataframe.process.results.AnalyticsResult;
 import org.elasticsearch.xpack.ml.dataframe.process.results.MemoryUsageEstimationResult;
-import org.elasticsearch.xpack.ml.inference.search.InferencePhase;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+import org.elasticsearch.xpack.ml.inference.search.InferencePhase;
+import org.elasticsearch.xpack.ml.inference.search.InferenceSearchExtBuilder;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.JobManagerHolder;
 import org.elasticsearch.xpack.ml.job.UpdateJobProcessNotifier;
@@ -895,16 +894,14 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
 
     @Override
     public List<FetchSubPhase> getFetchSubPhases(FetchPhaseConstructionContext context) {
-        // TODO: add a way to specify the model ID and necessary config.
-        // TODO: is the full inference config really needed?
-        String modelId = "model-id";
-        InferenceConfig config = new RegressionConfig("ignored");
-        return List.of(new InferencePhase(modelId, config, this.modelLoadingService));
+        return Collections.singletonList(new InferencePhase(modelLoadingService));
     }
 
     @Override
     public List<SearchExtSpec<?>> getSearchExts() {
-        return emptyList();
+        return Collections.singletonList(
+                new SearchExtSpec<>(InferenceSearchExtBuilder.NAME, InferenceSearchExtBuilder::new,
+                        InferenceSearchExtBuilder::fromXContent));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.inference.loadingservice;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
@@ -63,6 +64,15 @@ public class LocalModel implements Model {
     }
 
     @Override
+    public void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener) {
+        try {
+            listener.onResponse(infer(fields, inferenceConfig));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
     public InferenceResults infer(Map<String, Object> fields, InferenceConfig config) {
         if (fieldNames.stream().allMatch(f -> MapHelper.dig(f, fields) == null)) {
             return new WarningInferenceResults(Messages.getMessage(INFERENCE_WARNING_ALL_FIELDS_MISSING, modelId));
@@ -70,5 +80,4 @@ public class LocalModel implements Model {
 
         return trainedModelDefinition.infer(fields, config);
     }
-
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
@@ -10,12 +10,23 @@ import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 
 import java.util.Map;
+import java.util.Set;
 
 public interface Model {
 
     String getResultsType();
 
-    void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener);
+    default void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener) {
+        try {
+            listener.onResponse(infer(fields, inferenceConfig));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    InferenceResults infer(Map<String, Object> fields, InferenceConfig inferenceConfig);
 
     String getModelId();
+
+    Set<String> getFieldNames();
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
@@ -16,13 +16,7 @@ public interface Model {
 
     String getResultsType();
 
-    default void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener) {
-        try {
-            listener.onResponse(infer(fields, inferenceConfig));
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
-    }
+    void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener);
 
     InferenceResults infer(Map<String, Object> fields, InferenceConfig inferenceConfig);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -20,11 +20,11 @@ import java.util.Map;
 public class InferencePhase implements FetchSubPhase {
     private final String modelId;
     private final InferenceConfig config;
-    private final ModelLoadingService modelLoadingService;
+    private final SetOnce<ModelLoadingService> modelLoadingService;
 
     public InferencePhase(String modelId,
                           InferenceConfig config,
-                          ModelLoadingService modelLoadingService) {
+                          SetOnce<ModelLoadingService> modelLoadingService) {
         this.modelId = modelId;
         this.config = config;
         this.modelLoadingService = modelLoadingService;
@@ -33,7 +33,7 @@ public class InferencePhase implements FetchSubPhase {
     @Override
     public void hitsExecute(SearchContext searchContext, SearchHit[] hits) throws IOException {
         SetOnce<Model> model = new SetOnce<>();
-        modelLoadingService.getModel(modelId, ActionListener.wrap(
+        modelLoadingService.get().getModel(modelId, ActionListener.wrap(
             model::set,
             m -> {throw new RuntimeException();}));
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -1,0 +1,52 @@
+package org.elasticsearch.xpack.ml.inference.search;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.ml.inference.loadingservice.Model;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A very rough sketch of a fetch sub phase that performs inference on each search hit,
+ * then augments the hit with the result.
+ */
+public class InferencePhase implements FetchSubPhase {
+    private final String modelId;
+    private final InferenceConfig config;
+    private final ModelLoadingService modelLoadingService;
+
+    public InferencePhase(String modelId,
+                          InferenceConfig config,
+                          ModelLoadingService modelLoadingService) {
+        this.modelId = modelId;
+        this.config = config;
+        this.modelLoadingService = modelLoadingService;
+    }
+
+    @Override
+    public void hitsExecute(SearchContext searchContext, SearchHit[] hits) throws IOException {
+        SetOnce<Model> model = new SetOnce<>();
+        modelLoadingService.getModel(modelId, ActionListener.wrap(
+            model::set,
+            m -> {throw new RuntimeException();}));
+
+        for (SearchHit hit : hits) {
+            // TODO: get fields through context.lookup() (or from the search hit?)
+            Map<String, Object> document = Map.of();
+
+            SetOnce<InferenceResults> result = new SetOnce<>();
+            model.get().infer(document, config, ActionListener.wrap(
+                result::set,
+                m -> {throw new RuntimeException();}));
+
+            // TODO: add inference result to hit.
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -1,7 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
 package org.elasticsearch.xpack.ml.inference.search;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
@@ -10,43 +18,109 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.ml.inference.loadingservice.Model;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 
-import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * A very rough sketch of a fetch sub phase that performs inference on each search hit,
  * then augments the hit with the result.
  */
 public class InferencePhase implements FetchSubPhase {
-    private final String modelId;
-    private final InferenceConfig config;
+
     private final SetOnce<ModelLoadingService> modelLoadingService;
 
-    public InferencePhase(String modelId,
-                          InferenceConfig config,
-                          SetOnce<ModelLoadingService> modelLoadingService) {
-        this.modelId = modelId;
-        this.config = config;
+    public InferencePhase(SetOnce<ModelLoadingService> modelLoadingService) {
         this.modelLoadingService = modelLoadingService;
     }
 
     @Override
-    public void hitsExecute(SearchContext searchContext, SearchHit[] hits) throws IOException {
-        SetOnce<Model> model = new SetOnce<>();
-        modelLoadingService.get().getModel(modelId, ActionListener.wrap(
-            model::set,
-            m -> {throw new RuntimeException();}));
-
-        for (SearchHit hit : hits) {
-            // TODO: get fields through context.lookup() (or from the search hit?)
-            Map<String, Object> document = Map.of();
-
-            SetOnce<InferenceResults> result = new SetOnce<>();
-            model.get().infer(document, config, ActionListener.wrap(
-                result::set,
-                m -> {throw new RuntimeException();}));
-
-            // TODO: add inference result to hit.
+    public void hitsExecute(SearchContext searchContext, SearchHit[] hits) {
+        SearchExtBuilder inferenceBuider = searchContext.getSearchExt(InferenceSearchExtBuilder.NAME);
+        if (inferenceBuider == null) {
+            return;
         }
+
+        InferenceSearchExtBuilder infBuilder = (InferenceSearchExtBuilder)inferenceBuider;
+
+        SetOnce<Model> model = new SetOnce<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<Model> listener = new LatchedActionListener<>(
+                ActionListener.wrap(model::set, e -> { throw new RuntimeException();}), latch);
+
+        modelLoadingService.get().getModel(infBuilder.getModelId(), listener);
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Map<String, String> fieldMap = infBuilder.getFieldMap();
+        Set<String> fieldsToRead = new HashSet<>(model.get().getFieldNames());
+
+        // fieldMap is fieldname in doc -> fieldname expected by model.
+        // Reverse the map to find the name of the doc field
+        for (Map.Entry<String, String> entry : fieldMap.entrySet()) {
+            if (fieldsToRead.contains(entry.getValue())) {
+                fieldsToRead.remove(entry.getValue());
+                fieldsToRead.add(entry.getKey());
+            }
+        }
+
+        InferenceConfig config = infBuilder.getInferenceConfig();
+        for (SearchHit hit : hits) {
+            InferenceResults infer = model.get().infer(
+                    mapFields(
+                            extractFields(hit, fieldsToRead), fieldMap), config);
+
+            addFieldsToHit(hit, infer.writeResultToMap());
+        }
+    }
+
+    private Map<String, Object> extractFields(SearchHit hit, Set<String> fieldNames) {
+
+        Map<String, Object> doc = new HashMap<>();
+        Set<String> trackingFieldNames = new HashSet<>(fieldNames);
+
+        for (String fieldName : fieldNames) {
+            DocumentField field = hit.field(fieldName);
+            if (field != null) {
+                doc.put(fieldName, field.getValue());
+                trackingFieldNames.remove(fieldName);
+            }
+        }
+
+        Map<String, Object> sourceMap = hit.getSourceAsMap();
+        if (sourceMap != null) {
+            for (String fieldName : trackingFieldNames) {
+                Object fieldValue = sourceMap.get(fieldName);
+                if (fieldValue != null) {
+                     doc.put(fieldName, fieldValue);
+                }
+            }
+        }
+
+        return doc;
+    }
+
+    private Map<String, Object> mapFields(Map<String, Object> doc, Map<String, String> fieldMap) {
+        fieldMap.forEach((src, dest) -> {
+            Object srcValue = doc.get(src);
+            doc.put(dest, srcValue);
+        });
+
+        return doc;
+    }
+
+    private void addFieldsToHit(SearchHit hit, Map<String, Object> appends) {
+        Map<String, DocumentField> fields = new HashMap<>(hit.getFields());
+        for (Map.Entry<String, Object> entry : appends.entrySet()) {
+            DocumentField df = new DocumentField(entry.getKey(), Collections.singletonList(entry.getValue()));
+            fields.put(df.getName(), df);
+        }
+        hit.fields(fields);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -54,6 +54,7 @@ public class InferencePhase implements FetchSubPhase {
 
         modelLoadingService.get().getModel(infBuilder.getModelId(), listener);
         try {
+            // Eeek blocking on a latch we can't be doing that
             latch.await();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceSearchExtBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceSearchExtBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference.search;
+
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.SearchExtBuilder;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class InferenceSearchExtBuilder extends SearchExtBuilder {
+
+    public static final String NAME = "model";
+
+    public static final ParseField MODEL_ID = new ParseField("model_id");
+    private static final ParseField INFERENCE_CONFIG = new ParseField("inference_config");
+    private static final ParseField FIELD_MAPPINGS = new ParseField("field_mappings");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<InferenceSearchExtBuilder, Void> PARSER = new ConstructingObjectParser<>(
+            NAME,
+            args -> new InferenceSearchExtBuilder((String) args[0], (List<InferenceConfig>) args[1], (Map<String, String>) args[2])
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), MODEL_ID);
+        PARSER.declareNamedObjects(optionalConstructorArg(), (p, c, n) -> p.namedObject(InferenceConfig.class, n, c), INFERENCE_CONFIG);
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> p.mapStrings(), FIELD_MAPPINGS, ObjectParser.ValueType.OBJECT);
+    }
+
+    private final String modelId;
+    private final InferenceConfig inferenceConfig;
+    private final Map<String, String> fieldMap;
+
+    public InferenceSearchExtBuilder(String modelId, @Nullable List<InferenceConfig> config, @Nullable Map<String, String> fieldMap) {
+        this.modelId = modelId;
+        if (config != null) {
+            assert config.size() == 1;
+            this.inferenceConfig = config.get(0);
+        } else {
+            this.inferenceConfig = null;
+        }
+        this.fieldMap = fieldMap;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return null;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return false;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/inference/search/InferenceSearchExtBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/inference/search/InferenceSearchExtBuilderTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference.inference.search;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
+import org.elasticsearch.xpack.ml.inference.search.InferenceSearchExtBuilder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InferenceSearchExtBuilderTests extends AbstractSerializingTestCase<InferenceSearchExtBuilder> {
+    @Override
+    protected InferenceSearchExtBuilder doParseInstance(XContentParser parser) {
+        return InferenceSearchExtBuilder.fromXContent(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<InferenceSearchExtBuilder> instanceReader() {
+        return InferenceSearchExtBuilder::new;
+    }
+
+    @Override
+    protected InferenceSearchExtBuilder createTestInstance() {
+        InferenceConfig config = null;
+
+        if (randomBoolean()) {
+            config = ClassificationConfigTests.randomClassificationConfig();
+        } else {
+            config = RegressionConfigTests.randomRegressionConfig();
+        }
+
+        return new InferenceSearchExtBuilder(randomAlphaOfLength(8), Collections.singletonList(config), randomMapOrNull());
+    }
+
+    private Map<String, String> randomMapOrNull() {
+        if (randomBoolean()) {
+            return null;
+        }
+
+        int numEntries = randomIntBetween(0, 3);
+        Map<String, String> result = new HashMap<>();
+        for (int i = 0; i < numEntries; i++) {
+            result.put("field" + i, randomAlphaOfLength(5));
+        }
+
+        return result;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(new MlInferenceNamedXContentProvider().getNamedWriteables());
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/inference/search/InferenceSearchExtBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/inference/search/InferenceSearchExtBuilderTests.java
@@ -34,7 +34,7 @@ public class InferenceSearchExtBuilderTests extends AbstractSerializingTestCase<
 
     @Override
     protected InferenceSearchExtBuilder createTestInstance() {
-        InferenceConfig config = null;
+        InferenceConfig config;
 
         if (randomBoolean()) {
             config = ClassificationConfigTests.randomClassificationConfig();
@@ -42,7 +42,8 @@ public class InferenceSearchExtBuilderTests extends AbstractSerializingTestCase<
             config = RegressionConfigTests.randomRegressionConfig();
         }
 
-        return new InferenceSearchExtBuilder(randomAlphaOfLength(8), Collections.singletonList(config), randomMapOrNull());
+        return new InferenceSearchExtBuilder(randomAlphaOfLength(8), Collections.singletonList(config),
+                randomAlphaOfLength(6), randomMapOrNull());
     }
 
     private Map<String, String> randomMapOrNull() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/fetch_inference.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/fetch_inference.yml
@@ -1,0 +1,186 @@
+setup:
+  - skip:
+      features: headers
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model:
+        model_id: a-complex-regression-model
+        body: >
+          {
+            "description": "super complex model for tests",
+            "input": {"field_names": ["decider"]},
+            "definition": {
+              "trained_model": {
+                "ensemble": {
+                  "feature_names": [],
+                  "target_type": "regression",
+                  "trained_models": [
+                  {
+                    "tree": {
+                      "feature_names": [
+                        "decider"
+                      ],
+                      "tree_structure": [
+                      {
+                        "node_index": 0,
+                        "split_feature": 0,
+                        "split_gain": 12,
+                        "threshold": 38,
+                        "decision_type": "lte",
+                        "default_left": true,
+                        "left_child": 1,
+                        "right_child": 2
+                      },
+                      {
+                        "node_index": 1,
+                        "leaf_value": 5.0
+                      },
+                      {
+                        "node_index": 2,
+                        "leaf_value": 2.0
+                      }
+                      ],
+                      "target_type": "regression"
+                    }
+                  }
+                  ]
+                }
+              }
+            }
+          }
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model:
+        model_id: a-complex-classification-model
+        body: >
+          {
+            "description": "uncomprehendable black box",
+            "input": {
+              "field_names": [
+                "size"
+              ]
+            },
+            "definition": {
+              "trained_model": {
+                "ensemble": {
+                  "feature_names": [],
+                  "target_type": "classification",
+                  "classification_labels": [
+                    "widescreen",
+                    "bog standard"
+                  ],
+                  "trained_models": [
+                  {
+                    "tree": {
+                      "feature_names": [
+                        "size"
+                      ],
+                      "tree_structure": [
+                      {
+                        "node_index": 0,
+                        "split_feature": 0,
+                        "split_gain": 12,
+                        "threshold": 38,
+                        "decision_type": "lte",
+                        "default_left": true,
+                        "left_child": 1,
+                        "right_child": 2
+                      },
+                      {
+                        "node_index": 1,
+                        "leaf_value": 1.0
+                      },
+                      {
+                        "node_index": 2,
+                        "leaf_value": 0.0
+                      }
+                      ],
+                      "target_type": "classification"
+                    }
+                  }
+                  ],
+                  "aggregate_output" : {
+                    "weighted_mode" : {
+                      "num_classes" : 2
+                    }
+                  }
+                }
+              }
+            }
+          }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.create:
+        index: store
+        body:
+          mappings:
+            properties:
+              goods:
+                type: text
+              size:
+                type: double
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
+      bulk:
+        index: store
+        refresh: true
+        body: |
+          { "index": {} }
+          { "goods": "television", "size": 32.0 }
+          { "index": {} }
+          { "goods": "VCR", "size": 0 }
+          { "index": {} }
+          { "goods": "widescreen television", "size": 40.0 }
+---
+"Test fetch regression":
+
+  - do:
+      search:
+        index: store
+        body: |
+          {
+            "query": { "term" : { "goods": {"value": "television"} } },
+            "ext" : {
+              "ml_inf_search_ext": {
+                  "model_id": "a-complex-regression-model",
+                  "field_mappings": {"size": "decider"},
+                  "inference_config": {
+                    "regression": {
+                      "results_field": "regression-value"
+                    }
+                  }
+              }
+            }
+          }
+  - match: { hits.hits.0.fields.regression-value.0: 5.0 }
+  - match: { hits.hits.1.fields.regression-value.0: 2.0 }
+
+---
+"Test fetch classification":
+
+  - do:
+      search:
+        index: store
+        body: |
+          {
+            "query": { "term" : { "goods": {"value": "television"} } },
+            "ext" : {
+              "ml_inf_search_ext": {
+                  "model_id": "a-complex-classification-model",
+                  "inference_config": {
+                     "classification": {
+                       "num_top_classes": 1
+                     }
+                  }
+              }
+            }
+          }
+  - match: { hits.hits.0.fields.top_classes.0.0.class_name: "bog standard" }
+  - match: { hits.hits.1.fields.top_classes.0.0.class_name: "widescreen" }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/fetch_inference.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/fetch_inference.yml
@@ -148,7 +148,7 @@ setup:
           {
             "query": { "term" : { "goods": {"value": "television"} } },
             "ext" : {
-              "ml_inf_search_ext": {
+              "ml_inference": {
                   "model_id": "a-complex-regression-model",
                   "field_mappings": {"size": "decider"},
                   "inference_config": {
@@ -159,8 +159,8 @@ setup:
               }
             }
           }
-  - match: { hits.hits.0.fields.regression-value.0: 5.0 }
-  - match: { hits.hits.1.fields.regression-value.0: 2.0 }
+  - match: { hits.hits.0.fields.ml.0.regression-value: 5.0 }
+  - match: { hits.hits.1.fields.ml.0.regression-value: 2.0 }
 
 ---
 "Test fetch classification":
@@ -172,8 +172,9 @@ setup:
           {
             "query": { "term" : { "goods": {"value": "television"} } },
             "ext" : {
-              "ml_inf_search_ext": {
+              "ml_inference": {
                   "model_id": "a-complex-classification-model",
+                  "target_field" : "ml_class",
                   "inference_config": {
                      "classification": {
                        "num_top_classes": 1
@@ -182,5 +183,5 @@ setup:
               }
             }
           }
-  - match: { hits.hits.0.fields.top_classes.0.0.class_name: "bog standard" }
-  - match: { hits.hits.1.fields.top_classes.0.0.class_name: "widescreen" }
+  - match: { hits.hits.0.fields.ml_class.0.top_classes.0.class_name: "bog standard" }
+  - match: { hits.hits.1.fields.ml_class.0.top_classes.0.class_name: "widescreen" }


### PR DESCRIPTION
## Why here
Search hits can be modified at fetch with new fields added. Fetch sub phases run the on the data node so additional features used by the model can be extracted from Lucene.

## Configuration
There isn't a direct way of configuring FetchSubPhases so I have commandeered [SearchExtSpec](https://github.com/elastic/elasticsearch/blob/649cd637fa82de2681f8c01b77656c26d799c09f/server/src/main/java/org/elasticsearch/plugins/SearchPlugin.java#L460) for the purpose. The ext spec is accessible via the SearchContext [passed](https://github.com/elastic/elasticsearch/blob/067eecba2cd5b9981f01cc4793131d555cbd7e0f/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java#L167) to the fetch sub phase. Parsed [here](https://github.com/elastic/elasticsearch/blob/067eecba2cd5b9981f01cc4793131d555cbd7e0f/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java#L1104) SearchExtSpecs come under the "ext" field forcing this rather clunky nested config upon us:

```
    "query": { },
    "ext": {
        "ml_inference" : {
            "model_id" : "an_inference_model",
            "target_field" : "ml_results_field",
            "field_mappings": {"doc_field_name": "name_expected_by_model"},
            "inference_config": {
                "classification": {
                      "num_top_classes": 1
                }
            }
        }
    }
```

The usual config [options](https://www.elastic.co/guide/en/elasticsearch/reference/master/inference-processor.html) apply.

## Modifying the Search Hit
The goal is to append a field to each search hit with the inference result. I see 2 options for doing so:
1. Modify the document source
2. Add a `DocumentField`. The new field will appear under the `fields` section of the search hit as if it had been asked for in the search request via [docvalue_fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-docvalue-fields)

I've opted for the 2nd choice as modifying the source seems a little underhand. Again this is awkward putting the result where we would expect doc value fields, depending on the outcome of #49028 the future may offer another way to add fields to the search hit. 

```
"hits" : [
 {
   "_index" : "store",
   "_id" : "NIxgsHABziobK4pvOW_2",
   "_score" : 0.52354836,
   "_source" : {
        ...
   },
   "fields" : {           <-- Usually doc value fields
     "ml_results_field" : [
       {
         "top_classes" : [
           {
             "class_name" : "hot dog",
             "class_probability" : 0.99,
             "class_score" : 1.0
           }
         ],
         "predicted_value" : "hot dog"
       }
     ]
   }
 },
```

## The Problem
The `InferencePhase` class has access to the [ModelLoadingService](https://github.com/elastic/elasticsearch/blob/b0c249f693565688a4d8cba101fc137a920ca01c/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java#L53) which neatly deals with the model caching problem but there is still a blocking call to load the model (which may or not be cached) the first time `InferencePhase.hitsExecute(SearchContext, SearchHit[])` is called.  

## Wish List
- A way to configure the fetch phase without nesting it inside the "ext" field

## Why Here (Reprise)
Executing locally on the data node has the advantage of being close to any shard level features we want extract and use in inference. But it now occurs to me that those features could be extracted in a fetch sub phase and returned with the hit. Inference would then run on the coordinating node and the blocking call to load the model could be dropped.


This PR is raised against the feature branch `feature/search-inference` 
