### PR TITLE
[Doc]Replace outdated link with correct link

### DIFF
--- a/docs/reference/monitoring/how-monitoring-works.asciidoc
+++ b/docs/reference/monitoring/how-monitoring-works.asciidoc
@@ -22,7 +22,7 @@ To learn how to collect monitoring data, see:
 * <<collecting-monitoring-data>>
 * <<configuring-metricbeat>>
 * {kibana-ref}/xpack-monitoring.html[Monitoring {kib}]
-* {logstash-ref}/monitoring-logstash.html[Monitoring {ls}]
+* {logstash-ref}/configuring-logstash.html[Monitoring {ls}]
 * Monitoring Beats:
 ** {auditbeat-ref}/monitoring.html[{auditbeat}]
 ** {filebeat-ref}/monitoring.html[{filebeat}]


### PR DESCRIPTION
Doc contains link to Logstash OSS-only content.  Replace with link to general LS monitoring topic. 

**PREVIEW:** http://elasticsearch_54032.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/how-monitoring-works.html
