### PR TITLE
delete trailing whitespace

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/libs/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
@@ -138,7 +138,7 @@ public class JarHell {
                     // Eclipse adds this to the classpath when running unit tests...
                     continue;
                 }
-                URL url = PathUtils.get(element).toUri().toURL();               
+                URL url = PathUtils.get(element).toUri().toURL();
                 // junit4.childvm.count
                 if (urlElements.add(url) == false && element.endsWith(".jar")) {
                     throw new IllegalStateException("jar hell!" + System.lineSeparator() +


### PR DESCRIPTION
Delete trailing whitespace in `libs/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java`