### PR TITLE
Enforce consistent compile options across all projects

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
@@ -32,13 +32,11 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
 import org.gradle.plugins.ide.eclipse.model.EclipseModel
 import org.gradle.plugins.ide.idea.model.IdeaModel
@@ -67,8 +65,8 @@ class StandaloneRestTestPlugin implements Plugin<Project> {
         BuildPlugin.configureTestTasks(project)
         BuildPlugin.configureInputNormalization(project)
         BuildPlugin.configureFips140(project)
+        BuildPlugin.configureCompile(project)
 
-        ExtraPropertiesExtension ext = project.extensions.getByType(ExtraPropertiesExtension)
         project.extensions.getByType(JavaPluginExtension).sourceCompatibility = BuildParams.minimumRuntimeVersion
         project.extensions.getByType(JavaPluginExtension).targetCompatibility = BuildParams.minimumRuntimeVersion
 
@@ -96,13 +94,6 @@ class StandaloneRestTestPlugin implements Plugin<Project> {
         idea.module.scopes.put('TEST', [plus: [project.configurations.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)]] as Map<String, Collection<Configuration>>)
 
         PrecommitTasks.create(project, false)
-        project.tasks.getByName('check').dependsOn(project.tasks.getByName('precommit'))
-
-        project.tasks.withType(JavaCompile) { JavaCompile task ->
-            // This will be the default in Gradle 5.0
-            if (task.options.compilerArgs.contains("-processor") == false) {
-                task.options.compilerArgs << '-proc:none'
-            }
-        }
+        project.tasks.named('check').configure { it.dependsOn(project.tasks.named('precommit')) }
     }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -1556,6 +1556,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
     }
 
     // This method should be called inside an assertBusy, it has no retry logic of its own
