### PR TITLE
Remove the cluster.remote.connect setting

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -39,10 +39,8 @@ threads, the `node.processors` setting is now bounded by the number of available
 processors.
 
 [float]
-==== `cluster.remote.connect` is deprecated in favor of `node.remote_cluster_client`
+==== `cluster.remote.connect` is remove
 
-Previously the setting `cluster.remote.connect` was used to configure whether or
-not the local node is capable of acting as a remote cluster client in
-cross-cluster search and cross-cluster replication. This setting is deprecated
-in favor of `node.remote_cluster_client` serves the same purpose and identifies
-the local node as having the `remote_cluster_client` role.
+In Elasticsearch 7.7.0, the setting `cluster.remote.connect` was deprecated in
+favor of setting `node.remote_cluster_client`. In Elasticsearch 8.0.0, the
+setting `cluster.remote.connect` is removed.

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -39,7 +39,7 @@ threads, the `node.processors` setting is now bounded by the number of available
 processors.
 
 [float]
-==== `cluster.remote.connect` is remove
+==== `cluster.remote.connect` is removed
 
 In Elasticsearch 7.7.0, the setting `cluster.remote.connect` was deprecated in
 favor of setting `node.remote_cluster_client`. In Elasticsearch 8.0.0, the

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -294,7 +294,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
             SniffConnectionStrategy.REMOTE_CONNECTIONS_PER_CLUSTER,
             RemoteClusterService.REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING,
             RemoteClusterService.REMOTE_NODE_ATTRIBUTE,
-            RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
             RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE,
             RemoteClusterService.REMOTE_CLUSTER_COMPRESS,
             RemoteConnectionStrategy.REMOTE_CONNECTION_MODE,

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -202,7 +202,7 @@ public class Node implements Closeable {
     public static final Setting<Boolean> NODE_INGEST_SETTING =
         Setting.boolSetting("node.ingest", true, Property.NodeScope);
     public static final Setting<Boolean> NODE_REMOTE_CLUSTER_CLIENT =
-        Setting.boolSetting("node.remote_cluster_client", RemoteClusterService.ENABLE_REMOTE_CLUSTERS, Property.NodeScope);
+        Setting.boolSetting("node.remote_cluster_client", true, Property.NodeScope);
 
     /**
     * controls whether the node is allowed to persist things like metadata to disk

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -155,7 +155,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskResultsService;
 import org.elasticsearch.threadpool.ExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportService;

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -84,18 +84,6 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
     public static final Setting<String> REMOTE_NODE_ATTRIBUTE =
         Setting.simpleString("cluster.remote.node.attr", Setting.Property.NodeScope);
 
-    /**
-     * If <code>true</code> connecting to remote clusters is supported on this node. If <code>false</code> this node will not establish
-     * connections to any remote clusters configured. Search requests executed against this node (where this node is the coordinating node)
-     * will fail if remote cluster syntax is used as an index pattern. The default is <code>true</code>
-     */
-    public static final Setting<Boolean> ENABLE_REMOTE_CLUSTERS =
-        Setting.boolSetting(
-            "cluster.remote.connect",
-            true,
-            Setting.Property.Deprecated,
-            Setting.Property.NodeScope);
-
     public static final Setting.AffixSetting<Boolean> REMOTE_CLUSTER_SKIP_UNAVAILABLE =
         Setting.affixKeySetting(
             "cluster.remote.",

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterSettingsTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -27,7 +26,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.node.Node.NODE_REMOTE_CLUSTER_CLIENT;
-import static org.elasticsearch.transport.RemoteClusterService.ENABLE_REMOTE_CLUSTERS;
 import static org.elasticsearch.transport.RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE;
 import static org.elasticsearch.transport.RemoteClusterService.REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING;
 import static org.elasticsearch.transport.RemoteClusterService.REMOTE_NODE_ATTRIBUTE;
@@ -57,11 +55,6 @@ public class RemoteClusterSettingsTests extends ESTestCase {
 
     public void testDisableRemoteClusterClient() {
         assertFalse(NODE_REMOTE_CLUSTER_CLIENT.get(Settings.builder().put(NODE_REMOTE_CLUSTER_CLIENT.getKey(), false).build()));
-    }
-
-    public void testDisableEnableRemoteClusters() {
-        assertFalse(NODE_REMOTE_CLUSTER_CLIENT.get(Settings.builder().put(ENABLE_REMOTE_CLUSTERS.getKey(), false).build()));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[]{ENABLE_REMOTE_CLUSTERS});
     }
 
     public void testSkipUnavailableDefault() {


### PR DESCRIPTION
In Elasticsearch 7.7.0, the setting cluster.remote.connect was deprecated. In this commit, we remote the setting permanently in favor of setting node.remote_cluster_client.

Relates #53924 
