### PR TITLE
Deprecate beats enabled setting

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -86,7 +86,7 @@ public class XPackSettings {
 
     /** Setting for enabling or disabling Beats extensions. Defaults to true. */
     public static final Setting<Boolean> BEATS_ENABLED = Setting.boolSetting("xpack.beats.enabled", true,
-        Setting.Property.NodeScope);
+        Setting.Property.NodeScope, Property.Deprecated);
 
     /**
      * Setting for enabling or disabling the index lifecycle extension. Defaults to true.


### PR DESCRIPTION
The setting `xpack.beats.enabled` is not used anywhere in the codebase
and is not in our documentation either. This change deprecates the
setting in case there is someone using it prior to it being removed.