### PR TITLE
Explicitly set mappings in SearchAfterIT

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/test/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -50,7 +50,7 @@ public class SearchAfterIT extends ESIntegTestCase {
 
     public void testsShouldFail() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("test")
-            .setMapping("field2", "type=keyword")
+            .setMapping("field1", "type=long", "field2", "type=keyword")
             .get()
         );
         ensureGreen();


### PR DESCRIPTION
We have some very occasional failures in SearchAfterIT, where a search throws
an exception because the shard does not have a mapping for the requested sort
field.  The field should have been added in a dynamic mapping update after an
index event, but it seems that there can sometimes be a small delay in propagating
this update to the shards.

This commit changes the test to explicitly define the relevant field at index creation
time.

Fixes #51900 