### PR TITLE
Add Accept & Content-Type headers to rest api spec

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/api/scripts_painless_context.json
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/api/scripts_painless_context.json
@@ -5,6 +5,9 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html",
       "description": "Returns the painless contexts"
     },
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/plugins/examples/rest-handler/src/yamlRestTest/resources/rest-api-spec/api/cat.example.json
+++ b/plugins/examples/rest-handler/src/yamlRestTest/resources/rest-api-spec/api/cat.example.json
@@ -5,6 +5,9 @@
       "description": "Example"
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -5,6 +5,10 @@
       "description":"Allows to perform multiple index/update/delete operations in a single request."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/x-ndjson"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -5,6 +5,9 @@
       "description":"Shows information about currently configured aliases to indices including filter and routing infos."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -5,6 +5,9 @@
       "description":"Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -5,6 +5,9 @@
       "description":"Provides quick access to the document count of the entire cluster, or individual indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -5,6 +5,9 @@
       "description":"Shows how much heap memory is currently being used by fielddata on every data node in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -5,6 +5,9 @@
       "description":"Returns a concise representation of the cluster health."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
@@ -6,7 +6,7 @@
     },
     "stability":"stable",
     "headers":{
-      "accept": [ "text/plain", "application/json"]
+      "accept": [ "text/plain" ]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.help.json
@@ -5,6 +5,9 @@
       "description":"Returns help for the Cat APIs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -5,6 +5,9 @@
       "description":"Returns information about indices: number of primaries and replicas, document counts, disk size, ..."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -5,6 +5,9 @@
       "description":"Returns information about the master node."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -5,6 +5,9 @@
       "description":"Returns information about custom node attributes."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -5,6 +5,9 @@
       "description":"Returns basic statistics about performance of cluster nodes."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -5,6 +5,9 @@
       "description":"Returns a concise representation of the cluster pending tasks."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -5,6 +5,9 @@
       "description":"Returns information about installed plugins across nodes node."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -5,6 +5,9 @@
       "description":"Returns information about index shard recoveries, both on-going completed."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -5,6 +5,9 @@
       "description":"Returns information about snapshot repositories registered in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -5,6 +5,9 @@
       "description":"Provides low-level information about the segments in the shards of an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -5,6 +5,9 @@
       "description":"Provides a detailed view of shard allocation on nodes."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -5,6 +5,9 @@
       "description":"Returns all snapshots in a specific repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -5,6 +5,9 @@
       "description":"Returns information about the tasks currently executing on one or more nodes in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -5,6 +5,9 @@
       "description":"Returns information about existing templates."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -5,6 +5,9 @@
       "description":"Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -5,6 +5,10 @@
       "description":"Explicitly clears the search context for a scroll."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json","text/plain"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -5,6 +5,10 @@
       "description":"Provides explanations for shard allocations in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -5,6 +5,9 @@
       "description":"Deletes a component template"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_voting_config_exclusions.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_voting_config_exclusions.json
@@ -5,6 +5,9 @@
       "description":"Clears cluster voting config exclusions."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a particular component template exist"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -5,6 +5,9 @@
       "description":"Returns one or more component templates"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
@@ -5,6 +5,9 @@
       "description":"Returns cluster settings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -5,6 +5,9 @@
       "description":"Returns basic information about the health of the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
@@ -5,6 +5,9 @@
       "description":"Returns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.post_voting_config_exclusions.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.post_voting_config_exclusions.json
@@ -5,6 +5,9 @@
       "description":"Updates the cluster voting config exclusions by node ids or node names."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates a component template"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -5,6 +5,10 @@
       "description":"Updates the cluster settings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.remote_info.json
@@ -5,6 +5,9 @@
       "description":"Returns the information about configured remote clusters."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
@@ -5,6 +5,10 @@
       "description":"Allows to manually change the allocation of individual shards in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -5,6 +5,9 @@
       "description":"Returns a comprehensive information about the state of the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
@@ -5,6 +5,9 @@
       "description":"Returns high-level overview of cluster statistics."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -5,6 +5,10 @@
       "description":"Returns number of documents matching a query."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -5,6 +5,10 @@
       "description":"Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
@@ -5,6 +5,9 @@
       "description": "Deletes the specified dangling index"
     },
     "stability": "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
@@ -5,6 +5,9 @@
       "description": "Imports the specified dangling index"
     },
     "stability": "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.list_dangling_indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.list_dangling_indices.json
@@ -5,6 +5,9 @@
       "description": "Returns all dangling indices."
     },
     "stability": "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -5,6 +5,9 @@
       "description":"Removes a document from the index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -5,6 +5,10 @@
       "description":"Deletes documents matching the provided query."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query_rethrottle.json
@@ -5,6 +5,9 @@
       "description":"Changes the number of requests per second for a particular Delete By Query operation."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -5,6 +5,9 @@
       "description":"Deletes a script."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a document exists in an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a document source exists in an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -5,6 +5,10 @@
       "description":"Returns information about why a specific matches (or doesn't match) a query."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -5,6 +5,9 @@
       "description":"Returns the information about the capabilities of fields among multiple indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -5,6 +5,9 @@
       "description":"Returns a document."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
@@ -5,6 +5,9 @@
       "description":"Returns a script."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_context.json
@@ -5,6 +5,9 @@
       "description":"Returns all script contexts."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script_languages.json
@@ -5,6 +5,9 @@
       "description":"Returns available script types, languages and contexts"
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -5,6 +5,9 @@
       "description":"Returns the source of a document."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates a document in an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
@@ -5,6 +5,9 @@
       "description":"Adds a block to an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -5,6 +5,10 @@
       "description":"Performs the analysis process on a text and return the tokens breakdown of the text."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -5,6 +5,9 @@
       "description":"Clears all or specific caches for one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
