### PR TITLE
Fix potential NPE in FuzzyTermsEnum

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/SpanBooleanQueryRewriteWithMaxClause.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/SpanBooleanQueryRewriteWithMaxClause.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
+import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
 
 import java.io.IOException;
@@ -92,11 +93,12 @@ public class SpanBooleanQueryRewriteWithMaxClause extends SpanMultiTermQueryWrap
                         continue;
                     }
 
-                    final TermsEnum termsEnum = getTermsEnum(query, terms, null);
+                    final TermsEnum termsEnum = getTermsEnum(query, terms, new AttributeSource());
                     assert termsEnum != null;
 
-                    if (termsEnum == TermsEnum.EMPTY)
+                    if (termsEnum == TermsEnum.EMPTY) {
                         continue;
+                    }
 
                     BytesRef bytes;
                     while ((bytes = termsEnum.next()) != null) {

--- a/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.query;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.join.ScoreMode;
+import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.English;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -1763,10 +1764,11 @@ public class SearchQueryIT extends ESIntegTestCase {
    }
 
     /**
-     * Test fix for NPE from {@link SpanBooleanQueryRewriteWithMaxClause#rewrite(IndexReader, MultiTermQuery)}.
-     * See https://github.com/elastic/elasticsearch/issues/52894 for details
+     * Test correct handling {@link SpanBooleanQueryRewriteWithMaxClause#rewrite(IndexReader, MultiTermQuery)}. That rewrite method is e.g.
+     * set for fuzzy queries with "constant_score" rewrite nested inside a `span_multi` query and would cause NPEs due to an unset
+     * {@link AttributeSource}.
      */
-    public void testIssue52894() {
+    public void testIssueFuzzyInsideSpanMulti() {
         createIndex("test");
         client().prepareIndex("test").setId("1").setSource("field", "foobarbaz").get();
         ensureGreen();


### PR DESCRIPTION
Under certain circumstances SpanMultiTermQueryWrapper uses
SpanBooleanQueryRewriteWithMaxClause as its rewrite method, which in turn tries
to get a TermsEnum from the wrapped MultiTermQuery currently using a `null`
AttributeSource. While queries TermsQuery or subclasses of AutomatonQuery ignore
this argument, FuzzyQuery uses it to create a FuzzyTermsEnum which triggers an
NPE when the AttributeSource is not provided. This PR fixes this by supplying an
empty AttributeSource instead of a `null` value.

Closes #52894