### PR TITLE
Metricbeat elasticsearch-xpack : add enrich metricset from 7.5 documentation

### DIFF
--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -84,6 +84,7 @@ The `modules.d/elasticsearch-xpack.yml` file contains the following settings:
       - ml_job
       - node_stats
       - shard
+      - enrich
     period: 10s
     hosts: ["http://localhost:9200"]
     #username: "user"


### PR DESCRIPTION
In 7.5+, if enrich metricset is missing in elasticsearch-xpack module, metricbeat won't start with : 
```
Exiting: The elasticsearch module with xpack.enabled: true must have metricsets: [ccr enrich cluster_stats index index_recovery index_summary ml_job node_stats shard]
```

This PR adds the setting in documentation

