### PR TITLE
[DOCS] Clarify docs: how to add Routing enforcement

### DIFF
--- a/docs/reference/mapping/fields/routing-field.asciidoc
+++ b/docs/reference/mapping/fields/routing-field.asciidoc
@@ -92,7 +92,7 @@ PUT my_index2/_doc/1 <2>
 ------------------------------
 // TEST[catch:bad_request]
 
-<1> Routing is required for `_doc` documents.
+<1> Routing is required for all documents.
 <2> This index request throws a `routing_missing_exception`.
 
 ==== Unique IDs with custom routing


### PR DESCRIPTION
In 6.8, the `_doc` made sense: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/mapping-routing-field.html

but now it doesn't, and is confusing. I assume it applies to all documents(??)