### PR TITLE
[DOC] Add beta banner to main page of Transforms

### DIFF
--- a/docs/reference/transform/index.asciidoc
+++ b/docs/reference/transform/index.asciidoc
@@ -2,6 +2,8 @@
 [[transforms]]
 == Transforming data
 
+beta[]
+
 // tag::transform-intro[]
 {transforms-cap} enable you to convert existing {es} indices into summarized
 indices, which provide opportunities for new insights and analytics.


### PR DESCRIPTION
I would propose to add the `beta` banner to the Transforms page.
It would be nice to be backported to all 7.x versions.

I am not sure if the `beta[]` macro will be taken into account. 

Preview: http://elasticsearch_53399.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.6/transforms.html