### PR TITLE
[DOCS] Reduce content reuse in enrich docs

### DIFF
--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -67,22 +67,11 @@ If you use {es} {security-features}, you must have:
 Use the put enrich policy API
 to create a new <<enrich-policy,enrich policy>>.
 
-// tag::update-enrich-policy[]
 [WARNING]
 ====
-Once created, you can't update or change an enrich policy.
-Instead, you can:
-
-.   Create and <<execute-enrich-policy-api,execute>> a new enrich policy.
-
-.   Replace the previous enrich policy
-    with the new enrich policy
-    in any in-use enrich processors.
-
-.   Use the <<delete-enrich-policy-api, delete enrich policy>> API
-    to delete the previous enrich policy.
+include::../../enrich.asciidoc[tag=update-enrich-policy]
 ====
-// end::update-enrich-policy[]
+
 
 
 [[put-enrich-policy-api-path-params]]

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -150,7 +150,11 @@ include::enrich.asciidoc[tag=enrich-policy-fields]
 You can use this definition to create the enrich policy with the
 <<put-enrich-policy-api,put enrich policy API>>.
 
-include::apis/enrich/put-enrich-policy.asciidoc[tag=update-enrich-policy]
+[WARNING]
+====
+Once created, you can't update or change an enrich policy.
+See <<update-enrich-policies>>.
+====
 
 [[execute-enrich-policy]]
 ==== Execute the enrich policy
@@ -214,7 +218,19 @@ using your ingest pipeline.
 [[update-enrich-policies]]
 ==== Update an enrich policy
 
-include::apis/enrich/put-enrich-policy.asciidoc[tag=update-enrich-policy]
+// tag::update-enrich-policy[]
+Once created, you can't update or change an enrich policy.
+Instead, you can:
+
+.   Create and <<execute-enrich-policy-api,execute>> a new enrich policy.
+
+.   Replace the previous enrich policy
+    with the new enrich policy
+    in any in-use enrich processors.
+
+.   Use the <<delete-enrich-policy-api, delete enrich policy>> API
+    to delete the previous enrich policy.
+// end::update-enrich-policy[]
 
 [role="xpack"]
 [testenv="basic"]


### PR DESCRIPTION
Restructures the 'Update an enrich policy' section to:

* Migrate the content to the section. It was previously stored in the
  Put Enrich Policy API docs.
* Remove the warning tag admonition from the section content.
* Replace a reused section earlier in the "Set up an enrich processor"
  page with a link.

No substantive changes were made to the content.