### PR TITLE
[DOCS] Add EQL advantages to overview

### DIFF
--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -29,7 +29,7 @@ intuitively, which makes for quick, iterative searching.
 
 * *We designed EQL for security use cases.* +
 While you can use EQL for any event-based data, we created EQL for threat
-hunting. EQL  not only supports indicator of compromise (IOC) searching but
+hunting. EQL not only supports indicator of compromise (IOC) searching but
 makes it easy to describe activity that goes beyond IOCs.
 
 [float]

--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -16,6 +16,23 @@ quickly match events with shared properties. You can use EQL and query
 DSL together to better filter your searches.
 
 [float]
+[[eql-advantages]]
+=== Advantages of EQL
+
+* *EQL lets you express relationships between events.* +
+Many query languages allow you to match only single events. EQL lets you match a
+sequence of events across different event categories and time spans.
+
+* *EQL has a low learning curve.* +
+EQL syntax looks like other query languages. It lets you write and read queries
+intuitively, which makes for quick, iterative searching.
+
+* *We designed EQL for security use cases.* +
+While you can use EQL for any event-based data, we created EQL for threat
+hunting. EQL  not only supports indicator of compromise (IOC) searching but
+makes it easy to describe activity that goes beyond IOCs.
+
+[float]
 [[when-to-use-eql]]
 === When to use EQL
 


### PR DESCRIPTION
Adds a concise list of EQL advantages, based on the "EQL Advantages"
section in the [EQL for the masses][0] blog post.

The intent is to inform users how EQL could benefit at a high level.

[0]: https://www.elastic.co/blog/eql-for-the-masses