### PR TITLE
[7.7][DOCS] Add a lowercase email example to keyword tokenizer docs (#53257)

### DIFF
--- a/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
@@ -44,6 +44,54 @@ The above sentence would produce the following term:
 [ New York ]
 ---------------------------
 
+[discrete]
+[[analysis-keyword-tokenizer-token-filters]]
+=== Combine with token filters
+You can combine the `keyword` tokenizer with token filters to normalise
+structured data, such as product IDs or email addresses.
+
+For example, the following <<indices-analyze,analyze API>> request uses
+`keyword` tokenizer and <<analysis-lowercase-tokenfilter,`lowercase`>> filter to
+convert an email address to lowercase.
+
+[source,console]
+---------------------------
+POST _analyze
+{
+  "tokenizer": "keyword",
+  "filter": [ "lowercase" ],
+  "text": "john.SMITH@example.COM"
+}
+---------------------------
+
+/////////////////////
+
+[source,console-result]
+----------------------------
+{
+  "tokens": [
+    {
+      "token": "john.smith@example.com",
+      "start_offset": 0,
+      "end_offset": 22,
+      "type": "word",
+      "position": 0
+    }
+  ]
+}
+----------------------------
+
+/////////////////////
+
+
+The request produces the following token:
+
+[source,text]
+---------------------------
+[ john.smith@example.com ]
+---------------------------
+
+
 [float]
 === Configuration
 

--- a/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/keyword-tokenizer.asciidoc
@@ -50,7 +50,7 @@ The above sentence would produce the following term:
 You can combine the `keyword` tokenizer with token filters to normalise
 structured data, such as product IDs or email addresses.
 
-For example, the following <<indices-analyze,analyze API>> request uses
+For example, the following <<indices-analyze,analyze API>> request uses the
 `keyword` tokenizer and <<analysis-lowercase-tokenfilter,`lowercase`>> filter to
 convert an email address to lowercase.
 


### PR DESCRIPTION
7.7 backport of #53257.