### PR TITLE
[6.8][DOCS] Changes seconds to milliseconds since the epoch in AD docs

### DIFF
--- a/docs/reference/ml/apis/jobresource.asciidoc
+++ b/docs/reference/ml/apis/jobresource.asciidoc
@@ -302,9 +302,10 @@ A data description object has the following properties:
 
 `time_format`::
   (string) The time format, which can be `epoch`, `epoch_ms`, or a custom pattern.
-  The default value is `epoch`, which refers to UNIX or Epoch time (the number of seconds
-  since 1 Jan 1970).
-  The value `epoch_ms` indicates that time is measured in milliseconds since the epoch.
+  The default value is `epoch_ms`, which refers to milliseconds since the epoch 
+  (the number of milliseconds since 1 Jan 1970).
+  The value `epoch_ms` indicates that time is measured in milliseconds since the 
+  epoch.
   The `epoch` and `epoch_ms` time formats accept either integer or real values. +
 +
 --

--- a/docs/reference/ml/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/apis/start-datafeed.asciidoc
@@ -39,7 +39,7 @@ following formats: +
 
 - ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
 - ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
-- Seconds from the Epoch, for example `1390370400`
+- Milliseconds since the epoch, for example `1485061200000`
 
 Date-time arguments using either of the ISO 8601 formats must have a time zone
 designator, where Z is accepted as an abbreviation for UTC time.


### PR DESCRIPTION
This PR backports the relevant changes of the following commit: 
[DOCS] Changes seconds to milliseconds since the Epoch in AD docs #53797

And changes `epoch` to `epoch_ms` in the job resources.