### PR TITLE
Fix highlighter support in PinnedQuery and added test

### DIFF
--- a/x-pack/plugin/search-business-rules/src/main/java/org/apache/lucene/search/CappedScoreQuery.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/apache/lucene/search/CappedScoreQuery.java
@@ -35,7 +35,7 @@ public final class CappedScoreQuery extends Query {
 
     @Override
     public void visit(QueryVisitor visitor) {
-        query.visit(visitor);
+        query.visit(visitor.getSubVisitor(BooleanClause.Occur.MUST, this));
     }
 
     @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/apache/lucene/search/CappedScoreQuery.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/apache/lucene/search/CappedScoreQuery.java
@@ -34,6 +34,11 @@ public final class CappedScoreQuery extends Query {
     }
 
     @Override
+    public void visit(QueryVisitor visitor) {
+        query.visit(visitor);
+    }
+
+    @Override
     public Query rewrite(IndexReader reader) throws IOException {
         Query rewritten = query.rewrite(reader);
 


### PR DESCRIPTION
CappedScoreQuery was missing visit(QueryVisitor visitor) delegation to wrapped query.
Closes #53699 