### PR TITLE
Clean up IndexTemplateMetaData xcontent serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -30,8 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import static java.util.Collections.singletonMap;
 
 public class GetIndexTemplatesResponse extends ActionResponse implements ToXContentObject {
 
@@ -77,11 +74,9 @@ public class GetIndexTemplatesResponse extends ActionResponse implements ToXCont
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        params = new ToXContent.DelegatingMapParams(singletonMap("reduce_mappings", "true"), params);
-
         builder.startObject();
         for (IndexTemplateMetaData indexTemplateMetaData : getIndexTemplates()) {
-            IndexTemplateMetaData.Builder.toXContent(indexTemplateMetaData, builder, params);
+            indexTemplateMetaData.toXContent(builder, params);
         }
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -53,6 +53,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -426,10 +427,10 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
             coordinationMetaData().toXContent(builder, params);
             builder.endObject();
 
+            ToXContent.Params templateParams = new DelegatingMapParams(Map.of(IndexTemplateMetaData.INCLUDE_TYPE_NAME, "true"), params);
             builder.startObject("templates");
             for (ObjectCursor<IndexTemplateMetaData> cursor : metaData().templates().values()) {
-                IndexTemplateMetaData templateMetaData = cursor.value;
-                IndexTemplateMetaData.Builder.toXContentWithTypes(templateMetaData, builder, params);
+                cursor.value.toXContent(builder, templateParams);
             }
             builder.endObject();
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -20,36 +20,37 @@ package org.elasticsearch.cluster.metadata;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaData> {
+public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaData> implements ToXContentFragment {
 
     private final String name;
 
@@ -228,9 +229,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
     public String toString() {
         try {
             XContentBuilder builder = JsonXContent.contentBuilder();
-            builder.startObject();
-            IndexTemplateMetaData.Builder.toXContentWithTypes(this, builder, ToXContent.EMPTY_PARAMS);
-            builder.endObject();
+            this.toXContent(builder, ToXContent.EMPTY_PARAMS);
             return Strings.toString(builder);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -319,185 +318,113 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
             return this;
         }
 
+        public void putAliases(List<AliasMetaData> aliases) {
+            for (AliasMetaData alias : aliases) {
+                putAlias(alias);
+            }
+        }
+
         public IndexTemplateMetaData build() {
             return new IndexTemplateMetaData(name, order, version, indexPatterns, settings, mappings.build(), aliases.build());
         }
 
-        /**
-         * Serializes the template to xContent, using the legacy format where the mappings are
-         * nested under the type name.
-         *
-         * This method is used for serializing templates before storing them in the cluster metadata,
-         * and also in the REST layer when returning a deprecated typed response.
-         */
-        public static void toXContentWithTypes(IndexTemplateMetaData indexTemplateMetaData,
-                                               XContentBuilder builder,
-                                               ToXContent.Params params) throws IOException {
-            builder.startObject(indexTemplateMetaData.name());
-            toInnerXContent(indexTemplateMetaData, builder, params, true);
-            builder.endObject();
+    }
+
+    public static final String INCLUDE_TYPE_NAME = "include_type_name";
+    public static final String INCLUDE_TEMPLATE_NAME = "include_template_name";
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+
+        boolean includeTypeName = params.paramAsBoolean(INCLUDE_TYPE_NAME, false);
+        boolean includeTemplateName = params.paramAsBoolean(INCLUDE_TEMPLATE_NAME, true);
+
+        if (includeTemplateName) {
+            builder.startObject(this.name());
         }
 
-        /**
-         * Removes the nested type in the xContent representation of {@link IndexTemplateMetaData}.
-         *
-         * This method is useful to help bridge the gap between an the internal representation which still uses (the legacy format) a
-         * nested type in the mapping, and the external representation which does not use a nested type in the mapping.
-         */
-        public static void removeType(IndexTemplateMetaData indexTemplateMetaData, XContentBuilder builder) throws IOException {
-            builder.startObject();
-            toInnerXContent(indexTemplateMetaData, builder,
-                new ToXContent.MapParams(Collections.singletonMap("reduce_mappings", "true")), false);
-            builder.endObject();
+        builder.field("order", this.order());
+        if (this.version() != null) {
+            builder.field("version", this.version());
         }
+        builder.field("index_patterns", this.patterns());
 
-        /**
-         * Serializes the template to xContent, making sure not to nest mappings under the
-         * type name.
-         *
-         * Note that this method should currently only be used for creating REST responses,
-         * and not when directly updating stored templates. Index templates are still stored
-         * in the old, typed format, and have yet to be migrated to be typeless.
-         */
-        public static void toXContent(IndexTemplateMetaData indexTemplateMetaData,
-                                      XContentBuilder builder,
-                                      ToXContent.Params params) throws IOException {
-            builder.startObject(indexTemplateMetaData.name());
-            toInnerXContent(indexTemplateMetaData, builder, params, false);
-            builder.endObject();
-        }
+        builder.startObject("settings");
+        this.settings().toXContent(builder, params);
+        builder.endObject();
 
-
-        static void toInnerXContentWithTypes(IndexTemplateMetaData indexTemplateMetaData,
-                                             XContentBuilder builder,
-                                             ToXContent.Params params) throws IOException {
-            toInnerXContent(indexTemplateMetaData, builder, params, true);
-        }
-
-        private static void toInnerXContent(IndexTemplateMetaData indexTemplateMetaData,
-                                            XContentBuilder builder,
-                                            ToXContent.Params params,
-                                            boolean includeTypeName) throws IOException {
-
-            builder.field("order", indexTemplateMetaData.order());
-            if (indexTemplateMetaData.version() != null) {
-                builder.field("version", indexTemplateMetaData.version());
+        CompressedXContent m = this.mappings();
+        if (m != null) {
+            Map<String, Object> documentMapping = XContentHelper.convertToMap(new BytesArray(m.uncompressed()), true).v2();
+            if (includeTypeName == false) {
+                documentMapping = reduceMapping(documentMapping);
             }
-            builder.field("index_patterns", indexTemplateMetaData.patterns());
+            builder.field("mappings");
+            builder.map(documentMapping);
+        } else {
+            builder.startObject("mappings").endObject();
+        }
 
-            builder.startObject("settings");
-            indexTemplateMetaData.settings().toXContent(builder, params);
+        builder.startObject("aliases");
+        for (ObjectCursor<AliasMetaData> cursor : this.aliases().values()) {
+            AliasMetaData.Builder.toXContent(cursor.value, builder, params);
+        }
+        builder.endObject();
+
+        if (includeTemplateName) {
             builder.endObject();
+        }
 
-            includeTypeName &= (params.paramAsBoolean("reduce_mappings", false) == false);
+        return builder;
+    }
 
-            CompressedXContent m = indexTemplateMetaData.mappings();
-            if (m != null) {
-                Map<String, Object> documentMapping = XContentHelper.convertToMap(new BytesArray(m.uncompressed()), true).v2();
-                if (includeTypeName == false) {
-                    documentMapping = reduceMapping(documentMapping);
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> reduceMapping(Map<String, Object> mapping) {
+        assert mapping.keySet().size() == 1;
+        return (Map<String, Object>) mapping.values().iterator().next();
+    }
+
+    private static final ObjectParser<Builder, String> PARSER = ObjectParser.fromBuilder("index_template", Builder::new);
+
+    static {
+        PARSER.declareObject(Builder::settings,
+            (p, c) -> Settings.builder().put(Settings.fromXContent(p)).normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX).build(),
+            new ParseField("settings"));
+        PARSER.declareObject((builder, map) -> {
+            if (map.isEmpty() == false) {
+                String type = map.keySet().iterator().next();
+                builder.putMapping(type, map.get(type));
+            }
+        }, (p, c) -> parseMappings(p), new ParseField("mappings"));
+        PARSER.declareNamedObjects(Builder::putAliases, (p, c, n) -> AliasMetaData.Builder.fromXContent(p), new ParseField("aliases"));
+        PARSER.declareStringArray(Builder::patterns, new ParseField("index_patterns"));
+        PARSER.declareInt(Builder::order, new ParseField("order"));
+        PARSER.declareInt(Builder::version, new ParseField("version"));
+    }
+
+    // TODO it would be really nice if we could just copy bytes here, there's no need to parse and then
+    // re-stream the mappings
+    private static Map<String, CompressedXContent> parseMappings(XContentParser parser) throws IOException {
+        String mappingType = null;
+        String mappings = null;
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
+                mappingType = parser.currentName();
+            } else if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+                if (mappingType == null) {
+                    throw new XContentParseException(parser.getTokenLocation(), "Expected a mapping type");
                 }
-                builder.field("mappings");
-                builder.map(documentMapping);
-            } else {
-                builder.startObject("mappings").endObject();
+                mappings = Strings.toString(XContentFactory.jsonBuilder().map(Map.of(mappingType, parser.mapOrdered())));
             }
-
-            builder.startObject("aliases");
-            for (ObjectCursor<AliasMetaData> cursor : indexTemplateMetaData.aliases().values()) {
-                AliasMetaData.Builder.toXContent(cursor.value, builder, params);
-            }
-            builder.endObject();
         }
-
-        @SuppressWarnings("unchecked")
-        private static Map<String, Object> reduceMapping(Map<String, Object> mapping) {
-            assert mapping.keySet().size() == 1;
-            return (Map<String, Object>) mapping.values().iterator().next();
+        if (mappings == null) {
+            return Collections.emptyMap();
         }
+        return Map.of(mappingType, new CompressedXContent(mappings));
+    }
 
-        public static IndexTemplateMetaData fromXContent(XContentParser parser, String templateName) throws IOException {
-            Builder builder = new Builder(templateName);
-
-            String currentFieldName = skipTemplateName(parser);
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    if ("settings".equals(currentFieldName)) {
-                        Settings.Builder templateSettingsBuilder = Settings.builder();
-                        templateSettingsBuilder.put(Settings.fromXContent(parser));
-                        templateSettingsBuilder.normalizePrefix(IndexMetaData.INDEX_SETTING_PREFIX);
-                        builder.settings(templateSettingsBuilder.build());
-                    } else if ("mappings".equals(currentFieldName)) {
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                            if (token == XContentParser.Token.FIELD_NAME) {
-                                currentFieldName = parser.currentName();
-                            } else if (token == XContentParser.Token.START_OBJECT) {
-                                String mappingType = currentFieldName;
-                                Map<String, Object> mappingSource =
-                                    MapBuilder.<String, Object>newMapBuilder().put(mappingType, parser.mapOrdered()).map();
-                                builder.putMapping(mappingType, Strings.toString(XContentFactory.jsonBuilder().map(mappingSource)));
-                            }
-                        }
-                    } else if ("aliases".equals(currentFieldName)) {
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                            builder.putAlias(AliasMetaData.Builder.fromXContent(parser));
-                        }
-                    } else {
-                        throw new ElasticsearchParseException("unknown key [{}] for index template", currentFieldName);
-                    }
-                } else if (token == XContentParser.Token.START_ARRAY) {
-                    if ("mappings".equals(currentFieldName)) {
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            Map<String, Object> mapping = parser.mapOrdered();
-                            if (mapping.size() == 1) {
-                                String mappingType = mapping.keySet().iterator().next();
-                                String mappingSource = Strings.toString(XContentFactory.jsonBuilder().map(mapping));
-
-                                if (mappingSource == null) {
-                                    // crap, no mapping source, warn?
-                                } else {
-                                    builder.putMapping(mappingType, mappingSource);
-                                }
-                            }
-                        }
-                    } else if ("index_patterns".equals(currentFieldName)) {
-                        List<String> index_patterns = new ArrayList<>();
-                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                            index_patterns.add(parser.text());
-                        }
-                        builder.patterns(index_patterns);
-                    }
-                } else if (token.isValue()) {
-                    if ("order".equals(currentFieldName)) {
-                        builder.order(parser.intValue());
-                    } else if ("version".equals(currentFieldName)) {
-                        builder.version(parser.intValue());
-                    }
-                }
-            }
-            return builder.build();
-        }
-
-        private static String skipTemplateName(XContentParser parser) throws IOException {
-            XContentParser.Token token = parser.nextToken();
-            if (token == XContentParser.Token.START_OBJECT) {
-                token = parser.nextToken();
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    String currentFieldName = parser.currentName();
-                    if (VALID_FIELDS.contains(currentFieldName)) {
-                        return currentFieldName;
-                    } else {
-                        // we just hit the template name, which should be ignored and we move on
-                        parser.nextToken();
-                    }
-                }
-            }
-
-            return null;
-        }
+    public static IndexTemplateMetaData fromXContent(XContentParser parser, String templateName) throws IOException {
+        return PARSER.parse(parser, templateName).build();
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1372,9 +1372,11 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
                 builder.endObject();
             }
 
