### PR TITLE
Clarify the remove keystore command can handle many

### DIFF
--- a/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/common/settings/RemoveSettingKeyStoreCommand.java
+++ b/distribution/tools/keystore-cli/src/main/java/org/elasticsearch/common/settings/RemoveSettingKeyStoreCommand.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.common.settings;
 
-import java.util.List;
-
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.env.Environment;
+
+import java.util.List;
 
 /**
  * A subcommand for the keystore cli to remove a setting.
@@ -36,7 +36,7 @@ class RemoveSettingKeyStoreCommand extends BaseKeyStoreCommand {
     private final OptionSpec<String> arguments;
 
     RemoveSettingKeyStoreCommand() {
-        super("Remove a setting from the keystore", true);
+        super("Remove settings from the keystore", true);
         arguments = parser.nonOptions("setting names");
     }
 

--- a/docs/reference/commands/keystore.asciidoc
+++ b/docs/reference/commands/keystore.asciidoc
@@ -72,7 +72,7 @@ can optionally use an empty string to remove the password. If the keystore is
 not password protected, you can use this command to set a password.
 
 `remove <settings>`:: Removes settings from the keystore. Multiple setting
-names can be specified as arguments to the `add` command.
+names can be specified as arguments to the `remove` command.
 
 `-s, --silent`:: Shows minimal output.
 
@@ -193,6 +193,15 @@ To remove a setting from the keystore, use the `remove` command:
 [source,sh]
 ----------------------------------------------------------------
 bin/elasticsearch-keystore remove the.setting.name.to.remove
+----------------------------------------------------------------
+
+You can also remove multiple settings with the `remove` command:
+
+[source,sh]
+----------------------------------------------------------------
+bin/elasticsearch-keystore remove \
+  the.setting.name.to.remove \
+  the.other.setting.name.to.remove
 ----------------------------------------------------------------
 
 If the {es} keystore is password protected, you are prompted to enter the


### PR DESCRIPTION
The remove keystore command can handle multiple settings. In a few places, we were not consistent about mentioning this. This commit addreses this, in the CLI help, and the docs.

Relates #54229