### PR TITLE
Make it clear docs/freqs index options can lead to query errors

### DIFF
--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -14,11 +14,15 @@ It accepts the following values:
 
 `docs`::
 Only the doc number is indexed.  Can answer the question _Does this term
-exist in this field?_
+exist in this field?_ . This cannot be used for
+<<query-dsl-match-query-phrase,proximity or phrase queries>> and queries
+that attempt to use a `docs` index for that type of query will raise an error.
 
 `freqs`::
 Doc number and term frequencies are indexed.  Term frequencies are used to
-score repeated terms higher than single terms.
+score repeated terms higher than single terms. This cannot be used for
+<<query-dsl-match-query-phrase,proximity or phrase queries>> and queries
+that attempt to use a `freqs` index for that type of query will raise an error.
 
 `positions` (default)::
 Doc number, term frequencies, and term positions (or order) are indexed.

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -15,7 +15,9 @@ documents.
 While its syntax is more limited than the
 <<query-dsl-query-string-query,`query_string` query>>, the `simple_query_string`
 query does not return errors for invalid syntax. Instead, it ignores any invalid
-parts of the query string.
+parts of the query string. Note that it can still raise error if you attempt to
+use certain queries that are not valid for the index options. For example a
+phrase query that attempts to use a `docs` index will cause an error.
 
 [[simple-query-string-query-ex-request]]
 ==== Example request


### PR DESCRIPTION
Make it clear that changing from the default `index_options` can lead to certain
queries resulting in errors. At present the docs allude to the fact that the higher
level index options allow for proximity and phrase matches but they do not
explicitly call out the fact that if you change to the other options certain queries
will error out. This change makes it harder for people to miss this important
detail.

If there was some more detail about the implications of these options it might have saved a large outage for us. I'm not sure if this is the best place for the docs but these are at least the 2 places we were reading docs and would have been able to notice the problem with a similar warning.