### PR TITLE
Fix ShardSearchRequest cache key

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -219,7 +219,9 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             out.writeOptionalString(preference);
         }
         if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
-            out.writeBoolean(canReturnNullResponseIfMatchNoDocs);
+            if (asKey == false) {
+                out.writeBoolean(canReturnNullResponseIfMatchNoDocs);
+            }
             out.writeOptionalWriteable(bottomSortValues);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -218,10 +218,8 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             out.writeStringArray(indexRoutings);
             out.writeOptionalString(preference);
         }
-        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
-            if (asKey == false) {
-                out.writeBoolean(canReturnNullResponseIfMatchNoDocs);
-            }
+        if (out.getVersion().onOrAfter(Version.V_7_7_0) && asKey == false) {
+            out.writeBoolean(canReturnNullResponseIfMatchNoDocs);
             out.writeOptionalWriteable(bottomSortValues);
         }
     }


### PR DESCRIPTION
This commit ensures that we don't use the non-deterministic `canReturnNullResponseIfMatchNoDocs` boolean in the cache key of the `ShardSearchRequest`. 

The value of this boolean has no influence on the cacheability of the request.

Closes #32827