### PR TITLE
[Test] Don't expect specific scores in docs tests

### DIFF
--- a/docs/reference/search/suggesters/misc.asciidoc
+++ b/docs/reference/search/suggesters/misc.asciidoc
@@ -26,7 +26,6 @@ POST _search?typed_keys
 }
 --------------------------------------------------
 // TEST[setup:twitter]
-// TEST[skip:awaits fix of https://github.com/elastic/elasticsearch/issues/54257]
 
 In the response, the suggester names will be changed to respectively `term#my-first-suggester` and
 `phrase#my-second-suggester`, reflecting the types of each suggestion:
@@ -79,6 +78,8 @@ In the response, the suggester names will be changed to respectively `term#my-fi
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": "$body.took", "timed_out": false, "_shards": "$body._shards", "hits": "$body.hits"/]
+// TESTRESPONSE[s/"score": 0.8333333/"score": $body.suggest.term#my-first-suggester.2.options.0.score/]
+// TESTRESPONSE[s/"score": 0.030227963/"score": $body.suggest.phrase#my-second-suggester.0.options.0.score/]
 
 <1> The name `my-first-suggester` now contains the `term` prefix.
 <2> The name `my-second-suggester` now contains the `phrase` prefix.


### PR DESCRIPTION
The failing suggester documentation test was expecting specific scores in the
test response, which is fragile implementation details that e.g. can change with
different lucene versions and generally shouldn't be done in documentation test.
Instead we usually replace the float values in the output response by the ones
in the actual response.

Closes #54257