### PR TITLE
[ML] Add ModelLoadingService method for always caching models

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -75,13 +75,13 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
 
         if (licenseState.isMachineLearningAllowed()) {
             responseBuilder.setLicensed(true);
-            this.modelLoadingService.getModel(request.getModelId(), getModelListener);
+            this.modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
         } else {
             trainedModelProvider.getTrainedModel(request.getModelId(), false, ActionListener.wrap(
                 trainedModelConfig -> {
                     responseBuilder.setLicensed(licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()));
                     if (licenseState.isAllowedByLicense(trainedModelConfig.getLicenseLevel()) || request.isPreviouslyLicensed()) {
-                        this.modelLoadingService.getModel(request.getModelId(), getModelListener);
+                        this.modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
                     } else {
                         listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
                     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -65,7 +65,7 @@ public class ModelLoadingService implements ClusterStateListener {
     /**
      * How long should a model stay in the cache since its last access
      *
-     * If nothing references a model via getModelForPipeline for this configured timeValue, it will be evicted.
+     * If nothing references a model via getModelForPipeline or getModelAndCache for this configured timeValue, it will be evicted.
      *
      * Specifically, in the ingest scenario, a processor will call getModelForPipeline whenever it needs to run inference.
      * So, if a processor is not executed for an extended period of time, the model will be evicted and will have to be
@@ -153,7 +153,7 @@ public class ModelLoadingService implements ClusterStateListener {
     }
 
     /**
-     * Gets the model referenced by `modelId` caches it an responds on the listener. As opposed to
+     * Gets the model referenced by `modelId` caches it and responds on the listener. As opposed to
      * {@link #getModelForPipeline(String, ActionListener)} this method will always cache the retrieved
      * model if it is not currently cached.
       *

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -52,7 +52,7 @@ public class InferencePhase implements FetchSubPhase {
         ActionListener<Model> listener = new LatchedActionListener<>(
                 ActionListener.wrap(model::set, e -> { throw new RuntimeException();}), latch);
 
-        modelLoadingService.get().getModel(infBuilder.getModelId(), listener);
+        modelLoadingService.get().getModelForPipeline(infBuilder.getModelId(), listener);
         try {
             // Eeek blocking on a latch we can't be doing that
             latch.await();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -112,7 +112,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for(int i = 0; i < 10; i++) {
             String model = modelIds[i%3];
             PlainActionFuture<Model> future = new PlainActionFuture<>();
-            modelLoadingService.getModel(model, future);
+            modelLoadingService.getModelForPipeline(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -125,7 +125,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for(int i = 0; i < 10; i++) {
             String model = modelIds[i%3];
             PlainActionFuture<Model> future = new PlainActionFuture<>();
-            modelLoadingService.getModel(model, future);
+            modelLoadingService.getModelForPipeline(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -165,7 +165,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             // Only reference models 1 and 2, so that cache is only invalidated once for model3 (after initial load)
             String model = modelIds[i%2];
             PlainActionFuture<Model> future = new PlainActionFuture<>();
-            modelLoadingService.getModel(model, future);
+            modelLoadingService.getModelForPipeline(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -177,7 +177,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Load model 3, should invalidate 1
         for(int i = 0; i < 10; i++) {
             PlainActionFuture<Model> future3 = new PlainActionFuture<>();
-            modelLoadingService.getModel(model3, future3);
+            modelLoadingService.getModelForPipeline(model3, future3);
             assertThat(future3.get(), is(not(nullValue())));
         }
         verify(trainedModelProvider, atMost(2)).getTrainedModel(eq(model3), eq(true), any());
@@ -185,7 +185,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Load model 1, should invalidate 2
         for(int i = 0; i < 10; i++) {
             PlainActionFuture<Model> future1 = new PlainActionFuture<>();
-            modelLoadingService.getModel(model1, future1);
+            modelLoadingService.getModelForPipeline(model1, future1);
             assertThat(future1.get(), is(not(nullValue())));
         }
         verify(trainedModelProvider, atMost(3)).getTrainedModel(eq(model1), eq(true), any());
@@ -193,7 +193,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Load model 2, should invalidate 3
         for(int i = 0; i < 10; i++) {
             PlainActionFuture<Model> future2 = new PlainActionFuture<>();
-            modelLoadingService.getModel(model2, future2);
+            modelLoadingService.getModelForPipeline(model2, future2);
             assertThat(future2.get(), is(not(nullValue())));
         }
         verify(trainedModelProvider, atMost(3)).getTrainedModel(eq(model2), eq(true), any());
@@ -205,7 +205,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for(int i = 0; i < 10; i++) {
             String model = modelIds[i%3];
             PlainActionFuture<Model> future = new PlainActionFuture<>();
-            modelLoadingService.getModel(model, future);
+            modelLoadingService.getModelForPipeline(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -231,7 +231,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         for(int i = 0; i < 10; i++) {
             PlainActionFuture<Model> future = new PlainActionFuture<>();
-            modelLoadingService.getModel(model1, future);
+            modelLoadingService.getModelForPipeline(model1, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -251,7 +251,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(model));
 
         PlainActionFuture<Model> future = new PlainActionFuture<>();
-        modelLoadingService.getModel(model, future);
+        modelLoadingService.getModelForPipeline(model, future);
 
         try {
             future.get();
@@ -275,7 +275,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             Settings.EMPTY);
 
         PlainActionFuture<Model> future = new PlainActionFuture<>();
-        modelLoadingService.getModel(model, future);
+        modelLoadingService.getModelForPipeline(model, future);
         try {
             future.get();
             fail("Should not have succeeded");
@@ -297,7 +297,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         for(int i = 0; i < 3; i++) {
             PlainActionFuture<Model> future = new PlainActionFuture<>();
-            modelLoadingService.getModel(model, future);
+            modelLoadingService.getModelForPipeline(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -304,6 +304,27 @@ public class ModelLoadingServiceTests extends ESTestCase {
         verify(trainedModelProvider, times(3)).getTrainedModel(eq(model), eq(true), any());
     }
 
+    public void testGetModelAndCache() throws Exception {
+        String model = "test-get-model-and-cache";
+        withTrainedModel(model, 1L);
+
+        ModelLoadingService modelLoadingService = new ModelLoadingService(trainedModelProvider,
+                auditor,
+                threadPool,
+                clusterService,
+                NamedXContentRegistry.EMPTY,
+                Settings.EMPTY);
+
+        for(int i = 0; i < 3; i++) {
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
+            modelLoadingService.getModelAndCache(model, future);
+            assertThat(future.get(), is(not(nullValue())));
+        }
+
+        // provider will be called once, subsequent responses come from the cache
+        verify(trainedModelProvider, times(1)).getTrainedModel(eq(model), eq(true), any());
+    }
+
     @SuppressWarnings("unchecked")
     private void withTrainedModel(String modelId, long size) throws IOException {
         TrainedModelDefinition definition = mock(TrainedModelDefinition.class);


### PR DESCRIPTION
ModelLoadingService will only cache a model if it is reference by an inference processor in an ingest pipeline which is not what we want for the search use cases. 

1. Rename `getModel()` -> `getModelForPipeline()` which preserves the existing behaviour 
2. Add new method `getModelAndCache()` which always adds to model to the cache

ModelLoadingService now has 2 methods for getting a model which complicates the interface but both use the same cache at least. 

What this change does highlight is that `TransportInternalInferModelAction` has unexpected behaviour if used outside of an inference processor in that the model is not cached as could be assumed. 

Feature branch PR