### PR TITLE
Java8 implementation of Map.Entry

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/common/collect/Map.java
+++ b/libs/core/src/main/java/org/elasticsearch/common/collect/Map.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.collect;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -146,6 +147,13 @@ public class Map {
             }
             return Collections.unmodifiableMap(map);
         }
+    }
+
+    /**
+     * Returns an unmodifiable Map.Entry for the provided key and value.
+     */
+    public static <K, V> java.util.Map.Entry<K, V> entry(K k, V v) {
+        return new AbstractMap.SimpleImmutableEntry<>(k, v);
     }
 
     /**

--- a/libs/core/src/main/java11/org/elasticsearch/common/collect/Map.java
+++ b/libs/core/src/main/java11/org/elasticsearch/common/collect/Map.java
@@ -113,6 +113,13 @@ public class Map {
     }
 
     /**
+     * Delegates to the Java9 {@code Map.entry()} method.
+     */
+    public static <K, V> java.util.Map.Entry<K, V> entry(K k, V v) {
+        return java.util.Map.entry(k, v);
+    }
+
+    /**
      * Delegates to the Java10 {@code Map.copyOf()} method.
      */
     public static <K, V> java.util.Map<K, V> copyOf(java.util.Map<? extends K, ? extends V> map) {

--- a/libs/core/src/test/java/org/elasticsearch/common/collect/MapTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/common/collect/MapTests.java
@@ -21,8 +21,6 @@ package org.elasticsearch.common.collect;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.AbstractMap;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class MapTests extends ESTestCase {
@@ -101,9 +99,9 @@ public class MapTests extends ESTestCase {
 
     public void testOfEntries() {
         final java.util.Map<String, Integer> map = Map.ofEntries(
-            new AbstractMap.SimpleEntry<>(numbers[0], 0),
-            new AbstractMap.SimpleEntry<>(numbers[1], 1),
-            new AbstractMap.SimpleEntry<>(numbers[2], 2)
+            Map.entry(numbers[0], 0),
+            Map.entry(numbers[1], 1),
+            Map.entry(numbers[2], 2)
         );
         validateMapContents(map, 3);
     }


### PR DESCRIPTION
A Java8 compatible version of `Map.ofEntries()` was added in #54183,
but it really needs a compat version of `Map.entry` as well in order to
facilitate easy backports from master.
