### PR TITLE
Enable the remote build cache in BWC distribution builds

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -194,6 +194,10 @@ bwcVersions.forPreviousUnreleased { BwcVersions.UnreleasedVersionInfo unreleased
         if (gradle.startParameter.isOffline()) {
           args "--offline"
         }
+        String buildCacheUrl = System.getProperty('org.elasticsearch.build.cache.url')
+        if (buildCacheUrl) {
+          args "-Dorg.elasticsearch.build.cache.url=${buildCacheUrl}"
+        }
 
         args "-Dbuild.snapshot=true"
         args "-Dscan.tag.NESTED"


### PR DESCRIPTION
Turns out we aren't using the remote build cache when building BWC distributions because we need to explicitly pass thru the remote build cache URL. Ooops.