### PR TITLE
Fix serialization bug for aggs

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
@@ -19,11 +19,11 @@
 
 package org.elasticsearch.common.io.stream;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.common.bytes.BytesReference;
-
 import java.io.IOException;
 import java.util.function.Supplier;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
 
 /**
  * A holder for {@link Writeable}s that can delays reading the underlying
@@ -60,6 +60,7 @@ public abstract class DelayableWriteable<T extends Writeable> implements Supplie
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             try (BytesStreamOutput buffer = new BytesStreamOutput()) {
+                buffer.setVersion(out.getVersion());
                 reference.writeTo(buffer);
                 out.writeBytesReference(buffer.bytes());
             }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.common.io.stream;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
 
-import static java.util.Collections.singletonList;
-import static org.hamcrest.Matchers.equalTo;
+import org.elasticsearch.Version;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
 
 public class DelayableWriteableTests extends ESTestCase {
     // NOTE: we don't use AbstractWireSerializingTestCase because we don't implement equals and hashCode.

--- a/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
@@ -33,11 +33,11 @@ public class DelayableWriteableTests extends ESTestCase {
     private static class Example implements NamedWriteable {
         private final String s;
 
-        public Example(String s) {
+        Example(String s) {
             this.s = s;
         }
 
-        public Example(StreamInput in) throws IOException {
+        Example(StreamInput in) throws IOException {
             s = in.readString();
         }
 
@@ -69,11 +69,11 @@ public class DelayableWriteableTests extends ESTestCase {
     private static class NamedHolder implements Writeable {
         private final Example e;
 
-        public NamedHolder(Example e) {
+        NamedHolder(Example e) {
             this.e = e;
         }
 
-        public NamedHolder(StreamInput in) throws IOException {
+        NamedHolder(StreamInput in) throws IOException {
             e = in.readNamedWriteable(Example.class);
         }
 
@@ -100,11 +100,11 @@ public class DelayableWriteableTests extends ESTestCase {
     private static class SneakOtherSideVersionOnWire implements Writeable {
         private final Version version;
 
-        public SneakOtherSideVersionOnWire() {
+        SneakOtherSideVersionOnWire() {
             version = Version.CURRENT;
         }
 
-        public SneakOtherSideVersionOnWire(StreamInput in) throws IOException {
+        SneakOtherSideVersionOnWire(StreamInput in) throws IOException {
             version = Version.readVersion(in);
         }
 


### PR DESCRIPTION
I created this bug today in #53793. When a `DelayableWriteable` that
references an existing object serializes itself it wasn't taking the
version of the node on the other side of the wire into account. This
fixes that.
