### PR TITLE
Fix Azure Repository with HTTPs Endpoint

### DIFF
--- a/plugins/repository-azure/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/repository-azure/src/main/plugin-metadata/plugin-security.policy
@@ -20,4 +20,5 @@
 grant {
   // azure client opens socket connections for to access repository
   permission java.net.SocketPermission "*", "connect";
+  permission java.lang.RuntimePermission "setFactory";
 };


### PR DESCRIPTION
Upgrading to 8.6.2 in #53865 broke running against HTTPs endpoints (and hence real azure)
because the https url connection needs the newly added permission to work.
