### PR TITLE
Add allowed warnings to index template v2 YAML tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -2,8 +2,11 @@ setup:
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -37,8 +40,11 @@ setup:
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test2] has index patterns [test2-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test2] will take precedence during new index creation"
       indices.put_index_template:
         name: test2
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
@@ -3,8 +3,11 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -32,8 +35,11 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test] has index patterns [test-*, test2-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -69,8 +75,11 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test2] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test2] will take precedence during new index creation"
       indices.put_index_template:
         name: test2
         body:


### PR DESCRIPTION
There is a setting in `ESClientYamlSuiteTestCase` under `usually()` that can install a `global`
template changing the number of shards for all indices. This can cause warnings when installing v2
templates (see #54367). This adds these as optional warnings so they don't cause failures regardless
of whether the global template is installed or not.

These warnings can be removed when our internal template usage has been moved to index templates v2

Relates to #53101
