### PR TITLE
Fix sorting agg buckets by doc_count (backport of #53617)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
@@ -78,6 +78,10 @@ setup:
 
 ---
 "As a child of terms":
+  - skip:
+      version: " - 6.99.99"
+      reason: the test is written for hits.total.value
+
   - do:
       bulk:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
@@ -109,6 +109,10 @@ setup:
 
 ---
 "Sorting terms":
+  - skip:
+      version: " - 7.6.99"
+      reason: fixed in 7.7.0
+
   - do:
       bulk:
         refresh: true

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/50_filter.yml
@@ -14,10 +14,10 @@ setup:
                   type: keyword
 
   - do:
-        index:
-          index: test
-          id: foo|bar|baz0
-          body: { "notifications" : ["abc"] }
+      index:
+        index: test
+        id: foo|bar|baz0
+        body: { "notifications" : ["abc"] }
 
   - do:
       index:
@@ -75,3 +75,74 @@ setup:
   - match: { _all.total.request_cache.hit_count: 0 }
   - match: { _all.total.request_cache.miss_count: 1 }
   - is_true: indices.test
+
+---
+"As a child of terms":
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body: |
+          {"index":{}}
+          {"category": "bar", "val": 8}
+          {"index":{}}
+          {"category": "bar", "val": 0}
+  - do:
+      search:
+        size: 0
+        body:
+          aggs:
+            category:
+              terms:
+                field: category.keyword
+              aggs:
+                high:
+                  filter:
+                    range:
+                      val:
+                        gte: 7
+
+  - match: { hits.total.value: 4 }
+  - match: { aggregations.category.buckets.0.key: bar }
+  - match: { aggregations.category.buckets.0.doc_count: 2 }
+  - match: { aggregations.category.buckets.0.high.doc_count: 1 }
+
+---
+"Sorting terms":
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body: |
+          {"index":{}}
+          {"category": "foo", "val": 7}
+          {"index":{}}
+          {"category": "bar", "val": 8}
+          {"index":{}}
+          {"category": "bar", "val": 9}
+          {"index":{}}
+          {"category": "bar", "val": 0}
+  - do:
+      search:
+        size: 0
+        body:
+          aggs:
+            category:
+              terms:
+                field: category.keyword
+                order:
+                  high.doc_count: desc
+              aggs:
+                high:
+                  filter:
+                    range:
+                      val:
+                        gte: 7
+
+  - match: { hits.total.value: 6 }
+  - match: { aggregations.category.buckets.0.key: bar }
+  - match: { aggregations.category.buckets.0.doc_count: 3 }
+  - match: { aggregations.category.buckets.0.high.doc_count: 2 }
+  - match: { aggregations.category.buckets.1.key: foo }
+  - match: { aggregations.category.buckets.1.doc_count: 1 }
+  - match: { aggregations.category.buckets.1.high.doc_count: 1 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -176,7 +176,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
 
     @Override
     public BucketComparator bucketComparator(String key, SortOrder order) {
-        if (key == null || false == "doc_count".equals(key)) {
+        if (key == null || "doc_count".equals(key)) {
             return (lhs, rhs) -> order.reverseMul() * Integer.compare(bucketDocCount(lhs), bucketDocCount(rhs));
         }
         throw new IllegalArgumentException("Ordering on a single-bucket aggregation can only be done on its doc_count. " +


### PR DESCRIPTION
I broke sorting aggregations by `doc_count` in #51271 by mixing up true
and false. This flips that comparison and adds a few tests to double
check that we don't so this again.