### PR TITLE
Fix pipeline agg serialization for ccs

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
@@ -147,6 +148,7 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
     protected final Map<String, Object> metaData;
 
     private final List<PipelineAggregator> pipelineAggregators;
+    private List<PipelineAggregator> pipelineAggregatorsForBwcSerialization;
 
     /**
      * Constructs an aggregation result with a given name.
@@ -160,15 +162,24 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
     }
 
     /**
+     * Merge a {@linkplain PipelineAggregator.PipelineTree} into this
+     * aggregation result tree before serializing to a node older than
+     * 7.8.0.
+     */
+    public final void mergePipelineTreeForBWCSerialization(PipelineAggregator.PipelineTree pipelineTree) {
+        pipelineAggregatorsForBwcSerialization = pipelineTree.aggregators();
+        forEachBucket(bucketAggs -> bucketAggs.mergePipelineTreeForBWCSerialization(pipelineTree));
+    }
+
+    /**
      * Read from a stream.
      */
     protected InternalAggregation(StreamInput in) throws IOException {
         name = in.readString();
         metaData = in.readMap();
+        pipelineAggregators = emptyList();
         if (in.getVersion().before(Version.V_7_8_0)) {
-            pipelineAggregators = in.readNamedWriteableList(PipelineAggregator.class);
-        } else {
-            pipelineAggregators = emptyList();
+            in.readNamedWriteableList(PipelineAggregator.class);
         }
     }
 
@@ -177,7 +188,9 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
         out.writeString(name);
         out.writeGenericValue(metaData);
         if (out.getVersion().before(Version.V_7_8_0)) {
-            out.writeNamedWriteableList(pipelineAggregators);
+            assert pipelineAggregatorsForBwcSerialization != null :
+                "serializing to pre-7.8.0 versions should have called mergePipelineTreeForBWCSerialization";
+            out.writeNamedWriteableList(pipelineAggregatorsForBwcSerialization);
         }
         doWriteTo(out);
     }
@@ -211,6 +224,11 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
         throw new IllegalStateException(
                 "Aggregation [" + getName() + "] must be a bucket aggregation but was [" + getWriteableName() + "]");
     }
+
+    /**
+     * Run a {@linkplain Consumer} over all buckets in this aggregation.
+     */
+    public void forEachBucket(Consumer<InternalAggregations> consumer) {}
 
     /**
      * Creates the output from all pipeline aggs that this aggregation is associated with.  Should only
@@ -278,8 +296,21 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
         return metaData;
     }
 
+    /**
+     * @deprecated soon to be removed because it is not longer needed
+     */
+    @Deprecated
     public List<PipelineAggregator> pipelineAggregators() {
         return pipelineAggregators;
+    }
+
+    /**
+     * The {@linkplain PipelineAggregator}s sent to older versions of Elasticsearch.
+     * @deprecated only use these for serializing to older Elasticsearch versions
+     */
+    @Deprecated
+    public List<PipelineAggregator> pipelineAggregatorsForBwcSerialization() {
+        return pipelineAggregatorsForBwcSerialization;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public abstract class InternalMultiBucketAggregation<A extends InternalMultiBucketAggregation,
@@ -145,7 +146,7 @@ public abstract class InternalMultiBucketAggregation<A extends InternalMultiBuck
     }
 
     /**
-     * Amulti-bucket agg needs to first reduce the buckets and *their* pipelines
+     * A multi-bucket agg needs to first reduce the buckets and *their* pipelines
      * before allowing sibling pipelines to materialize.
      */
     @Override
@@ -171,6 +172,13 @@ public abstract class InternalMultiBucketAggregation<A extends InternalMultiBuck
             newBuckets.add(newBucket);
         }
         return modified ? create(newBuckets) : this;
+    }
+
+    @Override
+    public void forEachBucket(Consumer<InternalAggregations> consumer) {
+        for (B bucket : getBuckets()) {
+            consumer.accept((InternalAggregations) bucket.getAggregations());
+        }
     }
 
     private List<B> reducePipelineBuckets(ReduceContext reduceContext, PipelineTree pipelineTree) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -179,6 +180,11 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
             return this;
         }
         return create(rewritten);
+    }
+
+    @Override
+    public void forEachBucket(Consumer<InternalAggregations> consumer) {
+        consumer.accept(aggregations);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -102,6 +102,9 @@ public class SignificanceHeuristicTests extends ESTestCase {
         ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
         OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
         out.setVersion(version);
+        if (version.before(Version.V_7_8_0)) {
+            sigTerms.mergePipelineTreeForBWCSerialization(PipelineAggregator.PipelineTree.EMPTY);
+        }
         out.writeNamedWriteable(sigTerms);
 
         // read


### PR DESCRIPTION
This fixes pipeline aggregations used in cross cluster search from an older
version of Elasticsearch to a newer version of Elasticsearch. I broke
this in #53730 when I was too aggressive in shutting off serialization
of pipeline aggs. In particular, this comes up when the coordinating
node is pre-7.8.0 and the gateway node is on or after 7.8.0.

The fix is another step down the line to remove pipeline aggregators
from the aggregation tree. Sort of. It create a new
`List<PipelineAggregator>` member in `InternalAggregation` *but* it is
only used for bwc serialization and it is fed by the mechanism
established in #53730 to read the pipelines from the