+            ToXContent.Params typedParams
+                = new ToXContent.DelegatingMapParams(Map.of(IndexTemplateMetaData.INCLUDE_TYPE_NAME, "true"), params);
             builder.startObject("templates");
             for (ObjectCursor<IndexTemplateMetaData> cursor : metaData.templates().values()) {
-                IndexTemplateMetaData.Builder.toXContentWithTypes(cursor.value, builder, params);
+                cursor.value.toXContent(builder, typedParams);
             }
             builder.endObject();
 
@@ -1439,7 +1441,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
                         builder.hashesOfConsistentSettings(parser.mapStrings());
                     } else if ("templates".equals(currentFieldName)) {
                         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                            builder.put(IndexTemplateMetaData.Builder.fromXContent(parser, parser.currentName()));
+                            builder.put(IndexTemplateMetaData.fromXContent(parser, parser.currentName()));
                         }
                     } else {
                         try {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/TemplateUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/TemplateUpgradeService.java
@@ -57,8 +57,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 
-import static java.util.Collections.singletonMap;
-
 /**
  * Upgrades Templates on behalf of installed {@link Plugin}s when a node joins the cluster
  */
@@ -248,14 +246,12 @@ public class TemplateUpgradeService implements ClusterStateListener {
         return Optional.empty();
     }
 
-    private static final ToXContent.Params PARAMS = new ToXContent.MapParams(singletonMap("reduce_mappings", "true"));
+    private static final ToXContent.Params PARAMS
+        = new ToXContent.MapParams(Map.of(IndexTemplateMetaData.INCLUDE_TEMPLATE_NAME, "false"));
 
     private BytesReference toBytesReference(IndexTemplateMetaData templateMetaData) {
         try {
-            return XContentHelper.toXContent((builder, params) -> {
-                IndexTemplateMetaData.Builder.toInnerXContentWithTypes(templateMetaData, builder, params);
-                return builder;
-            }, XContentType.JSON, PARAMS, false);
+            return XContentHelper.toXContent(templateMetaData, XContentType.JSON, PARAMS, false);
         } catch (IOException ex) {
             throw new IllegalStateException("Cannot serialize template [" + templateMetaData.getName() + "]", ex);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/TemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/TemplateUtils.java
@@ -47,7 +47,7 @@ public class TemplateUtils {
         final String template = loadTemplate(resource, version, versionProperty);
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                 .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, template)) {
-            map.put(templateName, IndexTemplateMetaData.Builder.fromXContent(parser, templateName));
+            map.put(templateName, IndexTemplateMetaData.fromXContent(parser, templateName));
         } catch (IOException e) {
             // TODO: should we handle this with a thrown exception?
             logger.error("Error loading template [{}] as part of metadata upgrading", templateName);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -971,7 +972,7 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, internalRepresentation)) {
             XContentBuilder builder = JsonXContent.contentBuilder();
-            IndexTemplateMetaData.Builder.removeType(IndexTemplateMetaData.Builder.fromXContent(parser, ""), builder);
+            IndexTemplateMetaData.fromXContent(parser, "").toXContent(builder, ToXContent.EMPTY_PARAMS);
             return BytesReference.bytes(builder).utf8ToString();
         }
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -972,7 +972,10 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, internalRepresentation)) {
             XContentBuilder builder = JsonXContent.contentBuilder();
-            IndexTemplateMetaData.fromXContent(parser, "").toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ToXContent.Params params = new ToXContent.MapParams(Map.of(IndexTemplateMetaData.INCLUDE_TEMPLATE_NAME, "false"));
+            builder.startObject();
+            IndexTemplateMetaData.fromXContent(parser, "").toXContent(builder, params);
+            builder.endObject();
             return BytesReference.bytes(builder).utf8ToString();
         }
     }


### PR DESCRIPTION
IndexTemplateMetaData x-content serialization is a bit confused and trappy at the 
moment, with multiple static methods on the Builder object which may or may not
emit the template name and/or mapping types.  This commit consolidates everything
into a single `toXContent()` method on the base class, with different options passed
through as `ToXContent.Params`.  Deserialization is converted to use an `ObjectParser`,
taking the template name as a context.