### PR TITLE
[DOCS] Adds performance considerations section to transforms overview

### DIFF
--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -66,7 +66,7 @@ creates a new index that is dedicated to the transformed data.
 [[transform-performance]]
 ==== Performance considerations
 
-As mentioned earlier, {transforms} perform search aggregations on the source 
+{transforms-cap} perform search aggregations on the source 
 indices then index the results into the destination index. It means a 
 {transform} never will take less time than the cumulated duration of the 
 aggregation that it performs and the indexing process.

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -73,7 +73,6 @@ aggregation that it performs and the indexing process.
 
 For better performance, make sure that your search aggregations and queries are 
 optimized, so they don't process unnecessary data.
-{transform}.
 
 NOTE: When you use <<search-aggregations-bucket-datehistogram-aggregation>>, the 
 queries are not considered optimal as they run through a significant amount of 

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -67,7 +67,7 @@ creates a new index that is dedicated to the transformed data.
 ==== Performance considerations
 
 {transforms-cap} perform search aggregations on the source 
-indices then index the results into the destination index. It means a 
+indices then index the results into the destination index. Therefore, a 
 {transform} never will take less time than the cumulated duration of the 
 aggregation that it performs and the indexing process.
 

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -62,3 +62,20 @@ image::images/pivot-preview.jpg["Example of a {transform} pivot in {kib}"]
 IMPORTANT: The {transform} leaves your source index intact. It
 creates a new index that is dedicated to the transformed data.
 
+
+[[transform-performance]]
+==== Performance considerations
+
+As mentioned earlier, {transforms} perform search aggregations on the source 
+indices then index the results into the destination index. It means a 
+{transform} never will take less time than the cumulated duration of the 
+aggregation that it performs and the indexing process.
+
+For better performance, make sure that your search aggregations and queries are 
+optimized, so they don't process data that is not necessary for your 
+{transform}.
+
+NOTE: When you use <<search-aggregations-bucket-datehistogram-aggregation>>, the 
+queries are not considered optimal as they run through a significant amount of 
+data. For this reason, {transforms} performing date histogram aggregations take 
+longer to run.

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -72,7 +72,7 @@ indices then index the results into the destination index. Therefore, a
 aggregation that it performs and the indexing process.
 
 For better performance, make sure that your search aggregations and queries are 
-optimized, so they don't process data that is not necessary for your 
+optimized, so they don't process unnecessary data.
 {transform}.
 
 NOTE: When you use <<search-aggregations-bucket-datehistogram-aggregation>>, the 

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -68,7 +68,7 @@ creates a new index that is dedicated to the transformed data.
 
 {transforms-cap} perform search aggregations on the source 
 indices then index the results into the destination index. Therefore, a 
-{transform} never will take less time than the cumulated duration of the 
+{transform} never takes less time than the cumulated duration of the 
 aggregation that it performs and the indexing process.
 
 For better performance, make sure that your search aggregations and queries are 


### PR DESCRIPTION
This PR expands the transforms overview with a section called performance considerations and a note about date histogram aggregations in transforms.

Preview: http://elasticsearch_53791.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-overview.html