### PR TITLE
[DOCS] correct the field name in date_nanos doc

### DIFF
--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -71,7 +71,7 @@ GET my_index/_search
 {
   "docvalue_fields" : [
     {
-      "field" : "my_ip_field",
+      "field" : "date",
       "format": "strict_date_time" <7>
     }
   ]


### PR DESCRIPTION
The field name in the request body should be `date` in the date_nanos document:
https://www.elastic.co/guide/en/elasticsearch/reference/master/date_nanos.html