### PR TITLE
[7.x][ML] No refresh on indexing DFA stats (#53977)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/StatsPersister.java
@@ -47,7 +47,7 @@ public class StatsPersister {
                 MlStatsIndex.writeAlias(),
                 result,
                 new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true")),
-                WriteRequest.RefreshPolicy.IMMEDIATE,
+                WriteRequest.RefreshPolicy.NONE,
                 docIdSupplier.apply(jobId),
                 () -> isCancelled == false,
                 errorMsg -> auditor.error(jobId,


### PR DESCRIPTION
When we index data frame analytics stats docs we do not
need to refresh immediately.

Backport of #53977
