### PR TITLE
[7.6] Fix ingest pipeline _simulate api with empty docs never returns a response

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulateExecutionService.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulateExecutionService.java
@@ -69,6 +69,13 @@ class SimulateExecutionService {
             final AtomicInteger counter = new AtomicInteger();
             final List<SimulateDocumentResult> responses =
                 new CopyOnWriteArrayList<>(new SimulateDocumentBaseResult[request.getDocuments().size()]);
+
+            if (request.getDocuments().isEmpty()) {
+                l.onResponse(new SimulatePipelineResponse(request.getPipeline().getId(),
+                    request.isVerbose(), responses));
+                return;
+            }
+
             int iter = 0;
             for (IngestDocument ingestDocument : request.getDocuments()) {
                 final int index = iter;

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -173,8 +173,15 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
     private static List<IngestDocument> parseDocs(Map<String, Object> config) {
         List<Map<String, Object>> docs =
             ConfigurationUtils.readList(null, null, config, Fields.DOCS);
+        if (docs.isEmpty()) {
+            throw new IllegalArgumentException("must specify at least one document in [docs]");
+        }
         List<IngestDocument> ingestDocumentList = new ArrayList<>();
-        for (Map<String, Object> dataMap : docs) {
+        for (Object object : docs) {
+            if ((object instanceof Map) ==  false) {
+                throw new IllegalArgumentException("malformed [docs] section, should include an inner object");
+            }
+            Map<String, Object> dataMap = (Map<String, Object>) object;
             Map<String, Object> document = ConfigurationUtils.readMap(null, null,
                 dataMap, Fields.SOURCE);
             String index = ConfigurationUtils.readStringOrIntProperty(null, null,

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.ingest;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.ingest.CompoundProcessor;
 import org.elasticsearch.ingest.IngestDocument;
@@ -46,6 +47,7 @@ import static org.elasticsearch.ingest.IngestDocument.MetaData.ROUTING;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.TYPE;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.VERSION;
 import static org.elasticsearch.ingest.IngestDocument.MetaData.VERSION_TYPE;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
@@ -256,5 +258,34 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         Exception e = expectThrows(IllegalArgumentException.class,
             () -> SimulatePipelineRequest.parseWithPipelineId(pipelineId, requestContent, false, ingestService));
         assertThat(e.getMessage(), equalTo("pipeline [" + pipelineId + "] does not exist"));
+    }
+
+    public void testNotValidDocs() {
+        Map<String, Object> requestContent = new HashMap<>();
+        List<Map<String, Object>> docs = new ArrayList<>();
+        Map<String, Object> pipelineConfig = new HashMap<>();
+        List<Map<String, Object>> processors = new ArrayList<>();
+        pipelineConfig.put("processors", processors);
+        requestContent.put(Fields.DOCS, docs);
+        requestContent.put(Fields.PIPELINE, pipelineConfig);
+        Exception e1 = expectThrows(IllegalArgumentException.class,
+            () -> SimulatePipelineRequest.parse(requestContent, false, ingestService));
+        assertThat(e1.getMessage(), equalTo("must specify at least one document in [docs]"));
+
+        List<String> stringList = new ArrayList<>();
+        stringList.add("test");
+        pipelineConfig.put("processors", processors);
+        requestContent.put(Fields.DOCS, stringList);
+        requestContent.put(Fields.PIPELINE, pipelineConfig);
+        Exception e2 = expectThrows(IllegalArgumentException.class,
+            () -> SimulatePipelineRequest.parse(requestContent, false, ingestService));
+        assertThat(e2.getMessage(), equalTo("malformed [docs] section, should include an inner object"));
+
+        docs.add(new HashMap<>());
+        requestContent.put(Fields.DOCS, docs);
+        requestContent.put(Fields.PIPELINE, pipelineConfig);
+        Exception e3 = expectThrows(ElasticsearchParseException.class,
+            () -> SimulatePipelineRequest.parse(requestContent, false, ingestService));
+        assertThat(e3.getMessage(), containsString("required property is missing"));
     }
 }


### PR DESCRIPTION
This PR relates to #52833.

The main changes are:

Return 400 status code with error message if the docs array is empty.
Return 400 status code with error message if the element in docs array is not a map.
Check whether the docs array is empty again when executing the pipeline simulate, avoiding no response.
Add some test code for the changes.

Backport of #52937 