### PR TITLE
[DOCS] Adds example links to transform tutorial

### DIFF
--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -268,3 +268,7 @@ TIP: If you do not want to keep the {transform}, you can delete it in
 <<delete-transform,delete {transform} API>>. When
 you delete a {transform}, its destination index and {kib} index
 patterns remain.
+
+Now that you've created a simple {transform} for {kib} sample data, consider
+possible use cases for your own data. For more information, see
+<<transform-usage>> and <<transform-examples>>.

--- a/docs/reference/transform/ecommerce-tutorial.asciidoc
+++ b/docs/reference/transform/ecommerce-tutorial.asciidoc
@@ -270,5 +270,5 @@ you delete a {transform}, its destination index and {kib} index
 patterns remain.
 
 Now that you've created a simple {transform} for {kib} sample data, consider
-possible use cases for your own data. For more information, see
+possible use cases for your own data. For more ideas, see
 <<transform-usage>> and <<transform-examples>>.


### PR DESCRIPTION
This PR adds a link from the transform tutorial (https://www.elastic.co/guide/en/elasticsearch/reference/current/ecommerce-transforms.html) to the examples (https://www.elastic.co/guide/en/elasticsearch/reference/current/transform-examples.html).

Preview: http://elasticsearch_53640.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ecommerce-transforms.html