### PR TITLE
Removed unecessary misplaced id quoted within [[]]

### DIFF
--- a/docs/reference/ilm/getting-started-ilm.asciidoc
+++ b/docs/reference/ilm/getting-started-ilm.asciidoc
@@ -179,7 +179,6 @@ The response below shows that the bootstrap index is waiting in the `hot` phase'
 It remains in this state and {ilm-init} continues to call `attempt-rollover` 
 until the rollover conditions are met. 
 
-[[36818c6d9f434d387819c30bd9addb14]]
 [source,console-result]
 --------------------------------------------------
 {


### PR DESCRIPTION
A unnecessary random string quoted inside [[]] has been removed as it didn't add context to the documentation above or below it.