### PR TITLE
assertBusy in XPackRestIT#awaitCallApi

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
@@ -229,11 +230,14 @@ public class XPackRestIT extends ESClientYamlSuiteTestCase {
                               CheckedFunction<ClientYamlTestResponse, Boolean, IOException> success,
                               Supplier<String> error) {
         try {
-            // The actual method call that sends the API requests returns a Future, but we immediately
-            // call .get() on it so there's no need for this method to do any other awaiting.
-            ClientYamlTestResponse response = callApi(apiName, params, bodies, getApiCallHeaders());
-            assertEquals(response.getStatusCode(), HttpStatus.SC_OK);
-            success.apply(response);
+            final AtomicReference<ClientYamlTestResponse> response = new AtomicReference<>();
+            assertBusy(() -> {
+                // The actual method call that sends the API requests returns a Future, but we immediately
+                // call .get() on it so there's no need for this method to do any other awaiting.
+                response.set(callApi(apiName, params, bodies, getApiCallHeaders()));
+                assertEquals(HttpStatus.SC_OK, response.get().getStatusCode());
+            });
+            success.apply(response.get());
         } catch (Exception e) {
             throw new IllegalStateException(error.get(), e);
         }


### PR DESCRIPTION
Retries in this method were lost in #45794. This commit reinstates them.