### PR TITLE
Add logging and enable testQueryRewrite

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -124,7 +124,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         if (cacheLoader.isLoaded()) {
             key.entity.onMiss();
             if (logger.isTraceEnabled()) {
-                logger.trace("Cache miss for reader version [{}] and request:\n {}", reader.getVersion(), cacheKeyRenderer.get());
+                logger.trace("Cache miss for reader version [{}], max_doc[{}] and request:\n {}",
+                    reader.getVersion(), reader.maxDoc(), cacheKeyRenderer.get());
             }
             // see if its the first time we see this reader, and make sure to register a cleanup key
             CleanupKey cleanupKey = new CleanupKey(cacheEntity, reader.getReaderCacheHelper().getKey());
@@ -137,7 +138,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
         } else {
             key.entity.onHit();
             if (logger.isTraceEnabled()) {
-                logger.trace("Cache hit for reader version [{}] and request:\n {}", reader.getVersion(), cacheKeyRenderer.get());
+                logger.trace("Cache hit for reader version [{}], max_doc[{}] and request:\n {}",
+                    reader.getVersion(), reader.maxDoc(), cacheKeyRenderer.get());
             }
         }
         return value;

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -97,7 +98,9 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/32827")
+    @TestIssueLogging(
+        value = "org.elasticsearch.indices.IndicesRequestCache:TRACE",
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/32827")
     public void testQueryRewrite() throws Exception {
         Client client = client();
         assertAcked(client.admin().indices().prepareCreate("index").setMapping("s", "type=date")


### PR DESCRIPTION
A month ago there were a number of failures for 
testQueryRewrite and was muted.
This reenables IndicesRequestCacheIT.testQueryRewrite
and enables logging for it.

Relates to #32827
