### PR TITLE
[DOCS] Collapses content in machine learning APIs

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/estimate-model-memory.asciidoc
@@ -26,7 +26,7 @@ configuration details and cardinality estimates for the fields it references.
 
 `analysis_config`::
 (Required, object) For a list of the properties that you can specify in the
-`analysis_config` component of the body of this API, see <<put-analysisconfig>>.
+`analysis_config` component of the body of this API, see <<put-analysisconfig,`analysis_config`>>.
 
 `max_bucket_cardinality`::
 (Optional, object) Estimates of the highest cardinality in a single bucket

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -75,6 +75,7 @@ default, the buckets are sorted by the `timestamp` field.
 `start`::
 (Optional, string) Returns buckets with timestamps after this time.
 
+[role="child_attributes"]
 [[ml-get-bucket-results]]
 ==== {api-response-body-title}
 
@@ -87,49 +88,52 @@ records in the bucket contribute to this score. This value might be updated as
 new data is analyzed.
 
 `bucket_influencers`::
-(array) An array of bucket influencer objects, which have the following
-properties:
-
-`bucket_influencers`.`anomaly_score`:::
+(array) An array of bucket influencer objects.
++
+.Properties of `bucket_influencers`
+[%collapsible%open]
+====
+`anomaly_score`:::
 (number) A normalized score between 0-100, which is calculated for each bucket
 influencer. This score might be updated as newer data is analyzed.
 
-`bucket_influencers`.`bucket_span`:::
-(number) The length of the bucket in seconds. This value matches the `bucket_span`
-that is specified in the job.
+`bucket_span`:::
+(number) The length of the bucket in seconds. This value matches the 
+`bucket_span` that is specified in the job.
 
-`bucket_influencers`.`initial_anomaly_score`:::
+`initial_anomaly_score`:::
 (number) The score between 0-100 for each bucket influencer. This score is the
 initial value that was calculated at the time the bucket was processed.
 
-`bucket_influencers`.`influencer_field_name`:::
+`influencer_field_name`:::
 (string) The field name of the influencer.
 
-`bucket_influencers`.`influencer_field_value`:::
+`influencer_field_value`:::
 (string) The field value of the influencer. 
 
-`bucket_influencers`.`is_interim`:::
+`is_interim`:::
 (boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
 
-`bucket_influencers`.`job_id`:::
+`job_id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-`bucket_influencers`.`probability`:::
+`probability`:::
 (number) The probability that the bucket has this behavior, in the range 0 to 1.
 This value can be held to a high precision of over 300 decimal places, so the
 `anomaly_score` is provided as a human-readable and friendly interpretation of
 this.
 
-`bucket_influencers`.`raw_anomaly_score`:::
+`raw_anomaly_score`:::
 (number) Internal.
 
-`bucket_influencers`.`result_type`:::
+`result_type`:::
 (string) Internal. This value is always set to `bucket_influencer`.
 
-`bucket_influencers`.`timestamp`:::
+`timestamp`:::
 (date) The start time of the bucket for which these results were calculated.
+====
 
 `bucket_span`::
 (number)

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -60,7 +60,7 @@ all {dfeeds}.
 (Optional, boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
-[role="child_attribute"]
+[role="child_attributes"]
 [[ml-get-datafeed-stats-results]]
 ==== {api-response-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -60,7 +60,7 @@ all {dfeeds}.
 (Optional, boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
-
+[role="child_attribute"]
 [[ml-get-datafeed-stats-results]]
 ==== {api-response-body-title}
 
@@ -78,18 +78,23 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 `node`::
 (object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
-
-`node`.`id`:::
++
+--
+[%collapsible%open]
+====
+`id`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=node-id]
 
-`node`.`name`::: The node name. For example, `0-o0tOo`.
+`name`::: The node name. For example, `0-o0tOo`.
 
-`node`.`ephemeral_id`:::
+`ephemeral_id`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
 
-`node`.`transport_address`::: The host and port where transport HTTP connections are
+`transport_address`::: The host and port where transport HTTP connections are
 accepted. For example, `127.0.0.1:9300`.
-`node`.`attributes`::: For example, `{"ml.machine_memory": "17179869184"}`.
+`attributes`::: For example, `{"ml.machine_memory": "17179869184"}`.
+====
+--
 
 `state`::
 (string)
@@ -98,27 +103,32 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=state-datafeed]
 `timing_stats`::
 (object) An object that provides statistical information about timing aspect of
 this {dfeed}.
-
-`timing_stats`.`average_search_time_per_bucket_ms`:::
++
+--
+[%collapsible%open]
+====
+`average_search_time_per_bucket_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=search-bucket-avg]
 
-`timing_stats`.`bucket_count`:::
+`bucket_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count]
 
-`timing_stats`.`exponential_average_search_time_per_hour_ms`:::
+`exponential_average_search_time_per_hour_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=search-exp-avg-hour]
 
-`timing_stats`.`job_id`:::
+`job_id`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-`timing_stats`.`search_count`:::
+`search_count`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=search-count]
 
-`timing_stats`.`total_search_time_ms`:::
+`total_search_time_ms`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=search-time]
+====
+--
 
 
 [[ml-get-datafeed-stats-response-codes]]

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -61,6 +61,7 @@ job:
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-anomaly-jobs]
 
+//Begin data_counts
 [[datacounts]]`data_counts`::
 (object) An object that describes the quantity of input to the job and any
 related error counts. The `data_count` values are cumulative for the lifetime of
@@ -98,7 +99,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=input-record-count]
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
 
-`data_counts`.`job_id`:::
+`job_id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
@@ -139,12 +140,14 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=processed-record-count]
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
 ====
+//End data_counts
 
 `deleting`::
 (boolean)
 Indicates that the process of deleting the job is in progress but not yet 
 completed. It is only reported when `true`.
 
+//Begin forecasts_stats
 [[forecastsstats]]`forecasts_stats`::
 (object) An object that provides statistical information about forecasts 
 belonging to this job. Some statistics are omitted if no forecasts have been 
@@ -181,11 +184,13 @@ forecasts related to this job. If there are no forecasts, this property is omitt
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=forecast-total]
 ====
+//End forecasts_stats
 
 `job_id`::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+//Begin model_size_stats
 [[modelsizestats]]`model_size_stats`::
 (object) An object that provides information about the size and contents of the
 model.
@@ -263,7 +268,9 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=total-partition-field-count]
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-timestamp]
 ====
+//End model_size_stats
 
+//Begin node
 [[stats-node]]`node`::
 (object) Contains properties for the node that runs the job. This information is
 available only for open jobs.
@@ -289,6 +296,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=node-id]
 `transport_address`:::
 (string) The host and port where transport HTTP connections are accepted.
 ====
+//End node
 
 `open_time`::
 (string)
@@ -298,6 +306,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=open-time]
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=state-anomaly-job]
 
+//Begin timing_stats
 [[timingstats]]`timing_stats`::
 (object) An object that provides statistical information about timing aspect of
 this job.
@@ -336,6 +345,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-minimum]
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
 ====
+//End timing_stats
 
 [[ml-get-job-stats-response-codes]]
 ==== {api-response-codes-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -50,6 +50,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
 (Optional, boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
+[role="child_attributes"]
 [[ml-get-job-stats-results]]
 ==== {api-response-body-title}
 
@@ -65,32 +66,35 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-anomaly-jobs]
 related error counts. The `data_count` values are cumulative for the lifetime of
 a job. If a model snapshot is reverted or old results are deleted, the job
 counts are not reset.
-
-`data_counts`.`bucket_count`:::
++
+.Properties of `data_counts`
+[%collapsible%open]
+====
+`bucket_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count-anomaly-jobs]
 
