### PR TITLE
Preserve metric types in top_metrics (backport of #53288)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/ParsedTopMetrics.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/analytics/ParsedTopMetrics.java
@@ -24,12 +24,10 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,9 +86,9 @@ public class ParsedTopMetrics extends ParsedAggregation {
         private static final ParseField METRICS_FIELD = new ParseField("metrics");
 
         private final List<Object> sort;
-        private final Map<String, Double> metrics;
+        private final Map<String, Object> metrics;
 
-        private TopMetrics(List<Object> sort, Map<String, Double> metrics) {
+        private TopMetrics(List<Object> sort, Map<String, Object> metrics) {
             this.sort = sort;
             this.metrics = metrics;
         }
@@ -105,7 +103,7 @@ public class ParsedTopMetrics extends ParsedAggregation {
         /**
          * The top metric values returned by the aggregation.
          */
-        public Map<String, Double> getMetrics() {
+        public Map<String, Object> getMetrics() {
             return metrics;
         }
 
@@ -114,13 +112,13 @@ public class ParsedTopMetrics extends ParsedAggregation {
                     @SuppressWarnings("unchecked")
                     List<Object> sort = (List<Object>) args[0];
                     @SuppressWarnings("unchecked")
-                    Map<String, Double> metrics = (Map<String, Double>) args[1];
+                    Map<String, Object> metrics = (Map<String, Object>) args[1];
                     return new TopMetrics(sort, metrics);
                 });
         static {
             PARSER.declareFieldArray(constructorArg(), (p, c) -> XContentParserUtils.parseFieldsValue(p),
                     SORT_FIELD, ObjectParser.ValueType.VALUE_ARRAY);
-            PARSER.declareObject(constructorArg(), (p, c) -> p.map(HashMap::new, XContentParser::doubleValue), METRICS_FIELD);
+            PARSER.declareObject(constructorArg(), (p, c) -> p.map(), METRICS_FIELD);
         }
 
         public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/analytics/AnalyticsAggsIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/analytics/AnalyticsAggsIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.ESRestHighLevelClientTestCase;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -61,8 +62,8 @@ public class AnalyticsAggsIT extends ESRestHighLevelClientTestCase {
         assertThat(stats.getDistribution(), hasEntry(equalTo("t"), closeTo(.09, .005)));
     }
 
-    public void testTopMetricsSizeOne() throws IOException {
-        indexTopMetricsData();
+    public void testTopMetricsDoubleMetric() throws IOException {
+        indexTopMetricsDoubleTestData();
         SearchRequest search = new SearchRequest("test");
         search.source().aggregation(new TopMetricsAggregationBuilder(
                 "test", new FieldSortBuilder("s").order(SortOrder.DESC), 1, "v"));
@@ -74,8 +75,34 @@ public class AnalyticsAggsIT extends ESRestHighLevelClientTestCase {
         assertThat(metric.getMetrics(), equalTo(singletonMap("v", 3.0)));
     }
 
+    public void testTopMetricsLongMetric() throws IOException {
+        indexTopMetricsLongTestData();
+        SearchRequest search = new SearchRequest("test");
+        search.source().aggregation(new TopMetricsAggregationBuilder(
+                "test", new FieldSortBuilder("s").order(SortOrder.DESC), 1, "v"));
+        SearchResponse response = highLevelClient().search(search, RequestOptions.DEFAULT);
+        ParsedTopMetrics top = response.getAggregations().get("test");
+        assertThat(top.getTopMetrics(), hasSize(1));
+        ParsedTopMetrics.TopMetrics metric = top.getTopMetrics().get(0);
+        assertThat(metric.getSort(), equalTo(singletonList(2)));
+        assertThat(metric.getMetrics(), equalTo(singletonMap("v", 3)));
+    }
+
+    public void testTopMetricsDateMetric() throws IOException {
+        indexTopMetricsDateTestData();
+        SearchRequest search = new SearchRequest("test");
+        search.source().aggregation(new TopMetricsAggregationBuilder(
+                "test", new FieldSortBuilder("s").order(SortOrder.DESC), 1, "v"));
+        SearchResponse response = highLevelClient().search(search, RequestOptions.DEFAULT);
+        ParsedTopMetrics top = response.getAggregations().get("test");
+        assertThat(top.getTopMetrics(), hasSize(1));
+        ParsedTopMetrics.TopMetrics metric = top.getTopMetrics().get(0);
+        assertThat(metric.getSort(), equalTo(singletonList(2)));
+        assertThat(metric.getMetrics(), equalTo(singletonMap("v", "2020-01-02T01:01:00.000Z")));
+    }
+
     public void testTopMetricsManyMetrics() throws IOException {
-        indexTopMetricsData();
+        indexTopMetricsDoubleTestData();
         SearchRequest search = new SearchRequest("test");
         search.source().aggregation(new TopMetricsAggregationBuilder(
                 "test", new FieldSortBuilder("s").order(SortOrder.DESC), 1, "v", "m"));
@@ -89,7 +116,7 @@ public class AnalyticsAggsIT extends ESRestHighLevelClientTestCase {
     }
 
     public void testTopMetricsSizeTwo() throws IOException {
-        indexTopMetricsData();
+        indexTopMetricsDoubleTestData();
         SearchRequest search = new SearchRequest("test");
         search.source().aggregation(new TopMetricsAggregationBuilder(
                 "test", new FieldSortBuilder("s").order(SortOrder.DESC), 2, "v"));
@@ -104,10 +131,28 @@ public class AnalyticsAggsIT extends ESRestHighLevelClientTestCase {
         assertThat(metric.getMetrics(), equalTo(singletonMap("v", 2.0)));
     }
 
-    private void indexTopMetricsData() throws IOException {
+    private void indexTopMetricsDoubleTestData() throws IOException {
         BulkRequest bulk = new BulkRequest("test").setRefreshPolicy(RefreshPolicy.IMMEDIATE);
         bulk.add(new IndexRequest().source(XContentType.JSON, "s", 1, "v", 2.0, "m", 12.0));
         bulk.add(new IndexRequest().source(XContentType.JSON, "s", 2, "v", 3.0, "m", 13.0));
         highLevelClient().bulk(bulk, RequestOptions.DEFAULT);
     }
+
+    private void indexTopMetricsLongTestData() throws IOException {
+        BulkRequest bulk = new BulkRequest("test").setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+        bulk.add(new IndexRequest().source(XContentType.JSON, "s", 1, "v", 2));
+        bulk.add(new IndexRequest().source(XContentType.JSON, "s", 2, "v", 3));
+        highLevelClient().bulk(bulk, RequestOptions.DEFAULT);
+    }
+
+    private void indexTopMetricsDateTestData() throws IOException {
+        CreateIndexRequest create = new CreateIndexRequest("test");
+        create.mapping("{\"properties\": {\"v\": {\"type\": \"date\"}}}", XContentType.JSON);
+        highLevelClient().indices().create(create, RequestOptions.DEFAULT);
+        BulkRequest bulk = new BulkRequest("test").setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+        bulk.add(new IndexRequest().source(XContentType.JSON, "s", 1, "v", "2020-01-01T01:01:00Z"));
+        bulk.add(new IndexRequest().source(XContentType.JSON, "s", 2, "v", "2020-01-02T01:01:00Z"));
+        highLevelClient().bulk(bulk, RequestOptions.DEFAULT);
+    }
+
 }

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -70,23 +70,27 @@ the same sort values then this aggregation could return either document's fields
 
 ==== `metrics`
 
-`metrics` selects the fields to of the "top" document to return. Like most other
-aggregations, `top_metrics` casts these values cast to `double` precision
-floating point numbers. So they have to be numeric. Dates *work*, but they
-come back as a `double` precision floating point containing milliseconds since
-epoch. `keyword` fields aren't allowed.
+`metrics` selects the fields to of the "top" document to return.
 
 You can return multiple metrics by providing a list:
 
 [source,console,id=search-aggregations-metrics-top-metrics-list-of-metrics]
 ----
+PUT /test
+{
+  "mappings": {
+    "properties": {
+      "d": {"type": "date"}
+    }
+  }
+}
 POST /test/_bulk?refresh
 {"index": {}}
-{"s": 1, "v": 3.1415, "m": 1.9}
+{"s": 1, "v": 3.1415, "m": 1, "d": "2020-01-01T00:12:12Z"}
 {"index": {}}
-{"s": 2, "v": 1.0, "m": 6.7}
+{"s": 2, "v": 1.0, "m": 6, "d": "2020-01-02T00:12:12Z"}
 {"index": {}}
-{"s": 3, "v": 2.71828, "m": -12.2}
+{"s": 3, "v": 2.71828, "m": -12, "d": "2019-12-31T00:12:12Z"}
 POST /test/_search?filter_path=aggregations
 {
   "aggs": {
@@ -94,7 +98,8 @@ POST /test/_search?filter_path=aggregations
       "top_metrics": {
         "metrics": [
           {"field": "v"},
-          {"field": "m"}
+          {"field": "m"},
+          {"field": "d"}
         ],
         "sort": {"s": "desc"}
       }
@@ -114,7 +119,8 @@ Which returns:
         "sort": [3],
         "metrics": {
           "v": 2.718280076980591,
-          "m": -12.199999809265137
+          "m": -12,
+          "d": "2019-12-31T00:12:12.000Z"
         }
       } ]
     }
@@ -122,7 +128,6 @@ Which returns:
 }
 ----
 // TESTRESPONSE
-
 
 ==== `size`
 
@@ -246,14 +251,14 @@ Which returns:
           "key": "192.168.0.1",
           "doc_count": 2,
           "tm": {
-            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 2.0 } } ]
+            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 2 } } ]
           }
         },
         {
           "key": "192.168.0.2",
           "doc_count": 1,
           "tm": {
-            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 3.0 } } ]
+            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 3 } } ]
           }
         }
       ],
