### PR TITLE
Async search: prevent users from overriding pre_filter_shard_size

### DIFF
--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -109,9 +109,10 @@ become available, which happens whenever shard results are reduced. A partial
 reduction is performed every time the coordinating node has received a certain
 number of new shard responses (`5` by default).
 * `request_cache` defaults to `true`
-* `pre_filter_shard_size` defaults to `1`: this is to enforce the execution of
-a pre-filter roundtrip to retrieve statistics from each shard so that the ones
-that surely don't hold any document matching the query get skipped.
+* `pre_filter_shard_size` defaults to `1` and cannot be changed: this is to
+enforce the execution of a pre-filter roundtrip to retrieve statistics from
+each shard so that the ones that surely don't hold any document matching the
+query get skipped.
 * `ccs_minimize_roundtrips` defaults to `false`, which is also the only
 supported value
 

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
@@ -45,6 +45,9 @@ public final class RestSubmitAsyncSearchAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         SubmitAsyncSearchRequest submit = new SubmitAsyncSearchRequest();
         IntConsumer setSize = size -> submit.getSearchRequest().source().size(size);
+        //for simplicity, we share parsing with ordinary search. That means a couple of unsupported parameters, like scroll,
+        // pre_filter_shard_size and ccs_minimize_roundtrips get set to the search request although the REST spec don't list
+        //them as supported. We rely on SubmitAsyncSearchRequest#validate to fail in case they are set.
         request.withContentOrSourceParamParserOrNull(parser ->
             parseSearchRequest(submit.getSearchRequest(), request, parser, setSize));
 

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
@@ -109,4 +109,13 @@ public class SubmitAsyncSearchRequestTests extends AbstractWireSerializingTransf
         assertThat(exc.validationErrors().size(), equalTo(1));
         assertThat(exc.validationErrors().get(0), containsString("suggest"));
     }
+
+    public void testValidatePreFilterShardSize() {
+        SubmitAsyncSearchRequest req = new SubmitAsyncSearchRequest();
+        req.getSearchRequest().setPreFilterShardSize(randomIntBetween(2, Integer.MAX_VALUE));
+        ActionRequestValidationException exc = req.validate();
+        assertNotNull(exc);
+        assertThat(exc.validationErrors().size(), equalTo(1));
+        assertThat(exc.validationErrors().get(0), containsString("[pre_filter_shard_size]"));
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -128,7 +128,7 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = request.validate();
         if (request.scroll() != null) {
-            addValidationError("[scroll] queries are not supported", validationException);
+            validationException = addValidationError("[scroll] queries are not supported", validationException);
         }
         if (request.isSuggestOnly()) {
             validationException = addValidationError("suggest-only queries are not supported", validationException);
@@ -140,6 +140,10 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
         if (request.isCcsMinimizeRoundtrips()) {
             validationException =
                 addValidationError("[ccs_minimize_roundtrips] is not supported on async search queries", validationException);
+        }
+        if (request.getPreFilterShardSize() == null || request.getPreFilterShardSize() != 1) {
+            validationException =
+                addValidationError("[pre_filter_shard_size] cannot be changed for async search queries", validationException);
         }
 
         return validationException;


### PR DESCRIPTION
Submit async search forces pre_filter_shard_size for the underlying search that it creates.
With this commit we also prevent users from overriding such default as part of request validation.