### PR TITLE
[7.6][DOCS]Fix 7.5 highlights mistake about `shape` feild type 

### DIFF
--- a/docs/reference/release-notes/highlights-7.5.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.5.0.asciidoc
@@ -21,7 +21,7 @@ which can enrich documents with data from another index.
 ==== Shape support in SQL
 
 {ref}/xpack-sql.html[SQL] functionality that worked for geo_shape will
-now work for the {ref}/shape.html[`shape`] field type introduced in 7.3.
+now work for the {ref}/shape.html[`shape`] field type introduced in 7.4.
 
 
 // end::notable-highlights[]


### PR DESCRIPTION
according to the Elasticsearch 7.4 highlights doc. `shape` filed type is added by 7.4 , not 7.3.
