### PR TITLE
Add allowed warnings to index template v2 YAML tests (#54535)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -1,9 +1,12 @@
 setup:
   - skip:
-      version: " - 7.99.99"
-      reason: "index template v2 API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -35,10 +38,13 @@ setup:
 ---
 "Get all tindex emplates":
   - skip:
-      version: " - 7.99.99"
-      reason: "index template v2 API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test2] has index patterns [test2-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test2] will take precedence during new index creation"
       indices.put_index_template:
         name: test2
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
@@ -1,10 +1,13 @@
 ---
 "Put index template":
   - skip:
-      version: " - 7.99.99"
-      reason: "index template v2 API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -30,10 +33,13 @@
 ---
 "Put multiple index templates":
   - skip:
-      version: " - 7.99.99"
-      reason: "index template v2 API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test] has index patterns [test-*, test2-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -67,10 +73,13 @@
 ---
 "Put index template with 'create' flag":
   - skip:
-      version: " - 7.99.99"
-      reason: "index template v2 API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test2] has index patterns [test-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test2] will take precedence during new index creation"
       indices.put_index_template:
         name: test2
         body:


### PR DESCRIPTION
This is a backport (forwardport) of #54535

There is a setting in `ESClientYamlSuiteTestCase` under `usually()` that can install a `global`
template changing the number of shards for all indices. This can cause warnings when installing v2
templates (see #54367). This adds these as optional warnings so they don't cause failures regardless
of whether the global template is installed or not.

These warnings can be removed when our internal template usage has been moved to index templates v2

Relates to #53101
