### PR TITLE
Fix parseNamedObject leaving end object token

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
@@ -404,7 +404,11 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                 assert token == XContentParser.Token.FIELD_NAME;
                 String name = p.currentName();
                 try {
-                    return namedObjectParser.parse(p, c, name);
+                    T namedObject = namedObjectParser.parse(p, c, name);
+                    // consume the end object token
+                    token = p.nextToken();
+                    assert token == XContentParser.Token.END_OBJECT;
+                    return namedObject;
                 } catch (Exception e) {
                     throw new XContentParseException(p.getTokenLocation(), "[" + field + "] failed to parse field [" + name + "]", e);
                 }

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/ObjectParserTests.java
@@ -500,10 +500,12 @@ public class ObjectParserTests extends ESTestCase {
     }
 
     public void testParseNamedObject() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"named\": { \"a\": {\"foo\" : 11} }}");
+        XContentParser parser = createParser(JsonXContent.jsonXContent,
+                "{\"named\": { \"a\": {\"foo\" : 11} }, \"bar\": \"baz\"}");
         NamedObjectHolder h = NamedObjectHolder.PARSER.apply(parser, null);
         assertEquals("a", h.named.name);
         assertEquals(11, h.named.foo);
+        assertEquals("baz", h.bar);
     }
 
     public void testParseNamedObjectUnexpectedArray() throws IOException {
@@ -726,7 +728,7 @@ public class ObjectParserTests extends ESTestCase {
         assertEquals("parser for [noop] did not end on END_ARRAY", e.getMessage());
     }
 
-    public void testNoopDeclareObjectArray() throws IOException {
+    public void testNoopDeclareObjectArray() {
         ObjectParser<AtomicReference<String>, Void> parser = new ObjectParser<>("noopy", AtomicReference::new);
         parser.declareString(AtomicReference::set, new ParseField("body"));
         parser.declareObjectArray((a,b) -> {}, (p, c) -> null, new ParseField("noop"));
@@ -747,12 +749,18 @@ public class ObjectParserTests extends ESTestCase {
                 NamedObjectHolder::new);
         static {
             PARSER.declareNamedObject(NamedObjectHolder::setNamed, NamedObject.PARSER, new ParseField("named"));
+            PARSER.declareString(NamedObjectHolder::setBar, new ParseField("bar"));
         }
 
         private NamedObject named;
+        private String bar;
 
         public void setNamed(NamedObject named) {
             this.named = named;
+        }
+
+        public void setBar(String bar) {
+            this.bar = bar;
         }
     }
 


### PR DESCRIPTION
Following on from #53017 there is a bug that `ObjectParser.parseNamedObject` would leave the end object token unconsumed meaning subsequent fields would not be parsed. I've added a unit test to cover this case.


@nik9000 could you give me another review please
