### PR TITLE
[DOCS] Remove unused cat tasks request parameters

### DIFF
--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -29,27 +29,17 @@ of the JSON <<tasks,task management>> API.
 [[cat-tasks-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=actions]
-
 include::{docdir}/rest-api/common-parms.asciidoc[tag=detailed]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
-
-include::{docdir}/rest-api/common-parms.asciidoc[tag=group-by]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id-query-parm]
-
-include::{docdir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
-
 include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
-
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
 
 include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
 


### PR DESCRIPTION
These options were documented as available on the `_cat/tasks` endpoint because they are also used on the underlying task list action, but they are never registered and thus are not allowed in the request by the REST framework. Since we never allowed them, this PR just removes them from the reference docs.