### PR TITLE
Fix a master->7.x serialization bug

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
@@ -25,9 +25,6 @@ setup:
 
 ---
 "basic":
-  - skip:
-      version: " - 7.99.99"
-      reason: BWC test failures https://github.com/elastic/elasticsearch/issues/54396 && waiting for backport https://github.com/elastic/elasticsearch/pull/54379
   - do:
       search:
         body:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -127,7 +127,7 @@ public class AutoDateHistogramAggregationBuilder
     @Override
     protected void innerWriteTo(StreamOutput out) throws IOException {
         out.writeVInt(numBuckets);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
             out.writeOptionalString(minimumIntervalExpression);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -110,20 +110,6 @@ public class AutoDateHistogramAggregationBuilder
 
     private String minimumIntervalExpression;
 
-    public String getMinimumIntervalExpression() {
-        return minimumIntervalExpression;
-    }
-
-    public AutoDateHistogramAggregationBuilder setMinimumIntervalExpression(String minimumIntervalExpression) {
-        if (minimumIntervalExpression != null && !ALLOWED_INTERVALS.containsValue(minimumIntervalExpression)) {
-            throw new IllegalArgumentException(MINIMUM_INTERVAL_FIELD.getPreferredName() +
-                " must be one of [" + ALLOWED_INTERVALS.values().toString() + "]");
-        }
-        this.minimumIntervalExpression = minimumIntervalExpression;
-        return this;
-    }
-
-
     /** Create a new builder with the given name. */
     public AutoDateHistogramAggregationBuilder(String name) {
         super(name);
@@ -135,6 +121,14 @@ public class AutoDateHistogramAggregationBuilder
         numBuckets = in.readVInt();
         if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
             minimumIntervalExpression = in.readOptionalString();
+        }
+    }
+
+    @Override
+    protected void innerWriteTo(StreamOutput out) throws IOException {
+        out.writeVInt(numBuckets);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeOptionalString(minimumIntervalExpression);
         }
     }
 
@@ -157,16 +151,21 @@ public class AutoDateHistogramAggregationBuilder
     }
 
     @Override
-    protected void innerWriteTo(StreamOutput out) throws IOException {
-        out.writeVInt(numBuckets);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeOptionalString(minimumIntervalExpression);
-        }
-    }
-
-    @Override
     public String getType() {
         return NAME;
+    }
+
+    public String getMinimumIntervalExpression() {
+        return minimumIntervalExpression;
+    }
+
+    public AutoDateHistogramAggregationBuilder setMinimumIntervalExpression(String minimumIntervalExpression) {
+        if (minimumIntervalExpression != null && !ALLOWED_INTERVALS.containsValue(minimumIntervalExpression)) {
+            throw new IllegalArgumentException(MINIMUM_INTERVAL_FIELD.getPreferredName() +
+                " must be one of [" + ALLOWED_INTERVALS.values().toString() + "]");
+        }
+        this.minimumIntervalExpression = minimumIntervalExpression;
+        return this;
     }
 
     public AutoDateHistogramAggregationBuilder setNumBuckets(int numBuckets) {


### PR DESCRIPTION
`master` wasn't sending `auto_date_histogram`'s
`minimumIntervalExpression` over the wire to `7.x` nodes even though
everything above `7.3` expected it. We never noticed this because we
didn't have any yml tests for `auto_date_histogram` until I added some
in #54161.

Closes #54396
