### PR TITLE
Use boolean methods for allowed realm types in license state (#53456)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -402,8 +402,7 @@ public class XPackLicenseState {
     }
 
     /**
-     * @return true if authentication and authorization should be enabled. this does not indicate what realms are available
-     * @see #allowedRealmType() for the enabled realms
+     * @return true if authentication and authorization should be enabled.
      */
     public boolean isAuthAllowed() {
         return isAllowedBySecurityAndLicense(OperationMode.BASIC, false, true);
@@ -438,38 +437,12 @@ public class XPackLicenseState {
         return isAllowedBySecurityAndLicense(OperationMode.PLATINUM, false, true);
     }
 
-    /** Classes of realms that may be available based on the license type. */
-    public enum AllowedRealmType {
-        NONE,
-        NATIVE,
-        DEFAULT,
-        ALL
+    public boolean areAllRealmsAllowed() {
+        return isAllowedBySecurityAndLicense(OperationMode.PLATINUM, false, true);
     }
 
-    /**
-     * @return the type of realms that are enabled based on the license {@link OperationMode}
-     */
-    public AllowedRealmType allowedRealmType() {
-        return executeAgainstStatus(status -> {
-            final boolean isSecurityCurrentlyEnabled = isSecurityEnabled(status.mode, isSecurityExplicitlyEnabled, isSecurityEnabled);
-            if (isSecurityCurrentlyEnabled) {
-                switch (status.mode) {
-                    case PLATINUM:
-                    case ENTERPRISE:
-                    case TRIAL:
-                        return AllowedRealmType.ALL;
-                    case GOLD:
-                        return AllowedRealmType.DEFAULT;
-                    case BASIC:
-                    case STANDARD:
-                        return AllowedRealmType.NATIVE;
-                    default:
-                        return AllowedRealmType.NONE;
-                }
-            } else {
-                return AllowedRealmType.NONE;
-            }
-        });
+    public boolean areStandardRealmsAllowed() {
+        return isAllowedBySecurityAndLicense(OperationMode.GOLD, false, true);
     }
 
     public boolean isCustomRoleProvidersAllowed() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -82,7 +82,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(true));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
+        assertThat(licenseState.areAllRealmsAllowed(), is(true));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(true));
 
         licenseState = new XPackLicenseState(Settings.EMPTY);
@@ -105,7 +105,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NONE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(false));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(false));
@@ -124,7 +123,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NATIVE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(false));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
@@ -142,7 +140,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NONE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(false));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(false));
@@ -158,7 +155,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NATIVE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(false));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
@@ -174,7 +170,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NATIVE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
     }
 
@@ -188,7 +183,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NATIVE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
     }
 
@@ -202,7 +196,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(true));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.DEFAULT));
+        assertThat(licenseState.areStandardRealmsAllowed(), is(true));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(true));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
@@ -218,7 +212,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(true));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.DEFAULT));
+        assertThat(licenseState.areStandardRealmsAllowed(), is(true));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(true));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
@@ -234,7 +228,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(true));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
+        assertThat(licenseState.areAllRealmsAllowed(), is(true));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(true));
         assertThat(licenseState.isTokenServiceAllowed(), is(true));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
@@ -250,7 +244,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(true));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(true));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.ALL));
+        assertThat(licenseState.areAllRealmsAllowed(), is(true));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
         assertThat(licenseState.isTokenServiceAllowed(), is(true));
         assertThat(licenseState.isApiKeyServiceAllowed(), is(true));
@@ -270,7 +264,6 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isAuditingAllowed(), is(false));
         assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
         assertThat(licenseState.isDocumentAndFieldLevelSecurityAllowed(), is(false));
-        assertThat(licenseState.allowedRealmType(), is(XPackLicenseState.AllowedRealmType.NONE));
         assertThat(licenseState.isCustomRoleProvidersAllowed(), is(false));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.AllowedRealmType;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
