### PR TITLE
[7.7] Read the index.number_of_replicas from template so that wait_for_active_shards is interpreted correctly (#54231)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -388,13 +388,15 @@ public class MetaDataIndexTemplateService {
             int dummyPartitionSize = IndexMetaData.INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
             int dummyShards = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS,
                     dummyPartitionSize == 1 ? 1 : dummyPartitionSize + 1);
+            int shardReplicas = settings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0);
+
 
             //create index service for parsing and validating "mappings"
             Settings dummySettings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(settings)
                 .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, dummyShards)
-                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, shardReplicas)
                 .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                 .build();
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateServiceTests.java
@@ -75,6 +75,53 @@ public class MetaDataIndexTemplateServiceTests extends ESSingleNodeTestCase {
                                 "must be one of [true, false, checksum] but was: blargh"));
     }
 
+    public void testIndexTemplateValidationWithSpecifiedReplicas() throws Exception {
+        PutRequest request = new PutRequest("test", "test_replicas");
+        request.patterns(singletonList("test_shards_wait*"));
+
+        Settings.Builder settingsBuilder = builder()
+        .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "1")
+        .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, "1")
+        .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), "2");
+
+        request.settings(settingsBuilder.build());
+
+        List<Throwable> throwables = putTemplateDetail(request);
+
+        assertThat(throwables, is(empty()));
+    }
+
+    public void testIndexTemplateValidationErrorsWithSpecifiedReplicas() throws Exception {
+        PutRequest request = new PutRequest("test", "test_specified_replicas");
+        request.patterns(singletonList("test_shards_wait*"));
+
+        Settings.Builder settingsBuilder = builder()
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "1")
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, "1")
+            .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), "3");
+
+        request.settings(settingsBuilder.build());
+
+        List<Throwable> throwables = putTemplateDetail(request);
+
+        assertThat(throwables.get(0), instanceOf(IllegalArgumentException.class));
+        assertThat(throwables.get(0).getMessage(), containsString("[3]: cannot be greater than number of shard copies [2]"));
+    }
+
+    public void testIndexTemplateValidationWithDefaultReplicas() throws Exception {
+        PutRequest request = new PutRequest("test", "test_default_replicas");
+        request.patterns(singletonList("test_wait_shards_default_replica*"));
+
+        Settings.Builder settingsBuilder = builder()
+            .put(IndexMetaData.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), "2");
+
+        request.settings(settingsBuilder.build());
+
+        List<Throwable> throwables = putTemplateDetail(request);
+
+        assertThat(throwables.get(0), instanceOf(IllegalArgumentException.class));
+        assertThat(throwables.get(0).getMessage(), containsString("[2]: cannot be greater than number of shard copies [1]"));
+    }
     public void testIndexTemplateValidationAccumulatesValidationErrors() {
         PutRequest request = new PutRequest("test", "putTemplate shards");
         request.patterns(singletonList("_test_shards*"));


### PR DESCRIPTION
This commit takes into account the index.number_of_replicas (defaults to
0 - no replicas- ) value when setting an index template. This change
enables the index.wait_for_active_shards value to be interpreted
correctly

(cherry picked from commit 07026ac3d56dc9fae69467adfda7eaed7ea3ca00)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #54231 