### PR TITLE
[DOCS] Reformat `synonym_graph` token filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -131,7 +131,7 @@ Either this parameter or `synonyms_path` must be specified.
 [TIP]
 ====
 For large sets of synonyms, we recommend using a file and the `synonyms_path`
-parameter. Specifying a large number of inline synonym rules can increases
+parameter. Specifying a large number of inline synonym rules can increase
 cluster size.
 ====
 --

--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -4,58 +4,243 @@
 <titleabbrev>Synonym graph</titleabbrev>
 ++++
 
-The `synonym_graph` token filter allows to easily handle synonyms,
-including multi-word synonyms correctly during the analysis process.
+Adds synonyms to a token stream. For example, you can use the `synonym_graph`
+filter to add `fast` as a synonym for `quick`. You can also use the filter to
+add multi-word synonyms, such as `automated teller machine` as a synonym for
+`atm`.
 
-In order to properly handle multi-word synonyms this token filter
-creates a <<token-graphs,graph token stream>> during processing.  For more
-information on this topic and its various complexities, please read the
-http://blog.mikemccandless.com/2012/04/lucenes-tokenstreams-are-actually.html[Lucene's TokenStreams are actually graphs] blog post.
+The `synonym_graph` filter produces valid <<token-graphs,token graphs>>. Queries,
+such as the <<query-dsl-match-query,`match`>> or
+<<query-dsl-match-query-phrase,`match_phrase`>> query, can use these graphs to
+generate multiple sub-queries from a single query string. See <<token-graphs>>.
 
-["NOTE",id="synonym-graph-index-note"]
-===============================
-This token filter is designed to be used as part of a search analyzer
-only.  If you want to apply synonyms during indexing please use the
-standard <<analysis-synonym-tokenfilter,synonym token filter>>.
-===============================
+[WARNING,id="synonym-graph-index-note"]
+====
+Avoid using the `synonym_graph` filter in <<analysis-index-search-time,index
+analyzers>>. The `synonym_graph` filter can produce token graphs containing
+<<token-graphs-multi-position-tokens,multi-position tokens>>, which are not
+supported by indexing.
 
-Synonyms are configured using a configuration file.
-Here is an example:
+To add synonyms during index analysis, use the
+<<analysis-synonym-tokenfilter,`synonym`>> filter instead.
+====
+
+The `synonym_graph` filter uses Lucene's
+{lucene-analysis-docs}/synonym/SynonymGraphFilter.html[SynonymGraphFilter].
+
+[[analysis-synonym-graph-tokenfilter-analyze-ex]]
+==== Example
+
+The following <<indices-analyze,analyze API>> request uses the `synonym_graph`
+filter to add `dns` as a synonym for `domain name system` in the text
+`domain name system is fragile`:
 
 [source,console]
