### PR TITLE
Async Search: replicas to auto expand from 0 to 1

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchIndexService.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchIndexService.java
@@ -66,14 +66,14 @@ class AsyncSearchIndexService {
     public static final String EXPIRATION_TIME_FIELD = "expiration_time";
     public static final String RESULT_FIELD = "result";
 
-    public static Settings settings() {
+    private static Settings settings() {
         return Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
     }
 
-    public static XContentBuilder mappings() throws IOException {
+    private static XContentBuilder mappings() throws IOException {
         XContentBuilder builder = jsonBuilder()
             .startObject()
                 .startObject(SINGLE_MAPPING_NAME)

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchIndexServiceTests.java
@@ -5,6 +5,10 @@
  */
 package org.elasticsearch.xpack.search;
 
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -17,6 +21,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.xpack.search.AsyncSearchResponseTests.assertEqualResponses;
 import static org.elasticsearch.xpack.search.AsyncSearchResponseTests.randomAsyncSearchResponse;
@@ -99,5 +104,16 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
             new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), randomAlphaOfLengthBetween(5, 12), "node"));
         assertFalse(indexService.ensureAuthenticatedUserIsSame(original, runAsDiffType));
         assertFalse(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), runAsDiffType));
+    }
+
+    public void testSettings() throws ExecutionException, InterruptedException {
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        indexService.createIndexIfNecessary(future);
+        future.get();
+        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(
+            new GetIndexRequest().indices(AsyncSearchIndexService.INDEX)).actionGet();
+        Settings settings = getIndexResponse.getSettings().get(AsyncSearchIndexService.INDEX);
+        assertEquals("1", settings.get(IndexMetaData.SETTING_NUMBER_OF_SHARDS));
+        assertEquals("0-1", settings.get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS));
     }
 }


### PR DESCRIPTION
This way single node clusters that are green don't go yellow once async search is used, while
all the others still have one replica.