### PR TITLE
Submit async search to work only with POST

### DIFF
--- a/x-pack/plugin/async-search/qa/security/src/test/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
+++ b/x-pack/plugin/async-search/qa/security/src/test/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
@@ -44,7 +44,7 @@ public class AsyncSearchSecurityIT extends AsyncSearchRestTestCase {
     }
 
     @Before
-    private void indexDocuments() throws IOException {
+    public void indexDocuments() throws IOException {
         createIndex("index", Settings.EMPTY);
         index("index", "0", "foo", "bar");
         refresh("index");
@@ -122,24 +122,13 @@ public class AsyncSearchSecurityIT extends AsyncSearchRestTestCase {
         return client().performRequest(request);
     }
 
-    static Response submitAsyncSearch(String indexName, String query, String user) throws IOException {
-        return submitAsyncSearch(indexName, query, TimeValue.MINUS_ONE, user);
-    }
-
     static Response submitAsyncSearch(String indexName, String query, TimeValue waitForCompletion, String user) throws IOException {
-        final Request request = new Request("GET", indexName + "/_async_search");
+        final Request request = new Request("POST", indexName + "/_async_search");
         setRunAsHeader(request, user);
         request.addParameter("q", query);
         request.addParameter("wait_for_completion", waitForCompletion.toString());
         // we do the cleanup explicitly
         request.addParameter("clean_on_completion", "false");
-        return client().performRequest(request);
-    }
-
-    static Response search(String indexName, String query, String user) throws IOException {
-        final Request request = new Request("GET", indexName + "/_search");
-        setRunAsHeader(request, user);
-        request.addParameter("q", query);
         return client().performRequest(request);
     }
 

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
@@ -16,13 +16,12 @@ import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.function.IntConsumer;
-import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
-import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.action.search.RestSearchAction.parseSearchRequest;
 
@@ -34,9 +33,7 @@ public final class RestSubmitAsyncSearchAction extends BaseRestHandler {
     public List<Route> routes() {
         return unmodifiableList(asList(
             new Route(POST, "/_async_search"),
-            new Route(GET, "/_async_search"),
-            new Route(POST, "/{index}/_async_search"),
-            new Route(GET, "/{index}/_async_search")));
+            new Route(POST, "/{index}/_async_search")));
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
@@ -9,14 +9,12 @@
         {
           "path":"/_async_search",
           "methods":[
-            "GET",
             "POST"
           ]
         },
         {
           "path":"/{index}/_async_search",
           "methods":[
-            "GET",
             "POST"
           ],
           "parts":{


### PR DESCRIPTION
Currently the submit async search API can be called using both GET and POST at REST, but given that it submits a call and creates internal state, POST should be the only allowed method.

Relates to #49931