@@ -303,14 +308,14 @@ Which returns:
           "key": "192.168.0.2",
           "doc_count": 1,
           "tm": {
-            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 3.0 } } ]
+            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 3 } } ]
           }
         },
         {
           "key": "192.168.0.1",
           "doc_count": 2,
           "tm": {
-            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 2.0 } } ]
+            "top": [ {"sort": ["2020-01-01T02:01:01.000Z"], "metrics": {"v": 2 } } ]
           }
         }
       ],

--- a/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
@@ -117,6 +117,11 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
     @Override
     public abstract String toString();
 
+    /**
+     * Return this {@linkplain SortValue} as a boxed {@linkplain Number}.
+     */
+    public abstract Number numberValue();
+
     private static class DoubleSortValue extends SortValue {
         public static final String NAME = "double";
 
@@ -178,6 +183,11 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         @Override
         public String toString() {
             return Double.toString(key);
+        }
+
+        @Override
+        public Number numberValue() {
+            return key;
         }
     }
 
@@ -242,6 +252,11 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         @Override
         public String toString() {
             return Long.toString(key);
+        }
+
+        @Override
+        public Number numberValue() {
+            return key;
         }
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorFactory.java
@@ -57,14 +57,14 @@ public class TopMetricsAggregatorFactory extends AggregatorFactory {
                     + "]. This limit can be set by changing the [" + MAX_BUCKET_SIZE.getKey()
                     + "] index level setting.");
         }
