### PR TITLE
Backport of async search changes

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/AsyncSearchResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/asyncsearch/AsyncSearchResponse.java
@@ -41,7 +41,6 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 public class AsyncSearchResponse implements ToXContentObject  {
     @Nullable
     private final String id;
-    private final int version;
     @Nullable
     private final SearchResponse searchResponse;
     @Nullable
@@ -55,15 +54,13 @@ public class AsyncSearchResponse implements ToXContentObject  {
     /**
      * Creates an {@link AsyncSearchResponse} with the arguments that are always present in the server response
      */
-    AsyncSearchResponse(int version,
-                               boolean isPartial,
-                               boolean isRunning,
-                               long startTimeMillis,
-                               long expirationTimeMillis,
-                               @Nullable String id,
-                               @Nullable SearchResponse searchResponse,
-                               @Nullable ElasticsearchException error) {
-        this.version = version;
+    AsyncSearchResponse(boolean isPartial,
+                        boolean isRunning,
+                        long startTimeMillis,
+                        long expirationTimeMillis,
+                        @Nullable String id,
+                        @Nullable SearchResponse searchResponse,
+                        @Nullable ElasticsearchException error) {
         this.isPartial = isPartial;
         this.isRunning = isRunning;
         this.startTimeMillis = startTimeMillis;
@@ -79,13 +76,6 @@ public class AsyncSearchResponse implements ToXContentObject  {
     @Nullable
     public String getId() {
         return id;
-    }
-
-    /**
-     * Returns the version of this response.
-     */
-    public int getVersion() {
-        return version;
     }
 
     /**
@@ -145,7 +135,6 @@ public class AsyncSearchResponse implements ToXContentObject  {
         if (id != null) {
             builder.field("id", id);
         }
-        builder.field("version", version);
         builder.field("is_partial", isPartial);
         builder.field("is_running", isRunning);
         builder.field("start_time_in_millis", startTimeMillis);
@@ -165,7 +154,6 @@ public class AsyncSearchResponse implements ToXContentObject  {
     }
 
     public static final ParseField ID_FIELD = new ParseField("id");
-    public static final ParseField VERSION_FIELD = new ParseField("version");
     public static final ParseField IS_PARTIAL_FIELD = new ParseField("is_partial");
     public static final ParseField IS_RUNNING_FIELD = new ParseField("is_running");
     public static final ParseField START_TIME_FIELD = new ParseField("start_time_in_millis");
@@ -176,16 +164,14 @@ public class AsyncSearchResponse implements ToXContentObject  {
     public static final ConstructingObjectParser<AsyncSearchResponse, Void> PARSER = new ConstructingObjectParser<>(
             "submit_async_search_response", true,
             args -> new AsyncSearchResponse(
-                    (int) args[0],
+                    (boolean) args[0],
                     (boolean) args[1],
-                    (boolean) args[2],
+                    (long) args[2],
                     (long) args[3],
-                    (long) args[4],
-                    (String) args[5],
-                    (SearchResponse) args[6],
-                    (ElasticsearchException) args[7]));
+                    (String) args[4],
+                    (SearchResponse) args[5],
+                    (ElasticsearchException) args[6]));
     static {
-        PARSER.declareInt(constructorArg(), VERSION_FIELD);
         PARSER.declareBoolean(constructorArg(), IS_PARTIAL_FIELD);
         PARSER.declareBoolean(constructorArg(), IS_RUNNING_FIELD);
         PARSER.declareLong(constructorArg(), START_TIME_FIELD);
@@ -203,7 +189,7 @@ public class AsyncSearchResponse implements ToXContentObject  {
         return SearchResponse.innerFromXContent(p);
     }
 
-    public static AsyncSearchResponse fromXContent(XContentParser parser) throws IOException {
+    public static AsyncSearchResponse fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/asyncsearch/AsyncSearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/asyncsearch/AsyncSearchIT.java
@@ -40,7 +40,6 @@ public class AsyncSearchIT extends ESRestHighLevelClientTestCase {
         // 15 sec should be enough to make sure we always complete right away
         request.setWaitForCompletion(new TimeValue(15, TimeUnit.SECONDS));
         AsyncSearchResponse response = highLevelClient().asyncSearch().submitAsyncSearch(request, RequestOptions.DEFAULT);
-        assertTrue(response.getVersion() >= 0);
         assertFalse(response.isPartial());
         assertTrue(response.getStartTime() > 0);
         assertTrue(response.getExpirationTime() > 0);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/asyncsearch/AsyncSearchResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/asyncsearch/AsyncSearchResponseTests.java
@@ -36,7 +36,6 @@ public class AsyncSearchResponseTests
 
     @Override
     protected org.elasticsearch.xpack.core.search.action.AsyncSearchResponse createServerTestInstance(XContentType xContentType) {
-        int version = randomIntBetween(0, Integer.MAX_VALUE);
         boolean isPartial = randomBoolean();
         boolean isRunning = randomBoolean();
         long startTimeMillis = randomLongBetween(0, Long.MAX_VALUE);
@@ -48,7 +47,7 @@ public class AsyncSearchResponseTests
                 : new SearchResponse(InternalSearchResponse.empty(), randomAlphaOfLength(10), 1, 1, 0, randomIntBetween(0, 10000),
                         ShardSearchFailure.EMPTY_ARRAY, Clusters.EMPTY);
         org.elasticsearch.xpack.core.search.action.AsyncSearchResponse testResponse =
-                new org.elasticsearch.xpack.core.search.action.AsyncSearchResponse(id, version, searchResponse, error, isPartial, isRunning,
+                new org.elasticsearch.xpack.core.search.action.AsyncSearchResponse(id, searchResponse, error, isPartial, isRunning,
                         startTimeMillis, expirationTimeMillis);
         return testResponse;
     }
@@ -62,7 +61,6 @@ public class AsyncSearchResponseTests
     protected void assertInstances(org.elasticsearch.xpack.core.search.action.AsyncSearchResponse expected, AsyncSearchResponse parsed) {
         assertNotSame(parsed, expected);
         assertEquals(expected.getId(), parsed.getId());
-        assertEquals(expected.getVersion(), parsed.getVersion());
         assertEquals(expected.isRunning(), parsed.isRunning());
         assertEquals(expected.isPartial(), parsed.isPartial());
         assertEquals(expected.getStartTime(), parsed.getStartTime());

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -43,7 +43,6 @@ results are returned as part of the <<search-api-response-body,`response`>> obje
 --------------------------------------------------
 {
   "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=", <1>
-  "version" : 0,
   "is_partial" : true, <2>
   "is_running" : true, <3>
   "start_time_in_millis" : 1583945890986,
@@ -135,17 +134,16 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 --------------------------------------------------
 {
   "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
-  "version" : 2, <1>
-  "is_partial" : true, <2>
-  "is_running" : true, <3>
+  "is_partial" : true, <1>
+  "is_running" : true, <2>
   "start_time_in_millis" : 1583945890986,
-  "expiration_time_in_millis" : 1584377890986, <4>
+  "expiration_time_in_millis" : 1584377890986, <3>
   "response" : {
     "took" : 12144,
     "timed_out" : false,
-    "num_reduce_phases" : 38,
+    "num_reduce_phases" : 38, <4>
     "_shards" : {
-      "total" : 562,
+      "total" : 562, <5>
       "successful" : 188,
       "skipped" : 0,
       "failed" : 0
@@ -158,7 +156,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
       "max_score" : null,
       "hits" : [ ]
     },
-    "aggregations" : { <5>
+    "aggregations" : { <6>
       "sale_date" :  {
         "buckets" : []
       }
@@ -178,15 +176,16 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 // TESTRESPONSE[s/"buckets" : \[\]/"buckets": $body.response.aggregations.sale_date.buckets/]
 // TESTRESPONSE[s/"num_reduce_phases" : 38,//]
 
-<1> The returned `version` is useful to identify whether the response contains
-additional results compared to previously obtained responses. If the version
-stays the same, no new results have become available, otherwise a higher version
-number indicates that more shards have completed their execution of the query
-and their partial results are also included in the response.
-<2> Whether the returned search results are partial or final
-<3> Whether the search is still being executed or it has completed
-<4> When the async search will expire
-<5> Partial aggregations results, coming from the shards that have already
+<1> Whether the returned search results are partial or final
+<2> Whether the search is still being executed or it has completed
+<3> When the async search will expire
+<4> Indicates how many reduction of the results have been performed. If this
+number increases compared to the last retrieved results, you can expect
+additional results included in the search response
+<5> Indicates how many shards have executed the query. Note that in order for
+shard results to be included in the search response, they need to be reduced
+first.
+<6> Partial aggregations results, coming from the shards that have already
 completed the execution of the query.
 
 The `wait_for_completion` parameter, which defaults to `1`, can also be provided

--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -30,9 +30,8 @@ POST /sales*/_async_search?size=0
     }
 }
 --------------------------------------------------
-// TEST[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/53891"]
 // TEST[setup:sales]
-// TEST[s/size=0/size=0&wait_for_completion=0/]
+// TEST[s/size=0/size=0&wait_for_completion=10s&clean_on_completion=false/]
 
 The response contains an identifier of the search being executed.
 You can use this ID to later retrieve the search's final results.
@@ -69,12 +68,17 @@ results are returned as part of the <<search-api-response-body,`response`>> obje
 }
 --------------------------------------------------
 // TESTRESPONSE[s/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=/$body.id/]
+// TESTRESPONSE[s/"is_partial" : true/"is_partial": $body.is_partial/]
+// TESTRESPONSE[s/"is_running" : true/"is_running": $body.is_running/]
 // TESTRESPONSE[s/1583945890986/$body.start_time_in_millis/]
 // TESTRESPONSE[s/1584377890986/$body.expiration_time_in_millis/]
 // TESTRESPONSE[s/"took" : 1122/"took": $body.response.took/]
+// TESTRESPONSE[s/"num_reduce_phases" : 0,//]
 // TESTRESPONSE[s/"total" : 562/"total": $body.response._shards.total/]
 // TESTRESPONSE[s/"successful" : 3/"successful": $body.response._shards.successful/]
 // TESTRESPONSE[s/"value" : 157483/"value": $body.response.hits.total.value/]
+// TESTRESPONSE[s/"relation" : "gte"/"relation": $body.response.hits.total.relation/]
+// TESTRESPONSE[s/"hits" : \[ \]\n\s\s\s\s\}/"hits" : \[\]},"aggregations":  $body.response.aggregations/]
 
 <1> Identifier of the async search that can be used to monitor its progress, retrieve its results, and/or delete it.
 <2> Whether the returned search results are partial or final
@@ -141,7 +145,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
   "response" : {
     "took" : 12144,
     "timed_out" : false,
-    "num_reduce_phases" : 38, <4>
+    "num_reduce_phases" : 46, <4>
     "_shards" : {
       "total" : 562, <5>
       "successful" : 188,
@@ -174,7 +178,7 @@ GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsd
 // TESTRESPONSE[s/"successful" : 188/"successful": $body.response._shards.successful/]
 // TESTRESPONSE[s/"value" : 456433/"value": $body.response.hits.total.value/]
 // TESTRESPONSE[s/"buckets" : \[\]/"buckets": $body.response.aggregations.sale_date.buckets/]
-// TESTRESPONSE[s/"num_reduce_phases" : 38,//]
+// TESTRESPONSE[s/"num_reduce_phases" : 46,//]
 
 <1> Whether the returned search results are partial or final
 <2> Whether the search is still being executed or it has completed

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -420,9 +420,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
         }
 
         private Clusters(StreamInput in) throws IOException {
-            this.total = in.readVInt();
-            this.successful = in.readVInt();
-            this.skipped = in.readVInt();
+            this(in.readVInt(), in.readVInt(), in.readVInt());
         }
 
         @Override
@@ -434,7 +432,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            if (this != EMPTY) {
+            if (total > 0) {
                 builder.startObject(_CLUSTERS_FIELD.getPreferredName());
                 builder.field(TOTAL_FIELD.getPreferredName(), total);
                 builder.field(SUCCESSFUL_FIELD.getPreferredName(), successful);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -291,5 +292,14 @@ public class SearchResponseTests extends ESTestCase {
         assertEquals(searchResponse.getTotalShards(), deserialized.getTotalShards());
         assertEquals(searchResponse.getSkippedShards(), deserialized.getSkippedShards());
         assertEquals(searchResponse.getClusters(), deserialized.getClusters());
+    }
+
+    public void testToXContentEmptyClusters() throws IOException {
+        SearchResponse searchResponse = new SearchResponse(InternalSearchResponse.empty(), null, 1, 1, 0, 1,
+            ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY);
+        SearchResponse deserialized = copyWriteable(searchResponse, namedWriteableRegistry, SearchResponse::new, Version.CURRENT);
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        deserialized.getClusters().toXContent(builder, ToXContent.EMPTY_PARAMS);
+        assertEquals(0, Strings.toString(builder).length());
     }
 }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchIndexService.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchIndexService.java
@@ -66,14 +66,14 @@ class AsyncSearchIndexService {
     public static final String EXPIRATION_TIME_FIELD = "expiration_time";
     public static final String RESULT_FIELD = "result";
 
-    public static Settings settings() {
+    private static Settings settings() {
         return Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
+            .put(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
     }
 
-    public static XContentBuilder mappings() throws IOException {
+    private static XContentBuilder mappings() throws IOException {
         XContentBuilder builder = jsonBuilder()
             .startObject()
                 .startObject(SINGLE_MAPPING_NAME)

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchIndexServiceTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchIndexServiceTests.java
@@ -5,6 +5,10 @@
  */
 package org.elasticsearch.xpack.search;
 
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -17,6 +21,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.xpack.search.AsyncSearchResponseTests.assertEqualResponses;
 import static org.elasticsearch.xpack.search.AsyncSearchResponseTests.randomAsyncSearchResponse;
@@ -99,5 +104,16 @@ public class AsyncSearchIndexServiceTests extends ESSingleNodeTestCase {
             new Authentication.RealmRef(randomAlphaOfLengthBetween(1, 16), randomAlphaOfLengthBetween(5, 12), "node"));
         assertFalse(indexService.ensureAuthenticatedUserIsSame(original, runAsDiffType));
         assertFalse(indexService.ensureAuthenticatedUserIsSame(threadContext.getHeaders(), runAsDiffType));
+    }
+
+    public void testSettings() throws ExecutionException, InterruptedException {
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        indexService.createIndexIfNecessary(future);
+        future.get();
+        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(
+            new GetIndexRequest().indices(AsyncSearchIndexService.INDEX)).actionGet();
+        Settings settings = getIndexResponse.getSettings().get(AsyncSearchIndexService.INDEX);
+        assertEquals("1", settings.get(IndexMetaData.SETTING_NUMBER_OF_SHARDS));
+        assertEquals("0-1", settings.get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS));
     }
 }

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -91,15 +91,15 @@ public class AsyncSearchResponseTests extends ESTestCase {
         int rand = randomIntBetween(0, 2);
         switch (rand) {
             case 0:
-                return new AsyncSearchResponse(searchId, randomIntBetween(0, Integer.MAX_VALUE), randomBoolean(),
+                return new AsyncSearchResponse(searchId, randomBoolean(),
                     randomBoolean(), randomNonNegativeLong(), randomNonNegativeLong());
 
             case 1:
-                return new AsyncSearchResponse(searchId, randomIntBetween(0, Integer.MAX_VALUE), searchResponse, null,
+                return new AsyncSearchResponse(searchId, searchResponse, null,
                     randomBoolean(), randomBoolean(), randomNonNegativeLong(), randomNonNegativeLong());
 
             case 2:
-                return new AsyncSearchResponse(searchId, randomIntBetween(0, Integer.MAX_VALUE), searchResponse,
+                return new AsyncSearchResponse(searchId, searchResponse,
                     new ElasticsearchException(new IOException("boum")), randomBoolean(), randomBoolean(),
                     randomNonNegativeLong(), randomNonNegativeLong());
 
@@ -120,7 +120,6 @@ public class AsyncSearchResponseTests extends ESTestCase {
 
     static void assertEqualResponses(AsyncSearchResponse expected, AsyncSearchResponse actual) {
         assertEquals(expected.getId(), actual.getId());
-        assertEquals(expected.getVersion(), actual.getVersion());
         assertEquals(expected.status(), actual.status());
         assertEquals(expected.getFailure() == null, actual.getFailure() == null);
         assertEquals(expected.isRunning(), actual.isRunning());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -25,7 +25,6 @@ import static org.elasticsearch.rest.RestStatus.OK;
 public class AsyncSearchResponse extends ActionResponse implements StatusToXContentObject {
     @Nullable
     private final String id;
-    private final int version;
     @Nullable
     private final SearchResponse searchResponse;
     @Nullable
@@ -40,19 +39,17 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
      * Creates an {@link AsyncSearchResponse} with meta-information only (not-modified).
      */
     public AsyncSearchResponse(String id,
-                               int version,
                                boolean isPartial,
                                boolean isRunning,
                                long startTimeMillis,
                                long expirationTimeMillis) {
-        this(id, version, null, null, isPartial, isRunning, startTimeMillis, expirationTimeMillis);
+        this(id, null, null, isPartial, isRunning, startTimeMillis, expirationTimeMillis);
     }
 
     /**
      * Creates a new {@link AsyncSearchResponse}
      *
      * @param id The id of the search for further retrieval, <code>null</code> if not stored.
-     * @param version The version number of this response.
      * @param searchResponse The actual search response.
      * @param error The error if the search failed, <code>null</code> if the search is running
      *                or has completed without failure.
@@ -61,7 +58,6 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
      * @param startTimeMillis The start date of the search in milliseconds since epoch.
      */
     public AsyncSearchResponse(String id,
-                               int version,
                                SearchResponse searchResponse,
                                ElasticsearchException error,
                                boolean isPartial,
@@ -69,7 +65,6 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
                                long startTimeMillis,
                                long expirationTimeMillis) {
         this.id = id;
-        this.version = version;
         this.error = error;
         this.searchResponse = searchResponse;
         this.isPartial = isPartial;
@@ -80,7 +75,6 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
 
     public AsyncSearchResponse(StreamInput in) throws IOException {
         this.id = in.readOptionalString();
-        this.version = in.readVInt();
         this.error = in.readOptionalWriteable(ElasticsearchException::new);
         this.searchResponse = in.readOptionalWriteable(SearchResponse::new);
         this.isPartial = in.readBoolean();
@@ -92,7 +86,6 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(id);
-        out.writeVInt(version);
         out.writeOptionalWriteable(error);
         out.writeOptionalWriteable(searchResponse);
         out.writeBoolean(isPartial);
@@ -102,7 +95,7 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
     }
 
     public AsyncSearchResponse clone(String id) {
-        return new AsyncSearchResponse(id, version, searchResponse, error, isPartial, false, startTimeMillis, expirationTimeMillis);
+        return new AsyncSearchResponse(id, searchResponse, error, isPartial, false, startTimeMillis, expirationTimeMillis);
     }
 
     /**
@@ -111,13 +104,6 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
     @Nullable
     public String getId() {
         return id;
-    }
-
-    /**
-     * Returns the version of this response.
-     */
-    public int getVersion() {
-        return version;
     }
 
     /**
@@ -189,7 +175,6 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
         if (id != null) {
             builder.field("id", id);
         }
-        builder.field("version", version);
         builder.field("is_partial", isPartial);
         builder.field("is_running", isRunning);
         builder.field("start_time_in_millis", startTimeMillis);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
@@ -73,7 +73,6 @@
                 field: max
           sort: max
 
-  - set:    { id:                              id }
   - match:  { version:                          6 }
   - match:  { is_partial:                   false }
   - length: { response.hits.hits:               3 }
@@ -98,6 +97,7 @@
   - set:    { id:                                  id }
   - match:  { version:                              6 }
   - match:  { is_partial:                       false }
+  - is_false: response._clusters
   - length: { response.hits.hits:                   3 }
   - match:  { response.hits.hits.0._source.max:     1 }
   - match:  { response.aggregations.max#max.value:  3.0 }
@@ -108,6 +108,7 @@
 
   - match:  { version:                            6 }
   - match:  { is_partial:                     false }
+  - is_false: response._clusters
   - length: { response.hits.hits:                 3 }
   - match:  { response.hits.hits.0._source.max:   1 }
   - match:  { response.aggregations.max.value:    3.0 }
@@ -120,6 +121,7 @@
 
   - match:  { version:                              6 }
   - match:  { is_partial:                       false }
+  - is_false: response._clusters
   - length: { response.hits.hits:                   3 }
   - match:  { response.hits.hits.0._source.max:     1 }
   - match:  { response.aggregations.max#max.value:  3.0 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/async_search/10_basic.yml
@@ -54,7 +54,6 @@
           sort: max
 
   - is_false: id
-  - match:  { version:                          6 }
   - match:  { is_partial:                   false }
   - length: { response.hits.hits:               3 }
   - match:  { response.hits.hits.0._source.max: 1 }
@@ -73,7 +72,6 @@
                 field: max
           sort: max
 
-  - match:  { version:                          6 }
   - match:  { is_partial:                   false }
   - length: { response.hits.hits:               3 }
   - match:  { response.hits.hits.0._source.max: 1 }
@@ -95,7 +93,6 @@
           sort: max
 
   - set:    { id:                                  id }
-  - match:  { version:                              6 }
   - match:  { is_partial:                       false }
   - is_false: response._clusters
   - length: { response.hits.hits:                   3 }
@@ -106,7 +103,6 @@
       async_search.get:
         id: "$id"
 
-  - match:  { version:                            6 }
   - match:  { is_partial:                     false }
   - is_false: response._clusters
   - length: { response.hits.hits:                 3 }
@@ -119,7 +115,6 @@
         id: "$id"
         typed_keys: true
 
-  - match:  { version:                              6 }
   - match:  { is_partial:                       false }
   - is_false: response._clusters
   - length: { response.hits.hits:                   3 }


### PR DESCRIPTION
This PR includes the following async search changes that need to be backported to 7.x:

- Get Async Search: omit _clusters section when empty (#53907)
- Async search: remove version from response (#53960)
- Async Search: replicas to auto expand from 0 to 1 (#53964)
- [DOCS] address timing issue in async search docs tests (#53910) 