@@ -5,6 +5,10 @@
       "description": "Clones an index"
     },
     "stability": "stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -5,6 +5,9 @@
       "description":"Closes an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -5,6 +5,10 @@
       "description":"Creates an index with optional settings and mappings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -5,6 +5,9 @@
       "description":"Deletes an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
@@ -5,6 +5,9 @@
       "description":"Deletes an alias."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
@@ -5,6 +5,9 @@
       "description":"Deletes an index template."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -5,6 +5,9 @@
       "description":"Deletes an index template."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a particular index exists."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a particular alias exists."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a particular index template exists."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a particular index template exists."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_type.json
@@ -5,6 +5,9 @@
       "description":"Returns information about whether a particular document type exists. (DEPRECATED)"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
@@ -5,6 +5,9 @@
       "description":"Performs the flush operation on one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -5,6 +5,9 @@
       "description":"Performs the force merge operation on one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -5,6 +5,9 @@
       "description":"Returns information about one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -5,6 +5,9 @@
       "description":"Returns an alias."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -5,6 +5,9 @@
       "description":"Returns mapping for one or more fields."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -5,6 +5,9 @@
       "description":"Returns an index template."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -5,6 +5,9 @@
       "description":"Returns mappings for one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -5,6 +5,9 @@
       "description":"Returns settings for one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -5,6 +5,9 @@
       "description":"Returns an index template."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -5,6 +5,9 @@
       "description":"Opens an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates an alias."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates an index template."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -5,6 +5,10 @@
       "description":"Updates the index mappings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -5,6 +5,10 @@
       "description":"Updates the index settings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates an index template."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -5,6 +5,9 @@
       "description":"Returns information about ongoing index shard recoveries."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
@@ -5,6 +5,9 @@
       "description":"Performs the refresh operation in one or more indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -5,6 +5,9 @@
       "description":"Returns information about any matching indices, aliases, and data streams"
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -5,6 +5,10 @@
       "description":"Updates an alias to point to a new index when the existing index\nis considered to be too large or too old."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -5,6 +5,9 @@
       "description":"Provides low-level information about segments in a Lucene index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -5,6 +5,9 @@
       "description":"Provides store information for shard copies of indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -5,6 +5,10 @@
       "description":"Allow to shrink an existing index into a new index with fewer primary shards."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -5,6 +5,10 @@
       "description": "Simulate matching the given index name against the index templates in the system"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -5,6 +5,10 @@
       "description": "Simulate resolving the given template name or body"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -5,6 +5,10 @@
       "description":"Allows you to split an existing index into a new index with more primary shards."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -5,6 +5,9 @@
       "description":"Provides statistics on operations happening in an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
@@ -5,6 +5,10 @@
       "description":"Updates index aliases."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -5,6 +5,10 @@
       "description":"Allows a user to validate a potentially expensive query without executing it."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/info.json
@@ -5,6 +5,9 @@
       "description":"Returns basic information about the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -5,6 +5,9 @@
       "description":"Deletes a pipeline."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -5,6 +5,9 @@
       "description":"Returns a pipeline."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.processor_grok.json
@@ -5,6 +5,9 @@
       "description":"Returns a list of the built-in patterns."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates a pipeline."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.simulate.json
@@ -5,6 +5,10 @@
       "description":"Allows to simulate a pipeline with example documents."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -5,6 +5,10 @@
       "description":"Allows to get multiple documents in one request."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -5,6 +5,10 @@
       "description":"Allows to execute several search operations in one request."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/x-ndjson"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -5,6 +5,10 @@
       "description":"Allows to execute several search template operations in one request."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/x-ndjson"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -5,6 +5,10 @@
       "description":"Returns multiple termvectors in one request."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -5,6 +5,9 @@
       "description":"Returns information about hot threads on each node in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
@@ -5,6 +5,9 @@
       "description":"Returns information about nodes in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -5,6 +5,9 @@
       "description":"Reloads secure settings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -6,7 +6,8 @@
     },
     "stability":"stable",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": [ "application/json" ]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -5,6 +5,9 @@
       "description":"Returns statistical information about nodes in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -5,6 +5,9 @@
       "description":"Returns low-level information about REST actions usage on nodes."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
@@ -5,6 +5,9 @@
       "description":"Returns whether the cluster is running."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates a script."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -5,6 +5,10 @@
       "description":"Allows to evaluate the quality of ranked search results over a set of typical search queries"
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -5,6 +5,10 @@
       "description":"Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -5,6 +5,9 @@
       "description":"Changes the number of requests per second for a particular Reindex operation."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
@@ -5,6 +5,10 @@
       "description":"Allows to use the Mustache language to pre-render a search definition."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
@@ -5,6 +5,10 @@
       "description":"Allows an arbitrary script to be executed and a result to be returned"
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -5,6 +5,10 @@
       "description":"Allows to retrieve a large numbers of results from a single search request."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -5,6 +5,10 @@
       "description":"Returns results matching a query."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -5,6 +5,9 @@
       "description":"Returns information about the indices and shards that a search request would be executed against."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -5,6 +5,10 @@
       "description":"Allows to use the Mustache language to pre-render a search definition."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {
@@ -100,8 +104,7 @@
       }
     },
     "body":{
-      "description":"The search definition template and its params",
-      "required":true
+      "description":"The search definition template and its params"
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -104,7 +104,8 @@
       }
     },
     "body":{
-      "description":"The search definition template and its params"
+      "description":"The search definition template and its params",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
@@ -5,6 +5,9 @@
       "description": "Removes stale data from repository."
     },
     "stability": "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.clone.json
@@ -5,6 +5,10 @@
       "description":"Clones indices from one snapshot into another snapshot in the same repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
