### PR TITLE
Increase ensureGreen() timeout in CloseWhileRelocatingShardsIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDeci
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
@@ -117,7 +118,7 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
             indices[i] = indexName;
         }
 
-        ensureGreen(indices);
+        ensureGreen(TimeValue.timeValueSeconds(60L),indices);
         assertAcked(client().admin().cluster().prepareUpdateSettings()
             .setTransientSettings(Settings.builder()
                 .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), Rebalance.NONE.toString())));


### PR DESCRIPTION
The test in `CloseWhileRelocatingShardsIT` failed recently multiple times (3) when waiting for initial indices to be become green. Looking at the execution logs from  #53544 it appears at the very beginning of the test and when the WindowsFS file system is picked up (which is known to slow down tests).

This pull request simply increases the timeout for the first `ensureGreen()` to 60 seconds. If the test continues to fail, we might want to test a larger timeout or disable WindowsFS for this test.

Closes #53544
