### PR TITLE
Lower docker-compose version to allow for older Docker engine support

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 # Only used for testing the docker images
-version: '3.7'
+version: '3.4'
 services:
   elasticsearch-default-1:
     image: elasticsearch:test


### PR DESCRIPTION
The current docker-compose version requirement of `3.7` for our Docker distribution tests is overly strict and requires folks to have a newer version of Docker and compose then is otherwise necessary. This PR lowers the version to `3.4` which is the first version to introduce the `start_period` field for `heartbeat` which is used in this case. This will allow Docker versions as old at 17.09.0 to be supported.