### PR TITLE
Change token for nodes stats adaptive selection submetric

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequest.java
@@ -331,7 +331,7 @@ public class NodesStatsRequest extends BaseNodesRequest<NodesStatsRequest> {
         SCRIPT("script"),
         DISCOVERY("discovery"),
         INGEST("ingest"),
-        ADAPTIVE_SELECTION("adaptiveSelection");
+        ADAPTIVE_SELECTION("adaptive_selection");
 
         private String metricName;
 


### PR DESCRIPTION
This is a small bit of #53637 that will save us some headaches if it sneaks into 7.7 before we cut an official release. It just changes the value of a string constant that is being introduced in 7.7.

As described [here](https://github.com/elastic/elasticsearch/pull/53446#issuecomment-598409954), this is *not* a change to the user-facing value for the adaptive selection metric. It simply changes the internal token so that it matches the adaptive selection metric.