### PR TITLE
[DOCS] Adds date nanos transform limitation

### DIFF
--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -94,6 +94,6 @@ same mapping parameters than with the `date` field can be used.
 [[date-nanos-limitations]]
 ==== Limitations
 
-Aggregations are still on millisecond resolution, even when using a
-`date_nanos` field.
+Aggregations are still on millisecond resolution, even when using a `date_nanos`
+field. This limitation also affects <<transforms,{transforms}>>.
 

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -206,3 +206,10 @@ this entity will not be updated.
 If using a `sync.time.field` that represents the data ingest time and using a 
 zero second or very small `sync.time.delay`, then it is more likely that this 
 issue will occur.
+
+[[transform-date-nanos]]
+==== Support for date nanoseconds data type
+
+If your data uses the <<date_nanos,date nanosecond data type>>, aggregations
+are nonetheless on millisecond resolution. This limitation also affects the
+aggregations in your {transforms}.


### PR DESCRIPTION
This PR adds an item in the list of transforms limitations about the support for date nanoseconds data types (https://www.elastic.co/guide/en/elasticsearch/reference/master/date_nanos.html#date-nanos-limitations)