### PR TITLE
Move auditing license check into AuthenticationService

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -380,7 +380,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
         final List<AuditTrail> auditTrails = XPackSettings.AUDIT_ENABLED.get(settings)
                 ? Collections.singletonList(new LoggingAuditTrail(settings, clusterService, threadPool))
                 : Collections.emptyList();
-        final AuditTrailService auditTrailService = new AuditTrailService(auditTrails, getLicenseState());
+        final AuditTrailService auditTrailService = new AuditTrailService(auditTrails);
         components.add(auditTrailService);
         this.auditTrailService.set(auditTrailService);
 
@@ -446,7 +446,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
         getLicenseState().addListener(new SecurityStatusChangeListener(getLicenseState()));
 
         final AuthenticationFailureHandler failureHandler = createAuthenticationFailureHandler(realms, extensionComponents);
-        authcService.set(new AuthenticationService(settings, realms, auditTrailService, failureHandler, threadPool,
+        authcService.set(new AuthenticationService(settings, realms, getLicenseState(), auditTrailService, failureHandler, threadPool,
                 anonymousUser, tokenService, apiKeyService));
         components.add(authcService.get());
         securityIndex.get().addIndexStateListener(authcService.get()::onSecurityIndexStateChange);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
@@ -6,13 +6,12 @@
 package org.elasticsearch.xpack.security.audit;
 
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.transport.TransportMessage;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
-import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
+import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
 import java.net.InetAddress;
@@ -21,7 +20,6 @@ import java.util.List;
 
 public class AuditTrailService implements AuditTrail {
 
-    private final XPackLicenseState licenseState;
     private final List<AuditTrail> auditTrails;
 
     @Override
@@ -29,9 +27,8 @@ public class AuditTrailService implements AuditTrail {
         return "service";
     }
 
-    public AuditTrailService(List<AuditTrail> auditTrails, XPackLicenseState licenseState) {
+    public AuditTrailService(List<AuditTrail> auditTrails) {
         this.auditTrails = Collections.unmodifiableList(auditTrails);
-        this.licenseState = licenseState;
     }
 
     /** Returns the audit trail implementations that this service delegates to. */
@@ -41,186 +38,146 @@ public class AuditTrailService implements AuditTrail {
 
     @Override
     public void authenticationSuccess(String requestId, String realm, User user, RestRequest request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationSuccess(requestId, realm, user, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationSuccess(requestId, realm, user, request);
         }
     }
 
     @Override
     public void authenticationSuccess(String requestId, String realm, User user, String action, TransportMessage message) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationSuccess(requestId, realm, user, action, message);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationSuccess(requestId, realm, user, action, message);
         }
     }
 
     @Override
     public void anonymousAccessDenied(String requestId, String action, TransportMessage message) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.anonymousAccessDenied(requestId, action, message);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.anonymousAccessDenied(requestId, action, message);
         }
     }
 
     @Override
     public void anonymousAccessDenied(String requestId, RestRequest request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.anonymousAccessDenied(requestId, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.anonymousAccessDenied(requestId, request);
         }
     }
 
     @Override
     public void authenticationFailed(String requestId, RestRequest request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationFailed(requestId, request);
         }
     }
 
     @Override
     public void authenticationFailed(String requestId, String action, TransportMessage message) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, action, message);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationFailed(requestId, action, message);
         }
     }
 
     @Override
     public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportMessage message) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, token, action, message);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationFailed(requestId, token, action, message);
         }
     }
 
     @Override
     public void authenticationFailed(String requestId, String realm, AuthenticationToken token, String action, TransportMessage message) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, realm, token, action, message);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationFailed(requestId, realm, token, action, message);
         }
     }
 
     @Override
     public void authenticationFailed(String requestId, AuthenticationToken token, RestRequest request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, token, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationFailed(requestId, token, request);
         }
     }
 
     @Override
     public void authenticationFailed(String requestId, String realm, AuthenticationToken token, RestRequest request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, realm, token, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.authenticationFailed(requestId, realm, token, request);
         }
     }
 
     @Override
     public void accessGranted(String requestId, Authentication authentication, String action, TransportMessage msg,
                               AuthorizationInfo authorizationInfo) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.accessGranted(requestId, authentication, action, msg, authorizationInfo);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.accessGranted(requestId, authentication, action, msg, authorizationInfo);
         }
     }
 
     @Override
     public void accessDenied(String requestId, Authentication authentication, String action, TransportMessage message,
                              AuthorizationInfo authorizationInfo) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.accessDenied(requestId, authentication, action, message, authorizationInfo);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.accessDenied(requestId, authentication, action, message, authorizationInfo);
         }
     }
 
     @Override
     public void tamperedRequest(String requestId, RestRequest request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.tamperedRequest(requestId, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.tamperedRequest(requestId, request);
         }
     }
 
     @Override
     public void tamperedRequest(String requestId, String action, TransportMessage message) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.tamperedRequest(requestId, action, message);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.tamperedRequest(requestId, action, message);
         }
     }
 
     @Override
     public void tamperedRequest(String requestId, User user, String action, TransportMessage request) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.tamperedRequest(requestId, user, action, request);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.tamperedRequest(requestId, user, action, request);
         }
     }
 
     @Override
     public void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.connectionGranted(inetAddress, profile, rule);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.connectionGranted(inetAddress, profile, rule);
         }
     }
 
     @Override
     public void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.connectionDenied(inetAddress, profile, rule);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.connectionDenied(inetAddress, profile, rule);
         }
     }
 
     @Override
     public void runAsGranted(String requestId, Authentication authentication, String action, TransportMessage message,
                              AuthorizationInfo authorizationInfo) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.runAsGranted(requestId, authentication, action, message, authorizationInfo);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.runAsGranted(requestId, authentication, action, message, authorizationInfo);
         }
     }
 
     @Override
     public void runAsDenied(String requestId, Authentication authentication, String action, TransportMessage message,
                             AuthorizationInfo authorizationInfo) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.runAsDenied(requestId, authentication, action, message, authorizationInfo);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.runAsDenied(requestId, authentication, action, message, authorizationInfo);
         }
     }
 
     @Override
     public void runAsDenied(String requestId, Authentication authentication, RestRequest request,
                             AuthorizationInfo authorizationInfo) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.runAsDenied(requestId, authentication, request, authorizationInfo);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.runAsDenied(requestId, authentication, request, authorizationInfo);
         }
     }
 
