### PR TITLE
QL: Remove CONSTANT_KEYWORD from LiteralTests.java

### DIFF
--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/LiteralTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/expression/LiteralTests.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.xpack.ql.type.DataTypes.CONSTANT_KEYWORD;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BYTE;
 import static org.elasticsearch.xpack.ql.type.DataTypes.DOUBLE;
@@ -54,7 +53,7 @@ public class LiteralTests extends AbstractNodeTestCase<Literal, Expression> {
             new ValueAndCompatibleTypes(ESTestCase::randomLong, LONG, FLOAT, DOUBLE, BOOLEAN),
             new ValueAndCompatibleTypes(ESTestCase::randomFloat, FLOAT, LONG, DOUBLE, BOOLEAN),
             new ValueAndCompatibleTypes(ESTestCase::randomDouble, DOUBLE, LONG, FLOAT, BOOLEAN),
-            new ValueAndCompatibleTypes(() -> randomAlphaOfLength(5), KEYWORD, CONSTANT_KEYWORD));
+            new ValueAndCompatibleTypes(() -> randomAlphaOfLength(5), KEYWORD));
 
     public static Literal randomLiteral() {
         ValueAndCompatibleTypes gen = randomFrom(GENERATORS);


### PR DESCRIPTION
This is a follow small PR for https://github.com/elastic/elasticsearch/pull/53241, removing CONSTANT_KEYWORD from LiteralTests, as its presence there it's not relevant for the test itself. Without this code change, there are chances this test will fail similarly to https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request-2/18641/console.