### PR TITLE
[DOCS] Adds Beats tip to EQL search docs

### DIFF
--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -29,6 +29,15 @@ PUT sec_logs/_bulk?refresh
 ----
 // TESTSETUP
 
+[TIP]
+====
+You also can set up {beats-ref}/getting-started.html[{beats}], such as
+{auditbeat-ref}/auditbeat-getting-started.html[{auditbeat}] or
+{winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat}], to automatically
+send and index your event data in {es}. See
+{beats-ref}/getting-started.html[Getting started with {beats}].
+====
+
 You can now use the EQL search API to search this index using an EQL query.
 
 The following request searches the `sec_logs` index using the EQL query


### PR DESCRIPTION
Adds a tip admonition to the basic example in the EQL search docs.

This tip lets users know they can set up a Beat to automatically
ingest data in ES, rather than manually indexing using the bulk or index
APIs.