### PR TITLE
Update minimally supported version for IndexTemplateV2Metadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateV2Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateV2Metadata.java
@@ -98,8 +98,7 @@ public class IndexTemplateV2Metadata implements MetaData.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        // TODO: update this once backported
-        return Version.V_8_0_0;
+        return Version.V_7_7_0;
     }
 
     @Override


### PR DESCRIPTION
To be merged after #53827 and after bwc tests have been disabled
