### PR TITLE
[7.6][DOCS] Document missing data types for node stats API's response parameters (#53475)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -760,83 +760,131 @@ recovery operations were delayed due to throttling.
 [%collapsible]
 ====
 `os.timestamp`::
-    Last time the operating system statistics have been refreshed.
+    (integer)
+    Last time the operating system statistics were refreshed. Recorded in
+    milliseconds since the https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
 
 `os.cpu.percent`::
-    Recent CPU usage for the whole system, or -1 if not supported.
+    (integer)
+    Recent CPU usage for the whole system, or `-1` if not supported.
 
 `os.cpu.load_average.1m`::
+    (float)
     One-minute load average on the system (field is not present if one-minute 
     load average is not available).
     
 `os.cpu.load_average.5m`::
+    (float)
     Five-minute load average on the system (field is not present if five-minute 
     load average is not available).
 
 `os.cpu.load_average.15m`::
+    (float)
     Fifteen-minute load average on the system (field is not present if 
     fifteen-minute load average is not available).
 
+`os.mem.total`::
+    (<<byte-units,byte value>>)
+    Total amount of physical memory.
+
 `os.mem.total_in_bytes`::
+    (integer)
     Total amount of physical memory in bytes.
 
+`os.mem.free`::
+    (<<byte-units,byte value>>)
+    Amount of free physical memory.
+
 `os.mem.free_in_bytes`::
+    (integer)
     Amount of free physical memory in bytes.
 
-`os.mem.free_percent`::
-    Percentage of free memory.
+`os.mem.used`::
+    (<<byte-units,byte value>>)
+    Amount of used physical memory.
 
 `os.mem.used_in_bytes`::
+    (integer)
     Amount of used physical memory in bytes.
 
+`os.mem.free_percent`::
+    (integer)
+    Percentage of free memory.
+
 `os.mem.used_percent`::
+    (integer)
     Percentage of used memory.
 
+`os.swap.total`::
+    (<<byte-units,byte value>>)
+    Total amount of swap space.
+
 `os.swap.total_in_bytes`::
+    (integer)
     Total amount of swap space in bytes.
 
+`os.swap.free`::
+    (<<byte-units,byte value>>)
+    Amount of free swap space.
+
 `os.swap.free_in_bytes`::
+    (integer)
     Amount of free swap space in bytes.
 
+`os.swap.used`::
+    (<<byte-units,byte value>>)
+    Amount of used swap space.
+
 `os.swap.used_in_bytes`::
+    (integer)
     Amount of used swap space in bytes.
 
 `os.cgroup.cpuacct.control_group` (Linux only)::
+    (string)
     The `cpuacct` control group to which the {es} process belongs.
 
 `os.cgroup.cpuacct.usage_nanos` (Linux only)::
+    (integer)
     The total CPU time (in nanoseconds) consumed by all tasks in the same cgroup 
     as the {es} process.
 
 `os.cgroup.cpu.control_group` (Linux only)::
+    (string)
     The `cpu` control group to which the {es} process belongs.
 
 `os.cgroup.cpu.cfs_period_micros` (Linux only)::
+    (integer)
     The period of time (in microseconds) for how regularly all tasks in the same 
     cgroup as the {es} process should have their access to CPU resources 
     reallocated.
 
 `os.cgroup.cpu.cfs_quota_micros` (Linux only)::
+    (integer)
     The total amount of time (in microseconds) for which all tasks in
     the same cgroup as the {es} process can run during one period 
     `os.cgroup.cpu.cfs_period_micros`.
 
 `os.cgroup.cpu.stat.number_of_elapsed_periods` (Linux only)::
+    (integer)
     The number of reporting periods (as specified by
     `os.cgroup.cpu.cfs_period_micros`) that have elapsed.
 
 `os.cgroup.cpu.stat.number_of_times_throttled` (Linux only)::
+    (integer)
     The number of times all tasks in the same cgroup as the {es} process have 
     been throttled.
 
 `os.cgroup.cpu.stat.time_throttled_nanos` (Linux only)::