-        List<String> metricNames = metricFields.stream().map(MultiValuesSourceFieldConfig::getFieldName).collect(toList());
-        List<ValuesSource.Numeric> metricValuesSources = metricFields.stream().map(config -> {
+        List<TopMetricsAggregator.MetricSource> metricSources = metricFields.stream().map(config -> {
                     ValuesSourceConfig<ValuesSource.Numeric> resolved = ValuesSourceConfig.resolve(
                             searchContext.getQueryShardContext(), ValueType.NUMERIC,
                             config.getFieldName(), config.getScript(), config.getMissing(), config.getTimeZone(), null);
-                    return resolved.toValuesSource(searchContext.getQueryShardContext());
+                    return new TopMetricsAggregator.MetricSource(config.getFieldName(), resolved.format(),
+                            resolved.toValuesSource(searchContext.getQueryShardContext()));
                 }).collect(toList());
         return new TopMetricsAggregator(name, searchContext, parent, pipelineAggregators, metaData, size,
-                sortBuilders.get(0), metricNames, metricValuesSources);
+                sortBuilders.get(0), metricSources);
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsReduceTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsReduceTests.java
@@ -95,7 +95,9 @@ public class InternalTopMetricsReduceTests extends ESTestCase {
 
     private InternalTopMetrics.TopMetric top(SortValue sortValue, double metricValue) {
         DocValueFormat sortFormat = randomFrom(DocValueFormat.RAW, DocValueFormat.BINARY, DocValueFormat.BOOLEAN, DocValueFormat.IP);
-        return new InternalTopMetrics.TopMetric(sortFormat, sortValue, new double[] {metricValue});
+        DocValueFormat metricFormat = randomFrom(DocValueFormat.RAW, DocValueFormat.BINARY, DocValueFormat.BOOLEAN, DocValueFormat.IP);
+        InternalTopMetrics.MetricValue realMetricValue = new InternalTopMetrics.MetricValue(metricFormat, SortValue.from(metricValue));
+        return new InternalTopMetrics.TopMetric(sortFormat, sortValue, singletonList(realMetricValue));
     }
 
     private InternalTopMetrics reduce(InternalTopMetrics... results) {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -32,13 +32,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 
 public class InternalTopMetricsTests extends InternalAggregationTestCase<InternalTopMetrics> {
@@ -49,7 +51,11 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
      * would fail because the instances that it attempts to reduce don't
      * have their results in the same order.
      */
-    private SortOrder sortOrder = randomFrom(SortOrder.values());
+    private final SortOrder sortOrder = randomFrom(SortOrder.values());
+    private final InternalTopMetrics.MetricValue metricOneDouble =
+            new InternalTopMetrics.MetricValue(DocValueFormat.RAW, SortValue.from(1.0));
+    private final InternalTopMetrics.MetricValue metricOneLong =
+            new InternalTopMetrics.MetricValue(DocValueFormat.RAW, SortValue.from(1));
 
     public void testEmptyIsNotMapped() {
         InternalTopMetrics empty = InternalTopMetrics.buildEmptyAggregation(
@@ -63,9 +69,9 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     }
 
     public void testToXContentDoubleSortValue() throws IOException {
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1,
-                singletonList(new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), new double[] {1.0})),
-                emptyList(), null);
+        List<InternalTopMetrics.TopMetric> top = singletonList(
+                new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricOneDouble)));
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -83,12 +89,11 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 "}"));
     }
 
