### PR TITLE
[DOCS] Mentioning doc build alias file in docs/README.asciidoc

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -1,7 +1,7 @@
 The Elasticsearch docs are in AsciiDoc format and can be built using the
 Elasticsearch documentation build process.
 
-See: https://github.com/elastic/docs
+See `doc_build_aliases.sh` file in: https://github.com/elastic/docs
 
 === Backporting doc fixes
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

I modified a document file and I tried to see whether it is showing right.
I tried with the command stated in `README.asciidoc` at **elasitic/docs** repository, which keeps failing.

I found out there exists pre-defined alias for document build at that repository after a few hours of debugging.  I think this is too-much time consumed only for figuring out how to build document. The reference to this was only one line of sentence:
>Some documentation books require more complex build commands. doc_build_aliases.sh provides simplified aliases and the build commands for each book.



I think it is better to let people know the document build command is defined in `doc_build_aliases.sh` file in **elastic/docs** repository, so that people can save their valuable time.

### diff:
```diff
diff --git a/docs/README.asciidoc b/docs/README.asciidoc
index f6a8ed48e63..5531af10c34 100644
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -1,7 +1,7 @@
 The Elasticsearch docs are in AsciiDoc format and can be built using the
 Elasticsearch documentation build process.

-See: https://github.com/elastic/docs
+See `doc_build_aliases.sh` file in: https://github.com/elastic/docs

 === Backporting doc fixes

```