### PR TITLE
Fix Eclipse compile problem in ModelLoadingService

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -108,7 +108,7 @@ public class ModelLoadingService implements ClusterStateListener {
         this.localModelCache = CacheBuilder.<String, LocalModel<? extends InferenceConfig>>builder()
             .setMaximumWeight(this.maxCacheSize.getBytes())
             .weigher((id, localModel) -> localModel.ramBytesUsed())
-            // explicit declaration of the listener lambda necessary for Eclipse IDE
+            // explicit declaration of the listener lambda necessary for Eclipse IDE 4.14
             .removalListener(notification -> cacheEvictionListener(notification))
             .setExpireAfterAccess(INFERENCE_MODEL_CACHE_TTL.get(settings))
             .build();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -108,7 +108,8 @@ public class ModelLoadingService implements ClusterStateListener {
         this.localModelCache = CacheBuilder.<String, LocalModel<? extends InferenceConfig>>builder()
             .setMaximumWeight(this.maxCacheSize.getBytes())
             .weigher((id, localModel) -> localModel.ramBytesUsed())
-            .removalListener(this::cacheEvictionListener)
+            // explicit declaration of the listener lambda necessary for Eclipse IDE
+            .removalListener(notification -> cacheEvictionListener(notification))
             .setExpireAfterAccess(INFERENCE_MODEL_CACHE_TTL.get(settings))
             .build();
         clusterService.addListener(this);


### PR DESCRIPTION
The current Eclipse 4.14.0 compiler has problems with the method reference here, changing to
a lambda expression instead.