### PR TITLE
[DOCS] Changes seconds to milliseconds since the Epoch in AD docs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -98,7 +98,7 @@ on January 1, 2018:
 --------------------------------------------------
 POST _ml/anomaly_detectors/total-requests/_flush
 {
-  "advance_time": "1514804400"
+  "advance_time": "1514804400000"
 }
 --------------------------------------------------
 // TEST[skip:setup:server_metrics_openjob]

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -49,7 +49,7 @@ following formats: +
 
 - ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
 - ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
-- Seconds from the Epoch, for example `1390370400`
+- Milliseconds from the Epoch, for example `1485061200000`
 
 Date-time arguments using either of the ISO 8601 formats must have a time zone
 designator, where Z is accepted as an abbreviation for UTC time.


### PR DESCRIPTION
This PR changes seconds to milliseconds since the Epoch in two pages.
In `start-datafeed.asciidoc` the value `1390370400 ` has changed to `1485061200000 ` to be in line with the other two examples in the section (e.g.:`2017-01-22T06:00:00+00:00`).

Preview: 

* http://elasticsearch_53797.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-flush-job.html
* http://elasticsearch_53797.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html