### PR TITLE
Improve performance of docs snippet length checkstyle rule

### DIFF
--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -26,7 +26,7 @@
   -->
   <module name="RegexpMultiline">
     <property name="id" value="SnippetLength"/>
-    <property name="format" value="^( *)\/\/\s*tag(.+)\s*\n(.*\n)*\1.{77,}\n(.*\n)*\1\/\/\s*end\2\s*$"/>
+    <property name="format" value="^( *?)//\s*?tag(.+?)\s*?\n(.*?\n)*?\1.{77,}?\n(.*?\n)*?\1//\s*?end\2\s*$"/>
     <property name="fileExtensions" value="java"/>
     <property name="message" value="Code snippets longer than 76 characters get cut off when rendered in the docs"/>
   </module>


### PR DESCRIPTION
The multiline regex rule used to detect docs code snippets greater than
76 characters in length has considerable cost to. For the high level
rest client project alone, this was taking upwards of 3 minutes. This
commit updates the rule regex pattern to use non-greedy matching when
appropriate which results in a lot fewer backtracks and about a 70%
reduction in execution time on the high level rest client module.

Closes #53623 