### PR TITLE
[DOCS] EQL: Document `wildcard` function

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -290,7 +290,7 @@ expressions. Matching is case sensitive.
 *Example*
 [source,eql]
 ----
-// The following expressions are equivalent.
+// The two following expressions are equivalent.
 process.command_line == "*start*" or process.command_line == "*config*"
 wildcard(process.command_line, "*start*", "*config*")
 
@@ -307,7 +307,7 @@ wildcard(process.command_line, "*start*")               // returns false
 wildcard(process.command_line, "*start*", "*create*")   // returns true
 wildcard(process.command_line, "*start*", "*config*")   // returns false
 
-// case sensitivity
+// case sensitive matching
 wildcard("start explorer.exe", "*start*")                // returns true
 wildcard("start explorer.exe", "*Start*")                // returns false
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -338,7 +338,7 @@ field datatypes:
 +
 --
 (Required{multi-arg}, string)
-Wildcard expression used to match the source string.  If `null`, the function
+Wildcard expression used to match the source string. If `null`, the function
 returns `null`. Fields are not supported as arguments.
 -- 
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -291,29 +291,27 @@ expressions.
 [source,eql]
 ----
 // The two following expressions are equivalent.
-process.command_line == "*start*" or process.command_line == "*config*"
-wildcard(process.command_line, "*start*", "*config*")
+process.name == "*regsvr32*" or process.name == "*explorer*"
+wildcard(process.name, "*regsvr32*", "*explorer*")
 
-// process.command_line = "start explorer.exe"
-wildcard(process.command_line, "*start*")                // returns true
-wildcard(process.command_line, "*start*", "*config*")    // returns true
-wildcard(process.command_line, "*config*")               // returns false
-wildcard(process.command_line, "*config*", "*create*")   // returns false
+// process.name = "regsvr32.exe"
+wildcard(process.name, "*regsvr32*")                // returns true
+wildcard(process.name, "*regsvr32*", "*explorer*")  // returns true
+wildcard(process.name, "*explorer*")                // returns false
+wildcard(process.name, "*explorer*", "*scrobj*")    // returns false
 
-// process.command_line = [ "start explorer.exe", "create regsvr32.exe" ]
-wildcard(process.command_line, "*create*")              // returns true
-wildcard(process.command_line, "*create*", "*config*")  // returns true
-wildcard(process.command_line, "*start*")               // returns false
-wildcard(process.command_line, "*start*", "*create*")   // returns true
-wildcard(process.command_line, "*start*", "*config*")   // returns false
+// process.name = [ "explorer.exe", "regsvr32.exe" ]
+wildcard(process.name, "*regsvr32*")                // returns true
+wildcard(process.name, "*regsvr32*", "*scrobj*")    // returns true
+wildcard(process.name, "*scrobj*")                  // returns false
 
 // empty strings
-wildcard("", "*start*")                                  // returns false
-wildcard("", "*")                                        // returns true
-wildcard("", "")                                         // returns true
+wildcard("", "*start*")                             // returns false
+wildcard("", "*")                                   // returns true
+wildcard("", "")                                    // returns true
 
 // null handling
-wildcard(null, "*start*")                                // returns false
+wildcard(null, "*regsvr32*")                        // returns false
 ----
 
 *Syntax*

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -300,18 +300,14 @@ wildcard(process.name, "*regsvr32*", "*explorer*")  // returns true
 wildcard(process.name, "*explorer*")                // returns false
 wildcard(process.name, "*explorer*", "*scrobj*")    // returns false
 
-// process.name = [ "explorer.exe", "regsvr32.exe" ]
-wildcard(process.name, "*regsvr32*")                // returns true
-wildcard(process.name, "*regsvr32*", "*scrobj*")    // returns true
-wildcard(process.name, "*scrobj*")                  // returns false
-
 // empty strings
 wildcard("", "*start*")                             // returns false
 wildcard("", "*")                                   // returns true
 wildcard("", "")                                    // returns true
 
 // null handling
-wildcard(null, "*regsvr32*")                        // returns false
+wildcard(null, "*regsvr32*")                        // returns null
+wildcard(process.name, null)                        // returns null
 ----
 
 *Syntax*
@@ -327,7 +323,7 @@ wildcard(<source>, <wildcard_exp>[, ...])
 +
 --
 (Required, string)
-Source string.
+Source string. If `null`, the function returns `null`.
 
 If using a field as the argument, this parameter only supports the following
 field datatypes:
@@ -336,16 +332,14 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the last array item only.
 --
 
 `<wildcard_exp>`::
 +
 --
 (Required{multi-arg}, string)
-Wildcard expression used to match the source string. Fields are not supported as
-arguments.
+Wildcard expression used to match the source string.  If `null`, the function
+returns `null`. Fields are not supported as arguments.
 -- 
 
 *Returns:* boolean

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -12,6 +12,7 @@ experimental::[]
 * <<eql-fn-length>>
 * <<eql-fn-startswith>>
 * <<eql-fn-substring>>