@@ -105,35 +104,21 @@ public class Realms implements Iterable<Realm> {
 
     @Override
     public Iterator<Realm> iterator() {
-        if (licenseState.isAuthAllowed() == false) {
-            return Collections.emptyIterator();
-        }
-
-        AllowedRealmType allowedRealmType = licenseState.allowedRealmType();
-        switch (allowedRealmType) {
-            case ALL:
-                return realms.iterator();
-            case DEFAULT:
-                return standardRealmsOnly.iterator();
-            case NATIVE:
-                return nativeRealmsOnly.iterator();
-            default:
-                throw new IllegalStateException("authentication should not be enabled");
-        }
+        return asList().iterator();
     }
 
     /**
      * Returns a list of realms that are configured, but are not permitted under the current license.
      */
     public List<Realm> getUnlicensedRealms() {
+        final XPackLicenseState licenseStateSnapshot = licenseState.copyCurrentLicenseState();
         // If auth is not allowed, then everything is unlicensed
-        if (licenseState.isAuthAllowed() == false) {
+        if (licenseStateSnapshot.isAuthAllowed() == false) {
             return Collections.unmodifiableList(realms);
         }
 
-        AllowedRealmType allowedRealmType = licenseState.allowedRealmType();
         // If all realms are allowed, then nothing is unlicensed
-        if (allowedRealmType == AllowedRealmType.ALL) {
+        if (licenseStateSnapshot.areAllRealmsAllowed()) {
             return Collections.emptyList();
         }
 
@@ -153,20 +138,17 @@ public class Realms implements Iterable<Realm> {
     }
 
     public List<Realm> asList() {
-        if (licenseState.isAuthAllowed() == false) {
+        final XPackLicenseState licenseStateSnapshot = licenseState.copyCurrentLicenseState();
+        if (licenseStateSnapshot.isAuthAllowed() == false) {
             return Collections.emptyList();
         }
-
-        AllowedRealmType allowedRealmType = licenseState.allowedRealmType();
-        switch (allowedRealmType) {
-            case ALL:
-                return Collections.unmodifiableList(realms);
-            case DEFAULT:
-                return Collections.unmodifiableList(standardRealmsOnly);
-            case NATIVE:
-                return Collections.unmodifiableList(nativeRealmsOnly);
-            default:
-                throw new IllegalStateException("authentication should not be enabled");
+        if (licenseStateSnapshot.areAllRealmsAllowed()) {
+            return realms;
+        } else if (licenseStateSnapshot.areStandardRealmsAllowed()) {
+            return standardRealmsOnly;
+        } else {
+            // native realms are basic licensed, and always allowed, even for an expired license
+            return nativeRealmsOnly;
         }
     }
 
@@ -251,19 +233,20 @@ public class Realms implements Iterable<Realm> {
 
         logDeprecationIfFound(missingOrderRealmSettingKeys, orderToRealmOrderSettingKeys);
 
-        return realms;
+        return Collections.unmodifiableList(realms);
     }
 
     public void usageStats(ActionListener<Map<String, Object>> listener) {
+        final XPackLicenseState licenseStateSnapshot = licenseState.copyCurrentLicenseState();
         Map<String, Object> realmMap = new HashMap<>();
         final AtomicBoolean failed = new AtomicBoolean(false);
         final List<Realm> realmList = asList().stream()
             .filter(r -> ReservedRealm.TYPE.equals(r.type()) == false)
             .collect(Collectors.toList());
+        final Set<String> realmTypes = realmList.stream().map(Realm::type).collect(Collectors.toSet());
         final CountDown countDown = new CountDown(realmList.size());
         final Runnable doCountDown = () -> {
             if ((realmList.isEmpty() || countDown.countDown()) && failed.get() == false) {
-                final AllowedRealmType allowedRealmType = licenseState.allowedRealmType();
                 // iterate over the factories so we can add enabled & available info
                 for (String type : factories.keySet()) {
                     assert ReservedRealm.TYPE.equals(type) == false;
@@ -271,15 +254,13 @@ public class Realms implements Iterable<Realm> {
                         if (value == null) {
                             return MapBuilder.<String, Object>newMapBuilder()
                                 .put("enabled", false)
-                                .put("available", isRealmTypeAvailable(allowedRealmType, type))
+                                .put("available", isRealmTypeAvailable(licenseStateSnapshot, type))
                                 .map();
                         }
 
                         assert value instanceof Map;
                         Map<String, Object> realmTypeUsage = (Map<String, Object>) value;
                         realmTypeUsage.put("enabled", true);
-                        // the realms iterator returned this type so it must be enabled
-                        assert isRealmTypeAvailable(allowedRealmType, type);
                         realmTypeUsage.put("available", true);
                         return value;
                     });
@@ -354,18 +335,13 @@ public class Realms implements Iterable<Realm> {
         return converted;
     }
 
-    public static boolean isRealmTypeAvailable(AllowedRealmType enabledRealmType, String type) {
-        switch (enabledRealmType) {
-            case ALL:
-                return true;
-            case NONE:
-                return false;
-            case NATIVE:
-                return FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type);
-            case DEFAULT:
-                return InternalRealms.isStandardRealm(type) || ReservedRealm.TYPE.equals(type);
-            default:
-                throw new IllegalStateException("unknown enabled realm type [" + enabledRealmType + "]");
+    public static boolean isRealmTypeAvailable(XPackLicenseState licenseState, String type) {
+        if (licenseState.areAllRealmsAllowed()) {
+            return true;
+        } else if (licenseState.areStandardRealmsAllowed()) {
+            return InternalRealms.isStandardRealm(type) || ReservedRealm.TYPE.equals(type);
+        } else {
+            return FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationReq
 import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationResponse;
 import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
 import org.elasticsearch.xpack.security.action.TransportDelegatePkiAuthenticationAction;
-import org.elasticsearch.xpack.security.authc.Realms;
 
 import java.io.IOException;
 import java.util.List;
@@ -55,7 +54,7 @@ public final class RestDelegatePkiAuthenticationAction extends SecurityBaseRestH
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (Realms.isRealmTypeAvailable(licenseState.allowedRealmType(), PkiRealmSettings.TYPE)) {
+        } else if (licenseState.areStandardRealmsAllowed()) {
             return null;
         } else {
             logger.info("The '{}' realm is not available under the current license", PkiRealmSettings.TYPE);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/OpenIdConnectBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oidc/OpenIdConnectBaseRestHandler.java
@@ -33,7 +33,7 @@ public abstract class OpenIdConnectBaseRestHandler extends SecurityBaseRestHandl
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (Realms.isRealmTypeAvailable(licenseState.allowedRealmType(), OIDC_REALM_TYPE)) {
+        } else if (Realms.isRealmTypeAvailable(licenseState, OIDC_REALM_TYPE)) {
             return null;
         } else {
             logger.info("The '{}' realm is not available under the current license", OIDC_REALM_TYPE);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/SamlBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/saml/SamlBaseRestHandler.java
@@ -32,7 +32,7 @@ public abstract class SamlBaseRestHandler extends SecurityBaseRestHandler {
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (Realms.isRealmTypeAvailable(licenseState.allowedRealmType(), SAML_REALM_TYPE)) {
+        } else if (Realms.isRealmTypeAvailable(licenseState, SAML_REALM_TYPE)) {
             return null;
         } else {
             logger.info("The '{}' realm is not available under the current license", SAML_REALM_TYPE);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -188,10 +188,11 @@ public class AuthenticationServiceTests extends ESTestCase {
             .put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true)
             .build();
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.allowedRealmType()).thenReturn(XPackLicenseState.AllowedRealmType.ALL);
+        when(licenseState.areAllRealmsAllowed()).thenReturn(true);
         when(licenseState.isAuthAllowed()).thenReturn(true);
         when(licenseState.isApiKeyServiceAllowed()).thenReturn(true);
         when(licenseState.isTokenServiceAllowed()).thenReturn(true);
+        when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isAuditingAllowed()).thenReturn(true);
         ReservedRealm reservedRealm = mock(ReservedRealm.class);
         when(reservedRealm.type()).thenReturn("reserved");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.license.XPackLicenseState.AllowedRealmType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
@@ -72,12 +71,28 @@ public class RealmsTests extends ESTestCase {
             factories.put(name, config -> new DummyRealm(name, config));
         }
         licenseState = mock(XPackLicenseState.class);
+        when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         threadContext = new ThreadContext(Settings.EMPTY);
         reservedRealm = mock(ReservedRealm.class);
         when(licenseState.isAuthAllowed()).thenReturn(true);
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.ALL);
+        allowAllRealms();
         when(reservedRealm.type()).thenReturn(ReservedRealm.TYPE);
         when(reservedRealm.name()).thenReturn("reserved");
+    }
+
+    private void allowAllRealms() {
+        when(licenseState.areAllRealmsAllowed()).thenReturn(true);
+        when(licenseState.areStandardRealmsAllowed()).thenReturn(true);
+    }
+
+    private void allowOnlyStandardRealms() {
+        when(licenseState.areAllRealmsAllowed()).thenReturn(false);
+        when(licenseState.areStandardRealmsAllowed()).thenReturn(true);
+    }
+
+    private void allowOnlyNativeRealms() {
+        when(licenseState.areAllRealmsAllowed()).thenReturn(false);
+        when(licenseState.areStandardRealmsAllowed()).thenReturn(false);
     }
 
     public void testWithSettings() throws Exception {
@@ -249,7 +264,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), empty());
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.DEFAULT);
+        allowOnlyNativeRealms();
 
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
@@ -277,7 +292,7 @@ public class RealmsTests extends ESTestCase {
             i++;
         }
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.NATIVE);
+        allowOnlyNativeRealms();
 
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
@@ -333,7 +348,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), empty());
         assertThat(realms.getUnlicensedRealms(), sameInstance(realms.getUnlicensedRealms()));
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.DEFAULT);
+        allowOnlyStandardRealms();
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
         realm = iter.next();
@@ -351,7 +366,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), equalTo("type_0"));
         assertThat(realm.name(), equalTo("custom"));
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.NATIVE);
+        allowOnlyNativeRealms();
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
         realm = iter.next();
@@ -398,7 +413,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(iter.hasNext(), is(false));
         assertThat(realms.getUnlicensedRealms(), empty());
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.NATIVE);
+        allowOnlyNativeRealms();
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
         realm = iter.next();
@@ -433,7 +448,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(iter.hasNext(), is(false));
         assertThat(realms.getUnlicensedRealms(), empty());
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.DEFAULT);
+        allowOnlyStandardRealms();
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
         realm = iter.next();
@@ -451,7 +466,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realm.type(), equalTo(selectedRealmType));
         assertThat(realm.name(), equalTo("foo"));
 
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.NATIVE);
+        allowOnlyNativeRealms();
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));
         realm = iter.next();
