### PR TITLE
Fork CCR checkpoint listeners on CCR thread pool

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -395,7 +395,7 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
 
                         @Override
                         public Executor executor() {
-                            return threadPool.executor(ThreadPool.Names.LISTENER);
+                            return threadPool.executor(Ccr.CCR_THREAD_POOL_NAME);
                         }
 
                         @Override


### PR DESCRIPTION
This commit moves the global checkpoint listeners used in CCR to the CCR thread pool. This removes the last use of the listener thread pool in the codebase.

Relates #53049