-`data_counts`.`earliest_record_timestamp`:::
+`earliest_record_timestamp`:::
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=earliest-record-timestamp]
 
-`data_counts`.`empty_bucket_count`:::
+`empty_bucket_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=empty-bucket-count]
 
-`data_counts`.`input_bytes`:::
+`input_bytes`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=input-bytes]
 
-`data_counts`.`input_field_count`:::
+`input_field_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=input-field-count]
 
-`data_counts`.`input_record_count`:::
+`input_record_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=input-record-count]
 
-`data_counts`.`invalid_date_count`:::
+`invalid_date_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
 
@@ -98,42 +102,43 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-`data_counts`.`last_data_time`:::
+`last_data_time`:::
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=last-data-time]
 
-`data_counts`.`latest_empty_bucket_timestamp`:::
+`latest_empty_bucket_timestamp`:::
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=latest-empty-bucket-timestamp]
 
-`data_counts`.`latest_record_timestamp`:::
+`latest_record_timestamp`:::
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=latest-record-timestamp]
 
-`data_counts`.`latest_sparse_bucket_timestamp`:::
+`latest_sparse_bucket_timestamp`:::
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=latest-sparse-record-timestamp]
 
-`data_counts`.`missing_field_count`:::
+`missing_field_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=missing-field-count]
 +
 The value of `processed_record_count` includes this count.
 
-`data_counts`.`out_of_order_timestamp_count`:::
+`out_of_order_timestamp_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=out-of-order-timestamp-count]
 
-`data_counts`.`processed_field_count`:::
+`processed_field_count`:::
 include::{docdir}/ml/ml-shared.asciidoc[tag=processed-field-count]
 
-`data_counts`.`processed_record_count`:::
+`processed_record_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=processed-record-count]
 
-`data_counts`.`sparse_bucket_count`:::
+`sparse_bucket_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
+====
 
 `deleting`::
 (boolean)
@@ -143,38 +148,39 @@ completed. It is only reported when `true`.
 [[forecastsstats]]`forecasts_stats`::
 (object) An object that provides statistical information about forecasts 
 belonging to this job. Some statistics are omitted if no forecasts have been 
-made. It has the following properties:
+made.
 +
---
 NOTE: Unless there is at least one forecast, `memory_bytes`, `records`,
 `processing_time_ms` and `status` properties are omitted.
-
---
-
-`forecasts_stats`.`forecasted_jobs`:::
++
+.Properties of `forecasts_stats`
+[%collapsible%open]
+====
+`forecasted_jobs`:::
 (long) A value of `0` indicates that forecasts do not exist for this job. A 
 value of `1` indicates that at least one forecast exists.
 
-`forecasts_stats`.`memory_bytes`:::
+`memory_bytes`:::
 (object) The `avg`, `min`, `max` and `total` memory usage in bytes for forecasts 
 related to this job. If there are no forecasts, this property is omitted.
 
-`forecasts_stats`.`records`:::
+`records`:::
 (object) The `avg`, `min`, `max` and `total` number of `model_forecast` documents 
 written for forecasts related to this job. If there are no forecasts, this
 property is omitted.
 
-`forecasts_stats`.`processing_time_ms`:::
+`processing_time_ms`:::
 (object) The `avg`, `min`, `max` and `total` runtime in milliseconds for 
 forecasts related to this job. If there are no forecasts, this property is omitted.
 
-`forecasts_stats`.`status`:::
+`status`:::
 (object) The count of forecasts by their status. For example: 
 {"finished" : 2, "started" : 1}. If there are no forecasts, this property is omitted.
 
-`forecasts_stats`.`total`:::
+`total`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=forecast-total]
+====
 
 `job_id`::
 (string)
@@ -182,99 +188,107 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[modelsizestats]]`model_size_stats`::
 (object) An object that provides information about the size and contents of the
-model. It has the following properties:
- 
-`model_size_stats`.`bucket_allocation_failures_count`:::
+model.
++
+.Properties of `model_size_stats`
+[%collapsible%open]
+====
+`bucket_allocation_failures_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-allocation-failures-count]
 
-`model_size_stats`.`categorized_doc_count`:::
+`categorized_doc_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=categorized-doc-count]
 
-`model_size_stats`.`categorization_status`:::
+`categorization_status`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-status]
 
-`model_size_stats`.`dead_category_count`:::
+`dead_category_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=dead-category-count]
 
-`model_size_stats`.`frequent_category_count`:::
+`frequent_category_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=frequent-category-count]
 
-`model_size_stats`.`job_id`:::
+`job_id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-`model_size_stats`.`log_time`:::
+`log_time`:::
 (date) The timestamp of the `model_size_stats` according to server time.
 
-`model_size_stats`.`memory_status`:::
+`memory_status`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-status]
 
-`model_size_stats`.`model_bytes`:::
+`model_bytes`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-bytes]
 
-`model_size_stats`.`model_bytes_exceeded`:::
+`model_bytes_exceeded`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-bytes-exceeded]
 
-`model_size_stats`.`model_bytes_memory_limit`:::
+`model_bytes_memory_limit`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit-anomaly-jobs]
 
-`model_size_stats`.`rare_category_count`:::
+`rare_category_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=rare-category-count]
 
-`model_size_stats`.`result_type`:::
+`result_type`:::
 (string) For internal use. The type of result.
 
-`model_size_stats`.`total_by_field_count`:::
+`total_by_field_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=total-by-field-count]
 
-`model_size_stats`.`total_category_count`:::
+`total_category_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=total-category-count]
 
-`model_size_stats`.`total_over_field_count`:::
+`total_over_field_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=total-over-field-count]
 
-`model_size_stats`.`total_partition_field_count`:::
+`total_partition_field_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=total-partition-field-count]
 
-`model_size_stats`.`timestamp`:::
+`timestamp`:::
 (date)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-timestamp]
+====
 
 [[stats-node]]`node`::
 (object) Contains properties for the node that runs the job. This information is
 available only for open jobs.
