### PR TITLE
Updated enabled=0 to enabled=1

### DIFF
--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -53,7 +53,7 @@ name=Elasticsearch repository for {major-version} packages
 baseurl=https://artifacts.elastic.co/packages/{major-version}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
-enabled=0
+enabled=1
 autorefresh=1
 type=rpm-md
 --------------------------------------------------


### PR DESCRIPTION
When `enabled=0` is in the repo config file it will not be part of `yum update` and other `yum` commands, except when you explicitly enable this repository. For usability, I personally like to have it included in my repositories. Or at least point that one out in the documentation.

