### PR TITLE
[7.x][ML] Fix DF analytics explain API request in docs (#54510)

### DIFF
--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -61,9 +61,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 [[ml-explain-dfanalytics-request-body]]
 ==== {api-request-body-title}
 
-`data_frame_analytics_config`::
-  (Optional, object) Intended configuration of {dfanalytics-job}. Note that `id` 
-  and `dest` don't need to be provided in the context of this API.
+A {dataframe-analytics-config} as described in <<put-dfanalytics>>.
+Note that `id` and `dest` don't need to be provided in the context of this API.
 
 
 [[ml-explain-dfanalytics-results]]
@@ -87,14 +86,12 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=memory-estimation]
 --------------------------------------------------
 POST _ml/data_frame/analytics/_explain
 {
-  "data_frame_analytics_config": {
-    "source": {
-      "index": "houses_sold_last_10_yrs"
-    },
-    "analysis": {
-      "regression": {
-        "dependent_variable": "price"
-      }
+  "source": {
+    "index": "houses_sold_last_10_yrs"
+  },
+  "analysis": {
+    "regression": {
+      "dependent_variable": "price"
     }
   }
 }


### PR DESCRIPTION
The explain API expects a data frame analytics config
as its request.

Backport of #54410
