### PR TITLE
Complete a missing word in docs about _analyze api

### DIFF
--- a/docs/reference/analysis/testing.asciidoc
+++ b/docs/reference/analysis/testing.asciidoc
@@ -55,7 +55,7 @@ The API returns the following response:
 You can also test combinations of:
 
 * A tokenizer
-* Zero or token filters
+* Zero or more token filters
 * Zero or more character filters
 
 [source,console]


### PR DESCRIPTION
I found a small mistake in the documentation, and fixed it. 