### PR TITLE
Add hidden value to expand_wildcards params

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
@@ -105,6 +105,7 @@
         "options":[
           "open",
           "closed",
+          "hidden",
           "none",
           "all"
         ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.freeze.json
@@ -42,6 +42,7 @@
         "options":[
           "open",
           "closed",
+          "hidden",
           "none",
           "all"
         ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.reload_search_analyzers.json
@@ -35,6 +35,7 @@
         "options":[
           "open",
           "closed",
+          "hidden",
           "none",
           "all"
         ],

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/indices.unfreeze.json
@@ -42,6 +42,7 @@
         "options":[
           "open",
           "closed",
+          "hidden",
           "none",
           "all"
         ],


### PR DESCRIPTION
This commit adds the `hidden` enum value to all `expand_wildcards` params.

