### PR TITLE
Remove references to mapping type in painless ingest and update scripts

### DIFF
--- a/docs/painless/painless-contexts/painless-ingest-processor-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-ingest-processor-context.asciidoc
@@ -12,9 +12,6 @@ to modify documents upon insertion.
 {ref}/mapping-index-field.html[`ctx['_index']`] (`String`)::
         The name of the index.
 
-{ref}/mapping-type-field.html[`ctx['_type']`] (`String`)::
-        The type of document within an index.
-
 `ctx` (`Map`)::
         Contains extracted JSON in a `Map` and `List` structure for the fields
         that are part of the document.
@@ -23,9 +20,6 @@ to modify documents upon insertion.
 
 {ref}/mapping-index-field.html[`ctx['_index']`]::
         Modify this to change the destination index for the current document.
-
-{ref}/mapping-type-field.html[`ctx['_type']`]::
-        Modify this to change the type for the current document.
 
 `ctx` (`Map`)::
         Modify the values in the `Map/List` structure to add, modify, or delete

--- a/docs/painless/painless-contexts/painless-reindex-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-reindex-context.asciidoc
@@ -19,9 +19,6 @@ reindexed into a target index.
 {ref}/mapping-index-field.html[`ctx['_index']`] (`String`)::
         The name of the index.
 
-{ref}/mapping-type-field.html[`ctx['_type']`] (`String`)::
-        The type of document within an index.
-
 {ref}/mapping-id-field.html[`ctx['_id']`] (`int`, read-only)::
         The unique document id.
 
@@ -44,9 +41,6 @@ reindexed into a target index.
 
 {ref}/mapping-index-field.html[`ctx['_index']`]::
         Modify this to change the destination index for the current document.
-
-{ref}/mapping-type-field.html[`ctx['_type']`]::
-        Modify this to change the type for the current document.
 
 {ref}/mapping-id-field.html[`ctx['_id']`]::
         Modify this to change the id for the current document.

--- a/docs/painless/painless-contexts/painless-update-by-query-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-update-by-query-context.asciidoc
@@ -20,9 +20,6 @@ result of query.
 {ref}/mapping-index-field.html[`ctx['_index']`] (`String`, read-only)::
         The name of the index.
 
-{ref}/mapping-type-field.html[`ctx['_type']`] (`String`, read-only)::
-        The type of document within an index.
-
 {ref}/mapping-id-field.html[`ctx['_id']`] (`int`, read-only)::
         The unique document id.
 

--- a/docs/painless/painless-contexts/painless-update-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-update-context.asciidoc
@@ -18,9 +18,6 @@ add, modify, or delete fields within a single document.
 {ref}/mapping-index-field.html[`ctx['_index']`] (`String`, read-only)::
         The name of the index.
 
-{ref}/mapping-type-field.html[`ctx['_type']`] (`String`, read-only)::
-        The type of document within an index.
-
 {ref}/mapping-id-field.html[`ctx['_id']`] (`int`, read-only)::
         The unique document id.
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
-import org.elasticsearch.script.DeprecationMap;
 import org.elasticsearch.script.IngestScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
@@ -38,7 +37,6 @@ import org.elasticsearch.script.ScriptService;
 
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
@@ -47,9 +45,6 @@ import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationExcept
  * Processor that evaluates a script with an ingest document in its context.
  */
 public final class ScriptProcessor extends AbstractProcessor {
-
-    private static final Map<String, String> DEPRECATIONS =
-            Collections.singletonMap("_type", "[types removal] Looking up doc types [_type] in scripts is deprecated.");
 
     public static final String TYPE = "script";
 
@@ -77,8 +72,7 @@ public final class ScriptProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(IngestDocument document) {
         IngestScript.Factory factory = scriptService.compile(script, IngestScript.CONTEXT);
-        factory.newInstance(script.getParams()).execute(
-                new DeprecationMap(document.getSourceAndMetadata(), DEPRECATIONS, "script_processor"));
+        factory.newInstance(script.getParams()).execute(document.getSourceAndMetadata());
         CollectionUtils.ensureNoSelfReferences(document.getSourceAndMetadata(), "ingest script");
         return document;
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
@@ -74,28 +74,4 @@ public class ScriptProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getSourceAndMetadata(), hasKey("bytes_total"));
         assertThat(ingestDocument.getSourceAndMetadata().get("bytes_total"), is(randomBytesTotal));
     }
-
-    public void testTypeDeprecation() throws Exception {
-        String scriptName = "script";
-        ScriptService scriptService = new ScriptService(Settings.builder().build(),
-                Collections.singletonMap(
-                        Script.DEFAULT_SCRIPT_LANG, new MockScriptEngine(
-                                Script.DEFAULT_SCRIPT_LANG,
-                                Collections.singletonMap(
-                                        scriptName, ctx -> {
-                                            ctx.get("_type");
-                                            return null;
-                                        }
-                                ),
-                                Collections.emptyMap()
-                        )
-                ),
-                new HashMap<>(ScriptModule.CORE_CONTEXTS)
-        );
-        Script script = new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Collections.emptyMap());
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
-        ScriptProcessor processor = new ScriptProcessor(randomAlphaOfLength(10), script, scriptService);
-        processor.execute(ingestDocument);
-        assertWarnings("[types removal] Looking up doc types [_type] in scripts is deprecated.");
-    }
 }

--- a/server/src/main/java/org/elasticsearch/script/UpdateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateScript.java
@@ -27,9 +27,6 @@ import java.util.Map;
  */
 public abstract class UpdateScript {
 
-    private static final Map<String, String> DEPRECATIONS =
-            Map.of("_type", "[types removal] Looking up doc types [_type] in scripts is deprecated.");
-
     public static final String[] PARAMETERS = { };
 
     /** The context used to compile {@link UpdateScript} factories. */
@@ -43,7 +40,7 @@ public abstract class UpdateScript {
 
     public UpdateScript(Map<String, Object> params, Map<String, Object> ctx) {
         this.params = params;
-        this.ctx = new DeprecationMap(ctx, DEPRECATIONS, "update-script");
+        this.ctx = ctx;
     }
 
     /** Return the parameters for this script. */


### PR DESCRIPTION
Painless scripts no longer make the mapping type of a document available for
reference or mutation; however, there are still some references to the `_type`
field in the documentation for a number of script contexts.  This commit removes
these references, and additionally stops emitting deprecation messages when
a script tries to get the `_type` field.