### PR TITLE
Fix feature flag setting for ComponentTemplate APIs

### DIFF
--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -44,5 +46,11 @@ integTest.runner {
       'cat.templates/10_basic/Sort templates',
       'cat.templates/10_basic/Multiple template',
     ].join(',')
+  }
+}
+
+testClusters.integTest {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.itv2_feature_flag_registered', 'true'
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
@@ -1,8 +1,5 @@
 ---
 "Basic CRUD":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/53708"
 
   - do:
       cluster.put_component_template:

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -36,4 +38,10 @@ testClusters.integTest {
 
   user username: System.getProperty('tests.rest.cluster.username', 'test_user'),
     password: System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')
+}
+
+testClusters.integTest {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.itv2_feature_flag_registered', 'true'
+  }
 }


### PR DESCRIPTION
The feature flag was set for *most* of the builds, but there are a couple where it was missing.

Resolves #53708
