### PR TITLE
Do not execute ML CRUD actions when upgrade mode is enabled

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -139,6 +139,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
     }
 
     protected void cleanUp() {
+        setUpgradeModeTo(false);
         cleanUpResources();
         waitForPendingTasks();
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
@@ -35,6 +36,7 @@ import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
 import org.elasticsearch.xpack.core.ml.action.GetFiltersAction;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutFilterAction;
+import org.elasticsearch.xpack.core.ml.action.SetUpgradeModeAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedState;
@@ -63,6 +65,7 @@ import static org.elasticsearch.test.XContentTestUtils.convertToMap;
 import static org.elasticsearch.test.XContentTestUtils.differenceBetweenMapsIgnoringArrayOrder;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.security.test.SecurityTestUtils.writeFile;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Base class of ML integration tests that use a native autodetect process
@@ -152,6 +155,19 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
         } catch (Exception e) {
             throw new AssertionError("Failed to wait for pending tasks to complete", e);
         }
+    }
+
+    protected void setUpgradeModeTo(boolean enabled) {
+        AcknowledgedResponse response =
+            client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(enabled)).actionGet();
+        assertThat(response.isAcknowledged(), is(true));
+        assertThat(upgradeMode(), is(enabled));
+    }
+
+    protected boolean upgradeMode() {
+        ClusterState masterClusterState = client().admin().cluster().prepareState().all().get().getState();
+        MlMetadata mlMetadata = MlMetadata.getMlMetadata(masterClusterState);
+        return mlMetadata.isUpgradeMode();
     }
 
     protected DeleteExpiredDataAction.Response deleteExpiredData() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilter.java
@@ -130,9 +130,15 @@ class MlUpgradeModeActionFilter extends ActionFilter.Simple {
         return true;
     }
 
