### PR TITLE
Allow static cluster.max_voting_config_exclusions

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -39,8 +39,10 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -60,11 +62,21 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
     public static final Setting<Integer> MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING
         = Setting.intSetting("cluster.max_voting_config_exclusions", 10, 1, Property.Dynamic, Property.NodeScope);
 
+    private volatile int maxVotingConfigExclusions;
+
     @Inject
-    public TransportAddVotingConfigExclusionsAction(TransportService transportService, ClusterService clusterService, ThreadPool threadPool,
-                                                    ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+    public TransportAddVotingConfigExclusionsAction(Settings settings, ClusterSettings clusterSettings, TransportService transportService,
+                                                    ClusterService clusterService, ThreadPool threadPool, ActionFilters actionFilters,
+                                                    IndexNameExpressionResolver indexNameExpressionResolver) {
         super(AddVotingConfigExclusionsAction.NAME, transportService, clusterService, threadPool, actionFilters,
             AddVotingConfigExclusionsRequest::new, indexNameExpressionResolver);
+
+        maxVotingConfigExclusions = MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING, this::setMaxVotingConfigExclusions);
+    }
+
+    private void setMaxVotingConfigExclusions(int maxVotingConfigExclusions) {
+        this.maxVotingConfigExclusions = maxVotingConfigExclusions;
     }
 
     @Override
@@ -81,7 +93,8 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
     protected void masterOperation(Task task, AddVotingConfigExclusionsRequest request, ClusterState state,
                                    ActionListener<AddVotingConfigExclusionsResponse> listener) throws Exception {
 
-        resolveVotingConfigExclusionsAndCheckMaximum(request, state); // throws IAE if no nodes matched or maximum exceeded
+        resolveVotingConfigExclusionsAndCheckMaximum(request, state, maxVotingConfigExclusions);
+        // throws IAE if no nodes matched or maximum exceeded
 
         clusterService.submitStateUpdateTask("add-voting-config-exclusions", new ClusterStateUpdateTask(Priority.URGENT) {
 
@@ -90,14 +103,14 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
             @Override
             public ClusterState execute(ClusterState currentState) {
                 assert resolvedExclusions == null : resolvedExclusions;
-                resolvedExclusions = resolveVotingConfigExclusionsAndCheckMaximum(request, currentState);
+                final int finalMaxVotingConfigExclusions = TransportAddVotingConfigExclusionsAction.this.maxVotingConfigExclusions;
+                resolvedExclusions = resolveVotingConfigExclusionsAndCheckMaximum(request, currentState, finalMaxVotingConfigExclusions);
 
                 final CoordinationMetaData.Builder builder = CoordinationMetaData.builder(currentState.coordinationMetaData());
                 resolvedExclusions.forEach(builder::addVotingConfigExclusion);
                 final MetaData newMetaData = MetaData.builder(currentState.metaData()).coordinationMetaData(builder.build()).build();
                 final ClusterState newState = ClusterState.builder(currentState).metaData(newMetaData).build();
-                assert newState.getVotingConfigExclusions().size() <= MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.get(
-                    currentState.metaData().settings());
+                assert newState.getVotingConfigExclusions().size() <= finalMaxVotingConfigExclusions;
                 return newState;
             }
 
@@ -149,9 +162,10 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
     }
 
     private static Set<VotingConfigExclusion> resolveVotingConfigExclusionsAndCheckMaximum(AddVotingConfigExclusionsRequest request,
-                                                                                           ClusterState state) {
-        return request.resolveVotingConfigExclusionsAndCheckMaximum(state,
-            MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.get(state.metaData().settings()), MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.getKey());
+                                                                                           ClusterState state,
+                                                                                           int maxVotingConfigExclusions) {
+        return request.resolveVotingConfigExclusionsAndCheckMaximum(state, maxVotingConfigExclusions,
+            MAXIMUM_VOTING_CONFIG_EXCLUSIONS_SETTING.getKey());
     }
 
     @Override


### PR DESCRIPTION
Today we only read `cluster.max_voting_config_exclusions` from the dynamic
settings in the cluster metadata, ignoring any value set in
`elasticsearch.yml`. This commit addresses this.

Closes #53455