### PR TITLE
[DOCS] EQL: Document `startsWith` function

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -26,7 +26,7 @@ startsWith("regsvr32.exe", "regsvr32")  // returns true
 startsWith("regsvr32.exe", "explorer")  // returns false
 startsWith("", "")                      // returns true
 
-// process.path = "regsvr32.exe"
+// process.name = "regsvr32.exe"
 startsWith(process.name, "regsvr32")    // returns true
 startsWith(process.name, "explorer")    // returns false
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -8,7 +8,71 @@ experimental::[]
 
 {es} supports the following EQL functions:
 
+* <<eql-fn-startswith>>
 * <<eql-fn-substring>>
+
+[discrete]
+[[eql-fn-startswith]]
+=== `startsWith`
+
+Returns `true` if a specified source string begins with a provided substring.
+
+[%collapsible]
+====
+
+*Example*
+[source,eql]
+----
+startsWith("regsvr32.exe", "regsvr32")  // returns true
+startsWith("regsvr32.exe", "explorer")  // returns false
+startsWith("", "")                      // returns true
+
+// process.path = "regsvr32.exe"
+startsWith(process.name, "regsvr32")    // returns true
+startsWith(process.name, "explorer")    // returns false
+
+// process.name = "regsvr32"
+startsWith("regsvr32.exe", process.name) // returns true
+startsWith("explorer.exe", process.name) // returns false
+
+// process.name = [ "explorer.exe", "regsvr32.exe" ]
+startsWith(process.name, "explorer")    // returns true
+startsWith(process.name, "regsvr32")    // returns false
+
+// null handling
+startsWith("regsvr32.exe", null)        // returns null
+startsWith("", null)                    // returns null 
+startsWith(null, "regsvr32")            // returns null
+startsWith(null, null)                  // returns null
+----
+
+*Syntax*
+
+[source,txt]
+----
+substring(<source>, <substring>)
+----
+
+*Parameters*
+
+`<source>`::
+(Required, string or `null`)
+Source string. If `null`, the function returns `null`.
++
+If using a field as the argument, this parameter only supports the
+<<keyword,`keyword`>> and <<constant-keyword,`constant_keyword`>> field
+datatypes. Fields containing array values use the first array item only.
+
+`<substring>`::
+(Required, string or `null`)
+Substring to search for. If `null`, the function returns `null`.
++
+If using a field as the argument, this parameter only supports the
+<<keyword,`keyword`>> and <<constant-keyword,`constant_keyword`>> field
+datatypes.
+
+*Returns:* boolean or `null`
+====
 
 [discrete]
 [[eql-fn-substring]]

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -19,7 +19,6 @@ Returns `true` if a specified source string begins with a provided substring.
 
 [%collapsible]
 ====
-
 *Example*
 [source,eql]
 ----
@@ -50,7 +49,7 @@ startsWith(null, null)                  // returns null
 
 [source,txt]
 ----
-substring(<source>, <substring>)
+startsWith(<source>, <substring>)
 ----
 
 *Parameters*

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -57,20 +57,36 @@ startsWith(<source>, <substring>)
 *Parameters*
 
 `<source>`::
++
+--
 (Required, string or `null`)
 Source string. If `null`, the function returns `null`.
-+
-If using a field as the argument, this parameter only supports the
-<<keyword,`keyword`>> and <<constant-keyword,`constant_keyword`>> field
-datatypes. Fields containing array values use the first array item only.
+
+If using a field as the argument, this parameter only supports the following
+field datatypes:
+
+* <<keyword,`keyword`>>
+* <<constant-keyword,`constant_keyword`>>
+* <<text,`text`>> field with a <<keyword,`keyword`>> or
+  <<constant-keyword,`constant_keyword`>> sub-field
+
+Fields containing array values use the first array item only.
+--
 
 `<substring>`::
++
+--
 (Required, string or `null`)
 Substring to search for. If `null`, the function returns `null`.
-+
-If using a field as the argument, this parameter only supports the
-<<keyword,`keyword`>> and <<constant-keyword,`constant_keyword`>> field
-datatypes.
+
+If using a field as the argument, this parameter only supports the following
+field datatypes:
+
+* <<keyword,`keyword`>>
+* <<constant-keyword,`constant_keyword`>>
+* <<text,`text`>> field with a <<keyword,`keyword`>> or
+  <<constant-keyword,`constant_keyword`>> sub-field
+--
 
 *Returns:* boolean or `null`
 ====

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -15,7 +15,8 @@ experimental::[]
 [[eql-fn-startswith]]
 === `startsWith`
 
-Returns `true` if a source string begins with a provided substring. Matching is case insensitive.
+Returns `true` if a source string begins with a provided substring. Matching is
+case insensitive.
 
 [%collapsible]
 ====

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -15,7 +15,7 @@ experimental::[]
 [[eql-fn-startswith]]
 === `startsWith`
 
-Returns `true` if a source string begins with a provided substring.
+Returns `true` if a source string begins with a provided substring. Matching is case insensitive.
 
 [%collapsible]
 ====
@@ -23,6 +23,7 @@ Returns `true` if a source string begins with a provided substring.
 [source,eql]
 ----
 startsWith("regsvr32.exe", "regsvr32")  // returns true
+startsWith("regsvr32.exe", "RegSvr32")  // returns true
 startsWith("regsvr32.exe", "explorer")  // returns false
 startsWith("", "")                      // returns true
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -15,7 +15,7 @@ experimental::[]
 [[eql-fn-startswith]]
 === `startsWith`
 
-Returns `true` if a specified source string begins with a provided substring.
+Returns `true` if a source string begins with a provided substring.
 
 [%collapsible]
 ====


### PR DESCRIPTION
Adds documentation for the EQL `startsWith` function.

Relates to #54400