### PR TITLE
[DOCS]Add a lower-casing eamil address example to Keyword Tokenizer

### DIFF
--- a/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
@@ -44,6 +44,54 @@ The above sentence would produce the following term:
 [ New York ]
 ---------------------------
 
+[discrete]
+[[analysis-keyword-tokenizer-token-filters]]
+=== Combine with token filters
+You can combine the `keyword` tokenizer with token filters to normalise
+structured data, such as product IDs or email addresses.
+
+For example, the following <<indices-analyze,analyze API>> request uses
+`keyword` tokenizer and <<analysis-lowercase-tokenfilter,`lowercase`>> filter to
+convert an email address to lowercase.
+
+[source,console]
+---------------------------
+POST _analyze
+{
+  "tokenizer": "keyword",
+  "filter": [ "lowercase" ],
+  "text": "john.SMITH@example.COM"
+}
+---------------------------
+
+/////////////////////
+
+[source,console-result]
+----------------------------
+{
+  "tokens": [
+    {
+      "token": "john.smith@example.com",
+      "start_offset": 0,
+      "end_offset": 22,
+      "type": "word",
+      "position": 0
+    }
+  ]
+}
+----------------------------
+
+/////////////////////
+
+
+The request produces the following token:
+
+[source,text]
+---------------------------
+[ john.smith@example.com ]
+---------------------------
+
+
 [float]
 === Configuration
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

While reading a document for `Keyword Tokenizer`, I felt a bit confused why `Keyword Tokenizer` is needed.

`Keyword Tokenizer` is too simple to explain, which makes an example also simple.
However, as the document stated the other use-case(lower-casing email address) for users
to better understand the necessity of `Keyword Tokenizer`, I added the corresponding example.

### This is AS-IS:
![kwt-as-is](https://user-images.githubusercontent.com/24863651/76142634-e0c9fb00-60b2-11ea-928c-b801431636c6.PNG)

### This is Added Example:
![kwt-added-example](https://user-images.githubusercontent.com/24863651/76142641-f3443480-60b2-11ea-9833-e7d2864a25e9.PNG)
