### PR TITLE
Upgrade Gradle Enterprise plugin to 3.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.1.1"
+  id "com.gradle.enterprise" version "3.2"
 }
 
 String dirName = rootProject.projectDir.name


### PR DESCRIPTION
Since we've upgraded to [Gradle Enterprise 2020.1](https://gradle.com/enterprise/releases/2020.1/) we should update the plugin as well. This now captures task dependency information which is a nice new feature to have.