### PR TITLE
[DOCS] Adds stub for cat transform API

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -255,16 +255,18 @@ include::cat/recovery.asciidoc[]
 
 include::cat/repositories.asciidoc[]
 
-include::cat/tasks.asciidoc[]
-
-include::cat/thread_pool.asciidoc[]
-
-include::cat/trainedmodel.asciidoc[]
-
 include::cat/shards.asciidoc[]
 
 include::cat/segments.asciidoc[]
 
 include::cat/snapshots.asciidoc[]
 
+include::cat/tasks.asciidoc[]
+
 include::cat/templates.asciidoc[]
+
+include::cat/thread_pool.asciidoc[]
+
+include::cat/trainedmodel.asciidoc[]
+
+include::cat/transform.asciidoc[]

--- a/docs/reference/cat/transform.asciidoc
+++ b/docs/reference/cat/transform.asciidoc
@@ -1,0 +1,28 @@
+[[cat-transform]]
+=== cat transform API
+++++
+<titleabbrev>cat transform</titleabbrev>
+++++
+
+Returns configuration and usage information about {transforms}.
+
+
+[[cat-transform-api-request]]
+==== {api-request-title}
+
+`GET /_cat/transform`
+
+
+//[[cat-transform-api-desc]]
+//==== {api-description-title}
+
+
+//[[cat-transform-api-query-params]]
+//==== {api-query-parms-title}
+
+
+//[[cat-transform-api-response-codes]]
+//==== {api-response-codes-title}
+
+//[[cat-transform-api-examples]]
+//==== {api-examples-title}


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/53643

The documentation build is failing as follows:

> 07:37:09 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/master/api-reference.html:
07:37:09 INFO:build_docs:   - en/elasticsearch/reference/master/cat-transform.html

Therefore this PR creates a quick draft of the missing page, which will be augmented later.