### PR TITLE
Return 404s when autoscaling policies do not exist

### DIFF
--- a/x-pack/plugin/autoscaling/qa/rest/src/test/resources/rest-api-spec/test/autoscaling/delete_autoscaling_policy.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/test/resources/rest-api-spec/test/autoscaling/delete_autoscaling_policy.yml
@@ -21,8 +21,13 @@
         name: my_autoscaling_policy
 
 ---
-"Test delete non-existent policy":
+"Test delete non-existent autoscaling policy":
   - do:
-      catch: bad_request
+      catch: missing
+      autoscaling.delete_autoscaling_policy:
+        name: does_not_exist
+
+  - do:
+      catch: /autoscaling policy with name \[does_not_exist\] does not exist/
       autoscaling.delete_autoscaling_policy:
         name: does_not_exist

--- a/x-pack/plugin/autoscaling/qa/rest/src/test/resources/rest-api-spec/test/autoscaling/get_autoscaling_policy.yml
+++ b/x-pack/plugin/autoscaling/qa/rest/src/test/resources/rest-api-spec/test/autoscaling/get_autoscaling_policy.yml
@@ -24,7 +24,7 @@
 ---
 "Test get non-existent autoscaling policy":
   - do:
-      catch: bad_request
+      catch: missing
       autoscaling.get_autoscaling_policy:
         name: does_not_exist
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.autoscaling.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -103,7 +104,7 @@ public class TransportDeleteAutoscalingPolicyAction extends TransportMasterNodeA
             currentMetadata = AutoscalingMetadata.EMPTY;
         }
         if (currentMetadata.policies().containsKey(name) == false) {
-            throw new IllegalArgumentException("autoscaling policy with name [" + name + "] does not exist");
+            throw new ResourceNotFoundException("autoscaling policy with name [" + name + "] does not exist");
         }
         final SortedMap<String, AutoscalingPolicyMetadata> newPolicies = new TreeMap<>(currentMetadata.policies());
         final AutoscalingPolicyMetadata policy = newPolicies.remove(name);

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyAction.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling.action;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -76,7 +77,7 @@ public class TransportGetAutoscalingPolicyAction extends TransportMasterNodeActi
             metadata = AutoscalingMetadata.EMPTY;
         }
         if (metadata.policies().containsKey(name) == false) {
-            throw new IllegalArgumentException("autoscaling policy with name [" + name + "] does not exist");
+            throw new ResourceNotFoundException("autoscaling policy with name [" + name + "] does not exist");
         }
         return metadata.policies().get(name).policy();
     }

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling.action;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
@@ -34,8 +35,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
         assertThat(metadata.policies(), not(hasKey(policy.name())));
         // and verify that we can not obtain the policy via get
         final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(policy.name());
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
+        final ResourceNotFoundException e = expectThrows(
+            ResourceNotFoundException.class,
             () -> client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet()
         );
         assertThat(e.getMessage(), equalTo("autoscaling policy with name [" + policy.name() + "] does not exist"));
@@ -44,8 +45,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
     public void testDeleteNonExistentPolicy() {
         final String name = randomAlphaOfLength(8);
         final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(name);
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
+        final ResourceNotFoundException e = expectThrows(
+            ResourceNotFoundException.class,
             () -> client().execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet()
         );
         assertThat(e.getMessage(), containsString("autoscaling policy with name [" + name + "] does not exist"));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -114,8 +115,8 @@ public class TransportDeleteAutoscalingPolicyActionTests extends AutoscalingTest
         final AutoscalingMetadata currentMetadata = currentState.metadata().custom(AutoscalingMetadata.NAME);
         final String name = randomValueOtherThanMany(currentMetadata.policies().keySet()::contains, () -> randomAlphaOfLength(8));
         final Logger mockLogger = mock(Logger.class);
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
+        final ResourceNotFoundException e = expectThrows(
+            ResourceNotFoundException.class,
             () -> TransportDeleteAutoscalingPolicyAction.deleteAutoscalingPolicy(currentState, name, mockLogger)
         );
         assertThat(e.getMessage(), containsString("autoscaling policy with name [" + name + "] does not exist"));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionIT.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling.action;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 
@@ -30,8 +31,8 @@ public class TransportGetAutoscalingPolicyActionIT extends AutoscalingIntegTestC
     public void testGetNonExistentPolicy() {
         final String name = randomAlphaOfLength(8);
         final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(name);
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
+        final ResourceNotFoundException e = expectThrows(
+            ResourceNotFoundException.class,
             () -> client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet()
         );
         assertThat(e.getMessage(), containsString("autoscaling policy with name [" + name + "] does not exist"));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.autoscaling.action;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -100,8 +101,8 @@ public class TransportGetAutoscalingPolicyActionTests extends AutoscalingTestCas
         }
         final AutoscalingMetadata metadata = state.metadata().custom(AutoscalingMetadata.NAME);
         final String name = randomValueOtherThanMany(metadata.policies().keySet()::contains, () -> randomAlphaOfLength(8));
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
+        final ResourceNotFoundException e = expectThrows(
+            ResourceNotFoundException.class,
             () -> TransportGetAutoscalingPolicyAction.getAutoscalingPolicy(state, name)
         );
         assertThat(e.getMessage(), containsString("autoscaling policy with name [" + name + "] does not exist"));


### PR DESCRIPTION
This commit updates the autoscaling get and delete policy APIs to return 404s when the named policy does not exist.

