### PR TITLE
add `doc_values` mapping option to geo_shape/shape field mappers

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -58,10 +58,10 @@ public class GeoShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, G
         public GeoShapeFieldMapper build(BuilderContext context) {
             setupFieldType(context);
             return new GeoShapeFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
-                ignoreZValue(), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+                ignoreZValue(), docValues(), context.indexSettings(),
+                multiFieldsBuilder.build(this, context), copyTo);
         }
 
-        @Override
         protected void setupFieldType(BuilderContext context) {
             super.setupFieldType(context);
 
@@ -98,9 +98,9 @@ public class GeoShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, G
 
     public GeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
-                               Explicit<Boolean> ignoreZValue, Settings indexSettings,
+                               Explicit<Boolean> ignoreZValue, Explicit<Boolean> docValues, Settings indexSettings,
                                MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, indexSettings,
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, docValues, indexSettings,
             multiFields, copyTo);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapper.java
@@ -292,7 +292,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractGeometryFieldMapper<Shape
             setupFieldType(context);
 
             return new LegacyGeoShapeFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
-                coerce(context), orientation(), ignoreZValue(), context.indexSettings(),
+                coerce(context), orientation(), ignoreZValue(), docValues(), context.indexSettings(),
                 multiFieldsBuilder.build(this, context), copyTo);
         }
     }
@@ -318,6 +318,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractGeometryFieldMapper<Shape
             setStored(false);
             setStoreTermVectors(false);
             setOmitNorms(true);
+            setHasDocValues(false);
         }
 
         protected GeoShapeFieldType(GeoShapeFieldType ref) {
@@ -470,10 +471,10 @@ public class LegacyGeoShapeFieldMapper extends AbstractGeometryFieldMapper<Shape
 
     public LegacyGeoShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
                                Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce, Explicit<Orientation> orientation,
-                               Explicit<Boolean> ignoreZValue, Settings indexSettings,
+                               Explicit<Boolean> ignoreZValue, Explicit<Boolean> docValues, Settings indexSettings,
                                MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, indexSettings,
-            multiFields, copyTo);
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, docValues,
+            indexSettings, multiFields, copyTo);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -83,6 +83,10 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             equalTo(LegacyGeoShapeFieldMapper.DeprecatedParameters.Defaults.DISTANCE_ERROR_PCT));
         assertThat(geoShapeFieldMapper.fieldType().orientation(),
             equalTo(LegacyGeoShapeFieldMapper.Defaults.ORIENTATION.value()));
+        assertThat(geoShapeFieldMapper.docValues(),
+            equalTo(LegacyGeoShapeFieldMapper.Defaults.DOC_VALUES));
+        assertThat(geoShapeFieldMapper.fieldType().hasDocValues(),
+            equalTo(LegacyGeoShapeFieldMapper.Defaults.DOC_VALUES.value()));
         assertFieldWarnings("strategy");
     }
 
@@ -598,6 +602,7 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":21"));
+            assertTrue(serialized, serialized.contains("\"doc_values\":false"));
         }
         {
             String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
@@ -610,6 +615,7 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":9"));
+            assertTrue(serialized, serialized.contains("\"doc_values\":false"));
         }
         {
             String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
@@ -623,6 +629,7 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
             assertFalse(serialized, serialized.contains("\"precision\":"));
             assertTrue(serialized, serialized.contains("\"tree_levels\":6"));
+            assertTrue(serialized, serialized.contains("\"doc_values\":false"));
         }
         {
             String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
@@ -636,6 +643,7 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
             assertFalse(serialized, serialized.contains("\"tree_levels\":"));
+            assertTrue(serialized, serialized.contains("\"doc_values\":false"));
         }
         {
             String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
@@ -650,8 +658,27 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             String serialized = toXContentString((LegacyGeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":5"));
+            assertTrue(serialized, serialized.contains("\"doc_values\":false"));
         }
         assertFieldWarnings("tree", "tree_levels", "precision");
+    }
+
+    public void testSerializeDocValues() throws IOException {
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("doc_values", false)
+            .endObject().endObject()
+            .endObject().endObject());
+        DocumentMapper mapper = parser.parse("type1", new CompressedXContent(mapping));
+        String serialized = toXContentString((LegacyGeoShapeFieldMapper) mapper.mappers().getMapper("location"));
+        assertTrue(serialized, serialized.contains("\"orientation\":\"" +
+            AbstractGeometryFieldMapper.Defaults.ORIENTATION.value() + "\""));
+        assertTrue(serialized, serialized.contains("\"doc_values\":false"));
+
+        assertFieldWarnings("tree");
     }
 
     public void testPointsOnlyDefaultsWithTermStrategy() throws IOException {
@@ -700,6 +727,43 @@ public class LegacyGeoShapeFieldMapperTests extends ESSingleNodeTestCase {
         );
         assertThat(e.getMessage(), containsString("points_only cannot be set to false for term strategy"));
         assertFieldWarnings("tree", "precision", "strategy", "points_only");
+    }
+
+    /**
+     * Test that doc_values parameter correctly parses
+     */
+    public void testDocValues() throws IOException {
+        String trueMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("doc_values", true)
+            .endObject().endObject()
+            .endObject().endObject());
+
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class,
+            () -> createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(trueMapping)));
+        assertThat(e.getMessage(), equalTo("field [location] of type [geo_shape] does not support doc_values"));
+
+        // explicit false doc_values
+        String falseMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "geo_shape")
+            .field("tree", "quadtree")
+            .field("doc_values", "false")
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(falseMapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(LegacyGeoShapeFieldMapper.class));
+
+        assertTrue(((LegacyGeoShapeFieldMapper) fieldMapper).docValues().explicit());
+        assertFalse(((LegacyGeoShapeFieldMapper) fieldMapper).docValues().value());
+        assertFalse(((LegacyGeoShapeFieldMapper) fieldMapper).fieldType().hasDocValues());
+
+        assertFieldWarnings("tree");
     }
 
     public void testDisallowExpensiveQueries() throws IOException {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -53,7 +53,7 @@ public class ShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, Geom
         public ShapeFieldMapper build(BuilderContext context) {
             setupFieldType(context);
             return new ShapeFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context), coerce(context),
-                ignoreZValue(), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+                ignoreZValue(), docValues(), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
         }
 
         @Override
