### PR TITLE
[DOCS] Clarifies API key breaking change

### DIFF
--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -19,22 +19,22 @@ See also <<release-highlights>> and <<es-release-notes>>.
 === Security changes
 
 [discrete]
-==== {es} authentication API key privilege escalation
+==== {es} authentication API key privileges
 
 If you use the {es} API key service to generate API keys, the behavior of new
 API keys is impacted by the fix for
-[https://www.elastic.co/community/security]CVE-2020-7009.
+https://www.elastic.co/community/security[CVE-2020-7009].
 
 When you make a request to create API keys, you can specify an expiration and
 permissions for the API key. Previously, if you used an API key to create
 another API key (sometimes called a _derived key_), by default it had no
 privileges. It could nonetheless perform some operations such as running
-the <<security-api-authenticate,authenticate API>>. This is no longer the
-default behavior.
+the {ref}/security-api-authenticate.html[authenticate API]. This is no longer
+the default behavior.
 
 To create derived keys with no privileges, specify an empty object in the
 `role_descriptors` array when you run the
-<<security-api-create-api-key,create API key API>>. For example:
+{ref}/security-api-create-api-key.html[create API key API]. For example:
 
 [source,js]
 ----

--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -19,22 +19,20 @@ See also <<release-highlights>> and <<es-release-notes>>.
 === Security changes
 
 [discrete]
-==== {es} authentication API key privileges
+==== {es} API key privileges
 
-If you use the {es} API key service to generate API keys, the behavior of new
-API keys is impacted by the fix for
+If you use an API key to create another API key (sometimes called a
+_derived key_), its behavior is impacted by the fix for
 https://www.elastic.co/community/security[CVE-2020-7009].
 
 When you make a request to create API keys, you can specify an expiration and
-permissions for the API key. Previously, if you used an API key to create
-another API key (sometimes called a _derived key_), by default it had no
-privileges. It could nonetheless perform some operations such as running
-the {ref}/security-api-authenticate.html[authenticate API]. This is no longer
-the default behavior.
+privileges for the API key. Previously, when you created a derived key, it had
+no privileges. This behavior disregarded any privileges that you specified in
+the {ref}/security-api-create-api-key.html[create API key API].
 
-To create derived keys with no privileges, specify an empty object in the
-`role_descriptors` array when you run the
-{ref}/security-api-create-api-key.html[create API key API]. For example:
+As of 7.6.2, this behavior changes. To create derived keys with no privileges,
+you must explicitly specify an empty object in the `role_descriptors` array.
+For example:
 
 [source,js]
 ----

--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -31,8 +31,7 @@ no privileges. This behavior disregarded any privileges that you specified in
 the {ref}/security-api-create-api-key.html[create API key API].
 
 As of 7.6.2, this behavior changes. To create derived keys with no privileges,
-you must explicitly specify an empty object in the `role_descriptors` array.
-For example:
+you must explicitly specify an empty role descriptor. For example:
 
 [source,js]
 ----

--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -45,6 +45,7 @@ To create derived keys with no privileges, specify an empty object in the
 }
 ...
 ----
+// NOTCONSOLE
 
 //end::notable-breaking-changes[]
 

--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -14,12 +14,43 @@ See also <<release-highlights>> and <<es-release-notes>>.
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
+[discrete]
+[[breaking_76_security_changes]]
+=== Security changes
+
+[discrete]
+==== {es} authentication API key privilege escalation
+
+If you use the {es} API key service to generate API keys, the behavior of new
+API keys is impacted by the fix for
+[https://www.elastic.co/community/security]CVE-2020-7009.
+
+When you make a request to create API keys, you can specify an expiration and
+permissions for the API key. Previously, if you used an API key to create
+another API key (sometimes called a _derived key_), by default it had no
+privileges. It could nonetheless perform some operations such as running
+the <<security-api-authenticate,authenticate API>>. This is no longer the
+default behavior.
+
+To create derived keys with no privileges, specify an empty object in the
+`role_descriptors` array when you run the
+<<security-api-create-api-key,create API key API>>. For example:
+
+[source,js]
+----
+...
+"role_descriptors": { 
+    "no-privilege": {
+    }
+}
+...
+----
 
 //end::notable-breaking-changes[]
 
 [discrete]
 [[breaking_76_search_changes]]
-=== Search Changes
+=== Search changes
 
 [discrete]
 ==== Deprecation of sparse vector fields

--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -3,6 +3,13 @@
 
 Also see <<breaking-changes-7.6,Breaking changes in 7.6>>.
 
+[[breaking-7.6.2]]
+[float]
+=== Breaking changes
+
+Authorization::
+* Creation of child API keys (keys created by existing keys) now requires explicit "no privileges" configuration {pull}53647[#53647], https://www.elastic.co/community/security[CVE-2020-7009]
+
 [[bug-7.6.2]]
 [float]
 === Bug fixes
@@ -12,9 +19,6 @@ Allocation::
 
 Authentication::
 * Fix potential bug in concurrent token refresh support {pull}53668[#53668]
-
-Authorization::
-* Explicitly require that delegate API keys have no privileges {pull}53647[#53647]
 
 CCR::
 * Handle no such remote cluster exception in ccr {pull}53415[#53415] (issue: {issue}53225[#53225])

--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -8,7 +8,7 @@ Also see <<breaking-changes-7.6,Breaking changes in 7.6>>.
 === Breaking changes
 
 Authorization::
-* Creation of child API keys (keys created by existing keys) now requires explicit "no privileges" configuration {pull}53647[#53647], https://www.elastic.co/community/security[CVE-2020-7009]
+* Creation of derived API keys (keys created by existing keys) now requires explicit "no privileges" configuration {pull}53647[#53647], https://www.elastic.co/community/security[CVE-2020-7009]
 
 [[bug-7.6.2]]
 [float]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/53647

This PR adds a description for the breaking change related to API key privileges.

Preview:
* http://elasticsearch_54522.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.6/breaking-changes-7.6.html
* http://elasticsearch_54522.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.6/release-notes-7.6.2.html#breaking-7.6.2
