### PR TITLE
Allow joining node to trigger term bump

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -495,6 +495,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private void processJoinRequest(JoinRequest joinRequest, JoinHelper.JoinCallback joinCallback) {
         final Optional<Join> optionalJoin = joinRequest.getOptionalJoin();
         synchronized (mutex) {
+            updateMaxTermSeen(joinRequest.getTerm());
+
             final CoordinationState coordState = coordinationState.get();
             final boolean prevElectionWon = coordState.electionWon();
 
@@ -1115,7 +1117,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         protected void onActiveMasterFound(DiscoveryNode masterNode, long term) {
             synchronized (mutex) {
                 ensureTermAtLeast(masterNode, term);
-                joinHelper.sendJoinRequest(masterNode, joinWithDestination(lastJoin, masterNode, term));
+                joinHelper.sendJoinRequest(masterNode, getCurrentTerm(), joinWithDestination(lastJoin, masterNode, term));
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -130,7 +130,7 @@ public class JoinHelper {
             StartJoinRequest::new,
             (request, channel, task) -> {
                 final DiscoveryNode destination = request.getSourceNode();
-                sendJoinRequest(destination, Optional.of(joinLeaderInTerm.apply(request)));
+                sendJoinRequest(destination, currentTermSupplier.getAsLong(), Optional.of(joinLeaderInTerm.apply(request)));
                 channel.sendResponse(Empty.INSTANCE);
             });
 
@@ -230,9 +230,9 @@ public class JoinHelper {
         }
     }
 
-    public void sendJoinRequest(DiscoveryNode destination, Optional<Join> optionalJoin) {
+    public void sendJoinRequest(DiscoveryNode destination, long term, Optional<Join> optionalJoin) {
         assert destination.isMasterNode() : "trying to join master-ineligible " + destination;
-        final JoinRequest joinRequest = new JoinRequest(transportService.getLocalNode(), optionalJoin);
+        final JoinRequest joinRequest = new JoinRequest(transportService.getLocalNode(), term, optionalJoin);
         final Tuple<DiscoveryNode, JoinRequest> dedupKey = Tuple.tuple(destination, joinRequest);
         if (pendingOutgoingJoins.add(dedupKey)) {
             logger.debug("attempting to join {} with {}", destination, joinRequest);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -18,29 +18,53 @@
  */
 package org.elasticsearch.cluster.coordination;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 
 public class JoinRequest extends TransportRequest {
 
+    /**
+     * The sending (i.e. joining) node.
+     */
     private final DiscoveryNode sourceNode;
 
+    /**
+     * The minimum term for which the joining node will accept any cluster state publications. If the joining node is in a strictly greater
+     * term than the master it wants to join then the master must enter a new term and hold another election. Doesn't necessarily match
+     * {@link JoinRequest#optionalJoin} and may be zero in join requests sent prior to {@link Version#V_8_0_0}.
+     */
+    private final long minimumTerm;
+
+    /**
+     * A vote for the receiving node. This vote is optional since the sending node may have voted for a different master in this term.
+     * That's ok, the sender likely discovered that the master we voted for lost the election and now we're trying to join the winner. Once
+     * the sender has successfully joined the master, the lack of a vote in its term causes another election (see
+     * {@link Publication#onMissingJoin(DiscoveryNode)}).
+     */
     private final Optional<Join> optionalJoin;
 
-    public JoinRequest(DiscoveryNode sourceNode, Optional<Join> optionalJoin) {
+    public JoinRequest(DiscoveryNode sourceNode, long minimumTerm, Optional<Join> optionalJoin) {
         assert optionalJoin.isPresent() == false || optionalJoin.get().getSourceNode().equals(sourceNode);
         this.sourceNode = sourceNode;
+        this.minimumTerm = minimumTerm;
         this.optionalJoin = optionalJoin;
     }
 
     public JoinRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            minimumTerm = in.readLong();
+        } else {
+            minimumTerm = 0L;
+        }
         optionalJoin = Optional.ofNullable(in.readOptionalWriteable(Join::new));
     }
 
@@ -48,11 +72,25 @@ public class JoinRequest extends TransportRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceNode.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeLong(minimumTerm);
+        }
         out.writeOptionalWriteable(optionalJoin.orElse(null));
     }
 
     public DiscoveryNode getSourceNode() {
         return sourceNode;
+    }
+
+    public long getMinimumTerm() {
+        return minimumTerm;
+    }
+
+    public long getTerm() {
+        // If the join is also present then its term will normally equal the corresponding term, but we do not require callers to
+        // obtain the term and the join in a synchronized fashion so it's possible that they disagree. Also older nodes do not share the
+        // minimum term, so for BWC we can take it from the join if present.
+        return Math.max(minimumTerm, optionalJoin.map(Join::getTerm).orElse(0L));
     }
 
     public Optional<Join> getOptionalJoin() {
@@ -66,21 +104,21 @@ public class JoinRequest extends TransportRequest {
 
         JoinRequest that = (JoinRequest) o;
 
+        if (minimumTerm != that.minimumTerm) return false;
         if (!sourceNode.equals(that.sourceNode)) return false;
         return optionalJoin.equals(that.optionalJoin);
     }
 
     @Override
     public int hashCode() {
-        int result = sourceNode.hashCode();
-        result = 31 * result + optionalJoin.hashCode();
-        return result;
+        return Objects.hash(sourceNode, minimumTerm, optionalJoin);
     }
 
     @Override
     public String toString() {
         return "JoinRequest{" +
             "sourceNode=" + sourceNode +
+            ", minimumTerm=" + minimumTerm +
             ", optionalJoin=" + optionalJoin +
             '}';
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -68,7 +68,7 @@ public class JoinHelperTests extends ESTestCase {
         // check that sending a join to node1 works
         Optional<Join> optionalJoin1 = randomBoolean() ? Optional.empty() :
             Optional.of(new Join(localNode, node1, randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
-        joinHelper.sendJoinRequest(node1, optionalJoin1);
+        joinHelper.sendJoinRequest(node1, 0L, optionalJoin1);
         CapturedRequest[] capturedRequests1 = capturingTransport.getCapturedRequestsAndClear();
         assertThat(capturedRequests1.length, equalTo(1));
         CapturedRequest capturedRequest1 = capturedRequests1[0];
@@ -79,14 +79,14 @@ public class JoinHelperTests extends ESTestCase {
         // check that sending a join to node2 works
         Optional<Join> optionalJoin2 = randomBoolean() ? Optional.empty() :
             Optional.of(new Join(localNode, node2, randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
-        joinHelper.sendJoinRequest(node2, optionalJoin2);
+        joinHelper.sendJoinRequest(node2, 0L, optionalJoin2);
         CapturedRequest[] capturedRequests2 = capturingTransport.getCapturedRequestsAndClear();
         assertThat(capturedRequests2.length, equalTo(1));
         CapturedRequest capturedRequest2 = capturedRequests2[0];
         assertEquals(node2, capturedRequest2.node);
 
         // check that sending another join to node1 is a noop as the previous join is still in progress
-        joinHelper.sendJoinRequest(node1, optionalJoin1);
+        joinHelper.sendJoinRequest(node1, 0L, optionalJoin1);
         assertThat(capturingTransport.getCapturedRequestsAndClear().length, equalTo(0));
 
         // complete the previous join to node1
@@ -97,7 +97,7 @@ public class JoinHelperTests extends ESTestCase {
         }
 
         // check that sending another join to node1 now works again
-        joinHelper.sendJoinRequest(node1, optionalJoin1);
+        joinHelper.sendJoinRequest(node1, 0L, optionalJoin1);
         CapturedRequest[] capturedRequests1a = capturingTransport.getCapturedRequestsAndClear();
         assertThat(capturedRequests1a.length, equalTo(1));
         CapturedRequest capturedRequest1a = capturedRequests1a[0];
@@ -106,7 +106,7 @@ public class JoinHelperTests extends ESTestCase {
         // check that sending another join to node2 works if the optionalJoin is different
         Optional<Join> optionalJoin2a = optionalJoin2.isPresent() && randomBoolean() ? Optional.empty() :
             Optional.of(new Join(localNode, node2, randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
-        joinHelper.sendJoinRequest(node2, optionalJoin2a);
+        joinHelper.sendJoinRequest(node2, 0L, optionalJoin2a);
         CapturedRequest[] capturedRequests2a = capturingTransport.getCapturedRequestsAndClear();
         assertThat(capturedRequests2a.length, equalTo(1));
         CapturedRequest capturedRequest2a = capturedRequests2a[0];

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -179,13 +179,18 @@ public class MessagesTests extends ESTestCase {
         Join initialJoin = new Join(createNode(randomAlphaOfLength(10)), createNode(randomAlphaOfLength(10)), randomNonNegativeLong(),
             randomNonNegativeLong(), randomNonNegativeLong());
         JoinRequest initialJoinRequest = new JoinRequest(initialJoin.getSourceNode(),
-            randomBoolean() ? Optional.empty() : Optional.of(initialJoin));
+            randomNonNegativeLong(), randomBoolean() ? Optional.empty() : Optional.of(initialJoin));
         // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(initialJoinRequest,
                 (CopyFunction<JoinRequest>) joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
             joinRequest -> {
                 if (randomBoolean() && joinRequest.getOptionalJoin().isPresent() == false) {
-                    return new JoinRequest(createNode(randomAlphaOfLength(20)), joinRequest.getOptionalJoin());
+                    return new JoinRequest(createNode(randomAlphaOfLength(10)),
+                        joinRequest.getMinimumTerm(), joinRequest.getOptionalJoin());
+                } else if (randomBoolean()) {
+                    return new JoinRequest(joinRequest.getSourceNode(),
+                        randomValueOtherThan(joinRequest.getMinimumTerm(), ESTestCase::randomNonNegativeLong),
+                        joinRequest.getOptionalJoin());
                 } else {
                     // change OptionalJoin
                     final Optional<Join> newOptionalJoin;
@@ -195,7 +200,7 @@ public class MessagesTests extends ESTestCase {
                         newOptionalJoin = Optional.of(new Join(joinRequest.getSourceNode(), createNode(randomAlphaOfLength(10)),
                             randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
                     }
-                    return new JoinRequest(joinRequest.getSourceNode(), newOptionalJoin);
+                    return new JoinRequest(joinRequest.getSourceNode(), joinRequest.getMinimumTerm(), newOptionalJoin);
                 }
             });
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -74,6 +75,7 @@ import static java.util.Collections.singletonList;
 import static org.elasticsearch.transport.TransportService.HANDSHAKE_ACTION_NAME;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class NodeJoinTests extends ESTestCase {
 
@@ -278,7 +280,8 @@ public class NodeJoinTests extends ESTestCase {
         assertFalse(isLocalNodeElectedMaster());
         assertNull(coordinator.getStateForMasterService().nodes().getMasterNodeId());
         long newTerm = initialTerm + randomLongBetween(1, 10);
-        SimpleFuture fut = joinNodeAsync(new JoinRequest(node1, Optional.of(new Join(node1, node0, newTerm, initialTerm, initialVersion))));
+        SimpleFuture fut = joinNodeAsync(new JoinRequest(node1, newTerm,
+            Optional.of(new Join(node1, node0, newTerm, initialTerm, initialVersion))));
         assertEquals(Coordinator.Mode.LEADER, coordinator.getMode());
         assertNull(coordinator.getStateForMasterService().nodes().getMasterNodeId());
         deterministicTaskQueue.runAllRunnableTasks();
@@ -298,7 +301,8 @@ public class NodeJoinTests extends ESTestCase {
         long newTerm = initialTerm + randomLongBetween(1, 10);
         long higherVersion = initialVersion + randomLongBetween(1, 10);
         expectThrows(CoordinationStateRejectedException.class,
-            () -> joinNodeAndRun(new JoinRequest(node1, Optional.of(new Join(node1, node0, newTerm, initialTerm, higherVersion)))));
+            () -> joinNodeAndRun(new JoinRequest(node1, newTerm,
+                Optional.of(new Join(node1, node0, newTerm, initialTerm, higherVersion)))));
         assertFalse(isLocalNodeElectedMaster());
     }
 
@@ -312,7 +316,7 @@ public class NodeJoinTests extends ESTestCase {
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
         long higherVersion = initialVersion + randomLongBetween(1, 10);
-        joinNodeAndRun(new JoinRequest(node1, Optional.of(new Join(node1, node0, newTerm, initialTerm, higherVersion))));
+        joinNodeAndRun(new JoinRequest(node1, newTerm, Optional.of(new Join(node1, node0, newTerm, initialTerm, higherVersion))));
         assertTrue(isLocalNodeElectedMaster());
     }
 
@@ -325,12 +329,30 @@ public class NodeJoinTests extends ESTestCase {
             new VotingConfiguration(Collections.singleton(node0.getId()))));
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
-        joinNodeAndRun(new JoinRequest(node0, Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
+        joinNodeAndRun(new JoinRequest(node0, newTerm, Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
         assertTrue(isLocalNodeElectedMaster());
         assertFalse(clusterStateHasNode(node1));
-        joinNodeAndRun(new JoinRequest(node1, Optional.of(new Join(node1, node0, newTerm, initialTerm, initialVersion))));
+        joinNodeAndRun(new JoinRequest(node1, newTerm, Optional.of(new Join(node1, node0, newTerm, initialTerm, initialVersion))));
         assertTrue(isLocalNodeElectedMaster());
         assertTrue(clusterStateHasNode(node1));
+    }
+
+    public void testJoinElectedLeaderWithHigherTerm() {
+        DiscoveryNode node0 = newNode(0, true);
+        DiscoveryNode node1 = newNode(1, true);
+        long initialTerm = randomLongBetween(1, 10);
+        long initialVersion = randomLongBetween(1, 10);
+        setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
+            new VotingConfiguration(Collections.singleton(node0.getId()))));
+        long newTerm = initialTerm + randomLongBetween(1, 10);
+
+        joinNodeAndRun(new JoinRequest(node0, newTerm, Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
+        assertTrue(isLocalNodeElectedMaster());
+
+        long newerTerm = newTerm + randomLongBetween(1, 10);
+        joinNodeAndRun(new JoinRequest(node1, newerTerm, Optional.empty()));
+        assertThat(coordinator.getCurrentTerm(), greaterThanOrEqualTo(newerTerm));
+        assertTrue(isLocalNodeElectedMaster());
     }
 
     public void testJoinAccumulation() {
@@ -343,17 +365,17 @@ public class NodeJoinTests extends ESTestCase {
             new VotingConfiguration(Collections.singleton(node2.getId()))));
         assertFalse(isLocalNodeElectedMaster());
         long newTerm = initialTerm + randomLongBetween(1, 10);
-        SimpleFuture futNode0 = joinNodeAsync(new JoinRequest(node0, Optional.of(
+        SimpleFuture futNode0 = joinNodeAsync(new JoinRequest(node0, newTerm, Optional.of(
             new Join(node0, node0, newTerm, initialTerm, initialVersion))));
         deterministicTaskQueue.runAllRunnableTasks();
         assertFalse(futNode0.isDone());
         assertFalse(isLocalNodeElectedMaster());
-        SimpleFuture futNode1 = joinNodeAsync(new JoinRequest(node1, Optional.of(
+        SimpleFuture futNode1 = joinNodeAsync(new JoinRequest(node1, newTerm, Optional.of(
             new Join(node1, node0, newTerm, initialTerm, initialVersion))));
         deterministicTaskQueue.runAllRunnableTasks();
         assertFalse(futNode1.isDone());
         assertFalse(isLocalNodeElectedMaster());
-        joinNodeAndRun(new JoinRequest(node2, Optional.of(new Join(node2, node0, newTerm, initialTerm, initialVersion))));
+        joinNodeAndRun(new JoinRequest(node2, newTerm, Optional.of(new Join(node2, node0, newTerm, initialTerm, initialVersion))));
         assertTrue(isLocalNodeElectedMaster());
         assertTrue(clusterStateHasNode(node1));
         assertTrue(clusterStateHasNode(node2));
@@ -372,7 +394,7 @@ public class NodeJoinTests extends ESTestCase {
         handleStartJoinFrom(node1, newTerm);
         handleFollowerCheckFrom(node1, newTerm);
         long newerTerm = newTerm + randomLongBetween(1, 10);
-        joinNodeAndRun(new JoinRequest(node1,
+        joinNodeAndRun(new JoinRequest(node1, newerTerm,
             Optional.of(new Join(node1, node0, newerTerm, initialTerm, initialVersion))));
         assertTrue(isLocalNodeElectedMaster());
     }
@@ -447,7 +469,7 @@ public class NodeJoinTests extends ESTestCase {
         handleStartJoinFrom(node1, newTerm);
         handleFollowerCheckFrom(node1, newTerm);
         assertThat(expectThrows(CoordinationStateRejectedException.class,
-            () -> joinNodeAndRun(new JoinRequest(node1, Optional.empty()))).getMessage(),
+            () -> joinNodeAndRun(new JoinRequest(node1, newTerm, Optional.empty()))).getMessage(),
             containsString("join target is a follower"));
         assertFalse(isLocalNodeElectedMaster());
     }
@@ -460,7 +482,8 @@ public class NodeJoinTests extends ESTestCase {
         setupFakeMasterServiceAndCoordinator(initialTerm, initialState(node0, initialTerm, initialVersion,
             new VotingConfiguration(Collections.singleton(node1.getId()))));
         long newTerm = initialTerm + randomLongBetween(1, 10);
-        SimpleFuture fut = joinNodeAsync(new JoinRequest(node0, Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
+        SimpleFuture fut = joinNodeAsync(new JoinRequest(node0, newTerm,
+            Optional.of(new Join(node0, node0, newTerm, initialTerm, initialVersion))));
         deterministicTaskQueue.runAllRunnableTasks();
         assertFalse(fut.isDone());
         assertFalse(isLocalNodeElectedMaster());
@@ -501,7 +524,7 @@ public class NodeJoinTests extends ESTestCase {
         logger.info("Successful voting nodes: {}", successfulNodes);
 
         List<JoinRequest> correctJoinRequests = successfulNodes.stream().map(
-            node -> new JoinRequest(node, Optional.of(new Join(node, localNode, newTerm, initialTerm, initialVersion))))
+            node -> new JoinRequest(node, newTerm, Optional.of(new Join(node, localNode, newTerm, initialTerm, initialVersion))))
             .collect(Collectors.toList());
 
         List<DiscoveryNode> possiblyUnsuccessfulNodes = new ArrayList<>(allNodes);
@@ -512,15 +535,15 @@ public class NodeJoinTests extends ESTestCase {
         List<JoinRequest> possiblyFailingJoinRequests = possiblyUnsuccessfulNodes.stream().map(node -> {
             if (randomBoolean()) {
                 // a correct request
-                return new JoinRequest(node, Optional.of(new Join(node, localNode,
+                return new JoinRequest(node, newTerm, Optional.of(new Join(node, localNode,
                     newTerm, initialTerm, initialVersion)));
             } else if (randomBoolean()) {
                 // term too low
-                return new JoinRequest(node, Optional.of(new Join(node, localNode,
+                return new JoinRequest(node, newTerm, Optional.of(new Join(node, localNode,
                     randomLongBetween(0, initialTerm), initialTerm, initialVersion)));
             } else {
                 // better state
-                return new JoinRequest(node, Optional.of(new Join(node, localNode,
+                return new JoinRequest(node, newTerm, Optional.of(new Join(node, localNode,
                     newTerm, initialTerm, initialVersion + randomLongBetween(1, 10))));
             }
         }).collect(Collectors.toList());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
@@ -105,7 +105,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         final CompletableFuture<Throwable> future = new CompletableFuture<>();
         DiscoveryNode node = state.nodes().getLocalNode();
 
-        coordinator.sendValidateJoinRequest(stateWithCustomMetaData, new JoinRequest(node, Optional.empty()),
+        coordinator.sendValidateJoinRequest(stateWithCustomMetaData, new JoinRequest(node, 0L, Optional.empty()),
                 new JoinHelper.JoinCallback() {
             @Override
             public void onSuccess() {


### PR DESCRIPTION
In rare circumstances it is possible for an isolated node to have a greater
term than the currently-elected leader. Today such a node will attempt to join
the cluster but will not offer a vote to the leader and will reject its cluster
state publications due to their stale term. This situation persists since there
is no mechanism for the joining node to inform the leader that its term is
stale and a new election is required.

This commit adds the current term of the joining node to the join request. Once
the join has been validated, the leader will perform another election to
increase its term far enough to allow the isolated node to join properly.

Fixes #53271