### PR TITLE
Fix auto_date_histogram serialization bug

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/330_auto_date_histogram.yml
@@ -25,11 +25,9 @@ setup:
 
 ---
 "basic":
-  - skip:
-      version: " - 7.7.99"
-      reason: Tracked in https://github.com/elastic/elasticsearch/issues/54382
   - do:
       search:
+        rest_total_hits_as_int: true
         body:
           size: 0
           aggs:
@@ -37,7 +35,7 @@ setup:
               auto_date_histogram:
                 field: date
                 buckets: 2
-  - match: { hits.total.value: 4 }
+  - match: { hits.total: 4 }
   - length: { aggregations.histo.buckets: 2 }
   - match: { aggregations.histo.buckets.0.key_as_string: "2020-03-01T00:00:00.000Z" }
   - match: { aggregations.histo.buckets.0.doc_count: 2 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregationBuilder.java
@@ -113,20 +113,6 @@ public class AutoDateHistogramAggregationBuilder
 
     private String minimumIntervalExpression;
 
-    public String getMinimumIntervalExpression() {
-        return minimumIntervalExpression;
-    }
-
-    public AutoDateHistogramAggregationBuilder setMinimumIntervalExpression(String minimumIntervalExpression) {
-        if (minimumIntervalExpression != null && !ALLOWED_INTERVALS.containsValue(minimumIntervalExpression)) {
-            throw new IllegalArgumentException(MINIMUM_INTERVAL_FIELD.getPreferredName() +
-                " must be one of [" + ALLOWED_INTERVALS.values().toString() + "]");
-        }
-        this.minimumIntervalExpression = minimumIntervalExpression;
-        return this;
-    }
-
-
     /** Create a new builder with the given name. */
     public AutoDateHistogramAggregationBuilder(String name) {
         super(name, CoreValuesSourceType.NUMERIC, ValueType.DATE);
@@ -138,6 +124,14 @@ public class AutoDateHistogramAggregationBuilder
         numBuckets = in.readVInt();
         if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
             minimumIntervalExpression = in.readOptionalString();
+        }
+    }
+
+    @Override
+    protected void innerWriteTo(StreamOutput out) throws IOException {
+        out.writeVInt(numBuckets);
+        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+            out.writeOptionalString(minimumIntervalExpression);
         }
     }
 
@@ -154,16 +148,21 @@ public class AutoDateHistogramAggregationBuilder
     }
 
     @Override
-    protected void innerWriteTo(StreamOutput out) throws IOException {
-        out.writeVInt(numBuckets);
-        if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
-            out.writeOptionalString(minimumIntervalExpression);
-        }
-    }
-
-    @Override
     public String getType() {
         return NAME;
+    }
+
+    public String getMinimumIntervalExpression() {
+        return minimumIntervalExpression;
+    }
+
+    public AutoDateHistogramAggregationBuilder setMinimumIntervalExpression(String minimumIntervalExpression) {
+        if (minimumIntervalExpression != null && !ALLOWED_INTERVALS.containsValue(minimumIntervalExpression)) {
+            throw new IllegalArgumentException(MINIMUM_INTERVAL_FIELD.getPreferredName() +
+                " must be one of [" + ALLOWED_INTERVALS.values().toString() + "]");
+        }
+        this.minimumIntervalExpression = minimumIntervalExpression;
+        return this;
     }
 
     public AutoDateHistogramAggregationBuilder setNumBuckets(int numBuckets) {
@@ -262,7 +261,17 @@ public class AutoDateHistogramAggregationBuilder
             roughEstimateDurationMillis = in.readVLong();
             innerIntervals = in.readIntArray();
             unitAbbreviation = in.readString();
-            dateTimeUnit = in.readString();
+            if (in.getVersion().onOrAfter(Version.V_7_3_0)) {
+                dateTimeUnit = in.readString();
+            } else {
+                /*
+                 * This *should* be safe because we only deserialize RoundingInfo
+                 * when reading result and results don't actually use this at all.
+                 * We just set it to something non-null to line up with the normal
+                 * ctor. "seconds" is the smallest unit anyway.
+                 */
+                dateTimeUnit =  "second";
+            }
         }
 
         @Override
@@ -271,7 +280,9 @@ public class AutoDateHistogramAggregationBuilder
             out.writeVLong(roughEstimateDurationMillis);
             out.writeIntArray(innerIntervals);
             out.writeString(unitAbbreviation);
-            out.writeString(dateTimeUnit);
+            if (out.getVersion().onOrAfter(Version.V_7_3_0)) {
+                out.writeString(dateTimeUnit);
+            }
         }
 
         public int getMaximumInnerInterval() {


### PR DESCRIPTION
This fixes a serialization bug in `auto_date_histogram` that comes up in
a cluster mixed between pre-7.3.0 and post-7.3.0.

Includes #54429 to keep 7.x looking like master for simpler backports.

Closes #54382
