### PR TITLE
[DOCS] Clarify `max_shingle_size` parm def

### DIFF
--- a/docs/reference/mapping/types/search-as-you-type.asciidoc
+++ b/docs/reference/mapping/types/search-as-you-type.asciidoc
@@ -172,7 +172,7 @@ Largest shingle size to create. Valid values are `2` (inclusive) to `4`
 A subfield is created for each integer between `2` and this value. For example,
 a value of `3` creates two subfields: `my_field._2gram` and `my_field._3gram`
 
-More subfields enable more specific queries but increase index size.
+More subfields enables more specific queries but increases index size.
 --
 
 [[general-params]]

--- a/docs/reference/mapping/types/search-as-you-type.asciidoc
+++ b/docs/reference/mapping/types/search-as-you-type.asciidoc
@@ -162,15 +162,18 @@ GET my_index/_search
 The following parameters are accepted in a mapping for the `search_as_you_type`
 field and are specific to this field type
 
-[horizontal]
-
 `max_shingle_size`::
++
+--
+(Optional, integer)
+Largest shingle size to create. Valid values are `2` (inclusive) to `4`
+(inclusive). Defaults to `3`.
 
-    The largest shingle size to index the input with and create subfields for,
-    creating one subfield for each shingle size between 2 and
-    `max_shingle_size`. Accepts integer values between 2 and 4 inclusive. This
-    option defaults to 3.
+A subfield is created for each integer between `2` and this value. For example,
+a value of `3` creates two subfields: `my_field._2gram` and `my_field._3gram`
 
+More subfields enable more specific queries but increase index size.
+--
 
 [[general-params]]
 ==== Parameters of the field type as a text field


### PR DESCRIPTION
Rewrites the `search_as_you_type` field datatype's 
`max_shingle_size` mapping parameter to improve clarity
and better communicate trade-offs regarding index size.

Relates to [elastic/kibana#55161][0].

[0]: https://github.com/elastic/kibana/pull/55161#discussion_r368107177

Closes #51774