### PR TITLE
Skip bulk OCC deprecation validation until 6.8.8

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/60_deprecated.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/60_deprecated.yml
@@ -3,8 +3,8 @@
 "Deprecated parameters should produce warning in Bulk query":
 
    - skip:
-       version: " - 6.8.0"
-       reason:  versioned operations were deprecated in 6.7 but we won't issue deprecation unless all nodes are upgraded
+       version: " - 6.8.7"
+       reason:  versioned operations were deprecated in 6.7 but we won't issue deprecation unless all nodes are upgraded. 6.8.0-6.8.7 skipped due to new message
        features: "warnings"
 
    - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/20_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/20_internal_version.yml
@@ -1,8 +1,8 @@
 ---
 "Internal version":
  - skip:
-      version: " - 6.8.0"
-      reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.1+
+      version: " - 6.8.7"
+      reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.8+
       features: warnings
 
  - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_internal_version.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/30_internal_version.yml
@@ -1,8 +1,8 @@
 ---
 "Internal version":
  - skip:
-     version: " - 6.8.0"
-     reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.1+
+     version: " - 6.8.7"
+     reason:  versioned operations were deprecated in 6.7 but deprecation warnings are not consistent until all nodes on 6.8.8+
      features: warnings
 
  - do:


### PR DESCRIPTION
Skip deprecation validations until 6.8.8, since we changed
the message

Relates #53911
