### PR TITLE
[DOCS] Remove `force` as valid value for `version_type` parameter

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -922,7 +922,7 @@ end::segment-version[]
 tag::version_type[]
 `version_type`::
 (Optional, enum) Specific version type: `internal`, `external`,
-`external_gte`, `force`.
+`external_gte`.
 end::version_type[]
 
 tag::wait_for_active_shards[]


### PR DESCRIPTION
force is no longer a valid option for the version_type: flag -- this impacts at least version 6.8 and later.

Using force results in:

Error message from 6.8
{
  "error": {
    "root_cause": [
      {
        "type": "action_request_validation_exception",
        "reason": "Validation Failed: 1: version type [force] may no longer be used;"
      }
    ],
    "type": "action_request_validation_exception",
    "reason": "Validation Failed: 1: version type [force] may no longer be used;"
  },
  "status": 400
}

Error message from 7.6:
{
  "error" : {
    "root_cause" : [
      {
        "type" : "x_content_parse_exception",
        "reason" : "[8:21] [dest] failed to parse field [version_type]"
      }
    ],
    "type" : "x_content_parse_exception",
    "reason" : "[8:21] [reindex] failed to parse field [dest]",
    "caused_by" : {
      "type" : "x_content_parse_exception",
      "reason" : "[8:21] [dest] failed to parse field [version_type]",
      "caused_by" : {
        "type" : "illegal_argument_exception",
        "reason" : "No version type match [force]"
      }
    }
  },
  "status" : 400
}

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