@@ -5,6 +5,10 @@
       "description":"Creates a snapshot in a repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
@@ -5,6 +5,10 @@
       "description":"Creates a repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
@@ -5,6 +5,9 @@
       "description":"Deletes one or more snapshots."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -5,6 +5,9 @@
       "description":"Deletes a repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -5,6 +5,9 @@
       "description":"Returns information about a snapshot."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
@@ -5,6 +5,9 @@
       "description":"Returns information about a repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
@@ -5,6 +5,10 @@
       "description":"Restores a snapshot."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
@@ -5,6 +5,9 @@
       "description":"Returns information about the status of a snapshot."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
@@ -5,6 +5,9 @@
       "description":"Verifies a repository."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -5,6 +5,9 @@
       "description":"Cancels a task, if it can be cancelled through an API."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -5,6 +5,9 @@
       "description":"Returns information about a task."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -5,6 +5,9 @@
       "description":"Returns a list of tasks."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -5,6 +5,10 @@
       "description":"Returns information and statistics about terms in the fields of a particular document."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -5,6 +5,10 @@
       "description":"Updates a document with a script or partial document."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -5,6 +5,10 @@
       "description":"Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
@@ -5,6 +5,9 @@
       "description":"Changes the number of requests per second for a particular Update By Query operation."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -33,6 +33,9 @@
                     "type": "string",
                     "enum": ["stable", "beta", "experimental", "private"]
                 },
+                "headers": {
+                  "$ref": "#/definitions/Headers"
+                },
                 "url": {
                     "$ref": "#/definitions/Url"
                 },
@@ -173,6 +176,29 @@
             ],
             "title": "Documentation",
             "description": "API documentation including a link to the public reference and a short description"
+        },
+        "Headers": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accept": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minItems": 1
+                    }
+                },
+                "content_type": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minItems": 1
+                    }
+                }
+            },
+            "required": ["accept"],
+            "title": "Headers the API understands",
+            "description": "Documents the headers the API supports, at a minimum this should document the Accept header and Content-Type header if the API supports a body"
         },
         "Parts": {
             "type": "object",

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -80,6 +80,7 @@
             "required": [
                 "documentation",
                 "stability",
+                "headers",
                 "url"
             ],
             "title": "API components",

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -198,7 +198,7 @@
             },
             "required": ["accept"],
             "title": "Headers the API understands",
