### PR TITLE
Introduce a report for the location of the YAML REST tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ import org.elasticsearch.gradle.BwcVersions
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
+import org.elasticsearch.gradle.test.rest.report.RestResourcesReportsTask
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
@@ -470,6 +471,7 @@ wrapper {
   }
 }
 
+String restTestSourceReportDestination = System.getProperty("rest.test.source_report.destination")
 gradle.projectsEvaluated {
   subprojects {
     /*
@@ -498,6 +500,46 @@ gradle.projectsEvaluated {
           "This doesn't currently work correctly in Gradle, see: " +
           "https://github.com/gradle/gradle/issues/847"
       )
+    }
+  }
+
+  if (restTestSourceReportDestination != null) {
+    if (new File(restTestSourceReportDestination).exists()) {
+      throw new IllegalStateException("The file [" + restTestSourceReportDestination + "] " +
+        "for restTestsSourceReport already exists, please delete before re-running")
+    }
+    subprojects.findAll {
+      it.convention.findByName('java') != null &&
+        (it.plugins.hasPlugin('elasticsearch.testclusters') || it.plugins.hasPlugin('elasticsearch.rest-resources'))
+    }.each { p ->
+      Provider<Task> reportTask = p.tasks.register('restTestsSourceReport', RestResourcesReportsTask) {
+        reports {
+          source_report {
+            destination new File(restTestSourceReportDestination)
+            projects ':modules', ':plugins', ':rest-api-spec', ':x-pack:plugin'  //includes subprojects
+            //for example: -Drest.test.source_report.destination.excludes="**/watcher/qa/**/mustache/**, **/watcher/qa/with-security/**"
+            excludes System.getProperty("rest.test.source_report.destination.excludes", "").trim().split("\\s*,\\s*")
+            outputs.upToDateWhen { false }
+            enabled true
+          }
+        }
+      }
+      restTestsSourceReport.configure { t -> t.dependsOn(reportTask) }
+    }
+  }
+}
+
+//generate a report that lists all of the yaml based rest tests found in the source code.
+task restTestsSourceReport {
+  doFirst {
+    if (restTestSourceReportDestination == null) {
+      throw new IllegalStateException("The system property [rest.test.source_report.destination] must be set to a file location. " +
+        "For example [./gradlew restTestsSourceReport -Drest.test.source_report.destination=/tmp/report.txt]")
+    }
+  }
+  doLast {
+    if (new File(restTestSourceReportDestination).exists() == false) {
+      throw new IllegalStateException("The restTestsSourceReport was requested, but nothing was generated")
     }
   }
 }
@@ -546,6 +588,7 @@ allprojects {
   }
 }
 
+
 // TODO: remove this once 7.7 is released and the 7.x branch is 7.8
 subprojects {
   pluginManager.withPlugin('elasticsearch.testclusters') {
@@ -557,3 +600,4 @@ subprojects {
     }
   }
 }
+

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -149,5 +149,7 @@ public class RestResourcesPlugin implements Plugin<Project> {
             });
 
         project.getTasks().named("processTestResources").configure(t -> t.dependsOn(copyRestYamlSpecTask));
+
     }
+
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourceReport.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourceReport.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gradle.test.rest.report;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+
+import javax.inject.Inject;
+import java.io.File;
+
+/**
+ * Parent class for any rest resource report. Projects are the gradle path that used to find the rest resources. By default subprojects
+ * should also be included in the results. Excludes are ant style globs that should be applied prior to creating the report output.
+ */
+public abstract class RestResourceReport extends TaskGeneratedSingleFileReport {
+
+    @Inject
+    public RestResourceReport(String name, Task task) {
+        super(name, task);
+    }
+
+    @Input
+    public abstract void projects(String... paths);
+
+    @OutputFile
+    @Override
+    public void setDestination(File file) {
+        super.setDestination(file);
+    }
+
+    @Input
+    public abstract void excludes(String... excludes);
+
+    abstract void appendToReport(Project project, Logger logger);
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourcesReportsContainer.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourcesReportsContainer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gradle.test.rest.report;
+
+import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.reporting.internal.TaskReportContainer;
+import org.gradle.api.tasks.Internal;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Reports container for Rest Resources.
+ */
+public class RestResourcesReportsContainer extends TaskReportContainer<RestResourceReport> {
+
+    private final Map<String, Class<? extends RestResourceReport>> reports = Map.of("source_report", RestTestSourceReport.class);
+
+    @Inject
+    public RestResourcesReportsContainer(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(RestResourceReport.class, task, callbackActionDecorator);
+        reports.forEach((k, v) -> { add(v, k, task); });
+    }
+
+    RestResourceReport getReport(String reportName) {
+        return getByName(reportName);
+    }
+
+    @Internal
+    Set<String> getReportNames() {
+        return reports.keySet();
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourcesReportsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourcesReportsTask.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gradle.test.rest.report;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.reporting.Reporting;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.util.ClosureBackedAction;
+
+import javax.inject.Inject;
+
+/**
+ * The task which executes the reports.<br>
+ * For example:
+ * <pre>
+ *  Provider<Task> reportTask = p.tasks.register('restTestsSourceReport', RestResourcesReportsTask) {
+ *         reports {
+ *           source_report {
+ *             destination new File("/tmp/report.txt")
+ *             projects ':modules', ':plugins', ':rest-api-spec', ':x-pack:plugin'  //includes subprojects
+ *             excludes '&#42&#42/watcher/qa/&#42&#42/mustache/&#42&#42', '&#42&#42/watcher/qa/&#42&#42/painless/&#42&#42'
+ *             outputs.upToDateWhen { false }
+ *             enabled true
+ *           }
+ *         }
+ *       }
+ * </pre>
+ */
+public class RestResourcesReportsTask extends DefaultTask implements Reporting<RestResourcesReportsContainer> {
+
+    private final RestResourcesReportsContainer reports;
+
+    public RestResourcesReportsTask() {
+        this.reports = getObjectFactory().newInstance(RestResourcesReportsContainer.class, this);
+    }
+
+    @Inject
+    protected ObjectFactory getObjectFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @TaskAction
+    public void run() {
+        reports.getReportNames().forEach(name -> {
+            RestResourceReport report = reports.getReport(name);
+            if (report.isEnabled()) {
+                report.appendToReport(getProject(), getLogger());
+            }
+        });
+    }
+
+    @Override
+    @Nested
+    public final RestResourcesReportsContainer getReports() {
+        return reports;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public RestResourcesReportsContainer reports(
+        @DelegatesTo(value = RestResourcesReportsContainer.class, strategy = Closure.DELEGATE_FIRST) Closure closure
+    ) {
+        return reports(new ClosureBackedAction<>(closure));
+    }
+
+    @Override
+    public RestResourcesReportsContainer reports(Action<? super RestResourcesReportsContainer> configureAction) {
+        configureAction.execute(reports);
+        return reports;
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourcesReportsTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestResourcesReportsTask.java
@@ -34,12 +34,12 @@ import javax.inject.Inject;
  * The task which executes the reports.<br>
  * For example:
  * <pre>
- *  Provider<Task> reportTask = p.tasks.register('restTestsSourceReport', RestResourcesReportsTask) {
+ *  Provider&lt;Task&gt; reportTask = p.tasks.register('restTestsSourceReport', RestResourcesReportsTask) {
  *         reports {
  *           source_report {
  *             destination new File("/tmp/report.txt")
  *             projects ':modules', ':plugins', ':rest-api-spec', ':x-pack:plugin'  //includes subprojects
- *             excludes '&#42&#42/watcher/qa/&#42&#42/mustache/&#42&#42', '&#42&#42/watcher/qa/&#42&#42/painless/&#42&#42'
+ *             excludes '&#42;&#42;/watcher/qa/&#42;&#42;/mustache/&#42;&#42;', '&#42;&#42;/watcher/qa/&#42;&#42;/painless/&#42;&#42;'
  *             outputs.upToDateWhen { false }
  *             enabled true
  *           }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestTestSourceReport.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/report/RestTestSourceReport.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.gradle.test.rest.report;
+
+import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Reports on all rest tests that are found in the committed source code as new line delimited file.
+ */
+public abstract class RestTestSourceReport extends RestResourceReport {
+
+    private Set<String> includeProjects = new HashSet<>();
+    private Set<PathMatcher> excludesMatchers = new HashSet<>();
+    private static final String DOUBLE_STARS = "**"; // checkstyle thinks this is an empty javadoc statement, so string concat instead
+    private static final String INCLUDE_PATTERN = DOUBLE_STARS + "/rest-api-spec/test/" + DOUBLE_STARS + "/*.yml";
+
+    @Inject
+    public RestTestSourceReport(String name, Task task) {
+        super(name, task);
+    }
+
+    @Override
+    void appendToReport(Project project, Logger logger) {
+        if (includeProjects.contains(project.getPath())
+            || includeProjects.stream() // check if current project is a child of an included project
+                .anyMatch(
+                    parent -> project.findProject(parent).getSubprojects().stream().anyMatch(sub -> sub.getPath().equals(project.getPath()))
+                )) {
+            try (FileWriter fileWriter = new FileWriter(this.getOutputLocation().getAsFile().get(), true)) {
+                final Optional<FileTree> testFileTree = getTestSourceSet(project).map(SourceSet::getResources).map(FileTree::getAsFileTree);
+                final Optional<FileTree> mainFileTree = getMainSourceSet(project).map(SourceSet::getResources).map(FileTree::getAsFileTree);
+                FileTree sourceFileTree;
+                if (testFileTree.isPresent() && mainFileTree.isPresent()) {
+                    sourceFileTree = testFileTree.get().plus(mainFileTree.get());
+                } else {
+                    sourceFileTree = testFileTree.orElse(mainFileTree.orElse(null));
+                }
+
+                if (sourceFileTree != null && sourceFileTree.isEmpty() == false) {
+                    PatternSet includePattern = getPatternSetFactory().create();
+                    includePattern.include(INCLUDE_PATTERN);
+                    for (File f : sourceFileTree.getAsFileTree().matching(includePattern)) {
+                        boolean include = true;
+                        for (PathMatcher matcher : excludesMatchers) {
+                            if (matcher.matches(Paths.get(f.getCanonicalPath()))) {
+                                include = false;
+                            }
+                        }
+                        if (include) {
+                            fileWriter.append(f.getCanonicalPath()).append(System.lineSeparator());
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Unexpected exception while generating the REST test source report", e);
+            }
+            logger.info("Writing REST test source report to [{}]", getOutputLocation().getAsFile().get().getAbsolutePath());
+        }
+    }
+
+    @Override
+    public void projects(String... paths) {
+        this.includeProjects = Set.of(paths);
+    }
+
+    @Override
+    public void excludes(String... exclude) {
+        for (String pattern : exclude) {
+            this.excludesMatchers.add(FileSystems.getDefault().getPathMatcher("glob:" + pattern));
+        }
+    }
+
+    @Inject
+    protected Factory<PatternSet> getPatternSetFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    private Optional<SourceSet> getTestSourceSet(Project project) {
+        return Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(SourceSet.TEST_SOURCE_SET_NAME));
+    }
+
+    private Optional<SourceSet> getMainSourceSet(Project project) {
+        return Optional.ofNullable(GradleUtils.getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME));
+    }
+}

--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -40,7 +40,3 @@ testClusters.integTest {
   // (this is because the integTest node is not using default distribution, but only the minimal number of required modules)
   module file(project(':modules:lang-mustache').tasks.bundlePlugin.archiveFile)
 }
-
-
-
-

--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -40,3 +40,7 @@ testClusters.integTest {
   // (this is because the integTest node is not using default distribution, but only the minimal number of required modules)
   module file(project(':modules:lang-mustache').tasks.bundlePlugin.archiveFile)
 }
+
+
+
+


### PR DESCRIPTION
This report is intended to be used by any consumers that need
to run a comprehensive, but un-released set of the REST tests.
By default all core REST tests (x-pack and oss) are included
as well as all module and plugins (x-pack and oss). Since many
of the non-core tests can require special cluster setup, exclusions
may be defined through an ant style glob patterns via a system
property.

A new root level task `restTestsSourceReport` has been introduced
to generate this (single) report for which projects that have YAML
REST tests in the source. The new task is not wired into any existing
tasks, and is expected to be executed from the root project.

This also introduces a more general framework for reporting on
Rest based resources. Future reports may re-use this framework. 

========
cc: @elastic/es-clients 

example run:
```
./gradlew restTestsSourceReport -Drest.test.source_report.destination=/tmp/report.txt -Drest.test.source_report.destination.excludes="**/watcher/qa/**/mustache/**, **/watcher/qa/**/painless/**, **/watcher/qa/with-security/**"
```
example output:
```
head -10 /tmp/report.txt
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/40_keyword_ignore.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/10_unified.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_fvh.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/15_default_values.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/40_routing.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/70_source_filtering.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/80_missing.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/10_basic.yml
/Users/jakelandis/workspace/8x/elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/get_source/85_source_missing.yml
```
