### PR TITLE
Update the Skip version in hidden index YAML tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/40_hidden.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.aliases/40_hidden.yml
@@ -1,9 +1,8 @@
 ---
 "Test cat aliases output with a hidden index with a hidden alias":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices and aliases were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
 
   - do:
       indices.create:
@@ -59,9 +58,8 @@
 ---
 "Test cat aliases output with a hidden index with a visible alias":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices and aliases were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
 
   - do:
       indices.create:
@@ -106,9 +104,8 @@
 ---
 "Test cat aliases output with a visible index with a hidden alias":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices and aliases were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/20_hidden.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/20_hidden.yml
@@ -1,9 +1,8 @@
 ---
 "Test cat indices output for hidden index":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
   - do:
       indices.create:
         index: index1
@@ -40,9 +39,8 @@
 ---
 "Test cat indices output for dot-hidden index and dot-prefixed pattern":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
   - do:
       indices.create:
         index: .index1
@@ -79,9 +77,8 @@
 ---
 "Test cat indices output with a hidden index with a visible alias":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
 
   - do:
       indices.create:
@@ -142,9 +139,8 @@
 ---
 "Test cat indices output with a hidden index with a hidden alias":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices and aliases were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
 
   - do:
       indices.create:
@@ -203,9 +199,8 @@
 ---
 "Test cat indices output with a hidden index, dot-hidden alias and dot pattern":
   - skip:
-      version: "- 7.99.99"
+      version: "- 7.6.99"
       reason: "hidden indices and aliases were added in 7.7.0"
-      # TODO: Update this in/after backport of https://github.com/elastic/elasticsearch/pull/53248
 
   - do:
       indices.create:


### PR DESCRIPTION
This commit adjusts the version ranges used for the _cat API hidden
index/alias tests.

These changes were already made in 7.x as part of the backport of https://github.com/elastic/elasticsearch/pull/53248, this is just updating them in master.