### PR TITLE
Fix Snapshot Completion Listener Lost on Master Failover (#54286)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1104,7 +1104,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     // will try ending this snapshot again
                     logger.debug(() -> new ParameterizedMessage(
                         "[{}] failed to update cluster state during snapshot finalization", snapshot), e);
-                    endingSnapshots.remove(snapshot);
+                    failSnapshotCompletionListeners(snapshot,
+                        new SnapshotException(snapshot, "Failed to update cluster state during snapshot finalization", e));
                 } else {
                     logger.warn(() -> new ParameterizedMessage("[{}] failed to finalize snapshot", snapshot), e);
                     removeSnapshotFromClusterState(snapshot, null, e);
@@ -1158,7 +1159,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             @Override
             public void onFailure(String source, Exception e) {
                 logger.warn(() -> new ParameterizedMessage("[{}] failed to remove snapshot metadata", snapshot), e);
-                endingSnapshots.remove(snapshot);
+                failSnapshotCompletionListeners(
+                    snapshot, new SnapshotException(snapshot, "Failed to remove snapshot from cluster state", e));
                 if (listener != null) {
                     listener.onFailure(e);
                 }
@@ -1166,7 +1168,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public void onNoLongerMaster(String source) {
-                endingSnapshots.remove(snapshot);
+                failSnapshotCompletionListeners(
+                    snapshot, ExceptionsHelper.useOrSuppress(failure, new SnapshotException(snapshot, "no longer master")));
                 if (listener != null) {
                     listener.onNoLongerMaster();
                 }
@@ -1174,24 +1177,36 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                final List<ActionListener<SnapshotInfo>> completionListeners = snapshotCompletionListeners.remove(snapshot);
-                if (completionListeners != null) {
-                    try {
-                        if (snapshotInfo == null) {
-                            ActionListener.onFailure(completionListeners, failure);
-                        } else {
+                if (snapshotInfo == null) {
+                    failSnapshotCompletionListeners(snapshot, failure);
+                } else {
+                    final List<ActionListener<SnapshotInfo>> completionListeners = snapshotCompletionListeners.remove(snapshot);
+                    if (completionListeners != null) {
+                        try {
                             ActionListener.onResponse(completionListeners, snapshotInfo);
+                        } catch (Exception e) {
+                            logger.warn("Failed to notify listeners", e);
                         }
-                    } catch (Exception e) {
-                        logger.warn("Failed to notify listeners", e);
                     }
+                    endingSnapshots.remove(snapshot);
                 }
-                endingSnapshots.remove(snapshot);
                 if (listener != null) {
                     listener.onResponse(snapshotInfo);
                 }
             }
         });
+    }
+
+    private void failSnapshotCompletionListeners(Snapshot snapshot, Exception e) {
+        final List<ActionListener<SnapshotInfo>> completionListeners = snapshotCompletionListeners.remove(snapshot);
+        if (completionListeners != null) {
+            try {
+                ActionListener.onFailure(completionListeners, e);
+            } catch (Exception ex) {
+                logger.warn("Failed to notify listeners", ex);
+            }
+        }
+        endingSnapshots.remove(snapshot);
     }
 
     /**


### PR DESCRIPTION
* Fix Snapshot Completion Listener Lost on Master Failover

If master fails over before (or we run into any other exception) when removing
the snapshot from the CS we must still resolve all the completion listeners for
the snapshot.

backport of #54286 