### PR TITLE
[7.6] Fix null config in SnapshotLifecyclePolicy.toRequest (#53328)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
@@ -254,10 +254,10 @@ public class SnapshotLifecyclePolicy extends AbstractDiffable<SnapshotLifecycleP
      */
     public CreateSnapshotRequest toRequest() {
         CreateSnapshotRequest req = new CreateSnapshotRequest(repository, generateSnapshotName(new ResolverContext()));
+        Map<String, Object> mergedConfiguration = configuration == null ? new HashMap<>() : new HashMap<>(configuration);
         @SuppressWarnings("unchecked")
-        Map<String, Object> metadata = (Map<String, Object>) configuration.get("metadata");
+        Map<String, Object> metadata = (Map<String, Object>) mergedConfiguration.get("metadata");
         Map<String, Object> metadataWithAddedPolicyName = addPolicyNameToMetadata(metadata);
-        Map<String, Object> mergedConfiguration = new HashMap<>(configuration);
         mergedConfiguration.put("metadata", metadataWithAddedPolicyName);
         req.source(mergedConfiguration);
         req.waitForCompletion(true);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecyclePolicyTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecyclePolicyTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.slm;
 
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -29,6 +30,18 @@ import static org.hamcrest.Matchers.startsWith;
 public class SnapshotLifecyclePolicyTests extends AbstractSerializingTestCase<SnapshotLifecyclePolicy> {
 
     private String id;
+
+    public void testToRequest() {
+        SnapshotLifecyclePolicy p = new SnapshotLifecyclePolicy("id", "name", "0 1 2 3 4 ? 2099", "repo", Collections.emptyMap(),
+            SnapshotRetentionConfiguration.EMPTY);
+        CreateSnapshotRequest request = p.toRequest();
+        CreateSnapshotRequest expected = new CreateSnapshotRequest().userMetadata(Collections.singletonMap("policy", "id"));
+
+        p = new SnapshotLifecyclePolicy("id", "name", "0 1 2 3 4 ? 2099", "repo", null, null);
+        request = p.toRequest();
+        expected.waitForCompletion(true).snapshot(request.snapshot()).repository("repo");
+        assertEquals(expected, request);
+    }
 
     public void testNameGeneration() {
         long time = 1552684146542L; // Fri Mar 15 2019 21:09:06 UTC


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Fix null config in SnapshotLifecyclePolicy.toRequest (#53328)