### PR TITLE
Muting 330_auto_date_histogram/basic for BWC

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
@@ -25,6 +25,9 @@ setup:
 
 ---
 "basic":
+  - skip:
+      version: " - 7.99.99"
+      reason: BWC test failures https://github.com/elastic/elasticsearch/issues/54396 && waiting for backport https://github.com/elastic/elasticsearch/pull/54379
   - do:
       search:
         body:


### PR DESCRIPTION
Muting test as numerous failures have occurred: https://github.com/elastic/elasticsearch/issues/54396

Seems related to: https://github.com/elastic/elasticsearch/pull/54379