### PR TITLE
[Backport] Resolve SERVICE_UNAVAILABLE in IdP IntegTest

### DIFF
--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
@@ -295,6 +295,9 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     }
 
     private void registerServiceProvider(String entityId, String acsUrl) throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(1);
+        ensureYellowAndNoInitializingShards();
+
         Map<String, Object> spFields = new HashMap<>();
         spFields.put(SamlServiceProviderDocument.Fields.ACS.getPreferredName(), acsUrl);
         spFields.put(SamlServiceProviderDocument.Fields.ENTITY_ID.getPreferredName(), entityId);


### PR DESCRIPTION
The SamlIdentityProviderTests IntegTests would sometimes encounter a
service unavailable exception when registering a new service provider.

This change ensure that there is a data node, and that the cluster
state is recovered before registering providers

Backport of: #54622, #54700