-
-`node`.`attributes`:::
++
+.Properties of `node`
+[%collapsible%open]
+====
+`attributes`:::
 (object) Lists node attributes. For example,
 `{"ml.machine_memory": "17179869184", "ml.max_open_jobs" : "20"}`.
   
-`node`.`ephemeral_id`:::
+`ephemeral_id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
 
-`node`.`id`:::
+`id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=node-id]
 
-`node`.`name`:::
+`name`:::
 (string) The node name.
 
-`node`.`transport_address`:::
+`transport_address`:::
 (string) The host and port where transport HTTP connections are accepted.
+====
 
 `open_time`::
 (string)
@@ -286,38 +300,42 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=state-anomaly-job]
 
 [[timingstats]]`timing_stats`::
 (object) An object that provides statistical information about timing aspect of
-this job. It has the following properties:
-
-`timing_stats`.`average_bucket_processing_time_ms`:::
+this job.
++
+.Properties of `timing_stats`
+[%collapsible%open]
+====
+`average_bucket_processing_time_ms`:::
 (double) Average of all bucket processing times in milliseconds.
 
-`timing_stats`.`bucket_count`:::
+`bucket_count`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count]
 
-`timing_stats`.`exponential_average_bucket_processing_time_ms`:::
+`exponential_average_bucket_processing_time_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average]
 
-`timing_stats`.`exponential_average_bucket_processing_time_per_hour_ms`:::
+`exponential_average_bucket_processing_time_per_hour_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average-hour]
 
-`timing_stats`.`job_id`:::
+`job_id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-`timing_stats`.`maximum_bucket_processing_time_ms`:::
+`maximum_bucket_processing_time_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-maximum]
 
