### PR TITLE
Add server name to remote info API

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/cluster/ProxyModeInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/cluster/ProxyModeInfo.java
@@ -24,14 +24,17 @@ import java.util.Objects;
 public class ProxyModeInfo implements RemoteConnectionInfo.ModeInfo {
     static final String NAME = "proxy";
     static final String PROXY_ADDRESS = "proxy_address";
+    static final String SERVER_NAME = "server_name";
     static final String NUM_PROXY_SOCKETS_CONNECTED = "num_proxy_sockets_connected";
     static final String MAX_PROXY_SOCKET_CONNECTIONS = "max_proxy_socket_connections";
     private final String address;
+    private final String serverName;
     private final int maxSocketConnections;
     private final int numSocketsConnected;
 
-    ProxyModeInfo(String address, int maxSocketConnections, int numSocketsConnected) {
+    ProxyModeInfo(String address, String serverName, int maxSocketConnections, int numSocketsConnected) {
         this.address = address;
+        this.serverName = serverName;
         this.maxSocketConnections = maxSocketConnections;
         this.numSocketsConnected = numSocketsConnected;
     }
@@ -50,6 +53,10 @@ public class ProxyModeInfo implements RemoteConnectionInfo.ModeInfo {
         return address;
     }
 
+    public String getServerName() {
+        return serverName;
+    }
+
     public int getMaxSocketConnections() {
         return maxSocketConnections;
     }
@@ -65,11 +72,12 @@ public class ProxyModeInfo implements RemoteConnectionInfo.ModeInfo {
         ProxyModeInfo otherProxy = (ProxyModeInfo) o;
         return maxSocketConnections == otherProxy.maxSocketConnections &&
                 numSocketsConnected == otherProxy.numSocketsConnected &&
-                Objects.equals(address, otherProxy.address);
+                Objects.equals(address, otherProxy.address) &&
+                Objects.equals(serverName, otherProxy.serverName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(address, maxSocketConnections, numSocketsConnected);
+        return Objects.hash(address, serverName, maxSocketConnections, numSocketsConnected);
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/cluster/RemoteConnectionInfo.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/cluster/RemoteConnectionInfo.java
@@ -48,9 +48,9 @@ public final class RemoteConnectionInfo {
                 String mode = (String) args[1];
                 ModeInfo modeInfo;
                 if (mode.equals(ProxyModeInfo.NAME)) {
-                    modeInfo = new ProxyModeInfo((String) args[4], (int) args[5], (int) args[6]);
+                    modeInfo = new ProxyModeInfo((String) args[4], (String) args[5], (int) args[6], (int) args[7]);
                 } else if (mode.equals(SniffModeInfo.NAME)) {
-                    modeInfo = new SniffModeInfo((List<String>) args[7], (int) args[8], (int) args[9]);
+                    modeInfo = new SniffModeInfo((List<String>) args[8], (int) args[9], (int) args[10]);
                 } else {
                     throw new IllegalArgumentException("mode cannot be " + mode);
                 }
@@ -67,6 +67,7 @@ public final class RemoteConnectionInfo {
         PARSER.declareBoolean(constructorArg(), new ParseField(SKIP_UNAVAILABLE));
 
         PARSER.declareString(optionalConstructorArg(), new ParseField(ProxyModeInfo.PROXY_ADDRESS));
+        PARSER.declareString(optionalConstructorArg(), new ParseField(ProxyModeInfo.SERVER_NAME));
         PARSER.declareInt(optionalConstructorArg(), new ParseField(ProxyModeInfo.MAX_PROXY_SOCKET_CONNECTIONS));
         PARSER.declareInt(optionalConstructorArg(), new ParseField(ProxyModeInfo.NUM_PROXY_SOCKETS_CONNECTED));
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/cluster/RemoteInfoResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/cluster/RemoteInfoResponseTests.java
@@ -83,6 +83,7 @@ public class RemoteInfoResponseTests extends AbstractResponseTestCase<org.elasti
                 ProxyConnectionStrategy.ProxyModeInfo serverModeInfo =
                         (ProxyConnectionStrategy.ProxyModeInfo) serverRemoteInfo.getModeInfo();
                 assertThat(clientModeInfo.getAddress(), equalTo(serverModeInfo.getAddress()));
+                assertThat(clientModeInfo.getServerName(), equalTo(serverModeInfo.getServerName()));
                 assertThat(clientModeInfo.getMaxSocketConnections(), equalTo(serverModeInfo.getMaxSocketConnections()));
                 assertThat(clientModeInfo.getNumSocketsConnected(), equalTo(serverModeInfo.getNumSocketsConnected()));
             } else {
@@ -95,9 +96,10 @@ public class RemoteInfoResponseTests extends AbstractResponseTestCase<org.elasti
         RemoteConnectionInfo.ModeInfo modeInfo;
         if (randomBoolean()) {
             String address = randomAlphaOfLength(8);
+            String serverName = randomAlphaOfLength(8);
             int maxSocketConnections = randomInt(5);
             int numSocketsConnected = randomInt(5);
-            modeInfo = new ProxyConnectionStrategy.ProxyModeInfo(address, maxSocketConnections, numSocketsConnected);
+            modeInfo = new ProxyConnectionStrategy.ProxyModeInfo(address, serverName, maxSocketConnections, numSocketsConnected);
         } else {
             List<String> seedNodes = randomList(randomInt(8), () -> randomAlphaOfLength(8));
             int maxConnectionsPerCluster = randomInt(5);

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -346,6 +346,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
 
     public void testRemoteConnectionInfo() throws IOException {
         List<String> remoteAddresses = Collections.singletonList("seed:1");
+        String serverName = "the_server_name";
 
         RemoteConnectionInfo.ModeInfo modeInfo1;
         RemoteConnectionInfo.ModeInfo modeInfo2;
@@ -354,8 +355,8 @@ public class RemoteClusterConnectionTests extends ESTestCase {
             modeInfo1 = new SniffConnectionStrategy.SniffModeInfo(remoteAddresses, 4, 4);
             modeInfo2 = new SniffConnectionStrategy.SniffModeInfo(remoteAddresses, 4, 3);
         } else {
-            modeInfo1 = new ProxyConnectionStrategy.ProxyModeInfo(remoteAddresses.get(0), 18, 18);
-            modeInfo2 = new ProxyConnectionStrategy.ProxyModeInfo(remoteAddresses.get(0), 18, 17);
+            modeInfo1 = new ProxyConnectionStrategy.ProxyModeInfo(remoteAddresses.get(0), serverName, 18, 18);
+            modeInfo2 = new ProxyConnectionStrategy.ProxyModeInfo(remoteAddresses.get(0), serverName,18, 17);
         }
 
         RemoteConnectionInfo stats =
@@ -395,6 +396,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
 
     public void testRenderConnectionInfoXContent() throws IOException {
         List<String> remoteAddresses = Arrays.asList("seed:1", "seed:2");
+        String serverName = "the_server_name";
 
         RemoteConnectionInfo.ModeInfo modeInfo;
 
@@ -402,7 +404,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
         if (sniff) {
             modeInfo = new SniffConnectionStrategy.SniffModeInfo(remoteAddresses, 3, 2);
         } else {
-            modeInfo = new ProxyConnectionStrategy.ProxyModeInfo(remoteAddresses.get(0), 18, 16);
+            modeInfo = new ProxyConnectionStrategy.ProxyModeInfo(remoteAddresses.get(0), serverName,18, 16);
         }
 
         RemoteConnectionInfo stats = new RemoteConnectionInfo("test_cluster", modeInfo, TimeValue.timeValueMinutes(30), true);
@@ -418,8 +420,8 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                 "\"skip_unavailable\":true}}", Strings.toString(builder));
         } else {
             assertEquals("{\"test_cluster\":{\"connected\":true,\"mode\":\"proxy\",\"proxy_address\":\"seed:1\"," +
-                "\"num_proxy_sockets_connected\":16,\"max_proxy_socket_connections\":18,\"initial_connect_timeout\":\"30m\"," +
-                "\"skip_unavailable\":true}}", Strings.toString(builder));
+                "\"server_name\":\"the_server_name\",\"num_proxy_sockets_connected\":16,\"max_proxy_socket_connections\":18,"+
+                "\"initial_connect_timeout\":\"30m\",\"skip_unavailable\":true}}", Strings.toString(builder));
         }
     }
 


### PR DESCRIPTION
This commit adds the configured server_name to the proxy mode info so that it can be exposed in the remote info API.
