### PR TITLE
Reduce deprecation warnings from bulk OCC

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -117,7 +117,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync,
                     expectWarnings("Usage of internal versioning for optimistic concurrency control is deprecated and will be removed." +
                         " Please use the `if_seq_no` and `if_primary_term` parameters instead." +
-                        " (request for index [index], type [type], id [id])"));
+                        " (request for index [index], type [type])"));
             } else {
                 deleteResponse = execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync,
                     highLevelClient()::delete, highLevelClient()::deleteAsync);
@@ -156,7 +156,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                     execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync,
                         expectWarnings("Usage of internal versioning for optimistic concurrency control is deprecated and will be removed."
                             + " Please use the `if_seq_no` and `if_primary_term` parameters instead."
-                            + " (request for index [index], type [type], id [version_conflict])"));
+                            + " (request for index [index], type [type])"));
                 } else {
                     execute(deleteRequest, highLevelClient()::delete, highLevelClient()::deleteAsync,
                         highLevelClient()::delete, highLevelClient()::deleteAsync);
@@ -507,7 +507,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                     execute(wrongRequest, highLevelClient()::index, highLevelClient()::indexAsync,
                         expectWarnings("Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. "
                             + "Please use the `if_seq_no` and `if_primary_term` parameters instead. "
-                            + "(request for index [index], type [type], id [id])"));
+                            + "(request for index [index], type [type])"));
                 } else {
                     execute(wrongRequest, highLevelClient()::index, highLevelClient()::indexAsync,
                         highLevelClient()::index, highLevelClient()::indexAsync);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/60_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/60_deprecated.yml
@@ -16,8 +16,7 @@
                { "doc": { "f1": "v2" } }
        warnings:
            - "Deprecated field [_version] used, expected [version] instead"
-           - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_index], type [test_type], id [test_id_1])"
-           - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_index], type [test_type], id [test_id_2])"
+           - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_index], type [test_type])"
 
    - do:
        bulk:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/20_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/20_internal_version.yml
@@ -22,7 +22,7 @@
           id:      1
           version: 2
       warnings:
-        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test], id [1])"
+        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test])"
 
  - do:
       delete:
@@ -31,6 +31,6 @@
           id:      1
           version: 1
       warnings:
-        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test], id [1])"
+        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test])"
 
  - match: { _version: 2 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_internal_version.yml
@@ -31,7 +31,7 @@
           body:    { foo: bar }
           version: 1
       warnings:
-        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test], id [1])"
+        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test])"
 
  - do:
       index:
@@ -41,6 +41,6 @@
           body:    { foo: bar }
           version: 2
       warnings:
-        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test], id [1])"
+        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test])"
 
  - match: { _version: 3 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/30_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/30_internal_version.yml
@@ -15,7 +15,7 @@
           body:
             doc:    { foo: baz }
       warnings:
-        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test], id [1])"
+        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test])"
 
  - do:
       index:
@@ -35,4 +35,4 @@
           body:
             doc:    { foo: baz }
       warnings:
-        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test], id [1])"
+        - "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test_1], type [test])"

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -513,8 +513,8 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                 && request.version() != Versions.MATCH_DELETED) {
                 DEPRECATION_LOGGER.deprecatedAndMaybeLog("occ_internal_version",
                     "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use" +
-                        " the `if_seq_no` and `if_primary_term` parameters instead. (request for index [{}], type [{}], id [{}])",
-                    request.index(), request.type(), request.id());
+                        " the `if_seq_no` and `if_primary_term` parameters instead. (request for index [{}], type [{}])",
+                    request.index(), request.type());
             }
         } else {
             if (request.ifSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -853,10 +853,9 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             threadPool::absoluteTimeInMillis, new NoopMappingUpdatePerformer(), () -> {});
         closeShards(shard);
         if (deprecatedRequestIds.isEmpty() == false) {
-            assertWarnings(deprecatedRequestIds.stream().map(id ->
+            assertWarnings(
                 "Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. Please use the " +
-                    "`if_seq_no` and `if_primary_term` parameters instead. (request for index [index], type [_doc], id [" + id + "])")
-                .toArray(String[]::new));
+                    "`if_seq_no` and `if_primary_term` parameters instead. (request for index [index], type [_doc])");
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
@@ -519,7 +519,7 @@ public class IndexLevelReplicationTests extends ESIndexLevelReplicationTestCase 
                     indexShard.translogStats().estimatedNumberOfOperations(), equalTo(0));
             }
             assertWarnings("Usage of internal versioning for optimistic concurrency control is deprecated and will be removed. " +
-                "Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test], type [type], id [1])");
+                "Please use the `if_seq_no` and `if_primary_term` parameters instead. (request for index [test], type [type])");
         }
     }
 


### PR DESCRIPTION
Bulk optimistic concurrency control would emit a deprecation warning header
per bulk item using internal versioning for OCC. However, for applications
that have not yet been upgraded, this can lead to significant performance
issues. Also, delete and update by query can be significantly affected if
the indices were created and data indexed into them on a pre-6.x version.
