### PR TITLE
remove sneaked placeholder from histogram docs

### DIFF
--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -69,7 +69,6 @@ The following <<indices-create-index, create index>> API request creates a new i
 * `my_histogram`, a `histogram` field used to store percentile data
 * `my_text`, a `keyword` field used to store a title for the histogram
 
-[ INSERT CREATE INDEX SNIPPET ]
 [source,console]
 --------------------------------------------------
 PUT my_index


### PR DESCRIPTION
Remove a place holder from histogram field type docs.