### PR TITLE
Fix type list for missing agg

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
@@ -451,7 +451,10 @@ public class MissingAggregatorTests extends AggregatorTestCase {
             CoreValuesSourceType.BYTES,
             CoreValuesSourceType.GEOPOINT,
             CoreValuesSourceType.RANGE,
-            CoreValuesSourceType.HISTOGRAM
+            CoreValuesSourceType.HISTOGRAM,
+            CoreValuesSourceType.IP,
+            CoreValuesSourceType.BOOLEAN,
+            CoreValuesSourceType.DATE
         );
     }
 


### PR DESCRIPTION
Add the new `CoreValuesSourceType`s to the list of supported types for the missing agg.