-    public void testToXConentDateSortValue() throws IOException {
-        DocValueFormat sortFormat = new DocValueFormat.DateTime(DateFormatter.forPattern("strict_date_time"), ZoneId.of("UTC"),
-                DateFieldMapper.Resolution.MILLISECONDS);
+    public void testToXContentDateSortValue() throws IOException {
         SortValue sortValue = SortValue.from(ZonedDateTime.parse("2007-12-03T10:15:30Z").toInstant().toEpochMilli());
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1,
-                singletonList(new InternalTopMetrics.TopMetric(sortFormat, sortValue, new double[] {1.0})), emptyList(), null);
+        List<InternalTopMetrics.TopMetric> top = singletonList(new InternalTopMetrics.TopMetric(
+                strictDateTime(), sortValue, singletonList(metricOneDouble)));
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -106,10 +111,54 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 "}"));
     }
 
+    public void testToXContentLongMetricValue() throws IOException {
+        List<InternalTopMetrics.TopMetric> top = singletonList(
+                new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricOneLong)));
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
+        assertThat(Strings.toString(tm, true, true), equalTo(
+                "{\n" +
+                "  \"test\" : {\n" +
+                "    \"top\" : [\n" +
+                "      {\n" +
+                "        \"sort\" : [\n" +
+                "          1.0\n" +
+                "        ],\n" +
+                "        \"metrics\" : {\n" +
+                "          \"test\" : 1\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}"));
+    }
+
+    public void testToXContentDateMetricValue() throws IOException {
+        InternalTopMetrics.MetricValue metricValue = new InternalTopMetrics.MetricValue(
+                strictDateTime(), SortValue.from(ZonedDateTime.parse("2007-12-03T10:15:30Z").toInstant().toEpochMilli()));
+        List<InternalTopMetrics.TopMetric> top = singletonList(
+                new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricValue)));
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
+        assertThat(Strings.toString(tm, true, true), equalTo(
+                "{\n" +
+                "  \"test\" : {\n" +
+                "    \"top\" : [\n" +
+                "      {\n" +
+                "        \"sort\" : [\n" +
+                "          1.0\n" +
+                "        ],\n" +
+                "        \"metrics\" : {\n" +
+                "          \"test\" : \"2007-12-03T10:15:30.000Z\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}"));
+    }
+
     public void testToXContentManyMetrics() throws IOException {
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, Arrays.asList("foo", "bar", "baz"), 1,
-                singletonList(new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), new double[] {1.0, 2.0, 3.0})),
-                emptyList(), null);
+        List<InternalTopMetrics.TopMetric> top = singletonList(new InternalTopMetrics.TopMetric(
+                DocValueFormat.RAW, SortValue.from(1.0), Arrays.asList(metricOneDouble, metricOneLong, metricOneDouble)));
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, Arrays.asList("foo", "bar", "baz"), 1, top, emptyList(), null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -120,8 +169,8 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 "        ],\n" +
                 "        \"metrics\" : {\n" +
                 "          \"foo\" : 1.0,\n" +
