### PR TITLE
[7.x] Implement ILM policy for .ml-state* indices (#52356)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -14,6 +14,8 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.xpack.core.ml.utils.MlIndexAndAlias;
 import org.elasticsearch.xpack.core.template.TemplateUtils;
 
+import java.util.Collections;
+
 /**
  * Methods for handling index naming related functions
  */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/persistence/AnomalyDetectorsIndex.java
@@ -14,10 +14,6 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.xpack.core.ml.utils.MlIndexAndAlias;
 import org.elasticsearch.xpack.core.template.TemplateUtils;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.regex.Pattern;
-
 /**
  * Methods for handling index naming related functions
  */
@@ -28,31 +24,7 @@ public final class AnomalyDetectorsIndex {
     private static final String RESULTS_MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";
     private static final String RESOURCE_PATH = "/org/elasticsearch/xpack/core/ml/anomalydetection/";
 
-    // Visible for testing
-    static final Comparator<String> STATE_INDEX_NAME_COMPARATOR = new Comparator<String>() {
-
-        private final Pattern HAS_SIX_DIGIT_SUFFIX = Pattern.compile("\\d{6}");
-
-        @Override
-        public int compare(String index1, String index2) {
-            String[] index1Parts = index1.split("-");
-            String index1Suffix = index1Parts[index1Parts.length - 1];
-            boolean index1HasSixDigitsSuffix = HAS_SIX_DIGIT_SUFFIX.matcher(index1Suffix).matches();
-            String[] index2Parts = index2.split("-");
-            String index2Suffix = index2Parts[index2Parts.length - 1];
-            boolean index2HasSixDigitsSuffix = HAS_SIX_DIGIT_SUFFIX.matcher(index2Suffix).matches();
-            if (index1HasSixDigitsSuffix && index2HasSixDigitsSuffix) {
-                return index1Suffix.compareTo(index2Suffix);
-            } else if (index1HasSixDigitsSuffix != index2HasSixDigitsSuffix) {
-                return Boolean.compare(index1HasSixDigitsSuffix, index2HasSixDigitsSuffix);
-            } else {
-                return index1.compareTo(index2);
-            }
-        }
-    };
-
-    private AnomalyDetectorsIndex() {
-    }
+    private AnomalyDetectorsIndex() {}
 
     public static String jobResultsIndexPrefix() {
         return AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX;
@@ -109,8 +81,13 @@ public final class AnomalyDetectorsIndex {
      */
     public static void createStateIndexAndAliasIfNecessary(Client client, ClusterState state, IndexNameExpressionResolver resolver,
                                                            final ActionListener<Boolean> finalListener) {
-        MlIndexAndAlias.createIndexAndAliasIfNecessary(client, state, resolver,
-            AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX, AnomalyDetectorsIndex.jobStateIndexWriteAlias(), finalListener);
+        MlIndexAndAlias.createIndexAndAliasIfNecessary(
+            client,
+            state,
+            resolver,
+            AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
+            AnomalyDetectorsIndex.jobStateIndexWriteAlias(),
+            finalListener);
     }
 
     public static String resultsMapping() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -5,20 +5,28 @@
  */
 package org.elasticsearch.xpack.core.ml.utils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.Nullable;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
@@ -28,6 +36,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
  * Utils to create an ML index with alias ready for rollover with a 6-digit suffix
  */
 public final class MlIndexAndAlias {
+
+    private static final Logger logger = LogManager.getLogger(MlIndexAndAlias.class);
 
     // Visible for testing
     static final Comparator<String> INDEX_NAME_COMPARATOR = new Comparator<String>() {
@@ -60,60 +70,114 @@ public final class MlIndexAndAlias {
      * or to the index with the highest suffix if the index did not have to be created.
      * The listener is notified with a {@code boolean} that informs whether the index or the alias were created.
      */
-    public static void createIndexAndAliasIfNecessary(Client client, ClusterState clusterState, IndexNameExpressionResolver resolver,
-                                                      String indexPatternPrefix, String alias, ActionListener<Boolean> listener) {
-        if (clusterState.getMetaData().getAliasAndIndexLookup().containsKey(alias)) {
-            listener.onResponse(false);
-            return;
-        }
+    public static void createIndexAndAliasIfNecessary(Client client,
+                                                      ClusterState clusterState,
+                                                      IndexNameExpressionResolver resolver,
+                                                      String indexPatternPrefix,
+                                                      String alias,
+                                                      ActionListener<Boolean> listener) {
 
-        final ActionListener<String> createAliasListener = ActionListener.wrap(
-            concreteIndexName -> {
-                final IndicesAliasesRequest request = client.admin()
-                    .indices()
-                    .prepareAliases()
-                    .addAlias(concreteIndexName, alias)
-                    .request();
-                executeAsyncWithOrigin(client.threadPool().getThreadContext(),
-                    ML_ORIGIN,
-                    request,
-                    ActionListener.<AcknowledgedResponse>wrap(
-                        resp -> listener.onResponse(resp.isAcknowledged()),
-                        listener::onFailure),
-                    client.admin().indices()::aliases);
-            },
-            listener::onFailure
-        );
+        String legacyIndexWithoutSuffix = indexPatternPrefix;
+        String indexPattern = indexPatternPrefix + "*";
+        // The initial index name must be suitable for rollover functionality.
+        String firstConcreteIndex = indexPatternPrefix + "-000001";
+        String[] concreteIndexNames =
+            resolver.concreteIndexNames(clusterState, IndicesOptions.lenientExpandOpen(), indexPattern);
+        Optional<IndexMetaData> indexPointedByCurrentWriteAlias = clusterState.getMetaData().hasAlias(alias)
+            ? clusterState.getMetaData().getAliasAndIndexLookup().get(alias).getIndices().stream().findFirst()
+            : Optional.empty();
 
-        String[] stateIndices = resolver.concreteIndexNames(clusterState,
-            IndicesOptions.lenientExpandOpen(), indexPatternPrefix + "*");
-        if (stateIndices.length > 0) {
-            String latestStateIndex = Arrays.stream(stateIndices).max(INDEX_NAME_COMPARATOR).get();
-            createAliasListener.onResponse(latestStateIndex);
+        if (concreteIndexNames.length == 0) {
+            if (indexPointedByCurrentWriteAlias.isEmpty()) {
+                createFirstConcreteIndex(client, firstConcreteIndex, alias, true, listener);
+                return;
+            }
+            logger.error(
+                "There are no indices matching '{}' pattern but '{}' alias points at [{}]. This should never happen.",
+                indexPattern, alias, indexPointedByCurrentWriteAlias.get());
+        } else if (concreteIndexNames.length == 1 && concreteIndexNames[0].equals(legacyIndexWithoutSuffix)) {
+            if (indexPointedByCurrentWriteAlias.isEmpty()) {
+                createFirstConcreteIndex(client, firstConcreteIndex, alias, true, listener);
+                return;
+            }
+            if (indexPointedByCurrentWriteAlias.get().getIndex().getName().equals(legacyIndexWithoutSuffix)) {
+                createFirstConcreteIndex(
+                    client,
+                    firstConcreteIndex,
+                    alias,
+                    false,
+                    ActionListener.wrap(
+                        unused -> updateWriteAlias(client, alias, legacyIndexWithoutSuffix, firstConcreteIndex, listener),
+                        listener::onFailure)
+                );
+                return;
+            }
+            logger.error(
+                "There is exactly one index (i.e. '{}') matching '{}' pattern but '{}' alias points at [{}]. This should never happen.",
+                legacyIndexWithoutSuffix, indexPattern, alias, indexPointedByCurrentWriteAlias.get());
         } else {
-            // The initial index name must be suitable for rollover functionality.
-            String initialJobStateIndex = indexPatternPrefix + "-000001";
-            CreateIndexRequest createIndexRequest = client.admin()
-                .indices()
-                .prepareCreate(initialJobStateIndex)
-                .addAlias(new Alias(alias))
-                .request();
-            executeAsyncWithOrigin(client.threadPool().getThreadContext(),
-                ML_ORIGIN,
-                createIndexRequest,
-                ActionListener.<CreateIndexResponse>wrap(
-                    createIndexResponse -> listener.onResponse(true),
-                    createIndexFailure -> {
-                        // If it was created between our last check, and this request being handled, we should add the alias
-                        // Adding an alias that already exists is idempotent. So, no need to double check if the alias exists
-                        // as well.
-                        if (ExceptionsHelper.unwrapCause(createIndexFailure) instanceof ResourceAlreadyExistsException) {
-                            createAliasListener.onResponse(initialJobStateIndex);
-                        } else {
-                            listener.onFailure(createIndexFailure);
-                        }
-                    }),
-                client.admin().indices()::create);
+            if (indexPointedByCurrentWriteAlias.isEmpty()) {
+                assert concreteIndexNames.length > 0;
+                String latestConcreteIndexName = Arrays.stream(concreteIndexNames).max(INDEX_NAME_COMPARATOR).get();
+                updateWriteAlias(client, alias, null, latestConcreteIndexName, listener);
+                return;
+            }
         }
+        // If the alias is set, there is nothing more to do.
+        listener.onResponse(false);
+    }
+
+    private static void createFirstConcreteIndex(Client client,
+                                                 String index,
+                                                 String alias,
+                                                 boolean addAlias,
+                                                 ActionListener<Boolean> listener) {
+        CreateIndexRequestBuilder requestBuilder = client.admin()
+            .indices()
+            .prepareCreate(index);
+        if (addAlias) {
+            requestBuilder.addAlias(new Alias(alias));
+        }
+        CreateIndexRequest request = requestBuilder.request();
+
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(),
+            ML_ORIGIN,
+            request,
+            ActionListener.<CreateIndexResponse>wrap(
+                createIndexResponse -> listener.onResponse(true),
+                createIndexFailure -> {
+                    // If it was created between our last check, and this request being handled, we should add the alias
+                    // Adding an alias that already exists is idempotent. So, no need to double check if the alias exists
+                    // as well.
+                    if (ExceptionsHelper.unwrapCause(createIndexFailure) instanceof ResourceAlreadyExistsException) {
+                        updateWriteAlias(client, alias, null, index, listener);
+                    } else {
+                        listener.onFailure(createIndexFailure);
+                    }
+                }),
+            client.admin().indices()::create);
+    }
+
+    private static void updateWriteAlias(Client client,
+                                         String alias,
+                                         @Nullable String currentIndex,
+                                         String newIndex,
+                                         ActionListener<Boolean> listener) {
+        IndicesAliasesRequestBuilder requestBuilder = client.admin()
+            .indices()
+            .prepareAliases()
+            .addAlias(newIndex, alias);
+        if (currentIndex != null) {
+            requestBuilder.removeAlias(currentIndex, alias);
+        }
+        IndicesAliasesRequest request = requestBuilder.request();
+
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(),
+            ML_ORIGIN,
+            request,
+            ActionListener.<AcknowledgedResponse>wrap(
+                resp -> listener.onResponse(resp.isAcknowledged()),
+                listener::onFailure),
+            client.admin().indices()::aliases);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.Nullable;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
@@ -88,7 +87,7 @@ public final class MlIndexAndAlias {
             : Optional.empty();
 
         if (concreteIndexNames.length == 0) {
-            if (indexPointedByCurrentWriteAlias.isEmpty()) {
+            if (indexPointedByCurrentWriteAlias.isPresent() == false) {
                 createFirstConcreteIndex(client, firstConcreteIndex, alias, true, listener);
                 return;
             }
@@ -96,7 +95,7 @@ public final class MlIndexAndAlias {
                 "There are no indices matching '{}' pattern but '{}' alias points at [{}]. This should never happen.",
                 indexPattern, alias, indexPointedByCurrentWriteAlias.get());
         } else if (concreteIndexNames.length == 1 && concreteIndexNames[0].equals(legacyIndexWithoutSuffix)) {
-            if (indexPointedByCurrentWriteAlias.isEmpty()) {
+            if (indexPointedByCurrentWriteAlias.isPresent() == false) {
                 createFirstConcreteIndex(client, firstConcreteIndex, alias, true, listener);
                 return;
             }
@@ -116,7 +115,7 @@ public final class MlIndexAndAlias {
                 "There is exactly one index (i.e. '{}') matching '{}' pattern but '{}' alias points at [{}]. This should never happen.",
                 legacyIndexWithoutSuffix, indexPattern, alias, indexPointedByCurrentWriteAlias.get());
         } else {
-            if (indexPointedByCurrentWriteAlias.isEmpty()) {
+            if (indexPointedByCurrentWriteAlias.isPresent() == false) {
                 assert concreteIndexNames.length > 0;
                 String latestConcreteIndexName = Arrays.stream(concreteIndexNames).max(INDEX_NAME_COMPARATOR).get();
                 updateWriteAlias(client, alias, null, latestConcreteIndexName, listener);

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_ilm_policy.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_ilm_policy.json
@@ -1,0 +1,11 @@
+{
+  "phases": {
+    "hot": {
+      "actions": {
+        "rollover": {
+          "max_size": "50GB"
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_template.json
@@ -9,6 +9,7 @@
       "auto_expand_replicas" : "0-1",
       "hidden": true
     }
+    ${xpack.ml.index.lifecycle.settings}
   },
   "mappings" : {
     "_doc": {
@@ -18,5 +19,5 @@
       "enabled": false
     }
   },
-  "aliases" : { }
+  "aliases" : {}
 }

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'), configuration: 'default')
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testCompile project(path: xpackModule('ilm'), configuration: 'default')
   // This should not be here
   testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.ForecastRequestStats;
@@ -94,12 +95,14 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
     @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pulls/468")
     public void testDeleteExpiredData() throws Exception {
         // Index some unused state documents (more than 10K to test scrolling works)
-        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
-        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        String mlStateIndexName = AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001";
+        BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         for (int i = 0; i < 10010; i++) {
             String docId = "non_existing_job_" + randomFrom("model_state_1234567#" + i, "quantiles", "categorizer_state#" + i);
-            IndexRequest indexRequest = new IndexRequest(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).id(docId);
-            indexRequest.source(Collections.emptyMap());
+            IndexRequest indexRequest =
+                new IndexRequest(mlStateIndexName)
+                    .id(docId)
+                    .source(Collections.emptyMap());
             bulkRequestBuilder.add(indexRequest);
         }
         ActionFuture<BulkResponse> indexUnusedStateDocsResponse = bulkRequestBuilder.execute();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -28,6 +28,8 @@ import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
@@ -39,6 +41,8 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.xpack.core.security.authc.TokenMetaData;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -66,7 +70,12 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(LocalStateCompositeXPackPlugin.class, Netty4Plugin.class);
+        return Arrays.asList(
+            LocalStateCompositeXPackPlugin.class,
+            Netty4Plugin.class,
+            ReindexPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class);
     }
 
     @Override
@@ -88,6 +97,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, SecurityField.NAME4);
         builder.put(SecurityField.USER_SETTING.getKey(), "x_pack_rest_user:" + SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);
         builder.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), true);
+        builder.put(LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.getKey(), false);
         builder.put("xpack.security.transport.ssl.enabled", true);
         builder.put("xpack.security.transport.ssl.key", key.toAbsolutePath().toString());
         builder.put("xpack.security.transport.ssl.certificate", certificate.toAbsolutePath().toString());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
-import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
@@ -42,7 +41,6 @@ import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.elasticsearch.xpack.core.security.SecurityField;
 import org.elasticsearch.xpack.core.security.authc.TokenMetaData;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
-import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
 
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -71,14 +71,18 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
         return Arrays.asList(
             LocalStateCompositeXPackPlugin.class,
             Netty4Plugin.class,
-            ReindexPlugin.class,
             // ILM is required for .ml-state template index settings
             IndexLifecycle.class);
     }
 
     @Override
     protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        return Arrays.asList(XPackClientPlugin.class, Netty4Plugin.class, ReindexPlugin.class);
+        return Arrays.asList(
+            XPackClientPlugin.class,
+            Netty4Plugin.class,
+            ReindexPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ilm.LifecycleAction;
+import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.mock.orig.Mockito.verify;
+import static org.elasticsearch.mock.orig.Mockito.when;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class MlIndexTemplateRegistryTests extends ESTestCase {
+
+    private final DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+    private final DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+    private NamedXContentRegistry xContentRegistry;
+    private ClusterService clusterService;
+    private ThreadPool threadPool;
+    private Client client;
+    private ArgumentCaptor<PutIndexTemplateRequest> putIndexTemplateRequestCaptor;
+
+    @Before
+    public void setUpMocks() {
+        threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(threadPool.generic()).thenReturn(EsExecutors.newDirectExecutorService());
+
+        client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        AdminClient adminClient = mock(AdminClient.class);
+        IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+        when(client.admin()).thenReturn(adminClient);
+        doAnswer(withResponse(new AcknowledgedResponse(true))).when(indicesAdminClient).putTemplate(any(), any());
+
+        clusterService = mock(ClusterService.class);
+
+        List<NamedXContentRegistry.Entry> entries = new ArrayList<>(ClusterModule.getNamedXWriteables());
+        entries.add(new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RolloverAction.NAME), RolloverAction::parse));
+        xContentRegistry = new NamedXContentRegistry(entries);
+
+        putIndexTemplateRequestCaptor = ArgumentCaptor.forClass(PutIndexTemplateRequest.class);
+    }
+
+    public void testStateTemplateWithIlm() {
+        MlIndexTemplateRegistry registry =
+            new MlIndexTemplateRegistry(
+                Settings.builder()
+                    .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), true)
+                    .build(),
+                clusterService, threadPool, client, xContentRegistry);
+
+        registry.clusterChanged(createClusterChangedEvent(nodes));
+
+        verify(client.admin().indices(), times(7)).putTemplate(putIndexTemplateRequestCaptor.capture(), anyObject());
+
+        PutIndexTemplateRequest req = putIndexTemplateRequestCaptor.getAllValues().stream()
+            .filter(r -> r.name().equals(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected the ml state index template to be put"));
+        assertThat(req.settings().get("index.lifecycle.name"), equalTo("ml-state-ilm-policy"));
+        assertThat(req.settings().get("index.lifecycle.rollover_alias"), equalTo(".ml-state-write"));
+    }
+
+    public void testStateTemplateWithNoIlm() {
+        MlIndexTemplateRegistry registry =
+            new MlIndexTemplateRegistry(
+                Settings.builder()
+                    .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false)
+                    .build(),
+                clusterService, threadPool, client, xContentRegistry);
+
+        registry.clusterChanged(createClusterChangedEvent(nodes));
+
+        verify(client.admin().indices(), times(7)).putTemplate(putIndexTemplateRequestCaptor.capture(), anyObject());
+
+        PutIndexTemplateRequest req = putIndexTemplateRequestCaptor.getAllValues().stream()
+            .filter(r -> r.name().equals(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected the ml state index template to be put"));
+        assertThat(req.settings().get("index.lifecycle.name"), is(nullValue()));
+        assertThat(req.settings().get("index.lifecycle.rollover_alias"), is(nullValue()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <Response> Answer<Response> withResponse(Response response) {
+        return invocationOnMock -> {
+            ActionListener<Response> listener = (ActionListener<Response>) invocationOnMock.getArguments()[1];
+            listener.onResponse(response);
+            return null;
+        };
+    }
+
+    private static ClusterChangedEvent createClusterChangedEvent(DiscoveryNodes nodes) {
+        return new ClusterChangedEvent(
+            "created-from-test",
+            ClusterState.builder(new ClusterName("test")).nodes(nodes).build(),
+            ClusterState.builder(new ClusterName("test")).build());
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
@@ -15,7 +15,9 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,6 +46,8 @@ public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
         newSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         newSettings.put(XPackSettings.MONITORING_ENABLED.getKey(), false);
         newSettings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
+        // Disable ILM history index so that the tests don't have to clean it up
+        newSettings.put(LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.getKey(), false);
         return newSettings.build();
     }
 
@@ -55,7 +59,10 @@ public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(LocalStateMachineLearning.class);
+        return pluginList(
+            LocalStateMachineLearning.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class);
     }
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -10,8 +10,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -11,14 +11,13 @@ import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
-import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.junit.Before;
 
-import java.util.Collection;
 import java.util.List;
 
 public class AnnotationIndexIT extends MlSingleNodeTestCase {
@@ -31,11 +30,6 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         newSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         newSettings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
         return newSettings.build();
-    }
-
-    @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(LocalStateMachineLearning.class);
     }
 
     @Before

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.CategoryDefinition;
 import org.elasticsearch.xpack.core.ml.job.results.Influencer;
 import org.elasticsearch.xpack.core.ml.job.results.ModelPlot;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
@@ -94,7 +95,11 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
-        return pluginList(LocalStateMachineLearning.class, ReindexPlugin.class);
+        return pluginList(
+            LocalStateMachineLearning.class,
+            ReindexPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class);
     }
 
     @Before

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -6,14 +6,17 @@
 package org.elasticsearch.xpack.ml.job.process.autodetect;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.AliasOrIndex;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -37,6 +40,7 @@ import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
 import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
@@ -70,8 +74,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -82,6 +84,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
 import static org.elasticsearch.mock.orig.Mockito.doAnswer;
 import static org.elasticsearch.mock.orig.Mockito.doReturn;
 import static org.elasticsearch.mock.orig.Mockito.doThrow;
@@ -158,10 +163,21 @@ public class AutodetectProcessManagerTests extends ESTestCase {
                 new HashSet<>(Arrays.asList(MachineLearning.MAX_OPEN_JOBS_PER_NODE,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES)));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        MetaData metaData = mock(MetaData.class);
-        SortedMap<String, AliasOrIndex> aliasOrIndexSortedMap = new TreeMap<>();
-        aliasOrIndexSortedMap.put(AnomalyDetectorsIndex.jobStateIndexWriteAlias(), mock(AliasOrIndex.Alias.class));
-        when(metaData.getAliasAndIndexLookup()).thenReturn(aliasOrIndexSortedMap);
+        MetaData metaData = MetaData.builder()
+            .indices(ImmutableOpenMap.<String, IndexMetaData>builder()
+                .fPut(
+                    AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
+                    IndexMetaData.builder(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001")
+                        .settings(
+                            Settings.builder()
+                                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                                .put(SETTING_VERSION_CREATED, Version.CURRENT)
+                                .build())
+                        .putAlias(AliasMetaData.builder(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).build())
+                        .build())
+                .build())
+            .build();
         clusterState = mock(ClusterState.class);
         when(clusterState.getMetaData()).thenReturn(metaData);
         when(clusterState.metaData()).thenReturn(metaData);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -30,6 +30,8 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.action.util.QueryPage;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction;
@@ -55,6 +57,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.junit.After;
@@ -94,6 +97,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
         settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
         settings.put(XPackSettings.MONITORING_ENABLED.getKey(), false);
         settings.put(XPackSettings.GRAPH_ENABLED.getKey(), false);
+        settings.put(LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.getKey(), false);
         return settings.build();
     }
 
@@ -110,8 +114,12 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(LocalStateMachineLearning.class, CommonAnalysisPlugin.class,
-                ReindexPlugin.class);
+        return Arrays.asList(
+            LocalStateMachineLearning.class,
+            CommonAnalysisPlugin.class,
+            ReindexPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Implement ILM policy for .ml-state* indices  (#52356)