### PR TITLE
Fix test for binary

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -89,7 +90,15 @@ public class XContentParserUtilsTests extends ESTestCase {
 
     public void testStoredFieldsValueBinary() throws IOException {
         final byte[] value = randomUnicodeOfLength(scaledRandomIntBetween(10, 1000)).getBytes("UTF-8");
-        assertParseFieldsSimpleValue(value, (xcontentType, result) -> assertArrayEquals(value, ((BytesArray) result).array()));
+        assertParseFieldsSimpleValue(value, (xcontentType, result) -> {
+            if (xcontentType == XContentType.JSON) {
+                // binary values will be parsed back and returned as base64 strings when reading from json
+                assertArrayEquals(value, Base64.getDecoder().decode((String) result));
+            } else {
+                // cbor, smile, and yaml support binary
+                assertArrayEquals(value, ((BytesArray) result).array());
+            }
+        });
     }
 
     public void testStoredFieldsValueNull() throws IOException {


### PR DESCRIPTION
We had updated the test when upgrading jackson because yaml now supports
binary. But json still doesn't. This updates the test to reflect that.

Closes #53624
