### PR TITLE
Add error_trace parameter to REST test helper

### DIFF
--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/XPackRestTestHelper.java
@@ -43,6 +43,7 @@ public final class XPackRestTestHelper {
         assertBusy(() -> {
             Request request = new Request("GET", "/_cat/nodes");
             request.addParameter("h", "master,version");
+            request.addParameter("error_trace", "true");
             String response = EntityUtils.toString(client.performRequest(request).getEntity());
 
             for (String line : response.split("\n")) {
@@ -56,6 +57,7 @@ public final class XPackRestTestHelper {
 
         assertBusy(() -> {
             final Request request = new Request("GET", "_template");
+            request.addParameter("error_trace", "true");
 
             String string = EntityUtils.toString(client.performRequest(request).getEntity());
             Map<String, Object> response = XContentHelper.convertToMap(JsonXContent.jsonXContent, string, false);


### PR DESCRIPTION
Today the `XPackRestTestHelper` makes some REST calls without the `error_trace`
parameter, so that if they fail due to an exception we do not see very much
detail. This commit adds the `error_trace` parameter to help identify why these
REST calls fail.