### PR TITLE
[DOCS] EQL: Document `cidrMatch` function

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -147,7 +147,8 @@ cidrMatch(source.address, "10.0.0.0/8")                   // returns false
 cidrMatch(source.address, "10.0.0.0/8", "10.128.0.0/9")   // returns false
 
 // null handling
-cidrMatch(null, "10.0.0.0/8", "10.128.0.0/9")             // returns null
+cidrMatch(null, "10.0.0.0/8")                             // returns null
+cidrMatch(source.address, null)                           // returns null
 ----
 
 *Syntax*
@@ -159,7 +160,7 @@ cidrMatch(null, "10.0.0.0/8", "10.128.0.0/9")             // returns null
 *Parameters*
 
 `<ip_address>`::
-(Required, string)
+(Required, string or `null`)
 IP address. Supports
 https://en.wikipedia.org/wiki/IPv4[IPv4] and
 https://en.wikipedia.org/wiki/IPv6[IPv6] addresses. If `null`, the function
@@ -169,8 +170,8 @@ If using a field as the argument, this parameter only supports the <<ip,`ip`>>
 field datatype.
 
 `<cidr_block>`::
-(Required{multi-arg}, string)
-CIDR block you wish to search.
+(Required{multi-arg}, string or `null`)
+CIDR block you wish to search. If `null`, the function returns `null`.
 
 *Returns:* boolean or `null`
 ====

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -166,7 +166,7 @@ https://en.wikipedia.org/wiki/IPv4[IPv4] and
 https://en.wikipedia.org/wiki/IPv6[IPv6] addresses. If `null`, the function
 returns `null`.
 +
-If using a field as the argument, this parameter only supports the <<ip,`ip`>>
+If using a field as the argument, this parameter supports only the <<ip,`ip`>>
 field datatype.
 
 `<cidr_block>`::

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -8,10 +8,59 @@ experimental::[]
 
 {es} supports the following EQL functions:
 
+* <<eql-fn-cidrmatch>>
 * <<eql-fn-endswith>>
 * <<eql-fn-length>>
 * <<eql-fn-startswith>>
 * <<eql-fn-substring>>
+
+[discrete]
+[[eql-fn-cidrmatch]]
+==== `cidrMatch`
+
+Returns `true` if an IP address is contained in one or more provided
+https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing[CIDR] blocks.
+
+[%collapsible]
+====
+*Example*
+
+[source,eql]
+----
+// source.address = "192.168.152.12"
+cidrMatch(source.address, "192.168.0.0/16")               // returns true
+cidrMatch(source.address, "192.168.0.0/16", "10.0.0.0/8") // returns true
+cidrMatch(source.address, "10.0.0.0/8")                   // returns false
+cidrMatch(source.address, "10.0.0.0/8", "10.128.0.0/9")   // returns false
+
+// null handling
+cidrMatch(null, "10.0.0.0/8", "10.128.0.0/9")             // returns null
+----
+
+*Syntax*
+[source,txt]
+----
+`cidrMatch(<ip_address>, <cidr_block>[, ...])`
+----
+
+*Parameters*
+
+`<ip_address>`::
+(Required, string)
+IP address. Supports
+https://en.wikipedia.org/wiki/IPv4[IPv4] and
+https://en.wikipedia.org/wiki/IPv6[IPv6] addresses. If `null`, the function
+returns `null`.
++
+If using a field as the argument, this parameter only supports the <<ip,`ip`>>
+field datatype.
+
+`<cidr_block>`::
+(Required{multi-arg}, string)
+CIDR block you wish to search.
+
+*Returns:* boolean or `null`
+====
 
 [discrete]
 [[eql-fn-endswith]]


### PR DESCRIPTION
Adds documentation for the EQL `cidrMatch` function.

Depends on #54186