### PR TITLE
[DOCS] Clarify ML and transform settings on coordinating nodes

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -243,7 +243,8 @@ node.data: true <3>
 node.ingest: false <4>
 node.ml: false <5>
 node.transform: false <6>
-node.remote_cluster_client: false <7>
+xpack.transform.enabled: true <7>
+node.remote_cluster_client: false <8>
 -------------------
 <1> Disable the `node.master` role (enabled by default).
 <2> The `node.voting_only` role is disabled by default.
@@ -251,7 +252,8 @@ node.remote_cluster_client: false <7>
 <4> Disable the `node.ingest` role (enabled by default).
 <5> Disable the `node.ml` role (enabled by default).
 <6> Disable the `node.transform` role.
-<7> Disable remote cluster connections (enabled by default).
+<7> The `xpack.transform.enabled` setting is enabled by default.
+<8> Disable remote cluster connections (enabled by default).
 
 To create a dedicated data node in the {oss-dist}, set:
 [source,yaml]
@@ -341,7 +343,8 @@ node.ingest: false <4>
 node.ml: false <5>
 xpack.ml.enabled: true <6>
 node.transform: false <7>
-node.remote_cluster_client: false <8>
+xpack.transform.enabled: true <8>
+node.remote_cluster_client: false <9>
 -------------------
 <1> Disable the `node.master` role (enabled by default).
 <2> The `node.voting_only` role is disabled by default.
@@ -350,7 +353,8 @@ node.remote_cluster_client: false <8>
 <5> Disable the `node.ml` role (enabled by default).
 <6> The `xpack.ml.enabled` setting is enabled by default.
 <7> Disable the `node.transform` role.
-<8> Disable remote cluster connections (enabled by default).
+<8> The `xpack.transform.enabled` setting is enabled by default.
+<9> Disable remote cluster connections (enabled by default).
 
 To create a dedicated coordinating node in the {oss-dist}, set:
 
@@ -413,9 +417,11 @@ node.remote_cluster_client: false <9>
 
 If you want to use {transforms} in your cluster, you must have
 `xpack.transform.enabled` set to `true` on all master-eligible nodes and all
-data nodes. You must also have `node.transform` set to `true` on at least one
-node. This is the default behavior. If you have the {oss-dist}, do not use these
-settings. For more information, see <<transform-settings>>.
+data nodes. If you want to use {transforms} in clients (including {kib}), it
+must also be enabled on all coordinating nodes. You must also have
+`node.transform` set to `true` on at least one node. This is the default
+behavior. If you have the {oss-dist}, do not use these settings. For more
+information, see <<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -339,16 +339,18 @@ node.voting_only: false <2>
 node.data: false <3>
 node.ingest: false <4>
 node.ml: false <5>
-node.transform: false <6>
-node.remote_cluster_client: false <7>
+xpack.ml.enabled: true <6>
+node.transform: false <7>
+node.remote_cluster_client: false <8>
 -------------------
 <1> Disable the `node.master` role (enabled by default).
 <2> The `node.voting_only` role is disabled by default.
 <3> Disable the `node.data` role (enabled by default).
 <4> Disable the `node.ingest` role (enabled by default).
 <5> Disable the `node.ml` role (enabled by default).
-<6> Disable the `node.transform` role.
-<7> Disable remote cluster connections (enabled by default).
+<6> The `xpack.ml.enabled` setting is enabled by default.
+<7> Disable the `node.transform` role.
+<8> Disable remote cluster connections (enabled by default).
 
 To create a dedicated coordinating node in the {oss-dist}, set:
 
@@ -373,8 +375,9 @@ requests. If `xpack.ml.enabled` is set to `true` and `node.ml` is set to `false`
 the node can service API requests but it cannot run jobs.
 
 If you want to use {ml-features} in your cluster, you must enable {ml}
-(set `xpack.ml.enabled` to `true`) on all master-eligible nodes. If you have the
-{oss-dist}, do not use these settings.
+(set `xpack.ml.enabled` to `true`) on all master-eligible nodes. If you want to
+use {ml-features} in clients (including {kib}), it must also be enabled on all
+coordinating nodes. If you have the {oss-dist}, do not use these settings.
 
 For more information about these settings, see <<ml-settings>>.
 

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -36,19 +36,20 @@ IMPORTANT: On dedicated coordinating nodes or dedicated master nodes, disable
 the `node.ml` role.
 
 `xpack.ml.enabled`::
