### PR TITLE
Fix deprecation in history retention docs

### DIFF
--- a/docs/reference/index-modules/history-retention.asciidoc
+++ b/docs/reference/index-modules/history-retention.asciidoc
@@ -54,7 +54,7 @@ reasonable recovery scenarios.
 
 `index.soft_deletes.enabled`::
 
-  deprecated[7.6.0, Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.]
+  deprecated:[7.6.0, Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.]
   Whether or not soft deletes are enabled on the index. Soft deletes can only be
   configured at index creation and only on indices created on or after 6.5.0.
   The default value is `true`.

--- a/docs/reference/index-modules/history-retention.asciidoc
+++ b/docs/reference/index-modules/history-retention.asciidoc
@@ -54,7 +54,7 @@ reasonable recovery scenarios.
 
 `index.soft_deletes.enabled`::
 
-  deprecated[7.6, Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.]
+  deprecated[7.6.0, Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.]
   Whether or not soft deletes are enabled on the index. Soft deletes can only be
   configured at index creation and only on indices created on or after 6.5.0.
   The default value is `true`.

--- a/docs/reference/index-modules/history-retention.asciidoc
+++ b/docs/reference/index-modules/history-retention.asciidoc
@@ -54,12 +54,11 @@ reasonable recovery scenarios.
 
 `index.soft_deletes.enabled`::
 
+  deprecated[7.6, Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions.]
   Whether or not soft deletes are enabled on the index. Soft deletes can only be
   configured at index creation and only on indices created on or after 6.5.0.
   The default value is `true`.
 
-  deprecated::[7.6, Creating indices with soft-deletes disabled is
-  deprecated and will be removed in future Elasticsearch versions.]
 
 `index.soft_deletes.retention_lease.period`::
 


### PR DESCRIPTION
This commit adjusts a `deprecation[...]` message in the docs since such
messages must be on a single line. It also moves this message to the start of
the description of the deprecated setting as is the case with other such
messages.