### PR TITLE
[DOCS] Adds data_counts object to the GET DFA stats API

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -851,22 +851,22 @@ An object containing statistical data about the documents in the analysis.
 .Properties of `data_counts`
 [%collapsible%open]
 ====
-`training_docs_count`:::
+`skipped_docs_count`:::
 (integer)
-The number of documents that are used for training the model.
+The number of documents that are skipped during the analysis because they 
+contained values that are not supported by the analysis. For example, 
+{oldetection} does not support missing fields so it skips documents with missing 
+fields. Likewise, all types of analysis skip documents that contain arrays with 
+more than one element.
 
 `test_docs_count`:::
 (integer)
 The number of documents that are not used for training the model and can be used 
 for testing.
 
-`skipped_docs_count`:::
+`training_docs_count`:::
 (integer)
-The number of documents that are skipped during the analysis because they 
-contained values that are not supported by the analysis. Unsupported values are 
-arrays with more than one element and missing values in fields that are included 
-in an analysis that does not support missing fields (for example, 
-{oldetection}).
+The number of documents that are used for training the model.
 ====
 //End data_counts
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -843,6 +843,33 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-fold]
 For running jobs only, contains messages relating to the selection of a node to 
 run the job.
 
+//Begin data_counts
+`data_counts`:::
+(object)
+An object containing statistical data about the documents in the analysis.
++
+.Properties of `data_counts`
+[%collapsible%open]
+====
+`training_docs_count`:::
+(integer)
+The number of documents that are used for training the model.
+
+`test_docs_count`:::
+(integer)
+The number of documents that are not used for training the model and can be used 
+for testing.
+
+`skipped_docs_count`:::
+(integer)
+The number of documents that are skipped during the analysis because they 
+contained values that are not supported by the analysis. Unsupported values are 
+arrays with more than one element and missing values in fields that are included 
+in an analysis that does not support missing fields (for example, 
+{oldetection}).
+====
+//End data_counts
+
 `id`:::
 (string)
 The unique identifier of the {dfanalytics-job}.


### PR DESCRIPTION
This PR contains the description of the `data_counts` object and its properties that are exposed by the DFA stats API.

Preview: http://elasticsearch_54498.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html