### PR TITLE
[DOCS] Correct DFI docs regarding stopword removal

### DIFF
--- a/docs/reference/index-modules/similarity.asciidoc
+++ b/docs/reference/index-modules/similarity.asciidoc
@@ -124,7 +124,7 @@ This similarity has the following options:
     {lucene-core-javadoc}/org/apache/lucene/search/similarities/IndependenceSaturated.html[`saturated`],
     {lucene-core-javadoc}/org/apache/lucene/search/similarities/IndependenceChiSquared.html[`chisquared`].
 
-When using this similarity, it is highly recommended to remove stop words to get
+When using this similarity, it is highly recommended *not* to remove stop words to get
 good relevance. Also beware that terms whose frequency is less than the expected
 frequency will get a score equal to 0.
 


### PR DESCRIPTION
The documentation of DFI should recommend *not* to [remove stop words][1], since DFI is good at scoring queries that contain common terms: `the wall`, `the sun`, `the who`, etc.

[1]:https://lucene.apache.org/core/8_1_1/core/org/apache/lucene/search/similarities/DFISimilarity.html