### PR TITLE
Notify refresh listeners on the calling thread

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3101,7 +3101,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return new RefreshListeners(
             indexSettings::getMaxRefreshListeners,
             () -> refresh("too_many_listeners"),
-            threadPool.executor(ThreadPool.Names.LISTENER),
             logger, threadPool.getThreadContext(),
             externalRefreshMetric);
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -102,8 +102,6 @@ public class RefreshListenersTests extends ESTestCase {
         listeners = new RefreshListeners(
                 () -> maxListeners,
                 () -> engine.refresh("too-many-listeners"),
-                // Immediately run listeners rather than adding them to the listener thread pool like IndexShard does to simplify the test.
-                Runnable::run,
                 logger,
                 threadPool.getThreadContext(),
                 refreshMetric);


### PR DESCRIPTION
Today we notify refresh listeners by forking to the listener thread pool and then serially notifying listeners on a thread there. Refreshes are expensive though, so the expectation is that we are executing refreshes on threads that can afford an expensive operation (e.g., not a network thread) and as such, executing listeners that we expect to be cheap aon the calling thread is okay. This commit removes the forking of notifying refresh listeners to run directly on the calling thread that executed a refresh.

Relates #53049
