### PR TITLE
EQL: Extract query folder tests definitions into resources

### DIFF
--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
@@ -7,72 +7,19 @@
 package org.elasticsearch.xpack.eql.planner;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.eql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.eql.plan.physical.PhysicalPlan;
 
-import java.util.Arrays;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 
 import static org.elasticsearch.xpack.ql.type.DataTypes.KEYWORD;
 import static org.hamcrest.Matchers.containsString;
 
 public class QueryFolderOkTests extends AbstractQueryFolderTestCase {
-    private static Object[][] specs = {
-            {"basic", "process where true", null},
-            {"singleNumericFilterEquals", "process where serial_event_id = 1", "\"term\":{\"serial_event_id\":{\"value\":1"},
-            {"singleNumericFilterLess", "process where serial_event_id < 4",
-                    "\"range\":{\"serial_event_id\":{\"from\":null,\"to\":4,\"include_lower\":false,\"include_upper\":false"
-            },
-            {"singleNumericFilterLessSymmetry", "process where 4 > serial_event_id",
-                    "\"range\":{\"serial_event_id\":{\"from\":null,\"to\":4,\"include_lower\":false,\"include_upper\":false"
-            },
-            {"singleNumericFilterLessEquals", "process where serial_event_id <= 4",
-                    "\"range\":{\"serial_event_id\":{\"from\":null,\"to\":4,\"include_lower\":false,\"include_upper\":true"
-            },
-            {"singleNumericFilterGreater", "process where serial_event_id > 4",
-                    "\"range\":{\"serial_event_id\":{\"from\":4,\"to\":null,\"include_lower\":false,\"include_upper\":false"
-            },
-            {"singleNumericFilterGreaterEquals", "process where serial_event_id >= 4",
-                    "\"range\":{\"serial_event_id\":{\"from\":4,\"to\":null,\"include_lower\":true,\"include_upper\":false"
-            },
-            {"mixedTypeFilter", "process where process_name == \"notepad.exe\" or (serial_event_id < 4.5 and serial_event_id >= 3.1)",
-                    new Object[]{
-                            "\"term\":{\"process_name\":{\"value\":\"notepad.exe\"",
-                            "\"range\":{\"serial_event_id\":{\"from\":3.1,\"to\":4.5,\"include_lower\":true,\"include_upper\":false"
-                    }
-            },
-            {"notFilter", "process where not (exit_code > -1)",
-                    "\"range\":{\"exit_code\":{\"from\":null,\"to\":-1,\"include_lower\":false,\"include_upper\":true"
-            },
-            {"inFilter", "process where process_name in (\"python.exe\", \"SMSS.exe\", \"explorer.exe\")",
-                    new Object[]{
-                            "\"term\":{\"process_name\":{\"value\":\"python.exe\"",
-                            "\"term\":{\"process_name\":{\"value\":\"SMSS.exe\"",
-                            "\"term\":{\"process_name\":{\"value\":\"explorer.exe\"",
-                    }
-            },
-            {"equalsAndInFilter", "process where process_path == \"*\\\\red_ttp\\\\wininit.*\" and opcode in (0,1,2,3)",
-                    new Object[]{
-                            "\"wildcard\":{\"process_path\":{\"wildcard\":\"*\\\\\\\\red_ttp\\\\\\\\wininit.*\"",
-                            "\"term\":{\"opcode\":{\"value\":0",
-                            "\"term\":{\"opcode\":{\"value\":1",
-                            "\"term\":{\"opcode\":{\"value\":2",
-                            "\"term\":{\"opcode\":{\"value\":3",
-                    }
-            },
-            {"substringFunction", "process where substring(file_name, -4) == '.exe'",
-                    new Object[]{
-                            "{\"script\":{\"source\":\""
-                            + "InternalSqlScriptUtils.nullSafeFilter("
-                            + "InternalSqlScriptUtils.eq("
-                            + "InternalSqlScriptUtils.substring("
-                            + "InternalSqlScriptUtils.docValue(doc,params.v0),params.v1,params.v2),params.v3))",
-                            "\"params\":{\"v0\":\"file_name.keyword\",\"v1\":-4,\"v2\":null,\"v3\":\".exe\"}"
-                            
-                    }
-            }
-    };
-
     private final String name;
     private final String query;
     private final Object expect;
@@ -83,9 +30,64 @@ public class QueryFolderOkTests extends AbstractQueryFolderTestCase {
         this.expect = expect;
     }
 
-    @ParametersFactory(shuffle = false, argumentFormatting = "%1$s.test")
-    public static Iterable<Object[]> parameters() {
-        return Arrays.asList(specs);
+    @ParametersFactory(shuffle = false, argumentFormatting = "%1$s")
+    public static Iterable<Object[]> parameters() throws Exception {
+        ArrayList<Object[]> arr = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                QueryFolderOkTests.class.getResourceAsStream("/queryfolder_tests.txt"), StandardCharsets.UTF_8))) {
+            String line;
+            String name = null;
+            String query = null;
+            ArrayList<Object> expectations = null;
+            int newLineCount = 0;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith("//")) {
+                    continue;
+                }
+
+                line = line.trim();
+                if (Strings.isEmpty(line)) {
+                    if (name != null) {
+                        newLineCount++;
+                    }
+                    if (newLineCount >= 2) {
+                        // Add and zero out for the next spec
+                        addSpec(arr, name, query, expectations == null ? null : expectations.toArray());
+                        name = null;
+                        query = null;
+                        expectations = null;
+                        newLineCount = 0;
+                    }
+                    continue;
+                }
+
+                if (name == null) {
+                    name = line;
+                    continue;
+                }
+
+                if (query == null) {
+                    query = line;
+                    continue;
+                }
+
+                if (line.equals("null") == false) {  // special case for no expectations
+                    if (expectations == null) {
+                        expectations = new ArrayList<>();
+                    }
+                    expectations.add(line);
+                }
+            }
+            addSpec(arr, name, query, expectations.toArray());
+        }
+        return arr;
+    }
+
+    private static void addSpec(ArrayList<Object[]> arr, String name, String query, Object[] expectations) {
+        if ((Strings.isNullOrEmpty(name) == false) && (Strings.isNullOrEmpty(query) == false)) {
+            arr.add(new Object[]{name, query, expectations});
+        }
     }
 
     public void test() {

--- a/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
+++ b/x-pack/plugin/eql/src/test/resources/queryfolder_tests.txt
@@ -1,0 +1,66 @@
+//
+// QueryFolder test
+// Simple format of the following blocks, separated by two new lines
+// <name>
+// <eql query>
+// <expectation 1>
+// <expectation 2>
+// ...
+// <expectation n>
+
+
+basic
+process where true
+null
+
+
+singleNumericFilterEquals
+process where serial_event_id = 1
+"term":{"serial_event_id":{"value":1
+
+
+singleNumericFilterLess
+process where serial_event_id < 4
+"range":{"serial_event_id":{"from":null,"to":4,"include_lower":false,"include_upper":false
+
+
+singleNumericFilterLessEquals
+process where serial_event_id <= 4
+"range":{"serial_event_id":{"from":null,"to":4,"include_lower":false,"include_upper":true
+
+
+singleNumericFilterGreater
+process where serial_event_id > 4
+"range":{"serial_event_id":{"from":4,"to":null,"include_lower":false,"include_upper":false
+
+
+singleNumericFilterGreaterEquals
+process where serial_event_id >= 4
+"range":{"serial_event_id":{"from":4,"to":null,"include_lower":true,"include_upper":false
+
+
+mixedTypeFilter
+process where process_name == "notepad.exe" or (serial_event_id < 4.5 and serial_event_id >= 3.1)
+"term":{"process_name":{"value":"notepad.exe"
+"range":{"serial_event_id":{"from":3.1,"to":4.5,"include_lower":true,"include_upper":false
+
+
+notFilter
+process where not (exit_code > -1)
+"range":{"exit_code":{"from":null,"to":-1,"include_lower":false,"include_upper":true
+
+
+inFilter
+process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
+"term":{"process_name":{"value":"python.exe"
+"term":{"process_name":{"value":"SMSS.exe"
+"term":{"process_name":{"value":"explorer.exe"
+
+
+equalsAndInFilter
+process where process_path == "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3)
+"wildcard":{"process_path":{"wildcard":"*\\\\red_ttp\\\\wininit.*"
+"term":{"opcode":{"value":0
+"term":{"opcode":{"value":1
+"term":{"opcode":{"value":2
+"term":{"opcode":{"value":3


### PR DESCRIPTION
@costin, this addresses the other ask that you had for extracting the tests specs into resources.
As far as I understood we were talking about simple text file, but can change the format however needed. Let me know.

<img width="969" alt="Screen Shot 2020-03-19 at 10 24 39 AM" src="https://user-images.githubusercontent.com/872351/77077907-42039f80-69cc-11ea-9c27-1900336d5699.png">