-`timing_stats`.`minimum_bucket_processing_time_ms`:::
+`minimum_bucket_processing_time_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-minimum]
 
-`timing_stats`.`total_bucket_processing_time_ms`:::
+`total_bucket_processing_time_ms`:::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
+====
 
 [[ml-get-job-stats-response-codes]]
 ==== {api-response-codes-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -60,6 +60,7 @@ all model snapshots.
 `start`::
   (Optional, string) Returns snapshots with timestamps after this time.
 
+[role="child_attributes"]
 [[ml-get-snapshot-results]]
 ==== {api-response-body-title}
 
@@ -84,15 +85,18 @@ properties:
 
 `model_size_stats`::
 (object) Summary information describing the model.
-
-`model_size_stats`.`bucket_allocation_failures_count`:::
++
+.Properties of `model_size_stats`
+[%collapsible%open]
+====
+`bucket_allocation_failures_count`:::
 (long) The number of buckets for which entities were not processed due to memory
 limit constraints.
 
-`model_size_stats`.`categorized_doc_count`:::
+`categorized_doc_count`:::
 (long) The number of documents that have had a field categorized.
 
-`model_size_stats`.`categorization_status`:::
+`categorization_status`:::
 (string) The status of categorization for this job.
 Contains one of the following values.
 +
@@ -108,25 +112,25 @@ matched categories, or more than 50% of categories are dead.
 
 --
 
-`model_size_stats`.`dead_category_count`:::
+`dead_category_count`:::
 (long) The number of categories created by categorization that will
 never be assigned again because another category's definition
 makes it a superset of the dead category.  (Dead categories are a
 side effect of the way categorization has no prior training.)
 
-`model_size_stats`.`frequent_category_count`:::
+`frequent_category_count`:::
 (long) The number of categories that match more than 1% of categorized
 documents.
 
-`model_size_stats`.`job_id`:::
+`job_id`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
-`model_size_stats`.`log_time`:::
+`log_time`:::
 (date) The timestamp that the `model_size_stats` were recorded, according to
 server-time.
 
-`model_size_stats`.`memory_status`:::
+`memory_status`:::
 (string) The status of the memory in relation to its `model_memory_limit`.
 Contains one of the following values.
 +
@@ -139,38 +143,39 @@ memory limit and more aggressive pruning will be performed in order to try to
 reclaim space.
 --
 
-`model_size_stats`.`model_bytes`:::
+`model_bytes`:::
 (long) An approximation of the memory resources required for this analysis.
 
-`model_size_stats`.`model_bytes_exceeded`:::
+`model_bytes_exceeded`:::
 (long) The number of bytes over the high limit for memory usage at the last allocation failure.
 
-`model_size_stats`.`model_bytes_memory_limit`:::
+`model_bytes_memory_limit`:::
 (long) The upper limit for memory usage, checked on increasing values.
 
-`model_size_stats`.`rare_category_count`:::
+`rare_category_count`:::
 (long) The number of categories that match just one categorized document.
 
-`model_size_stats`.`result_type`:::
+`result_type`:::
 (string) Internal. This value is always `model_size_stats`.
 
-`model_size_stats`.`timestamp`:::
+`timestamp`:::
 (date) The timestamp that the `model_size_stats` were recorded, according to the
 bucket timestamp of the data.
 
-`model_size_stats`.`total_by_field_count`:::
+`total_by_field_count`:::
 (long) The number of _by_ field values analyzed. Note that these are counted
 separately for each detector and partition.
 
-`model_size_stats`.`total_category_count`:::
+`total_category_count`:::
 (long) The number of categories created by categorization.
 
-`model_size_stats`.`total_over_field_count`:::
+`total_over_field_count`:::
 (long) The number of _over_ field values analyzed. Note that these are counted
 separately for each detector and partition.
 
-`model_size_stats`.`total_partition_field_count`:::
+`total_partition_field_count`:::
 (long) The number of _partition_ field values analyzed.
+====
 
 `retain`::
 (boolean)

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -83,6 +83,7 @@ properties:
 `min_version`::
 (string) The minimum version required to be able to restore the model snapshot.
 
+//Begin model_size_stats
 `model_size_stats`::
 (object) Summary information describing the model.
 +
@@ -176,6 +177,7 @@ separately for each detector and partition.
 `total_partition_field_count`:::
 (long) The number of _partition_ field values analyzed.
 ====
+//End model_size_stats
 
 `retain`::
 (boolean)

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -33,28 +33,29 @@ of which must have a start time, end time, and description.
 (Required, string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
+[role="child_attributes"]
 [[ml-post-calendar-event-request-body]]
 ==== {api-request-body-title}
 
 `events`::
 (Required, array) A list of one of more scheduled events. The event's start and
 end times may be specified as integer milliseconds since the epoch or as a
-string in ISO 8601 format. An event resource has the following properties:
-
-`events`.`calendar_id`:::
-(Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
-
-`events`.`description`:::
+string in ISO 8601 format.
++
+.Properties of events
+[%collapsible%open]
+====
+`description`:::
 (Optional, string) A description of the scheduled event.
 
-`events`.`end_time`:::
+`end_time`:::
 (Required, date) The timestamp for the end of the scheduled event in
 milliseconds since the epoch or ISO 8601 format.
 
-`events`.`start_time`:::
+`start_time`:::
 (Required, date) The timestamp for the beginning of the scheduled event in
 milliseconds since the epoch or ISO 8601 format.
+====
 
 [[ml-post-calendar-event-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -51,6 +51,7 @@ those same roles.
 (Required, string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
+[role="child_attributes"]
 [[ml-put-datafeed-request-body]]
 ==== {api-request-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -35,6 +35,7 @@ a job directly to the `.ml-config` index using the {es} index API. If {es}
 (Required, string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-define]
 
+[role="child_attributes"]
 [[ml-put-job-request-body]]
 ==== {api-request-body-title}
 
@@ -42,148 +43,171 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-define]
 (Optional, boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=allow-lazy-open]
 
+//Begin analysis_config
 [[put-analysisconfig]]`analysis_config`::
 (Required, object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-config]
-
-`analysis_config`.`bucket_span`:::
++
+.Properties of `analysis_config`
+[%collapsible%open]
+====
+`bucket_span`:::
 (<<time-units,time units>>)
 include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span]
 
-`analysis_config`.`categorization_field_name`:::
-(string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-field-name]
-
-`analysis_config`.`categorization_filters`:::
-(array of strings)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-filters]
-
-`analysis_config`.`categorization_analyzer`:::
+`categorization_analyzer`:::
 (object or string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-analyzer]
 
-`analysis_config`.`detectors`:::
+`categorization_field_name`:::
+(string)
+include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-field-name]
+
+`categorization_filters`:::
+(array of strings)
+include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-filters]
+
+//Begin detectors
+`detectors`:::
 (array) An array of detector configuration objects. Detector configuration
 objects specify which data fields a job analyzes. They also specify which
 analytical functions are used. You can specify multiple detectors for a job. 
 +
---
 NOTE: If the `detectors` array does not contain at least one detector,
 no analysis can occur and an error is returned.
-
-A detector has the following properties:
---
-
-`analysis_config`.`detectors`.`by_field_name`::::
++
+.Properties of `detectors`
+[%collapsible%open]
+=====
+`by_field_name`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=by-field-name]
 
-[[put-customrules]]`analysis_config`.`detectors`.`custom_rules`::::
-+
---
+//Begin custom_rules
+[[put-customrules]]`custom_rules`::::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
-
-`analysis_config`.`detectors`.`custom_rules`.`actions`:::
++
+.Properties of `custom_rules`
+[%collapsible%open]
+======
+`actions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
-`analysis_config`.`detectors`.`custom_rules`.`scope`:::
+//Begin scope
+`scope`:::
 (object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
-
-`analysis_config`.`detectors`.`custom_rules`.`scope`.`filter_id`::::
++
+.Properties of `scope`
+[%collapsible%open]
+=======
+`filter_id`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
 
-`analysis_config`.`detectors`.`custom_rules`.`scope`.`filter_type`::::
+`filter_type`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
+=======
+//End scope
 
-`analysis_config`.`detectors`.`custom_rules`.`conditions`:::
+//Begin conditions
+`conditions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
-
-`analysis_config`.`detectors`.`custom_rules`.`conditions`.`applies_to`::::
++
+.Properties of `conditions`
+[%collapsible%open]
+=======
+`applies_to`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
 
-`analysis_config`.`detectors`.`custom_rules`.`conditions`.`operator`::::
+`operator`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 
-`analysis_config`.`detectors`.`custom_rules`.`conditions`.`value`::::
+`value`::::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
---
+=======
+//End conditions
+======
+//End custom_rules
 
-`analysis_config`.`detectors`.`detector_description`::::
+`detector_description`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=detector-description]
 
-`analysis_config`.`detectors`.`detector_index`::::
-+
---
+`detector_index`::::
 (integer)
 include::{docdir}/ml/ml-shared.asciidoc[tag=detector-index]
++
 If you specify a value for this property, it is ignored.
---
 
-`analysis_config`.`detectors`.`exclude_frequent`::::
+`exclude_frequent`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=exclude-frequent]
 
-`analysis_config`.`detectors`.`field_name`::::
+`field_name`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=detector-field-name]
 
-`analysis_config`.`detectors`.`function`::::
+`function`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=function]
 
-`analysis_config`.`detectors`.`over_field_name`::::
+`over_field_name`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=over-field-name]
 
-`analysis_config`.`detectors`.`partition_field_name`::::
+`partition_field_name`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=partition-field-name]
 
-`analysis_config`.`detectors`.`use_null`::::
+`use_null`::::
 (boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=use-null]
+=====
+//End detectors
 
-`analysis_config`.`influencers`:::
+`influencers`:::
 (array of strings)
 include::{docdir}/ml/ml-shared.asciidoc[tag=influencers]
 
-`analysis_config`.`latency`:::
+`latency`:::
 (time units)
 include::{docdir}/ml/ml-shared.asciidoc[tag=latency]
 
-`analysis_config`.`multivariate_by_fields`:::
+`multivariate_by_fields`:::
 (boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=multivariate-by-fields]
 
-`analysis_config`.`summary_count_field_name`:::
+`summary_count_field_name`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=summary-count-field-name]
+====
+//End analysis_config
 
+//Begin analysis_limits
 [[put-analysislimits]]`analysis_limits`::
 (Optional, object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 +
---
-The `analysis_limits` object has the following properties:
---
-
-`analysis_limits`.`categorization_examples_limit`:::
+.Properties of `analysis_limits`
+[%collapsible%open]
+====
+`categorization_examples_limit`:::
 (long)
 include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-examples-limit]
 
-`analysis_limits`.`model_memory_limit`:::
+`model_memory_limit`:::
 (long or string) 
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
+====
+//End analysis_limits
 
 `background_persist_interval`::
 (Optional, <<time-units, time units>>)
@@ -193,9 +217,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
 (Optional, object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-settings]
 
+//Begin data_description
 [[put-datadescription]]`data_description`::
 (Required, object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=data-description]
+//End data_description
 
 `description`::
   (Optional, string) A description of the job.
@@ -204,17 +230,23 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=data-description]
 (Optional, array of strings)
 include::{docdir}/ml/ml-shared.asciidoc[tag=groups]
 
+//Begin model_plot_config
 `model_plot_config`::
 (Optional, object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config]
-
-`model_plot_config`.`enabled`:::
++
+.Properties of `model_plot_config`
+[%collapsible%open]
+====
+`enabled`:::
 (boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 
-`model_plot_config`.`terms`:::
+`terms`:::
 experimental[] (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
+====
+//End model_plot_config
 
 `model_snapshot_retention_days`::
 (Optional, long)

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -67,7 +67,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-field-name]
 (array of strings)
 include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-filters]
 
-//Begin detectors
+//Begin analysis_config.detectors
 `detectors`:::
 (array) An array of detector configuration objects. Detector configuration
 objects specify which data fields a job analyzes. They also specify which
@@ -83,7 +83,7 @@ no analysis can occur and an error is returned.
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=by-field-name]
 
-//Begin custom_rules
+//Begin analysis_config.detectors.custom_rules
 [[put-customrules]]`custom_rules`::::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
@@ -91,29 +91,12 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
 .Properties of `custom_rules`
 [%collapsible%open]
 ======
+
 `actions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
-//Begin scope
-`scope`:::
-(object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
-+
-.Properties of `scope`
-[%collapsible%open]
-=======
-`filter_id`::::
-(string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
-
-`filter_type`::::
-(string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
-=======
-//End scope
-
-//Begin conditions
+//Begin analysis_config.detectors.custom_rules.conditions
 `conditions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
@@ -133,9 +116,27 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
 =======
-//End conditions
+//End analysis_config.detectors.custom_rules.conditions
+
+//Begin analysis_config.detectors.custom_rules.scope
+`scope`:::
+(object)
+include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
++
+.Properties of `scope`
+[%collapsible%open]
+=======
+`filter_id`::::
+(string)
+include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
+
+`filter_type`::::
+(string)
+include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
+=======
+//End analysis_config.detectors.custom_rules.scope
 ======
-//End custom_rules
+//End analysis_config.detectors.custom_rules
 
 `detector_description`::::
 (string)
@@ -171,7 +172,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=partition-field-name]
 (boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=use-null]
 =====
-//End detectors
+//End analysis_config.detectors
 
 `influencers`:::
 (array of strings)

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -42,6 +42,7 @@ using those same roles.
 (Required, string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
+[role="child_attributes"]
 [[ml-update-datafeed-request-body]]
 ==== {api-request-body-title}
 

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -28,6 +28,7 @@ Updates certain properties of an {anomaly-job}.
 (Required, string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+[role="child_attributes"]
 [[ml-update-job-request-body]]
 ==== {api-request-body-title}
 
@@ -43,7 +44,14 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 
 --
 
-[[update-analysislimits]]`analysis_limits`.`model_memory_limit`::
+[[update-analysislimits]]`analysis_limits`::
+(Optional, object)
+include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-limits]
++
+.Properties of `analysis_limits`
+[%collapsible%open]
+====
+`model_memory_limit`:::
 (long or string) 
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
 +
@@ -52,11 +60,12 @@ NOTE: You can update the `analysis_limits` only while the job is closed. The
 `model_memory_limit` property value cannot be decreased below the current usage.
  
 TIP: If the `memory_status` property in the
-<<ml-get-snapshot-results,`model_size_stats` object>> has a value of `hard_limit`,
-this means that it was unable to process some data. You might want to re-run the
-job with an increased `model_memory_limit`.
+<<ml-get-snapshot-results,`model_size_stats` object>> has a value of 
+`hard_limit`,mthis means that it was unable to process some data. You might want 
+to re-run the job with an increased `model_memory_limit`.
 
 --
+====
 
 `background_persist_interval`::
 (<<time-units,time units>>)
@@ -77,58 +86,76 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-settings]
 
 `detectors`::
 (array) An array of detector update objects.
-
-`detectors`.`custom_rules`:::
 +
---
+.Properties of `detectors`
+[%collapsible%open]
+====
+`custom_rules`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
-
-`detectors`.`custom_rules`.`actions`:::
++
+.Properties of `custom_rules`
+[%collapsible%open]
+=====
+`actions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
-`detectors`.`custom_rules`.`scope`:::
-(object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
-
-`detectors`.`custom_rules`.`scope`.`filter_id`::::
-(string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
-
-`detectors`.`custom_rules`.`scope`.`filter_type`::::
-(string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
-
-`detectors`.`custom_rules`.`conditions`:::
+// Begin conditions
+`conditions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
-
-`detectors`.`custom_rules`.`conditions`.`applies_to`::::
++
+.Properties of `conditions`
+[%collapsible%open]
+======
+`applies_to`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
 
-`detectors`.`custom_rules`.`conditions`.`operator`::::
+`operator`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 
-`detectors`.`custom_rules`.`conditions`.`value`::::
+`value`::::
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
---
+======
+//End conditions
+//Begin scope
+`scope`:::
+(object)
+include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
++
+.Properties of `scope`
+[%collapsible%open]
+======
+`filter_id`::::
+(string)
+include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
 
-`detectors`.`description`:::
+`filter_type`::::
+(string)
+include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
+======
+//End scope
+=====
+//End custom_rules
+
+`description`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=detector-description]
 
-`detectors`.`detector_index`:::
-+
---
+`detector_index`:::
 (integer)
 include::{docdir}/ml/ml-shared.asciidoc[tag=detector-index]
++
+--
 If you want to update a specific detector, you must use this identifier. You
 cannot, however, change the `detector_index` value for a detector.
 --
+====
+//End detectors
 
 `groups`::
 (array of strings)
@@ -137,14 +164,18 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=groups]
 `model_plot_config`::
 (object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config]
-
-`model_plot_config`.`enabled`:::
++
+.Properties of `model_plot_config`
+[%collapsible%open]
+====
+`enabled`:::
 (boolean)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 
-`model_plot_config`.`terms`:::
+`terms`:::
 experimental[] (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
+====
 
 `model_snapshot_retention_days`::
 (long)

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -43,7 +43,7 @@ NOTE: If the job is open when you make the update, you must stop the {dfeed},
 close the job, then reopen the job and restart the {dfeed} for the changes to take effect.
 
 --
-
+//Begin analysis_limits
 [[update-analysislimits]]`analysis_limits`::
 (Optional, object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-limits]
@@ -66,6 +66,7 @@ to re-run the job with an increased `model_memory_limit`.
 
 --
 ====
+//End analysis_limits
 
 `background_persist_interval`::
 (<<time-units,time units>>)
@@ -84,12 +85,15 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-settings]
 `description`::
 (string) A description of the job.
 
+//Begin detectors
 `detectors`::
 (array) An array of detector update objects.
 +
 .Properties of `detectors`
 [%collapsible%open]
 ====
+
+//Begin detectors.custom_rules
 `custom_rules`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
@@ -97,11 +101,12 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
 .Properties of `custom_rules`
 [%collapsible%open]
 =====
+
 `actions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
-// Begin conditions
+// Begin detectors.custom_rules.conditions
 `conditions`:::
 (array)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
@@ -109,6 +114,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
 .Properties of `conditions`
 [%collapsible%open]
 ======
+
 `applies_to`::::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
@@ -121,8 +127,9 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 (double)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
 ======
-//End conditions
-//Begin scope
+//End detectors.custom_rules.conditions
+
+//Begin detectors.custom_rules.scope
 `scope`:::
 (object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
@@ -138,9 +145,9 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
 ======
-//End scope
+//End detectors.custom_rules.scope
 =====
-//End custom_rules
+//End detectors.custom_rules
 
 `description`:::
 (string)
@@ -161,6 +168,7 @@ cannot, however, change the `detector_index` value for a detector.
 (array of strings)
 include::{docdir}/ml/ml-shared.asciidoc[tag=groups]
 
+//Begin model_plot_config
 `model_plot_config`::
 (object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config]
@@ -176,6 +184,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 experimental[] (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
 ====
+//End model_plot_config
 
 `model_snapshot_retention_days`::
 (long)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -232,24 +232,26 @@ process. The syntax is very similar to that used to define the `analyzer` in the
 <<indices-analyze,Analyze endpoint>>. For more information, see
 {ml-docs}/ml-configuring-categories.html[Categorizing log messages].
 +
---
 The `categorization_analyzer` field can be specified either as a string or as an
 object. If it is a string it must refer to a
 <<analysis-analyzers,built-in analyzer>> or one added by another plugin. If it
 is an object it has the following properties:
---
-
-`analysis_config`.`categorization_analyzer`.`char_filter`::::
++
+.Properties of `categorization_analyzer`
+[%collapsible%open]
+=====
+`char_filter`::::
 (array of strings or objects)
 include::{docdir}/ml/ml-shared.asciidoc[tag=char-filter]
 
-`analysis_config`.`categorization_analyzer`.`tokenizer`::::
+`tokenizer`::::
 (string or object)
 include::{docdir}/ml/ml-shared.asciidoc[tag=tokenizer]
 
-`analysis_config`.`categorization_analyzer`.`filter`::::
+`filter`::::
 (array of strings or objects)
 include::{docdir}/ml/ml-shared.asciidoc[tag=filter]
+=====
 end::categorization-analyzer[]
 
 tag::categorization-examples-limit[]
@@ -258,12 +260,9 @@ data store. The default value is 4.  If you increase this value, more examples
 are available, however it requires that you have more storage available. If you
 set this value to `0`, no examples are stored.
 +
---
 NOTE: The `categorization_examples_limit` only applies to analysis that uses
 categorization. For more information, see
 {ml-docs}/ml-configuring-categories.html[Categorizing log messages].
-
---
 end::categorization-examples-limit[]
 
 tag::categorization-field-name[]
@@ -420,23 +419,24 @@ end::custom-settings[]
 tag::data-description[]
 The data description defines the format of the input data when you send data to
 the job by using the <<ml-post-data,post data>> API. Note that when configure
-a {dfeed}, these properties are automatically set.
+a {dfeed}, these properties are automatically set. When data is received via 
+the <<ml-post-data,post data>> API, it is not stored in {es}. Only the results 
+for {anomaly-detect} are retained.
 +
---
-When data is received via the <<ml-post-data,post data>> API, it is not stored
-in {es}. Only the results for {anomaly-detect} are retained.
-
-`data_description`.`format`:::
+.Properties of `data_description`
+[%collapsible%open]
+====
+`format`:::
   (string) Only `JSON` format is supported at this time.
 
-`data_description`.`time_field`:::
+`time_field`:::
   (string) The name of the field that contains the timestamp.
   The default value is `time`.
 
-`data_description`.`time_format`:::
+`time_format`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=time-format]
---
+====
 end::data-description[]
 
 tag::data-frame-analytics[]
@@ -1031,19 +1031,17 @@ cardinality fields, but the default is set to a relatively small size to ensure
 that high resource usage is a conscious decision. The default value for jobs
 created in versions earlier than 6.1 is `4096mb`.
 +
---
 If you specify a number instead of a string, the units are assumed to be MiB.
 Specifying a string is recommended for clarity. If you specify a byte size unit
 of `b` or `kb` and the number does not equate to a discrete number of megabytes,
 it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you
 specify a value less than 1 MiB, an error occurs. For more information about
 supported byte size units, see <<byte-units>>.
-
++
 If your `elasticsearch.yml` file contains an `xpack.ml.max_model_memory_limit`
 setting, an error occurs when you try to create jobs that have
 `model_memory_limit` values greater than that setting. For more information,
 see <<ml-settings>>.
---
 end::model-memory-limit[]
 
 tag::model-memory-limit-anomaly-jobs[]
@@ -1433,14 +1431,11 @@ seconds since 1 Jan 1970). The value `epoch_ms` indicates that time is measured
 in milliseconds since the epoch. The `epoch` and `epoch_ms` time formats accept 
 either integer or real values. +
 +
---
 NOTE: Custom patterns must conform to the Java `DateTimeFormatter` class.
 When you use date-time formatting patterns, it is recommended that you provide
 the full date, time and time zone. For example: `yyyy-MM-dd'T'HH:mm:ssX`.
 If the pattern that you specify is not sufficient to produce a complete 
 timestamp, job creation fails.
-
---
 end::time-format[]
 
 tag::time-span[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -327,15 +327,18 @@ tag::chunking-config[]
 months or years. This search is split into time chunks in order to ensure the 
 load on {es} is managed. Chunking configuration controls how the size of these 
 time chunks are calculated and is an advanced configuration option.
-A chunking configuration object has the following properties:
-
-`chunking_config`.`mode`:::
++
+.Properties of `chunking_config`
+[%collapsible%open]
+====
+`mode`:::
 (string)
 include::{docdir}/ml/ml-shared.asciidoc[tag=mode]
 
-`chunking_config`.`time_span`:::
+`time_span`:::
 (<<time-units,time units>>)
 include::{docdir}/ml/ml-shared.asciidoc[tag=time-span]
+====
 end::chunking-config[]
 
 tag::class-assignment-objective[]
@@ -598,27 +601,29 @@ tag::delayed-data-check-config[]
 Specifies whether the {dfeed} checks for missing data and the size of the
 window. For example: `{"enabled": true, "check_window": "1h"}`.
 +
---
 The {dfeed} can optionally search over indices that have already been read in
 an effort to determine whether any data has subsequently been added to the 
 index. If missing data is found, it is a good indication that the `query_delay` 
 option is set too low and the data is being indexed after the {dfeed} has passed 
 that moment in time. See 
 {ml-docs}/ml-delayed-data-detection.html[Working with delayed data].
-
++
 This check runs only on real-time {dfeeds}.
-
-`delayed_data_check_config`.`enabled`::
-(boolean) Specifies whether the {dfeed} periodically checks for delayed data.
-Defaults to `true`.
-
-`delayed_data_check_config`.`check_window`::
++
+.Properties of `delayed_data_check_config`
+[%collapsible%open]
+====
+`check_window`::
 (<<time-units,time units>>) The window of time that is searched for late data.
 This window of time ends with the latest finalized bucket. It defaults to
 `null`, which causes an appropriate `check_window` to be calculated when the
 real-time {dfeed} runs. In particular, the default `check_window` span
 calculation is based on the maximum of `2h` or `8 * bucket_span`.
---
+
+`enabled`::
+(boolean) Specifies whether the {dfeed} periodically checks for delayed data.
+Defaults to `true`.
+====
 end::delayed-data-check-config[]
 
 tag::dependent-variable[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -88,7 +88,6 @@ tag::analysis-limits[]
 Limits can be applied for the resources required to hold the mathematical models
 in memory. These limits are approximate and can be set per job. They do not
 control the memory used by other processes, for example the {es} Java processes.
-If necessary, you can increase the limits after the job is created.
 end::analysis-limits[]
 
 tag::analyzed-fields[]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -67,6 +67,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=from-transforms]
 (Optional, integer)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=size-transforms]
 
+[role="child_attributes"]
 [[get-transform-stats-response]]
 ==== {api-response-body-title}
 
@@ -74,107 +75,168 @@ The API returns an array of statistics objects for {transforms}, which are
 sorted by the `id` value in ascending order. All of these properties are
 informational; you cannot update their values.
 
+//Begin checkpointing
 `checkpointing`::
 (object) Contains statistics about <<transform-checkpoints,checkpoints>>.
-`checkpointing`.`changes_last_detected_at`:::
++
+.Properties of `checkpointing`
+[%collapsible%open]
+====
+`changes_last_detected_at`:::
 (date)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=checkpointing-changes-last-detected-at]
-`checkpointing`.`last`:::
+
+//Begin checkpointing.last
+`last`:::
 (object) Contains statistics about the last completed checkpoint. 
-`checkpointing`.`last`.`checkpoint`::::
++
+.Properties of `last`
+[%collapsible%open]
+=====
+`checkpoint`::::
 (integer) The sequence number for the checkpoint.
-`checkpointing`.`last`.`time_upper_bound_millis`::::
+`time_upper_bound_millis`::::
 (date) When using time-based synchronization, this timestamp indicates the
 upper bound of data that is included in the checkpoint.
-`checkpointing`.`last`.`timestamp_millis`::::
+`timestamp_millis`::::
 (date) The timestamp of the checkpoint, which indicates when the checkpoint
 was created.
-`checkpointing`.`next`:::
+=====
+//End checkpointing.last
+
+//Begin checkpointing.next
+`next`:::
 (object) Contains statistics about the next checkpoint that is currently in
 progress. This object appears only when the {transform} `state` is `indexing`.
-`checkpointing`.`next`.`checkpoint`::::
++
+.Properties of `next`
+[%collapsible%open]
+=====
+`checkpoint`::::
 (integer) The sequence number for the checkpoint.
-`checkpointing`.`next`.`checkpoint_progress`::::
+
+`checkpoint_progress`::::
 (object) Contains statistics about the progress of the checkpoint. For example,
 it lists the `total_docs`, `docs_remaining`, `percent_complete`,
 `docs_processed`, and `docs_indexed`. This information is available only for
 batch {transforms} and the first checkpoint of {ctransforms}.
-`checkpointing`.`next`.`time_upper_bound_millis`::::
+
+`time_upper_bound_millis`::::
 (date) When using time-based synchronization, this timestamp indicates the
 upper bound of data that is included in the checkpoint.
-`checkpointing`.`next`.`timestamp_millis`::::
+
+`timestamp_millis`::::
 (date) The timestamp of the checkpoint, which indicates when the checkpoint was
 created.
-`checkpointing`.`operations_behind`:::
+=====
+//End checkpointing.next
+
+`operations_behind`:::
 (integer) The number of operations that have occurred on the source index but
 have not been applied to the destination index yet. A high number can indicate
 that the {transform} is failing to keep up. 
+====
+//End checkpointing
 
 `id`::
 (string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
+//Begin node
 `node`::
 (object) For started {transforms} only, the node upon which the {transform} is
 started.
-`node`.`attributes`:::
++
+.Properties of `node`
+[%collapsible%open]
+====
+`attributes`:::
 (object) A list of attributes for the node.
-`node`.`ephemeral_id`:::
+
+`ephemeral_id`:::
 (string) The node ephemeral ID.
-`node`.`id`:::
+
+`id`:::
 (string) The unique identifier of the node. For example, "0-o0tOoRTwKFZifatTWKNw".
-`node`.`name`:::
+
+`name`:::
 (string) The node name. For example, `0-o0tOo`.
-`node`.`transport_address`:::
+
+`transport_address`:::
 (string) The host and port where transport HTTP connections are accepted. For
 example, `127.0.0.1:9300`.
+====
+//End node
+
 `reason`::
 (string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform-reason]
+
 `state`::
 (string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform]
+
+//Begin stats
 `stats`::
 (object) An object that provides statistical information about the {transform}.
-`stats`.`documents_indexed`:::
++
+.Properties of `stats`
+[%collapsible%open]
+====
+
+`documents_indexed`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-indexed]
-`stats`.`documents_processed`:::
+
+`documents_processed`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-processed]
-`stats`.`exponential_avg_checkpoint_duration_ms`:::
+
+`exponential_avg_checkpoint_duration_ms`:::
 (double)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-checkpoint-duration-ms]
-`stats`.`exponential_avg_documents_indexed`:::
+
+`exponential_avg_documents_indexed`:::
 (double)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-indexed]
-`stats`.`exponential_avg_documents_processed`:::
+
+`exponential_avg_documents_processed`:::
 (double)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-processed]
-`stats`.`index_failures`:::
+
+`index_failures`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-failures]
-`stats`.`index_time_in_ms`:::
+
+`index_time_in_ms`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-time-ms]
-`stats`.`index_total`:::
+
+`index_total`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=index-total]
-`stats`.`pages_processed`:::
+
+`pages_processed`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pages-processed]
-`stats`.`search_failures`:::
+
+`search_failures`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=search-failures]
-`stats`.`search_time_in_ms`:::
+
+`search_time_in_ms`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=search-time-ms]
-`stats`.`search_total`:::
+
+`search_total`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=search-total]
-`stats`.`trigger_count`:::
+
+`trigger_count`:::
 (long)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=trigger-count]
