### PR TITLE
TermsLookup uses ObjectParser for x-content parsing

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -76,6 +78,17 @@ public class TermsLookupTests extends ESTestCase {
                 assertNotSame(deserializedLookup, termsLookup);
             }
         }
+    }
+
+    public void testXContentParsing() throws IOException {
+        XContentParser parser = createParser(JsonXContent.jsonXContent,
+            "{ \"index\" : \"index\", \"id\" : \"id\", \"path\" : \"path\", \"routing\" : \"routing\" }");
+
+        TermsLookup tl = TermsLookup.parseTermsLookup(parser);
+        assertEquals("index", tl.index());
+        assertEquals("id", tl.id());
+        assertEquals("path", tl.path());
+        assertEquals("routing", tl.routing());
     }
 
     public static TermsLookup randomTermsLookup() {


### PR DESCRIPTION
This commit refactors the `fromXContent` method in `TermsLookup` to use an
`ObjectParser` and adds an explicit parsing test.

Related to #53731 