+    (integer)
     The total amount of time (in nanoseconds) for which all tasks in the same 
     cgroup as the {es} process have been throttled.
 
 `os.cgroup.memory.control_group` (Linux only)::
+    (string)
     The `memory` control group to which the {es} process belongs.
 
 `os.cgroup.memory.limit_in_bytes` (Linux only)::
+    (string)
     The maximum amount of user memory (including file cache) allowed for all 
     tasks in the same cgroup as the {es} process. This value can be too big to 
     store in a `long`, so is returned as a string so that the value returned can 
@@ -845,6 +893,7 @@ recovery operations were delayed due to throttling.
     limit has been set for the cgroup.
 
 `os.cgroup.memory.usage_in_bytes` (Linux only)::
+    (string)
     The total current memory usage by processes in the cgroup (in bytes) by all 
     tasks in the same cgroup as the {es} process. This value is stored as a 
     string for consistency with `os.cgroup.memory.limit_in_bytes`.
@@ -860,24 +909,41 @@ must be readable from `/sys/fs/cgroup/cpu` and `/sys/fs/cgroup/cpuacct`.
 [%collapsible]
 ====
 `process.timestamp`::
-    Last time the process statistics have been refreshed.
+    (integer)
+    Last time the process statistics were refreshed. Recorded in milliseconds
+    since the https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
 
 `process.open_file_descriptors`::
-    Number of opened file descriptors associated with the current process, or -1 
-    if not supported.
+    (integer)
+    Number of opened file descriptors associated with the current process, or
+    `-1` if not supported.
 
 `process.max_file_descriptors`::
-    Maximum number of file descriptors allowed on the system, or -1 if not 
+    (integer)
+    Maximum number of file descriptors allowed on the system, or `-1` if not 
     supported.
 
 `process.cpu.percent`::
-    CPU usage in percent, or -1 if not known at the time the stats are computed
+    (integer)
+    CPU usage in percent, or `-1` if not known at the time the stats are
+    computed.
+
+`process.cpu.total`::
+    (<<time-units,time value>>)
+    CPU time used by the process on which the Java virtual machine is running.
 
 `process.cpu.total_in_millis`::
+    (integer)
     CPU time (in milliseconds) used by the process on which the Java virtual 
-    machine is running, or -1 if not supported.
+    machine is running, or `-1` if not supported.
+
+`process.mem.total_virtual`::
+    (<<byte-units,byte value>>)
+    Size of virtual memory that is guaranteed to be available to the 
+    running process.
 
 `process.mem.total_virtual_in_bytes`::
+    (integer)
     Size in bytes of virtual memory that is guaranteed to be available to the 
     running process.
 ====
@@ -1070,85 +1136,154 @@ Number of tasks completed by the thread pool executor.
 [%collapsible]
 ====
 `fs.timestamp`::
-    Last time the file stores statistics have been refreshed.
+    (integer)
+    Last time the file stores statistics were refreshed. Recorded in
+    milliseconds since the https://en.wikipedia.org/wiki/Unix_time[Unix Epoch].
+
+`fs.total.total`::
+    (<<byte-units,byte value>>)
+    Total size of all file stores.
 
 `fs.total.total_in_bytes`::
+    (integer)
     Total size (in bytes) of all file stores.
 
+`fs.total.free`::
+    (<<byte-units,byte value>>)
+    Total unallocated disk space in all file stores.
+
 `fs.total.free_in_bytes`::
+    (integer)
     Total number of unallocated bytes in all file stores.
 
+`fs.total.available`::
+    (<<byte-units,byte value>>)
+    Total disk space available to this Java virtual machine on all file 
+    stores. Depending on OS or process level restrictions, this might appear 
+    less than `fs.total.free`. This is the actual amount of free disk 
+    space the {es} node can utilise.
+
 `fs.total.available_in_bytes`::
+    (integer)
     Total number of bytes available to this Java virtual machine on all file 
     stores. Depending on OS or process level restrictions, this might appear 
     less than `fs.total.free_in_bytes`. This is the actual amount of free disk 
     space the {es} node can utilise.
 
