### PR TITLE
Fix test to always have roles

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnAction.java
@@ -113,6 +113,7 @@ public class TransportSamlInitiateSingleSignOnAction
                         if (userPrivileges.hasAccess == false) {
                             listener.onResponse(null);
                         } else {
+                            logger.debug("Resolved [{}] for [{}]", userPrivileges, user);
                             listener.onResponse(new UserServiceAuthentication(user.principal(), user.fullName(), user.email(),
                                 userPrivileges.roles, serviceProvider));
                         }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilder.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SuccessfulAuthenticationResponseMessageBuilder.java
@@ -6,6 +6,8 @@
 
 package org.elasticsearch.xpack.idp.saml.authn;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.idp.authc.AuthenticationMethod;
@@ -51,6 +53,8 @@ import static org.opensaml.saml.saml2.core.NameIDType.TRANSIENT;
  */
 public class SuccessfulAuthenticationResponseMessageBuilder {
 
+    private final Logger logger = LogManager.getLogger();
+
     private final Clock clock;
     private final SamlIdentityProvider idp;
     private final SamlFactory samlFactory;
@@ -63,6 +67,7 @@ public class SuccessfulAuthenticationResponseMessageBuilder {
     }
 
     public Response build(UserServiceAuthentication user, @Nullable SamlAuthenticationState authnState) {
+        logger.debug("Building success response for [{}] from [{}]", user, authnState);
         final DateTime now = now();
         final SamlServiceProvider serviceProvider = user.getServiceProvider();
 

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/UserServiceAuthentication.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/UserServiceAuthentication.java
@@ -69,4 +69,17 @@ public class UserServiceAuthentication {
     public Set<NetworkControl> getNetworkControls() {
         return networkControls;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" +
+            "principal='" + principal + '\'' +
+            ", name='" + name + '\'' +
+            ", email='" + email + '\'' +
+            ", roles=" + roles +
+            ", serviceProvider=" + serviceProvider +
+            ", authenticationMethods=" + authenticationMethods +
+            ", networkControls=" + networkControls +
+            '}';
+    }
 }

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/support/SamlAuthenticationState.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/support/SamlAuthenticationState.java
@@ -129,6 +129,11 @@ public class SamlAuthenticationState implements Writeable, ToXContentObject {
     }
 
     @Override
+    public String toString() {
+        return getClass().getSimpleName() + Strings.toString(this);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnRequestTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/TransportSamlInitiateSingleSignOnRequestTests.java
@@ -157,7 +157,7 @@ public class TransportSamlInitiateSingleSignOnRequestTests extends IdpSamlTestCa
             ActionListener<UserPrivilegeResolver.UserPrivileges> listener
                 = (ActionListener<UserPrivilegeResolver.UserPrivileges>) args[args.length - 1];
             final UserPrivilegeResolver.UserPrivileges privileges = new UserPrivilegeResolver.UserPrivileges(
-                "saml_enduser", true, Set.of(generateRandomStringArray(5, 8, false, true))
+                "saml_enduser", true, Set.of(generateRandomStringArray(5, 8, false, false))
             );
             listener.onResponse(privileges);
             return null;


### PR DESCRIPTION
This change fixes a radomised failure in
TransportSamlInitiateSingleSignOnRequestTests

Under some seeds (e.g. 856F19C80D0A73B6) the roles array would be
empty, which would mean that the generated SAML response would not
contain a roles attribute.
