### PR TITLE
Upgrade the bundled JDK to JDK 14

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.0.0
 lucene            = 8.5.0-snapshot-7f057455901
 
 bundled_jdk_vendor = adoptopenjdk
-bundled_jdk = 13.0.2+8
+bundled_jdk = 14+36
 
 # optional dependencies
 spatial4j         = 0.7


### PR DESCRIPTION
This commit upgrades the bundled JDK to JDK 14.

Closes #53575 