+`fs.least_usage_estimate`::
+    (object)
+    Object containing statistics for the file store with the least estimated
+    usage. See <<cluster-nodes-stats-fs-data,`fs.data`>> for a list of child
+    parameters.
+    
+
+`fs.most_usage_estimate`::
+    (object)
+    Object containing statistics for the file store with the most estimated
+    usage. See <<cluster-nodes-stats-fs-data,`fs.data`>> for a list of child
+    parameters.
+
+[[cluster-nodes-stats-fs-data]]
 `fs.data`::
+    (array of objects)
     List of all file stores.
 
 `fs.data.path`::
+    (string)
     Path to the file store.
 
 `fs.data.mount`::
+    (string)
     Mount point of the file store (ex: /dev/sda2).
+    +
+    NOTE: This parameter is not provided for the `least_usage_estimate` or 
+    `most_usage_estimate` file stores.
 
 `fs.data.type`::
+    (string)
     Type of the file store (ex: ext4).
 
+`fs.data.total`::
+    (<<byte-units,byte value>>)
+    Total size of the file store.
+
 `fs.data.total_in_bytes`::
+    (integer)
     Total size (in bytes) of the file store.
 
+`fs.data.free`::
+    (<<byte-units,byte value>>)
+    Total amount of unallocated disk space in the file store.
+
 `fs.data.free_in_bytes`::
+    (integer)
     Total number of unallocated bytes in the file store.
 
+`fs.data.available`::
+    (<<byte-units,byte value>>)
+    Total amount of disk space available to this Java virtual machine on this file 
+    store.
+
 `fs.data.available_in_bytes`::
+    (integer)
     Total number of bytes available to this Java virtual machine on this file 
     store.
 
 `fs.io_stats.devices` (Linux only)::
+    (array)
     Array of disk metrics for each device that is backing an {es} data path. 
     These disk metrics are probed periodically and averages between the last 
     probe and the current probe are computed.
 
 `fs.io_stats.devices.device_name` (Linux only)::
+    (string)
     The Linux device name.
 
 `fs.io_stats.devices.operations` (Linux only)::
+    (integer)
     The total number of read and write operations for the device completed since 
     starting {es}.
 
 `fs.io_stats.devices.read_operations` (Linux only)::
+    (integer)
     The total number of read operations for the device completed since starting 
     {es}.
 
 `fs.io_stats.devices.write_operations` (Linux only)::
+    (integer)
     The total number of write operations for the device completed since starting 
     {es}.
 
 `fs.io_stats.devices.read_kilobytes` (Linux only)::
+    (integer)
     The total number of kilobytes read for the device since starting {es}.
 
 `fs.io_stats.devices.write_kilobytes` (Linux only)::
+    (integer)
     The total number of kilobytes written for the device since starting {es}.
 
 `fs.io_stats.operations` (Linux only)::
+    (integer)
     The total number of read and write operations across all devices used by 
     {es} completed since starting {es}.
 
 `fs.io_stats.read_operations` (Linux only)::
+    (integer)
     The total number of read operations for across all devices used by {es} 
     completed since starting {es}.
 
 `fs.io_stats.write_operations` (Linux only)::
+    (integer)
     The total number of write operations across all devices used by {es} 
     completed since starting {es}.
 
 `fs.io_stats.read_kilobytes` (Linux only)::
+    (integer)
     The total number of kilobytes read across all devices used by {es} since 
     starting {es}.
 
 `fs.io_stats.write_kilobytes` (Linux only)::
+    (integer)
     The total number of kilobytes written across all devices used by {es} since 
     starting {es}.
 ====
@@ -1167,6 +1302,10 @@ Number of open TCP connections used for internal communication between nodes.
 Total number of RX (receive) packets received by the node during internal
 cluster communication.
 
+`transport.rx_size`::
+(<<byte-units,byte value>>)
+Size of RX packets received by the node during internal cluster communication.
+
 `transport.rx_size_in_bytes`::
 (integer)
 Size, in bytes, of RX packets received by the node during internal cluster
