### PR TITLE
Fix BlobStoreIncrementalityIT Assertion (#54149)

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -191,7 +191,6 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         final SnapshotStats firstSnapshotShardStatus = getStats(repo, snapshot1).getIndices().get(indexName).getShards().get(0).getStats();
         final int totalFilesInShard = firstSnapshotShardStatus.getTotalFileCount();
         assertThat(totalFilesInShard, greaterThan(0));
-        assertThat(firstSnapshotShardStatus.getIncrementalFileCount(), is(totalFilesInShard));
         final SnapshotStats secondSnapshotShardStatus =
             getStats(repo, snapshot2).getIndices().get(indexName).getShards().get(0).getStats();
         assertThat(secondSnapshotShardStatus.getTotalFileCount(), is(totalFilesInShard));


### PR DESCRIPTION
We are using this assertion for identical shard snapshots
for situations where `snapshot1` wasn't the first snapshot
for the tested shard. Hence, we can't assume that it will
not share any files with previous snapshots.
This showed up in failing tests when `snapshot1` was equivalent
to a previous snapshot because no documents were deleted from the
repo randomly in the failing test but even if documents are deleted
there is no guarantee that no files will be shared.

=> I removed this assertion since its immaterial for what is tested
here anyway.

Closes #54034

backport of #54149 