### PR TITLE
[7.7][DOCS] Makes PUT inference API docs collapsible

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -44,6 +44,7 @@ is not created by {dfanalytics}.
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
+role="child_attributes"]
 [[ml-put-inference-request-body]]
 ==== {api-request-body-title}
 
@@ -52,20 +53,290 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 The compressed (GZipped and Base64 encoded) {infer} definition of the model. 
 If `compressed_definition` is specified, then `definition` cannot be specified.
 
+//Begin definition
 `definition`::
 (Required, object) 
 The {infer} definition for the model. If `definition` is specified, then 
 `compressed_definition` cannot be specified.
 
-`definition`.`preprocessors`:::
+.Properties of `definition`
+[%collapsible%open]
+====
+//Begin preprocessors
+`preprocessors`::
 (Optional, object)
-Collection of preprocessors. See <<ml-put-inference-preprocessors>> for the full 
-list of available preprocessors.
+Collection of preprocessors.
 
-`definition`.`trained_model`:::
+.Properties of `preprocessors`
+[%collapsible%open]
+=====
+//Begin frequency encoding
+`frequency_encoding`::
 (Required, object) 
-The definition of the trained model. See <<ml-put-inference-trained-model>> for 
-details.
+Defines a frequency encoding for a field.
+
+.Properties of `frequency_encoding`
+[%collapsible%open]
+======
+`feature_name`::
+(Required, string) 
+The name of the resulting feature.
+
+`field`::
+(Required, string) 
+The field name to encode.
+
+`frequency_map`::
+(Required, object map of string:double) 
+Object that maps the field value to the frequency encoded value.
+======
+//End frequency encoding
+
+//Begin one hot encoding
+`one_hot_encoding`::
+(Required, object) 
+Defines a one hot encoding map for a field.
+
+.Properties of `one_hot_encoding`
+[%collapsible%open]
+======
+`field`::
+(Required, string) 
+The field name to encode.
+
+`hot_map`::
+(Required, object map of strings) 
+String map of "field_value: one_hot_column_name".
+======
+//End one hot encoding
+
+//Begin target mean encoding
+`target_mean_encoding`::
+(Required, object) 
+Defines a target mean encoding for a field.
+
+.Properties of `target_mean_encoding`
+[%collapsible%open]
+======
+`default_value`:::
+(Required, double) 
+The feature value if the field value is not in the `target_map`.
+
+`feature_name`:::
+(Required, string) 
+The name of the resulting feature.
+
+`field`:::
+(Required, string)
+The field name to encode.
+
+`target_map`:::
+(Required, object map of string:double) 
+Object that maps the field value to the target mean value.
+======
+//End target mean encoding
+
+See <<ml-put-inference-preprocessor-example>> for more details.
+
+=====
+//End preprocessors
+
+//Begin trained model
+`trained_model`::
+(Required, object) 
+The definition of the trained model.
+
+.Properties of `trained_model`
+[%collapsible%open]
+=====
+//Begin tree
+`tree`::
+(Required, object) 
+The definition for a binary decision tree.
+
+.Properties of `tree`
+[%collapsible%open]
+======
+`classification_labels`:::
+(Optional, string) An array of classification labels (used for 
+`classification`).
+
+`feature_names`:::
+(Required, string)
+Features expected by the tree, in their expected order.
+
+`target_type`:::
+(Required, string) 
+String indicating the model target type; `regression` or `classification`.
+
+`tree_structure`:::
+(Required, object) 
+An array of `tree_node` objects. The nodes must be in ordinal order by their 
+`tree_node.node_index` value.
+======
+//End tree
+
+//Begin tree node
+`tree_node`::
+(Required, object) 
+The definition of a node in a tree.
+
+There are two major types of nodes: leaf nodes and not-leaf nodes.
+
+* Leaf nodes only need `node_index` and `leaf_value` defined.
+* All other nodes need `split_feature`, `left_child`, `right_child`, 
+  `threshold`, `decision_type`, and `default_left` defined.
+
+.Properties of `tree_node`
+[%collapsible%open]
+======
+`decision_type`::
+(Optional, string) 
+Indicates the positive value (in other words, when to choose the left node) 
+decision type. Supported `lt`, `lte`, `gt`, `gte`. Defaults to `lte`.
+
+`default_left`::
+(Optional, boolean) 
+Indicates whether to default to the left when the feature is missing. Defaults 
+to `true`.
+
+`leaf_value`::
+(Optional, double) 
+The leaf value of the of the node, if the value is a leaf (in other words, no 
+children).
+
+`left_child`::
+(Optional, integer) 
+The index of the left child.
+
+`node_index`::
+(Integer) 
+The index of the current node.
+
+`right_child`::
+(Optional, integer) 
+The index of the right child.
+
+`split_feature`::
+(Optional, integer) 
+The index of the feature value in the feature array.
+
+`split_gain`::
+(Optional, double) The information gain from the split.
+
+`threshold`::
+(Optional, double) 
+The decision threshold with which to compare the feature value.
+======
+//End tree node
+
+//Begin ensemble
+`ensemble`::
+(Optional, object)
+The definition for an ensemble model.
+
+.Properties of `ensemble`
+[%collapsible%open]
+======
+//Begin aggregate output
+`aggregate_output`::
+(Required, object) 
+An aggregated output object that defines how to aggregate the outputs of the 
+`trained_models`. Supported objects are `weighted_mode`, `weighted_sum`, and 
+`logistic_regression`.
+
+.Properties of `aggregate_output`
+[%collapsible%open]
+=======
+//Begin logistic regression
+`logistic_regression`::
+(Optional, object) 
+This `aggregated_output` type works with binary classification (classification 
+for values [0, 1]). It multiplies the outputs (in the case of the `ensemble` 
+model, the inference model values) by the supplied `weights`. The resulting 
+vector is summed and passed to a 
+https://en.wikipedia.org/wiki/Sigmoid_function[`sigmoid` function]. The result 
+of the `sigmoid` function is considered the probability of class 1 (`P_1`), 
+consequently, the probability of class 0 is `1 - P_1`. The class with the 
+highest probability (either 0 or 1) is then returned. For more information about 
+logistic regression, see 
+https://en.wikipedia.org/wiki/Logistic_regression[this wiki article].
+
+.Properties of `logistic_regression`
+[%collapsible%open]
+========
+`weights`:::
+(Required, double) 
+The weights to multiply by the input values (the inference values of the trained 
+models).
+========
+//End logistic regression
+
+//Begin weighted sum
+`weighted_sum`::
+(Optional, object) 
+This `aggregated_output` type works with regression. The weighted sum of the 
+input values.
+
+.Properties of `weighted_sum`
+[%collapsible%open]
+========
+`weights`:::
+(Required, double) 
+The weights to multiply by the input values (the inference values of the trained 
+models).
+========
+//End weighted sum
+
+//Begin weighted mode
+`weighted_mode`::
+(Optional, object) 
+This `aggregated_output` type works with regression or classification. It takes 
+a weighted vote of the input values. The most common input value (taking the 
+weights into account) is returned.
+
+.Properties of `weighted_mode`
+[%collapsible%open]
+========
+`weights`:::
+(Required, double) 
+The weights to multiply by the input values (the inference values of the trained 
+models).
+========
+//End weighted mode
+
+See <<ml-put-inference-aggregated-output-example>> for more details.
+
+=======
+//End aggregate output
+
+`classification_labels`::
+(Optional, string) 
+An array of classification labels.
+
+`feature_names`::
+(Optional, string)
+Features expected by the ensemble, in their expected order.
+
+`target_type`::
+(Required, string) 
+String indicating the model target type; `regression` or `classification.`
+
+`trained_models`::
+(Required, object)
+An array of `trained_model` objects. Supported trained models are `tree` and 
+`ensemble`.
+======
+//End ensemble
+
+See <<ml-put-inference-model-example>> for more details.
+
+=====
+//End trained model
+
+====
+//End definition
+
 
 `description`::
 (Optional, string) 
