### PR TITLE
Fix compilation in Eclipse

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetaDataRolloverServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/MetaDataRolloverServiceTests.java
@@ -357,7 +357,13 @@ public class MetaDataRolloverServiceTests extends ESTestCase {
         }
     }
 
-    private IndicesService mockIndicesServices() throws java.io.IOException {
+    private IndicesService mockIndicesServices() throws Exception {
+        /*
+         * Throws Exception because Eclipse uses the lower bound for
+         * CheckedFunction's exception type so it thinks the "when" call
+         * can throw Exception. javac seems to be ok inferring something
+         * else.
+         */
         IndicesService indicesService = mock(IndicesService.class);
         when(indicesService.withTempIndexService(any(IndexMetaData.class), any(CheckedFunction.class)))
             .then(invocationOnMock -> {

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -95,7 +95,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -175,7 +175,13 @@ public class ClusterStateChanges {
                     //noinspection unchecked
                     return ((CheckedFunction) invocationOnMock.getArguments()[1]).apply(indexService);
                 });
-        } catch (IOException e) {
+        } catch (Exception e) {
+            /*
+             * Catch Exception because Eclipse uses the lower bound for
+             * CheckedFunction's exception type so it thinks the "when" call
+             * can throw Exception. javac seems to be ok inferring something
+             * else.
+             */
             throw new IllegalStateException(e);
         }
 


### PR DESCRIPTION
These mock calls cause Eclipse to think that `Exception` can be thrown
because `CheckedFunction`'s lower bound is `Exception`. This makes
Eclipse happy.
