### PR TITLE
Fix testToAndFromXContentEmbedded after Jackson upgrade

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
@@ -136,8 +136,8 @@ public final class RandomObjects {
      */
     public static Object getExpectedParsedValue(XContentType xContentType, Object value) {
         if (value instanceof BytesArray) {
-            if (xContentType == XContentType.JSON || xContentType == XContentType.YAML) {
-                //JSON and YAML write the base64 format
+            if (xContentType == XContentType.JSON) {
+                //JSON writes base64 format
                 return Base64.getEncoder().encodeToString(((BytesArray)value).toBytesRef().bytes);
             }
         }


### PR DESCRIPTION
With the upgrade from Jackson 2.8.11 to 2.10.3 there is no longer a
need to Base64 encode BytesArray for comparing YAML serializations.

Fixes #53625