@@ -228,11 +185,9 @@ public class AuditTrailService implements AuditTrail {
     public void explicitIndexAccessEvent(String requestId, AuditLevel eventType, Authentication authentication, String action,
                                          String indices, String requestName, TransportAddress remoteAddress,
                                          AuthorizationInfo authorizationInfo) {
-        if (licenseState.isAuditingAllowed()) {
-            for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.explicitIndexAccessEvent(requestId, eventType, authentication, action, indices, requestName, remoteAddress,
-                        authorizationInfo);
-            }
+        for (AuditTrail auditTrail : auditTrails) {
+            auditTrail.explicitIndexAccessEvent(requestId, eventType, authentication, action, indices, requestName, remoteAddress,
+                    authorizationInfo);
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -5,15 +5,14 @@
  */
 package org.elasticsearch.xpack.security.audit;
 
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportMessage;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
-import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
+import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 import org.junit.Before;
@@ -27,8 +26,6 @@ import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail.PRINCIPAL_ROLES_FIELD_NAME;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 public class AuditTrailServiceTests extends ESTestCase {
     private List<AuditTrail> auditTrails;
@@ -37,8 +34,6 @@ public class AuditTrailServiceTests extends ESTestCase {
     private AuthenticationToken token;
     private TransportMessage message;
     private RestRequest restRequest;
-    private XPackLicenseState licenseState;
-    private boolean isAuditingAllowed;
 
     @Before
     public void init() throws Exception {
@@ -47,10 +42,7 @@ public class AuditTrailServiceTests extends ESTestCase {
             auditTrailsBuilder.add(mock(AuditTrail.class));
         }
         auditTrails = unmodifiableList(auditTrailsBuilder);
-        licenseState = mock(XPackLicenseState.class);
-        service = new AuditTrailService(auditTrails, licenseState);
-        isAuditingAllowed = randomBoolean();
-        when(licenseState.isAuditingAllowed()).thenReturn(isAuditingAllowed);
+        service = new AuditTrailService(auditTrails);
         token = mock(AuthenticationToken.class);
         message = mock(TransportMessage.class);
         restRequest = mock(RestRequest.class);
@@ -59,91 +51,56 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailed() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationFailed(requestId, token, "_action", message);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, token, "_action", message);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationFailed(requestId, token, "_action", message);
         }
     }
 
     public void testAuthenticationFailedNoToken() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationFailed(requestId, "_action", message);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, "_action", message);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationFailed(requestId, "_action", message);
         }
     }
 
     public void testAuthenticationFailedRestNoToken() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationFailed(requestId, restRequest);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, restRequest);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationFailed(requestId, restRequest);
         }
     }
 
     public void testAuthenticationFailedRest() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationFailed(requestId, token, restRequest);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, token, restRequest);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationFailed(requestId, token, restRequest);
         }
     }
 
     public void testAuthenticationFailedRealm() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationFailed(requestId, "_realm", token, "_action", message);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, "_realm", token, "_action", message);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationFailed(requestId, "_realm", token, "_action", message);
         }
     }
 
     public void testAuthenticationFailedRestRealm() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationFailed(requestId, "_realm", token, restRequest);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, "_realm", token, restRequest);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationFailed(requestId, "_realm", token, restRequest);
         }
     }
 
     public void testAnonymousAccess() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.anonymousAccessDenied(requestId, "_action", message);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).anonymousAccessDenied(requestId, "_action", message);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).anonymousAccessDenied(requestId, "_action", message);
         }
     }
 
@@ -154,13 +111,8 @@ public class AuditTrailServiceTests extends ESTestCase {
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.accessGranted(requestId, authentication, "_action", message, authzInfo);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).accessGranted(requestId, authentication, "_action", message, authzInfo);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).accessGranted(requestId, authentication, "_action", message, authzInfo);
         }
     }
 