@@ -1176,6 +1315,10 @@ communication.
 (integer)
 Total number of TX (transmit) packets sent by the node during internal cluster
 communication.
+
+`transport.tx_size`::
+(<<byte-units,byte value>>)
+Size of TX packets sent by the node during internal cluster communication.
 
 `transport.tx_size_in_bytes`::
 (integer)
@@ -1287,10 +1430,15 @@ Number of compatible differences between published cluster states.
     (integer)
     Total number of documents ingested during the lifetime of this node.
 
-`ingest.total.time_in_millis`::
-    (integer)
+`ingest.total.time`::
+    (<<time-units,time value>>)
     Total time spent preprocessing ingest documents during the lifetime of this
     node.
+
+`ingest.total.time_in_millis`::
+    (integer)
+    Total time, in milliseconds, spent preprocessing ingest documents during the
+    lifetime of this node.
 
 `ingest.total.current`::
     (integer)
@@ -1304,27 +1452,36 @@ Number of compatible differences between published cluster states.
     (integer)
     Number of documents preprocessed by the ingest pipeline.
 
+`ingest.pipelines.<pipeline_id>.time`::
+    (<<time-units,time value>>)
+    Total time spent preprocessing documents in the ingest pipeline.
+
 `ingest.pipelines.<pipeline_id>.time_in_millis`::
     (integer)
-    Total time spent preprocessing documents in the ingest pipeline.
+    Total time, in milliseconds, spent preprocessing documents in the ingest
+    pipeline.
 
 `ingest.pipelines.<pipeline_id>.failed`::
     (integer)
     Total number of failed operations for the ingest pipeline.
 
-`ingest.pipelines.<pipeline_id>.<processor>.count`::
+`ingest.pipelines.<pipeline_id>.processors.<processor>.count`::
     (integer)
     Number of documents transformed by the processor.
 
-`ingest.pipelines.<pipeline_id>.<processor>.time_in_millis`::
-    (integer)
+`ingest.pipelines.<pipeline_id>.processors.<processor>.time`::
+    (<<time-units,time value>>)
     Time spent by the processor transforming documents.
 
-`ingest.pipelines.<pipeline_id>.<processor>.current`::
+`ingest.pipelines.<pipeline_id>.processors.<processor>.time_in_millis`::
+    (integer)
+    Time, in milliseconds, spent by the processor transforming documents.
+
+`ingest.pipelines.<pipeline_id>.processors.<processor>.current`::
     (integer)
     Number of documents currently being transformed by the processor.
 
-`ingest.pipelines.<pipeline_id>.<processor>.failed`::
+`ingest.pipelines.<pipeline_id>.processors.<processor>.failed`::
     (integer)
     Number of failed operations for the processor.
 ====
@@ -1335,22 +1492,37 @@ Number of compatible differences between published cluster states.
 [%collapsible]
 ====
 `adaptive_selection.outgoing_searches`::
+    (integer)
     The number of outstanding search requests from the node these stats are for 
     to the keyed node.
 
-`avg_queue_size`::
+`adaptive_selection.avg_queue_size`::
+    (integer)
     The exponentially weighted moving average queue size of search requests on 
     the keyed node.
 
-`avg_service_time_ns`::
+`adaptive_selection.avg_service_time`::
+    (<<time-units,time value>>)
     The exponentially weighted moving average service time of search requests on
     the keyed node.
 
-`avg_response_time_ns`::
+`adaptive_selection.avg_service_time_ns`::
+    (integer)
+    The exponentially weighted moving average service time, in nanoseconds, of
+    search requests on the keyed node.
+
+`adaptive_selection.avg_response_time`::
+    (<<time-units,time value>>)
     The exponentially weighted moving average response time of search requests 
     on the keyed node.
 
-`rank`::
+`adaptive_selection.avg_response_time_ns`::
+    (integer)
+    The exponentially weighted moving average response time, in nanoseconds, of
+    search requests on the keyed node.
+
+`adaptive_selection.rank`::
+    (string)
     The rank of this node; used for shard selection when routing search 
     requests.
 ====


### PR DESCRIPTION
7.6 backport of #53475