### PR TITLE
Adjust skip version for Index Template V2 tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/10_basic.yml
@@ -111,8 +111,8 @@
 ---
 "Put index template without index_patterns":
   - skip:
-      version: " - 7.99.99"
-      reason: "index template v2 API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
 
   - do:
       catch: bad_request

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -1,8 +1,8 @@
 ---
 "Component and index template composition":
   - skip:
-      version: " - 7.99.99"
-      reason: "not yet backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
 
   - do:
       cluster.put_component_template:
@@ -85,8 +85,8 @@
 ---
 "Index template priority":
   - skip:
-      version: " - 7.99.99"
-      reason: "not yet backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
 
   - do:
       indices.put_index_template:
@@ -123,8 +123,8 @@
 ---
 "Component template only composition":
   - skip:
-      version: " - 7.99.99"
-      reason: "not yet backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
 
   - do:
       cluster.put_component_template:
@@ -165,8 +165,8 @@
 ---
 "Index template without component templates":
   - skip:
-      version: " - 7.99.99"
-      reason: "not yet backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
 
   - do:
       indices.put_index_template:


### PR DESCRIPTION
These were skipped for all 7.x until the backport was finished, it's now backported so these can be
adjusted to be run on 7.8+

Relates to #53101
