### PR TITLE
Complete keystore CLI options documentation

### DIFF
--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -52,7 +52,7 @@ two confirmation prompts, use the `-f` parameter.
 
 `create`:: Creates the keystore.
 
-`-f`:: When used with the `add` parameter, the command no longer prompts you
+`-f, --force`:: When used with the `add` parameter, the command no longer prompts you
 before overwriting existing entries in the keystore. Also, if you haven't
 created a keystore yet, it creates a keystore that is obfuscated but not
 password protected.
@@ -76,7 +76,7 @@ names can be specified as arguments to the `add` command.
 
 `-s, --silent`:: Shows minimal output.
 
-`--stdin`:: When used with the `add` parameter, you can pass the settings values
+`-x, --stdin`:: When used with the `add` parameter, you can pass the settings values
 through standard input (stdin). Separate multiple values with carriage returns
 or newlines. See <<add-string-to-keystore>>.
 


### PR DESCRIPTION
The documentation was missing the long option for the force option, and the short option for the stdin option. This commit addresses this by adding these to the documentation.

Relates #54229
