### PR TITLE
[DOCS] Adds snippet comparing two indices to the painless examples

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -14,6 +14,8 @@ more about the Painless scripting language in the
 * <<painless-time-features>>
 * <<painless-group-by>>
 * <<painless-bucket-script>>
+* <<painless-count-http>>
+* <<painless-compare>>
 
 NOTE: While the context of the following examples is the {transform} use case, 
 the Painless scripts in the snippets below can be used in other {es} search 
@@ -399,3 +401,68 @@ by each shard and assigns the different response types to the appropriate
 properties of the `counts` object; error responses to the error counts, success 
 responses to the success counts, and other responses to the other counts. 
 Finally, returns the `counts` array with the response counts.
+
+
+[discrete]
+[[painless-compare]]
+==== Comparing indices by using scripted metric aggregations
+
+This example shows how to compare two 
+
+[source,console]
+--------------------------------------------------
+POST _transform/_preview
+{
+  "id" : "index_compare",
+  "source" : { <1>
+    "index" : [
+      "index1",
+      "index2"
+    ],
+    "query" : {
+      "match_all" : { }
+    }
+  },
+  "dest" : { <2>
+    "index" : "compare"
+  },
+  "pivot" : {
+    "group_by" : {
+      "unique-id" : {
+        "terms" : {
+          "field" : "<unique-id-field>" <3>
+        }
+      }
+    },
+    "aggregations" : {
+      "compare" : { <4>
+        "scripted_metric" : {
+          "init_script" : "", <5>
+          "map_script" : "state.doc = new HashMap(params['_source'])", <6>
+          "combine_script" : "return state", <7>
+          "reduce_script" : """ <8>
+            if (states.size() != 2) {
+              return "count_mismatch"
+            }
+            if (states.get(0).equals(states.get(1))) {
+              return "match"
+            } else {
+              return "mismatch"
+            }
+            """
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TEST[skip:setup kibana sample data]
+
+<1>
+<2>
+<3>
+<4>
+<5>
+<6>
+<7>
+<8>

--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -61,8 +61,8 @@ scripted metric aggregation in a {transform}, which provides a metric output.
 `last_doc` in the `state` object.
 <2> The `map_script` defines `current_date` based on the timestamp of the 
 document, then compares `current_date` with `state.timestamp_latest`, finally 
-returns `state.last_doc` from the shard. By using `new HashMap(...)` we copy the 
-source document, this is important whenever you want to pass the full source 
+returns `state.last_doc` from the shard. By using `new HashMap(...)` you copy 
+the source document, this is important whenever you want to pass the full source 
 object from one phase to the next.
 <3> The `combine_script` returns `state` from each shard.
 <4> The `reduce_script` iterates through the value of `s.timestamp_latest` 
@@ -407,7 +407,8 @@ Finally, returns the `counts` array with the response counts.
 [[painless-compare]]
 ==== Comparing indices by using scripted metric aggregations
 
-This example shows how to compare two 
+This example shows how to compare the content of two indices by a {transform} 
+that uses a scripted metric aggregation. 
 
 [source,console]
 --------------------------------------------------
@@ -437,10 +438,10 @@ POST _transform/_preview
     "aggregations" : {
       "compare" : { <4>
         "scripted_metric" : {
-          "init_script" : "", <5>
-          "map_script" : "state.doc = new HashMap(params['_source'])", <6>
-          "combine_script" : "return state", <7>
-          "reduce_script" : """ <8>
+          "init_script" : "",
+          "map_script" : "state.doc = new HashMap(params['_source'])", <5>
+          "combine_script" : "return state", <6>
+          "reduce_script" : """ <7>
             if (states.size() != 2) {
               return "count_mismatch"
             }
@@ -458,11 +459,15 @@ POST _transform/_preview
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
 
-<1>
-<2>
-<3>
-<4>
-<5>
-<6>
-<7>
-<8>
+<1> The indices referenced in the `source` object are compared to each other.
+<2> The `dest` index contains the results of the comparison.
+<3> The `group_by` field needs to be a unique identifier for each document.
+<4> Object of the `scripted_metric` aggregation.
+<5> The `map_script` defines `doc` in the state object. By using 
+`new HashMap(...)` you copy the source document, this is important whenever you 
+want to pass the full source object from one phase to the next.
+<6> The `combine_script` returns `state` from each shard.
+<7> The `reduce_script` checks if the size of the indices are equal. If they are 
+not equal, than it reports back a `count_mismatch`. Then it iterates through all 
+the values of the two indices and compare them. If the values are equal, then it 
+returns a `match`, otherwise returns a `mismatch`.


### PR DESCRIPTION
This PR contains a snippet that compares two indices by using scripted metric aggregation. It puts the snippet to the _Painless examples for transforms_ page.

Preview: http://elasticsearch_54563.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-painless-examples.html#painless-compare