+====
+//End stats
   
 [[get-transform-stats-response-codes]]
 ==== {api-response-codes-title}

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -42,6 +42,7 @@ might result in poor mappings. As a work-around, create the destination index
 or an index template with your preferred mappings before you start the
 {transform}.
 
+[role="child_attributes"]
 [[preview-transform-request-body]]
 ==== {api-request-body-title}
 
@@ -49,83 +50,127 @@ or an index template with your preferred mappings before you start the
 `description`::
 (Optional, string) Free text description of the {transform}.
 
+//Begin dest
 `dest`::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
-  
-`dest`.`index`:::
++
+.Properties of `dest`
+[%collapsible%open]
+====
+`index`:::
 (Optional, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
-`dest`.`pipeline`:::
+`pipeline`:::
 (Optional, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+====
+//End dest
 
 `frequency`::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
 
+//Begin pivot
 `pivot`::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
++
+.Properties of `pivot`
+[%collapsible%open]
+====
 
-`pivot`.`aggregations` or `aggs`:::
+`aggregations` or `aggs`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 
-`pivot`.`group_by`:::
+`group_by`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 
-`pivot`.`max_page_search_size`:::
+`max_page_search_size`:::
 (Optional, integer)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-max-page-search-size]
+====
+//End pivot
 
+//Begin source
 `source`::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
++
+.Properties of `source`
+[%collapsible%open]
+====
 
-`source`.`index`:::
+`index`:::
 (Required, string or array)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
 
-`source`.`query`:::
+`query`:::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
+====
+//End source
 
+//Begin sync
 `sync`::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
-  
-`sync`.`time`:::
++
+.Properties of `sync`
+[%collapsible%open]
+====
+//Begin sync.time
+
+`time`:::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
++
+.Properties of `analysis_config`
+[%collapsible%open]
+=====
 
-`sync`.`time`.`delay`::::
+`delay`::::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
     
-`sync`.`time`.`field`::::
+`field`::::
 (Optional, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
+=====
+//End sync.time
+====
+//End sync
 
-
+[role="child_attributes"]
 [[preview-transform-response]]
 ==== {api-response-body-title}
 
 `preview`::
-  (array) An array of documents. In particular, they are the JSON
-  representation of the documents that would be created in the destination index
-  by the {transform}.
-  
+(array) An array of documents. In particular, they are the JSON representation 
+of the documents that would be created in the destination index by the 
+{transform}.
+
+//Begin generated_dest_index  
 `generated_dest_index`::
-  (object) Contains details about the destination index.
-    `mappings`:::
-    (object) The <<mapping,mappings>> for each document in the destination index. 
-    `settings`:::
-    (object) The <<index-modules-settings,index settings>> for the destination
-    index.
-    `aliases`::: The aliases for the destination index.
+(object) Contains details about the destination index.
++
+.Properties of `generated_dest_index`
+[%collapsible%open]
+====
+
+`aliases`:::
+(object) The aliases for the destination index.
+
+`mappings`:::
+(object) The <<mapping,mappings>> for each document in the destination index. 
+
+`settings`:::
+(object) The <<index-modules-settings,index settings>> for the destination index.
+====
+//End generated_dest_index
 
 ==== {api-examples-title}
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -72,69 +72,96 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
   behavior may be desired if the source index does not exist until after the
   {transform} is created.
 
+[role="child_attributes"]
 [[put-transform-request-body]]
 ==== {api-request-body-title}
 
 `description`::
   (Optional, string) Free text description of the {transform}.
 
+//Begin dest
 `dest`::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
-  
-`dest`.`index`:::
++
+.Properties of `dest`
+[%collapsible%open]
+====
+`index`:::
 (Required, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
-`dest`.`pipeline`:::
+`pipeline`:::
 (Optional, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+====
+//End dest
 
 `frequency`::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
 
+//Begin pivot
 `pivot`::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
-
-`pivot`.`aggregations` or `aggs`:::
++
+.Properties of `pivot`
+[%collapsible%open]
+====
+`aggregations` or `aggs`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 
-`pivot`.`group_by`:::
+`group_by`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 
-`pivot`.`max_page_search_size`:::
+`max_page_search_size`:::
 (Optional, integer)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-max-page-search-size]
+====
+//End pivot
 
+//Begin source
 `source`::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
-
-`source`.`index`:::
++
+.Properties of `source`
+[%collapsible%open]
+====
+`index`:::
 (Required, string or array)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
 
-`source`.`query`:::
+`query`:::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
-  
+====
+//End source
+
+//Begin sync
 `sync`::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
-  
-`sync`.`time`:::
++
+.Properties of `sync`
+[%collapsible%open]
+====
+//Begin time
+`time`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
-
-`sync`.`time`.`delay`::::
++
+.Properties of `time`
+[%collapsible%open]
+=====
+`delay`::::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
     
-`sync`.`time`.`field`::::
+`field`::::
 (Required, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 +
@@ -145,6 +172,10 @@ you might need to set the `delay` such that it accounts for data transmission
 delays.
 
 --
+=====
+//End time
+====
+//End sync
 
 [[put-transform-example]]
 ==== {api-examples-title}

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -87,6 +87,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
 .Properties of `dest`
 [%collapsible%open]
 ====
+
 `index`:::
 (Required, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
@@ -109,6 +110,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
 .Properties of `pivot`
 [%collapsible%open]
 ====
+
 `aggregations` or `aggs`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
@@ -131,6 +133,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 .Properties of `source`
 [%collapsible%open]
 ====
+
 `index`:::
 (Required, string or array)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
@@ -149,6 +152,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
 .Properties of `sync`
 [%collapsible%open]
 ====
+
 //Begin time
 `time`:::
 (Required, object)
@@ -157,6 +161,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
 .Properties of `time`
 [%collapsible%open]
 =====
+
 `delay`::::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -67,53 +67,78 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
   behavior may be desired if the source index does not exist until after the
   {transform} is updated.
 
+[role="child_attributes"]
 [[update-transform-request-body]]
 ==== {api-request-body-title}
 
 `description`::
   (Optional, string) Free text description of the {transform}.
 
+//Begin dest
 `dest`::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
-  
-`dest`.`index`:::
++
+.Properties of `dest`
+[%collapsible%open]
+====
+
+`index`:::
 (Required, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
-`dest`.`pipeline`:::
+`pipeline`:::
 (Optional, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+====
+//End dest
 
 `frequency`::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
 
+//Begin source
 `source`::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
-  
-`source`.`index`:::
++
+.Properties of `source`
+[%collapsible%open]
+====  
+
+`index`:::
 (Required, string or array)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
     
-`source`.`query`:::
+`query`:::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
-  
+====
+//End source
+
+//Begin sync
 `sync`::
 (Optional, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
-  
-`sync`.`time`:::
++
+.Properties of `sync`
+[%collapsible%open]
+====
+
+//Begin sync.time
+`time`:::
 (Required, object)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
++
+.Properties of `time`
+[%collapsible%open]
+=====
 
-`sync`.`time`.`delay`::::
+`delay`::::
 (Optional, <<time-units, time units>>)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
 
-`sync`.`time`.`field`::::
+`field`::::
 (Required, string)
 include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 +
@@ -124,6 +149,10 @@ you might need to set the `delay` such that it accounts for data transmission
 delays.
 
 --
+=====
+//End sync.time
+====
+//End sync
 
 [[update-transform-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
This PR adds collapsed sections that use the "child_attributes" role in anomaly detection and transform APIs so that it's easier to see which properties are nested in each object. 

Relies on the CSS changes in https://github.com/elastic/docs/pull/1786

Preview:
* http://elasticsearch_54234.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-job.html
* http://elasticsearch_54234.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-get-datafeed-stats.html
* http://elasticsearch_54234.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-transform-stats.html