### PR TITLE
Update policy-definitions.asciidoc

### DIFF
--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -204,20 +204,7 @@ PUT _ilm/policy/my_policy
 }
 --------------------------------------------------
 
-NOTE: To add attributes `box_type` with values of `hot` and `warm` add lines to `elasticsearch.yaml`:
-
-[source,yaml]
---------------------------------------------------------
-node.attr.data: hot
-node.attr.data: warm
---------------------------------------------------------
-
-Or, instead set custom attributes when you start a node:
-
-[source,sh]
---------------------------------------------------------
-./bin/elasticsearch -Enode.attr.data=hot -Enode.attr.data=warm
---------------------------------------------------------
+This depends on `hot` and `warm` attributes specified in the node configurations. For example, to designate a node as a _hot_ node, set `node.attr.data: hot` in `elasticsearch.yml`. For more information, see <<index-allocation-filters>>
 
 ===== Example: Assign index to a specific node and update replica settings
 

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -204,6 +204,21 @@ PUT _ilm/policy/my_policy
 }
 --------------------------------------------------
 
+NOTE: To add attributes `box_type` with values of `hot` and `warm` add lines to `elasticsearch.yaml` like so:
++
+[source,yaml]
+--------------------------------------------------------
+node.attr.data: hot
+node.attr.data: warm
+--------------------------------------------------------
++
+You can also set custom attributes when you start a node:
++
+[source,sh]
+--------------------------------------------------------
+`./bin/elasticsearch -Enode.attr.data=hot -Enode.attr.data=warm
+--------------------------------------------------------
+
 ===== Example: Assign index to a specific node and update replica settings
 
 This example updates the index to have one replica per shard and be allocated

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -204,7 +204,7 @@ PUT _ilm/policy/my_policy
 }
 --------------------------------------------------
 
-This depends on `hot` and `warm` attributes specified in the node configurations. For example, to designate a node as a _hot_ node, set `node.attr.data: hot` in `elasticsearch.yml`. For more information, see <<index-allocation-filters>>
+This depends on `hot` and `warm` attributes specified in the node configurations. For example, to designate a node as a _hot_ node, set `node.attr.data: hot` in `elasticsearch.yml`. For more information, see <<index-allocation-filters>>.
 
 ===== Example: Assign index to a specific node and update replica settings
 

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -206,17 +206,17 @@ PUT _ilm/policy/my_policy
 
 NOTE: To add attributes `box_type` with values of `hot` and `warm` add lines to `elasticsearch.yaml` like so:
 
-[source,yaml]
+[source,yaml,indent=4]
 --------------------------------------------------------
 node.attr.data: hot
 node.attr.data: warm
 --------------------------------------------------------
 
-You can also set custom attributes when you start a node:
+    You can also set custom attributes when you start a node:
 
-[source,sh]
+[source,sh,indent=4]
 --------------------------------------------------------
-`./bin/elasticsearch -Enode.attr.data=hot -Enode.attr.data=warm
+./bin/elasticsearch -Enode.attr.data=hot -Enode.attr.data=warm
 --------------------------------------------------------
 
 ===== Example: Assign index to a specific node and update replica settings

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -204,17 +204,17 @@ PUT _ilm/policy/my_policy
 }
 --------------------------------------------------
 
-NOTE: To add attributes `box_type` with values of `hot` and `warm` add lines to `elasticsearch.yaml` like so:
+NOTE: To add attributes `box_type` with values of `hot` and `warm` add lines to `elasticsearch.yaml`:
 
-[source,yaml,indent=4]
+[source,yaml]
 --------------------------------------------------------
 node.attr.data: hot
 node.attr.data: warm
 --------------------------------------------------------
 
-    You can also set custom attributes when you start a node:
+Or, instead set custom attributes when you start a node:
 
-[source,sh,indent=4]
+[source,sh]
 --------------------------------------------------------
 ./bin/elasticsearch -Enode.attr.data=hot -Enode.attr.data=warm
 --------------------------------------------------------

--- a/docs/reference/ilm/policy-definitions.asciidoc
+++ b/docs/reference/ilm/policy-definitions.asciidoc
@@ -205,15 +205,15 @@ PUT _ilm/policy/my_policy
 --------------------------------------------------
 
 NOTE: To add attributes `box_type` with values of `hot` and `warm` add lines to `elasticsearch.yaml` like so:
-+
+
 [source,yaml]
 --------------------------------------------------------
 node.attr.data: hot
 node.attr.data: warm
 --------------------------------------------------------
-+
+
 You can also set custom attributes when you start a node:
-+
+
 [source,sh]
 --------------------------------------------------------
 `./bin/elasticsearch -Enode.attr.data=hot -Enode.attr.data=warm


### PR DESCRIPTION
The docs show how to create an ILM policy, but not how to add the attr `node.attr.data: warm` (or hot).

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?

Yes

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?

Yes

- If submitting code

No code, strictly docs

This PR adds an example to the ILM instructions.  The instructions show how to create a policy, and the policy refers to `node.attr.data` being `hot` or `warm`.    I added an example showing how to set the attr in both elasticsearch.yaml and on the commandline.