### PR TITLE
[DOCS] Adds transform security privileges

### DIFF
--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -31,10 +31,18 @@ For more information, see <<transform-settings>> and <<modules-node>>.
 
 The {es} {security-features} provide <<built-in-roles,built-in roles>>
 and <<security-privileges,privileges>> that make it easier to control
-which users can manage or view {transforms}. 
+which users can manage or view {transforms}.
 
-For example, you need `manage_transform` cluster privileges to preview and
-create {transforms}. Members of the built-in `transform_admin` role have these 
-privileges. You also need `read` and `view_index_metadata` index privileges on
-the source index and `read`, `create_index`, and `index` privileges on the
-destination index.
+To _view_ the configuration and status of {transforms}, you must have:
+
+* `transform_user` built-in role or `monitor_transform` 
+cluster privileges
+
+To _manage_ {transforms}, you must have:
+
+* `transform_admin` built-in role or `manage_transform` 
+cluster privileges
+* `read` and `view_index_metadata` index privileges on source indices
+* `read`, `create_index`, and `index` index privileges on destination indices
+  
+For more information, see <<security-privileges>> and <<built-in-roles>>.


### PR DESCRIPTION
This PR adds a list of security privileges to the transform setup details (https://www.elastic.co/guide/en/machine-learning/master/setup.html).

Preview: http://elasticsearch_53908.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-setup.html#transform-privileges