### PR TITLE
Drop action future that forks on listener executor

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/PlainListenableActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainListenableActionFuture.java
@@ -30,8 +30,7 @@ public class PlainListenableActionFuture<T> extends AdapterActionFuture<T, T> im
     volatile Object listeners;
     boolean executedListeners = false;
 
-    protected PlainListenableActionFuture() {
-    }
+    protected PlainListenableActionFuture() {}
 
     /**
      * This method returns a listenable future. The listeners will be called on completion of the future.

--- a/server/src/main/java/org/elasticsearch/action/support/PlainListenableActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainListenableActionFuture.java
@@ -19,11 +19,8 @@
 
 package org.elasticsearch.action.support;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ListenableActionFuture;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +30,8 @@ public class PlainListenableActionFuture<T> extends AdapterActionFuture<T, T> im
     volatile Object listeners;
     boolean executedListeners = false;
 
-    protected PlainListenableActionFuture() {}
+    protected PlainListenableActionFuture() {
+    }
 
     /**
      * This method returns a listenable future. The listeners will be called on completion of the future.
@@ -44,17 +42,6 @@ public class PlainListenableActionFuture<T> extends AdapterActionFuture<T, T> im
      */
     public static <T> PlainListenableActionFuture<T> newListenableFuture() {
         return new PlainListenableActionFuture<>();
-    }
-
-    /**
-     * This method returns a listenable future. The listeners will be called on completion of the future.
-     * The listeners will be executed on the LISTENER thread pool.
-     * @param threadPool the thread pool used to execute listeners
-     * @param <T> the result of the future
-     * @return a listenable future
-     */
-    public static <T> PlainListenableActionFuture<T> newDispatchingListenableFuture(ThreadPool threadPool) {
-        return new DispatchingListenableActionFuture<>(threadPool);
     }
 
     @Override
@@ -121,18 +108,4 @@ public class PlainListenableActionFuture<T> extends AdapterActionFuture<T, T> im
         }
     }
 
-    private static final class DispatchingListenableActionFuture<T> extends PlainListenableActionFuture<T> {
-
-        private static final Logger logger = LogManager.getLogger(DispatchingListenableActionFuture.class);
-        private final ThreadPool threadPool;
-
-        private DispatchingListenableActionFuture(ThreadPool threadPool) {
-            this.threadPool = threadPool;
-        }
-
-        @Override
-        public void addListener(final ActionListener<T> listener) {
-            super.addListener(new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.LISTENER, listener, false));
-        }
-    }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/ListenableActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ListenableActionFutureTests.java
@@ -34,12 +34,7 @@ public class ListenableActionFutureTests extends ESTestCase {
     public void testListenerIsCallableFromNetworkThreads() throws Throwable {
         ThreadPool threadPool = new TestThreadPool("testListenerIsCallableFromNetworkThreads");
         try {
-            final PlainListenableActionFuture<Object> future;
-            if (randomBoolean()) {
-                future = PlainListenableActionFuture.newDispatchingListenableFuture(threadPool);
-            } else {
-                future = PlainListenableActionFuture.newListenableFuture();
-            }
+            final PlainListenableActionFuture<Object> future = PlainListenableActionFuture.newListenableFuture();
             final CountDownLatch listenerCalled = new CountDownLatch(1);
             final AtomicReference<Throwable> error = new AtomicReference<>();
             final Object response = new Object();


### PR DESCRIPTION
This commit drops the dispatching listenable action future that forks to the listener thread pool. This was previously used in the transport client but is no longer used.

Relates #53049
