### PR TITLE
[DOCS] Edits create data frame analytics job API

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -48,13 +48,11 @@ start the job. See <<start-dfanalytics>>.
 
 If you supply only a subset of the {regression} or {classification} parameters,
 _hyperparameter optimization_ occurs. It determines a value for each of the
-undefined parameters. A fixed number of rounds is used for optimization which
-depends on the number of parameters being optimized.
-// TBD: Does this "fixed number of rounds" sentence mean that the more undefined
-// parameters you have, the less optimized their values are?
-// Or just that it takes longer? This sentence is unclear.
+undefined parameters.
+
 ////
-TBD: Are these low-level details required?
+A fixed number of rounds is used for optimization which
+depends on the number of parameters being optimized.
 The starting point is calculated for data dependent parameters by examining the loss
 on the training data. Subject to the size constraint, this operation provides an
 upper bound on the improvement in validation loss.
@@ -127,7 +125,8 @@ any class. Defaults to `maximize_minimum_recall`.
 include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 The data type of the field must be numeric (`integer`, `short`, `long`, `byte`), 
-categorical (`ip` or `keyword`), or boolean.
+categorical (`ip` or `keyword`), or boolean. There must be be no more than 30
+different values in this field. 
 
 `eta`::::
 (Optional, double) 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -126,7 +126,7 @@ any class. Defaults to `maximize_minimum_recall`.
 include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 The data type of the field must be numeric (`integer`, `short`, `long`, `byte`), 
-categorical (`ip` or `keyword`), or boolean. There must be be no more than 30
+categorical (`ip` or `keyword`), or boolean. There must be no more than 30
 different values in this field. 
 
 `eta`::::

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -27,57 +27,46 @@ built-in roles and privileges:
 * `kibana_admin` (UI only)
 
 
-* source index: `read`, `view_index_metadata`
+* source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `manage` and `index`
 * cluster: `monitor` (UI only)
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
-+
---
 NOTE: It is possible that secondary authorization headers are supplied in the
 request. If this is the case, the secondary authorization headers are used
 instead of the primary headers.
---
 
 [[ml-put-dfanalytics-desc]]
 ==== {api-description-title}
 
 This API creates a {dfanalytics-job} that performs an analysis on the source 
-index and stores the outcome in a destination index.
+indices and stores the outcome in a destination index.
 
-The destination index will be automatically created if it does not exist. The 
-`index.number_of_shards` and `index.number_of_replicas` settings of the source 
-index will be copied over the destination index. When the source index matches 
-multiple indices, these settings will be set to the maximum values found in the 
-source indices.
+If the destination index does not exist, it is created automatically when you
+start the job. See <<start-dfanalytics>>.
 
-The mappings of the source indices are also attempted to be copied over
-to the destination index, however, if the mappings of any of the fields don't 
-match among the source indices, the attempt will fail with an error message.
-
-If the destination index already exists, then it will be use as is. This makes 
-it possible to set up the destination index in advance with custom settings 
-and mappings.
-
-[discrete]
-[[ml-hyperparam-optimization]]
-===== Hyperparameter optimization
-
-If you don't supply {regression} or {classification} parameters, _hyperparameter 
-optimization_ occurs, which sets a value for the undefined parameters. The
-starting point is calculated for data dependent parameters by examining the loss
+If you supply only a subset of the {regression} or {classification} parameters,
+_hyperparameter optimization_ occurs. It determines a value for each of the
+undefined parameters. A fixed number of rounds is used for optimization which
+depends on the number of parameters being optimized.
+// TBD: Does this "fixed number of rounds" sentence mean that the more undefined
+// parameters you have, the less optimized their values are?
+// Or just that it takes longer? This sentence is unclear.
+////
+TBD: Are these low-level details required?
+The starting point is calculated for data dependent parameters by examining the loss
 on the training data. Subject to the size constraint, this operation provides an
 upper bound on the improvement in validation loss.
 
-A fixed number of rounds is used for optimization which depends on the number of 
-parameters being optimized. The optimization starts with random search, then 
+The optimization starts with random search, then 
 Bayesian optimization is performed that is targeting maximum expected 
 improvement. If you override any parameters by explicitely setting it, the 
 optimization calculates the value of the remaining parameters accordingly and 
 uses the value you provided for the overridden parameter. The number of rounds 
 are reduced respectively. The validation error is estimated in each round by 
 using 4-fold cross validation.
