### PR TITLE
Fix ReloadSynonymAnalyzerIT failure (#53663)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/ReloadAnalyzersResponse.java
@@ -164,7 +164,7 @@ public class ReloadAnalyzersResponse extends BroadcastResponse  {
         }
 
         void merge(ReloadResult other) {
-            assert this.indexName == other.index;
+            assert this.indexName.equals(other.index);
             this.reloadedAnalyzers.addAll(other.reloadedSearchAnalyzers);
             this.reloadedIndicesNodes.add(other.nodeId);
         }


### PR DESCRIPTION
There is an assertion in ReloadAnalyzersResponse.merge that compares index names
of merged responses that was falsely using object equality instead of
String.equals(). In the past this didn't seem to matter but with changes in the
test setup we started to see failures. Correcting this and also simplifying test
a bit to be able to run it repeatedly if needed.

Backport of #53663