### PR TITLE
EQL: Remove non-integer time units

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
@@ -433,7 +433,7 @@ expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
 
 [[queries]]
 query = '''
-sequence with maxspan=0.5s
+sequence with maxspan=500ms
   [file where event_subtype_full == "file_create_event"] by file_path
   [process where opcode == 1] by process_path
   [process where opcode == 2] by process_path

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
@@ -340,7 +340,7 @@ expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
 
 [[queries]]
 query = '''
-sequence with maxspan=0.5s
+sequence with maxspan=500ms
   [file where event_subtype_full == "file_create_event"] by file_path
   [process where opcode == 1] by process_path
   [process where opcode == 2] by process_path

--- a/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
+++ b/x-pack/plugin/eql/src/main/antlr/EqlBase.g4
@@ -130,7 +130,7 @@ identifier
     ;
 
 timeUnit
-    : number unit=IDENTIFIER?
+    : INTEGER_VALUE unit=IDENTIFIER?
     ;
 
 number

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseLexer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseLexer.java
@@ -17,38 +17,38 @@ class EqlBaseLexer extends Lexer {
   protected static final PredictionContextCache _sharedContextCache =
     new PredictionContextCache();
   public static final int
-    AND=1, ANY=2, BY=3, FALSE=4, FORK=5, IN=6, JOIN=7, MAXSPAN=8, NOT=9, NULL=10,
-    OF=11, OR=12, SEQUENCE=13, TRUE=14, UNTIL=15, WHERE=16, WITH=17, EQ=18,
-    NEQ=19, LT=20, LTE=21, GT=22, GTE=23, PLUS=24, MINUS=25, ASTERISK=26,
-    SLASH=27, PERCENT=28, DOT=29, COMMA=30, LB=31, RB=32, LP=33, RP=34, PIPE=35,
-    ESCAPED_IDENTIFIER=36, STRING=37, INTEGER_VALUE=38, DECIMAL_VALUE=39,
+    AND=1, ANY=2, BY=3, FALSE=4, FORK=5, IN=6, JOIN=7, MAXSPAN=8, NOT=9, NULL=10, 
+    OF=11, OR=12, SEQUENCE=13, TRUE=14, UNTIL=15, WHERE=16, WITH=17, EQ=18, 
+    NEQ=19, LT=20, LTE=21, GT=22, GTE=23, PLUS=24, MINUS=25, ASTERISK=26, 
+    SLASH=27, PERCENT=28, DOT=29, COMMA=30, LB=31, RB=32, LP=33, RP=34, PIPE=35, 
+    ESCAPED_IDENTIFIER=36, STRING=37, INTEGER_VALUE=38, DECIMAL_VALUE=39, 
     IDENTIFIER=40, LINE_COMMENT=41, BRACKETED_COMMENT=42, WS=43;
   public static String[] modeNames = {
     "DEFAULT_MODE"
   };
 
   public static final String[] ruleNames = {
-    "AND", "ANY", "BY", "FALSE", "FORK", "IN", "JOIN", "MAXSPAN", "NOT", "NULL",
-    "OF", "OR", "SEQUENCE", "TRUE", "UNTIL", "WHERE", "WITH", "EQ", "NEQ",
-    "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH", "PERCENT",
-    "DOT", "COMMA", "LB", "RB", "LP", "RP", "PIPE", "ESCAPED_IDENTIFIER",
-    "STRING", "INTEGER_VALUE", "DECIMAL_VALUE", "IDENTIFIER", "EXPONENT",
+    "AND", "ANY", "BY", "FALSE", "FORK", "IN", "JOIN", "MAXSPAN", "NOT", "NULL", 
+    "OF", "OR", "SEQUENCE", "TRUE", "UNTIL", "WHERE", "WITH", "EQ", "NEQ", 
+    "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH", "PERCENT", 
+    "DOT", "COMMA", "LB", "RB", "LP", "RP", "PIPE", "ESCAPED_IDENTIFIER", 
+    "STRING", "INTEGER_VALUE", "DECIMAL_VALUE", "IDENTIFIER", "EXPONENT", 
     "DIGIT", "LETTER", "LINE_COMMENT", "BRACKETED_COMMENT", "WS"
   };
 
   private static final String[] _LITERAL_NAMES = {
-    null, "'and'", "'any'", "'by'", "'false'", "'fork'", "'in'", "'join'",
-    "'maxspan'", "'not'", "'null'", "'of'", "'or'", "'sequence'", "'true'",
-    "'until'", "'where'", "'with'", null, "'!='", "'<'", "'<='", "'>'", "'>='",
-    "'+'", "'-'", "'*'", "'/'", "'%'", "'.'", "','", "'['", "']'", "'('",
+    null, "'and'", "'any'", "'by'", "'false'", "'fork'", "'in'", "'join'", 
+    "'maxspan'", "'not'", "'null'", "'of'", "'or'", "'sequence'", "'true'", 
+    "'until'", "'where'", "'with'", null, "'!='", "'<'", "'<='", "'>'", "'>='", 
+    "'+'", "'-'", "'*'", "'/'", "'%'", "'.'", "','", "'['", "']'", "'('", 
     "')'", "'|'"
   };
   private static final String[] _SYMBOLIC_NAMES = {
-    null, "AND", "ANY", "BY", "FALSE", "FORK", "IN", "JOIN", "MAXSPAN", "NOT",
-    "NULL", "OF", "OR", "SEQUENCE", "TRUE", "UNTIL", "WHERE", "WITH", "EQ",
-    "NEQ", "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH",
-    "PERCENT", "DOT", "COMMA", "LB", "RB", "LP", "RP", "PIPE", "ESCAPED_IDENTIFIER",
-    "STRING", "INTEGER_VALUE", "DECIMAL_VALUE", "IDENTIFIER", "LINE_COMMENT",
+    null, "AND", "ANY", "BY", "FALSE", "FORK", "IN", "JOIN", "MAXSPAN", "NOT", 
+    "NULL", "OF", "OR", "SEQUENCE", "TRUE", "UNTIL", "WHERE", "WITH", "EQ", 
+    "NEQ", "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH", 
+    "PERCENT", "DOT", "COMMA", "LB", "RB", "LP", "RP", "PIPE", "ESCAPED_IDENTIFIER", 
+    "STRING", "INTEGER_VALUE", "DECIMAL_VALUE", "IDENTIFIER", "LINE_COMMENT", 
     "BRACKETED_COMMENT", "WS"
   };
   public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/EqlBaseParser.java
@@ -17,42 +17,42 @@ class EqlBaseParser extends Parser {
   protected static final PredictionContextCache _sharedContextCache =
     new PredictionContextCache();
   public static final int
-    AND=1, ANY=2, BY=3, FALSE=4, FORK=5, IN=6, JOIN=7, MAXSPAN=8, NOT=9, NULL=10,
-    OF=11, OR=12, SEQUENCE=13, TRUE=14, UNTIL=15, WHERE=16, WITH=17, EQ=18,
-    NEQ=19, LT=20, LTE=21, GT=22, GTE=23, PLUS=24, MINUS=25, ASTERISK=26,
-    SLASH=27, PERCENT=28, DOT=29, COMMA=30, LB=31, RB=32, LP=33, RP=34, PIPE=35,
-    ESCAPED_IDENTIFIER=36, STRING=37, INTEGER_VALUE=38, DECIMAL_VALUE=39,
+    AND=1, ANY=2, BY=3, FALSE=4, FORK=5, IN=6, JOIN=7, MAXSPAN=8, NOT=9, NULL=10, 
+    OF=11, OR=12, SEQUENCE=13, TRUE=14, UNTIL=15, WHERE=16, WITH=17, EQ=18, 
+    NEQ=19, LT=20, LTE=21, GT=22, GTE=23, PLUS=24, MINUS=25, ASTERISK=26, 
+    SLASH=27, PERCENT=28, DOT=29, COMMA=30, LB=31, RB=32, LP=33, RP=34, PIPE=35, 
+    ESCAPED_IDENTIFIER=36, STRING=37, INTEGER_VALUE=38, DECIMAL_VALUE=39, 
     IDENTIFIER=40, LINE_COMMENT=41, BRACKETED_COMMENT=42, WS=43;
   public static final int
-    RULE_singleStatement = 0, RULE_singleExpression = 1, RULE_statement = 2,
-    RULE_query = 3, RULE_sequenceParams = 4, RULE_sequence = 5, RULE_join = 6,
-    RULE_pipe = 7, RULE_joinKeys = 8, RULE_joinTerm = 9, RULE_sequenceTerm = 10,
-    RULE_subquery = 11, RULE_eventQuery = 12, RULE_expression = 13, RULE_booleanExpression = 14,
-    RULE_valueExpression = 15, RULE_predicate = 16, RULE_primaryExpression = 17,
-    RULE_functionExpression = 18, RULE_constant = 19, RULE_comparisonOperator = 20,
-    RULE_booleanValue = 21, RULE_qualifiedName = 22, RULE_identifier = 23,
+    RULE_singleStatement = 0, RULE_singleExpression = 1, RULE_statement = 2, 
+    RULE_query = 3, RULE_sequenceParams = 4, RULE_sequence = 5, RULE_join = 6, 
+    RULE_pipe = 7, RULE_joinKeys = 8, RULE_joinTerm = 9, RULE_sequenceTerm = 10, 
+    RULE_subquery = 11, RULE_eventQuery = 12, RULE_expression = 13, RULE_booleanExpression = 14, 
+    RULE_valueExpression = 15, RULE_predicate = 16, RULE_primaryExpression = 17, 
+    RULE_functionExpression = 18, RULE_constant = 19, RULE_comparisonOperator = 20, 
+    RULE_booleanValue = 21, RULE_qualifiedName = 22, RULE_identifier = 23, 
     RULE_timeUnit = 24, RULE_number = 25, RULE_string = 26;
   public static final String[] ruleNames = {
-    "singleStatement", "singleExpression", "statement", "query", "sequenceParams",
-    "sequence", "join", "pipe", "joinKeys", "joinTerm", "sequenceTerm", "subquery",
-    "eventQuery", "expression", "booleanExpression", "valueExpression", "predicate",
-    "primaryExpression", "functionExpression", "constant", "comparisonOperator",
+    "singleStatement", "singleExpression", "statement", "query", "sequenceParams", 
+    "sequence", "join", "pipe", "joinKeys", "joinTerm", "sequenceTerm", "subquery", 
+    "eventQuery", "expression", "booleanExpression", "valueExpression", "predicate", 
+    "primaryExpression", "functionExpression", "constant", "comparisonOperator", 
     "booleanValue", "qualifiedName", "identifier", "timeUnit", "number", "string"
   };
 
   private static final String[] _LITERAL_NAMES = {
-    null, "'and'", "'any'", "'by'", "'false'", "'fork'", "'in'", "'join'",
-    "'maxspan'", "'not'", "'null'", "'of'", "'or'", "'sequence'", "'true'",
-    "'until'", "'where'", "'with'", null, "'!='", "'<'", "'<='", "'>'", "'>='",
-    "'+'", "'-'", "'*'", "'/'", "'%'", "'.'", "','", "'['", "']'", "'('",
+    null, "'and'", "'any'", "'by'", "'false'", "'fork'", "'in'", "'join'", 
+    "'maxspan'", "'not'", "'null'", "'of'", "'or'", "'sequence'", "'true'", 
+    "'until'", "'where'", "'with'", null, "'!='", "'<'", "'<='", "'>'", "'>='", 
+    "'+'", "'-'", "'*'", "'/'", "'%'", "'.'", "','", "'['", "']'", "'('", 
     "')'", "'|'"
   };
   private static final String[] _SYMBOLIC_NAMES = {
-    null, "AND", "ANY", "BY", "FALSE", "FORK", "IN", "JOIN", "MAXSPAN", "NOT",
-    "NULL", "OF", "OR", "SEQUENCE", "TRUE", "UNTIL", "WHERE", "WITH", "EQ",
-    "NEQ", "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH",
-    "PERCENT", "DOT", "COMMA", "LB", "RB", "LP", "RP", "PIPE", "ESCAPED_IDENTIFIER",
-    "STRING", "INTEGER_VALUE", "DECIMAL_VALUE", "IDENTIFIER", "LINE_COMMENT",
+    null, "AND", "ANY", "BY", "FALSE", "FORK", "IN", "JOIN", "MAXSPAN", "NOT", 
+    "NULL", "OF", "OR", "SEQUENCE", "TRUE", "UNTIL", "WHERE", "WITH", "EQ", 
+    "NEQ", "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH", 
+    "PERCENT", "DOT", "COMMA", "LB", "RB", "LP", "RP", "PIPE", "ESCAPED_IDENTIFIER", 
+    "STRING", "INTEGER_VALUE", "DECIMAL_VALUE", "IDENTIFIER", "LINE_COMMENT", 
     "BRACKETED_COMMENT", "WS"
   };
   public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
@@ -474,7 +474,7 @@ class EqlBaseParser extends Parser {
       }
       setState(88);
       sequenceTerm();
-      setState(90);
+      setState(90); 
       _errHandler.sync(this);
       _la = _input.LA(1);
       do {
@@ -484,7 +484,7 @@ class EqlBaseParser extends Parser {
         sequenceTerm();
         }
         }
-        setState(92);
+        setState(92); 
         _errHandler.sync(this);
         _la = _input.LA(1);
       } while ( _la==LB );
@@ -564,7 +564,7 @@ class EqlBaseParser extends Parser {
 
       setState(102);
       joinTerm();
-      setState(104);
+      setState(104); 
       _errHandler.sync(this);
       _la = _input.LA(1);
       do {
@@ -574,7 +574,7 @@ class EqlBaseParser extends Parser {
         joinTerm();
         }
         }
-        setState(106);
+        setState(106); 
         _errHandler.sync(this);
         _la = _input.LA(1);
       } while ( _la==LB );
@@ -1065,7 +1065,7 @@ class EqlBaseParser extends Parser {
       super(parent, invokingState);
     }
     @Override public int getRuleIndex() { return RULE_booleanExpression; }
-
+   
     public BooleanExpressionContext() { }
     public void copyFrom(BooleanExpressionContext ctx) {
       super.copyFrom(ctx);
@@ -1252,7 +1252,7 @@ class EqlBaseParser extends Parser {
             }
             break;
           }
-          }
+          } 
         }
         setState(180);
         _errHandler.sync(this);
