### PR TITLE
Add deprecation check for listener thread pool

### DIFF
--- a/docs/reference/migration/migrate_7_7.asciidoc
+++ b/docs/reference/migration/migrate_7_7.asciidoc
@@ -66,6 +66,7 @@ do this. The behavior is now the same for both field types like documented in
 <<range-query-date-math-rounding>>.
 
 [float]
+[[deprecate-listener-thread-pool]]
 ==== `thread_pool.listener.size` and `thread_pool.listener.queue_size` have been deprecated
 
 The listener thread pool is no longer used internally by Elasticsearch.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -45,7 +45,9 @@ public class DeprecationChecks {
             NodeDeprecationChecks::checkPidfile,
             NodeDeprecationChecks::checkProcessors,
             NodeDeprecationChecks::checkMissingRealmOrders,
-            NodeDeprecationChecks::checkUniqueRealmOrders
+            NodeDeprecationChecks::checkUniqueRealmOrders,
+            NodeDeprecationChecks::checkThreadPoolListenerQueueSize,
+            NodeDeprecationChecks::checkThreadPoolListenerSize
         ));
 
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -46,8 +46,8 @@ public class DeprecationChecks {
             NodeDeprecationChecks::checkProcessors,
             NodeDeprecationChecks::checkMissingRealmOrders,
             NodeDeprecationChecks::checkUniqueRealmOrders,
-            NodeDeprecationChecks::checkThreadPoolListenerQueueSize,
-            NodeDeprecationChecks::checkThreadPoolListenerSize
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkThreadPoolListenerQueueSize(settings),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkThreadPoolListenerSize(settings)
         ));
 
     static List<Function<IndexMetaData, DeprecationIssue>> INDEX_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -11,12 +11,14 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -94,6 +96,25 @@ class NodeDeprecationChecks {
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-duplicated-realm-orders",
             details
         );
+    }
+
+    static DeprecationIssue checkThreadPoolListenerQueueSize(final Settings settings, final PluginsAndModules pluginsAndModules) {
+        return checkThreadPoolListenerSetting("thread_pool.listener.queue_size", settings, pluginsAndModules);
+    }
+
+    static DeprecationIssue checkThreadPoolListenerSize(final Settings settings, final PluginsAndModules pluginsAndModules) {
+        return checkThreadPoolListenerSetting("thread_pool.listener.size", settings, pluginsAndModules);
+    }
+
+    private static DeprecationIssue checkThreadPoolListenerSetting(final String name, final Settings settings, final PluginsAndModules pluginsAndModules) {
+        final FixedExecutorBuilder builder = new FixedExecutorBuilder(settings, "listener", 1, -1, "thread_pool.listener", true);
+        final List<Setting<?>> listenerSettings = builder.getRegisteredSettings();
+        final Optional<Setting<?>> setting = listenerSettings.stream().filter(s -> s.getKey().equals(name)).findFirst();
+        assert setting.isPresent();
+        return checkRemovedSetting(
+            settings,
+            setting.get(),
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool");
     }
 
     private static DeprecationIssue checkDeprecatedSetting(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -98,19 +98,15 @@ class NodeDeprecationChecks {
         );
     }
 
-    static DeprecationIssue checkThreadPoolListenerQueueSize(final Settings settings, final PluginsAndModules pluginsAndModules) {
-        return checkThreadPoolListenerSetting("thread_pool.listener.queue_size", settings, pluginsAndModules);
+    static DeprecationIssue checkThreadPoolListenerQueueSize(final Settings settings) {
+        return checkThreadPoolListenerSetting("thread_pool.listener.queue_size", settings);
     }
 
-    static DeprecationIssue checkThreadPoolListenerSize(final Settings settings, final PluginsAndModules pluginsAndModules) {
-        return checkThreadPoolListenerSetting("thread_pool.listener.size", settings, pluginsAndModules);
+    static DeprecationIssue checkThreadPoolListenerSize(final Settings settings) {
+        return checkThreadPoolListenerSetting("thread_pool.listener.size", settings);
     }
 
-    private static DeprecationIssue checkThreadPoolListenerSetting(
-        final String name,
-        final Settings settings,
-        final PluginsAndModules pluginsAndModules
-    ) {
+    private static DeprecationIssue checkThreadPoolListenerSetting(final String name, final Settings settings) {
         final FixedExecutorBuilder builder = new FixedExecutorBuilder(settings, "listener", 1, -1, "thread_pool.listener", true);
         final List<Setting<?>> listenerSettings = builder.getRegisteredSettings();
         final Optional<Setting<?>> setting = listenerSettings.stream().filter(s -> s.getKey().equals(name)).findFirst();

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -106,7 +106,11 @@ class NodeDeprecationChecks {
         return checkThreadPoolListenerSetting("thread_pool.listener.size", settings, pluginsAndModules);
     }
 
-    private static DeprecationIssue checkThreadPoolListenerSetting(final String name, final Settings settings, final PluginsAndModules pluginsAndModules) {
+    private static DeprecationIssue checkThreadPoolListenerSetting(
+        final String name,
+        final Settings settings,
+        final PluginsAndModules pluginsAndModules
+    ) {
         final FixedExecutorBuilder builder = new FixedExecutorBuilder(settings, "listener", 1, -1, "thread_pool.listener", true);
         final List<Setting<?>> listenerSettings = builder.getRegisteredSettings();
         final Optional<Setting<?>> setting = listenerSettings.stream().filter(s -> s.getKey().equals(name)).findFirst();

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -146,6 +146,36 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertEquals(0, deprecationIssues.size());
     }
 
+    public void testThreadPoolListenerQueueSize() {
+        final int size = randomIntBetween(1, 4);
+        final Settings settings = Settings.builder().put("thread_pool.listener.queue_size", size).build();
+        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
+        final List<DeprecationIssue> issues =
+            DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings, pluginsAndModules));
+        final DeprecationIssue expected = new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            "setting [thread_pool.listener.queue_size] is deprecated and will be removed in the next major version",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool",
+            "the setting [thread_pool.listener.queue_size] is currently set to [" + size + "], remove this setting");
+        assertThat(issues, contains(expected));
+        assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.queue_size"});
+    }
+
+    public void testThreadPoolListenerSize() {
+        final int size = randomIntBetween(1, 4);
+        final Settings settings = Settings.builder().put("thread_pool.listener.size", size).build();
+        final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
+        final List<DeprecationIssue> issues =
+            DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings, pluginsAndModules));
+        final DeprecationIssue expected = new DeprecationIssue(
+            DeprecationIssue.Level.CRITICAL,
+            "setting [thread_pool.listener.size] is deprecated and will be removed in the next major version",
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html#deprecate-listener-thread-pool",
+            "the setting [thread_pool.listener.size] is currently set to [" + size + "], remove this setting");
+        assertThat(issues, contains(expected));
+        assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.listener.size"});
+    }
+
     public void testRemovedSettingNotSet() {
         final Settings settings = Settings.EMPTY;
         final Setting<?> removedSetting = Setting.simpleString("node.removed_setting");


### PR DESCRIPTION
This commit adds a deprecation check for the listener thread pool settings as these will be removed in 8.0.0.

Relates #53049
Relates #53317