@@ -86,209 +357,6 @@ An object map that contains metadata about the model.
 `tags`::
 (Optional, string) 
 An array of tags to organize the model.
-
-
-[[ml-put-inference-preprocessors]]
-===== {infer-cap} preprocessor definitions
-
-`frequency_encoding`::
-(Required, object) 
-Defines a frequency encoding for a field.
-
-`frequency_encoding`.`field`:::
-(Required, string) 
-The field name to encode.
-
-`frequency_encoding`.`feature_name`:::
-(Required, string) 
-The name of the resulting feature.
-
-`frequency_encoding`.`frequency_map`:::
-(Required, object map of string:double) 
-Object that maps the field value to the frequency encoded value.
-
-`one_hot_encoding`::
-(Required, object) 
-Defines a one hot encoding map for a field.
-
-`one_hot_encoding`.`field`:::
-(Required, string) 
-The field name to encode.
-
-`one_hot_encoding`.`hot_map`:::
-(Required, object map of strings) 
-String map of "field_value: one_hot_column_name".
-
-`target_mean_encoding`::
-(Required, object) 
-Defines a target mean encoding for a field.
-
-`target_mean_encoding`.`field`:::
-(Required, string)
-The field name to encode.
-
-`target_mean_encoding`.`feature_name`:::
-(Required, string) 
-The name of the resulting feature.
-
-`target_mean_encoding`.`target_map`:::
-(Required, object map of string:double) 
-Object that maps the field value to the target mean value.
-
-`target_mean_encoding`.`default_value`:::
-(Required, double) 
-The feature value if the field value is not in the `target_map`.
-
-See <<ml-put-inference-preprocessor-example>> for more details.
-
-
-[[ml-put-inference-trained-model]]
-===== {infer-cap} trained model definitions
-
-`tree`::
-(Required, object) 
-The definition for a binary decision tree.
-
-`tree`.`feature_names`:::
-(Required, string)
-Features expected by the tree, in their expected order.
-
-`tree`.`tree_structure`:::
-(Required, object) 
-An array of `tree_node` objects. The nodes must be in ordinal order by their 
-`tree_node.node_index` value.
-
-`tree`.`classification_labels`:::
-(Optional, string) An array of classification labels (used for 
-`classification`).
-
-`tree`.`target_type`:::
-(Required, string) 
-String indicating the model target type; `regression` or `classification`.
-
-There are two major types of nodes: leaf nodes and not-leaf nodes.
-
-* Leaf nodes only need `node_index` and `leaf_value` defined.
-* All other nodes need `split_feature`, `left_child`, `right_child`, 
-  `threshold`, `decision_type`, and `default_left` defined.
-
-
-
-`tree_node`::
-(Required, object) 
-The definition of a node in a tree.
-
-`tree_node`.`decision_type`:::
-(Optional, string) 
-Indicates the positive value (in other words, when to choose the left node) 
-decision type. Supported `lt`, `lte`, `gt`, `gte`. Defaults to `lte`.
-
-`tree_node`.`threshold`:::
-(Optional, double) 
-The decision threshold with which to compare the feature value.
-
-`tree_node`.`left_child`:::
-(Optional, integer) 
-The index of the left child.
-
-`tree_node`.`right_child`:::
-(Optional, integer) 
-The index of the right child.
-
-`tree_node`.`default_left`:::
-(Optional, boolean) 
-Indicates whether to default to the left when the feature is missing. Defaults 
-to `true`.
-
-`tree_node`.`split_feature`:::
-(Optional, integer) 
-The index of the feature value in the feature array.
-
-`tree_node`.`node_index`:::
-(Integer) 
-The index of the current node.
-
-`tree_node`.`split_gain`:::
-(Optional, double) The information gain from the split.
-
-`tree_node`.`leaf_value`:::
-(Optional, double) 
-The leaf value of the of the node, if the value is a leaf (in other words, no 
-children).
-
-`ensemble`::
-(Optional, object)
-The definition for an ensemble model.
-
-`ensemble`.`feature_names`:::
-(Optional, string)
-Features expected by the ensemble, in their expected order.
-
-`ensemble`.`trained_models`:::
-(Required, object)
-An array of `trained_model` objects. Supported trained models are `tree` and 
-`ensemble`.
-
-`ensemble`.`classification_labels`:::
-(Optional, string) 
-An array of classification labels.
-
-`ensemble`.`target_type`:::
-(Required, string) 
-String indicating the model target type; `regression` or `classification.`
-
-`ensemble`.`aggregate_output`:::
-(Required, object) 
-An aggregated output object that defines how to aggregate the outputs of the 
-`trained_models`. Supported objects are `weighted_mode`, `weighted_sum`, and 
-`logistic_regression`.
-
-See <<ml-put-inference-model-example>> for more details.
-
-
-[[ml-put-inference-aggregated-output]]
-===== Aggregated output types
-
-`logistic_regression`::
-(Optional, object) 
-This `aggregated_output` type works with binary classification (classification 
-for values [0, 1]). It multiplies the outputs (in the case of the `ensemble` 
-model, the inference model values) by the supplied `weights`. The resulting 
-vector is summed and passed to a 
-https://en.wikipedia.org/wiki/Sigmoid_function[`sigmoid` function]. The result 
-of the `sigmoid` function is considered the probability of class 1 (`P_1`), 
-consequently, the probability of class 0 is `1 - P_1`. The class with the 
-highest probability (either 0 or 1) is then returned. For more information about 
-logistic regression, see 
-https://en.wikipedia.org/wiki/Logistic_regression[this wiki article].
-
-`logistic_regression`.`weights`:::
-(Required, double) 
-The weights to multiply by the input values (the inference values of the trained 
-models).
-
-`weighted_sum`::
-(Optional, object) 
-This `aggregated_output` type works with regression. The weighted sum of the 
-input values.
-
-`weighted_sum`.`weights`:::
-(Required, double) 
-The weights to multiply by the input values (the inference values of the trained 
-models).
-
-`weighted_mode`::
-(Optional, object) 
-This `aggregated_output` type works with regression or classification. It takes 
-a weighted vote of the input values. The most common input value (taking the 
-weights into account) is returned.
-
-`weighted_mode`.`weights`:::
-(Required, double) 
-The weights to multiply by the input values (the inference values of the trained 
-models).
-
-See <<ml-put-inference-aggregated-output-example>> for more details.
 
 
 [[ml-put-inference-example]]


### PR DESCRIPTION
This PR backports the relevant changes of the following pull request to the 7.7 branch:
[DOCS] Makes PUT inference API docs collapsible #54653