@@ -171,13 +123,8 @@ public class AuditTrailServiceTests extends ESTestCase {
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.accessDenied(requestId, authentication, "_action", message, authzInfo);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).accessDenied(requestId, authentication, "_action", message, authzInfo);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).accessDenied(requestId, authentication, "_action", message, authzInfo);
         }
     }
 
@@ -185,13 +132,8 @@ public class AuditTrailServiceTests extends ESTestCase {
         InetAddress inetAddress = InetAddress.getLoopbackAddress();
         SecurityIpFilterRule rule = randomBoolean() ? SecurityIpFilterRule.ACCEPT_ALL : IPFilter.DEFAULT_PROFILE_ACCEPT_ALL;
         service.connectionGranted(inetAddress, "client", rule);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).connectionGranted(inetAddress, "client", rule);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).connectionGranted(inetAddress, "client", rule);
         }
     }
 
@@ -199,13 +141,8 @@ public class AuditTrailServiceTests extends ESTestCase {
         InetAddress inetAddress = InetAddress.getLoopbackAddress();
         SecurityIpFilterRule rule = new SecurityIpFilterRule(false, "_all");
         service.connectionDenied(inetAddress, "client", rule);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).connectionDenied(inetAddress, "client", rule);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).connectionDenied(inetAddress, "client", rule);
         }
     }
 
@@ -214,13 +151,8 @@ public class AuditTrailServiceTests extends ESTestCase {
         String realm = "_realm";
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationSuccess(requestId, realm, user, restRequest);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationSuccess(requestId, realm, user, restRequest);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationSuccess(requestId, realm, user, restRequest);
         }
     }
 
@@ -229,13 +161,8 @@ public class AuditTrailServiceTests extends ESTestCase {
         String realm = "_realm";
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.authenticationSuccess(requestId, realm, user, "_action", message);
-        verify(licenseState).isAuditingAllowed();
-        if (isAuditingAllowed) {
-            for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationSuccess(requestId, realm, user, "_action", message);
-            }
-        } else {
-            verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
+        for (AuditTrail auditTrail : auditTrails) {
+            verify(auditTrail).authenticationSuccess(requestId, realm, user, "_action", message);
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
@@ -121,7 +121,7 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
         tokenService = new TokenService(settings, clock, client, licenseState, securityContext, securityIndex, tokensIndex, clusterService);
         final ApiKeyService apiKeyService = new ApiKeyService(settings, clock, client, licenseState,
             securityIndex, clusterService, threadPool);
-        authenticationService = new AuthenticationService(settings, realms, auditTrail, failureHandler, threadPool, anonymous,
+        authenticationService = new AuthenticationService(settings, realms, licenseState, auditTrail, failureHandler, threadPool, anonymous,
             tokenService, apiKeyService);
         authenticator = new SecondaryAuthenticator(securityContext, authenticationService);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
@@ -49,7 +49,7 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         when(licenseState.isAuditingAllowed()).thenReturn(true);
         when(licenseState.isDocumentAndFieldLevelSecurityAllowed()).thenReturn(true);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
+        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList());
         Authentication authentication = new Authentication(new User("john", "role"), new RealmRef(null, null, null),
                 new RealmRef(null, null, null));
         final FieldPermissions fieldPermissions;
@@ -108,7 +108,7 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         when(licenseState.isAuditingAllowed()).thenReturn(true);
         when(licenseState.isDocumentAndFieldLevelSecurityAllowed()).thenReturn(randomBoolean());
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
+        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList());
         Authentication authentication = new Authentication(new User("john", "role"), new RealmRef(null, null, null),
                 new RealmRef(null, null, null));
         final String action = IndicesAliasesAction.NAME;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
@@ -55,7 +55,7 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
+        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList());
         final Authentication authentication = new Authentication(new User("john", "role"), new RealmRef(null, null, null), null);
         final FieldPermissions fieldPermissions;
         final boolean useFls = randomBoolean();
@@ -107,7 +107,7 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
+        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList());
         final Authentication authentication = new Authentication(new User("john", "role"), new RealmRef(null, null, null), null);
         Role role = Role.builder()
                 .add(IndexPrivilege.ALL, "target")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
@@ -57,7 +57,7 @@ public class IpFilterRemoteAddressFilterTests extends ESTestCase {
                 IPFilter.PROFILE_FILTER_DENY_SETTING)));
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isIpFilteringAllowed()).thenReturn(true);
-        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
+        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList());
         IPFilter ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
         if (isHttpEnabled) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/NioIPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/NioIPFilterTests.java
@@ -60,7 +60,7 @@ public class NioIPFilterTests extends ESTestCase {
             IPFilter.PROFILE_FILTER_DENY_SETTING)));
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isIpFilteringAllowed()).thenReturn(true);
-        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
+        AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList());
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
         if (isHttpEnabled) {


### PR DESCRIPTION
Currently the AuditTrailService does the audit licensing check,
duplicated within each AuditTrail method. This commit moves the check
into the AuthenticationService where the AuditTrail methods are called,
so that only one check is needed.