### PR TITLE
[DOCS] Fix broken deprecated macros

### DIFF
--- a/docs/reference/index-modules/translog.asciidoc
+++ b/docs/reference/index-modules/translog.asciidoc
@@ -80,9 +80,7 @@ update, or bulk request. This setting accepts the following parameters:
 [[index-modules-translog-retention]]
 ==== Translog retention
 
-deprecated::[7.4.0, translog retention settings are deprecated in favor of
-<<index-modules-history-retention,soft deletes>>. These settings are
-effectively ignored since 7.4 and will be removed in a future version].
+deprecated::[7.4.0, "Translog retention settings are deprecated in favor of <<index-modules-history-retention,soft deletes>>. These settings are effectively ignored since 7.4 and will be removed in a future version."]
 
 If an index is not using <<index-modules-history-retention,soft deletes>> to
 retain historical operations then {es} recovers each replica shard by replaying

--- a/docs/reference/indices/synced-flush.asciidoc
+++ b/docs/reference/indices/synced-flush.asciidoc
@@ -4,9 +4,7 @@
 <titleabbrev>Synced flush</titleabbrev>
 ++++
 
-deprecated::[7.6, synced-flush is deprecated and will be removed in 8.0.
-Use <<indices-flush,flush>> instead. A <<indices-flush,flush>> has the
-same effect as a synced flush on Elasticsearch 7.6 or later]
+deprecated::[7.6, "Synced-flush is deprecated and will be removed in 8.0. Use <<indices-flush,flush>> instead. A flush has the same effect as a synced flush on Elasticsearch 7.6 or later."]
 
 Performs a synced flush on one or more indices.
 


### PR DESCRIPTION
Updates formatting for `deprecated` macros in the translog and
synced flush docs.

Previously, these macros were rendering literally.