### PR TITLE
ILM don't fail the mount step on ACCEPTED response

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -92,7 +92,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
             false);
         getClient().execute(MountSearchableSnapshotAction.INSTANCE, mountSearchableSnapshotRequest,
             ActionListener.wrap(response -> {
-                if (response.status() != RestStatus.OK) {
+                if (response.status() != RestStatus.OK || response.status() != RestStatus.ACCEPTED) {
                     logger.debug("mount snapshot response failed to complete");
                     throw new ElasticsearchException("mount snapshot response failed to complete, got response " + response.status());
                 }


### PR DESCRIPTION
The mount api will accept the request and go ahead and create the index.
This makes the MountSnapshotStep complete in case ACCEPTED is the response
status as the next step will wait for the index to be created and reach the
GREEN state.