### PR TITLE
Remove persistent task when AllocatedTask fails during init

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
@@ -197,9 +197,11 @@ public class PersistentTasksNodeService implements ClusterStateListener {
         } finally {
             if (processed == false) {
                 // something went wrong - unregistering task
-                logger.warn("Persistent task [{}] with id [{}] and allocation id [{}] failed to create", task.getAction(),
-                        task.getPersistentTaskId(), task.getAllocationId());
+                ParameterizedMessage e = new ParameterizedMessage("Persistent task [{}] with id [{}] and allocation id " +
+                    "[{}] failed to create", task.getAction(), task.getPersistentTaskId(), task.getAllocationId());
+                logger.warn(e.getFormattedMessage());
                 taskManager.unregister(task);
+                notifyMasterOfFailedTask(taskInProgress, new RuntimeException(e.getFormattedMessage()));
             }
         }
     }


### PR DESCRIPTION
If a task encounters an issue while initializing, the allocated task is correctly removed from the running tasks and a warning is logged.  But the persistent task remains in the cluster state, which leads to a "zombie" persistent task that cannot be removed. The allocated task is gone so it can't be canceled, and if the persistent task is re-allocated it is likely to fail again because the issue happened during initialization.

This adjusts the error handling to also inform the master that the task failed, so that it may be removed from the CS

I wasn't really sure what exception to throw, so just used a RuntimeException.  Happy to change it to something more appropriate.