### PR TITLE
Adapt serialization version checks in ShardSearchRequest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,8 +221,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/53659" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -179,12 +179,9 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         preference = in.readOptionalString();
         if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             canReturnNullResponseIfMatchNoDocs = in.readBoolean();
-        } else {
-            canReturnNullResponseIfMatchNoDocs = false;
-        }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
             bottomSortValues = in.readOptionalWriteable(SearchSortValuesAndFormats::new);
         } else {
+            canReturnNullResponseIfMatchNoDocs = false;
             bottomSortValues = null;
         }
         originalIndices = OriginalIndices.readOriginalIndices(in);
@@ -223,8 +220,6 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         }
         if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
             out.writeBoolean(canReturnNullResponseIfMatchNoDocs);
-        }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
             out.writeOptionalWriteable(bottomSortValues);
         }
     }


### PR DESCRIPTION
This change adapts the serialization checks to 7.7.0 in order to cope with #53659.
Note that this commit also disables the bwc tests temporarily in order to be able to
merge #53659 first.

Relates #51852