### PR TITLE
Wait for ML templates after creating a new cluster in TooManyJobsIT

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/TooManyJobsIT.java
@@ -74,6 +74,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         }
         logger.info("Started [{}] nodes", numNodes);
         ensureStableCluster(numNodes);
+        ensureTemplatesArePresent();
         logger.info("[{}] is [{}]", MachineLearning.MAX_LAZY_ML_NODES.getKey(), maxNumberOfLazyNodes);
         // Set our lazy node number
         assertTrue(client().admin()
@@ -208,6 +209,7 @@ public class TooManyJobsIT extends BaseMlIntegTestCase {
         }
         logger.info("Started [{}] nodes", numNodes);
         ensureStableCluster(numNodes);
+        ensureTemplatesArePresent();
     }
 
     private long calculateMaxMlMemory() {


### PR DESCRIPTION
`TooManyJobsIT.testCloseFailedJob` stops all the data nodes in the cluster and restarts them again, in effect this is a brand new cluster and the test should wait for the ml templates to be installed before continuing. 

This handles 2 of the failures listed in #54162 where indices in the new cluster are created without a template but there is still one failure where the test timed out waiting for the templates in the _original_ cluster. This may just be due to a slow machine I will unmute the test in the backport to 7.x and watch for new failures.

As to why the tests staring failing now and only on 7.x I am not sure, possibly something in #51765. The best way forward is to unmute the test and see if it happens again
 