@@ -521,7 +536,7 @@ public class RealmsTests extends ESTestCase {
         assertThat(realms.getUnlicensedRealms(), empty());
 
         // check that disabled realms are not included in unlicensed realms
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.NATIVE);
+        allowOnlyNativeRealms();
         assertThat(realms.getUnlicensedRealms(), hasSize(orderToIndex.size()));
     }
 
@@ -574,23 +589,9 @@ public class RealmsTests extends ESTestCase {
             assertThat(typeMap.size(), is(2));
         }
 
-        // disable ALL using license
-        when(licenseState.isAuthAllowed()).thenReturn(false);
-        when(licenseState.allowedRealmType()).thenReturn(AllowedRealmType.NONE);
-        future = new PlainActionFuture<>();
-        realms.usageStats(future);
-        usageStats = future.get();
-        assertThat(usageStats.size(), is(factories.size()));
-        for (Entry<String, Object> entry : usageStats.entrySet()) {
-            Map<String, Object> typeMap = (Map<String, Object>) entry.getValue();
-            assertThat(typeMap, hasEntry("enabled", false));
-            assertThat(typeMap, hasEntry("available", false));
-            assertThat(typeMap.size(), is(2));
-        }
-
-        // check native or internal realms enabled only
+        // check standard realms include native
         when(licenseState.isAuthAllowed()).thenReturn(true);
-        when(licenseState.allowedRealmType()).thenReturn(randomFrom(AllowedRealmType.NATIVE, AllowedRealmType.DEFAULT));
+        allowOnlyStandardRealms();
         future = new PlainActionFuture<>();
         realms.usageStats(future);
         usageStats = future.get();


### PR DESCRIPTION
In xpack the license state contains methods to determine whether a
particular feature is allowed to be used. The one exception is
allowsRealmTypes() which returns an enum of the types of realms allowed.
This change converts the enum values to boolean methods. There are 2
notable changes: NONE is removed as we always fall back to basic license
behavior, and NATIVE is not needed because it would always return true
since we should always have a basic license.