### PR TITLE
[7.x] Disallow Password Change when authenticated by Token (#49694)

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -539,9 +539,12 @@ public class RBACEngine implements AuthorizationEngine {
         }
 
         assert realmType != null;
-        // ensure the user was authenticated by a realm that we can change a password for. The native realm is an internal realm and
-        // right now only one can exist in the realm configuration - if this changes we should update this check
-        return ReservedRealm.TYPE.equals(realmType) || NativeRealmSettings.TYPE.equals(realmType);
+        // Ensure that the user is not authenticated with an access token or an API key.
+        // Also ensure that the user was authenticated by a realm that we can change a password for. The native realm is an internal realm
+        // and right now only one can exist in the realm configuration - if this changes we should update this check
+        final Authentication.AuthenticationType authType = authentication.getAuthenticationType();
+        return (authType.equals(Authentication.AuthenticationType.REALM)
+            && (ReservedRealm.TYPE.equals(realmType) || NativeRealmSettings.TYPE.equals(realmType)));
     }
 
     static class RBACAuthorizationInfo implements AuthorizationInfo {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/change_password/11_token.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/change_password/11_token.yml
@@ -1,0 +1,67 @@
+---
+setup:
+  - skip:
+      features: headers
+  - do:
+      cluster.health:
+        wait_for_status: yellow
+  - do:
+      security.put_user:
+        username: "token_joe"
+        body:  >
+          {
+            "password": "s3krit",
+            "roles" : [ "token_admin" ]
+          }
+  - do:
+      security.put_role:
+        name: "token_admin"
+        body:  >
+          {
+            "cluster": ["manage_token"],
+            "indices": [
+              {
+                "names": "*",
+                "privileges": ["all"]
+              }
+            ]
+          }
+---
+teardown:
+  - do:
+      security.delete_user:
+        username: "token_joe"
+        ignore: 404
+  - do:
+      security.delete_role:
+        name: "token_admin"
+        ignore: 404
+
+---
+"Test user changing their password authenticating with token not allowed":
+
+  - do:
+      headers:
+        Authorization: "Basic dG9rZW5fam9lOnMza3JpdA=="
+      security.get_token:
+        body:
+          grant_type: "password"
+          username: "token_joe"
+          password: "s3krit"
+
+  - match: { type: "Bearer" }
+  - is_true: access_token
+  - set: { access_token: token }
+  - match: { expires_in: 1200 }
+  - is_false: scope
+
+  - do:
+      headers:
+        Authorization: Bearer ${token}
+      catch: forbidden
+      security.change_password:
+        username: "joe"
+        body:  >
+          {
+            "password" : "s3krit2"
+          }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disallow Password Change when authenticated by Token (#49694)