### PR TITLE
Scripting: Context script cache unlimited compile

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -40,14 +40,16 @@ public class ScriptCache {
 
     private static final Logger logger = LogManager.getLogger(ScriptService.class);
 
+    static final Tuple<Integer, TimeValue> UNLIMITED_COMPILATION_RATE = new Tuple<>(0, TimeValue.ZERO);
+
     private final Cache<CacheKey, Object> cache;
     private final ScriptMetrics scriptMetrics;
 
     private final Object lock = new Object();
 
-    // Mutable fields
-    private long lastInlineCompileTime;
-    private double scriptsPerTimeWindow;
+    // Mutable fields, visible for tests
+    long lastInlineCompileTime;
+    double scriptsPerTimeWindow;
 
     // Cache settings or derived from settings
     final int cacheSize;
@@ -150,8 +152,7 @@ public class ScriptCache {
      * is discarded - there can never be more water in the bucket than the size of the bucket.
      */
     void checkCompilationLimit() {
-        if (rate.v1() == 0 && rate.v2().getNanos() == 0) {
-            // unlimited
+        if (rate.equals(UNLIMITED_COMPILATION_RATE)) {
             return;
         }
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -128,10 +128,16 @@ public class ScriptService implements Closeable, ClusterStateApplier {
             key -> Setting.positiveTimeSetting(key, SCRIPT_GENERAL_CACHE_EXPIRE_SETTING, TimeValue.timeValueMillis(0),
                                                Property.NodeScope, Property.Dynamic));
 
+    // Unlimited compilation rate for context-specific script caches
+    static final String UNLIMITED_COMPILATION_RATE_KEY = "unlimited";
+
     public static final Setting.AffixSetting<Tuple<Integer, TimeValue>> SCRIPT_MAX_COMPILATIONS_RATE_SETTING =
         Setting.affixKeySetting(CONTEXT_PREFIX,
             "max_compilations_rate",
-            key -> new Setting<>(key, "75/5m", MAX_COMPILATION_RATE_FUNCTION, Property.NodeScope, Property.Dynamic));
+            key -> new Setting<>(key, "75/5m",
+                (String value) -> value.equals(UNLIMITED_COMPILATION_RATE_KEY) ? ScriptCache.UNLIMITED_COMPILATION_RATE:
+                                                                                 MAX_COMPILATION_RATE_FUNCTION.apply(value),
+                Property.NodeScope, Property.Dynamic));
 
     private static final Tuple<Integer, TimeValue> SCRIPT_COMPILATION_RATE_ZERO = new Tuple<>(0, TimeValue.ZERO);
 

--- a/server/src/test/java/org/elasticsearch/script/ScriptCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptCacheTests.java
@@ -52,4 +52,17 @@ public class ScriptCacheTests extends ESTestCase {
             cache.checkCompilationLimit();
         }
     }
+
+    public void testUnlimitedCompilationRate() {
+        final Integer size = ScriptService.SCRIPT_GENERAL_CACHE_SIZE_SETTING.get(Settings.EMPTY);
+        final TimeValue expire = ScriptService.SCRIPT_GENERAL_CACHE_EXPIRE_SETTING.get(Settings.EMPTY);
+        ScriptCache cache = new ScriptCache(size, expire, ScriptCache.UNLIMITED_COMPILATION_RATE);
+        long lastInlineCompileTime = cache.lastInlineCompileTime;
+        double scriptsPerTimeWindow = cache.scriptsPerTimeWindow;
+        for(int i=0; i < 3000; i++) {
+            cache.checkCompilationLimit();
+            assertEquals(lastInlineCompileTime, cache.lastInlineCompileTime);
+            assertEquals(scriptsPerTimeWindow, cache.scriptsPerTimeWindow, 0.0); // delta of 0.0 because it should never change
+        }
+    }
 }


### PR DESCRIPTION
* Adds "unlimited" compilation rate for context script caches
* `script.context.${CONTEXT}.max_compilations_rate` = `unlimited`
  disables compilation rate limiting for `${CONTEXT}`'s script
  cache

Refs: #50152
