### PR TITLE
Parse single named objects with ObjectParser.declareNamedObject

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/TrainedModelDefinition.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/TrainedModelDefinition.java
@@ -43,9 +43,8 @@ public class TrainedModelDefinition implements ToXContentObject {
             true,
             TrainedModelDefinition.Builder::new);
     static {
-        PARSER.declareNamedObjects(TrainedModelDefinition.Builder::setTrainedModel,
+        PARSER.declareNamedObject(TrainedModelDefinition.Builder::setTrainedModel,
             (p, c, n) -> p.namedObject(TrainedModel.class, n, null),
-            (modelDocBuilder) -> { /* Noop does not matter client side*/ },
             TRAINED_MODEL);
         PARSER.declareNamedObjects(TrainedModelDefinition.Builder::setPreProcessors,
             (p, c, n) -> p.namedObject(PreProcessor.class, n, null),
@@ -122,11 +121,6 @@ public class TrainedModelDefinition implements ToXContentObject {
         public Builder setTrainedModel(TrainedModel trainedModel) {
             this.trainedModel = trainedModel;
             return this;
-        }
-
-        private Builder setTrainedModel(List<TrainedModel> trainedModel) {
-            assert trainedModel.size() == 1;
-            return setTrainedModel(trainedModel.get(0));
         }
 
         public TrainedModelDefinition build() {

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -56,9 +56,8 @@ public class Ensemble implements TrainedModel {
                     p.namedObject(TrainedModel.class, n, null),
             (ensembleBuilder) -> { /* Noop does not matter client side */ },
             TRAINED_MODELS);
-        PARSER.declareNamedObjects(Ensemble.Builder::setOutputAggregatorFromParser,
+        PARSER.declareNamedObject(Ensemble.Builder::setOutputAggregator,
             (p, c, n) -> p.namedObject(OutputAggregator.class, n, null),
-            (ensembleBuilder) -> { /* Noop does not matter client side */ },
             AGGREGATE_OUTPUT);
         PARSER.declareString(Ensemble.Builder::setTargetType, TARGET_TYPE);
         PARSER.declareStringArray(Ensemble.Builder::setClassificationLabels, CLASSIFICATION_LABELS);
@@ -194,9 +193,6 @@ public class Ensemble implements TrainedModel {
             return this;
         }
 
-        private void setOutputAggregatorFromParser(List<OutputAggregator> outputAggregators) {
-            this.setOutputAggregator(outputAggregators.get(0));
-        }
 
         private void setTargetType(String targetType) {
             this.targetType = TargetType.fromString(targetType);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelDefinition.java
@@ -53,11 +53,10 @@ public class TrainedModelDefinition implements ToXContentObject, Writeable, Acco
         ObjectParser<TrainedModelDefinition.Builder, Void> parser = new ObjectParser<>(NAME,
             ignoreUnknownFields,
             TrainedModelDefinition.Builder::builderForParser);
-        parser.declareNamedObjects(TrainedModelDefinition.Builder::setTrainedModel,
+        parser.declareNamedObject(TrainedModelDefinition.Builder::setTrainedModel,
             (p, c, n) -> ignoreUnknownFields ?
                 p.namedObject(LenientlyParsedTrainedModel.class, n, null) :
                 p.namedObject(StrictlyParsedTrainedModel.class, n, null),
-            (modelDocBuilder) -> { /* Noop does not matter as we will throw if more than one is defined */ },
             TRAINED_MODEL);
         parser.declareNamedObjects(TrainedModelDefinition.Builder::setPreProcessors,
             (p, c, n) -> ignoreUnknownFields ?

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -73,11 +73,10 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
                     p.namedObject(StrictlyParsedTrainedModel.class, n, null),
             (ensembleBuilder) -> ensembleBuilder.setModelsAreOrdered(true),
             TRAINED_MODELS);
-        parser.declareNamedObjects(Ensemble.Builder::setOutputAggregatorFromParser,
+        parser.declareNamedObject(Ensemble.Builder::setOutputAggregator,
             (p, c, n) ->
                 lenient ? p.namedObject(LenientlyParsedOutputAggregator.class, n, null) :
                     p.namedObject(StrictlyParsedOutputAggregator.class, n, null),
-            (ensembleBuilder) -> {/*Noop as it could be an array or object, it just has to be a one*/},
             AGGREGATE_OUTPUT);
         parser.declareString(Ensemble.Builder::setTargetType, TARGET_TYPE);
         parser.declareStringArray(Ensemble.Builder::setClassificationLabels, CLASSIFICATION_LABELS);
@@ -412,14 +411,6 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
         public Builder setClassificationWeights(List<Double> classificationWeights) {
             this.classificationWeights = classificationWeights.stream().mapToDouble(Double::doubleValue).toArray();
             return this;
-        }
-
-        private void setOutputAggregatorFromParser(List<OutputAggregator> outputAggregators) {
-            if (outputAggregators.size() != 1) {
-                throw ExceptionsHelper.badRequestException("[{}] must have exactly one aggregator defined.",
-                    AGGREGATE_OUTPUT.getPreferredName());
-            }
-            this.setOutputAggregator(outputAggregators.get(0));
         }
 
         private void setTargetType(String targetType) {


### PR DESCRIPTION
As opposed to the declareNamedObject*s* method which generates a list where only the first item is used. 