---------------------------------------------------
-PUT /test_index
+----
+GET /_analyze
 {
-    "settings": {
-        "index" : {
-            "analysis" : {
-                "analyzer" : {
-                    "search_synonyms" : {
-                        "tokenizer" : "whitespace",
-                        "filter" : ["graph_synonyms"]
-                    }
-                },
-                "filter" : {
-                    "graph_synonyms" : {
-                        "type" : "synonym_graph",
-                        "synonyms_path" : "analysis/synonym.txt"
-                    }
-                }
-            }
-        }
+  "tokenizer": "standard",
+  "filter": [
+    {
+      "type": "synonym_graph",
+      "synonyms": [ "dns, domain name system" ]
     }
+  ],
+  "text": "domain name system is fragile"
 }
---------------------------------------------------
+----
 
-The above configures a `search_synonyms` filter, with a path of
-`analysis/synonym.txt` (relative to the `config` location). The
-`search_synonyms` analyzer is then configured with the filter.
+The filter produces the following tokens:
 
-Additional settings are:
+[source,txt]
+----
+[ dns, domain, name, system, is, fragile ]
+----
 
-* `expand` (defaults to `true`).
-* `lenient` (defaults to `false`). If `true` ignores exceptions while parsing the synonym configuration. It is important
-to note that only those synonym rules which cannot get parsed are ignored. For instance consider the following request:
+This stream can be represented as the following token graph:
+
+image::images/analysis/token-graph-dns-synonym-ex.svg[align="center"]
+
+////
+[source,console-result]
+----
+{
+  "tokens": [
+    {
+      "token": "dns",
+      "start_offset": 0,
+      "end_offset": 18,
+      "type": "SYNONYM",
+      "position": 0,
+      "positionLength": 3
+    },
+    {
+      "token": "domain",
+      "start_offset": 0,
+      "end_offset": 6,
+      "type": "<ALPHANUM>",
+      "position": 0
+    },
+    {
+      "token": "name",
+      "start_offset": 7,
+      "end_offset": 11,
+      "type": "<ALPHANUM>",
+      "position": 1
+    },
+    {
+      "token": "system",
+      "start_offset": 12,
+      "end_offset": 18,
+      "type": "<ALPHANUM>",
+      "position": 2
+    },
+    {
+      "token": "is",
+      "start_offset": 19,
+      "end_offset": 21,
+      "type": "<ALPHANUM>",
+      "position": 3
+    },
+    {
+      "token": "fragile",
+      "start_offset": 22,
+      "end_offset": 29,
+      "type": "<ALPHANUM>",
+      "position": 4
+    }
+  ]
+}
+----
+////
+
+[[analysis-synonym-graph-tokenfilter-configure-parms]]
+==== Configurable parameters
+
+`synonyms`::
++
+--
+(Required*, array of strings)
+Array of synonym rules used to add synonyms to the token stream. These rules
+must be written in <<analysis-solr-synonym-syntax,Solr>> or
+<<analysis-wordnet-synonym-syntax,WordNet>> syntax, based on the `format`
+parameter.
+
+Either this parameter or `synonyms_path` must be specified.
+
+[TIP]
+====
+For large sets of synonyms, we recommend using a file and the `synonyms_path`
+parameter. Specifying a large number of inline synonym rules can increases
+cluster size.
+====
+--
+
+`synonyms_path`::
++
+--
+(Required*, string)
+Path to a file containing synonym rules used to add synonyms to the token
+stream. These rules must be written in <<analysis-solr-synonym-syntax,Solr>> or
+<<analysis-wordnet-synonym-syntax,WordNet>> syntax, based on the `format`
+parameter.
+
+This path must be absolute or relative to the `config` location, and the file
+must be UTF-8 encoded. Each synonym rule in the file must be separated by a line
+break.
+
+Either this parameter or `synonyms` must be specified.
+--
+
+`expand`::
++
+--
+(Optional, boolean)
+If `true`, the filter expands equivalent synonyms. When a token matches an
+equivalent synonym, the filter adds all other equivalent synonyms to the token stream.
+
+If `false`, the filter contracts equivalent synonyms. The filter replaces any
+matching tokens with the first equivalent synonym in the list.
+
+Defaults to `true`.
+
+See <<analysis-synonym-graph-expand-contract>>.
+--
+
+`format`::
+(Optional, string)
+Syntax used to parse synonym rules. Valid values are `solr` and `wordnet`.
+Defaults to `solr`.
++
+See <<analysis-solr-synonym-syntax>> and <<analysis-wordnet-synonym-syntax>>.
+
+`lenient`::
+(Optional, boolean)
+If `true`, the filter ignores exceptions while parsing synonyms rules.
+Synonym rules that cannot be parsed are skipped. Defaults to `false`.
++
+See <<lenient-synonym-parsing>>.
+
+`ignore_case`::
+deprecated:[6.0.0]
+(Optional, boolean)
+If `true`, synonyms ignore lettercase when matching tokens. Defaults to `false`.
++
+Instead of using this parameter, we recommend using a `lowercase` filter
+before the `synonym_graph` filter for case-insensitive matching.
+
+`tokenizer`::
+deprecated:[6.0.0]
+(Optional, string)
+<<analysis-tokenizers,Tokenizer>> used to convert synonyms into tokens.
+Defaults to the tokenizer configured in the analyzer.
+
+[[analysis-synonym-graph-tokenfilter-customize]]
+==== Customize
+
+To customize the `synonym_graph` filter, duplicate it to create the basis
+for a new custom token filter. You can modify the filter using its configurable
+parameters.
+
+For example, the following <<indices-create-index,create index API>> request
+uses a custom `synonym_graph` filter to configure a new
+<<analysis-custom-analyzer,custom analyzer>>.
+
+The custom `synonym_graph` filter adds synonyms using rules from the
+`analysis/synonym.txt` file. The filter ignores any malformed rules in the file.
+
+[source,console]
+----
+PUT /my_index
+{
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "search_synonyms": {
+            "tokenizer": "standard",
+            "filter": [ "my_graph_synonyms_filter" ]
+          }
+        },
+        "filter": {
+          "my_graph_synonyms_filter": {
+            "type": "synonym_graph",
+            "synonyms_path": "analysis/synonym.txt",
+            "lenient": true
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+[[lenient-synonym-parsing]]
+==== Lenient synonym parsing
+
+When `lenient` is `true`, synonym rules that cannot be parsed are ignored. For
+example, the following <<indices-create-index,create index API>> request uses a
+synonym rule that contains a stop word.
 
 [source,console]
 --------------------------------------------------
@@ -94,18 +279,8 @@ set to `false` no mapping would get added as when `expand=false` the target mapp
 `expand=true` then the mappings added would be equivalent to `foo, baz => foo, baz` i.e, all mappings other than the
 stop word.
 
-[float]
-[[synonym-graph-tokenizer-ignore_case-deprecated]]
-==== `tokenizer` and `ignore_case` are deprecated
-
-The `tokenizer` parameter controls the tokenizers that will be used to
-tokenize the synonym, this parameter is for backwards compatibility for indices that created before 6.0..
-The `ignore_case` parameter works with `tokenizer` parameter only.
-
-Two synonym formats are supported: Solr, WordNet.
-
-[float]
-==== Solr synonyms
+[[analysis-solr-synonym-syntax]]
+==== Solr synonym syntax
 
 The following is a sample format of the file:
 
@@ -142,8 +317,8 @@ PUT /test_index
 However, it is recommended to define large synonyms set in a file using
 `synonyms_path`, because specifying them inline increases cluster size unnecessarily.
 
-[float]
-==== WordNet synonyms
+[[analysis-wordnet-synonym-syntax]]
+==== WordNet synonym syntax
 
 Synonyms based on http://wordnet.princeton.edu/[WordNet] format can be
 declared using `format`:
@@ -175,8 +350,169 @@ PUT /test_index
 Using `synonyms_path` to define WordNet synonyms in a file is supported
 as well.
 
-[float]
-==== Parsing synonym files
+[[analysis-synonym-graph-expand-contract]]
+==== Synonym expansion and contraction
+
+You can use the `expand` parameter to indicate whether the `synonym_graph`
+filter expands or contracts equivalent synonyms.
+
+In Solr, equivalent synonyms are comma-separated. For example, the following
+Solr synonym rule designates `fast`, `speedy`, and `quick` as equivalent
+synonyms.
+
+[source,txt]
+----
+"fast, speedy, quick"
+----
+
+With synonym expansion, when a token matches an equivalent synonym, the filter
+adds all other equivalent synonyms to the token stream.
+
+.*Expansion example*
+[%collapsible]
+====
+In the following analyze API request, `fast`, `speedy`, and `quick` are
+equivalent synonyms. `expand` is set to `true`, meaning synonyms should be
+expanded.
+
+[source,console]
+----
+GET /_analyze
+{
+  "tokenizer": "whitespace",
+  "filter": [
+    {
+      "type": "synonym_graph",
+      "synonyms": [ "fast, speedy, quick" ],
+      "expand": true
+    }
+  ],
+  "text": "quick brown fox"
+}
+----
+
+The filter produces the following tokens. Note that `fast` and `speedy` were
+added to the token stream.
+
+[source,text]
+----
+[ fast, speedy, quick, brown, fox ]
+----
+
+////
+[source,console-result]
+----
+{
+  "tokens": [
+    {
+      "token": "fast",
+      "start_offset": 0,
+      "end_offset": 5,
+      "type": "SYNONYM",
+      "position": 0
+    },
+    {
+      "token": "speedy",
+      "start_offset": 0,
+      "end_offset": 5,
+      "type": "SYNONYM",
+      "position": 0
+    },
+    {
+      "token": "quick",
+      "start_offset": 0,
+      "end_offset": 5,
+      "type": "word",
+      "position": 0
+    },
+    {
+      "token": "brown",
+      "start_offset": 6,
+      "end_offset": 11,
+      "type": "word",
+      "position": 1
+    },
+    {
+      "token": "fox",
+      "start_offset": 12,
+      "end_offset": 15,
+      "type": "word",
+      "position": 2
+    }
+  ]
+}
+----
+////
+====
+
+With synonym contraction, the first synonym replaces any equivalent synonyms in
+the token stream.
+
+.*Contraction example*
+[%collapsible]
+====
+In the following analyze API request, `fast`, `speedy`, and `quick` are
+equivalent synonyms. Because `expand` is set to `false`, these equivalent
+synonyms will contract to `fast`.
+
+[source,console]
+----
+GET /_analyze
+{
+  "tokenizer": "whitespace",
+  "filter": [
+    {
+      "type": "synonym_graph",
+      "synonyms": [ "fast, speedy, quick" ],
+      "expand": false
+    }
+  ],
+  "text": "quick brown fox"
+}
+----
+
+The filter produces the following tokens. Note that `quick` was replaced with
+`fast`. `speedy` was not added to the stream.
+
+[source,text]
+----
+[ fast, brown, fox ]
+----
+
+////
+[source,console-result]
+----
+{
+  "tokens": [
+    {
+      "token": "fast",
+      "start_offset": 0,
+      "end_offset": 5,
+      "type": "SYNONYM",
+      "position": 0
+    },
+    {
+      "token": "brown",
+      "start_offset": 6,
+      "end_offset": 11,
+      "type": "word",
+      "position": 1
+    },
+    {
+      "token": "fox",
+      "start_offset": 12,
+      "end_offset": 15,
+      "type": "word",
+      "position": 2
+    }
+  ]
+}
+----
+////
+====
+
+[[analysis-synonym-graph-tokenfilter-parsing-synonyms]]
+==== Parsing synonyms
 
 Elasticsearch will use the token filters preceding the synonym filter
 in a tokenizer chain to parse the entries in a synonym file.  So, for example, if a


### PR DESCRIPTION
Makes the following changes to the `synonym_graph` token filter docs:

* Rewrites description and adds Lucene link
* Adds detailed analyze example
* Rewrites parameter definitions
* Adds custom analyzer example
* Adds examples for synonym expansion and contraction
* Updates headers and section anchors