### PR TITLE
Handle shard closed during prerecovery

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1311,7 +1311,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     public void preRecovery() {
-        assert state == IndexShardState.RECOVERING : "expected a recovering shard " + shardId + " but got " + state;
+        final IndexShardState currentState = this.state; // single volatile read
+        if (currentState == IndexShardState.CLOSED) {
+            throw new IndexShardNotRecoveringException(shardId, currentState);
+        }
+        assert currentState == IndexShardState.RECOVERING : "expected a recovering shard " + shardId + " but got " + currentState;
         indexEventListener.beforeIndexShardRecovery(this, indexSettings);
     }
 


### PR DESCRIPTION
Today we assert that the shard is in state RECOVERING during prerecovery, but
the recovery may already have been cancelled by a subsequent cluster state
update. This commit adds handling for this cancellation.

Relates #50999.