### PR TITLE
Restrict template name when putting index template

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -125,6 +125,8 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         ActionRequestValidationException validationException = null;
         if (name == null) {
             validationException = addValidationError("name is missing", validationException);
+        } else if (name.contains("*")) {
+            validationException = addValidationError("may not contain an asterisk", validationException);
         }
         if (indexPatterns == null || indexPatterns.size() == 0) {
             validationException = addValidationError("index patterns are missing", validationException);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
@@ -54,6 +54,11 @@ public class PutIndexTemplateRequestTests extends ESTestCase {
         request.patterns(Collections.singletonList("test-*"));
         ActionRequestValidationException noError = request.validate();
         assertThat(noError, is(nullValue()));
+
+        request.name("*");
+        ActionRequestValidationException badIndexTemplateName = request.validate();
+        assertThat(badIndexTemplateName.validationErrors(), hasSize(1));
+        assertThat(badIndexTemplateName.getMessage(), containsString("may not contain an asterisk"));
     }
 
     public void testMappingKeyedByType() throws IOException {


### PR DESCRIPTION
Storing an index template named `*` will result in the in ability to
delete it. Also that naming is really confusing.

Reviewers Note: I pretty much like the logic in `MetaDataCreateIndexService.validateIndexOrAliasName` that we could probably use for templates as well. I just added the smallest fix to prevent the above behaviour.

This change breaks BWC, but I still think it's worth getting in (in master), as this happens due to user mistakes. See https://discuss.elastic.co/t/template-with-asterisk-name/224452