### PR TITLE
Mute AsyncSearchActionTests testTermsAggregation

### DIFF
--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchActionTests.java
@@ -123,6 +123,7 @@ public class AsyncSearchActionTests extends AsyncSearchIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/53360")
     public void testTermsAggregation() throws Exception {
         int step = numShards > 2 ? randomIntBetween(2, numShards) : 2;
         int numFailures = randomBoolean() ? randomIntBetween(0, numShards) : 0;


### PR DESCRIPTION
This test failed in CI and there has been an ongoing issue for tests
in this class failing.

Relates #53360