### PR TITLE
Fix serialization versions for hidden aliases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,8 +220,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/52547" // backport thereof
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -75,7 +75,7 @@ public class Alias implements Writeable, ToXContentFragment {
         indexRouting = in.readOptionalString();
         searchRouting = in.readOptionalString();
         writeIndex = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
+        if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             isHidden = in.readOptionalBoolean();
         }
     }
@@ -219,7 +219,7 @@ public class Alias implements Writeable, ToXContentFragment {
         out.writeOptionalString(indexRouting);
         out.writeOptionalString(searchRouting);
         out.writeOptionalBoolean(writeIndex);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
+        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeOptionalBoolean(isHidden);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -251,7 +251,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             searchRouting = in.readOptionalString();
             indexRouting = in.readOptionalString();
             writeIndex = in.readOptionalBoolean();
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) { //TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
+            if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
                 isHidden = in.readOptionalBoolean();
             }
             originalAliases = in.readStringArray();
@@ -267,7 +267,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             out.writeOptionalString(searchRouting);
             out.writeOptionalString(indexRouting);
             out.writeOptionalBoolean(writeIndex);
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) { //TODO fix for backport https://github.com/elastic/elasticsearch/pull/52547
+            if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
                 out.writeOptionalBoolean(isHidden);
             }
             out.writeStringArray(originalAliases);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -198,7 +198,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> implements To
         }
         out.writeOptionalBoolean(writeIndex());
 
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { //TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
+        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeOptionalBoolean(isHidden);
         }
     }
@@ -224,7 +224,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> implements To
         }
         writeIndex = in.readOptionalBoolean();
 
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { //TODO fix for backport of https://github.com/elastic/elasticsearch/pull/52547
+        if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             isHidden = in.readOptionalBoolean();
         } else {
             isHidden = null;


### PR DESCRIPTION
This commit corrects the serialization versions for hidden alias data
following the backport of #52547.

Also re-enables BWC tests.