### PR TITLE
Increase timeout for ES startup checks on Docker

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Docker.java
@@ -61,6 +61,8 @@ public class Docker {
 
     private static final Shell sh = new Shell();
     private static final DockerShell dockerShell = new DockerShell();
+    public static final int STARTUP_SLEEP_INTERVAL_MILLISECONDS = 1000;
+    public static final int STARTUP_ATTEMPTS_MAX = 10;
 
     /**
      * Tracks the currently running Docker image. An earlier implementation used a fixed container name,
@@ -178,7 +180,7 @@ public class Docker {
         do {
             try {
                 // Give the container a chance to crash out
-                Thread.sleep(1000);
+                Thread.sleep(STARTUP_SLEEP_INTERVAL_MILLISECONDS);
 
                 psOutput = dockerShell.run("ps -ww ax").stdout;
 
@@ -189,7 +191,7 @@ public class Docker {
             } catch (Exception e) {
                 logger.warn("Caught exception while waiting for ES to start", e);
             }
-        } while (attempt++ < 5);
+        } while (attempt++ < STARTUP_ATTEMPTS_MAX);
 
         if (isElasticsearchRunning == false) {
             final Shell.Result dockerLogs = getContainerLogs();


### PR DESCRIPTION
We're seeing some timeout failures on certain DockerTests in the qa/os project. This commit changes the 7.6 branch to match what's on 7.7 and master.

This backports a bit of code that came in with the password-protected keystore in #51123.

Closes #53662