### PR TITLE
[ML] change response code if allocation fails at start of analytics job

### DIFF
--- a/docs/changelog/53658.yaml
+++ b/docs/changelog/53658.yaml
@@ -1,0 +1,6 @@
+pr: 53658
+summary: Change response code if allocation fails at start of analytics job
+area: Machine Learning
+type: bug
+issues:
+ - 52826

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -422,7 +422,7 @@ public class TransportStartDataFrameAnalyticsAction
                             new ElasticsearchStatusException(
                                 "Could not start data frame analytics task, timed out after [{}] waiting for task assignment. "
                                     + "Assignment explanation [{}]",
-                                RestStatus.TOO_MANY_REQUESTS,
+                                RestStatus.CONFLICT,
                                 timeout,
                                 predicate.assignmentExplanation),
                             listener);


### PR DESCRIPTION
change response codes for dfa if allocation fails on start due to
persistent tasks disabled

fixes #52826