### PR TITLE
Remove extra code in allocation commands parsing

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
@@ -140,9 +140,6 @@ public class AllocationCommands implements ToXContentFragment {
             if (!parser.currentName().equals("commands")) {
                 throw new ElasticsearchParseException("expected field name to be named [commands], got [{}] instead", parser.currentName());
             }
-            if (!parser.currentName().equals("commands")) {
-                throw new ElasticsearchParseException("expected field name to be named [commands], got [{}] instead", parser.currentName());
-            }
             token = parser.nextToken();
             if (token != XContentParser.Token.START_ARRAY) {
                 throw new ElasticsearchParseException("commands should follow with an array element");


### PR DESCRIPTION
This commit removes some code that is duplicated in the parsing of allocation commands in the cluster reroute API.
