### PR TITLE
Add an end to end QA test

### DIFF
--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -23,11 +23,23 @@ testClusters.integTest {
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.security.authc.token.enabled', 'true'
   setting 'xpack.security.authc.api_key.enabled', 'true'
+  setting 'xpack.security.authc.realms.file.file.order', '0'
+  setting 'xpack.security.authc.realms.saml.cloud-saml.order', '1'
+  setting 'xpack.security.authc.realms.saml.cloud-saml.idp.entity_id', 'https://idp.test.es.elasticsearch.org/'
+  setting 'xpack.security.authc.realms.saml.cloud-saml.idp.metadata.path', 'idp-metadata.xml'
+  setting 'xpack.security.authc.realms.saml.cloud-saml.sp.entity_id', 'ec:123456:abcdefg'
+  // This is a dummy one, we simulate the browser and a web app in our tests
+  setting 'xpack.security.authc.realms.saml.cloud-saml.sp.acs', 'https://sp1.test.es.elasticsearch.org/saml/acs'
+  setting 'xpack.security.authc.realms.saml.cloud-saml.attributes.principal', 'https://idp.test.es.elasticsearch.org/attribute/principal'
+  setting 'xpack.security.authc.realms.saml.cloud-saml.attributes.name', 'https://idp.test.es.elasticsearch.org/attribute/name'
 
   extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
   extraConfigFile 'idp-sign.crt', file('src/test/resources/idp-sign.crt')
   extraConfigFile 'idp-sign.key', file('src/test/resources/idp-sign.key')
+  // The SAML SP is preconfigured with the metadata of the IDP
+  extraConfigFile 'idp-metadata.xml', file('src/test/resources/idp-metadata.xml')
 
   user username: "admin_user", password: "admin-password"
-  user username: "idp_user", password: "idp-password", role: "idp_role"
+  user username: "idp_admin", password: "idp-password", role: "idp_admin"
+  user username: "idp_user", password: "idp-password", role: "idp_user"
 }

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/java/org/elasticsearch/xpack/idp/IdentityProviderAuthenticationIT.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/java/org/elasticsearch/xpack/idp/IdentityProviderAuthenticationIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.idp;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.ObjectPath;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderIndex;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class IdentityProviderAuthenticationIT extends IdpRestTestCase {
+
+    // From build.gradle
+    private final String SP_ENTITY_ID = "ec:123456:abcdefg";
+    private final String SP_ACS = "https://sp1.test.es.elasticsearch.org/saml/acs";
+
+    public void testRegisterAndIdpInitiatedSso() throws Exception {
+        final Map<String, Object> request = Map.ofEntries(
+            Map.entry("name", "Test SP"),
+            Map.entry("acs", SP_ACS),
+            Map.entry("privileges", Map.ofEntries(
+                Map.entry("resource", SP_ENTITY_ID),
+                Map.entry("roles", Map.of("superuser", "role:superuser", "viewer", "role:viewer"))
+            )),
+            Map.entry("attributes", Map.ofEntries(
+                Map.entry("principal", "https://idp.test.es.elasticsearch.org/attribute/principal"),
+                Map.entry("name", "https://idp.test.es.elasticsearch.org/attribute/name"),
+                Map.entry("email", "https://idp.test.es.elasticsearch.org/attribute/email"),
+                Map.entry("roles", "https://idp.test.es.elasticsearch.org/attribute/roles")
+            )));
+        final SamlServiceProviderIndex.DocumentVersion docVersion = createServiceProvider(SP_ENTITY_ID, request);
+        checkIndexDoc(docVersion);
+        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        final String samlResponse = generateSamlResponse(SP_ENTITY_ID, SP_ACS);
+        authenticateWithSamlResponse(samlResponse);
+    }
+
+    private void checkIndexDoc(SamlServiceProviderIndex.DocumentVersion docVersion) throws IOException {
+        final Request request = new Request("GET", SamlServiceProviderIndex.INDEX_NAME + "/_doc/" + docVersion.id);
+        final Response response = adminClient().performRequest(request);
+        final Map<String, Object>
+            map = entityAsMap(response);
+        assertThat(map.get("_index"), equalTo(SamlServiceProviderIndex.INDEX_NAME));
+        assertThat(map.get("_id"), equalTo(docVersion.id));
+        assertThat(asLong(map.get("_seq_no")), equalTo(docVersion.seqNo));
+        assertThat(asLong(map.get("_primary_term")), equalTo(docVersion.primaryTerm));
+    }
+
+    private SamlServiceProviderIndex.DocumentVersion createServiceProvider(String entityId, Map<String, Object> body) throws IOException {
+        final Request request =
+            new Request("PUT", "/_idp/saml/sp/" + encode(entityId) + "?refresh=" + WriteRequest.RefreshPolicy.IMMEDIATE.getValue());
+        final String entity = Strings.toString(JsonXContent.contentBuilder().map(body));
+        request.setJsonEntity(entity);
+        final Response response = client().performRequest(request);
+        final Map<String, Object> map = entityAsMap(response);
+        assertThat(ObjectPath.eval("service_provider.entity_id", map), equalTo(entityId));
+        assertThat(ObjectPath.eval("service_provider.enabled", map), equalTo(true));
+
+        final Object docId = ObjectPath.eval("document._id", map);
+        final Object seqNo = ObjectPath.eval("document._seq_no", map);
+        final Object primaryTerm = ObjectPath.eval("document._primary_term", map);
+        assertThat(docId, instanceOf(String.class));
+        assertThat(seqNo, instanceOf(Number.class));
+        assertThat(primaryTerm, instanceOf(Number.class));
+        return new SamlServiceProviderIndex.DocumentVersion((String) docId, asLong(primaryTerm), asLong(seqNo));
+    }
+
+    private String generateSamlResponse(String entityId, String acs) throws Exception {
+        final Request request = new Request("POST", "/_idp/saml/init");
+        request.setJsonEntity("{\"entity_id\":\"" + entityId + "\"}");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder()
+            .addHeader("es-secondary-authorization", basicAuthHeaderValue("idp_user",
+                new SecureString("idp-password".toCharArray())))
+            .build());
+        final Response response = client().performRequest(request);
+        final Map<String, Object> map = entityAsMap(response);
+        assertThat(ObjectPath.eval("service_provider.entity_id", map), equalTo(entityId));
+        assertThat(ObjectPath.eval("post_url", map), equalTo(acs));
+        assertThat(ObjectPath.eval("saml_response", map), instanceOf(String.class));
+        return (String) ObjectPath.eval("saml_response", map);
+    }
+
+
+    private void authenticateWithSamlResponse(String samlResponse) throws Exception{
+        final String encodedResponse = Base64.getEncoder().encodeToString(samlResponse.getBytes(StandardCharsets.UTF_8));
+        final Request request = new Request("POST", "/_security/saml/authenticate");
+        request.setJsonEntity("{\"content\":\""+encodedResponse+"\", \"realm\":\"cloud-saml\"}");
+        final Response response = client().performRequest(request);
+        final Map<String, Object> map = entityAsMap(response);
+        assertThat(ObjectPath.eval("username", map), instanceOf(String.class));
+        assertThat(ObjectPath.eval("username", map), equalTo("idp_user"));
+        assertThat(ObjectPath.eval("realm", map), instanceOf(String.class));
+        assertThat(ObjectPath.eval("realm", map), equalTo("cloud-saml"));
+        assertThat(ObjectPath.eval("access_token", map), instanceOf(String.class));
+        assertThat(ObjectPath.eval("refresh_token", map), instanceOf(String.class));
+        try (RestClient accessTokenClient = restClientWithToken(ObjectPath.eval("access_token", map))) {
+            final Request authenticateRequest = new Request("GET", "/_security/_authenticate");
+            final Response authenticateResponse = accessTokenClient.performRequest(authenticateRequest);
+            final Map<String, Object> authMap = entityAsMap(authenticateResponse);
+            assertThat(ObjectPath.eval("username", authMap), instanceOf(String.class));
+            assertThat(ObjectPath.eval("username", authMap), equalTo("idp_user"));
+            assertThat(ObjectPath.eval("metadata.saml_nameid_format", authMap), instanceOf(String.class));
+            assertThat(ObjectPath.eval("metadata.saml_nameid_format", authMap),
+                equalTo("urn:oasis:names:tc:SAML:2.0:nameid-format:transient"));
+            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), instanceOf(List.class));
+            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), hasSize(1));
+            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), contains("viewer"));
+        }
+    }
+
+    private String encode(String param) {
+        return URLEncoder.encode(param, StandardCharsets.UTF_8);
+    }
+
+    private Long asLong(Object val) {
+        if (val == null) {
+            return null;
+        }
+        if (val instanceof Long) {
+            return (Long) val;
+        }
+        if (val instanceof Number) {
+            return ((Number) val).longValue();
+        }
+        if (val instanceof String) {
+            return Long.parseLong((String) val);
+        }
+        throw new IllegalArgumentException("Value [" + val + "] of type [" + val.getClass() + "] is not a Long");
+    }
+
+    private RestClient restClientWithToken(String accessToken) throws IOException {
+        return buildClient(
+            Settings.builder().put(ThreadContext.PREFIX + ".Authorization", "Bearer "+accessToken).build(),
+            getClusterHosts().toArray(new HttpHost[getClusterHosts().size()]));
+    }
+}
+

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
@@ -24,7 +24,7 @@ public abstract class IdpRestTestCase extends ESRestTestCase {
 
     @Override
     protected Settings restClientSettings() {
-        String token = basicAuthHeaderValue("idp_user", new SecureString("idp-password".toCharArray()));
+        String token = basicAuthHeaderValue("idp_admin", new SecureString("idp-password".toCharArray()));
         return Settings.builder()
             .put(ThreadContext.PREFIX + ".Authorization", token)
             .build();

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/resources/idp-metadata.xml
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/resources/idp-metadata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.test.es.elasticsearch.org/">
+    <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>
+MIIDoDCCAoigAwIBAgIVAPVpXjny5MCPPsCCGvInDfZQu+4JMA0GCSqGSIb3DQEBCwUAMF8xEzAR
+BgoJkiaJk/IsZAEZFgNvcmcxHTAbBgoJkiaJk/IsZAEZFg1lbGFzdGljc2VhcmNoMQswCQYDVQQL
+EwJlczENMAsGA1UECxMEdGVzdDENMAsGA1UEAxMEc2lnbjAeFw0yMDAzMTMwNDAzNDFaFw00NzA3
+MjkwNDAzNDFaMF8xEzARBgoJkiaJk/IsZAEZFgNvcmcxHTAbBgoJkiaJk/IsZAEZFg1lbGFzdGlj
+c2VhcmNoMQswCQYDVQQLEwJlczENMAsGA1UECxMEdGVzdDENMAsGA1UEAxMEc2lnbjCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAI/JK5IlwBixo2mqX8wDnH2F+tXDJKU8uNezoulYFVMp
+17iK41sOIwCInd6DGDJPkgIIkobnmp3gDgnLckzApC8Ck9xmnjmEQdg+gZO1gtgBVU6Lj8haCzPU
+MVszGodlraeaRMTIBrNG6GPMo/PN5hj2vyC383jiDlE9K3I+Y0rxhnPj6Ic3aTO/bXiMG4FiIvag
+/ViITnvkL1mREwF9JER40dgQoaJJJFTfjcWYnd1q9FDlIhylj2KJwXhOkSZ5znGM93b3GZ5VZUm8
+zzMlq/RzyywDet2jyOSrBn9X3lrp0fPjfhTW+O/+2G/k6bVP29BYJ5Im+JVjjaYbYFI5pQ0CAwEA
+AaNTMFEwHQYDVR0OBBYEFEghxQTreebAJEak+zywt5B/LpaLMB8GA1UdIwQYMBaAFEghxQTreebA
+JEak+zywt5B/LpaLMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBACtGNnaUK4Ut
+KPOSg7fOW3/tIJoPhriuSlAdqQxNRYjkdmPJsY7Gra/kikCm0dRUbttMTfOqwZwu5KdKJUo3duXK
+pRVK3emFDixM8FxFbhtA19+Newzcp6mS0K0T4wqAI5jH/a+eHJb6hDWuCrm9RICxXwqpUdn3HfJr
+YQzsOCuecTAy60jfxjjZeZxAMRIARkhaHQeOdX3rg5v9kWzFXRD0Y7nlqqqCa0el2gs9yZqjDYRM
+Fzz8z4qN9q2NzjohhxgIwuWK+0R6qOIg3XK53kdh6YjgWqlGn1aX9z7ztqlDmiD7LIsPgWL2BARh
+WOexDVOg4wTpACOt4c84VVAVt98=</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://idp.test.es.elasticsearch.org/test/saml/redirect"/>
+    </md:IDPSSODescriptor>
+</md:EntityDescriptor>

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/resources/roles.yml
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/test/resources/roles.yml
@@ -1,6 +1,12 @@
 # A basic role that is used to call the IdP's APIs
-idp_role:
+idp_admin:
   cluster:
     - monitor
     - "cluster:admin/idp/*"
+    - "cluster:admin/xpack/security/saml/*"
 
+idp_user:
+  applications:
+    - application: elastic-cloud
+      resources: ["ec:123456:abcdefg"]
+      privileges: ["role:viewer"]

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolver.java
@@ -81,7 +81,7 @@ public class UserPrivilegeResolver {
         final String username = securityContext.requireUser().principal();
         request.username(username);
         request.applicationPrivileges(buildResourcePrivilege(service));
-        request.applicationPrivileges(buildResourcePrivilege(service));
+        request.indexPrivileges(new RoleDescriptor.IndicesPrivileges[0]);
         request.clusterPrivileges(Strings.EMPTY_ARRAY);
         client.execute(HasPrivilegesAction.INSTANCE, request, ActionListener.wrap(
             response -> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRequestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRequestHandler.java
@@ -47,7 +47,9 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.AccessController;
 import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
@@ -141,14 +143,20 @@ public class SamlRequestHandler {
         }
 
         checkIdpSignature(credential -> {
-            try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(SignatureValidator.class)) {
-                SignatureValidator.validate(signature, credential);
-                logger.debug(() -> new ParameterizedMessage("SAML Signature [{}] matches credentials [{}] [{}]",
-                        signatureText, credential.getEntityId(), credential.getPublicKey()));
-                return true;
+            try {
+                return AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () -> {
+                    try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(SignatureValidator.class)) {
+                        SignatureValidator.validate(signature, credential);
+                        logger.debug(() -> new ParameterizedMessage("SAML Signature [{}] matches credentials [{}] [{}]",
+                            signatureText, credential.getEntityId(), credential.getPublicKey()));
+                        return true;
+                    } catch (PrivilegedActionException e) {
+                        logger.warn("SecurityException while attempting to validate SAML signature", e);
+                        return false;
+                    }
+                });
             } catch (PrivilegedActionException e) {
-                logger.warn("SecurityException while attempting to validate SAML signature", e);
-                return false;
+                throw new SecurityException("failed to sign SAML object ", e);
             }
         }, signatureText);
     }


### PR DESCRIPTION
A single ES cluster is used as an IDP and an SP and the browser is
simulated by the rest client.