### PR TITLE
Ensure jdk download uses a unique maven group

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
@@ -143,7 +143,7 @@ public class JdkDownloadPlugin implements Plugin<Project> {
                     repo.patternLayout(layout -> layout.artifact(artifactPattern));
                 });
                 repositories.exclusiveContent(exclusiveContentRepository -> {
-                    exclusiveContentRepository.filter(config -> config.includeGroup(jdk.getVendor()));
+                    exclusiveContentRepository.filter(config -> config.includeGroup(groupName(jdk)));
                     exclusiveContentRepository.forRepositories(ivyRepo);
                 });
             }
@@ -254,7 +254,11 @@ public class JdkDownloadPlugin implements Plugin<Project> {
             : jdk.getPlatform();
         String extension = jdk.getPlatform().equals("windows") ? "zip" : "tar.gz";
 
-        return jdk.getVendor() + ":" + platformDep + ":" + jdk.getBaseVersion() + "@" + extension;
+        return groupName(jdk) + ":" + platformDep + ":" + jdk.getBaseVersion() + "@" + extension;
+    }
+
+    private static String groupName(Jdk jdk) {
+        return jdk.getVendor() + "_" + jdk.getMajor();
     }
 
     private static String configName(String... parts) {


### PR DESCRIPTION
The maven coordinates for jdks in the jdk download plugin contain a
group name local to our build. However, this still needs to be unique in
order for the group filtering to a single ivy repository to work. This
commit adjusts the group name to include both the jdk vendor as well as
major version.

Note: this change was already included in the backport of #53358