### PR TITLE
Include autoscaling APIs in API docs

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -11,6 +11,9 @@ We are working on including more {es} APIs in this section. Some content might
 not be included yet.
 
 * <<api-conventions, API conventions>>
+ifdef::permanently-unreleased-branch[]
+* <<autoscaling-apis, Autoscaling APIs>>
+endif::[]
 * <<cat, cat APIs>>
 * <<cluster, Cluster APIs>>
 * <<ccr-apis,{ccr-cap} APIs>>
@@ -36,7 +39,9 @@ not be included yet.
 --
 
 include::{es-repo-dir}/api-conventions.asciidoc[]
+ifdef::permanently-unreleased-branch[]
 include::{es-repo-dir}/autoscaling/apis/autoscaling-apis.asciidoc[]
+endif::[]
 include::{es-repo-dir}/cat.asciidoc[]
 include::{es-repo-dir}/cluster.asciidoc[]
 include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]


### PR DESCRIPTION
This commit adds a top-level link to the autoscaling API reference page to the API docs. Additionally, we add a conditional guard on the API pages to only include them in development builds of the docs.
