### PR TITLE
Wildcard field - added case insensitive search option

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -368,14 +368,14 @@ public abstract class MappedFieldType extends FieldType {
     }
 
     public Query prefixQuery(String value, @Nullable MultiTermQuery.RewriteMethod method, QueryShardContext context) {
-        throw new QueryShardException(context, "Can only use prefix queries on keyword and text fields - not on [" + name
+        throw new QueryShardException(context, "Can only use prefix queries on keyword, text and wildcard fields - not on [" + name
             + "] which is of type [" + typeName() + "]");
     }
 
     public Query wildcardQuery(String value,
                                @Nullable MultiTermQuery.RewriteMethod method,
                                QueryShardContext context) {
-        throw new QueryShardException(context, "Can only use wildcard queries on keyword and text fields - not on [" + name
+        throw new QueryShardException(context, "Can only use wildcard queries on keyword, text and wildcard fields - not on [" + name
             + "] which is of type [" + typeName() + "]");
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -239,7 +239,7 @@ public final class QueryBuilders {
      * which matches any single character. Note this query can be slow, as it
      * needs to iterate over many terms. In order to prevent extremely slow WildcardQueries,
      * a Wildcard term should not start with one of the wildcards {@code *} or
-     * {@code ?}.
+     * {@code ?}. (The new wildcard field type however, is optimised for leading wildcards)_ 
      *
      * @param name  The field name
      * @param query The wildcard query string

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -1,8 +1,8 @@
 setup:
   - skip:
       features: headers
-      version: " - 7.9.99"
-      reason: "wildcard fields were added from 8.0"
+      version: " - 7.6.99"
+      reason: "wildcard fields were added from 7.7"
 
   - do:
       indices.create:
@@ -26,6 +26,12 @@ setup:
         id: 2
         body:
           my_wildcard: goodbye world
+  - do:
+      index:
+        index: test-index
+        id: 3
+        body:
+          my_wildcard: cAsE iNsEnSiTiVe World
 
   - do:
       indices.refresh: {}
@@ -83,6 +89,19 @@ setup:
   - match: {hits.total.value: 1}
 
 ---
+"Case insensitive query":
+  - do:
+      search:
+        body:
+          track_total_hits: true
+          query:
+            wildcard:
+              my_wildcard._case_insensitive: {value: "*Worl*" }
+
+
+  - match: {hits.total.value: 3}
+
+---
 "Short suffix query":
   - do:
       search:
@@ -93,7 +112,7 @@ setup:
               my_wildcard: {value: "*ld" }
 
 
-  - match: {hits.total.value: 2}
+  - match: {hits.total.value: 3}
 
 ---
 "Long suffix query":
@@ -199,10 +218,11 @@ setup:
           track_total_hits: true
           sort: [ { "my_wildcard": "desc" } ]
 
-  - match: { hits.total.value: 2 }
-  - length: { hits.hits: 2 }
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 3 }
   - match: { hits.hits.0._id: "1" }
   - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
 
   - do:
       search:
@@ -210,9 +230,10 @@ setup:
           track_total_hits: true
           sort: [ { "my_wildcard": "asc" } ]
 
-  - match: { hits.total.value: 2 }
-  - length: { hits.hits: 2 }
-  - match: { hits.hits.0._id: "2" }
-  - match: { hits.hits.1._id: "1" }
+  - match: { hits.total.value: 3 }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "3" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "1" }
 
 

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -24,6 +24,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -77,7 +78,7 @@ public class AutomatonQueryOnBinaryDv extends Query {
                         if (normalizer == null) {
                             return bytesMatcher.run(bytes, badi.getPosition(), valLength);                 
                         } else {
-                            String s = new String(bytes, position, valLength);
+                            String s = new String(bytes, position, valLength, StandardCharsets.UTF_8);
                             BytesRef normalized = normalizer.normalize(null, s);
                             return (bytesMatcher.run(normalized.bytes, normalized.offset, normalized.length));                  
                         }                        

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -184,7 +184,8 @@ public class WildcardFieldMapper extends FieldMapper {
             String fullName =  buildFullName(context);
             CaseInsensitiveFieldType caseInsensitiveFieldType =
                     new CaseInsensitiveFieldType(fullName, fullName + "._case_insensitive");
-            CaseInsensitiveFieldMapper caseInsensitiveFieldMapper = new CaseInsensitiveFieldMapper(caseInsensitiveFieldType, context.indexSettings());            
+            CaseInsensitiveFieldMapper caseInsensitiveFieldMapper = 
+                    new CaseInsensitiveFieldMapper(caseInsensitiveFieldType, context.indexSettings());            
             
             return new WildcardFieldMapper(
                     name, fieldType, defaultFieldType, ignoreAbove, 
@@ -520,7 +521,8 @@ public class WildcardFieldMapper extends FieldMapper {
                 verifyingBuilder.add(new BooleanClause(approximation, Occur.MUST));
                 Automaton automaton = WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
                 Analyzer normalizer = caseSensitive ? null: WILDCARD_ANALYZER;
-                verifyingBuilder.add(new BooleanClause(new AutomatonQueryOnBinaryDv(name(), wildcardPattern, automaton, normalizer), Occur.MUST));
+                verifyingBuilder.add(new BooleanClause(
+                        new AutomatonQueryOnBinaryDv(name(), wildcardPattern, automaton, normalizer), Occur.MUST));
                 return verifyingBuilder.build();
             }
             return approximation;
@@ -620,7 +622,8 @@ public class WildcardFieldMapper extends FieldMapper {
     private CaseInsensitiveFieldMapper caseInsensitiveFieldMapper;
 
     private WildcardFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
-                int ignoreAbove, Settings indexSettings, MultiFields multiFields, CopyTo copyTo, CaseInsensitiveFieldMapper caseInsensitiveFieldMapper) {
+                int ignoreAbove, Settings indexSettings, MultiFields multiFields, CopyTo copyTo, 
+                CaseInsensitiveFieldMapper caseInsensitiveFieldMapper) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.ignoreAbove = ignoreAbove;
         assert fieldType.indexOptions() == IndexOptions.DOCS;


### PR DESCRIPTION
Generally in elasticsearch, the case sensitivity or not of searches is normally dictated by the choice of field a user searches. In keeping with this practice this change automatically creates a multi-field for wildcard fields so that a wildcard field called `foo` also has a `foo._case_insensitive` variant.

However, unlike other fields this comes at no extra storage cost. The `.case_insensitive` field type just uses the same data structures as the case sensitive one - it just relaxes the matching logic in the verification phase. The ngram index used for the approximation query is lower-cased and therefore may produce more false positives for case-sensitive searches but these are expected to be low in number (how many docs differ only by case?).
