### PR TITLE
Use snake case for nodes stats/info metric names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,7 +222,7 @@ task verifyVersions {
  */
 
 boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/53446" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -286,7 +286,7 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
         OS("os"),
         PROCESS("process"),
         JVM("jvm"),
-        THREAD_POOL("threadPool"),
+        THREAD_POOL("thread_pool"),
         TRANSPORT("transport"),
         HTTP("http"),
         PLUGINS("plugins"),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -319,7 +319,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         OS("os"),
         PROCESS("process"),
         JVM("jvm"),
-        THREAD_POOL("threadPool"),
+        THREAD_POOL("thread_pool"),
         FS("fs"),
         TRANSPORT("transport"),
         HTTP("http"),


### PR DESCRIPTION
The REST API [uses "thread_pool"](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html#cluster-nodes-info-api-path-params) as the name of the thread pool metric. If we use this name internally when we serialize nodes stats and info requests, we won't need to do any fancy logic to check for and switch out "threadPool", which was the previous internal name.

I'm doing this in its own PR to isolate the amount of code for which I have to do a bwc-tests shuffle.

Relates #53410
Relates #52975 