+* <<eql-fn-wildcard>>
 
 [discrete]
 [[eql-fn-endswith]]
@@ -276,4 +277,82 @@ function returns the remaining string.
 Positions are zero-indexed. Negative offsets are supported.
 
 *Returns:* string
+====
+
+[discrete]
+[[eql-fn-wildcard]]
+=== `wildcard`
+Returns `true` if a source string matches one or more provided wildcard
+expressions. Matching is case sensitive.
+
+[%collapsible]
+====
+*Example*
+[source,eql]
+----
+// The following expressions are equivalent.
+process.command_line == "*start*" or process.command_line == "*config*"
+wildcard(process.command_line, "*start*", "*config*")
+
+// process.command_line = "start explorer.exe"
+wildcard(process.command_line, "*start*")                // returns true
+wildcard(process.command_line, "*start*", "*config*")    // returns true
+wildcard(process.command_line, "*config*")               // returns false
+wildcard(process.command_line, "*config*", "*create*")   // returns false
+
+// process.command_line = [ "start explorer.exe", "create regsvr32.exe" ]
+wildcard(process.command_line, "*create*")              // returns true
+wildcard(process.command_line, "*create*", "*config*")  // returns true
+wildcard(process.command_line, "*start*")               // returns false
+wildcard(process.command_line, "*start*", "*create*")   // returns true
+wildcard(process.command_line, "*start*", "*config*")   // returns false
+
+// case sensitivity
+wildcard("start explorer.exe", "*start*")                // returns true
+wildcard("start explorer.exe", "*Start*")                // returns false
+
+// null handling
+wildcard(null, "*start*")                                // returns false
+wildcard(null, null)                                     // returns 500 error
+wildcard("start explorer.exe", null)                     // returns 500 error
+wildcard("start explorer.exe", null, "*start*")          // returns 500 error
+wildcard("", null)                                       // returns 500 error
+wildcard("", "")                                         // returns true
+----
+
+*Syntax*
+
+[source,txt]
+----
+wildcard(<source>, <wildcard_exp>[, ...])
+----
+
+*Parameters*
+
+`<source>`::
++
+--
+(Required, string)
+Source string.
+
+If using a field as the argument, this parameter only supports the following
+field datatypes:
+
+* <<keyword,`keyword`>>
+* <<constant-keyword,`constant_keyword`>>
+* <<text,`text`>> field with a <<keyword,`keyword`>> or
+  <<constant-keyword,`constant_keyword`>> sub-field
+
+Fields containing <<array,array values>> use the last array item only.
+--
+
+`<wildcard_exp>`::
++
+--
+(Required{multi-arg}, string)
+Wildcard expression used to match the source string. Fields are not supported as
+arguments. If `null`, the function returns a 500 error.
+-- 
+
+*Returns:* boolean
 ====

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -311,13 +311,13 @@ wildcard(process.command_line, "*start*", "*config*")   // returns false
 wildcard("start explorer.exe", "*start*")                // returns true
 wildcard("start explorer.exe", "*Start*")                // returns false
 
+// empty strings
+wildcard("", "*start*")                                  // returns false
+wildcard("", "*")                                        // returns true
+wildcard("", "")                                         // returns true
+
 // null handling
 wildcard(null, "*start*")                                // returns false
-wildcard(null, null)                                     // returns 500 error
-wildcard("start explorer.exe", null)                     // returns 500 error
-wildcard("start explorer.exe", null, "*start*")          // returns 500 error
-wildcard("", null)                                       // returns 500 error
-wildcard("", "")                                         // returns true
 ----
 
 *Syntax*
@@ -351,7 +351,7 @@ Fields containing <<array,array values>> use the last array item only.
 --
 (Required{multi-arg}, string)
 Wildcard expression used to match the source string. Fields are not supported as
-arguments. If `null`, the function returns a 500 error.
+arguments.
 -- 
 
 *Returns:* boolean

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -283,7 +283,7 @@ Positions are zero-indexed. Negative offsets are supported.
 [[eql-fn-wildcard]]
 === `wildcard`
 Returns `true` if a source string matches one or more provided wildcard
-expressions. Matching is case sensitive.
+expressions.
 
 [%collapsible]
 ====
@@ -306,10 +306,6 @@ wildcard(process.command_line, "*create*", "*config*")  // returns true
 wildcard(process.command_line, "*start*")               // returns false
 wildcard(process.command_line, "*start*", "*create*")   // returns true
 wildcard(process.command_line, "*start*", "*config*")   // returns false
-
-// case sensitive matching
-wildcard("start explorer.exe", "*start*")                // returns true
-wildcard("start explorer.exe", "*Start*")                // returns false
 
 // empty strings
 wildcard("", "*start*")                                  // returns false


### PR DESCRIPTION
Adds documentation for the EQL `wildcard` function.

Depends on #54020