### PR TITLE
[Transform] change response codes if allocation fails

### DIFF
--- a/docs/changelog/53657.yaml
+++ b/docs/changelog/53657.yaml
@@ -1,0 +1,6 @@
+pr: 53657
+summary: Change response codes if allocation fails
+area: Transform
+type: bug
+issues:
+ - 52825

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -430,7 +430,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 // Consider this a failure.
                 exception = new ElasticsearchStatusException(
                     "Could not start transform, allocation explanation [" + assignment.getExplanation() + "]",
-                    RestStatus.TOO_MANY_REQUESTS
+                    RestStatus.CONFLICT
                 );
                 return true;
             }


### PR DESCRIPTION
change response codes for transform if allocation fails on start due to
persistent tasks disabled

fixes #52825