### PR TITLE
Remove Redundant Buffer From Recovery Source

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -209,6 +209,16 @@ public abstract class StreamOutput extends OutputStream {
 
     private static final ThreadLocal<byte[]> scratch = ThreadLocal.withInitial(() -> new byte[1024]);
 
+    /**
+     * Returns a thread-local byte array to be used as an IO buffer. The returned buffer may no be escaped to another
+     * thread.
+     *
+     * @return thread-local IO Buffer
+     */
+    public static byte[] buffer() {
+        return scratch.get();
+    }
+
     public final void writeShort(short v) throws IOException {
         final byte[] buffer = scratch.get();
         buffer[0] = (byte) (v >> 8);


### PR DESCRIPTION
We don't need to buffer file chunks from the recovery source on heap
when reading them. We already buffer them on heap before writing the
transport message and at least there we use pooled buffers.
This saves half a MB per recovery source in buffers as well
as removes on round of copying on heap in the recovery source.

WIP: still some open questions here