### PR TITLE
[DOCS] Remove incorrect parms from put index template API docs

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -93,8 +93,6 @@ Name of the index template to create.
 If `true`, this request cannot replace or update existing index templates.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
-
 `order`::
 (Optional,integer)
 Order in which {es} applies this template
@@ -104,7 +102,7 @@ Templates with lower `order` values are merged first.
 Templates with higher `order` values are merged later,
 overriding templates with lower values.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[put-index-template-api-request-body]]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -35,7 +35,7 @@
       "master_timeout":{
         "type":"time",
         "description":"Specify timeout for connection to master"
-      },
+      }
     },
     "body":{
       "description":"The template definition",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -32,18 +32,10 @@
         "description":"Whether the index template should only be added if new or can also replace an existing one",
         "default":false
       },
-      "timeout":{
-        "type":"time",
-        "description":"Explicit operation timeout"
-      },
       "master_timeout":{
         "type":"time",
         "description":"Specify timeout for connection to master"
       },
-      "flat_settings":{
-        "type":"boolean",
-        "description":"Return settings in flat format (default: false)"
-      }
     },
     "body":{
       "description":"The template definition",


### PR DESCRIPTION
Removes the `flat_settings` and `timeout` query parameters from the JSON
spec and asciidoc docs for the put index template API.

These parameters are not supported by the API.