### PR TITLE
[DOCS] address timing issue in async search docs tests

### DIFF
--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -178,7 +178,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 // TESTRESPONSE[s/"successful" : 188/"successful": $body.response._shards.successful/]
 // TESTRESPONSE[s/"value" : 456433/"value": $body.response.hits.total.value/]
 // TESTRESPONSE[s/"buckets" : \[\]/"buckets": $body.response.aggregations.sale_date.buckets/]
-// TESTRESPONSE[s/"num_reduce_phases" : 38,//]
+// TESTRESPONSE[s/"num_reduce_phases" : 46,//]
 
 <1> Whether the returned search results are partial or final
 <2> Whether the search is still being executed or it has completed

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -68,7 +68,6 @@ results are returned as part of the <<search-api-response-body,`response`>> obje
 }
 --------------------------------------------------
 // TESTRESPONSE[s/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=/$body.id/]
-// TESTRESPONSE[s/"version" : 0/"version": $body.version/]
 // TESTRESPONSE[s/"is_partial" : true/"is_partial": $body.is_partial/]
 // TESTRESPONSE[s/"is_running" : true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]
@@ -170,7 +169,6 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 }
 --------------------------------------------------
 // TESTRESPONSE[s/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=/$body.id/]
-// TESTRESPONSE[s/"version" : 39/"version" : $body.version/]
 // TESTRESPONSE[s/"is_partial" : true/"is_partial" : false/]
 // TESTRESPONSE[s/"is_running" : true/"is_running" : false/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -146,7 +146,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
   "response" : {
     "took" : 12144,
     "timed_out" : false,
-    "num_reduce_phases" : 38, <4>
+    "num_reduce_phases" : 46, <4>
     "_shards" : {
       "total" : 562, <5>
       "successful" : 188,

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -30,9 +30,8 @@ POST /sales*/_async_search?size=0
     }
 }
 --------------------------------------------------
-// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/53887"]
 // TEST[setup:sales]
-// TEST[s/size=0/size=0&wait_for_completion=0/]
+// TEST[s/size=0/size=0&wait_for_completion=10s&clean_on_completion=false/]
 
 The response contains an identifier of the search being executed.
 You can use this ID to later retrieve the search's final results.
@@ -70,12 +69,18 @@ results are returned as part of the <<search-api-response-body,`response`>> obje
 }
 --------------------------------------------------
 // TESTRESPONSE[s/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=/$body.id/]
+// TESTRESPONSE[s/"version" : 0/"version": $body.version/]
+// TESTRESPONSE[s/"is_partial" : true/"is_partial": $body.is_partial/]
+// TESTRESPONSE[s/"is_running" : true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1584377890986/$body.expiration_time_in_millis/]
 // TESTRESPONSE[s/"took" : 1122/"took": $body.response.took/]
+// TESTRESPONSE[s/"num_reduce_phases" : 0,//]
 // TESTRESPONSE[s/"total" : 562/"total": $body.response._shards.total/]
 // TESTRESPONSE[s/"successful" : 3/"successful": $body.response._shards.successful/]
 // TESTRESPONSE[s/"value" : 157483/"value": $body.response.hits.total.value/]
+// TESTRESPONSE[s/"relation" : "gte"/"relation": $body.response.hits.total.relation/]
+// TESTRESPONSE[s/"hits" : \[ \]\n\s\s\s\s\}/"hits" : \[\]},"aggregations":  $body.response.aggregations/]
 
 <1> Identifier of the async search that can be used to monitor its progress, retrieve its results, and/or delete it.
 <2> Whether the returned search results are partial or final
@@ -135,7 +140,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 --------------------------------------------------
 {
   "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
-  "version" : 2, <1>
+  "version" : 39, <1>
   "is_partial" : true, <2>
   "is_running" : true, <3>
   "start_time_in_millis" : 1583945890986,

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -163,7 +163,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
       "max_score" : null,
       "hits" : [ ]
     },
-    "aggregations" : { <5>
+    "aggregations" : { <5>ok
       "sale_date" :  {
         "buckets" : []
       }
@@ -172,6 +172,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 }
 --------------------------------------------------
 // TESTRESPONSE[s/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=/$body.id/]
+// TESTRESPONSE[s/"version" : 39/"version" : $body.version/]
 // TESTRESPONSE[s/"is_partial" : true/"is_partial" : false/]
 // TESTRESPONSE[s/"is_running" : true/"is_running" : false/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]


### PR DESCRIPTION
The docs snippets for submit async search have proven difficult to test as it is not possible to guarantee that you get a response that is not final, even when providing `wait_for_completion=0`. In the docs we want to show though a proper long-running query, and its first response should be partial rather than final.

With this commit we adapt the docs snippets to show a partial response, and replace under the hood all that's needed to make the snippets tests succeed when we get a final response. Also, increased the timeout so we always get a final response.

Closes #53887
Closes #53891