### PR TITLE
Be lenient when deleting index and component templates after tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -553,11 +553,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                     adminClient().performRequest(new Request("DELETE", "_index_template/*"));
                     adminClient().performRequest(new Request("DELETE", "_component_template/*"));
                 } catch (ResponseException e) {
-                    if (e.getResponse().getStatusLine().getStatusCode() == 405) {
-                        // We hit a version of ES that doesn't support index templates v2 yet, so it's safe to ignore
-                    } else {
-                        throw e;
-                    }
+                    // We hit a version of ES that doesn't support index templates v2 yet, so it's safe to ignore
                 }
             } else {
                 logger.debug("Clearing all templates");
@@ -566,11 +562,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                     adminClient().performRequest(new Request("DELETE", "_index_template/*"));
                     adminClient().performRequest(new Request("DELETE", "_component_template/*"));
                 } catch (ResponseException e) {
-                    if (e.getResponse().getStatusLine().getStatusCode() == 405) {
-                        // We hit a version of ES that doesn't support index templates v2 yet, so it's safe to ignore
-                    } else {
-                        throw e;
-                    }
+                    // We hit a version of ES that doesn't support index templates v2 yet, so it's safe to ignore
                 }
             }
         }


### PR DESCRIPTION
We previously checked for a 405 response, but on 7.x BWC tests may be hitting versions that don't
support the 405 response (returning 400 or 500), so be more lenient in those cases.

Relates to #54513
