### PR TITLE
Avoid holding onto bulk items until all completed

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -388,7 +388,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
      * */
     private final class BulkOperation extends ActionRunnable<BulkResponse> {
         private final Task task;
-        private volatile BulkRequest bulkRequest; // set to null once all requests are sent out
+        private BulkRequest bulkRequest; // set to null once all requests are sent out
         private final AtomicArray<BulkItemResponse> responses;
         private final long startTimeNanos;
         private final ClusterStateObserver observer;

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -464,6 +464,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                 if (request == null) {
                     continue;
                 }
+                bulkRequest.requests.set(i, null); // allow memory for bulk item to be reclaimed before all items have been completed
                 String concreteIndex = concreteIndices.getConcreteIndex(request.index()).getName();
                 ShardId shardId = clusterService.operationRouting().indexShards(clusterState, concreteIndex, request.id(),
                     request.routing()).shardId();


### PR DESCRIPTION
Bulk requests currently keep a reference to all bulk item requests until every one of them has completed. There is no need to do so, however, and, in case of large bulks, can mean unnecessary holding onto memory that might be better used elsewhere. More so as different shard-level bulks can complete at different speeds, and one slow shard-level request should not require holding onto every other shard-level request.