### PR TITLE
[DOCS] Add redirect for changed anchor ID

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -543,6 +543,11 @@ See <<ml-get-bucket>>,
 
 See <<snapshot-restore>>.
 
+[role="exclude",id="_repository_plugins"]
+==== Repository plugins
+
+See <<snapshots-repository-plugins>>.
+
 [role="exclude",id="restore-snapshot"]
 === Restore snapshot
 


### PR DESCRIPTION
The anchor ID for the snapshot repository plugins section in the docs
was recently changed from `_repository_plugins` to
`snapshots-repository-plugins`.

This adds a corresponding redirect so no links are broken.