### PR TITLE
[7.x] Hide I/SLM history aliases (#53564)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/history/SnapshotHistoryStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/history/SnapshotHistoryStore.java
@@ -98,7 +98,8 @@ public class SnapshotHistoryStore {
             client.admin().indices().prepareCreate(initialHistoryIndexName)
                 .setWaitForActiveShards(1)
                 .addAlias(new Alias(SLM_HISTORY_ALIAS)
-                    .writeIndex(true))
+                    .writeIndex(true)
+                    .isHidden(true))
                 .execute(new ActionListener<CreateIndexResponse>() {
                     @Override
                     public void onResponse(CreateIndexResponse response) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/history/SnapshotLifecycleTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/history/SnapshotLifecycleTemplateRegistry.java
@@ -43,6 +43,11 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
 
     public static final String SLM_POLICY_NAME = "slm-history-ilm-policy";
 
+    @Override
+    protected boolean requiresMasterNode() {
+        return true;
+    }
+
     public static final IndexTemplateConfig TEMPLATE_SLM_HISTORY = new IndexTemplateConfig(
         SLM_TEMPLATE_NAME,
         "/slm-history.json",

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
@@ -187,7 +187,7 @@ public class ILMHistoryStore implements Closeable {
                 .setSettings((Map<String, ?>) templateAsMap.get("settings"))
                 .addMapping("_doc", (Map<String, Object>) templateAsMap.get("mappings"))
                 .setWaitForActiveShards(1)
-                .addAlias(new Alias(ILM_HISTORY_ALIAS).writeIndex(true))
+                .addAlias(new Alias(ILM_HISTORY_ALIAS).writeIndex(true).isHidden(true))
                 .execute(new ActionListener<CreateIndexResponse>() {
                     @Override
                     public void onResponse(CreateIndexResponse response) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
@@ -35,6 +35,11 @@ public class ILMHistoryTemplateRegistry extends IndexTemplateRegistry {
 
     public static final String ILM_POLICY_NAME = "ilm-history-ilm-policy";
 
+    @Override
+    protected boolean requiresMasterNode() {
+        return true;
+    }
+
     public static final IndexTemplateConfig TEMPLATE_ILM_HISTORY = new IndexTemplateConfig(
         ILM_TEMPLATE_NAME,
         "/ilm-history.json",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Hide I/SLM history aliases (#53564)