### PR TITLE
Fix ClusterHealthIT.testHealthOnMasterFailover

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -303,7 +303,8 @@ public class ClusterHealthIT extends ESIntegTestCase {
         // Run a few health requests concurrent to master fail-overs against a data-node to make sure master failover is handled
         // without exceptions
         for (int i = 0; i < 20; ++i) {
-            responseFutures.add(client(node).admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).execute());
+            responseFutures.add(client(node).admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID)
+                .setWaitForGreenStatus().execute());
             internalCluster().restartNode(internalCluster().getMasterName(), InternalTestCluster.EMPTY_CALLBACK);
         }
         for (ActionFuture<ClusterHealthResponse> responseFuture : responseFutures) {


### PR DESCRIPTION
We can run into a state where there's no more events to wait for temporarily
but the cluster still isn't green. I added the wait for green flag to the request
so the assertion for green cluster health below doesn't fail.

Closes #53457
