### PR TITLE
Small corrections to stored_fields docs.

### DIFF
--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -40,8 +40,7 @@ If the requested fields are not stored (`store` mapping set to `false`), they wi
 
 Stored field values fetched from the document itself are always returned as an array. On the contrary, metadata fields like `_routing` are never returned as an array.
 
-Also only leaf fields can be returned via the `stored_fields` option. So object fields can't be returned and such requests
-will fail.
+Also only leaf fields can be returned via the `stored_fields` option. If an object field is specified, it will be ignored.
 
 NOTE: On its own, `stored_fields` cannot be used to load fields in nested
 objects -- if a field contains a nested object in its path, then no data will

--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -40,7 +40,7 @@ If the requested fields are not stored (`store` mapping set to `false`), they wi
 
 Stored field values fetched from the document itself are always returned as an array. On the contrary, metadata fields like `_routing` are never returned as an array.
 
-Also only leaf fields can be returned via the `field` option. So object fields can't be returned and such requests
+Also only leaf fields can be returned via the `stored_fields` option. So object fields can't be returned and such requests
 will fail.
 
 Script fields can also be automatically detected and used as fields, so

--- a/docs/reference/search/request/stored-fields.asciidoc
+++ b/docs/reference/search/request/stored-fields.asciidoc
@@ -43,10 +43,6 @@ Stored field values fetched from the document itself are always returned as an a
 Also only leaf fields can be returned via the `stored_fields` option. So object fields can't be returned and such requests
 will fail.
 
-Script fields can also be automatically detected and used as fields, so
-things like `_source.obj1.field1` can be used, though not recommended, as
-`obj1.field1` will work as well.
-
 NOTE: On its own, `stored_fields` cannot be used to load fields in nested
 objects -- if a field contains a nested object in its path, then no data will
 be returned for that stored field. To access nested fields, `stored_fields`


### PR DESCRIPTION
* Fix a place where `stored_fields` was referred to as `field`.
* Remove claim about being able to detect script fields, as it's no longer true.
* Specify that object fields will be ignored, instead of causing the request to fail.