### PR TITLE
Remove support for fractional byte size values

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -37,3 +37,10 @@ processors. As this leads to more context switches and more threads but without
 an increase in the number of physical CPUs on which to schedule these additional
 threads, the `node.processors` setting is now bounded by the number of available
 processors.
+
+[float]
+==== Fractional byte size values are no longer supported
+
+Using fractional byte size values such as `23.5pb` have been deprecated since
+Elasticsearch 6.2.0. As of Elasticsearch 8.0.0, fractional byte size values are
+now rejected.

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1299,7 +1299,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, ByteSizeValue value, Property... properties) {
-        return byteSizeSetting(key, (s) -> value.toString(), properties);
+        return byteSizeSetting(key, (s) -> value.getStringRep(), properties);
     }
 
     public static Setting<ByteSizeValue> byteSizeSetting(String key, Setting<ByteSizeValue> fallbackSetting,

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.common.unit;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -34,8 +32,6 @@ import java.util.Locale;
 import java.util.Objects;
 
 public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXContentFragment {
-
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(LogManager.getLogger(ByteSizeValue.class));
 
     public static final ByteSizeValue ZERO = new ByteSizeValue(0, ByteSizeUnit.BYTES);
 
@@ -225,15 +221,7 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
             try {
                 return new ByteSizeValue(Long.parseLong(s), unit);
             } catch (final NumberFormatException e) {
-                try {
-                    final double doubleValue = Double.parseDouble(s);
-                    deprecationLogger.deprecated(
-                            "Fractional bytes values are deprecated. Use non-fractional bytes values instead: [{}] found for setting [{}]",
-                            initialInput, settingName);
-                    return new ByteSizeValue((long) (doubleValue * unit.toBytes(1)));
-                } catch (final NumberFormatException ignored) {
-                    throw new ElasticsearchParseException("failed to parse [{}]", e, initialInput);
-                }
+                throw new ElasticsearchParseException("failed to parse [{}]", e, initialInput);
             }
         } catch (IllegalArgumentException e) {
             throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}] as a size in bytes", e, settingName,


### PR DESCRIPTION
These have been deprecated since Elasticsearch 6.2.0. This commit finishes them off by removing support for parsing them.

Relates #27702
