### PR TITLE
[DOCS] Include 7.7.0 release notes

### DIFF
--- a/docs/reference/migration/migrate_7_6.asciidoc
+++ b/docs/reference/migration/migrate_7_6.asciidoc
@@ -9,8 +9,6 @@ your application to Elasticsearch 7.6.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming[7.6.0]
-
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.7.0>>
 * <<release-notes-7.6.2>>
 * <<release-notes-7.6.1>>
 * <<release-notes-7.6.0>>
@@ -31,6 +32,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/7.7.asciidoc[]
 include::release-notes/7.6.asciidoc[]
 include::release-notes/7.5.asciidoc[]
 include::release-notes/7.4.asciidoc[]

--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -145,8 +145,6 @@ Authentication::
 [[release-notes-7.6.0]]
 == {es} version 7.6.0
 
-coming[7.6.0]
-
 Also see <<breaking-changes-7.6,Breaking changes in 7.6>>.
 
 [[known-issues-7.6.0]]


### PR DESCRIPTION
Includes the 7.7.0 release notes so they render in the HTML docs.

Also removes a few legacy `coming[7.6.0]` tags.