### PR TITLE
Remove the top-level 'mapping type' section.

### DIFF
--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -27,6 +27,9 @@ treated. Examples of meta-fields include the document's
 A mapping contains a list of fields or `properties` pertinent to the
 document.
 
+NOTE: Before 7.0.0, the 'mappings' definition used to include a type name.
+For more details, please see <<removal-of-types>>.
+
 [float]
 [[field-datatypes]]
 == Field datatypes

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -13,29 +13,19 @@ are stored and indexed. For instance, use mappings to define:
 * custom rules to control the mapping for
   <<dynamic-mapping,dynamically added fields>>.
 
-[float]
-[[mapping-type]]
-== Mapping Type
-
-Each index has one _mapping type_ which determines how the document will be
-indexed.
-
-deprecated::[6.0.0,See <<removal-of-types>>]
-
-A mapping type has:
+A mapping definition has:
 
 <<mapping-fields,Meta-fields>>::
 
 Meta-fields are used to customize how a document's metadata associated is
 treated. Examples of meta-fields include the document's
-<<mapping-index-field,`_index`>>, <<mapping-type-field,`_type`>>,
-<<mapping-id-field,`_id`>>,  and <<mapping-source-field,`_source`>> fields.
+<<mapping-index-field,`_index`>>, <<mapping-id-field,`_id`>>, and
+<<mapping-source-field,`_source`>> fields.
 
 <<mapping-types,Fields>> or _properties_::
 
-A mapping type contains a list of fields or `properties` pertinent to the
+A mapping contains a list of fields or `properties` pertinent to the
 document.
-
 
 [float]
 [[field-datatypes]]

--- a/docs/reference/mapping/fields.asciidoc
+++ b/docs/reference/mapping/fields.asciidoc
@@ -15,7 +15,7 @@ can be customised when a mapping type is created.
 
 <<mapping-type-field,`_type`>>::
 
-    The document's <<mapping-type,mapping type>>.
+    The document's mapping type.
 
 <<mapping-id-field,`_id`>>::
 

--- a/docs/reference/mapping/fields/type-field.asciidoc
+++ b/docs/reference/mapping/fields/type-field.asciidoc
@@ -3,9 +3,9 @@
 
 deprecated[6.0.0,See <<removal-of-types>>]
 
-Each document indexed is associated with a <<mapping-type-field,`_type`>> (see
-<<mapping-type>>) and an <<mapping-id-field,`_id`>>.  The `_type` field is
-indexed in order to make searching by type name fast.
+Each document indexed is associated with a <<mapping-type-field,`_type`>> and
+an <<mapping-id-field,`_id`>>.  The `_type` field is indexed in order to make
+searching by type name fast.
 
 The value of the `_type` field is accessible in queries, aggregations,
 scripts, and when sorting:


### PR DESCRIPTION
It seemed confusing for users that our top-level mapping page still had a
prominent section named 'Mapping Type'. I've reworked the docs to remove this
reference and add a note about types removal (similar to the note we added to
other APIs  like [put mapping](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-put-mapping.html)).