### PR TITLE
Fix t_test usage stats

### DIFF
--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
@@ -57,22 +57,22 @@ public class TransportAnalyticsStatsActionTests extends ESTestCase {
                 new ActionFilters(Collections.emptySet()), usage);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54744")
     public void test() throws IOException {
-        AnalyticsUsage.Item item = randomFrom(AnalyticsUsage.Item.values());
-        AnalyticsUsage realUsage = new AnalyticsUsage();
-        AnalyticsUsage emptyUsage = new AnalyticsUsage();
-        ContextParser<Void, Void> parser = realUsage.track(item, (p, c) -> c);
-        ObjectPath unused = run(realUsage, emptyUsage);
-        assertThat(unused.evaluate("stats.0." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(0));
-        assertThat(unused.evaluate("stats.1." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(0));
-        int count = between(1, 10000);
-        for (int i = 0; i < count; i++) {
-            assertNull(parser.parse(null, null));
+        for (AnalyticsUsage.Item item : AnalyticsUsage.Item.values()) {
+            AnalyticsUsage realUsage = new AnalyticsUsage();
+            AnalyticsUsage emptyUsage = new AnalyticsUsage();
+            ContextParser<Void, Void> parser = realUsage.track(item, (p, c) -> c);
+            ObjectPath unused = run(realUsage, emptyUsage);
+            assertThat(unused.evaluate("stats.0." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(0));
+            assertThat(unused.evaluate("stats.1." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(0));
+            int count = between(1, 10000);
+            for (int i = 0; i < count; i++) {
+                assertNull(parser.parse(null, null));
+            }
+            ObjectPath used = run(realUsage, emptyUsage);
+            assertThat(item.name(), used.evaluate("stats.0." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(count));
+            assertThat(item.name(), used.evaluate("stats.1." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(0));
         }
-        ObjectPath used = run(realUsage, emptyUsage);
-        assertThat(used.evaluate("stats.0." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(count));
-        assertThat(used.evaluate("stats.1." + item.name().toLowerCase(Locale.ROOT) + "_usage"), equalTo(0));
     }
 
     private ObjectPath run(AnalyticsUsage... nodeUsages) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/action/AnalyticsStatsAction.java
@@ -114,6 +114,7 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
         static final ParseField CUMULATIVE_CARDINALITY_USAGE = new ParseField("cumulative_cardinality_usage");
         static final ParseField STRING_STATS_USAGE = new ParseField("string_stats_usage");
         static final ParseField TOP_METRICS_USAGE = new ParseField("top_metrics_usage");
+        static final ParseField T_TEST_USAGE = new ParseField("t_test_usage");
 
         private final long boxplotUsage;
         private final long cumulativeCardinalityUsage;
@@ -176,6 +177,7 @@ public class AnalyticsStatsAction extends ActionType<AnalyticsStatsAction.Respon
             builder.field(CUMULATIVE_CARDINALITY_USAGE.getPreferredName(), cumulativeCardinalityUsage);
             builder.field(STRING_STATS_USAGE.getPreferredName(), stringStatsUsage);
             builder.field(TOP_METRICS_USAGE.getPreferredName(), topMetricsUsage);
+            builder.field(T_TEST_USAGE.getPreferredName(), ttestUsage);
             builder.endObject();
             return builder;
         }


### PR DESCRIPTION
Adds missing t_test usage stats to XContent output.

Fixes #54744