+////
 
 [[ml-put-dfanalytics-path-params]]
 ==== {api-path-parms-title}
@@ -92,7 +81,13 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
 
 `allow_lazy_start`::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-lazy-start]
+Specifies whether this job can start when there is insufficient {ml} node 
+capacity for it to be immediately assigned to a node. The default is `false`; if
+a {ml} node with capacity to run the job cannot immediately be found, the API
+returns an error. However, this is also subject to the cluster-wide
+`xpack.ml.max_lazy_ml_nodes` setting. See <<advanced-ml-settings>>. If this
+option is set to `true`, the API does not return an error and the job waits in
+the `starting` state until sufficient {ml} node capacity is available.
 
 //Begin analysis
 `analysis`::
@@ -111,16 +106,20 @@ The configuration information necessary to perform
 {ml-docs}/dfa-classification.html[{classification}].
 +
 TIP: Advanced parameters are for fine-tuning {classanalysis}. They are set 
-automatically by <<ml-hyperparam-optimization,hyperparameter optimization>> 
-to give minimum validation error. It is highly recommended to use the default 
-values unless you fully understand the function of these parameters.
+automatically by hyperparameter optimization to give the minimum validation
+error. It is highly recommended to use the default values unless you fully
+understand the function of these parameters.
 +
 .Properties of `classification`
 [%collapsible%open]
 =====
 `class_assignment_objective`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=class-assignment-objective]
+Defines the objective to optimize when assigning class labels:
+`maximize_accuracy` or `maximize_minimum_recall`. When maximizing accuracy,
+class labels are chosen to maximize the number of correct predictions. When
+maximizing minimum recall, labels are chosen to maximize the minimum recall for
+any class. Defaults to `maximize_minimum_recall`.
 
 `dependent_variable`::::
 (Required, string)
@@ -152,7 +151,9 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
 
 `num_top_classes`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=num-top-classes]
+Defines the number of categories for which the predicted probabilities are
+reported. It must be non-negative. If it is greater than the total number of
+categories, the API reports all category probabilities. Defaults to 2.
 
 `num_top_feature_importance_values`::::
 (Optional, integer)
@@ -215,9 +216,9 @@ The configuration information necessary to perform
 {ml-docs}/dfa-regression.html[{regression}].
 +
 TIP: Advanced parameters are for fine-tuning {reganalysis}. They are set 
-automatically by <<ml-hyperparam-optimization,hyperparameter optimization>> 
-to give minimum validation error. It is highly recommended to use the default 
-values unless you fully understand the function of these parameters.
+automatically by hyperparameter optimization to give the minimum validation
+error. It is highly recommended to use the default values unless you fully
+understand the function of these parameters.
 +
 .Properties of `regression`
 [%collapsible%open]

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -46,6 +46,7 @@ indices and stores the outcome in a destination index.
 If the destination index does not exist, it is created automatically when you
 start the job. See <<start-dfanalytics>>.
 
