### PR TITLE
Drop Eclipse instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,9 +111,9 @@ using the wrapper via the `gradlew` script on Unix systems or `gradlew.bat`
 script on Windows in the root of the repository. The examples below show the
 usage on Unix.
 
-We support development in the Eclipse and IntelliJ IDEs.
-For Eclipse, the minimum version that we support is [4.13][eclipse].
-For IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij].
+We support development in IntelliJ versions [IntelliJ 2017.2][intellij] and
+onwards. We would like to support Eclipse, but few of us use it and has fallen
+into [disrepair][eclipse].
 
 [Docker](https://docs.docker.com/install/) is required for building some Elasticsearch artifacts and executing certain test suites. You can run Elasticsearch without building all the artifacts with:
 
@@ -124,11 +124,6 @@ You can access Elasticsearch with:
     curl -u elastic:password localhost:9200
 
 ### Configuring IDEs And Running Tests
-
-Eclipse users can automatically configure their IDE: `./gradlew eclipse`
-then `File: Import: Gradle : Existing Gradle Project`.
-Additionally you will want to ensure that Eclipse is using 2048m of heap by modifying
-`eclipse.ini` accordingly to avoid GC overhead and OOM errors.
 
 IntelliJ users can automatically configure their IDE: `./gradlew idea`
 then `File->New Project From Existing Sources`. Point to the root of
@@ -154,16 +149,13 @@ The Elasticsearch codebase makes heavy use of Java `assert`s and the
 test runner requires that assertions be enabled within the JVM. This
 can be accomplished by passing the flag `-ea` to the JVM on startup.
 
-For IntelliJ, go to
+You can enable these in IntelliJ by going to
 `Run->Edit Configurations...->Defaults->JUnit->VM options` and input
 `-ea`.
 
-For Eclipse, go to `Preferences->Java->Installed JREs` and add `-ea` to
-`VM Arguments`.
-
 Some tests related to locale testing also require the flag
 `-Djava.locale.providers` to be set. Set the VM options/VM arguments for
-IntelliJ or Eclipse like describe above to use
+IntelliJ like describe above to use
 `-Djava.locale.providers=SPI,COMPAT`.
 
 ### REST Endpoint Conventions
@@ -213,9 +205,6 @@ Please follow these formatting guidelines:
   of the code, while keeping lines to maximum length of 76 characters.
 * Wildcard imports (`import foo.bar.baz.*`) are forbidden and will cause
   the build to fail. This can be done automatically by your IDE:
-   * Eclipse: `Preferences->Java->Code Style->Organize Imports`. There are
-     two boxes labeled "`Number of (static )? imports needed for .*`". Set
-     their values to 99999 or some other absurdly high value.
    * IntelliJ: `Preferences/Settings->Editor->Code Style->Java->Imports`.
      There are two configuration options: `Class count to use import with
      '*'` and `Names count to use static import with '*'`. Set their values
@@ -233,9 +222,6 @@ Please follow these formatting guidelines:
   reviews as something to change.
 
 #### Editor / IDE Support
-
-Eclipse IDEs can import the file [.eclipseformat.xml]
-directly.
 
 IntelliJ IDEs can
 [import](https://blog.jetbrains.com/idea/2014/01/intellij-idea-13-importing-code-formatter-settings-from-eclipse/)
@@ -608,6 +594,5 @@ Finally, we require that you run `./gradlew check` before submitting a
 non-documentation contribution. This is mentioned above, but it is worth
 repeating in this section because it has come up in this context.
 
-[eclipse]: https://download.eclipse.org/eclipse/downloads/drops4/R-4.13-201909161045/
 [intellij]: https://blog.jetbrains.com/idea/2017/07/intellij-idea-2017-2-is-here-smart-sleek-and-snappy/
-[shadow-plugin]: https://github.com/johnrengelman/shadow
+[eclipse]: https://github.com/elastic/elasticsearch/issues/53664


### PR DESCRIPTION
Hacking Elasticsearch with Eclipse is fairly broken. Some things work,
but we can't in good concience point contributors to Eclipse. This drops
the instrucions for Eclipse from CONTRIBUTING.md. We *do* want to fix
Eclipse. But we don't see that happening in the next few months. Once we
*have* fixed Eclipse we'll rewrite the instructions.

Relates #53664
