### PR TITLE
Improve stability of SamlServiceProviderIndexTests

### DIFF
--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -162,12 +162,16 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         assertThat(readDocument(document.docId), equalTo(document));
     }
 
-    public void testInstallTemplateAutomaticallyOnClusterChange() {
+    public void testInstallTemplateAutomaticallyOnClusterChange() throws Exception {
         // Create an index that will trigger a cluster state change
-        client().admin().indices().create(new CreateIndexRequest(randomAlphaOfLength(7).toLowerCase(Locale.ROOT))).actionGet();
+        final String indexName = randomAlphaOfLength(7).toLowerCase(Locale.ROOT);
+        client().admin().indices().create(new CreateIndexRequest(indexName)).actionGet();
+
+        ensureGreen(indexName);
 
         IndexTemplateMetaData templateMeta = clusterService.state().metaData().templates().get(SamlServiceProviderIndex.TEMPLATE_NAME);
-        assertNotNull(templateMeta);
+
+        assertBusy(() -> assertThat("template should have been installed", templateMeta, notNullValue()));
 
         final PlainActionFuture<Boolean> installTemplate = new PlainActionFuture<>();
         serviceProviderIndex.installIndexTemplate(installTemplate);
@@ -181,7 +185,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         assertThat(readDocument(doc.docId), equalTo(doc));
 
         IndexTemplateMetaData templateMeta = clusterService.state().metaData().templates().get(SamlServiceProviderIndex.TEMPLATE_NAME);
-        assertNotNull(templateMeta);
+        assertThat("template should have been installed", templateMeta, notNullValue());
 
         final PlainActionFuture<Boolean> installTemplate = new PlainActionFuture<>();
         serviceProviderIndex.installIndexTemplate(installTemplate);


### PR DESCRIPTION
This test assumed cluster events would be processed quickly which is
not always true

Backport of: #54166