### PR TITLE
Remove toXContent from autoscaling request classess

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/DeleteAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/DeleteAutoscalingPolicyAction.java
@@ -12,8 +12,6 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/DeleteAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/DeleteAutoscalingPolicyAction.java
@@ -27,7 +27,7 @@ public class DeleteAutoscalingPolicyAction extends ActionType<AcknowledgedRespon
         super(NAME, AcknowledgedResponse::new);
     }
 
-    public static class Request extends AcknowledgedRequest<DeleteAutoscalingPolicyAction.Request> implements ToXContentObject {
+    public static class Request extends AcknowledgedRequest<DeleteAutoscalingPolicyAction.Request> {
 
         private final String name;
 
@@ -53,16 +53,6 @@ public class DeleteAutoscalingPolicyAction extends ActionType<AcknowledgedRespon
         @Override
         public ActionRequestValidationException validate() {
             return null;
-        }
-
-        @Override
-        public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
-            builder.startObject();
-            {
-
-            }
-            builder.endObject();
-            return builder;
         }
 
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingDecisionAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingDecisionAction.java
@@ -31,7 +31,7 @@ public class GetAutoscalingDecisionAction extends ActionType<GetAutoscalingDecis
         super(NAME, Response::new);
     }
 
-    public static class Request extends AcknowledgedRequest<GetAutoscalingDecisionAction.Request> implements ToXContentObject {
+    public static class Request extends AcknowledgedRequest<GetAutoscalingDecisionAction.Request> {
 
         public Request() {
 
@@ -49,16 +49,6 @@ public class GetAutoscalingDecisionAction extends ActionType<GetAutoscalingDecis
         @Override
         public ActionRequestValidationException validate() {
             return null;
-        }
-
-        @Override
-        public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
-            builder.startObject();
-            {
-
-            }
-            builder.endObject();
-            return builder;
         }
 
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
@@ -30,7 +30,7 @@ public class PutAutoscalingPolicyAction extends ActionType<AcknowledgedResponse>
         super(NAME, AcknowledgedResponse::new);
     }
 
-    public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
+    public static class Request extends AcknowledgedRequest<Request> {
 
         static final ParseField POLICY_FIELD = new ParseField("policy");
 
@@ -73,16 +73,6 @@ public class PutAutoscalingPolicyAction extends ActionType<AcknowledgedResponse>
         public ActionRequestValidationException validate() {
             // TODO: validate that the policy deciders are non-empty
             return null;
-        }
-
-        @Override
-        public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
-            builder.startObject();
-            {
-                builder.field(POLICY_FIELD.getPreferredName(), policy);
-            }
-            builder.endObject();
-            return builder;
         }
 
     }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/PutAutoscalingPolicyAction.java
@@ -14,8 +14,6 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 


### PR DESCRIPTION
These methods are not needed, we were only following a pattern in the rest of the codebase, but it's legacy from the HLRC sharing request/response objects with the server.