-            "description": "Documents the headers the API supports, at a minimum this should document the Accept header and Content-Type header if the API supports a body"
+            "description": "Documents the headers the API supports, at a minimum this must document the Accept header. The Content-Type header should be documented if the API supports a body"
         },
         "Parts": {
             "type": "object",

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
@@ -43,6 +43,8 @@ public class ClientYamlSuiteRestApi {
     private Map<String, Boolean> params = new HashMap<>();
     private Body body = Body.NOT_SUPPORTED;
     private Stability stability;
+    private List<String> responseMimeTypes;
+    private List<String> requestMimeTypes;
 
     public enum Stability {
         EXPERIMENTAL, BETA, STABLE
@@ -120,6 +122,19 @@ public class ClientYamlSuiteRestApi {
     }
 
     public Stability getStability() { return this.stability; }
+
+    public void setResponseMimeTypes(List<String> mimeTypes) {
+        this.responseMimeTypes = mimeTypes;
+    }
+
+    public List<String> getResponseMimeTypes() { return this.responseMimeTypes; }
+
+    public void setRequestMimeTypes(List<String> mimeTypes) {
+        this.requestMimeTypes = mimeTypes;
+    }
+
+    public List<String> getRequestMimeTypes() { return this.requestMimeTypes; }
+
 
     /**
      * Returns the best matching paths based on the provided parameters, which may include either path parts or query_string parameters.

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
@@ -60,7 +60,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         restApi.getParams().forEach((key, value) -> assertThat(value, equalTo(false)));
         assertThat(restApi.isBodySupported(), equalTo(true));
         assertThat(restApi.isBodyRequired(), equalTo(true));
-        assertThat(restApi.getRequestMimeTypes(), containsInAnyOrder("application/json"));
+        assertThat(restApi.getRequestMimeTypes(), containsInAnyOrder("application/json", "a/mime-type"));
         assertThat(restApi.getResponseMimeTypes(), containsInAnyOrder("application/json"));
     }
 
@@ -172,7 +172,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      \"description\":\"Returns number of documents matching a query.\"\n" +
         "    },\n" +
         "    \"stability\": \"stable\",\n" +
-        "    \"response_types\": [\"application/json\"],\n" +
+        "    \"headers\": { \"accept\": [\"application/json\"] },\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
         "        {\n" +
@@ -234,7 +234,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      \"url\":\"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html\",\n" +
         "      \"description\":\"Returns an index template.\"\n" +
         "    },\n" +
-        "    \"response_types\": [\"application/json\"],\n" +
+        "    \"headers\": { \"accept\": [\"application/json\"] },\n" +
         "    \"stability\": \"stable\",\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
@@ -268,7 +268,10 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      \"description\":\"Creates or updates a document in an index.\"\n" +
         "    },\n" +
         "    \"stability\": \"stable\",\n" +
-        "    \"response_types\": [\"application/json\"],\n" +
+        "    \"headers\": { " +
+        "       \"accept\": [\"application/json\"],\n " +
+        "       \"content_type\": [\"application/json\", \"a/mime-type\"]\n " +
+        "   },\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
         "        {\n" +

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFragmentParserTestCase {
     public void testParseRestSpecIndexApi() throws Exception {
@@ -59,6 +60,8 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         restApi.getParams().forEach((key, value) -> assertThat(value, equalTo(false)));
         assertThat(restApi.isBodySupported(), equalTo(true));
         assertThat(restApi.isBodyRequired(), equalTo(true));
+        assertThat(restApi.getRequestMimeTypes(), containsInAnyOrder("application/json"));
+        assertThat(restApi.getResponseMimeTypes(), containsInAnyOrder("application/json"));
     }
 
     public void testParseRestSpecGetTemplateApi() throws Exception {
@@ -86,6 +89,8 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         assertThat(restApi.getParams().size(), equalTo(0));
         assertThat(restApi.isBodySupported(), equalTo(false));
         assertThat(restApi.isBodyRequired(), equalTo(false));
+        assertThat(restApi.getRequestMimeTypes(), nullValue());
+        assertThat(restApi.getResponseMimeTypes(), containsInAnyOrder("application/json"));
     }
 
     public void testParseRestSpecCountApi() throws Exception {
@@ -167,6 +172,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      \"description\":\"Returns number of documents matching a query.\"\n" +
         "    },\n" +
         "    \"stability\": \"stable\",\n" +
+        "    \"response_types\": [\"application/json\"],\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
         "        {\n" +
@@ -216,7 +222,8 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      }\n" +
         "    },\n" +
         "    \"body\":{\n" +
-        "      \"description\":\"A query to restrict the results specified with the Query DSL (optional)\"\n" +
+        "      \"description\":\"A query to restrict the results specified with the Query DSL (optional)\",\n" +
+        "      \"content_type\": [\"application/json\"]\n" +
         "    }\n" +
         "  }\n" +
         "}\n\n";
@@ -227,6 +234,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      \"url\":\"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html\",\n" +
         "      \"description\":\"Returns an index template.\"\n" +
         "    },\n" +
+        "    \"response_types\": [\"application/json\"],\n" +
         "    \"stability\": \"stable\",\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
@@ -260,6 +268,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "      \"description\":\"Creates or updates a document in an index.\"\n" +
         "    },\n" +
         "    \"stability\": \"stable\",\n" +
+        "    \"response_types\": [\"application/json\"],\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
         "        {\n" +
@@ -336,6 +345,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         "    },\n" +
         "    \"body\":{\n" +
         "      \"description\":\"The document\",\n" +
+        "      \"content_type\": [\"application/json\"],\n" +
         "      \"required\":true\n" +
         "    }\n" +
         "  }\n" +

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiTests.java
@@ -118,6 +118,7 @@ public class ClientYamlSuiteRestApiTests extends ESTestCase {
         "      \"description\":\"Creates or updates a document in an index.\"\n" +
         "    },\n" +
         "    \"stability\":\"stable\",\n" +
+        "    \"response_types\": [\"application/json\"],\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
         "        {\n" +
@@ -308,6 +309,7 @@ public class ClientYamlSuiteRestApiTests extends ESTestCase {
         "    },\n" +
         "    \"body\":{\n" +
         "      \"description\":\"The document\",\n" +
+        "      \"content_type\": [\"application/json\"],\n" +
         "      \"required\":true\n" +
         "    }\n" +
         "  }\n" +

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiTests.java
@@ -118,7 +118,7 @@ public class ClientYamlSuiteRestApiTests extends ESTestCase {
         "      \"description\":\"Creates or updates a document in an index.\"\n" +
         "    },\n" +
         "    \"stability\":\"stable\",\n" +
-        "    \"response_types\": [\"application/json\"],\n" +
+        "    \"headers\": { \"accept\": [\"application/json\"] },\n" +
         "    \"url\":{\n" +
         "      \"paths\":[\n" +
         "        {\n" +
@@ -309,7 +309,6 @@ public class ClientYamlSuiteRestApiTests extends ESTestCase {
         "    },\n" +
         "    \"body\":{\n" +
         "      \"description\":\"The document\",\n" +
-        "      \"content_type\": [\"application/json\"],\n" +
         "      \"required\":true\n" +
         "    }\n" +
         "  }\n" +

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.delete.json
@@ -5,6 +5,9 @@
       "description": "Deletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.get.json
@@ -5,6 +5,9 @@
       "description": "Retrieves the results of a previously submitted async search request given its ID."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.status.json
@@ -5,6 +5,9 @@
       "description": "Retrieves the status of a previously submitted async search request given its ID."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
@@ -5,6 +5,10 @@
       "description": "Executes a search request asynchronously."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
@@ -5,6 +5,9 @@
       "description":"Deletes an autoscaling policy."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
@@ -5,6 +5,9 @@
       "description": "Gets the current autoscaling capacity based on the configured autoscaling policy."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
@@ -5,6 +5,9 @@
       "description": "Retrieves an autoscaling policy."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -5,6 +5,10 @@
       "description": "Creates a new autoscaling policy."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
@@ -5,6 +5,9 @@
       "description": "Gets configuration and usage information about data frame analytics jobs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -5,6 +5,9 @@
       "description": "Gets configuration and usage information about datafeeds."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -5,6 +5,9 @@
       "description": "Gets configuration and usage information about anomaly detection jobs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_trained_models.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.ml_trained_models.json
@@ -5,6 +5,9 @@
       "description": "Gets configuration and usage information about inference trained models."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.transforms.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/cat.transforms.json
@@ -5,6 +5,9 @@
       "description": "Gets configuration and usage information about transforms."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
@@ -5,6 +5,9 @@
       "description": "Deletes auto-follow patterns."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow.json
@@ -5,6 +5,10 @@
       "description": "Creates a new follower index configured to follow the referenced leader index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_info.json
@@ -5,6 +5,9 @@
       "description": "Retrieves information about all follower indices, including parameters and status for each follower index"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.follow_stats.json
@@ -5,6 +5,9 @@
       "description": "Retrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.forget_follower.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.forget_follower.json
@@ -5,6 +5,10 @@
       "description": "Removes the follower retention leases from the leader."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
@@ -5,6 +5,9 @@
       "description": "Gets configured auto-follow patterns. Returns the specified auto-follow pattern collection."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_auto_follow_pattern.json
@@ -5,6 +5,9 @@
       "description": "Pauses an auto-follow pattern"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.pause_follow.json
@@ -5,6 +5,9 @@
       "description": "Pauses a follower index. The follower index will not fetch any additional operations from the leader index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
@@ -5,6 +5,10 @@
       "description": "Creates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_auto_follow_pattern.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_auto_follow_pattern.json
@@ -5,6 +5,9 @@
       "description": "Resumes an auto-follow pattern that has been paused"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_follow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.resume_follow.json
@@ -5,6 +5,10 @@
       "description": "Resumes a follower index that has been paused"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.stats.json
@@ -5,6 +5,9 @@
       "description": "Gets all stats related to cross-cluster replication."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ccr.unfollow.json
@@ -5,6 +5,9 @@
       "description": "Stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/close_point_in_time.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/close_point_in_time.json
@@ -5,6 +5,9 @@
       "description":"Close a point in time"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.delete_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.delete_transform.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing transform."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform.json
@@ -5,6 +5,9 @@
       "description":"Retrieves configuration information for transforms."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.get_transform_stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information for transforms."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.preview_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.preview_transform.json
@@ -5,6 +5,10 @@
       "description":"Previews a transform."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.put_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.put_transform.json
@@ -5,6 +5,10 @@
       "description":"Instantiates a transform."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.start_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.start_transform.json
@@ -5,6 +5,9 @@
       "description":"Starts one or more transforms."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.stop_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.stop_transform.json
@@ -5,6 +5,9 @@
       "description":"Stops one or more transforms."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.update_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/data_frame_transform_deprecated.update_transform.json
@@ -5,6 +5,10 @@
       "description":"Updates certain properties of a transform."
     },
     "stability":"beta",
+    "headers":{
+      "accept":[ "application/json"],
+      "content_type":["application/json"]
+    },
     "url":{
       "paths":[
         {
@@ -34,7 +38,7 @@
       }
     },
     "body":{
-      "description":"The update transform definition",
+      "description" :"The update transform definition",
       "required":true
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.delete_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.delete_policy.json
@@ -5,6 +5,9 @@
       "description": "Deletes an existing enrich policy and its enrich index."
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.execute_policy.json
@@ -5,6 +5,9 @@
       "description": "Creates the enrich index for an existing enrich policy."
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.get_policy.json
@@ -5,6 +5,9 @@
       "description": "Gets information about an enrich policy."
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.put_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.put_policy.json
@@ -5,6 +5,10 @@
       "description": "Creates a new enrich policy."
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/enrich.stats.json
@@ -5,6 +5,9 @@
       "description": "Gets enrich coordinator statistics and information about enrich policies that are currently executing."
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.delete.json
@@ -5,6 +5,9 @@
       "description": "Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.get.json
@@ -5,6 +5,9 @@
       "description": "Returns async results from previously executed Event Query Language (EQL) search"
     },
     "stability": "beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/eql.search.json
@@ -5,6 +5,10 @@
       "description": "Returns results matching a query expressed in Event Query Language (EQL)"
     },
     "stability": "beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/graph.explore.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/graph.explore.json
@@ -5,6 +5,10 @@
       "description": "Explore extracted and summarized information about the documents and terms in an index."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -5,6 +5,9 @@
       "description": "Deletes the specified lifecycle policy definition. A currently used policy cannot be deleted."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -5,6 +5,9 @@
       "description": "Retrieves information about the index's current lifecycle state, such as the currently executing phase, action, and step."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -5,6 +5,9 @@
       "description": "Returns the specified policy definition. Includes the policy version and last modified date."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.get_status.json
@@ -5,6 +5,9 @@
       "description":"Retrieves the current index lifecycle management (ILM) status."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.move_to_step.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.move_to_step.json
@@ -5,6 +5,10 @@
       "description":"Manually moves an index into the specified step and executes that step."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -5,6 +5,10 @@
       "description":"Creates a lifecycle policy"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.remove_policy.json
@@ -5,6 +5,9 @@
       "description":"Removes the assigned lifecycle policy and stops managing the specified index"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.retry.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.retry.json
@@ -5,6 +5,9 @@
       "description":"Retries executing the policy for an index that is in the ERROR step."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.start.json
@@ -5,6 +5,9 @@
       "description":"Start the index lifecycle management (ILM) plugin."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ilm.stop.json
@@ -5,6 +5,9 @@
       "description":"Halts all lifecycle management operations and stops the index lifecycle management (ILM) plugin"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.create_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.create_data_stream.json
@@ -5,6 +5,9 @@
       "description":"Creates a data stream"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.data_streams_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.data_streams_stats.json
@@ -5,6 +5,9 @@
       "description":"Provides statistics on operations happening in a data stream."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.delete_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.delete_data_stream.json
@@ -5,6 +5,9 @@
       "description":"Deletes a data stream."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
@@ -5,6 +5,9 @@
       "description":"Freezes an index. A frozen index has almost no overhead on the cluster (except for maintaining its metadata in memory) and is read-only."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -5,6 +5,9 @@
       "description":"Returns data streams."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
@@ -5,6 +5,9 @@
       "description":"Migrates an alias to a data stream"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
@@ -5,6 +5,9 @@
       "description":"Reloads an index's search analyzers and their resources."
     },
     "stability" : "stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
@@ -5,6 +5,9 @@
       "description":"Unfreezes an index. When a frozen index is unfrozen, the index goes through the normal recovery process and becomes writeable again."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.delete.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.delete.json
@@ -5,6 +5,9 @@
       "description":"Deletes licensing information for the cluster"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get.json
@@ -5,6 +5,9 @@
       "description":"Retrieves licensing information for the cluster"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_basic_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_basic_status.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about the status of the basic license."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_trial_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.get_trial_status.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about the status of the trial license."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post.json
@@ -5,6 +5,10 @@
       "description":"Updates the license for the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_basic.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_basic.json
@@ -5,6 +5,9 @@
       "description":"Starts an indefinite basic license."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/license.post_start_trial.json
@@ -5,6 +5,9 @@
       "description":"starts a limited time trial license."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/migration.deprecations.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/migration.deprecations.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.close_job.json
@@ -5,6 +5,10 @@
       "description":"Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar.json
@@ -5,6 +5,9 @@
       "description":"Deletes a calendar."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_event.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_event.json
@@ -5,6 +5,9 @@
       "description":"Deletes scheduled events from a calendar."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_calendar_job.json
@@ -5,6 +5,9 @@
       "description":"Deletes anomaly detection jobs from a calendar."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_data_frame_analytics.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing data frame analytics job."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_datafeed.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing datafeed."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -5,6 +5,9 @@
       "description":"Deletes expired and unused machine learning data."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_filter.json
@@ -5,6 +5,9 @@
       "description":"Deletes a filter."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_forecast.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_forecast.json
@@ -5,6 +5,9 @@
       "description":"Deletes forecasts from a machine learning job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_job.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing anomaly detection job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_model_snapshot.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing model snapshot."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_trained_model.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_trained_model.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing trained inference model that is currently not referenced by an ingest pipeline."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.estimate_model_memory.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.estimate_model_memory.json
@@ -5,6 +5,10 @@
       "description":"Estimates the model memory"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.evaluate_data_frame.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.evaluate_data_frame.json
@@ -5,6 +5,10 @@
       "description":"Evaluates the data frame analytics for an annotated index."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.explain_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.explain_data_frame_analytics.json
@@ -5,6 +5,10 @@
       "description":"Explains a data frame analytics config."
     },
     "stability":"beta",
+    "headers":{
+      "accept":[ "application/json"],
+      "content_type":["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.find_file_structure.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.find_file_structure.json
@@ -5,6 +5,10 @@
       "description":"Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/x-ndjson"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.flush_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.flush_job.json
@@ -5,6 +5,10 @@
       "description":"Forces any buffered data to be processed by the job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.forecast.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.forecast.json
@@ -5,6 +5,9 @@
       "description":"Predicts the future behavior of a time series by using its historical behavior."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_buckets.json
@@ -5,6 +5,10 @@
       "description":"Retrieves anomaly detection job results for one or more buckets."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendar_events.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendar_events.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about the scheduled events in calendars."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_calendars.json
@@ -5,6 +5,10 @@
       "description":"Retrieves configuration information for calendars."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_categories.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_categories.json
@@ -5,6 +5,10 @@
       "description":"Retrieves anomaly detection job results for one or more categories."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
@@ -5,6 +5,9 @@
       "description":"Retrieves configuration information for data frame analytics jobs."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_data_frame_analytics_stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information for data frame analytics jobs."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information for datafeeds."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -5,6 +5,9 @@
       "description":"Retrieves configuration information for datafeeds."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_filters.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_filters.json
@@ -5,6 +5,9 @@
       "description":"Retrieves filters."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_influencers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_influencers.json
@@ -5,6 +5,10 @@
       "description":"Retrieves anomaly detection job results for one or more influencers."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information for anomaly detection jobs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_jobs.json
@@ -5,6 +5,9 @@
       "description":"Retrieves configuration information for anomaly detection jobs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_model_snapshots.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_model_snapshots.json
@@ -5,6 +5,10 @@
       "description":"Retrieves information about model snapshots."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -5,6 +5,10 @@
       "description":"Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_records.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_records.json
@@ -5,6 +5,10 @@
       "description":"Retrieves anomaly records for an anomaly detection job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models.json
@@ -5,6 +5,9 @@
       "description":"Retrieves configuration information for a trained inference model."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.get_trained_models_stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information for trained inference models."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.info.json
@@ -5,6 +5,9 @@
       "description":"Returns defaults and limits used by machine learning."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.open_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.open_job.json
@@ -5,6 +5,9 @@
       "description":"Opens one or more anomaly detection jobs."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_calendar_events.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_calendar_events.json
@@ -5,6 +5,10 @@
       "description":"Posts scheduled events in a calendar."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.post_data.json
@@ -5,6 +5,10 @@
       "description":"Sends data to an anomaly detection job for analysis."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/x-ndjson", "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -5,6 +5,9 @@
       "description":"Previews a datafeed."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar.json
@@ -5,6 +5,10 @@
       "description":"Instantiates a calendar."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_calendar_job.json
@@ -5,6 +5,9 @@
       "description":"Adds an anomaly detection job to a calendar."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_data_frame_analytics.json
@@ -5,6 +5,10 @@
       "description":"Instantiates a data frame analytics job."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -5,6 +5,10 @@
       "description":"Instantiates a datafeed."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_filter.json
@@ -5,6 +5,10 @@
       "description":"Instantiates a filter."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_job.json
@@ -5,6 +5,10 @@
       "description":"Instantiates an anomaly detection job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_trained_model.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.put_trained_model.json
@@ -5,6 +5,10 @@
       "description":"Creates an inference trained model."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.revert_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.revert_model_snapshot.json
@@ -5,6 +5,10 @@
       "description":"Reverts to a specific snapshot."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.set_upgrade_mode.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.set_upgrade_mode.json
@@ -5,6 +5,9 @@
       "description":"Sets a cluster wide upgrade_mode setting that prepares machine learning indices for an upgrade."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
@@ -5,6 +5,10 @@
       "description":"Starts a data frame analytics job."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -5,6 +5,10 @@
       "description":"Starts one or more datafeeds."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
@@ -5,6 +5,10 @@
       "description":"Stops one or more data frame analytics jobs."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -5,6 +5,9 @@
       "description":"Stops one or more datafeeds."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_data_frame_analytics.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_data_frame_analytics.json
@@ -5,6 +5,10 @@
       "description":"Updates certain properties of a data frame analytics job."
     },
     "stability":"beta",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -5,6 +5,10 @@
       "description":"Updates certain properties of a datafeed."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_filter.json
@@ -5,6 +5,10 @@
       "description":"Updates the description of a filter, adds items, or removes items."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_job.json
@@ -5,6 +5,10 @@
       "description":"Updates certain properties of an anomaly detection job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_model_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.update_model_snapshot.json
@@ -5,6 +5,10 @@
       "description":"Updates certain properties of a snapshot."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.upgrade_job_snapshot.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.upgrade_job_snapshot.json
@@ -5,6 +5,9 @@
       "description":"Upgrades a given job snapshot to the current major version."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
@@ -5,6 +5,10 @@
       "description":"Validates an anomaly detection job."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
@@ -5,6 +5,10 @@
       "description":"Validates an anomaly detection detector."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/monitoring.bulk.json
@@ -5,6 +5,10 @@
       "description":"Used by the monitoring features to send monitoring data."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/open_point_in_time.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/open_point_in_time.json
@@ -5,6 +5,9 @@
       "description":"Open a point in time that can be used in subsequent searches"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.delete_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.delete_job.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing rollup job."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_jobs.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_jobs.json
@@ -5,6 +5,9 @@
       "description":"Retrieves the configuration, stats, and status of rollup jobs."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_caps.json
@@ -5,6 +5,9 @@
       "description":"Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
@@ -5,6 +5,9 @@
       "description":"Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the index where rollup data is stored)."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.put_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.put_job.json
@@ -5,6 +5,10 @@
       "description":"Creates a rollup job."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup.json
@@ -5,6 +5,10 @@
       "description":"Rollup an index"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -5,6 +5,10 @@
       "description":"Enables searching rolled-up data using the standard query DSL."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.start_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.start_job.json
@@ -5,6 +5,9 @@
       "description":"Starts an existing, stopped rollup job."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/rollup.stop_job.json
@@ -5,6 +5,9 @@
       "description":"Stops an existing, started rollup job."
     },
     "stability":"experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -5,6 +5,9 @@
       "description" : "Clear the cache of searchable snapshots."
     },
     "stability": "experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -5,6 +5,10 @@
       "description": "Mount a snapshot as a searchable index."
     },
     "stability": "experimental",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
@@ -5,6 +5,9 @@
       "description": "Retrieve various statistics about searchable snapshots."
     },
     "stability": "experimental",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url": {
       "paths": [
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.authenticate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.authenticate.json
@@ -5,6 +5,9 @@
       "description":"Enables authentication as a user and retrieve information about the authenticated user."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.change_password.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.change_password.json
@@ -5,6 +5,10 @@
       "description":"Changes the passwords of users in the native realm and built-in users."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_api_key_cache.json
@@ -5,6 +5,9 @@
       "description":"Clear a subset or all entries from the API key cache."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_privileges.json
@@ -5,6 +5,9 @@
       "description":"Evicts application privileges from the native application privileges cache."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_realms.json
@@ -5,6 +5,9 @@
       "description":"Evicts users from the user cache. Can completely clear the cache or evict specific users."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.clear_cached_roles.json
@@ -5,6 +5,9 @@
       "description":"Evicts roles from the native role cache."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.create_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.create_api_key.json
@@ -5,6 +5,10 @@
       "description":"Creates an API key for access without requiring basic authentication."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_privileges.json
@@ -5,6 +5,9 @@
       "description":"Removes application privileges."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role.json
@@ -5,6 +5,9 @@
       "description":"Removes roles in the native realm."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_role_mapping.json
@@ -5,6 +5,9 @@
       "description":"Removes role mappings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.delete_user.json
@@ -5,6 +5,9 @@
       "description":"Deletes users from the native realm."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.disable_user.json
@@ -5,6 +5,9 @@
       "description":"Disables users in the native realm."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.enable_user.json
@@ -5,6 +5,9 @@
       "description":"Enables users in the native realm."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_api_key.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information for one or more API keys."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_builtin_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_builtin_privileges.json
@@ -5,6 +5,9 @@
       "description":"Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_privileges.json
@@ -5,6 +5,9 @@
       "description":"Retrieves application privileges."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role.json
@@ -5,6 +5,9 @@
       "description":"Retrieves roles in the native realm."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_role_mapping.json
@@ -5,6 +5,9 @@
       "description":"Retrieves role mappings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_token.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_token.json
@@ -5,6 +5,10 @@
       "description":"Creates a bearer token for access without requiring basic authentication."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about users in the native realm and built-in users."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.get_user_privileges.json
@@ -5,6 +5,9 @@
       "description":"Retrieves application privileges."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.grant_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.grant_api_key.json
@@ -5,6 +5,10 @@
       "description":"Creates an API key on behalf of another user."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.has_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.has_privileges.json
@@ -5,6 +5,10 @@
       "description":"Determines whether the specified user has a specified list of privileges."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_api_key.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_api_key.json
@@ -5,6 +5,10 @@
       "description":"Invalidates one or more API keys."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_token.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.invalidate_token.json
@@ -5,6 +5,10 @@
       "description":"Invalidates one or more access tokens or refresh tokens."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_privileges.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_privileges.json
@@ -5,6 +5,10 @@
       "description":"Adds or updates application privileges."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role.json
@@ -5,6 +5,10 @@
       "description":"Adds and updates roles in the native realm."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role_mapping.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_role_mapping.json
@@ -5,6 +5,10 @@
       "description":"Creates and updates role mappings."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_user.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/security.put_user.json
@@ -5,6 +5,10 @@
       "description":"Adds and updates users in the native realm. These users are commonly referred to as native users."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.delete_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.delete_lifecycle.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing snapshot lifecycle policy."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -5,6 +5,9 @@
       "description":"Immediately creates a snapshot according to the lifecycle policy, without waiting for the scheduled time."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_retention.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.execute_retention.json
@@ -5,6 +5,9 @@
       "description":"Deletes any snapshots that are expired according to the policy's retention rules."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -5,6 +5,9 @@
       "description":"Retrieves one or more snapshot lifecycle policy definitions and information about the latest snapshot attempts."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_stats.json
@@ -5,6 +5,9 @@
       "description":"Returns global and policy-level statistics about actions taken by snapshot lifecycle management."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.get_status.json
@@ -5,6 +5,9 @@
       "description":"Retrieves the status of snapshot lifecycle management (SLM)."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -5,6 +5,10 @@
       "description":"Creates or updates a snapshot lifecycle policy."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.start.json
@@ -5,6 +5,9 @@
       "description":"Turns on snapshot lifecycle management (SLM)."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/slm.stop.json
@@ -5,6 +5,9 @@
       "description":"Turns off snapshot lifecycle management (SLM)."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.clear_cursor.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.clear_cursor.json
@@ -5,6 +5,10 @@
       "description":"Clears the SQL cursor"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.query.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.query.json
@@ -5,6 +5,10 @@
       "description":"Executes a SQL request"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/sql.translate.json
@@ -5,6 +5,10 @@
       "description":"Translates SQL into Elasticsearch queries"
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ssl.certificates.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ssl.certificates.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about the X.509 certificates used to encrypt communications in the cluster."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.delete_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.delete_transform.json
@@ -5,6 +5,9 @@
       "description":"Deletes an existing transform."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform.json
@@ -5,6 +5,9 @@
       "description":"Retrieves configuration information for transforms."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information for transforms."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.preview_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.preview_transform.json
@@ -5,6 +5,10 @@
       "description":"Previews a transform."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.put_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.put_transform.json
@@ -5,6 +5,10 @@
       "description":"Instantiates a transform."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.start_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.start_transform.json
@@ -5,6 +5,9 @@
       "description":"Starts one or more transforms."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.stop_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.stop_transform.json
@@ -5,6 +5,9 @@
       "description":"Stops one or more transforms."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.update_transform.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/transform.update_transform.json
@@ -5,6 +5,10 @@
       "description":"Updates certain properties of a transform."
     },
     "stability":"stable",
+    "headers":{
+      "accept":[ "application/json"],
+      "content_type":["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.ack_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.ack_watch.json
@@ -5,6 +5,9 @@
       "description":"Acknowledges a watch, manually throttling the execution of the watch's actions."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.activate_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.activate_watch.json
@@ -5,6 +5,9 @@
       "description":"Activates a currently inactive watch."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.deactivate_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.deactivate_watch.json
@@ -5,6 +5,9 @@
       "description":"Deactivates a currently active watch."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.delete_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.delete_watch.json
@@ -5,6 +5,9 @@
       "description":"Removes a watch from Watcher."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.execute_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.execute_watch.json
@@ -5,6 +5,10 @@
       "description":"Forces the execution of a stored watch."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.get_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.get_watch.json
@@ -5,6 +5,9 @@
       "description":"Retrieves a watch by its ID."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.put_watch.json
@@ -5,6 +5,10 @@
       "description":"Creates a new watch, or updates an existing one."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.query_watches.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.query_watches.json
@@ -5,6 +5,10 @@
       "description":"Retrieves stored watches."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.start.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.start.json
@@ -5,6 +5,9 @@
       "description":"Starts Watcher if it is not already running."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stats.json
@@ -5,6 +5,9 @@
       "description":"Retrieves the current Watcher metrics."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stop.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/watcher.stop.json
@@ -5,6 +5,9 @@
       "description":"Stops Watcher if it is running."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
@@ -5,6 +5,9 @@
       "description":"Retrieves information about the installed X-Pack features."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.usage.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.usage.json
@@ -5,6 +5,9 @@
       "description":"Retrieves usage information about the installed X-Pack features."
     },
     "stability":"stable",
+    "headers":{
+      "accept": [ "application/json"]
+    },
     "url":{
       "paths":[
         {

--- a/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/funny-timeout-watch.json
+++ b/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/funny-timeout-watch.json
@@ -15,7 +15,7 @@
         "attachments": {
           "test_report.pdf": {
             "http": {
-              "response_types": "application/pdf",
+              "content_type": "application/pdf",
               "request": {
                 "read_timeout": "100s",
                 "scheme": "https",

--- a/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/funny-timeout-watch.json
+++ b/x-pack/qa/full-cluster-restart/src/test/resources/org/elasticsearch/xpack/restart/funny-timeout-watch.json
@@ -15,7 +15,7 @@
         "attachments": {
           "test_report.pdf": {
             "http": {
-              "content_type": "application/pdf",
+              "response_types": "application/pdf",
               "request": {
                 "read_timeout": "100s",
                 "scheme": "https",


### PR DESCRIPTION
This documents the preferred `Accept` and `Content-Type` headers to be
sent with API calls.


Elasticsearch supports more content types e.g `CBOR` and `smile` but none of
our REST clients actively support these so we don't make an active
effort documenting these.

In some cases there `response_accepts` documents multiple formats e.g for the `_cat` API's to signal the preferred mimetype is `text/plain` but still advertise the fact it can return `application/json`.