### PR TITLE
[7.x] [Transform] Remove node.attr.transform.remote_connect and use new remote cluster client node role (#54217)

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -34,7 +34,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -150,7 +149,6 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
      * These attributes should never be set directly, use the node setting counter parts instead.
      */
     public static final String TRANSFORM_ENABLED_NODE_ATTR = "transform.node";
-    public static final String TRANSFORM_REMOTE_ENABLED_NODE_ATTR = "transform.remote_connect";
 
     /**
      * Setting whether transform (the coordinator task) can run on this node and REST API's are available,
@@ -367,9 +365,8 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
     @Override
     public Settings additionalSettings() {
         String transformEnabledNodeAttribute = "node.attr." + TRANSFORM_ENABLED_NODE_ATTR;
-        String transformRemoteEnabledNodeAttribute = "node.attr." + TRANSFORM_REMOTE_ENABLED_NODE_ATTR;
 
-        if (settings.get(transformEnabledNodeAttribute) != null || settings.get(transformRemoteEnabledNodeAttribute) != null) {
+        if (settings.get(transformEnabledNodeAttribute) != null) {
             throw new IllegalArgumentException(
                 "Directly setting transform node attributes is not permitted, please use the documented node settings instead"
             );
@@ -382,7 +379,6 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
         Settings.Builder additionalSettings = Settings.builder();
 
         additionalSettings.put(transformEnabledNodeAttribute, TRANSFORM_ENABLED_NODE.get(settings));
-        additionalSettings.put(transformRemoteEnabledNodeAttribute, Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings));
 
         return additionalSettings.build();
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -186,7 +186,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         }
 
         // does the transform require a remote and remote is enabled?
-        if (params.requiresRemote() && Boolean.parseBoolean(nodeAttributes.get(Transform.TRANSFORM_REMOTE_ENABLED_NODE_ATTR)) == false) {
+        if (params.requiresRemote() && node.isRemoteClusterClient() == false) {
             if (explain != null) {
                 explain.put(node.getId(), "transform requires a remote connection but remote is disabled");
             }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
@@ -19,16 +19,10 @@ public class TransformTests extends ESTestCase {
         Settings.Builder builder = Settings.builder();
         boolean transformEnabled = randomBoolean();
         boolean transformPluginEnabled = randomBoolean();
-        boolean remoteClusterClient = randomBoolean();
 
         // randomly use explicit or default setting
         if ((transformEnabled && randomBoolean()) == false) {
             builder.put("node.transform", transformEnabled);
-        }
-
-        // randomly use explicit or default setting
-        if ((remoteClusterClient && randomBoolean()) == false) {
-            builder.put("node.remote_cluster_client", remoteClusterClient);
         }
 
         if (transformPluginEnabled == false) {
@@ -42,23 +36,14 @@ public class TransformTests extends ESTestCase {
             transformPluginEnabled && transformEnabled,
             Boolean.parseBoolean(transform.additionalSettings().get("node.attr.transform.node"))
         );
-        assertEquals(
-            transformPluginEnabled && remoteClusterClient,
-            Boolean.parseBoolean(transform.additionalSettings().get("node.attr.transform.remote_connect"))
-        );
     }
 
     public void testNodeAttributesDirectlyGiven() {
         Settings.Builder builder = Settings.builder();
-
-        if (randomBoolean()) {
-            builder.put("node.attr.transform.node", randomBoolean());
-        } else {
-            builder.put("node.attr.transform.remote_connect", randomBoolean());
-        }
+        builder.put("node.attr.transform.node", randomBoolean());
 
         Transform transform = createTransform(builder.build());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> transform.additionalSettings());
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, transform::additionalSettings);
         assertThat(
             e.getMessage(),
             equalTo("Directly setting transform node attributes is not permitted, please use the documented node settings instead")

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -170,7 +170,6 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
     public void testDoNotSelectOldNodes() {
         Map<String, String> transformNodeAttributes = new HashMap<>();
         transformNodeAttributes.put(Transform.TRANSFORM_ENABLED_NODE_ATTR, "true");
-        transformNodeAttributes.put(Transform.TRANSFORM_REMOTE_ENABLED_NODE_ATTR, "true");
         MetaData.Builder metaData = MetaData.builder();
         RoutingTable.Builder routingTable = RoutingTable.builder();
         addIndices(metaData, routingTable);
@@ -201,7 +200,11 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
                     "current-data-node-with-1-task",
                     buildNewFakeTransportAddress(),
                     transformNodeAttributes,
-                    new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)),
+                    new HashSet<>(Arrays.asList(
+                        DiscoveryNodeRole.DATA_ROLE,
+                        DiscoveryNodeRole.MASTER_ROLE,
+                        DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE
+                    )),
                     Version.CURRENT
                 )
             )
@@ -358,18 +361,13 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         boolean dedicatedTransformNode,
         boolean pastDataNode,
         boolean transformRemoteNodes,
-        boolean transformLocanOnlyNodes,
+        boolean transformLocalOnlyNodes,
         boolean currentDataNode
     ) {
         Map<String, String> transformNodeAttributes = new HashMap<>();
         transformNodeAttributes.put(Transform.TRANSFORM_ENABLED_NODE_ATTR, "true");
-        transformNodeAttributes.put(Transform.TRANSFORM_REMOTE_ENABLED_NODE_ATTR, "true");
         Map<String, String> transformNodeAttributesDisabled = new HashMap<>();
         transformNodeAttributesDisabled.put(Transform.TRANSFORM_ENABLED_NODE_ATTR, "false");
-        transformNodeAttributesDisabled.put(Transform.TRANSFORM_REMOTE_ENABLED_NODE_ATTR, "true");
-        Map<String, String> transformNodeAttributesNoRemote = new HashMap<>();
-        transformNodeAttributesNoRemote.put(Transform.TRANSFORM_ENABLED_NODE_ATTR, "true");
-        transformNodeAttributesNoRemote.put(Transform.TRANSFORM_REMOTE_ENABLED_NODE_ATTR, "false");
 
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
 
@@ -379,7 +377,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
                     "dedicated-transform-node",
                     buildNewFakeTransportAddress(),
                     transformNodeAttributes,
-                    Collections.singleton(DiscoveryNodeRole.MASTER_ROLE),
+                    new HashSet<>(Arrays.asList(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)),
                     Version.CURRENT
                 )
             );
@@ -403,7 +401,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
                     "current-data-node-with-2-tasks",
                     buildNewFakeTransportAddress(),
                     transformNodeAttributes,
-                    new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE)),
+                    new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)),
                     Version.CURRENT
                 )
             )
@@ -412,18 +410,18 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
                         "current-data-node-with-1-tasks",
                         buildNewFakeTransportAddress(),
                         transformNodeAttributes,
-                        new HashSet<>(Arrays.asList(DiscoveryNodeRole.MASTER_ROLE)),
+                        new HashSet<>(Arrays.asList(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)),
                         Version.CURRENT
                     )
                 );
         }
 
-        if (transformLocanOnlyNodes) {
+        if (transformLocalOnlyNodes) {
             nodes.add(
                 new DiscoveryNode(
                     "current-data-node-with-0-tasks-transform-remote-disabled",
                     buildNewFakeTransportAddress(),
-                    transformNodeAttributesNoRemote,
+                    transformNodeAttributes,
                     new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)),
                     Version.CURRENT
                 )
@@ -436,7 +434,11 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
                     "current-data-node-with-transform-disabled",
                     buildNewFakeTransportAddress(),
                     transformNodeAttributesDisabled,
-                    new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)),
+                    new HashSet<>(Arrays.asList(
+                        DiscoveryNodeRole.DATA_ROLE,
+                        DiscoveryNodeRole.MASTER_ROLE,
+                        DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE
+                    )),
                     Version.CURRENT
                 )
             );


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] Remove node.attr.transform.remote_connect and use new remote cluster client node role (#54217)