### PR TITLE
Missed an annotation

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/HistogramValuesSource.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/HistogramValuesSource.java
@@ -43,6 +43,7 @@ public class HistogramValuesSource {
                 };
             }
 
+            @Override
             public HistogramValues getHistogramValues(LeafReaderContext context) throws IOException {
                 return indexFieldData.load(context).getHistogramValues();
             }


### PR DESCRIPTION
Just noticed this while looking at how we implemented the histogram values source.  Method is clearly an override, was just missing the annotation.