-                "          \"bar\" : 2.0,\n" +
-                "          \"baz\" : 3.0\n" +
+                "          \"bar\" : 1,\n" +
+                "          \"baz\" : 1.0\n" +
                 "        }\n" +
                 "      }\n" +
                 "    ]\n" +
@@ -130,11 +179,10 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     }
 
     public void testToXContentManyTopMetrics() throws IOException {
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 2,
-                Arrays.asList(
-                    new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), new double[] {1.0}),
-                    new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(2.0), new double[] {2.0})),
-                emptyList(), null);
+        List<InternalTopMetrics.TopMetric> top = Arrays.asList(
+                new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricOneDouble)),
+                new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(2.0), singletonList(metricOneLong)));
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 2, top, emptyList(), null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -152,7 +200,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 "          2.0\n" +
                 "        ],\n" +
                 "        \"metrics\" : {\n" +
-                "          \"test\" : 2.0\n" +
+                "          \"test\" : 1\n" +
                 "        }\n" +
                 "      }\n" +
                 "    ]\n" +
@@ -171,10 +219,15 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     @Override
     protected InternalTopMetrics createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
+        return createTestInstance(name, pipelineAggregators, metaData, InternalAggregationTestCase::randomNumericDocValueFormat);
+    }
+
+    private InternalTopMetrics createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData, Supplier<DocValueFormat> randomDocValueFormat) {
         int metricCount = between(1, 5);
         List<String> metricNames = randomMetricNames(metricCount);
         int size = between(1, 100);
-        List<InternalTopMetrics.TopMetric> topMetrics = randomTopMetrics(between(0, size), metricCount);
+        List<InternalTopMetrics.TopMetric> topMetrics = randomTopMetrics(randomDocValueFormat, between(0, size), metricCount);
         return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics, pipelineAggregators, metaData);
     }
 
@@ -203,7 +256,8 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         case 4:
             int fixedSize = size;
             int fixedMetricsSize = metricNames.size();
-            topMetrics = randomValueOtherThan(topMetrics, () -> randomTopMetrics(between(1, fixedSize), fixedMetricsSize));
+            topMetrics = randomValueOtherThan(topMetrics, () -> randomTopMetrics(
+                    InternalAggregationTestCase::randomNumericDocValueFormat, between(1, fixedSize), fixedMetricsSize));
             break;
         default:
             throw new IllegalArgumentException("bad mutation");
@@ -215,6 +269,18 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     @Override
     protected Reader<InternalTopMetrics> instanceReader() {
         return InternalTopMetrics::new;
+    }
+
+    /**
+     * An extra test for parsing dates from xcontent because we can't random
+     * into {@link DocValueFormat.DateTime} because it doesn't
+     * implement {@link Object#equals(Object)}.
+     */
+    public void testFromXContentDates() throws IOException {
+        InternalTopMetrics aggregation = createTestInstance(
+                randomAlphaOfLength(3), emptyList(), emptyMap(), InternalTopMetricsTests::strictDateTime);
+        ParsedAggregation parsedAggregation = parseAndAssert(aggregation, randomBoolean(), randomBoolean());
+        assertFromXContent(aggregation, parsedAggregation);
     }
 
     @Override
