### PR TITLE
[DOCS] Add admonition for EQL exact matches on text fields

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -7,7 +7,7 @@ experimental::[]
 
 [IMPORTANT]
 ====
-{es} supports a subset of EQL syntax.
+{es} supports a subset of EQL syntax. See <<eql-limitations>>.
 ====
 
 [discrete]
@@ -68,6 +68,19 @@ You can specify and combine these criteria using the following operators:
 ----
 <   <=   ==   !=   >=   >
 ----
+
+[IMPORTANT]
+====
+Avoid using the equal operator (`==`) to perform exact matching on `text` field
+values.
+
+By default, {es} changes the values of <<text,`text`>> fields as part of
+<<analysis, analysis>>. This can make finding exact matches for `text` field
+values difficult.
+
+To search `text` fields, consider using a <<eql-search-filter-query-dsl,query
+DSL filter>> that contains a <<query-dsl-match-query,`match`>> query.
+====
 
 .*Definitions*
 [%collapsible]


### PR DESCRIPTION
Adds a important admonition to the EQL syntax page noting that
the equal (`==`) operator should not be used to match `text` field
values.

Relates to #52709 and #53020