### PR TITLE
[DOCS] Add temporary redirect for missing component template API docs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -380,3 +380,8 @@ See <<ccs-gateway-seed-nodes>> and <<ccs-min-roundtrips>>.
 === Asynchronous search
 
 coming::[7.x]
+
+[role="exclude",id="indices-component-templates"]
+=== Component template APIs
+
+coming::[7.x]


### PR DESCRIPTION
The following API spec files contain a link to a not-yet-created
doc page for the component template APIs:

* [cluster.delete_component_template.json][0]
* [cluster.get_component_template.json][1]
* [cluster.put_component_template.json][2]

The Elaticsearch-js client uses these spec files to create their docs.
This created a broken link in the Elaticsearch-js, which has broken
the docs build.

This PR adds a temporary redirect for the docs page. This redirect
should be removed when the actual API docs are added.

[0]: https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
[1]: https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
[2]: https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json

Relates to #53558.

CC @dakrone  @martijnvg 
