### PR TITLE
[7.7] Cat tasks output should respect time display settings (#54536)

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTasksAction.java
@@ -145,7 +145,7 @@ public class RestTasksAction extends AbstractCatAction {
         table.addCell(taskInfo.getStartTime());
         table.addCell(FORMATTER.format(Instant.ofEpochMilli(taskInfo.getStartTime())));
         table.addCell(taskInfo.getRunningTimeNanos());
-        table.addCell(TimeValue.timeValueNanos(taskInfo.getRunningTimeNanos()).toString());
+        table.addCell(TimeValue.timeValueNanos(taskInfo.getRunningTimeNanos()));
 
         // Node information. Note that the node may be null because it has left the cluster between when we got this response and now.
         table.addCell(fullId ? nodeId : Strings.substring(nodeId, 0, 4));


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Cat tasks output should respect time display settings  (#54536)