### PR TITLE
Mute failing test JvmGcMonitorServiceSettingsTests.testNegativeSetting

### DIFF
--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
@@ -60,6 +60,7 @@ public class JvmGcMonitorServiceSettingsTests extends ESTestCase {
             () -> assertFalse(scheduled.get()));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54485")
     public void testNegativeSetting() throws InterruptedException {
         String collector = randomAlphaOfLength(5);
         final String timeValue = "-" + randomTimeValue();


### PR DESCRIPTION
Mute failing test JvmGcMonitorServiceSettingsTests.testNegativeSetting()

Opened ticket #54485