### PR TITLE
Defer repo ops in searchable snapshot restore

### DIFF
--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryTests.java
@@ -42,7 +42,7 @@ public class URLRepositoryTests extends ESTestCase {
         return new URLRepository(repositoryMetaData, TestEnvironment.newEnvironment(baseSettings),
             new NamedXContentRegistry(Collections.emptyList()), BlobStoreTestUtil.mockClusterService()) {
             @Override
-            protected void assertSnapshotOrGenericThread() {
+            protected void assertUsingPermittedThreadPool() {
                 // eliminate thread name check as we create repo manually on test/main threads
             }
         };

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
@@ -149,7 +149,7 @@ public class RepositoryCredentialsTests extends ESSingleNodeTestCase {
                                                 NamedXContentRegistry registry, ClusterService clusterService) {
             return new S3Repository(metadata, registry, service, clusterService) {
                 @Override
-                protected void assertSnapshotOrGenericThread() {
+                protected void assertUsingPermittedThreadPool() {
                     // eliminate thread name check as we create repo manually on test/main threads
                 }
             };

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -121,7 +121,7 @@ public class S3RepositoryTests extends ESTestCase {
     private S3Repository createS3Repo(RepositoryMetaData metadata) {
         return new S3Repository(metadata, NamedXContentRegistry.EMPTY, new DummyS3Service(), BlobStoreTestUtil.mockClusterService()) {
             @Override
-            protected void assertSnapshotOrGenericThread() {
+            protected void assertUsingPermittedThreadPool() {
                 // eliminate thread name check as we create repo manually on test/main threads
             }
         };

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -32,7 +32,6 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -139,7 +138,6 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.cluster.service.ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME;
 import static org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo.canonicalName;
 
 /**

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -198,7 +198,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
         final ClusterService clusterService = BlobStoreTestUtil.mockClusterService(repositoryMetaData);
         final FsRepository repository = new FsRepository(repositoryMetaData, createEnvironment(), xContentRegistry(), clusterService) {
             @Override
-            protected void assertSnapshotOrGenericThread() {
+            protected void assertUsingPermittedThreadPool() {
                 // eliminate thread name check as we create repo manually
             }
         };

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -67,7 +67,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         return Arrays.asList(FsLikeRepoPlugin.class);
     }
 
-    // the reason for this plug-in is to drop any assertSnapshotOrGenericThread as mostly all access in this test goes from test threads
+    // the reason for this plug-in is to drop any assertUsingPermittedThreadPool as mostly all access in this test goes from test threads
     public static class FsLikeRepoPlugin extends Plugin implements RepositoryPlugin {
 
         @Override
@@ -76,7 +76,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
             return Collections.singletonMap(REPO_TYPE,
                 (metadata) -> new FsRepository(metadata, env, namedXContentRegistry, clusterService) {
                     @Override
-                    protected void assertSnapshotOrGenericThread() {
+                    protected void assertUsingPermittedThreadPool() {
                         // eliminate thread name check as we access blobStore on test/main threads
                     }
                 });

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1406,7 +1406,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 if (blobStoreContext == null) {
                     return metaData -> new FsRepository(metaData, environment, xContentRegistry(), clusterService) {
                         @Override
-                        protected void assertSnapshotOrGenericThread() {
+                        protected void assertUsingPermittedThreadPool() {
                             // eliminate thread name check as we create repo in the test thread
                         }
                     };

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
@@ -98,7 +98,7 @@ public class MockEventuallyConsistentRepository extends BlobStoreRepository {
     }
 
     @Override
-    protected void assertSnapshotOrGenericThread() {
+    protected void assertUsingPermittedThreadPool() {
         // eliminate thread name check as we create repo in the test thread
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotDirectory.java
@@ -19,14 +19,15 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public abstract class BaseSearchableSnapshotDirectory extends BaseDirectory {
 
-    protected final BlobStoreIndexShardSnapshot snapshot;
-    protected final BlobContainer blobContainer;
+    protected final Supplier<BlobStoreIndexShardSnapshot> snapshot;
+    protected final Supplier<BlobContainer> blobContainer;
     private final AtomicBoolean closed;
 
-    public BaseSearchableSnapshotDirectory(BlobContainer blobContainer, BlobStoreIndexShardSnapshot snapshot) {
+    public BaseSearchableSnapshotDirectory(Supplier<BlobContainer> blobContainer, Supplier<BlobStoreIndexShardSnapshot> snapshot) {
         super(new SingleInstanceLockFactory());
         this.snapshot = Objects.requireNonNull(snapshot);
         this.blobContainer = Objects.requireNonNull(blobContainer);
@@ -34,11 +35,11 @@ public abstract class BaseSearchableSnapshotDirectory extends BaseDirectory {
     }
 
     public BlobContainer blobContainer() {
-        return blobContainer;
+        return blobContainer.get();
     }
 
     protected final FileInfo fileInfo(final String name) throws FileNotFoundException {
-        return snapshot.indexFiles()
+        return snapshot.get().indexFiles()
             .stream()
             .filter(fileInfo -> fileInfo.physicalName().equals(name))
             .findFirst()
@@ -48,7 +49,7 @@ public abstract class BaseSearchableSnapshotDirectory extends BaseDirectory {
     @Override
     public final String[] listAll() {
         ensureOpen();
-        return snapshot.indexFiles().stream().map(FileInfo::physicalName).sorted(String::compareTo).toArray(String[]::new);
+        return snapshot.get().indexFiles().stream().map(FileInfo::physicalName).sorted(String::compareTo).toArray(String[]::new);
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectory.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 /**
  * {@link CacheDirectory} uses a {@link CacheService} to cache Lucene files provided by another {@link Directory}.
@@ -39,7 +40,7 @@ public class CacheDirectory extends BaseSearchableSnapshotDirectory {
     private final Path cacheDir;
     private final LongSupplier currentTimeNanosSupplier;
 
-    public CacheDirectory(final BlobStoreIndexShardSnapshot snapshot, final BlobContainer blobContainer,
+    public CacheDirectory(final Supplier<BlobStoreIndexShardSnapshot> snapshot, final Supplier<BlobContainer> blobContainer,
                           CacheService cacheService, Path cacheDir, SnapshotId snapshotId, IndexId indexId, ShardId shardId,
                           LongSupplier currentTimeNanosSupplier)
         throws IOException {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheBufferedIndexInputStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheBufferedIndexInputStatsTests.java
@@ -443,7 +443,7 @@ public class CacheBufferedIndexInputStatsTests extends ESIndexInputTestCase {
 
         try (CacheService ignored = cacheService;
              CacheDirectory cacheDirectory =
-                 new CacheDirectory(snapshot, blobContainer, cacheService, createTempDir(), snapshotId, indexId, shardId,
+                 new CacheDirectory(() -> snapshot, () -> blobContainer, cacheService, createTempDir(), snapshotId, indexId, shardId,
                      () -> fakeClock.addAndGet(FAKE_CLOCK_ADVANCE_NANOS)) {
                      @Override
                      IndexInputStats createIndexInputStats(long fileLength) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/CacheDirectoryTests.java
@@ -93,8 +93,8 @@ public class CacheDirectoryTests extends ESTestCase {
 
     private CacheDirectory newCacheDirectory(BlobStoreIndexShardSnapshot snapshot, BlobContainer container,
                                              CacheService cacheService, Path cacheDir) throws IOException {
-        return new CacheDirectory(snapshot, container, cacheService, cacheDir, new SnapshotId("_na","_na"), new IndexId("_na", "_na"),
-            new ShardId("_na", "_na", 0), () -> 0L);
+        return new CacheDirectory(() -> snapshot, () -> container, cacheService, cacheDir, new SnapshotId("_na","_na"),
+            new IndexId("_na", "_na"), new ShardId("_na", "_na", 0), () -> 0L);
     }
 
     private void assertListOfFiles(Path cacheDir, Matcher<Integer> matchNumberOfFiles, Matcher<Long> matchSizeOfFiles) throws IOException {


### PR DESCRIPTION
A searchable snapshots `Directory` requires a `BlobContainer` and a
`BlobStoreIndexShardSnapshot`, which require us to read some data from the
repository. Today we construct these objects on the cluster applier thread,
blocking that thread on remote operations.

This commit defers their construction until the restore process starts, so that
they can happen on a more appropriate thread. It also reinstates the assertion
that snapshot/restore operations are all on the snapshot or generic threadpool,
but weakens it to allow them to occur on the search threadpool too.