### PR TITLE
Fix assertion on byte array values reading YAML from MapXContentParser

### DIFF
--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/MapXContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/MapXContentParserTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.xcontent.support.MapXContentParser;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentParserTests.generateRandomObject;
@@ -73,7 +74,13 @@ public class MapXContentParserTests extends ESTestCase {
     }
 
     public void compareTokens(CheckedConsumer<XContentBuilder, IOException> consumer) throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
+        for (XContentType xContentType : EnumSet.allOf(XContentType.class)) {
+            logger.info("--> testing with xcontent type: {}", xContentType);
+            compareTokens(consumer, xContentType);
+        }
+    }
+
+    public void compareTokens(CheckedConsumer<XContentBuilder, IOException> consumer, XContentType xContentType) throws IOException {
         try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
             consumer.accept(builder);
             final Map<String, Object> map;
@@ -94,7 +101,13 @@ public class MapXContentParserTests extends ESTestCase {
                         assertEquals(token, mapToken);
                         assertEquals(parser.currentName(), mapParser.currentName());
                         if (token != null && (token.isValue() || token == XContentParser.Token.VALUE_NULL)) {
-                            assertEquals(parser.textOrNull(), mapParser.textOrNull());
+                            if (xContentType != XContentType.YAML || token != XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
+                                // YAML struggles with converting byte arrays into text, because it
+                                // does weird base64 decoding to the values. We don't do this
+                                // weirdness in the MapXContentParser, so don't try to stringify it.
+                                // The .binaryValue() comparison below still works correctly though.
+                                assertEquals(parser.textOrNull(), mapParser.textOrNull());
+                            }
                             switch (token) {
                                 case VALUE_STRING:
                                     assertEquals(parser.text(), mapParser.text());


### PR DESCRIPTION
Jackson's YAML parser does weirdness with a custom base64 decoding when trying to "read" text (using
`.text()` or `.textOrNull()`) from a YAML byte array. Because of this, we need to skip comparing
these fields with `.textOrNull`, instead using the correct `.binaryValue()` comparison.

This also removes the "randomly pick an xcontent type" and switches it to just test every type.

Resolves #53622