-Set to `true` (default) to enable {ml} on the node. +
+Set to `true` (default) to enable {ml} on the node.
 +
-If set to `false` in `elasticsearch.yml`, the {ml} APIs are disabled on the node.
-Therefore the node cannot open jobs, start {dfeeds}, or receive transport (internal)
-communication requests related to {ml} APIs. It also affects all {kib} instances
-that connect to this {es} instance; you do not need to disable {ml} in those
-`kibana.yml` files. For more information about disabling {ml} in specific {kib}
-instances, see
-{kibana-ref}/ml-settings-kb.html[{kib} Machine Learning Settings].
+If set to `false`, the {ml} APIs are disabled on the node. Therefore the node
+cannot open jobs, start {dfeeds}, or receive transport (internal) communication
+requests related to {ml} APIs. If the node is a coordinating node, {ml} requests
+from clients (including {kib}) also fail. For more information about disabling
+{ml} in specific {kib} instances, see
+{kibana-ref}/ml-settings-kb.html[{kib} {ml} settings].
 +
-IMPORTANT: If you want to use {ml} features in your cluster, you must have
-`xpack.ml.enabled` set to `true` on all master-eligible nodes. This is the
-default behavior.
+IMPORTANT: If you want to use {ml-features} in your cluster, it is recommended
+that you set `xpack.ml.enabled` to `true` on all nodes. This is the
+default behavior. At a minimum, it must be enabled on all master-eligible nodes.
+If you want to use {ml-features} in clients or {kib}, it must also be enabled on
+all coordinating nodes.
 
 `xpack.ml.inference_model.cache_size`::
 The maximum inference cache size allowed. The inference cache exists in the JVM

--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -21,8 +21,9 @@ file.
 ==== General {transforms} settings
 
 `node.transform`::
-Set to `true` to identify the node as a _transform node_. The default is `false` if
-either `node.data` or `xpack.transform.enabled` is `false` for the node, and `true` otherwise. +
+Set to `true` to identify the node as a _transform node_. If either `node.data`
+or `xpack.transform.enabled` is `false` for the node, the default value is
+`false`. Otherwise, the default value is `true`.
 +
 If set to `false` in `elasticsearch.yml`, the node cannot run transforms. If set to
 `true` but `xpack.transform.enabled` is set to `false`, the `node.transform` setting is
@@ -36,13 +37,17 @@ coordinating nodes or dedicated master nodes, disable the node.transform role.
 `xpack.transform.enabled`::
 Set to `true` (default) to enable {transforms} on the node. +
 +
-If set to `false` in `elasticsearch.yml`, the {transform} APIs are disabled on the node.
-Therefore the node cannot start or administrate {transform} or receive transport (internal)
-communication requests related to {transform} APIs.
+If set to `false` in `elasticsearch.yml`, the {transform} APIs are disabled on
+the node. Therefore the node cannot start or administrate {transforms} or
+receive transport (internal) communication requests related to {transform} APIs.
+If the node is a coordinating node, {transform} requests from clients (including
+{kib}) also fail. 
 +
-IMPORTANT: If you want to use {transform} features in your cluster, you must have
-`xpack.transform.enabled` set to `true` on all master-eligible nodes and all data nodes.
-This is the default behavior.
+IMPORTANT: If you want to use {transform} features in your cluster, it is
+recommended that you set `xpack.transform.enabled` to `true` on all nodes. This
+is the default behavior. At a minimum, it must be enabled on all master-eligible
+nodes and all data nodes. If you want to use {transforms} in clients or {kib},
+it must also be enabled on all coordinating nodes.
 
 `xpack.transform.num_transform_failure_retries` (<<cluster-update-settings,Dynamic>>)::
 The number of times that a {transform} retries when it experiences a


### PR DESCRIPTION
This PR forward-fits https://github.com/elastic/elasticsearch/pull/54552
and makes similar changes for transform nodes.

Preview:
* http://elasticsearch_54676.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-settings.html
* http://elasticsearch_54676.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html
* http://elasticsearch_54676.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html