@@ -1276,7 +1276,7 @@ class EqlBaseParser extends Parser {
       super(parent, invokingState);
     }
     @Override public int getRuleIndex() { return RULE_valueExpression; }
-
+   
     public ValueExpressionContext() { }
     public void copyFrom(ValueExpressionContext ctx) {
       super.copyFrom(ctx);
@@ -1515,7 +1515,7 @@ class EqlBaseParser extends Parser {
             }
             break;
           }
-          }
+          } 
         }
         setState(204);
         _errHandler.sync(this);
@@ -1627,7 +1627,7 @@ class EqlBaseParser extends Parser {
       super(parent, invokingState);
     }
     @Override public int getRuleIndex() { return RULE_primaryExpression; }
-
+   
     public PrimaryExpressionContext() { }
     public void copyFrom(PrimaryExpressionContext ctx) {
       super.copyFrom(ctx);
@@ -1858,7 +1858,7 @@ class EqlBaseParser extends Parser {
       super(parent, invokingState);
     }
     @Override public int getRuleIndex() { return RULE_constant; }
-
+   
     public ConstantContext() { }
     public void copyFrom(ConstantContext ctx) {
       super.copyFrom(ctx);
@@ -2168,7 +2168,7 @@ class EqlBaseParser extends Parser {
             {
             setState(256);
             match(LB);
-            setState(258);
+            setState(258); 
             _errHandler.sync(this);
             _la = _input.LA(1);
             do {
@@ -2178,7 +2178,7 @@ class EqlBaseParser extends Parser {
               match(INTEGER_VALUE);
               }
               }
-              setState(260);
+              setState(260); 
               _errHandler.sync(this);
               _la = _input.LA(1);
             } while ( _la==INTEGER_VALUE );
@@ -2189,7 +2189,7 @@ class EqlBaseParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          }
+          } 
         }
         setState(267);
         _errHandler.sync(this);