+    /**
+     * To prevent leaking information to unauthorized users, it is extremely important that this filter is executed *after* the
+     * {@code SecurityActionFilter}.
+     * To achieve that, the number returned by this method must be greater than the number returned by the
+     * {@code SecurityActionFilter::order} method.
+     */
     @Override
     public int order() {
-        return 666;
+        return Integer.MAX_VALUE;
     }
 
     // Visible for testing

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteCalendarAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteCalendarEventAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteFilterAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteForecastAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteModelSnapshotAction;
+import org.elasticsearch.xpack.core.ml.action.DeleteTrainedModelAction;
+import org.elasticsearch.xpack.core.ml.action.FinalizeJobExecutionAction;
+import org.elasticsearch.xpack.core.ml.action.FlushJobAction;
+import org.elasticsearch.xpack.core.ml.action.ForecastJobAction;
+import org.elasticsearch.xpack.core.ml.action.KillProcessAction;
+import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
+import org.elasticsearch.xpack.core.ml.action.PersistJobAction;
+import org.elasticsearch.xpack.core.ml.action.PostCalendarEventsAction;
+import org.elasticsearch.xpack.core.ml.action.PostDataAction;
+import org.elasticsearch.xpack.core.ml.action.PutCalendarAction;
+import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.PutFilterAction;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAction;
+import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
+import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.StopDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateCalendarJobAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateProcessAction;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link MlUpgradeModeActionFilter} disallows certain actions if the cluster is currently in upgrade mode.
+ *
+ * Disallowed actions are the ones which can access/alter the state of ML internal indices.
+ */
+class MlUpgradeModeActionFilter extends ActionFilter.Simple {
+
+    private static final Set<String> ACTIONS_DISALLOWED_IN_UPGRADE_MODE =
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            PutJobAction.NAME,
+            UpdateJobAction.NAME,
+            DeleteJobAction.NAME,
+            OpenJobAction.NAME,
+            FlushJobAction.NAME,
+            CloseJobAction.NAME,
+            PersistJobAction.NAME,
+
+            FinalizeJobExecutionAction.NAME,
+            PostDataAction.NAME,
+
+            RevertModelSnapshotAction.NAME,
+            UpdateModelSnapshotAction.NAME,
+            DeleteModelSnapshotAction.NAME,
+
+            PutDatafeedAction.NAME,
+            UpdateDatafeedAction.NAME,
+            DeleteDatafeedAction.NAME,
+            StartDatafeedAction.NAME,
+            StopDatafeedAction.NAME,
+
+            PutFilterAction.NAME,
+            UpdateFilterAction.NAME,
+            DeleteFilterAction.NAME,
+
+            PutCalendarAction.NAME,
+            UpdateCalendarJobAction.NAME,
+            PostCalendarEventsAction.NAME,
+            DeleteCalendarAction.NAME,
+            DeleteCalendarEventAction.NAME,
+
+            UpdateProcessAction.NAME,
+            KillProcessAction.NAME,
+
+            DeleteExpiredDataAction.NAME,
+
+            ForecastJobAction.NAME,
+            DeleteForecastAction.NAME,
+
+            PutDataFrameAnalyticsAction.NAME,
+            DeleteDataFrameAnalyticsAction.NAME,
+            StartDataFrameAnalyticsAction.NAME,
+            StopDataFrameAnalyticsAction.NAME,
+
+            PutTrainedModelAction.NAME,
+            DeleteTrainedModelAction.NAME
+        )));
+
+    private final AtomicBoolean isUpgradeMode = new AtomicBoolean();
+
+    MlUpgradeModeActionFilter(ClusterService clusterService) {
+        Objects.requireNonNull(clusterService);
+        clusterService.addListener(this::setIsUpgradeMode);
+    }
+
+    @Override
+    protected boolean apply(String action, ActionRequest request, ActionListener<?> listener) {
+        if (isUpgradeMode.get() && ACTIONS_DISALLOWED_IN_UPGRADE_MODE.contains(action)) {
+            throw new ElasticsearchStatusException(
+                "Cannot perform {} action while upgrade mode is enabled", RestStatus.TOO_MANY_REQUESTS, action);
+        }
+        return true;
+    }
+
+    @Override
+    public int order() {
+        return 666;
+    }
+
+    // Visible for testing
+    void setIsUpgradeMode(ClusterChangedEvent event) {
+        isUpgradeMode.set(MlMetadata.getMlMetadata(event.state()).isUpgradeMode());
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlUpgradeModeActionFilterTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionFilterChain;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.MlMetadata;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.SetUpgradeModeAction;
+import org.junit.After;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class MlUpgradeModeActionFilterTests extends ESTestCase {
+
+    private static final String DISALLOWED_ACTION = PutJobAction.NAME;
+    private static final String ALLOWED_ACTION = SetUpgradeModeAction.NAME;
+
+    private ClusterService clusterService;
+    private Task task;
+    private ActionRequest request;
+    private ActionListener<ActionResponse> listener;
+    private ActionFilterChain<ActionRequest, ActionResponse> chain;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUpMocks() {
+        clusterService = mock(ClusterService.class);
+        task = mock(Task.class);
+        request = mock(ActionRequest.class);
+        listener = mock(ActionListener.class);
+        chain = mock(ActionFilterChain.class);
+    }
+
+    @After
+    public void assertNoMoreInteractions() {
+        verifyNoMoreInteractions(task, request, listener, chain);
+    }
+
+    public void testApply_ActionDisallowedInUpgradeMode() {
+        MlUpgradeModeActionFilter filter = new MlUpgradeModeActionFilter(clusterService);
+        filter.apply(task, DISALLOWED_ACTION, request, listener, chain);
+
+        filter.setIsUpgradeMode(createClusterChangedEvent(createClusterState(true)));
+        ElasticsearchStatusException e =
+            expectThrows(
+                ElasticsearchStatusException.class,
+                () -> filter.apply(task, DISALLOWED_ACTION, request, listener, chain));
+
+        filter.setIsUpgradeMode(createClusterChangedEvent(createClusterState(false)));
+        filter.apply(task, DISALLOWED_ACTION, request, listener, chain);
+
+        assertThat(e.getMessage(), is(equalTo("Cannot perform " + DISALLOWED_ACTION + " action while upgrade mode is enabled")));
+        assertThat(e.status(), is(equalTo(RestStatus.TOO_MANY_REQUESTS)));
+
+        verify(chain, times(2)).proceed(task, DISALLOWED_ACTION, request, listener);
+    }
+
+    public void testApply_ActionAllowedInUpgradeMode() {
+        MlUpgradeModeActionFilter filter = new MlUpgradeModeActionFilter(clusterService);
+        filter.apply(task, ALLOWED_ACTION, request, listener, chain);
+
+        filter.setIsUpgradeMode(createClusterChangedEvent(createClusterState(true)));
+        filter.apply(task, ALLOWED_ACTION, request, listener, chain);
+
+        filter.setIsUpgradeMode(createClusterChangedEvent(createClusterState(false)));
+        filter.apply(task, ALLOWED_ACTION, request, listener, chain);
+
+        verify(chain, times(3)).proceed(task, ALLOWED_ACTION, request, listener);
+    }
+
+    private static ClusterChangedEvent createClusterChangedEvent(ClusterState clusterState) {
+        return new ClusterChangedEvent("created-from-test", clusterState, clusterState);
+    }
+
+    private static ClusterState createClusterState(boolean isUpgradeMode) {
+        return ClusterState.builder(new ClusterName("MlUpgradeModeActionFilterTests"))
+            .metadata(Metadata.builder().putCustom(MlMetadata.TYPE, new MlMetadata.Builder().isUpgradeMode(isUpgradeMode).build()))
+            .build();
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/set_upgrade_mode.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/set_upgrade_mode.yml
@@ -221,11 +221,6 @@ teardown:
 ---
 "Attempt to open job when upgrade_mode is enabled":
   - do:
-      ml.set_upgrade_mode:
-        enabled: true
-  - match: { acknowledged: true }
-
-  - do:
       ml.put_job:
         job_id: failing-set-upgrade-mode-job
         body:  >
@@ -243,6 +238,11 @@ teardown:
           }
 
   - do:
-      catch: /Cannot open jobs when upgrade mode is enabled/
+      ml.set_upgrade_mode:
+        enabled: true
+  - match: { acknowledged: true }
+
+  - do:
+      catch: /Cannot perform cluster:admin/xpack/ml/job/open action while upgrade mode is enabled/
       ml.open_job:
         job_id: failing-set-upgrade-mode-job


### PR DESCRIPTION
This PR does not allow ML CRUD actions to be executed when ML upgrade mode is enabled.
This is achieved using `MlUpgradeModeActionFilter` that keeps track of current cluster state so it knows whether upgrade mode is currently enabled.

Relates https://github.com/elastic/elasticsearch/issues/54326