+    @SuppressWarnings("unchecked")
     private void assertHistoryIsPresent(String policyName, String indexName, boolean success,
                                         @Nullable String phase, @Nullable String action, String stepName) throws IOException {
         logger.info("--> checking for history item [{}], [{}], success: [{}], phase: [{}], action: [{}], step: [{}]",

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -573,6 +573,7 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
     }
 
     // This method should be called inside an assertBusy, it has no retry logic of its own
+    @SuppressWarnings("unchecked")
     private void assertHistoryIsPresent(String policyName, boolean success, String repository, String operation) throws IOException {
         final Request historySearchRequest = new Request("GET", ".slm-history*/_search");
         historySearchRequest.setJsonEntity("{\n" +

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -314,7 +314,8 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
      * - allows dots (".") in the path elements provided as arguments
      * - supports implicit casting to the appropriate type
      */
+    @SuppressWarnings("unchecked")
     protected static <T> T getFieldValue(Map<String, Object> doc, String... path) {
-        return (T)extractValue(String.join(".", path), doc);
+        return (T) extractValue(String.join(".", path), doc);
     }
 }

--- a/x-pack/plugin/security/qa/security-trial/src/test/java/org/elasticsearch/xpack/security/SecurityOnTrialLicenseRestTestCase.java
+++ b/x-pack/plugin/security/qa/security-trial/src/test/java/org/elasticsearch/xpack/security/SecurityOnTrialLicenseRestTestCase.java
@@ -72,7 +72,7 @@ public abstract class SecurityOnTrialLicenseRestTestCase extends ESRestTestCase 
         final RestHighLevelClient client = getHighLevelAdminClient();
         final CreateTokenRequest request = CreateTokenRequest.passwordGrant(username, password.getChars());
         final CreateTokenResponse response = client.security().createToken(request, RequestOptions.DEFAULT);
-        return new Tuple(response.getAccessToken(), response.getRefreshToken());
+        return Tuple.tuple(response.getAccessToken(), response.getRefreshToken());
     }
 
     protected void deleteUser(String username) throws IOException {

--- a/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/tls-basic/src/test/java/org/elasticsearch/xpack/security/TlsWithBasicLicenseIT.java
@@ -98,6 +98,7 @@ public class TlsWithBasicLicenseIT extends ESRestTestCase {
         assertThat(ObjectPath.evaluate(usage, "security.ssl.transport.enabled"), equalTo(true));
     }
 
+    @SuppressWarnings("unchecked")
     private void checkCertificateAPI() throws IOException {
         Response response = client().performRequest(new Request("GET", "/_ssl/certificates"));
         ObjectPath path = ObjectPath.createFromResponse(response);

--- a/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SpnegoHttpClientConfigCallbackHandler.java
+++ b/x-pack/qa/kerberos-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SpnegoHttpClientConfigCallbackHandler.java
@@ -148,7 +148,7 @@ public class SpnegoHttpClientConfigCallbackHandler implements HttpClientConfigCa
      * returns {@link LoginContext}
      *
      * @return {@link LoginContext}
-     * @throws PrivilegedActionException
+     * @throws PrivilegedActionException if the login triggers a checked exception
      */
     public synchronized LoginContext login() throws PrivilegedActionException {
         if (this.loginContext == null) {
@@ -181,9 +181,9 @@ public class SpnegoHttpClientConfigCallbackHandler implements HttpClientConfigCa
      *            Subject.doAs
      * @param acc the {@link AccessControlContext} to be tied to the specified
      *            subject and action see
-     *            {@link Subject#doAsPrivileged(Subject, PrivilegedExceptionAction, AccessControlContext)
+     *            {@link Subject#doAsPrivileged(Subject, PrivilegedExceptionAction, AccessControlContext)}
      * @return the value returned by the PrivilegedExceptionAction's run method
-     * @throws PrivilegedActionException
+     * @throws PrivilegedActionException if the specified action's run method threw a checked exception
      */
     static <T> T doAsPrivilegedWrapper(final Subject subject, final PrivilegedExceptionAction<T> action, final AccessControlContext acc)
             throws PrivilegedActionException {

--- a/x-pack/qa/oidc-op-tests/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthIT.java
+++ b/x-pack/qa/oidc-op-tests/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthIT.java
@@ -327,7 +327,7 @@ public class OpenIdConnectAuthIT extends ESRestTestCase {
         logger.info(" OpenIDConnect authentication response {}", responseBody);
         assertNotNull(responseBody.get("access_token"));
         assertNotNull(responseBody.get("refresh_token"));
-        return new Tuple(responseBody.get("access_token"), responseBody.get("refresh_token"));
+        return Tuple.tuple(responseBody.get("access_token").toString(), responseBody.get("refresh_token").toString());
     }
 
     private Request buildRequest(String method, String endpoint, Map<String, ?> body, Header... headers) throws IOException {

--- a/x-pack/qa/saml-idp-tests/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
+++ b/x-pack/qa/saml-idp-tests/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
@@ -297,7 +297,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
     }
 
     /**
-     * Verifies that the provided "Access Token" (see {@link org.elasticsearch.xpack.security.authc.TokenService})
+     * Verifies that the provided "Access Token" (see org.elasticsearch.xpack.security.authc.TokenService)
      * is for the expected user with the expected name and roles if the user was created from Role-Mapping
      */
     private void verifyElasticsearchAccessTokenForRoleMapping(String accessToken) throws IOException {
@@ -315,7 +315,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
     }
 
     /**
-     * Verifies that the provided "Access Token" (see {@link org.elasticsearch.xpack.security.authc.TokenService})
+     * Verifies that the provided "Access Token" (see org.elasticsearch.xpack.security.authc.TokenService)
      * is for the expected user with the expected name and roles if the user was retrieved from the native realm
      */
     private void verifyElasticsearchAccessTokenForAuthorizingRealms(String accessToken) throws IOException {
@@ -602,7 +602,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         assertThat(id, notNullValue());
         assertThat(realmName, notNullValue());
 
-        final MapBuilder<String, Object> bodyBuilder = new MapBuilder()
+        final MapBuilder<String, Object> bodyBuilder = new MapBuilder<String, Object>()
             .put("content", saml)
             .put("ids", Collections.singletonList(id));
         if (randomBoolean()) {
@@ -643,7 +643,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
             final List<Cookie> parsed = new DefaultCookieSpec().parse(header, origin);
             return parsed.stream().filter(c -> SAML_REQUEST_COOKIE.equals(c.getName())).map(c -> {
                 String[] values = c.getValue().split("&");
-                return new Tuple(values[0], values[1]);
+                return Tuple.tuple(values[0], values[1]);
             }).findFirst().orElse(null);
         } catch (MalformedCookieException e) {
             throw new IOException("Cannot read cookies", e);

--- a/x-pack/qa/smoke-test-plugins-ssl/src/test/java/org/elasticsearch/smoketest/SmokeTestMonitoringWithSecurityIT.java
+++ b/x-pack/qa/smoke-test-plugins-ssl/src/test/java/org/elasticsearch/smoketest/SmokeTestMonitoringWithSecurityIT.java
@@ -257,6 +257,7 @@ public class SmokeTestMonitoringWithSecurityIT extends ESRestTestCase {
         assertThat(settings, not(hasKey("ssl")));
     }
 
+    @SuppressWarnings("unchecked")
     private String randomNodeHttpAddress() throws IOException {
         Response response = client().performRequest(new Request("GET", "/_nodes"));
         assertOK(response);


### PR DESCRIPTION
Standalone rest test projects (i.e. `:qa`) have not been using the same compiler options as other projects. This can result is some odd behavior in tests where using a later compiler will gladly allow you to use APIs that are not available in the configured minimum runtime JDK version.

This PR enforces consistent compiler options across all projects, and as a result, fixes (or ignores) some compiler warnings in test code that was previously unlinted.