### PR TITLE
Fix issue with pipeline releasing bytes early

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
@@ -189,10 +189,10 @@ public class InboundPipelineTests extends ESTestCase {
 
             OutboundMessage message;
             if (isRequest) {
-                message = new OutboundMessage.Request(threadContext, new TestRequest(value),
+                message = new OutboundMessage.Request(threadContext, new String[0], new TestRequest(value),
                     version, actionName, requestId, false, false);
             } else {
-                message = new OutboundMessage.Response(threadContext, new TestResponse(value),
+                message = new OutboundMessage.Response(threadContext, Collections.emptySet(), new TestResponse(value),
                     version, requestId, false, false);
             }
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundPipelineTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -169,6 +171,53 @@ public class InboundPipelineTests extends ESTestCase {
                     assertEquals(0, released.refCount());
                 }
             }
+        }
+    }
+
+    public void testEnsureBodyIsNotPrematurelyReleased() throws IOException {
+        final PageCacheRecycler recycler = PageCacheRecycler.NON_RECYCLING_INSTANCE;
+        BiConsumer<TcpChannel, InboundMessage> messageHandler = (c, m) -> {};
+        BiConsumer<TcpChannel, Tuple<Header, Exception>> errorHandler = (c, e) -> {};
+        final InboundPipeline pipeline = new InboundPipeline(Version.CURRENT, recycler, messageHandler, errorHandler);
+
+        try (BytesStreamOutput streamOutput = new BytesStreamOutput()) {
+            String actionName = "actionName";
+            final Version version = Version.CURRENT;
+            final String value = randomAlphaOfLength(1000);
+            final boolean isRequest = randomBoolean();
+            final long requestId = randomNonNegativeLong();
+
+            OutboundMessage message;
+            if (isRequest) {
+                message = new OutboundMessage.Request(threadContext, new TestRequest(value),
+                    version, actionName, requestId, false, false);
+            } else {
+                message = new OutboundMessage.Response(threadContext, new TestResponse(value),
+                    version, requestId, false, false);
+            }
+
+            final BytesReference reference = message.serialize(streamOutput);
+            final int fixedHeaderSize = TcpHeader.headerSize(Version.CURRENT);
+            final int variableHeaderSize = reference.getInt(fixedHeaderSize - 4);
+            final int totalHeaderSize = fixedHeaderSize + variableHeaderSize;
+            final AtomicBoolean bodyReleased = new AtomicBoolean(false);
+            for (int i = 0; i < totalHeaderSize - 1; ++i) {
+                try (ReleasableBytesReference slice = ReleasableBytesReference.wrap(reference.slice(i, 1))) {
+                    pipeline.handleBytes(new FakeTcpChannel(), slice);
+                }
+            }
+
+            final Releasable releasable = () -> bodyReleased.set(true);
+            final int from = totalHeaderSize - 1;
+            final BytesReference partHeaderPartBody = reference.slice(from, reference.length() - from - 1);
+            try (ReleasableBytesReference slice = new ReleasableBytesReference(partHeaderPartBody, releasable)) {
+                pipeline.handleBytes(new FakeTcpChannel(), slice);
+            }
+            assertFalse(bodyReleased.get());
+            try (ReleasableBytesReference slice = new ReleasableBytesReference(reference.slice(reference.length() - 1, 1), releasable)) {
+                pipeline.handleBytes(new FakeTcpChannel(), slice);
+            }
+            assertTrue(bodyReleased.get());
         }
     }
 


### PR DESCRIPTION
Currently there is an issue with the InboundPipeline releasing bytes
earlier than appropriate. This can lead to the bytes being reused before
the message is handled. This commit fixes that issue and adds a test to
detect when it is occurring.