### PR TITLE
[DOCS] Adds description of analysis_stats object and its properties to GET DFA stats API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -58,7 +58,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=from]
 (Optional, integer) 
 include::{docdir}/ml/ml-shared.asciidoc[tag=size]
 
-
+[role="child_attributes"]
 [[ml-get-dfanalytics-stats-response-body]]
 ==== {api-response-body-title}
 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -35,7 +35,6 @@ privileges:
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
-[role="child_attributes"]
 [[ml-get-dfanalytics-stats-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -35,7 +35,7 @@ privileges:
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
-
+[role="child_attributes"]
 [[ml-get-dfanalytics-stats-path-params]]
 ==== {api-path-parms-title}
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -550,8 +550,8 @@ The value of the eta hyperparameter.
 
 `eta_growth_rate_per_tree`::::
 (double)
-Specifies with what rate to increase `eta` for every new tree added to the 
-forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
+Specifies the rate at which the `eta` increases for each new tree that is added to the 
+forest. For example, a rate of `1.05` increases `eta` 
 by 5%.
 
 `feature_bag_fraction`::::
@@ -577,8 +577,8 @@ training stops.
 `max_optimization_rounds_per_hyperparameter`::::
 (integer)
 A multiplier responsible for determining the maximum number of 
-hyperparameter optimization steps in the bayesian optimization procedure. 
-Maximum number of steps is determined as the number of undefined hyperparameters 
+hyperparameter optimization steps in the Bayesian optimization procedure. 
+The maximum number of steps is determined based on the number of undefined hyperparameters 
 times the maximum optimization rounds per hyperparameter.
 
 `max_trees`::::
@@ -587,7 +587,7 @@ The maximum number of trees in the forest.
 
 `num_folds`::::
 (integer)
-Maximum number of folds for the cross-validation procedure.
+The maximum number of folds for the cross-validation procedure.
 
 `num_splits_per_feature`::::
 (integer)
@@ -732,7 +732,7 @@ An object containing statistical data about the {reganalysis}.
 //Begin reg_hyperparameters
 `hyperparameters`::::
 (object)
-An object containing the paramters of the {reganalysis}.
+An object containing the parameters of the {reganalysis}.
 +
 .Properties of `hyperparameters`
 [%collapsible%open]
@@ -751,7 +751,7 @@ The value of the eta hyperparameter.
 
 `eta_growth_rate_per_tree`::::
 (double)
-Specifies with what rate to increase `eta` for every new tree added to the 
+Specifies the rate at which the `eta` increases for every new tree that is added to the 
 forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
 by 5%.
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -534,7 +534,7 @@ An object containing the parameters of the {classanalysis}.
 `class_assignment_objective`::::
 (string)
 Defines whether class assignment maximizes the accuracy or the minimum recall 
-metric. Possible values are `accuracy` and `minimum_recall`.
+metric. Possible values are `maximize_accuracy` and `maximize_minimum_recall`.
 
 `downsample_factor`::::
 (double)
@@ -571,7 +571,7 @@ times the maximum optimization rounds per hyperparameter.
 
 `max_trees`::::
 (integer)
-The maximum number of trees.
+The maximum number of trees in the forest.
 
 `num_folds`::::
 (integer)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -526,7 +526,7 @@ An object containing statistical data about the {classanalysis}.
 //Begin class_hyperparameters
 `hyperparameters`::::
 (object)
-An object containing the hyperparameters of the {classanalysis}.
+An object containing the parameters of the {classanalysis}.
 +
 .Properties of `hyperparameters`
 [%collapsible%open]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -636,13 +636,13 @@ end::dfas-soft-tolerance[]
 tag::dfas-iteration[]
 `iteration`::::
 (integer)
-The number of iterations on the {dfanalytics-job}.
+The number of iterations on the analysis.
 end::dfas-iteration[]
 
 tag::dfas-timestamp[]
 `timestamp`::::
 (date)
-The timestamp when the statistics returned in milliseconds since the epoch.
+The timestamp when the statistics were reported in milliseconds since the epoch.
 end::dfas-timestamp[]
 
 //Begin class_timing_stats
@@ -658,13 +658,13 @@ end::dfas-timing-stats[]
 tag::dfas-timing-stats-elapsed[]
 `elapsed_time`::::
 (integer)
-Runtime of the {dfanalytics-job} in milliseconds.
+Runtime of the analysis in milliseconds.
 end::dfas-timing-stats-elapsed[]
 
 tag::dfas-timing-stats-iteration[]
 `iteration_time`::::
 (integer)
-Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+Runtime of the latest iteration of the analysis in milliseconds.
 end::dfas-timing-stats-iteration[]
 ======
 //End class_timing_stats
@@ -682,7 +682,7 @@ end::dfas-validation-loss[]
 tag::dfas-validation-loss-type[]
 `loss_type`::::
 (string)
-The name of the loss metric. For example, `binomial_logistic`.
+The type of the loss metric. For example, `binomial_logistic`.
 end::dfas-validation-loss-type[]
 
 tag::dfas-validation-loss-fold[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -594,12 +594,12 @@ Maximum number of folds for the cross-validation procedure.
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`regularization_soft_tree_depth_limit`::::
+`soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
 
-`regularization_soft_tree_depth_tolerance`::::
+`soft_tree_depth_tolerance`::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
@@ -795,12 +795,12 @@ Maximum number of folds for the cross-validation procedure.
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`regularization_soft_tree_depth_limit`::::
+`soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
 
-`regularization_soft_tree_depth_tolerance`::::
+`soft_tree_depth_tolerance`::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -531,123 +531,166 @@ An object containing the parameters of the {classanalysis}.
 .Properties of `hyperparameters`
 [%collapsible%open]
 ======
+tag::dfas-alpha[]
 `alpha`::::
 (double)
 Regularization factor to penalize deeper trees when training decision trees.
+end::dfas-alpha[]
 
 `class_assignment_objective`::::
 (string)
 Defines whether class assignment maximizes the accuracy or the minimum recall 
 metric. Possible values are `maximize_accuracy` and `maximize_minimum_recall`.
 
+tag::dfas-downsample-factor[]
 `downsample_factor`::::
 (double)
 The value of the downsample factor.
+end::dfas-downsample-factor[]
 
+tag::dfas-eta[]
 `eta`::::
 (double)
 The value of the eta hyperparameter.
+end::dfas-eta[]
 
+tag::dfas-eta-growth[]
 `eta_growth_rate_per_tree`::::
 (double)
 Specifies the rate at which the `eta` increases for each new tree that is added to the 
-forest. For example, a rate of `1.05` increases `eta` 
-by 5%.
+forest. For example, a rate of `1.05` increases `eta` by 5%.
+end::dfas-eta-growth[]
 
+tag::dfas-feature-bag-fraction[]
 `feature_bag_fraction`::::
 (double)
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
+end::dfas-feature-bag-fraction[]
 
+tag::dfas-gamma[]
 `gamma`::::
 (double)
 Regularization factor to penalize trees with large numbers of nodes.
+end::dfas-gamma[]
 
+tag::dfas-lambda[]
 `lambda`::::
 (double)
 Regularization factor to penalize large leaf weights.
+end::dfas-lambda[]
 
+tag::dfas-max-attempts[]
 `max_attempts_to_add_tree`::::
 (integer)
 If the algorithm fails to determine a non-trivial tree (more than a single 
 leaf), this parameter determines how many of such consecutive failures are 
 tolerated. Once the number of attempts exceeds the threshold, the forest 
 training stops.
+end::dfas-max-attempts[]
 
+tag::dfas-max-optimization-rounds[]
 `max_optimization_rounds_per_hyperparameter`::::
 (integer)
 A multiplier responsible for determining the maximum number of 
 hyperparameter optimization steps in the Bayesian optimization procedure. 
 The maximum number of steps is determined based on the number of undefined hyperparameters 
 times the maximum optimization rounds per hyperparameter.
+end::dfas-max-optimization-rounds[]
 
+tag::dfas-max-trees[]
 `max_trees`::::
 (integer)
 The maximum number of trees in the forest.
+end::dfas-max-trees[]
 
+tag::dfas-num-folds[]
 `num_folds`::::
 (integer)
 The maximum number of folds for the cross-validation procedure.
+end::dfas-num-folds[]
 
+tag::dfas-num-splits[]
 `num_splits_per_feature`::::
 (integer)
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
+end::dfas-num-splits[]
 
+tag::dfas-soft-limit[]
 `soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
+end::dfas-soft-limit[]
 
+tag::dfas-soft-tolerance[]
 `soft_tree_depth_tolerance`::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
+end::dfas-soft-tolerance[]
 ======
 //End class_hyperparameters
 
+tag::dfas-iteration[]
 `iteration`::::
 (integer)
 The number of iterations on the {dfanalytics-job}.
+end::dfas-iteration[]
 
+tag::dfas-timestamp[]
 `timestamp`::::
 (date)
 The timestamp when the statistics returned in milliseconds since the epoch.
+end::dfas-timestamp[]
 
 //Begin class_timing_stats
+tag::dfas-timing-stats[]
 `timing_stats`::::
 (object)
 An object containing time statistics about the {dfanalytics-job}.
+end::dfas-timing-stats[]
 +
 .Properties of `timing_stats`
 [%collapsible%open]
 ======
+tag::dfas-timing-stats-elapsed[]
 `elapsed_time`::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
+end::dfas-timing-stats-elapsed[]
 
+tag::dfas-timing-stats-iteration[]
 `iteration_time`::::
 (integer)
 Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+end::dfas-timing-stats-iteration[]
 ======
 //End class_timing_stats
 
 //Begin class_validation_loss
+tag::dfas-validation-loss[]
 `validation_loss`::::
 (object)
 An object containing information about validation loss.
+end::dfas-validation-loss[]
 +
 .Properties of `validation_loss`
 [%collapsible%open]
 ======
+tag::dfas-validation-loss-type[]
 `loss_type`::::
 (string)
 The name of the loss metric. For example, `binomial_logistic`.
+end::dfas-validation-loss-type[]
 
+tag::dfas-validation-loss-fold[]
 `fold_values`::::
 (array of strings)
 Validation loss values for every added decision tree during the forest growing 
 procedure.
+end::dfas-validation-loss-fold[]
 ======
 //End class_validation_loss
 =====
@@ -701,21 +744,15 @@ computing {olscores}: (x_i - mean(x_i)) / sd(x_i).
 ======
 //End parameters
 
-`timestamp`::::
-(date)
-The timestamp when the statistics returned in milliseconds since the epoch.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
 
 //Begin od_timing_stats
-`timing_stats`::::
-(object)
-An object containing time statistics about the {dfanalytics-job}.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
 +
 .Property of `timing_stats`
 [%collapsible%open]
 ======
-`elapsed_time`::::
-(integer)
-Runtime of the {dfanalytics-job} in milliseconds.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
 ======
 //End od_timing_stats
 =====
@@ -737,118 +774,61 @@ An object containing the parameters of the {reganalysis}.
 .Properties of `hyperparameters`
 [%collapsible%open]
 ======
-`alpha`::::
-(double)
-Regularization factor to penalize deeper trees when training decision trees.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-alpha]
 
-`downsample_factor`::::
-(double)
-The value of the downsample factor.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-downsample-factor]
 
-`eta`::::
-(double)
-The value of the eta hyperparameter.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-eta]
 
-`eta_growth_rate_per_tree`::::
-(double)
-Specifies the rate at which the `eta` increases for every new tree that is added to the 
-forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
-by 5%.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-eta-growth]
 
-`feature_bag_fraction`::::
-(double)
-The fraction of features that is used when selecting a random bag for each 
-candidate split.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-feature-bag-fraction]
 
-`gamma`::::
-(double)
-Regularization factor to penalize trees with large numbers of nodes.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-gamma]
 
-`lambda`::::
-(double)
-Regularization factor to penalize large leaf weights.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-lambda]
 
-`max_attempts_to_add_tree`::::
-(integer)
-If the algorithm fails to determine a non-trivial tree (more than a single 
-leaf), this parameter determines how many of such consecutive failures are 
-tolerated. Once the number of attempts exceeds the threshold, the forest 
-training stops.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-attempts]
 
-`max_optimization_rounds_per_hyperparameter`::::
-(integer)
-A multiplier responsible for determining the maximum number of 
-hyperparameter optimization steps in the bayesian optimization procedure. 
-Maximum number of steps is determined as the number of undefined hyperparameters 
-times the maximum optimization rounds per hyperparameter.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
 
-`max_trees`::::
-(integer)
-The maximum number of trees in the forest.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-trees]
 
-`num_folds`::::
-(integer)
-Maximum number of folds for the cross-validation procedure.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-num-folds]
 
-`num_splits_per_feature`::::
-(integer)
-Determines the maximum number of splits for every feature that can occur in a 
-decision tree when the tree is trained.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-num-splits]
 
-`soft_tree_depth_limit`::::
-(double)
-Tree depth limit is used for calculating the tree depth penalty. This is a soft 
-limit, it can be exceeded.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-soft-limit]
 
-`soft_tree_depth_tolerance`::::
-(double)
-Tree depth tolerance is used for calculating the tree depth penalty. This is a 
-soft limit, it can be exceeded.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-soft-tolerance]
 ======
 //End reg_hyperparameters
 
-`iteration`::::
-(integer)
-The number of iterations on the {dfanalytics-job}.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-iteration]
 
-`timestamp`::::
-(date)
-The timestamp when the statistics returned in milliseconds since the epoch.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
 
 //Begin reg_timing_stats
-`timing_stats`::::
-(object)
-An object containing time statistics about the {dfanalytics-job}.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
 +
 .Propertis of `timing_stats`
 [%collapsible%open]
 ======
-`elapsed_time`::::
-(integer)
-Runtime of the {dfanalytics-job} in milliseconds.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
 
-`iteration_time`::::
-(integer)
-Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-iteration]
 ======
 //End reg_timing_stats
 
 //Begin reg_validation_loss
-`validation_loss`::::
-(object)
-An object containing information about validation loss.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss]
 +
 .Properties of `validation_loss`
 [%collapsible%open]
 ======
-`loss_type`::::
-(string)
-The name of the loss metric. For example, `mse`.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-type]
 
-`fold_values`::::
-(array of strings)
-Validation loss values for every added decision tree during the forest growing 
-procedure.
+include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-fold]
 ======
 //End reg_validation_loss
 =====

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -531,6 +531,10 @@ An object containing the parameters of the {classanalysis}.
 .Properties of `hyperparameters`
 [%collapsible%open]
 ======
+`alpha`::::
+(double)
+Regularization factor to penalize deeper trees when training decision trees.
+
 `class_assignment_objective`::::
 (string)
 Defines whether class assignment maximizes the accuracy or the minimum recall 
@@ -554,6 +558,14 @@ by 5%.
 (double)
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
+
+`gamma`::::
+(double)
+Regularization factor to penalize trees with large numbers of nodes.
+
+`lambda`::::
+(double)
+Regularization factor to penalize large leaf weights.
 
 `max_attempts_to_add_tree`::::
 (integer)
@@ -582,15 +594,6 @@ Maximum number of folds for the cross-validation procedure.
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`regularization_depth_penalty_multiplier`::::
-(double)
-Regularization factor to penalize deeper trees when training decision trees.
-
-`regularization_leaf_weight_penalty_multiplier`::::
-(double)
-Regularization factor to penalize large leaf weights. This parameter is also 
-referred to as `lambda`.
-
 `regularization_soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
@@ -600,10 +603,6 @@ limit, it can be exceeded.
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
-
-`regularization_tree_size_penalty_multiplier`::::
-(double)
-Regularization factor to penalize trees with large numbers of nodes.
 ======
 //End class_hyperparameters
 
@@ -733,11 +732,15 @@ An object containing statistical data about the {reganalysis}.
 //Begin reg_hyperparameters
 `hyperparameters`::::
 (object)
-An object containing the hyperparameters of the {reganalysis}.
+An object containing the paramters of the {reganalysis}.
 +
 .Properties of `hyperparameters`
 [%collapsible%open]
 ======
+`alpha`::::
+(double)
+Regularization factor to penalize deeper trees when training decision trees.
+
 `downsample_factor`::::
 (double)
 The value of the downsample factor.
@@ -757,6 +760,14 @@ by 5%.
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
 
+`gamma`::::
+(double)
+Regularization factor to penalize trees with large numbers of nodes.
+
+`lambda`::::
+(double)
+Regularization factor to penalize large leaf weights.
+
 `max_attempts_to_add_tree`::::
 (integer)
 If the algorithm fails to determine a non-trivial tree (more than a single 
@@ -773,7 +784,7 @@ times the maximum optimization rounds per hyperparameter.
 
 `max_trees`::::
 (integer)
-The maximum number of trees.
+The maximum number of trees in the forest.
 
 `num_folds`::::
 (integer)
@@ -784,15 +795,6 @@ Maximum number of folds for the cross-validation procedure.
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`regularization_depth_penalty_multiplier`::::
-(double)
-Regularization factor to penalize deeper trees when training decision trees.
-
-`regularization_leaf_weight_penalty_multiplier`::::
-(double)
-Regularization factor to penalize large leaf weights. This parameter is also 
-referred to as `lambda`.
-
 `regularization_soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
@@ -802,10 +804,6 @@ limit, it can be exceeded.
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
-
-`regularization_tree_size_penalty_multiplier`::::
-(double)
-Regularization factor to penalize trees with large numbers of nodes.
 ======
 //End reg_hyperparameters
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -507,284 +507,356 @@ tag::data-frame-analytics-stats[]
 An array of statistics objects for {dfanalytics-jobs}, which are
 sorted by the `id` value in ascending order.
 
-`analysis_stats`:::
+//Begin analysis_stats
+`analysis_stats`::
 (object)
 An object containing statistical data about the analysis.
-
-`analysis_stats`.`classification_stats`:::
++
+.Properties of `analysis_stats`
+[%collapsible%open]
+====
+//Begin classification_stats
+`classification_stats`:::
 (object)
 An object containing statistical data about the {classanalysis}.
-
-`analysis_stats`.`classification_stats`.`hyperparameters`:::
++
+.Properties of `classification_stats`
+[%collapsible%open]
+=====
+//Begin class_hyperparameters
+`hyperparameters`::::
 (object)
 An object containing the hyperparameters of the {classanalysis}.
-
-`analysis_stats`.`classification_stats`.`hyperparameters`.`class_assignment_objective`:::
++
+.Properties of `hyperparameters`
+[%collapsible%open]
+======
+`class_assignment_objective`:::::
 (string)
 Defines whether class assignment maximizes the accuracy or the minimum recall 
 metric. Possible values are `accuracy` and `minimum_recall`.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`downsample_factor`:::
+`downsample_factor`:::::
 (double)
 The value of the downsample factor.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`eta`:::
+`eta`:::::
 (double)
 The value of the eta hyperparameter.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`eta_growth_rate_per_tree`:::
+`eta_growth_rate_per_tree`:::::
 (double)
 Specifies with what rate to increase `eta` for every new tree added to the 
 forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
 by 5%.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`feature_bag_fraction`:::
+`feature_bag_fraction`:::::
 (double)
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`max_attempts_to_add_tree`:::
+`max_attempts_to_add_tree`:::::
 (integer)
 If the algorithm fails to determine a non-trivial tree (more than a single 
 leaf), this parameter determines how many of such consecutive failures are 
 tolerated. Once the number of attempts exceeds the threshold, the forest 
 training stops.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`max_optimization_rounds_per_hyperparameter`:::
+`max_optimization_rounds_per_hyperparameter`:::::
 (integer)
 A multiplier responsible for determining the maximum number of 
 hyperparameter optimization steps in the bayesian optimization procedure. 
 Maximum number of steps is determined as the number of undefined hyperparameters 
 times the maximum optimization rounds per hyperparameter.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`max_trees`:::
+`max_trees`:::::
 (integer)
 The maximum number of trees.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`num_folds`:::
+`num_folds`:::::
 (integer)
 Maximum number of folds for the cross-validation procedure.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`num_splits_per_feature`:::
+`num_splits_per_feature`:::::
 (integer)
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_depth_penalty_multiplier`:::
+`regularization_depth_penalty_multiplier`:::::
 (double)
 Regularization factor to penalize deeper trees when training decision trees.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_leaf_weight_penalty_multiplier`:::
+`regularization_leaf_weight_penalty_multiplier`:::::
 (double)
 Regularization factor to penalize large leaf weights. This parameter is also 
 referred to as `lambda`.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_soft_tree_depth_limit`:::
+`regularization_soft_tree_depth_limit`:::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_soft_tree_depth_tolerance`:::
+`regularization_soft_tree_depth_tolerance`:::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
 
-`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_tree_size_penalty_multiplier`:::
+`regularization_tree_size_penalty_multiplier`:::::
 (double)
 Regularization factor to penalize trees with large numbers of nodes.
+======
+//End class_hyperparameters
 
-`analysis_stats`.`classification_stats`.`iteration`:::
+`iteration`::::
 (integer)
 The number of iterations on the {dfanalytics-job}.
 
-`analysis_stats`.`classification_stats`.`timestamp`:::
+`timestamp`::::
 (date)
 The timestamp when the statistics returned in milliseconds since the epoch.
 
-`analysis_stats`.`classification_stats`.`timing_stats`:::
+//Begin class_timing_stats
+`timing_stats`::::
 (object)
 An object containing time statistics about the {dfanalytics-job}.
-
-`analysis_stats`.`classification_stats`.`timing_stats`.`elapsed_time`:::
++
+.Properties of `timing_stats`
+[%collapsible%open]
+======
+`elapsed_time`:::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
 
-`analysis_stats`.`classification_stats`.`timing_stats`.`iteration_time`:::
+`iteration_time`:::::
 (integer)
 Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+======
+//End class_timing_stats
 
-`analysis_stats`.`classification_stats`.`validation_loss`:::
+//Begin class_validation_loss
+`validation_loss`::::
 (object)
 An object containing information about validation loss.
-
-`analysis_stats`.`classification_stats`.`validation_loss`.`loss_type`:::
++
+.Properties of `validation_loss`
+[%collapsible%open]
+======
+`loss_type`:::::
 (string)
 The name of the loss metric. For example, `binomial_logistic`.
 
-`analysis_stats`.`classification_stats`.`validation_loss`.`fold_values`:::
+`fold_values`:::::
 (array of strings)
 Validation loss values for every added decision tree during the forest growing 
 procedure.
+======
+//End class_validation_loss
+=====
+//End classification_stats
 
-`analysis_stats`.`outlier_detection_stats`:::
+//Begin outlier_detection_stats
+`outlier_detection_stats`:::
 (object)
 An object containing statistical data about the {oldetection} job.
-
-`analysis_stats`.`outlier_detection_stats`.`parameters`:::
++
+.Properties of `outlier_detection_stats`
+[%collapsible%open]
+=====
+//Begin parameters
+`parameters`::::
 (object)
 The list of job parameters specified by the user or determined by algorithmic 
 heuristics.
-
-`analysis_stats`.`outlier_detection_stats`.`parameters`.`compute_feature_influence`:::
++
+.Properties of `parameters`
+[%collapsible%open]
+======
+`compute_feature_influence`:::::
 (boolean)
 If true, feature influence calculation is enabled.
 
-`analysis_stats`.`outlier_detection_stats`.`parameters`.`feature_influence_threshold`:::
+`feature_influence_threshold`:::::
 (double)
 The minimum {olscore} that a document needs to have to calculate its feature 
 influence score.
 
-`analysis_stats`.`outlier_detection_stats`.`parameters`.`method`:::
+`method`:::::
 (string)
 The method that {oldetection} uses. Possible values are `lof`, `ldof`, 
 `distance_kth_nn`, `distance_knn`, and `ensemble`.
 
-`analysis_stats`.`outlier_detection_stats`.`parameters`.`n_neighbors`:::
+`n_neighbors`:::::
 (integer)
 The value for how many nearest neighbors each method of {oldetection} uses to 
 calculate its outlier score.
 
-`analysis_stats`.`outlier_detection_stats`.`parameters`.`outlier_fraction`:::
+`outlier_fraction`:::::
 (double)
 The proportion of the data set that is assumed to be outlying prior to 
 {oldetection}.
 
-`analysis_stats`.`outlier_detection_stats`.`parameters`.`standardization_enabled`:::
+`standardization_enabled`:::::
 (boolean)
 If true, then the following operation is performed on the columns before 
 computing {olscores}: (x_i - mean(x_i)) / sd(x_i).
+======
+//End parameters
 
-`analysis_stats`.`outlier_detection_stats`.`timestamp`:::
+`timestamp`::::
 (date)
 The timestamp when the statistics returned in milliseconds since the epoch.
 
-`analysis_stats`.`outlier_detection_stats`.`timing_stats`:::
+//Begin od_timing_stats
+`timing_stats`::::
 (object)
 An object containing time statistics about the {dfanalytics-job}.
-
-`analysis_stats`.`outlier_detection_stats`.`timing_stats`.`elapsed_time`:::
++
+.Property of `timing_stats`
+[%collapsible%open]
+======
+`elapsed_time`:::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
+======
+//End od_timing_stats
+=====
+//End outlier_detection_stats
 
-`analysis_stats`.`regression_stats`:::
+//Begin regression_stats
+`regression_stats`:::
 (object)
 An object containing statistical data about the {reganalysis}.
-
-`analysis_stats`.`regression_stats`.`hyperparameters`:::
++
+.Properties of `regression_stats`
+[%collapsible%open]
+=====
+//Begin reg_hyperparameters
+`hyperparameters`::::
 (object)
 An object containing the hyperparameters of the {reganalysis}.
-
-`analysis_stats`.`regression_stats`.`hyperparameters`.`downsample_factor`:::
++
+.Properties of `hyperparameters`
+[%collapsible%open]
+======
+`downsample_factor`:::::
 (double)
 The value of the downsample factor.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`eta`:::
+`eta`:::::
 (double)
 The value of the eta hyperparameter.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`eta_growth_rate_per_tree`:::
+`eta_growth_rate_per_tree`:::::
 (double)
 Specifies with what rate to increase `eta` for every new tree added to the 
 forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
 by 5%.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`feature_bag_fraction`:::
+`feature_bag_fraction`:::::
 (double)
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`max_attempts_to_add_tree`:::
+`max_attempts_to_add_tree`:::::
 (integer)
 If the algorithm fails to determine a non-trivial tree (more than a single 
 leaf), this parameter determines how many of such consecutive failures are 
 tolerated. Once the number of attempts exceeds the threshold, the forest 
 training stops.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`max_optimization_rounds_per_hyperparameter`:::
+`max_optimization_rounds_per_hyperparameter`:::::
 (integer)
 A multiplier responsible for determining the maximum number of 
 hyperparameter optimization steps in the bayesian optimization procedure. 
 Maximum number of steps is determined as the number of undefined hyperparameters 
 times the maximum optimization rounds per hyperparameter.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`max_trees`:::
+`max_trees`:::::
 (integer)
 The maximum number of trees.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`num_folds`:::
+`num_folds`:::::
 (integer)
 Maximum number of folds for the cross-validation procedure.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`num_splits_per_feature`:::
+`num_splits_per_feature`:::::
 (integer)
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_depth_penalty_multiplier`:::
+`regularization_depth_penalty_multiplier`:::::
 (double)
 Regularization factor to penalize deeper trees when training decision trees.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_leaf_weight_penalty_multiplier`:::
+`regularization_leaf_weight_penalty_multiplier`:::::
 (double)
 Regularization factor to penalize large leaf weights. This parameter is also 
 referred to as `lambda`.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_soft_tree_depth_limit`:::
+`regularization_soft_tree_depth_limit`:::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_soft_tree_depth_tolerance`:::
+`regularization_soft_tree_depth_tolerance`:::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
 
-`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_tree_size_penalty_multiplier`:::
+`regularization_tree_size_penalty_multiplier`:::::
 (double)
 Regularization factor to penalize trees with large numbers of nodes.
+======
+//End reg_hyperparameters
 
-`analysis_stats`.`regression_stats`.`iteration`:::
+`iteration`::::
 (integer)
 The number of iterations on the {dfanalytics-job}.
 
-`analysis_stats`.`regression_stats`.`timestamp`:::
+`timestamp`::::
 (date)
 The timestamp when the statistics returned in milliseconds since the epoch.
 
-`analysis_stats`.`regression_stats`.`timing_stats`:::
+//Begin reg_timing_stats
+`timing_stats`::::
 (object)
 An object containing time statistics about the {dfanalytics-job}.
-
-`analysis_stats`.`regression_stats`.`timing_stats`.`elapsed_time`:::
++
+.Propertis of `timing_stats`
+[%collapsible%open]
+======
+`elapsed_time`:::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
 
-`analysis_stats`.`regression_stats`.`timing_stats`.`iteration_time`:::
+`iteration_time`:::::
 (integer)
 Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+======
+//End reg_timing_stats
 
-`analysis_stats`.`regression_stats`.`validation_loss`:::
+//Begin reg_validation_loss
+`validation_loss`::::
 (object)
 An object containing information about validation loss.
-
-`analysis_stats`.`regression_stats`.`validation_loss`.`loss_type`:::
++
+.Properties of `validation_loss`
+[%collapsible%open]
+======
+`loss_type`:::::
 (string)
 The name of the loss metric. For example, `mse`.
 
-`analysis_stats`.`regression_stats`.`validation_loss`.`fold_values`:::
+`fold_values`:::::
 (array of strings)
 Validation loss values for every added decision tree during the forest growing 
 procedure.
+======
+//End reg_validation_loss
+=====
+//End regression_stats
+====
+//End analysis_stats
 
 `assignment_explanation`:::
 (string)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -526,7 +526,7 @@ Possible values are `accuracy` and `minimum_recall`.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`downsample_factor`:::
 (double)
-Th value of the downsample factor.
+The value of the downsample factor.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`eta`:::
 (double)
@@ -674,7 +674,7 @@ An object containing the hyperparameters of the {reganalysis}.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`downsample_factor`:::
 (double)
-Th value of the downsample factor.
+The value of the downsample factor.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`eta`:::
 (double)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -507,6 +507,7 @@ tag::data-frame-analytics-stats[]
 An array of statistics objects for {dfanalytics-jobs}, which are
 sorted by the `id` value in ascending order.
 
+[role="child_attributes"]
 //Begin analysis_stats
 `analysis_stats`::
 (object)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -507,7 +507,6 @@ tag::data-frame-analytics-stats[]
 An array of statistics objects for {dfanalytics-jobs}, which are
 sorted by the `id` value in ascending order.
 
-[role="child_attributes"]
 //Begin analysis_stats
 `analysis_stats`::
 (object)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -507,6 +507,261 @@ tag::data-frame-analytics-stats[]
 An array of statistics objects for {dfanalytics-jobs}, which are
 sorted by the `id` value in ascending order.
 
+`analysis_stats`:::
+(object)
+An object containing statistical data about the analysis.
+
+`analysis_stats`.`classification_stats`:::
+(object)
+An object containing statistical data about the {classanalysis}.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`:::
+(object)
+An object containing the hyperparameters of the {classanalysis}.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`class_assignment_objective`:::
+(string)
+(TBD)
+Possible values are `accuracy` and `minimum_recall`.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`downsample_factor`:::
+(double)
+Th value of the downsample factor.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`eta`:::
+(double)
+The value of the eta hyperparameter.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`eta_growth_rate_per_tree`:::
+(double)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`feature_bag_fraction`:::
+(double)
+The fraction of features that is used when selecting a random bag for each 
+candidate split.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`max_attempts_to_add_tree`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`max_optimization_rounds_per_hyperparameter`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`max_trees`:::
+(integer)
+The maximum number of trees.
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`num_folds`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`num_splits_per_feature`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_depth_penalty_multiplier`:::
+(double)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_leaf_weight_penalty_multiplier`:::
+(double)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_soft_tree_depth_limit`:::
+(double)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_soft_tree_depth_tolerance`:::
+(double)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_tree_size_penalty_multiplier`:::
+(double)
+(TBD)
+
+`analysis_stats`.`classification_stats`.`iteration`:::
+(integer)
+The number of iterations on the {dfanalytics-job}.
+
+`analysis_stats`.`classification_stats`.`timestamp`:::
+(date)
+The timestamp when the statistics returned in milliseconds since the epoch.
+
+`analysis_stats`.`classification_stats`.`timing_stats`:::
+(object)
+An object containing time statistics about the {dfanalytics-job}.
+
+`analysis_stats`.`classification_stats`.`timing_stats`.`elapsed_time`:::
+(integer)
+Runtime of the {dfanalytics-job} in milliseconds.
+
+`analysis_stats`.`classification_stats`.`timing_stats`.`iteration_time`:::
+(integer)
+Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+
+`analysis_stats`.`classification_stats`.`validation_loss`:::
+(object)
+An object containing information about validation loss.
+
+`analysis_stats`.`classification_stats`.`validation_loss`.`loss_type`:::
+(string)
+The name of the loss metric. For example, `binomial_logistic`.
+
+`analysis_stats`.`classification_stats`.`validation_loss`.`fold_values`:::
+(array of strings)
+Validation loss values for every added decision tree during the forest growing 
+procedure.
+
+`analysis_stats`.`outlier_detection_stats`:::
+(object)
+An object containing statistical data about the {oldetection} job.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`:::
+(object)
+The list of job parameters specified by the user or determined by algorithmic 
+heuristics.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`.`compute_feature_influence`:::
+(boolean)
+If true, feature influence calculation is enabled.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`.`feature_influence_threshold`:::
+(double)
+The minimum {olscore} that a document needs to have to calculate its feature 
+influence score.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`.`method`:::
+(string)
+The method that {oldetection} uses. Possible values are `lof`, `ldof`, 
+`distance_kth_nn`, `distance_knn`, and `ensemble`.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`.`n_neighbors`:::
+(integer)
+The value for how many nearest neighbors each method of {oldetection} uses to 
+calculate its outlier score.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`.`outlier_fraction`:::
+(double)
+The proportion of the data set that is assumed to be outlying prior to 
+{oldetection}.
+
+`analysis_stats`.`outlier_detection_stats`.`parameters`.`standardization_enabled`:::
+(boolean)
+If true, then the following operation is performed on the columns before 
+computing {olscores}: (x_i - mean(x_i)) / sd(x_i).
+
+`analysis_stats`.`outlier_detection_stats`.`timestamp`:::
+(date)
+The timestamp when the statistics returned in milliseconds since the epoch.
+
+`analysis_stats`.`outlier_detection_stats`.`timing_stats`:::
+(object)
+An object containing time statistics about the {dfanalytics-job}.
+
+`analysis_stats`.`outlier_detection_stats`.`timing_stats`.`elapsed_time`:::
+(integer)
+Runtime of the {dfanalytics-job} in milliseconds.
+
+`analysis_stats`.`regression_stats`:::
+(object)
+An object containing statistical data about the {reganalysis}.
+
+`analysis_stats`.`regression_stats`.`hyperparameters`:::
+(object)
+An object containing the hyperparameters of the {reganalysis}.
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`downsample_factor`:::
+(double)
+Th value of the downsample factor.
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`eta`:::
+(double)
+The value of the eta hyperparameter.
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`eta_growth_rate_per_tree`:::
+(double)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`feature_bag_fraction`:::
+(double)
+The fraction of features that is used when selecting a random bag for each 
+candidate split.
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`max_attempts_to_add_tree`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`max_optimization_rounds_per_hyperparameter`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`max_trees`:::
+(integer)
+The maximum number of trees.
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`num_folds`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`num_splits_per_feature`:::
+(integer)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_depth_penalty_multiplier`:::
+(double)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_leaf_weight_penalty_multiplier`:::
+(double)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_soft_tree_depth_limit`:::
+(double)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_soft_tree_depth_tolerance`:::
+(double)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_tree_size_penalty_multiplier`:::
+(double)
+(TBD)
+
+`analysis_stats`.`regression_stats`.`iteration`:::
+(integer)
+The number of iterations on the {dfanalytics-job}.
+
+`analysis_stats`.`regression_stats`.`timestamp`:::
+(date)
+The timestamp when the statistics returned in milliseconds since the epoch.
+
+`analysis_stats`.`regression_stats`.`timing_stats`:::
+(object)
+An object containing time statistics about the {dfanalytics-job}.
+
+`analysis_stats`.`regression_stats`.`timing_stats`.`elapsed_time`:::
+(integer)
+Runtime of the {dfanalytics-job} in milliseconds.
+
+`analysis_stats`.`regression_stats`.`timing_stats`.`iteration_time`:::
+(integer)
+Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
+
+`analysis_stats`.`regression_stats`.`validation_loss`:::
+(object)
+An object containing information about validation loss.
+
+`analysis_stats`.`regression_stats`.`validation_loss`.`loss_type`:::
+(string)
+The name of the loss metric. For example, `mse`.
+
+`analysis_stats`.`regression_stats`.`validation_loss`.`fold_values`:::
+(array of strings)
+Validation loss values for every added decision tree during the forest growing 
+procedure.
+
 `assignment_explanation`:::
 (string)
 For running jobs only, contains messages relating to the selection of a node to 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -521,8 +521,8 @@ An object containing the hyperparameters of the {classanalysis}.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`class_assignment_objective`:::
 (string)
-(TBD)
-Possible values are `accuracy` and `minimum_recall`.
+Defines whether class assignment maximizes the accuracy or the minimum recall 
+metric. Possible values are `accuracy` and `minimum_recall`.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`downsample_factor`:::
 (double)
@@ -534,7 +534,9 @@ The value of the eta hyperparameter.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`eta_growth_rate_per_tree`:::
 (double)
-(TBD)
+Specifies with what rate to increase `eta` for every new tree added to the 
+forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
+by 5%.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`feature_bag_fraction`:::
 (double)
@@ -543,11 +545,17 @@ candidate split.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`max_attempts_to_add_tree`:::
 (integer)
-(TBD)
+If the algorithm fails to determine a non-trivial tree (more than a single 
+leaf), this parameter determines how many of such consecutive failures are 
+tolerated. Once the number of attempts exceeds the threshold, the forest 
+training stops.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`max_optimization_rounds_per_hyperparameter`:::
 (integer)
-(TBD)
+A multiplier responsible for determining the maximum number of 
+hyperparameter optimization steps in the bayesian optimization procedure. 
+Maximum number of steps is determined as the number of undefined hyperparameters 
+times the maximum optimization rounds per hyperparameter.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`max_trees`:::
 (integer)
@@ -555,31 +563,35 @@ The maximum number of trees.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`num_folds`:::
 (integer)
-(TBD)
+Maximum number of folds for the cross-validation procedure.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`num_splits_per_feature`:::
 (integer)
-(TBD)
+Determines the maximum number of splits for every feature that can occur in a 
+decision tree when the tree is trained.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_depth_penalty_multiplier`:::
 (double)
-(TBD)
+Regularization factor to penalize deeper trees when training decision trees.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_leaf_weight_penalty_multiplier`:::
 (double)
-(TBD)
+Regularization factor to penalize large leaf weights. This parameter is also 
+referred to as `lambda`.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_soft_tree_depth_limit`:::
 (double)
-(TBD)
+Tree depth limit is used for calculating the tree depth penalty. This is a soft 
+limit, it can be exceeded.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_soft_tree_depth_tolerance`:::
 (double)
-(TBD)
+Tree depth tolerance is used for calculating the tree depth penalty. This is a 
+soft limit, it can be exceeded.
 
 `analysis_stats`.`classification_stats`.`hyperparameters`.`regularization_tree_size_penalty_multiplier`:::
 (double)
-(TBD)
+Regularization factor to penalize trees with large numbers of nodes.
 
 `analysis_stats`.`classification_stats`.`iteration`:::
 (integer)
@@ -682,7 +694,9 @@ The value of the eta hyperparameter.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`eta_growth_rate_per_tree`:::
 (double)
-(TBD)
+Specifies with what rate to increase `eta` for every new tree added to the 
+forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
+by 5%.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`feature_bag_fraction`:::
 (double)
@@ -691,11 +705,17 @@ candidate split.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`max_attempts_to_add_tree`:::
 (integer)
-(TBD)
+If the algorithm fails to determine a non-trivial tree (more than a single 
+leaf), this parameter determines how many of such consecutive failures are 
+tolerated. Once the number of attempts exceeds the threshold, the forest 
+training stops.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`max_optimization_rounds_per_hyperparameter`:::
 (integer)
-(TBD)
+A multiplier responsible for determining the maximum number of 
+hyperparameter optimization steps in the bayesian optimization procedure. 
+Maximum number of steps is determined as the number of undefined hyperparameters 
+times the maximum optimization rounds per hyperparameter.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`max_trees`:::
 (integer)
@@ -703,31 +723,35 @@ The maximum number of trees.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`num_folds`:::
 (integer)
-(TBD)
+Maximum number of folds for the cross-validation procedure.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`num_splits_per_feature`:::
 (integer)
-(TBD)
+Determines the maximum number of splits for every feature that can occur in a 
+decision tree when the tree is trained.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_depth_penalty_multiplier`:::
 (double)
-(TBD)
+Regularization factor to penalize deeper trees when training decision trees.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_leaf_weight_penalty_multiplier`:::
 (double)
-(TBD)
+Regularization factor to penalize large leaf weights. This parameter is also 
+referred to as `lambda`.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_soft_tree_depth_limit`:::
 (double)
-(TBD)
+Tree depth limit is used for calculating the tree depth penalty. This is a soft 
+limit, it can be exceeded.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_soft_tree_depth_tolerance`:::
 (double)
-(TBD)
+Tree depth tolerance is used for calculating the tree depth penalty. This is a 
+soft limit, it can be exceeded.
 
 `analysis_stats`.`regression_stats`.`hyperparameters`.`regularization_tree_size_penalty_multiplier`:::
 (double)
-(TBD)
+Regularization factor to penalize trees with large numbers of nodes.
 
 `analysis_stats`.`regression_stats`.`iteration`:::
 (integer)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -531,77 +531,77 @@ An object containing the hyperparameters of the {classanalysis}.
 .Properties of `hyperparameters`
 [%collapsible%open]
 ======
-`class_assignment_objective`:::::
+`class_assignment_objective`::::
 (string)
 Defines whether class assignment maximizes the accuracy or the minimum recall 
 metric. Possible values are `accuracy` and `minimum_recall`.
 
-`downsample_factor`:::::
+`downsample_factor`::::
 (double)
 The value of the downsample factor.
 
-`eta`:::::
+`eta`::::
 (double)
 The value of the eta hyperparameter.
 
-`eta_growth_rate_per_tree`:::::
+`eta_growth_rate_per_tree`::::
 (double)
 Specifies with what rate to increase `eta` for every new tree added to the 
 forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
 by 5%.
 
-`feature_bag_fraction`:::::
+`feature_bag_fraction`::::
 (double)
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
 
-`max_attempts_to_add_tree`:::::
+`max_attempts_to_add_tree`::::
 (integer)
 If the algorithm fails to determine a non-trivial tree (more than a single 
 leaf), this parameter determines how many of such consecutive failures are 
 tolerated. Once the number of attempts exceeds the threshold, the forest 
 training stops.
 
-`max_optimization_rounds_per_hyperparameter`:::::
+`max_optimization_rounds_per_hyperparameter`::::
 (integer)
 A multiplier responsible for determining the maximum number of 
 hyperparameter optimization steps in the bayesian optimization procedure. 
 Maximum number of steps is determined as the number of undefined hyperparameters 
 times the maximum optimization rounds per hyperparameter.
 
-`max_trees`:::::
+`max_trees`::::
 (integer)
 The maximum number of trees.
 
-`num_folds`:::::
+`num_folds`::::
 (integer)
 Maximum number of folds for the cross-validation procedure.
 
-`num_splits_per_feature`:::::
+`num_splits_per_feature`::::
 (integer)
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`regularization_depth_penalty_multiplier`:::::
+`regularization_depth_penalty_multiplier`::::
 (double)
 Regularization factor to penalize deeper trees when training decision trees.
 
-`regularization_leaf_weight_penalty_multiplier`:::::
+`regularization_leaf_weight_penalty_multiplier`::::
 (double)
 Regularization factor to penalize large leaf weights. This parameter is also 
 referred to as `lambda`.
 
-`regularization_soft_tree_depth_limit`:::::
+`regularization_soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
 
-`regularization_soft_tree_depth_tolerance`:::::
+`regularization_soft_tree_depth_tolerance`::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
 
-`regularization_tree_size_penalty_multiplier`:::::
+`regularization_tree_size_penalty_multiplier`::::
 (double)
 Regularization factor to penalize trees with large numbers of nodes.
 ======
@@ -623,11 +623,11 @@ An object containing time statistics about the {dfanalytics-job}.
 .Properties of `timing_stats`
 [%collapsible%open]
 ======
-`elapsed_time`:::::
+`elapsed_time`::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
 
-`iteration_time`:::::
+`iteration_time`::::
 (integer)
 Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
 ======
@@ -641,11 +641,11 @@ An object containing information about validation loss.
 .Properties of `validation_loss`
 [%collapsible%open]
 ======
-`loss_type`:::::
+`loss_type`::::
 (string)
 The name of the loss metric. For example, `binomial_logistic`.
 
-`fold_values`:::::
+`fold_values`::::
 (array of strings)
 Validation loss values for every added decision tree during the forest growing 
 procedure.
@@ -671,31 +671,31 @@ heuristics.
 .Properties of `parameters`
 [%collapsible%open]
 ======
-`compute_feature_influence`:::::
+`compute_feature_influence`::::
 (boolean)
 If true, feature influence calculation is enabled.
 
-`feature_influence_threshold`:::::
+`feature_influence_threshold`::::
 (double)
 The minimum {olscore} that a document needs to have to calculate its feature 
 influence score.
 
-`method`:::::
+`method`::::
 (string)
 The method that {oldetection} uses. Possible values are `lof`, `ldof`, 
 `distance_kth_nn`, `distance_knn`, and `ensemble`.
 
-`n_neighbors`:::::
+`n_neighbors`::::
 (integer)
 The value for how many nearest neighbors each method of {oldetection} uses to 
 calculate its outlier score.
 
-`outlier_fraction`:::::
+`outlier_fraction`::::
 (double)
 The proportion of the data set that is assumed to be outlying prior to 
 {oldetection}.
 
-`standardization_enabled`:::::
+`standardization_enabled`::::
 (boolean)
 If true, then the following operation is performed on the columns before 
 computing {olscores}: (x_i - mean(x_i)) / sd(x_i).
@@ -714,7 +714,7 @@ An object containing time statistics about the {dfanalytics-job}.
 .Property of `timing_stats`
 [%collapsible%open]
 ======
-`elapsed_time`:::::
+`elapsed_time`::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
 ======
@@ -738,72 +738,72 @@ An object containing the hyperparameters of the {reganalysis}.
 .Properties of `hyperparameters`
 [%collapsible%open]
 ======
-`downsample_factor`:::::
+`downsample_factor`::::
 (double)
 The value of the downsample factor.
 
-`eta`:::::
+`eta`::::
 (double)
 The value of the eta hyperparameter.
 
-`eta_growth_rate_per_tree`:::::
+`eta_growth_rate_per_tree`::::
 (double)
 Specifies with what rate to increase `eta` for every new tree added to the 
 forest. The rate of 1.0 does not change `eta`, the rate of 1.05 increases `eta` 
 by 5%.
 
-`feature_bag_fraction`:::::
+`feature_bag_fraction`::::
 (double)
 The fraction of features that is used when selecting a random bag for each 
 candidate split.
 
-`max_attempts_to_add_tree`:::::
+`max_attempts_to_add_tree`::::
 (integer)
 If the algorithm fails to determine a non-trivial tree (more than a single 
 leaf), this parameter determines how many of such consecutive failures are 
 tolerated. Once the number of attempts exceeds the threshold, the forest 
 training stops.
 
-`max_optimization_rounds_per_hyperparameter`:::::
+`max_optimization_rounds_per_hyperparameter`::::
 (integer)
 A multiplier responsible for determining the maximum number of 
 hyperparameter optimization steps in the bayesian optimization procedure. 
 Maximum number of steps is determined as the number of undefined hyperparameters 
 times the maximum optimization rounds per hyperparameter.
 
-`max_trees`:::::
+`max_trees`::::
 (integer)
 The maximum number of trees.
 
-`num_folds`:::::
+`num_folds`::::
 (integer)
 Maximum number of folds for the cross-validation procedure.
 
-`num_splits_per_feature`:::::
+`num_splits_per_feature`::::
 (integer)
 Determines the maximum number of splits for every feature that can occur in a 
 decision tree when the tree is trained.
 
-`regularization_depth_penalty_multiplier`:::::
+`regularization_depth_penalty_multiplier`::::
 (double)
 Regularization factor to penalize deeper trees when training decision trees.
 
-`regularization_leaf_weight_penalty_multiplier`:::::
+`regularization_leaf_weight_penalty_multiplier`::::
 (double)
 Regularization factor to penalize large leaf weights. This parameter is also 
 referred to as `lambda`.
 
-`regularization_soft_tree_depth_limit`:::::
+`regularization_soft_tree_depth_limit`::::
 (double)
 Tree depth limit is used for calculating the tree depth penalty. This is a soft 
 limit, it can be exceeded.
 
-`regularization_soft_tree_depth_tolerance`:::::
+`regularization_soft_tree_depth_tolerance`::::
 (double)
 Tree depth tolerance is used for calculating the tree depth penalty. This is a 
 soft limit, it can be exceeded.
 
-`regularization_tree_size_penalty_multiplier`:::::
+`regularization_tree_size_penalty_multiplier`::::
 (double)
 Regularization factor to penalize trees with large numbers of nodes.
 ======
@@ -825,11 +825,11 @@ An object containing time statistics about the {dfanalytics-job}.
 .Propertis of `timing_stats`
 [%collapsible%open]
 ======
-`elapsed_time`:::::
+`elapsed_time`::::
 (integer)
 Runtime of the {dfanalytics-job} in milliseconds.
 
-`iteration_time`:::::
+`iteration_time`::::
 (integer)
 Runtime of the {dfanalytics-job} since the last iteration in milliseconds.
 ======
@@ -843,11 +843,11 @@ An object containing information about validation loss.
 .Properties of `validation_loss`
 [%collapsible%open]
 ======
-`loss_type`:::::
+`loss_type`::::
 (string)
 The name of the loss metric. For example, `mse`.
 
-`fold_values`:::::
+`fold_values`::::
 (array of strings)
 Validation loss values for every added decision tree during the forest growing 
 procedure.


### PR DESCRIPTION
This PR contains the documentation of the new `analysis_stats` object and its properties that are exposed in GET DFA stats.

Preview: http://elasticsearch_53881.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html