### PR TITLE
[DOCS] Adds a warning about reindexing docs with the same ID to the PUT DFA docs

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1317,6 +1317,11 @@ The configuration of how to source the analysis data. It requires an
   (Required, string or array) Index or indices on which to perform the 
   analysis. It can be a single index or index pattern as well as an array of 
   indices or patterns.
++
+--
+WARNING: If your source indices contain documents with the same IDs, only the 
+document that is indexed last appears in the destination index.
+--
   
 `query`:::
   (Optional, object) The {es} query domain-specific language 


### PR DESCRIPTION
This PR adds a warning message to the `source` resource of the PUT DFA API docs about reindexing docs with the same IDs.