@@ -116,9 +116,9 @@ public class ShapeFieldMapper extends AbstractGeometryFieldMapper<Geometry, Geom
 
     public ShapeFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
                             Explicit<Boolean> ignoreMalformed, Explicit<Boolean> coerce,
-                            Explicit<Boolean> ignoreZValue, Settings indexSettings,
+                            Explicit<Boolean> ignoreZValue, Explicit<Boolean> docValues, Settings indexSettings,
                             MultiFields multiFields, CopyTo copyTo) {
-        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, indexSettings,
+        super(simpleName, fieldType, defaultFieldType, ignoreMalformed, coerce, ignoreZValue, docValues, indexSettings,
             multiFields, copyTo);
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -54,6 +55,9 @@ public class ShapeFieldMapperTests extends ESSingleNodeTestCase {
         ShapeFieldMapper shapeFieldMapper = (ShapeFieldMapper) fieldMapper;
         assertThat(shapeFieldMapper.fieldType().orientation(),
             equalTo(ShapeFieldMapper.Defaults.ORIENTATION.value()));
+        assertFalse(shapeFieldMapper.docValues().value());
+        assertFalse(shapeFieldMapper.docValues().explicit());
+        assertFalse(shapeFieldMapper.fieldType().hasDocValues());
     }
 
     /**
@@ -94,6 +98,40 @@ public class ShapeFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.COUNTER_CLOCKWISE));
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.RIGHT));
         assertThat(orientation, equalTo(ShapeBuilder.Orientation.CCW));
+    }
+
+    /**
+     * Test that doc_values parameter correctly parses
+     */
+    public void testDocValues() throws IOException {
+        String trueMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("doc_values", true)
+            .endObject().endObject()
+            .endObject().endObject());
+
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class,
+            () -> createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(trueMapping)));
+        assertThat(e.getMessage(), equalTo("field [location] of type [shape] does not support doc_values"));
+
+        // explicit false doc_values
+        String falseMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("doc_values", false)
+            .endObject().endObject()
+            .endObject().endObject());
+
+        DocumentMapper defaultMapper = createIndex("test2").mapperService().documentMapperParser()
+            .parse("type1", new CompressedXContent(falseMapping));
+        Mapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        assertThat(fieldMapper, instanceOf(ShapeFieldMapper.class));
+
+        // since shape field has no doc-values, this field is ignored
+        assertTrue(((ShapeFieldMapper)fieldMapper).docValues().explicit());
+        assertFalse(((ShapeFieldMapper)fieldMapper).docValues().value());
+        assertFalse(((ShapeFieldMapper)fieldMapper).fieldType().hasDocValues());
     }
 
     /**
@@ -276,7 +314,23 @@ public class ShapeFieldMapperTests extends ESSingleNodeTestCase {
             String serialized = toXContentString((ShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
             assertTrue(serialized, serialized.contains("\"orientation\":\"" +
                 AbstractGeometryFieldMapper.Defaults.ORIENTATION.value() + "\""));
+            assertTrue(serialized, serialized.contains("\"doc_values\":false"));
         }
+    }
+
+    public void testSerializeDocValues() throws IOException {
+        DocumentMapperParser parser = createIndex("test").mapperService().documentMapperParser();
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("location")
+            .field("type", "shape")
+            .field("doc_values", false)
+            .endObject().endObject()
+            .endObject().endObject());
+        DocumentMapper mapper = parser.parse("type1", new CompressedXContent(mapping));
+        String serialized = toXContentString((ShapeFieldMapper) mapper.mappers().getMapper("location"));
+        assertTrue(serialized, serialized.contains("\"orientation\":\"" +
+            AbstractGeometryFieldMapper.Defaults.ORIENTATION.value() + "\""));
+        assertTrue(serialized, serialized.contains("\"doc_values\":false"));
     }
 
     public String toXContentString(ShapeFieldMapper mapper, boolean includeDefaults) throws IOException {


### PR DESCRIPTION
This PR adds support for the `doc_values` field mapping parameter.

`false` is currently the only supported value to explicitly
set, and is also the default.