### PR TITLE
Increase step between checks for cancellation

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
@@ -245,7 +245,7 @@ class ExitableDirectoryReader extends FilterDirectoryReader {
 
     private static class ExitableIntersectVisitor implements PointValues.IntersectVisitor {
 
-        private static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = (1 << 4) - 1; // 15
+        private static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = 1 << 10; // 1024
 
         private final PointValues.IntersectVisitor in;
         private final QueryCancellation queryCancellation;

--- a/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
@@ -245,7 +245,7 @@ class ExitableDirectoryReader extends FilterDirectoryReader {
 
     private static class ExitableIntersectVisitor implements PointValues.IntersectVisitor {
 
-        private static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = 1 << 10; // 1024
+        private static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = (1 << 10) - 1; // 1023
 
         private final PointValues.IntersectVisitor in;
         private final QueryCancellation queryCancellation;


### PR DESCRIPTION
The introduction of the ExitableDirectoryReader showed increase of 
latencies for range queries using pointvalues. 

Check for cancellation every 1024 docs instead of every 15 to lower
the impact of the check in query's performance.

Follows: #52822
Fixes: #53496