@@ -2259,9 +2259,7 @@ class EqlBaseParser extends Parser {
 
   public static class TimeUnitContext extends ParserRuleContext {
     public Token unit;
-    public NumberContext number() {
-      return getRuleContext(NumberContext.class,0);
-    }
+    public TerminalNode INTEGER_VALUE() { return getToken(EqlBaseParser.INTEGER_VALUE, 0); }
     public TerminalNode IDENTIFIER() { return getToken(EqlBaseParser.IDENTIFIER, 0); }
     public TimeUnitContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
@@ -2290,7 +2288,7 @@ class EqlBaseParser extends Parser {
       enterOuterAlt(_localctx, 1);
       {
       setState(270);
-      number();
+      match(INTEGER_VALUE);
       setState(272);
       _la = _input.LA(1);
       if (_la==IDENTIFIER) {
@@ -2318,7 +2316,7 @@ class EqlBaseParser extends Parser {
       super(parent, invokingState);
     }
     @Override public int getRuleIndex() { return RULE_number; }
-
+   
     public NumberContext() { }
     public void copyFrom(NumberContext ctx) {
       super.copyFrom(ctx);
@@ -2560,7 +2558,7 @@ class EqlBaseParser extends Parser {
     "\3\2\2\2\u0107\u0108\3\2\2\2\u0108\u010a\7\"\2\2\u0109\u0100\3\2\2\2\u0109"+
     "\u0102\3\2\2\2\u010a\u010d\3\2\2\2\u010b\u0109\3\2\2\2\u010b\u010c\3\2"+
     "\2\2\u010c/\3\2\2\2\u010d\u010b\3\2\2\2\u010e\u010f\t\6\2\2\u010f\61\3"+
-    "\2\2\2\u0110\u0112\5\64\33\2\u0111\u0113\7*\2\2\u0112\u0111\3\2\2\2\u0112"+
+    "\2\2\2\u0110\u0112\7(\2\2\u0111\u0113\7*\2\2\u0112\u0111\3\2\2\2\u0112"+
     "\u0113\3\2\2\2\u0113\63\3\2\2\2\u0114\u0117\7)\2\2\u0115\u0117\7(\2\2"+
     "\u0116\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117\65\3\2\2\2\u0118\u0119"+
     "\7\'\2\2\u0119\67\3\2\2\2&BHRVX^bflpy|\u0084\u0089\u008f\u0091\u0094\u009c"+

--- a/x-pack/plugin/eql/src/test/resources/queries-unsupported.eql
+++ b/x-pack/plugin/eql/src/test/resources/queries-unsupported.eql
@@ -112,13 +112,13 @@ sequence by pid with maxspan=2sec [process where process_name == "*" ] [file whe
 
 sequence by pid with maxspan=2seconds [process where process_name == "*" ] [file where file_path == "*"];
 
-sequence with maxspan=2.5m [process where x == x] by pid [file where file_path == "*"] by ppid;
+sequence with maxspan=150s [process where x == x] by pid [file where file_path == "*"] by ppid;
 
-sequence by pid with maxspan=2.0h [process where process_name == "*"] [file where file_path == "*"];
+sequence by pid with maxspan=2h [process where process_name == "*"] [file where file_path == "*"];
 
-sequence by pid with maxspan=2.0h [process where process_name == "*"] [file where file_path == "*"];
+sequence by pid with maxspan=2h [process where process_name == "*"] [file where file_path == "*"];
 
-sequence by pid with maxspan=1.0075d [process where process_name == "*"] [file where file_path == "*"];
+sequence by pid with maxspan=1d [process where process_name == "*"] [file where file_path == "*"];
 
 dns where pid == 100 | head 100 | tail 50 | unique pid;
 
@@ -386,7 +386,7 @@ sequence with maxspan=10s
 | head 4
 | tail 2;
 
-sequence with maxspan=0.5s
+sequence with maxspan=500ms
   [file where event_subtype_full == "file_create_event"] by file_path
   [process where opcode == 1] by process_path
   [process where opcode == 2] by process_path


### PR DESCRIPTION
Relates to #54597 

Removed non-integer time units from the grammar for `maxspan`, and updated tests. There aren't any parser rules yet to check for which identifiers are valid units (`ms|s|sec|h|hr|d|day`), so no work is needed (yet) to add the additional unit.

@colings86 I think it's worth adding this to the existing EQL python library and Endpoint Platform. I think we can leave the grammar as-is, but can specifically check for floats, and return a meaningful error message with a recommended change to apply
> Invalid time unit: `0.5s`. Non-integer time units are no longer supported. Try again with `500ms`.

Also, the python library is _too_ forgiving with time units, and accepts things like  `hou`. It accepts any substring that starts a known identifier. For hours, that means all of these are valid: `h`, `ho`, `hou`, `hour`, `hours`

Should we make Endpoint EQL and Elasticsearch EQL fully consistent with existing Elasticsearch time units? We can port that to EQL as well, as long as we have a constructive error message for any mismatches. That would leave us with `d`, `h`, `m`, `s`, `ms`, `micros`, `nanos`
https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units



