### PR TITLE
Handle properly indexing rectangles that crosses the dateline

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.geo.GeoLineDecomposer;
 import org.elasticsearch.common.geo.GeoPolygonDecomposer;
 import org.elasticsearch.common.geo.GeoShapeUtils;
 import org.elasticsearch.common.geo.GeoShapeType;
+import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
@@ -261,7 +262,15 @@ public final class GeoShapeIndexer implements AbstractGeometryFieldMapper.Indexe
 
         @Override
         public Void visit(Rectangle r) {
-            addFields(LatLonShape.createIndexableFields(name, GeoShapeUtils.toLucenePolygon(r)));
+            if (r.getMinLon() > r.getMaxLon()) {
+                Rectangle left = new Rectangle(r.getMaxX(), GeoUtils.MAX_LON, r.getMaxY(), r.getMinY());
+                addFields(LatLonShape.createIndexableFields(name, GeoShapeUtils.toLucenePolygon(left)));
+                Rectangle right = new Rectangle(GeoUtils.MIN_LON, r.getMaxLon(), r.getMaxY(), r.getMinY());
+                addFields(LatLonShape.createIndexableFields(name, GeoShapeUtils.toLucenePolygon(right)));
+
+            } else {
+                addFields(LatLonShape.createIndexableFields(name, GeoShapeUtils.toLucenePolygon(r)));
+            }
             return null;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeIndexer.java
@@ -263,9 +263,9 @@ public final class GeoShapeIndexer implements AbstractGeometryFieldMapper.Indexe
         @Override
         public Void visit(Rectangle r) {
             if (r.getMinLon() > r.getMaxLon()) {
-                Rectangle left = new Rectangle(r.getMaxX(), GeoUtils.MAX_LON, r.getMaxY(), r.getMinY());
+                Rectangle left = new Rectangle(r.getMinLon(), GeoUtils.MAX_LON, r.getMaxLat(), r.getMinLat());
                 addFields(LatLonShape.createIndexableFields(name, GeoShapeUtils.toLucenePolygon(left)));
-                Rectangle right = new Rectangle(GeoUtils.MIN_LON, r.getMaxLon(), r.getMaxY(), r.getMinY());
+                Rectangle right = new Rectangle(GeoUtils.MIN_LON, r.getMaxLon(), r.getMaxLat(), r.getMinLat());
                 addFields(LatLonShape.createIndexableFields(name, GeoShapeUtils.toLucenePolygon(right)));
 
             } else {


### PR DESCRIPTION
When indexing a rectangle that crosses the dateline, we are currently not handling it properly and we index a polygon that do not cross the dateline. This changes generates two polygons wrapping the dateline.