@@ -230,8 +296,14 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
             assertThat(parsedTop.getSort(), equalTo(singletonList(expectedSort)));
             assertThat(parsedTop.getMetrics().keySet(), hasSize(aggregation.getMetricNames().size()));
             for (int m = 0; m < aggregation.getMetricNames().size(); m++) {
-                assertThat(parsedTop.getMetrics(),
-                        hasEntry(aggregation.getMetricNames().get(m), internalTop.getMetricValues()[m]));
+                String name = aggregation.getMetricNames().get(m);
+                InternalTopMetrics.MetricValue value = internalTop.getMetricValues().get(m);
+                assertThat(parsedTop.getMetrics(), hasKey(name));
+                if (value.getFormat() == DocValueFormat.RAW) {
+                    assertThat(parsedTop.getMetrics().get(name), equalTo(value.numberValue()));
+                } else {
+                    assertThat(parsedTop.getMetrics().get(name), equalTo(value.getValue().format(value.getFormat())));
+                }
             }
         }
     }
@@ -251,10 +323,11 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         assertThat(reduced.getTopMetrics(), equalTo(winners));
     }
 
-    private List<InternalTopMetrics.TopMetric> randomTopMetrics(int length, int metricCount) {
+    private List<InternalTopMetrics.TopMetric> randomTopMetrics(
+            Supplier<DocValueFormat> randomDocValueFormat, int length, int metricCount) {
         return IntStream.range(0, length)
                 .mapToObj(i -> new InternalTopMetrics.TopMetric(
-                        randomNumericDocValueFormat(), randomSortValue(), randomMetricValues(metricCount)
+                        randomDocValueFormat.get(), randomSortValue(), randomMetricValues(randomDocValueFormat, metricCount)
                 ))
                 .sorted((lhs, rhs) -> sortOrder.reverseMul() * lhs.getSortValue().compareTo(rhs.getSortValue()))
                 .collect(toList());
@@ -268,9 +341,17 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         return new ArrayList<>(names);
     }
 
-    private double[] randomMetricValues(int metricCount) {
-        return IntStream.range(0, metricCount).mapToDouble(i -> randomDouble()).toArray();
+    private List<InternalTopMetrics.MetricValue> randomMetricValues(Supplier<DocValueFormat> randomDocValueFormat, int metricCount) {
+        return IntStream.range(0, metricCount)
+                .mapToObj(i -> new InternalTopMetrics.MetricValue(randomDocValueFormat.get(), randomSortValue()))
+                .collect(toList());
     }
+
+    private static DocValueFormat strictDateTime() {
+        return new DocValueFormat.DateTime(
+            DateFormatter.forPattern("strict_date_time"), ZoneId.of("UTC"), DateFieldMapper.Resolution.MILLISECONDS);
+    }
+
 
     private static SortValue randomSortValue() {
         if (randomBoolean()) {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorMetricsTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.analytics.topmetrics;
+
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.sort.SortValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.analytics.topmetrics.InternalTopMetrics.MetricValue;
+import org.elasticsearch.xpack.analytics.topmetrics.InternalTopMetrics.TopMetric;
+import org.elasticsearch.xpack.analytics.topmetrics.TopMetricsAggregator.MetricSource;
+import org.elasticsearch.xpack.analytics.topmetrics.TopMetricsAggregator.Metrics;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notANumber;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TopMetricsAggregatorMetricsTests extends ESTestCase {
+    public void testUnmapped() throws IOException {
+        withMetric(null, (m, source) -> {
+            // Load from doc is a noop
+            m.loader(null).loadFromDoc(0, randomInt());
+            assertNullMetric(m, source, randomInt());
+        });
+    }
+
+    public void testEmptyLong() throws IOException {
+        SortedNumericDocValues values = mock(SortedNumericDocValues.class);
+        when(values.advanceExact(0)).thenReturn(false);
+        withMetric(valuesSource(values), (m, source) -> {
+            m.loader(null).loadFromDoc(0, 0);
+            assertNullMetric(m, source, 0);
+        });
+    }
+
+    public void testEmptyDouble() throws IOException {
+        SortedNumericDoubleValues values = mock(SortedNumericDoubleValues.class);
+        when(values.advanceExact(0)).thenReturn(false);
+        withMetric(valuesSource(values), (m, source) -> {
+            m.loader(null).loadFromDoc(0, 0);
+            assertNullMetric(m, source, 0);
+        });
+    }
+
+    public void testLoadLong() throws IOException {
+        long value = randomLong();
+        SortedNumericDocValues values = mock(SortedNumericDocValues.class);
+        when(values.advanceExact(0)).thenReturn(true);
+        when(values.docValueCount()).thenReturn(1);
+        when(values.nextValue()).thenReturn(value);
+        withMetric(valuesSource(values), (m, source) -> {
+            m.loader(null).loadFromDoc(0, 0);
+            assertMetricValue(m, 0, source, SortValue.from(value));
+        });
+    }
+
+    public void testLoadDouble() throws IOException {
+        double value = randomDouble();
+        SortedNumericDoubleValues values = mock(SortedNumericDoubleValues.class);
+        when(values.advanceExact(0)).thenReturn(true);
+        when(values.docValueCount()).thenReturn(1);
+        when(values.nextValue()).thenReturn(value);
+        withMetric(valuesSource(values), (m, source) -> {
+            m.loader(null).loadFromDoc(0, 0);
+            assertMetricValue(m, 0, source, SortValue.from(value));
+        });
+    }
+
+    public void testLoadAndSwapLong() throws IOException {
+        long firstValue = randomLong();
+        long secondValue = randomLong();
+        SortedNumericDocValues values = mock(SortedNumericDocValues.class);
+        when(values.advanceExact(0)).thenReturn(true);
+        when(values.advanceExact(1)).thenReturn(true);
+        when(values.docValueCount()).thenReturn(1);
+        when(values.nextValue()).thenReturn(firstValue, secondValue);
+        withMetric(valuesSource(values), (m, source) -> {
+            assertLoadTwoAndSwap(m, source, SortValue.from(firstValue), SortValue.from(secondValue));
+        });
+    }
+
+    public void testLoadAndSwapDouble() throws IOException {
+        double firstValue = randomDouble();
+        double secondValue = randomDouble();
+        SortedNumericDoubleValues values = mock(SortedNumericDoubleValues.class);
+        when(values.advanceExact(0)).thenReturn(true);
+        when(values.advanceExact(1)).thenReturn(true);
+        when(values.docValueCount()).thenReturn(1);
+        when(values.nextValue()).thenReturn(firstValue, secondValue);
+        withMetric(valuesSource(values), (m, source) -> {
+            assertLoadTwoAndSwap(m, source, SortValue.from(firstValue), SortValue.from(secondValue));
+        });
+    }
+
+    public void testManyValues() throws IOException {
+        long[] values = IntStream.range(0, between(2, 100)).mapToLong(i -> randomLong()).toArray();
+        List<ValuesSource.Numeric> valuesSources = Arrays.stream(values)
+                .mapToObj(v -> {
+                    try {
+                        SortedNumericDocValues docValues = mock(SortedNumericDocValues.class);
+                        when(docValues.advanceExact(0)).thenReturn(true);
+                        when(docValues.docValueCount()).thenReturn(1);
+                        when(docValues.nextValue()).thenReturn(v);
+                        return valuesSource(docValues);
+                    } catch (IOException e) {
+                        throw new AssertionError(e);
+                    }
+                })
+                .collect(toList());
+        withMetrics(valuesSources, (m, sources) -> {
+            m.loader(null).loadFromDoc(0, 0);
+            TopMetric metric = m.resultBuilder(DocValueFormat.RAW).build(0, SortValue.from(1));
+            assertThat(metric.getMetricValues(), hasSize(values.length));
+            for (int i = 0; i < values.length; i++) {
+                MetricSource source = sources.get(i);
+                assertThat(m.metric(source.getName(), 0), equalTo((double) values[i]));
+                assertThat(metric.getMetricValues(),
+                        hasItem(new MetricValue(source.getFormat(), SortValue.from(values[i]))));
+            }
+        });
+    }
+
+    private ValuesSource.Numeric valuesSource(SortedNumericDocValues values) throws IOException {
+        ValuesSource.Numeric source = mock(ValuesSource.Numeric.class);
+        when(source.isFloatingPoint()).thenReturn(false);
+        when(source.longValues(null)).thenReturn(values);
+        return source;
+    }
+
+    private ValuesSource.Numeric valuesSource(SortedNumericDoubleValues values) throws IOException {
+        ValuesSource.Numeric source = mock(ValuesSource.Numeric.class);
+        when(source.isFloatingPoint()).thenReturn(true);
+        when(source.doubleValues(null)).thenReturn(values);
+        return source;
+    }
+
+    private void withMetric(ValuesSource.Numeric valuesSource,
+            CheckedBiConsumer<Metrics, MetricSource, IOException> consumer) throws IOException {
+        withMetrics(singletonList(valuesSource), (m, sources) -> consumer.accept(m, sources.get(0)));
+    }
+
+    private void withMetrics(List<ValuesSource.Numeric> valuesSources,
+            CheckedBiConsumer<Metrics, List<MetricSource>, IOException> consumer) throws IOException {
+        Set<String> names = new HashSet<>();
+        List<MetricSource> sources = new ArrayList<>(valuesSources.size());
+        for (ValuesSource.Numeric valuesSource : valuesSources) {
+            String name = randomValueOtherThanMany(names::contains, () -> randomAlphaOfLength(5));
+            names.add(name);
+            sources.add(new MetricSource(name, randomDocValueFormat(), valuesSource));
+        }
+        try (Metrics m = new Metrics(1, BigArrays.NON_RECYCLING_INSTANCE, sources)) {
+            consumer.accept(m, sources);
+        }
+    }
+
+    private void assertNullMetric(Metrics m, MetricSource source, long index) {
+        DocValueFormat sortFormat = randomDocValueFormat();
+        assertThat(m.metric(source.getName(), index), notANumber());
+        TopMetric metric = m.resultBuilder(sortFormat).build(index, SortValue.from(1));
+        assertThat(metric.getSortFormat(), sameInstance(sortFormat));
+        assertThat(metric.getMetricValues(), equalTo(singletonList(null)));
+    }
+
+    private void assertMetricValue(Metrics m, long index, MetricSource source, SortValue value) {
+        DocValueFormat sortFormat = randomDocValueFormat();
+        assertThat(m.metric(source.getName(), index), equalTo(value.numberValue().doubleValue()));
+        TopMetric metric = m.resultBuilder(sortFormat).build(index, SortValue.from(1));
+        assertThat(metric.getSortValue(), equalTo(SortValue.from(1)));
+        assertThat(metric.getSortFormat(), sameInstance(sortFormat));
+        assertThat(metric.getMetricValues(), equalTo(singletonList(new MetricValue(source.getFormat(), value))));
+    }
+
+    private void assertLoadTwoAndSwap(Metrics m, MetricSource source, SortValue firstValue, SortValue secondValue) throws IOException {
+        m.loader(null).loadFromDoc(0, 0);
+        m.loader(null).loadFromDoc(1, 1);
+        assertMetricValue(m, 0, source, firstValue);
+        assertMetricValue(m, 1, source, secondValue);
+        m.swap(0, 1);
+        assertMetricValue(m, 0, source, secondValue);
+        assertMetricValue(m, 1, source, firstValue);
+        m.loader(null).loadFromDoc(2, 2); // 2 is empty
+        assertNullMetric(m, source, 2);
+        m.swap(0, 2);
+        assertNullMetric(m, source, 0);
+        assertMetricValue(m, 2, source, secondValue);
+    }
+
+    private DocValueFormat randomDocValueFormat() {
+        return randomFrom(DocValueFormat.RAW, DocValueFormat.BINARY, DocValueFormat.BOOLEAN);
+    }
+}


### PR DESCRIPTION
This changes the `top_metrics` aggregation to return metrics in their
original type. Since it only supports numerics, that means that dates,
longs, and doubles will come back as stored, with their appropriate
formatter applied.
