### PR TITLE
EQL: Remove parser handling for functions

### DIFF
--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlParser.java
@@ -133,24 +133,6 @@ public class EqlParser {
             this.ruleNames = ruleNames;
         }
 
-
-        @Override
-        public void exitFunctionExpression(EqlBaseParser.FunctionExpressionContext context) {
-            Token token = context.name;
-            String functionName = token.getText();
-
-            switch (functionName) {
-                case "arrayContains":
-                case "arrayCount":
-                case "arraySearch":
-                    throw new ParsingException(
-                        "Unsupported function [" + functionName + "]",
-                        null,
-                        token.getLine(),
-                        token.getCharPositionInLine());
-            }
-        }
-
         @Override
         public void exitJoin(EqlBaseParser.JoinContext context) {
             Token token = context.JOIN().getSymbol();

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlParser.java
@@ -43,7 +43,7 @@ public class EqlParser {
     public LogicalPlan createStatement(String eql) {
         return createStatement(eql, new ParserParams());
     }
-    
+
     public LogicalPlan createStatement(String eql, ParserParams params) {
         if (log.isDebugEnabled()) {
             log.debug("Parsing as statement: {}", eql);
@@ -140,38 +140,11 @@ public class EqlParser {
             String functionName = token.getText();
 
             switch (functionName) {
-                case "add":
-                case "between":
-                case "cidrMatch":
-                case "concat":
-                case "divide":
-                case "endsWith":
-                case "indexOf":
-                case "length":
-                case "match":
-                case "modulo":
-                case "multiply":
-                case "number":
-                case "startsWith":
-                case "string":
-                case "stringContains":
-                case "substring":
-                case "subtract":
-                case "wildcard":
-                    break;
-
                 case "arrayContains":
                 case "arrayCount":
                 case "arraySearch":
                     throw new ParsingException(
                         "Unsupported function [" + functionName + "]",
-                        null,
-                        token.getLine(),
-                        token.getCharPositionInLine());
-
-                default:
-                    throw new ParsingException(
-                        "Unknown function [" + functionName + "]",
                         null,
                         token.getLine(),
                         token.getCharPositionInLine());

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
@@ -124,9 +124,9 @@ public class VerifierTests extends ESTestCase {
     // Some functions fail with "Unknown" message at the parse stage
     public void testFunctionParsingUnknown() {
         assertEquals("1:15: Unknown function [matchLite]",
-                errorParsing("process where matchLite(?'.*?net1\\s+localgroup\\s+.*?', command_line)"));
+                error("process where matchLite(?'.*?net1\\s+localgroup\\s+.*?', command_line)"));
         assertEquals("1:15: Unknown function [safe]",
-                errorParsing("network where safe(divide(process_name, process_name))"));
+                error("network where safe(process_name)"));
     }
 
     // Test the known EQL functions that are not supported

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
@@ -113,12 +113,12 @@ public class VerifierTests extends ESTestCase {
 
     // Some functions fail with "Unsupported" message at the parse stage
     public void testArrayFunctionsUnsupported() {
-        assertEquals("1:16: Unsupported function [arrayContains]",
-                errorParsing("registry where arrayContains(bytes_written_string_list, 'En')"));
-        assertEquals("1:16: Unsupported function [arraySearch]",
-                errorParsing("registry where arraySearch(bytes_written_string_list, a, a == 'en-us')"));
-        assertEquals("1:16: Unsupported function [arrayCount]",
-                errorParsing("registry where arrayCount(bytes_written_string_list, s, s == '*-us') == 1"));
+        assertEquals("1:16: Unknown function [arrayContains]",
+                error("registry where arrayContains(bytes_written_string_list, 'En')"));
+        assertEquals("1:16: Unknown function [arraySearch]",
+            error("registry where arraySearch(bytes_written_string_list, bytes_written_string, true)"));
+        assertEquals("1:16: Unknown function [arrayCount]",
+            error("registry where arrayCount(bytes_written_string_list, bytes_written_string, true) == 1"));
     }
 
     // Some functions fail with "Unknown" message at the parse stage

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
@@ -94,7 +94,7 @@ public class QueryFolderOkTests extends AbstractQueryFolderTestCase {
         PhysicalPlan p = plan(query);
         assertEquals(EsQueryExec.class, p.getClass());
         EsQueryExec eqe = (EsQueryExec) p;
-        assertEquals(23, eqe.output().size());
+        assertEquals(25, eqe.output().size());
         assertEquals(KEYWORD, eqe.output().get(0).dataType());
 
         final String query = eqe.queryContainer().toString().replaceAll("\\s+", "");

--- a/x-pack/plugin/eql/src/test/resources/mapping-default.json
+++ b/x-pack/plugin/eql/src/test/resources/mapping-default.json
@@ -1,5 +1,11 @@
 {
     "properties" : {
+        "bytes_written_string" : {
+            "type" : "keyword"
+        },
+        "bytes_written_string_list" : {
+            "type" : "keyword"
+        },
         "command_line" : {
             "type" : "keyword"
         },

--- a/x-pack/plugin/eql/src/test/resources/queries-unsupported.eql
+++ b/x-pack/plugin/eql/src/test/resources/queries-unsupported.eql
@@ -626,58 +626,44 @@ any where process_name == "svchost.exe"
 ;
 
 
-// array functions
-registry where arrayContains(bytes_written_string_list, 'En-uS');
-registry where arrayContains(bytes_written_string_list, 'En');
+// Array functions
+// * parser will recognize as valid, but functions will fail to resolve in verifier
 
 
-network where mysterious_field
-  and arraySearch(mysterious_field.subarray, s, true)
-;
+// registry where arrayContains(bytes_written_string_list, 'En-uS');
+// registry where arrayContains(bytes_written_string_list, 'En');
 
-registry where arraySearch(bytes_written_string_list, a, a == 'en-us');
+// network where mysterious_field
+//  and arraySearch(mysterious_field.subarray, s, true);
 
-registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'));
+// registry where arraySearch(bytes_written_string_list, a, a == 'en-us');
+// registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'));
+// network where mysterious_field and arraySearch(mysterious_field.subarray, s, false);
+// network where mysterious_field and arraySearch(mysterious_field.subarray, s, s.a == 's0-*');
+// network where mysterious_field and arraySearch(mysterious_field.subarray, s, s.a != 's0-*');
 
+// network where mysterious_field
+//   and arraySearch(mysterious_field.subarray, sub1,
+//     arraySearch(sub1.c, nested, nested.x.y == '*'))
+// ;
 
-network where mysterious_field and arraySearch(mysterious_field.subarray, s, false)
-;
+// network where mysterious_field
+//   and arraySearch(mysterious_field.subarray, sub1,
+//     sub1.a == 's0-a' and arraySearch(sub1.c, nested, nested.z == 's0-c1-x-z'))
+// ;
 
-network where mysterious_field and arraySearch(mysterious_field.subarray, s, s.a == 's0-*')
-;
+// network where mysterious_field
+//   and arraySearch(mysterious_field.subarray, sub1,
+//     sub1.a == 's0-a' and arraySearch(sub1.c, nested, nested.z == sub1.cross_match));
 
-network where mysterious_field and arraySearch(mysterious_field.subarray, s, s.a != 's0-*')
-;
+// network where mysterious_field
+//   and arraySearch(mysterious_field.subarray, sub1,
+//     arraySearch(sub1.c, nested, nested.x.y == mysterious_field.outer_cross_match));
 
-network where mysterious_field
-  and arraySearch(mysterious_field.subarray, sub1,
-    arraySearch(sub1.c, nested, nested.x.y == '*'))
-;
+// registry where arrayCount(bytes_written_string_list, s, s == '*-us') == 1;
+// registry where arrayCount(bytes_written_string_list, s, s == '*en*') == 2;
+// registry where arrayContains(bytes_written_string_list, "missing", "en-US");
 
-network where mysterious_field
-  and arraySearch(mysterious_field.subarray, sub1,
-    sub1.a == 's0-a' and arraySearch(sub1.c, nested, nested.z == 's0-c1-x-z'))
-;
-
-network where mysterious_field
-  and arraySearch(mysterious_field.subarray, sub1,
-    sub1.a == 's0-a' and arraySearch(sub1.c, nested, nested.z == sub1.cross_match))
-;
-
-network where mysterious_field
-  and arraySearch(mysterious_field.subarray, sub1,
-    arraySearch(sub1.c, nested, nested.x.y == mysterious_field.outer_cross_match))
-;
-
-
-registry where arrayCount(bytes_written_string_list, s, s == '*-us') == 1
-;
-
-registry where arrayCount(bytes_written_string_list, s, s == '*en*') == 2
-;
-
-registry where arrayContains(bytes_written_string_list, "missing", "en-US")
-;
 
 // array fields
 


### PR DESCRIPTION
Relates to #51556 

Removed the parser handling for all functions, and letting the Verifier handle it. I commented out the array functions in `queries-unsupported.eql`, because they on longer raise ParsingExceptions, and only VerifierExceptions.

https://github.com/elastic/elasticsearch/blob/a462700f9c8e1fb977d62d42eb0077403b8fa98b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/parser/GrammarTests.java#L39-L47