### PR TITLE
Test to enforce response to invalid data stream names

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
@@ -31,3 +31,19 @@
       indices.delete_data_stream:
         name: simple-data-stream2
   - is_true: acknowledged
+
+---
+"Create data stream with invalid name":
+  - skip:
+      version: " - 7.7.99"
+      reason: available only in 7.8+
+
+  - do:
+      catch: bad_request
+      indices.create_data_stream:
+        name: invalid-data-stream#-name
+        body:
+          timestamp_field: "@timestamp"
+
+  - match: { status: 400 }
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }


### PR DESCRIPTION
Adds the test mentioned here: https://github.com/elastic/elasticsearch/pull/54083#discussion_r398873313

Relates to #53100 
