### PR TITLE
Wait for ES to be green before deleting configs

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -145,15 +145,19 @@ public class DockerTests extends PackagingTestCase {
     /**
      * Check that a keystore can be manually created using the provided CLI tool.
      */
-    public void test040CreateKeystoreManually() throws InterruptedException {
+    public void test040CreateKeystoreManually() throws Exception {
         final Installation.Executables bin = installation.executables();
+
+        // wait until Elasticsearch is green before messing around with the
+        // files it needs for startup
+        waitForElasticsearch(installation);
 
         final Path keystorePath = installation.config("elasticsearch.keystore");
 
         waitForPathToExist(keystorePath);
 
         // Move the auto-created one out of the way, or else the CLI prompts asks us to confirm
-        sh.run("mv " + keystorePath + " " + keystorePath + ".bak");
+        sh.run("rm " + keystorePath);
 
         sh.run(bin.keystoreTool + " create");
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -180,9 +180,9 @@ public class Docker {
                 // Give the container a chance to crash out
                 Thread.sleep(1000);
 
-                psOutput = dockerShell.run("ps -w ax").stdout;
+                psOutput = dockerShell.run("ps -ww ax").stdout;
 
-                if (psOutput.contains("/usr/share/elasticsearch/jdk/bin/java")) {
+                if (psOutput.contains("org.elasticsearch.bootstrap.Elasticsearch")) {
                     isElasticsearchRunning = true;
                     break;
                 }


### PR DESCRIPTION
Testing manual creation of a keystore in Docker fails unpredictably on
7.6, possibly indicating a problem with deleting the keystore file
at a particular moment during Elasticsearch startup. In order to cut
this Gordian Knot, we should just wait for Elasticsearch to become green
before messing around with files that it needs for startup.

I'm also backporting a change to how we check whether ES is running. It
doesn't seem to be a problem with this test, but I think it's more
reliable. This got into 7.7 and master via #50610.

Closes #51316 