### PR TITLE
[7.7] Handle -1 gc_threshold settings explicitly (#54546)

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -177,6 +177,10 @@ public class JvmGcMonitorService extends AbstractLifecycleComponent {
 
         if (threshold == null) {
             throw new IllegalArgumentException("missing gc_threshold for [" + getThresholdName(key, level) + "]");
+        } else if (threshold.nanos() < 0) {
+            final String settingValue = settings.get(level);
+            throw new IllegalArgumentException("invalid gc_threshold [" + getThresholdName(key, level) + "] value [" +
+                settingValue + "]: value cannot be negative");
         }
 
         return threshold;

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
@@ -62,12 +62,23 @@ public class JvmGcMonitorServiceSettingsTests extends ESTestCase {
 
     public void testNegativeSetting() throws InterruptedException {
         String collector = randomAlphaOfLength(5);
-        final String timeValue = "-" + randomTimeValue();
+        final String timeValue = "-" + randomTimeValue(2,1000); // -1 is handled separately
         Settings settings = Settings.builder().put("monitor.jvm.gc.collector." + collector + ".warn", timeValue).build();
         execute(settings, (command, interval, name) -> null, e -> {
             assertThat(e, instanceOf(IllegalArgumentException.class));
             assertThat(e.getMessage(), equalTo("failed to parse setting [monitor.jvm.gc.collector." + collector + ".warn] " +
                 "with value [" + timeValue + "] as a time value"));
+        }, true, null);
+    }
+
+    public void testNegativeOneSetting() throws InterruptedException {
+        String collector = randomAlphaOfLength(5);
+        final String timeValue = "-1" + randomFrom("", "d", "h", "m", "s", "ms", "nanos");
+        Settings settings = Settings.builder().put("monitor.jvm.gc.collector." + collector + ".warn", timeValue).build();
+        execute(settings, (command, interval, name) -> null, e -> {
+            assertThat(e, instanceOf(IllegalArgumentException.class));
+            assertThat(e.getMessage(), equalTo("invalid gc_threshold [monitor.jvm.gc.collector." + collector + ".warn] " +
+                "value [" + timeValue + "]: value cannot be negative"));
         }, true, null);
     }
 


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Handle -1 gc_threshold settings explicitly (#54546)