### PR TITLE
[DOCS] Adds feature importance mapping subsection to inference processor docs

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -34,7 +34,6 @@ include::common-options.asciidoc[]
 // NOTCONSOLE
 
 
-
 [discrete]
 [[inference-processor-regression-opt]]
 ==== {regression-cap} configuration options
@@ -50,6 +49,7 @@ Specifies the maximum number of
 {ml-docs}/dfa-regression.html#dfa-regression-feature-importance[feature
 importance] values per document. By default, it is zero and no feature importance
 calculation occurs.
+
 
 [discrete]
 [[inference-processor-classification-opt]]
@@ -73,8 +73,9 @@ Specifies the field to which the top classes are written. Defaults to
 (Optional, integer)
 Specifies the maximum number of
 {ml-docs}/dfa-classification.html#dfa-classification-feature-importance[feature
-importance] values per document. By default, it is zero and no feature importance
-calculation occurs.
+importance] values per document. By default, it is zero and no feature 
+importance calculation occurs.
+
 
 [discrete]
 [[inference-processor-config-example]]
@@ -116,3 +117,36 @@ categories for which the predicted probabilities are reported is 2
 (`num_top_classes`). The result is written to the `prediction` field and the top 
 classes to the `probabilities` field. Both fields are contained in the 
 `target_field` results object.
+
+
+[discrete]
+[[inference-processor-feature-importance]]
+==== {feat-imp-cap} object mapping
+
+Update your index mapping as you can see below to get the full benefit of 
+aggregating and searching for 
+{ref}/dfa-classification.html#dfa-classification-feature-importance[{feat-imp}].
+
+[source,js]
+--------------------------------------------------
+{
+	"type": "nested",
+	"dynamic": true,
+	"properties": {
+		"feature_name": {
+			"type": "keyword"
+		},
+		"importance": {
+			"type": "double"
+		}
+	}
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+The mapping field name for {feat-imp} is compounded as follows:
+
+`ml.<inference.target_field>`.`<inference.tag>`.`feature_importance`
+
+If `inference.tag` is not provided in the processor definition, it is not part 
+of the field path. The `<inference.target_field>` defaults to `ml.inference`.

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -146,10 +146,10 @@ get the full benefit of aggregating and searching for
 
 The mapping field name for {feat-imp} is compounded as follows:
 
-`ml.<inference.target_field>`.`<inference.tag>`.`feature_importance`
+`<ml.inference.target_field>`.`<inference.tag>`.`feature_importance`
 
 If `inference.tag` is not provided in the processor definition, it is not part 
-of the field path. The `<inference.target_field>` defaults to `inference`.
+of the field path. The `<ml.inference.target_field>` defaults to `ml.inference`.
 
 For example, you provide a tag `foo` in the definition as you can see below:
 
@@ -178,4 +178,4 @@ You can also specify a target field as follows:
 // NOTCONSOLE
 
 In this case, `{feat-imp}` is exposed in the 
-`ml.my_field.foo.feature_importance` field.
+`my_field.foo.feature_importance` field.

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -123,8 +123,8 @@ classes to the `probabilities` field. Both fields are contained in the
 [[inference-processor-feature-importance]]
 ==== {feat-imp-cap} object mapping
 
-Update your index mapping as you can see below to get the full benefit of 
-aggregating and searching for 
+Update your index mapping of the {feat-imp} result field as you can see below to 
+get the full benefit of aggregating and searching for 
 {ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{feat-imp}].
 
 [source,js]
@@ -150,3 +150,32 @@ The mapping field name for {feat-imp} is compounded as follows:
 
 If `inference.tag` is not provided in the processor definition, it is not part 
 of the field path. The `<inference.target_field>` defaults to `inference`.
+
+For example, you provide a tag `foo` in the definition as you can see below:
+
+[source,js]
+--------------------------------------------------
+{
+  "tag": "foo",
+  ...
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+
+The `{feat-imp}` value is written to the `ml.inference.foo.feature_importance` 
+field.
+
+You can also specify a target field as follows:
+
+[source,js]
+--------------------------------------------------
+{
+  "tag": "foo",
+  "target_field": "my_field"
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+In this case, `{feat-imp}` is exposed in the 
+`ml.my_field.foo.feature_importance` field.

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -149,4 +149,4 @@ The mapping field name for {feat-imp} is compounded as follows:
 `ml.<inference.target_field>`.`<inference.tag>`.`feature_importance`
 
 If `inference.tag` is not provided in the processor definition, it is not part 
-of the field path. The `<inference.target_field>` defaults to `ml.inference`.
+of the field path. The `<inference.target_field>` defaults to `inference`.

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -125,7 +125,7 @@ classes to the `probabilities` field. Both fields are contained in the
 
 Update your index mapping as you can see below to get the full benefit of 
 aggregating and searching for 
-{ref}/dfa-classification.html#dfa-classification-feature-importance[{feat-imp}].
+{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{feat-imp}].
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -129,7 +129,7 @@ get the full benefit of aggregating and searching for
 
 [source,js]
 --------------------------------------------------
-{
+"ml.inference.feature_importance": {
   "type": "nested",
   "dynamic": true,
   "properties": {

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -130,16 +130,16 @@ aggregating and searching for
 [source,js]
 --------------------------------------------------
 {
-	"type": "nested",
-	"dynamic": true,
-	"properties": {
-		"feature_name": {
-			"type": "keyword"
-		},
-		"importance": {
-			"type": "double"
-		}
-	}
+  "type": "nested",
+  "dynamic": true,
+  "properties": {
+    "feature_name": {
+      "type": "keyword"
+    },
+    "importance": {
+      "type": "double"
+    }
+  }
 }
 --------------------------------------------------
 // NOTCONSOLE


### PR DESCRIPTION
This PR adds preferred field mapping and field path to feature importance in the inference processor documentation.

Preview: http://elasticsearch_54190.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-processor.html

Depends on https://github.com/elastic/docs/pull/1784