### PR TITLE
Fixed issuer of leaf certificate in case of intermediary, non-root CA

### DIFF
--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertGenUtils.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/CertGenUtils.java
@@ -175,7 +175,7 @@ public class CertGenUtils {
             if (caCert.getBasicConstraints() < 0) {
                 throw new IllegalArgumentException("ca certificate is not a CA!");
             }
-            issuer = X500Name.getInstance(caCert.getIssuerX500Principal().getEncoded());
+            issuer = X500Name.getInstance(caCert.getSubjectX500Principal().getEncoded());
             authorityKeyIdentifier = extUtils.createAuthorityKeyIdentifier(caCert.getPublicKey());
         } else {
             issuer = subject;


### PR DESCRIPTION
When using the elasticsearch-certutil utility with the `--ca-key` and `--ca-cert` options AND with a CA that is not a root but is an intermediate CA in a chain, the certutil utility uses the issuer of the intermediate CA as issuer of the leaf certificate. 

It should instead take the subject of the intermediate CA as issuer of the leaf certificate, since the issuer of the intermediate CA is the root CA. 