### PR TITLE
Add SystemCallFilter support for ppc64le and s390x

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -241,6 +241,8 @@ final class SystemCallFilter {
         ARCHITECTURES = Map.of(
                 "amd64", new Arch(0xC000003E, 0x3FFFFFFF, 57, 58, 59, 322, 317),
                 "aarch64", new Arch(0xC00000B7, 0xFFFFFFFF, 1079, 1071, 221, 281, 277));
+                "ppc64le", new Arch(0xC0000015, 0xFFFFFFFF, 2, 189, 11, 362, 358));
+                "s390x", new Arch(0x80000016, 0x3FFFFFFF, 2, 190, 11, 354, 348));
     }
 
     /** invokes prctl() from linux libc library */


### PR DESCRIPTION
IBM would like to see this backported to upstream-supported stable branch(es) as well.