+[[ml-hyperparam-optimization]]
 If you supply only a subset of the {regression} or {classification} parameters,
 _hyperparameter optimization_ occurs. It determines a value for each of the
 undefined parameters.

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -33,6 +33,22 @@ built-in roles and privileges:
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 
+[[ml-start-dfanalytics-desc]]
+==== {api-description-title}
+
+A {dfanalytics-job} can be started and stopped multiple times throughout its 
+lifecycle.
+
+If the destination index does not exist, it is created automatically the first
+time you start the {dfanalytics-job}. The `index.number_of_shards` and
+`index.number_of_replicas` settings for the destination index are copied from
+the source index. If there are multiple source indices, the destination index
+copies the highest setting values. The mappings for the destination index are
+also copied from the source indices. If there any mapping conflicts, the job
+fails to start.
+
+If the destination index exists, it is used as is. You can therefore set up the
+destination index in advance with custom settings and mappings.
 
 [[ml-start-dfanalytics-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -17,17 +17,6 @@ return an error and the job waits in the `opening` state until sufficient {ml}
 node capacity is available.
 end::allow-lazy-open[]
 
-tag::allow-lazy-start[]
-Whether this job should be allowed to start when there is insufficient {ml} node 
-capacity for it to be immediately assigned to a node. The default is `false`, 
-which means that the <<start-dfanalytics>> will return an error if a {ml} node 
-with capacity to run the job cannot immediately be found. (However, this is also 
-subject to the cluster-wide `xpack.ml.max_lazy_ml_nodes` setting - see 
-<<advanced-ml-settings>>.) If this option is set to `true` then the 
-<<start-dfanalytics>> will not return an error, and the job will wait in the 
-`starting` state until sufficient {ml} node capacity is available.
-end::allow-lazy-start[]
-
 tag::allow-no-datafeeds[]
 Specifies what to do when the request:
 +
@@ -339,14 +328,6 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=mode]
 include::{docdir}/ml/ml-shared.asciidoc[tag=time-span]
 ====
 end::chunking-config[]
-
-tag::class-assignment-objective[]
-Defines the objective to optimize when assigning class labels. Available
-objectives are `maximize_accuracy` and `maximize_minimum_recall`. When maximizing
-accuracy class labels are chosen to maximize the number of correct predictions.
-When maximizing minimum recall labels are chosen to maximize the minimum recall
-for any class. Defaults to maximize_minimum_recall.
-end::class-assignment-objective[]
 
 tag::custom-rules[]
 An array of custom rule objects, which enable you to customize the way detectors
@@ -1071,7 +1052,7 @@ end::empty-bucket-count[]
 
 tag::eta[]
 Advanced configuration option. The shrinkage applied to the weights. Smaller
-values result in larger forests which have better generalization error. However,
+values result in larger forests which have a better generalization error. However,
 the smaller the value the longer the training will take. For more information
 about shrinkage, see
 https://en.wikipedia.org/wiki/Gradient_boosting#Shrinkage[this wiki article].
@@ -1170,10 +1151,10 @@ end::function[]
 
 tag::gamma[]
 Advanced configuration option. Regularization parameter to prevent overfitting
-on the training dataset. Multiplies a linear penalty associated with the size of 
+on the training data set. Multiplies a linear penalty associated with the size of 
 individual trees in the forest. The higher the value the more training will 
 prefer smaller trees. The smaller this parameter the larger individual trees
-will be and the longer train will take.
+will be and the longer training will take.
 end::gamma[]
 
 tag::groups[]
@@ -1328,12 +1309,12 @@ end::job-id-datafeed[]
 
 tag::lambda[]
 Advanced configuration option. Regularization parameter to prevent overfitting
-on the training dataset. Multiplies an L2 regularisation term which applies to
+on the training data set. Multiplies an L2 regularisation term which applies to
 leaf weights of the individual trees in the forest. The higher the value the
 more training will attempt to keep leaf weights small. This makes the prediction  
 function smoother at the expense of potentially not being able to capture 
 relevant relationships between the features and the {depvar}. The smaller this 
-parameter the larger individual trees will be and the longer train will take.
+parameter the larger individual trees will be and the longer training will take.
 end::lambda[]
 
 tag::last-data-time[]
@@ -1591,13 +1572,6 @@ tag::node-jobs[]
 Contains properties for the node that runs the job. This information is
 available only for open jobs.
 end::node-jobs[]
-
-tag::num-top-classes[]
-Defines the number of categories for which the predicted 
-probabilities are reported. It must be non-negative. If it is greater than the 
-total number of categories (in the {version} version of the {stack}, it's two) 
-to predict then we will report all category probabilities. Defaults to 2.
-end::num-top-classes[]
 
 tag::open-time[]
 For open jobs only, the elapsed time for which the job has been open.


### PR DESCRIPTION
This PR updates the create data frame analytics job API (https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html) related to the addition of multiclass classification. For example, it updates the dependent_variable and num_top_classes definitions.

It also edits some existing unrelated content. For example, it comments out hyperparameter optimization details that are moving in https://github.com/elastic/stack-docs/pull/990 and it moves details about mappings from the create DFA job API to the start DFA job API.

Preview:
* http://elasticsearch_54751.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html
* http://elasticsearch_54751.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/start-dfanalytics.html