### PR TITLE
[ML] Fix typo in outlier detection timing stats

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
@@ -36,7 +36,7 @@ public class OutlierDetectionStats implements AnalysisStats {
 
     public static final ParseField TIMESTAMP = new ParseField("timestamp");
     public static final ParseField PARAMETERS = new ParseField("parameters");
-    public static final ParseField TIMING_STATS = new ParseField("timings_stats");
+    public static final ParseField TIMING_STATS = new ParseField("timing_stats");
 
     public static final ConstructingObjectParser<OutlierDetectionStats, Void> PARSER = new ConstructingObjectParser<>(
         NAME.getPreferredName(), true,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/stats/outlierdetection/OutlierDetectionStats.java
@@ -26,7 +26,7 @@ public class OutlierDetectionStats implements AnalysisStats {
     public static final String TYPE_VALUE = "outlier_detection_stats";
 
     public static final ParseField PARAMETERS = new ParseField("parameters");
-    public static final ParseField TIMING_STATS = new ParseField("timings_stats");
+    public static final ParseField TIMING_STATS = new ParseField("timing_stats");
 
     public static final ConstructingObjectParser<OutlierDetectionStats, Void> STRICT_PARSER = createParser(false);
     public static final ConstructingObjectParser<OutlierDetectionStats, Void> LENIENT_PARSER = createParser(true);


### PR DESCRIPTION
The field holding the timing stats was mistakenly called
`timings_stats`.
