### PR TITLE
Clean up eclipse build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,16 @@
  * under the License.
  */
 
-
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.BwcVersions
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
+import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
@@ -405,6 +406,19 @@ allprojects {
       classpath.entries.findAll { it instanceof SourceFolder }.each { folder ->
         i++;
         folder.output = "build-eclipse/" + i
+      }
+      /*
+       * Allow accessing com/sun/net/httpserver in projects that have
+       * configured forbidden apis to allow it.
+       */
+      plugins.withType(ForbiddenApisPlugin) {
+        if (false == forbiddenApisTest.bundledSignatures.contains('jdk-non-portable')) {
+          classpath.entries
+            .findAll { it.kind == "con" && it.toString().contains("org.eclipse.jdt.launching.JRE_CONTAINER") }
+            .each {
+              it.accessRules.add(new AccessRule("accessible", "com/sun/net/httpserver/*"))
+            }
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -407,18 +407,20 @@ allprojects {
         i++;
         folder.output = "build-eclipse/" + i
       }
-      /*
-       * Allow accessing com/sun/net/httpserver in projects that have
-       * configured forbidden apis to allow it.
-       */
-      plugins.withType(ForbiddenApisPlugin) {
-        if (false == forbiddenApisTest.bundledSignatures.contains('jdk-non-portable')) {
-          classpath.entries
-            .findAll { it.kind == "con" && it.toString().contains("org.eclipse.jdt.launching.JRE_CONTAINER") }
-            .each {
-              it.accessRules.add(new AccessRule("accessible", "com/sun/net/httpserver/*"))
-            }
-        }
+    }
+  }
+  /*
+   * Allow accessing com/sun/net/httpserver in projects that have
+   * configured forbidden apis to allow it.
+   */
+  plugins.withType(ForbiddenApisPlugin) {
+    eclipse.classpath.file.whenMerged { classpath ->
+      if (false == forbiddenApisTest.bundledSignatures.contains('jdk-non-portable')) {
+        classpath.entries
+          .findAll { it.kind == "con" && it.toString().contains("org.eclipse.jdt.launching.JRE_CONTAINER") }
+          .each {
+            it.accessRules.add(new AccessRule("accessible", "com/sun/net/httpserver/*"))
+          }
       }
     }
   }

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -34,16 +34,3 @@ forbiddenApisTest {
 forbiddenPatterns {
   exclude '**/*.keystore'
 }
-
-// Allow for com.sun.net.httpserver.* usage for testing
-eclipse {
-  classpath.file {
-    whenMerged { cp ->
-      def con = entries.find { e ->
-        e.kind == "con" && e.toString().contains("org.eclipse.jdt.launching.JRE_CONTAINER")
-      }
-      con.accessRules.add(new org.gradle.plugins.ide.eclipse.model.AccessRule(
-        "accessible", "com/sun/net/httpserver/*"))
-    }
-  }
-}


### PR DESCRIPTION
Fixes up the "forbidden" warnings that you get when you import
Elasticsearch using "import gradle projects".

With this, and the manual step of switching circular project definitions
to warnings this gets most thing *compiling*.
