### PR TITLE
Update skip after backport of #53296

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -894,8 +894,8 @@ setup:
 ---
 "Terms source from part of sorted":
   - skip:
-      version: " - 7.99.99"
-      reason:  fixed in 8.0.0. will be backported to 7.7.0.
+      version: " - 7.6.99"
+      reason:  fixed in 7.7.0.
 
   - do:
         indices.create:


### PR DESCRIPTION
Now that #53296 is backported to 7.x we can run its tests against 7.7.0.
