### PR TITLE
Draft: Fix value scripts in composite aggs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -367,6 +367,11 @@ public enum FieldData {
                 return values.lookupOrd(values.nextOrd());
             }
 
+            @Override
+            public BytesRef normalizeValue(BytesRef value) {
+                return value;
+            }
+
         };
     }
 
@@ -410,6 +415,11 @@ public enum FieldData {
                 }
                 sort();
                 return true;
+            }
+
+            @Override
+            public BytesRef normalizeValue(BytesRef value) {
+                return value;
             }
 
         };

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SingletonSortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SingletonSortedBinaryDocValues.java
@@ -51,4 +51,9 @@ final class SingletonSortedBinaryDocValues extends SortedBinaryDocValues {
         return in;
     }
 
+    @Override
+    public BytesRef normalizeValue(BytesRef value) {
+        return value;
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SortedBinaryDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SortedBinaryDocValues.java
@@ -52,4 +52,10 @@ public abstract class SortedBinaryDocValues {
      */
     public abstract BytesRef nextValue() throws IOException;
 
+    /**
+     * Applies normalization to the value for example a value script if needed.
+     * @return {@link BytesRef} of the normalized value which can be value if no
+     * normalization is required.
+     */
+    public abstract BytesRef normalizeValue(BytesRef value);
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/BytesBinaryDVAtomicFieldData.java
@@ -85,6 +85,11 @@ final class BytesBinaryDVAtomicFieldData implements AtomicFieldData {
                 return scratch;
             }
 
+            @Override
+            public BytesRef normalizeValue(BytesRef value) {
+                return value;
+            }
+
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -48,10 +48,10 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.search.sort.BucketedSort;
-import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -274,6 +274,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
                     @Override
                     public boolean advanceExact(int doc) throws IOException {
                         return inValues.advanceExact(doc);
+                    }
+
+                    @Override
+                    public BytesRef normalizeValue(BytesRef value) {
+                        return value;
                     }
                 };
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/BinaryValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/BinaryValuesSource.java
@@ -173,11 +173,13 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
     }
 
     @Override
-    LeafBucketCollector getLeafCollector(Comparable value, LeafReaderContext context, LeafBucketCollector next) {
+    LeafBucketCollector getLeafCollector(Comparable value, LeafReaderContext context, LeafBucketCollector next) throws IOException {
         if (value.getClass() != BytesRef.class) {
             throw new IllegalArgumentException("Expected BytesRef, got " + value.getClass());
         }
-        currentValue = (BytesRef) value;
+        final SortedBinaryDocValues dvs = docValuesFunc.apply(context);
+        currentValue = dvs.normalizeValue((BytesRef) value);
+
         return new LeafBucketCollector() {
             @Override
             public void collect(int doc, long bucket) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MissingValues.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MissingValues.java
@@ -91,6 +91,11 @@ public enum MissingValues {
             public String toString() {
                 return "anon SortedBinaryDocValues of [" + super.toString() + "]";
             }
+
+            @Override
+            public BytesRef normalizeValue(BytesRef value) {
+                return value;
+            }
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -283,6 +283,13 @@ public abstract class ValuesSource {
                 }
 
                 @Override
+                public BytesRef normalizeValue(BytesRef value) {
+                    script.setNextAggregationValue(value.utf8ToString());
+                    Object run = script.execute();
+                    return new BytesRef(run.toString());
+                }
+
+                @Override
                 public boolean advanceExact(int doc) throws IOException {
                     if (bytesValues.advanceExact(doc)) {
                         count = bytesValues.docValueCount();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptBytesValues.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptBytesValues.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.support.values;
 
 import org.apache.lucene.search.Scorable;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
@@ -87,5 +88,12 @@ public class ScriptBytesValues extends SortingBinaryDocValues implements ScorerA
     @Override
     public void setScorer(Scorable scorer) {
         script.setScorer(scorer);
+    }
+
+    @Override
+    public BytesRef normalizeValue(BytesRef value) {
+        script.setNextAggregationValue(value.utf8ToString());
+        Object run = script.execute();
+        return new BytesRef(run.toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreTests.java
@@ -119,6 +119,11 @@ public class FunctionScoreTests extends ESTestCase {
                         public BytesRef nextValue() {
                             return new BytesRef("0");
                         }
+
+                        @Override
+                        public BytesRef normalizeValue(BytesRef value) {
+                            return value;
+                        }
                     };
                 }
 

--- a/server/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
@@ -524,6 +524,11 @@ public class MultiValueModeTests extends ESTestCase {
             public int docValueCount() {
                 return array[doc].length;
             }
+
+            @Override
+            public BytesRef normalizeValue(BytesRef value) {
+                return value;
+            }
         };
         verifySortedBinary(multiValues, numDocs);
         final FixedBitSet rootDocs = randomRootDocs(numDocs);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorTests.java
@@ -18,10 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import com.carrotsearch.hppc.LongHashSet;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.TestUtil;
@@ -32,7 +29,10 @@ import org.elasticsearch.search.aggregations.bucket.range.BinaryRangeAggregator.
 import org.elasticsearch.search.aggregations.bucket.range.BinaryRangeAggregator.SortedSetRangeLeafCollector;
 import org.elasticsearch.test.ESTestCase;
 
-import com.carrotsearch.hppc.LongHashSet;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 public class BinaryRangeAggregatorTests extends ESTestCase {
 
@@ -167,6 +167,11 @@ public class BinaryRangeAggregatorTests extends ESTestCase {
         @Override
         public BytesRef nextValue() {
             return terms[(int) ords[i++]];
+        }
+
+        @Override
+        public BytesRef normalizeValue(BytesRef value) {
+            return value;
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/MissingValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/MissingValuesTests.java
@@ -73,6 +73,11 @@ public class MissingValuesTests extends ESTestCase {
             public int docValueCount() {
                 return values[doc].length;
             }
+
+            @Override
+            public BytesRef normalizeValue(BytesRef value) {
+                return value;
+            }
         };
         final BytesRef missing = new BytesRef(RandomStrings.randomAsciiOfLength(random(), 2));
         SortedBinaryDocValues withMissingReplaced = MissingValues.replaceMissing(asBinaryValues, missing);


### PR DESCRIPTION
add a normalizeValue method to normalize values for scripted fields

fixes #53135


This is a draft fix for #53135 after debugging it. It turns out that the problem is a regression of the optimization in #28745 (easy to prove: just add a query to the repro steps I gave in #53135). I further found out that the script isn't applied for this optimization and that's how I fixed it. In order to do so, I introduced a new method for standalone value normalization, which does nothing if no script is used. 

This fix is best effort, I do not know much about the codebase. I think it works but might not be a good implementation. This might just be a helper for creating a proper fix or I can make this a proper change (including test coverage) after getting some guidance.