### PR TITLE
[Backport] Turn on trace logging for failing test

### DIFF
--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderAction.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/TransportPutSamlServiceProviderAction.java
@@ -63,12 +63,14 @@ public class TransportPutSamlServiceProviderAction
             listener.onFailure(new IllegalArgumentException("NameID format [" + document.nameIdFormat + "] is not supported."));
             return;
         }
+        logger.trace("Searching for existing ServiceProvider with id [{}] for [{}]", document.entityId, request);
         index.findByEntityId(document.entityId, ActionListener.wrap(matchingDocuments -> {
             if (matchingDocuments.isEmpty()) {
                 // derive a document id from the entity id so that don't accidentally create duplicate entities due to a race condition
                 document.docId = deriveDocumentId(document);
                 // force a create in case there are concurrent requests. This way, if two nodes/threads are trying to create the SP at
                 // the same time, one will fail. That's not ideal, but it's better than having 1 silently overwrite the other.
+                logger.trace("No existing ServiceProvider for EntityID=[{}], writing new doc [{}]", document.entityId, document.docId);
                 writeDocument(document, DocWriteRequest.OpType.CREATE, request.getRefreshPolicy(), listener);
             } else if (matchingDocuments.size() == 1) {
                 final SamlServiceProviderDocument existingDoc = Iterables.get(matchingDocuments, 0).getDocument();
@@ -76,6 +78,7 @@ public class TransportPutSamlServiceProviderAction
                 assert existingDoc.entityId.equals(document.entityId) : "Loaded document with non-matching entity-id";
                 document.setDocId(existingDoc.docId);
                 document.setCreated(existingDoc.created);
+                logger.trace("Found existing ServiceProvider for EntityID=[{}], writing to doc [{}]", document.entityId, document.docId);
                 writeDocument(document, DocWriteRequest.OpType.INDEX, request.getRefreshPolicy(), listener);
             } else {
                 logger.warn("Found multiple existing service providers in [{}] with entity id [{}] - [{}]",

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
 import org.elasticsearch.xpack.core.security.action.CreateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
@@ -61,6 +62,9 @@ import static org.joda.time.DateTime.now;
 import static org.opensaml.saml.saml2.core.NameIDType.TRANSIENT;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numClientNodes = 0, numDataNodes = 0, transportClientRatio = 0)
+@TestLogging(value = "org.elasticsearch.xpack.idp.action.TransportPutSamlServiceProviderAction:TRACE," +
+    "org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderIndex:TRACE",
+    reason = "https://github.com/elastic/elasticsearch/issues/54423")
 public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
 
     private final SamlFactory samlFactory = new SamlFactory();


### PR DESCRIPTION
SamlIdentityProviderTests is failing with 409 conflicts that have not
been reproducible outside of CI.
This change turn on additional logging in this test to determine why
these conflict occur.

Relates: #54423
Backport of: #54475
