### PR TITLE
Correct Version Constant in NodeStats

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -113,7 +113,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
         ingestStats = in.readOptionalWriteable(IngestStats::new);
         adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
-        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
             scriptCacheStats = in.readOptionalWriteable(ScriptCacheStats::new);
         } else {
             scriptCacheStats = null;
@@ -266,7 +266,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(discoveryStats);
         out.writeOptionalWriteable(ingestStats);
         out.writeOptionalWriteable(adaptiveSelectionStats);
-        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
             out.writeOptionalWriteable(scriptCacheStats);
         }
     }


### PR DESCRIPTION
In #54008 we used v7.8 here but never backported to 7.x.
now that 7.x has moved to 7.8 BwC serialization is broken => adjusting the constant here until we backport.

Closes #54313