### PR TITLE
Do not stash environment in security

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -130,7 +130,7 @@ public class SecurityTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(settings);
         return security.createComponents(client, threadPool, clusterService, mock(ResourceWatcherService.class), mock(ScriptService.class),
-            xContentRegistry(), new IndexNameExpressionResolver());
+            xContentRegistry(), env, new IndexNameExpressionResolver());
     }
 
     private static <T> T findComponent(Class<T> type, Collection<Object> components) {


### PR DESCRIPTION
Today the security plugin stashes a copy of the environment in its constructor, and uses the stashed copy to construct its components even though it is provided with an environment to create these components. What is more, the environment it creates in its constructor is not fully initialized, as it does not have the final copy of the settings, but the environment passed in while creating components does. This commit removes that stashed copy of the environment.
