### PR TITLE
[7.x] Add read/writeOptionalVLong to StreamInput/Output (#53145) (0b38b6a5)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -315,6 +315,14 @@ public abstract class StreamInput extends InputStream {
         return i;
     }
 
+    @Nullable
+    public Long readOptionalVLong() throws IOException {
+        if (readBoolean()) {
+            return readVLong();
+        }
+        return null;
+    }
+
     public long readZLong() throws IOException {
         long accumulator = 0L;
         int i = 0;

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -301,6 +301,15 @@ public abstract class StreamOutput extends OutputStream {
         writeVLongNoCheck(i);
     }
 
+    public void writeOptionalVLong(@Nullable  Long l) throws IOException {
+        if (l == null) {
+            writeBoolean(false);
+        } else {
+            writeBoolean(true);
+            writeVLong(l);
+        }
+    }
+
     /**
      * Writes a long in a variable-length format without first checking if it is negative. Package private for testing. Use
      * {@link #writeVLong(long)} instead.

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests for {@link BytesStreamOutput} paging behaviour.
@@ -275,6 +276,8 @@ public class BytesStreamsTests extends ESTestCase {
         out.writeLong(-3);
         out.writeVLong(4);
         out.writeOptionalLong(11234234L);
+        out.writeOptionalVLong(5L);
+        out.writeOptionalVLong(null);
         out.writeFloat(1.1f);
         out.writeDouble(2.2);
         int[] intArray = {1, 2, 3};
@@ -311,6 +314,8 @@ public class BytesStreamsTests extends ESTestCase {
         assertThat(in.readLong(), equalTo(-3L));
         assertThat(in.readVLong(), equalTo(4L));
         assertThat(in.readOptionalLong(), equalTo(11234234L));
+        assertThat(in.readOptionalVLong(), equalTo(5L));
+        assertThat(in.readOptionalVLong(), nullValue());
         assertThat((double)in.readFloat(), closeTo(1.1, 0.0001));
         assertThat(in.readDouble(), closeTo(2.2, 0.0001));
         assertThat(in.readGenericValue(), equalTo((Object) intArray));


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add read/writeOptionalVLong to StreamInput/Output (#53145) (0b38b6a5)