### PR TITLE
[DOCS] Add generated_dest_index to preview transform API

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -118,7 +118,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
   representation of the documents that would be created in the destination index
   by the {transform}.
   
-`generated_dest_inded`::
+`generated_dest_index`::
   (object) Contains details about the destination index.
     `mappings`:::
     (object) The <<mapping,mappings>> for each document in the destination index. 

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -30,7 +30,17 @@ on the source index for the {transform}. For more information, see
 This API generates a preview of the results that you will get when you run the
 <<put-transform,create {transforms} API>> with the same
 configuration. It returns a maximum of 100 results. The calculations are based
-on all the current data in the source index. 
+on all the current data in the source index.
+
+It also generates a list of mappings and settings for the destination index.
+If the destination index does not exist when you start a {transform}, these are
+the mappings and settings that are used. These values are determined based on
+the field types of the source index and the {transform} aggregations.
+
+TIP: There are some <<transform-aggresponse-limitations,limitations>> that
+might result in poor mappings. As a work-around, create the destination index
+or an index template with your preferred mappings before you start the
+{transform}.
 
 [[preview-transform-request-body]]
 ==== {api-request-body-title}
@@ -106,7 +116,16 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 `preview`::
   (array) An array of documents. In particular, they are the JSON
   representation of the documents that would be created in the destination index
-  by the {transform}. 
+  by the {transform}.
+  
+`generated_dest_inded`::
+  (object) Contains details about the destination index.
+    `mappings`:::
+    (object) The <<mapping,mappings>> for each document in the destination index. 
+    `settings`:::
+    (object) The <<index-modules-settings,index settings>> for the destination
+    index.
+    `aliases`::: The aliases for the destination index.
 
 ==== {api-examples-title}
 
@@ -156,15 +175,34 @@ The data that is returned for this example is as follows:
     }
     ...
   ],
-  "mappings": {
-    "properties": {
-      "max_price": {
-        "type": "double"
+  "generated_dest_index" : {
+    "mappings" : {
+      "_meta" : {
+        "_transform" : {
+          "transform" : "transform-preview",
+          "version" : {
+            "created" : "7.7.0"
+          },
+          "creation_date_in_millis" : 1584738236757
+        },
+        "created_by" : "transform"
       },
-      "customer_id": {
-        "type": "keyword"
+      "properties" : {
+        "max_price" : {
+          "type" : "half_float"
+        },
+        "customer_id" : {
+          "type" : "keyword"
+        }
       }
-    }
+    },
+    "settings" : {
+      "index" : {
+        "number_of_shards" : "1",
+        "auto_expand_replicas" : "0-1"
+      }
+    },
+    "aliases" : { }
   }
 }
 ----


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/53572

This PR adds the `generated_dest_index` object to the "preview transform" API.

Preview: http://elasticsearch_53905.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html