### PR TITLE
Use onlyIf for build Docker image task execution

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -191,8 +191,8 @@ void addBuildDockerImage(final String architecture, final boolean oss) {
       ]
     }
   }
+  buildDockerImageTask.onlyIf { Architecture.current().name().toLowerCase().equals(architecture) }
   assemble.dependsOn(buildDockerImageTask)
-  buildDockerImageTask.enabled = Architecture.current().name().toLowerCase().equals(architecture)
 }
 
 for (final String architecture : ["aarch64", "x64"]) {


### PR DESCRIPTION
This commit switches to using an onlyIf to determine if a build Docker image task execution should occur. This is preferred since it means that the determination is performed at task execution time, rather than during configuration.

Relates #53936 
