### PR TITLE
[7.7] Fix testGenerateAndSignMetadata in FIPS mode (#54115)

### DIFF
--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/idp/SamlMetadataGeneratorTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/idp/SamlMetadataGeneratorTests.java
@@ -128,7 +128,11 @@ public class SamlMetadataGeneratorTests extends IdpSamlTestCase {
         //no exception thrown
         SignatureException e = expectThrows(SignatureException.class,
             () -> SignatureValidator.validate(signature, readCredentials("RSA", 2048)));
-        assertThat(e.getMessage(), containsString("Unable to evaluate key against signature"));
+        if (inFipsJvm()) {
+            assertThat(e.getMessage(), containsString("Signature cryptographic validation not successful"));
+        } else {
+            assertThat(e.getMessage(), containsString("Unable to evaluate key against signature"));
+        }
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Fix testGenerateAndSignMetadata in FIPS mode (#54115)