### PR TITLE
[DOCS] Updates transform prerequisites

### DIFF
--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -21,11 +21,11 @@ Deletes an existing {transform}.
 * Before you can delete the {transform}, you must stop it.
 
 If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
-
-* `transform_admin`
+privileges:
 
 * `manage_transform` 
+
+The built-in `transform_admin` role has this privilege. 
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -19,10 +19,15 @@ Deletes an existing {transform}.
 ==== {api-prereq-title}
 
 * Before you can delete the {transform}, you must stop it.
-* If the {es} {security-features} are enabled, you must have `manage_transform` 
-cluster privileges to use this API. The built-in `transform_admin` role has 
-these privileges. For more information, see <<security-privileges>> and 
-<<built-in-roles>>.
+
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_admin`
+
+* `manage_transform` 
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[delete-transform-path-parms]]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -28,10 +28,14 @@ Retrieves usage information for {transforms}.
 [[get-transform-stats-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_transform` 
-cluster privileges to use this API. The built-in `transform_user` role has these 
-privileges. For more information, see <<security-privileges>> and 
-<<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_admin`
+
+* `manage_transform` 
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[get-transform-stats-desc]]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -31,9 +31,9 @@ Retrieves usage information for {transforms}.
 If the {es} {security-features} are enabled, you must have the following 
 privileges:
 
-* `manage_transform` 
+* `monitor_transform` 
 
-The built-in `transform_admin` role has this privilege. 
+The built-in `transform_user` role has this privilege. 
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -29,11 +29,11 @@ Retrieves usage information for {transforms}.
 ==== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
-
-* `transform_admin`
+privileges:
 
 * `manage_transform` 
+
+The built-in `transform_admin` role has this privilege. 
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -27,11 +27,11 @@ Retrieves configuration information for {transforms}.
 ==== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
-
-* `transform_user`
+privileges:
 
 * `monitor_transform` 
+
+The built-in `transform_user` role has this privilege. 
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -26,10 +26,14 @@ Retrieves configuration information for {transforms}.
 [[get-transform-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `monitor_transform` 
-cluster privileges to use this API. The built-in `transform_user` role has these 
-privileges. For more information, see <<security-privileges>> and 
-<<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_user`
+
+* `monitor_transform` 
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 [[get-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -19,12 +19,12 @@ Previews a {transform}.
 ==== {api-prereq-title}
 
 If the {es} {security-features} are enabled, you must have the following 
-built-in roles and privileges:
-
-* `transform_admin`
+privileges:
 
 * `manage_transform` 
 * source index: `read`, `view_index_metadata`
+
+The built-in `transform_admin` role has the `manage_transform` privilege.
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -18,11 +18,16 @@ Previews a {transform}.
 [[preview-transform-prereq]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_transform` 
-cluster privileges to use this API. The built-in `transform_admin` role has 
-these privileges. You must also have `read` and `view_index_metadata` privileges 
-on the source index for the {transform}. For more information, see 
-<<security-privileges>> and <<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_admin`
+
+* `manage_transform` 
+* source index: `read`, `view_index_metadata`
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[preview-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -18,12 +18,18 @@ Instantiates a {transform}.
 [[put-transform-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_transform` 
-cluster privileges to use this API. The built-in `transform_admin` role has 
-these privileges. You must also have `read` and `view_index_metadata` privileges 
-on the source index and `read`, `create_index`, and `index` privileges on the 
-destination index. For more information, see <<security-privileges>> and 
-<<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_admin`
+* `kibana_admin` (UI only)
+
+* source index: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, `manage` and `index`
+* cluster: `monitor` (UI only)
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[put-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -18,10 +18,14 @@ Starts one or more {transforms}.
 [[start-transform-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_transform` 
-cluster privileges to use this API. You must also have `view_index_metadata` 
-privileges on the source index for the {transform}. For more information, see 
-<<security-privileges>> and <<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `manage_transform`
+* source index: `view_index_metadata`  
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[start-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -27,9 +27,9 @@ Stops one or more {transforms}.
 If the {es} {security-features} are enabled, you must have the following 
 built-in roles and privileges:
 
-* `transform_admin`
-
 * `manage_transform` 
+
+The built-in `transform_admin` role has this privilege. 
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -24,10 +24,14 @@ Stops one or more {transforms}.
 [[stop-transform-prereq]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_transform` 
-cluster privileges to use this API. The built-in `transform_admin` role has 
-these privileges. For more information, see <<security-privileges>> and 
-<<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_admin`
+
+* `manage_transform` 
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 
 [[stop-transform-desc]]

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -18,12 +18,17 @@ Updates certain properties of a {transform}.
 [[update-transform-prereqs]]
 ==== {api-prereq-title}
 
-* If the {es} {security-features} are enabled, you must have `manage_transform` 
-cluster privileges to use this API. The built-in  `transform_admin` role has 
-these privileges. You must also have `read` and  `view_index_metadata` 
-privileges on the source index and `read`, `create_index`, and `index` 
-privileges on the destination index. For more information, see 
-<<security-privileges>> and <<built-in-roles>>.
+If the {es} {security-features} are enabled, you must have the following 
+built-in roles and privileges:
+
+* `transform_admin`
+
+* `manage_transform`
+* source index: `read`, `view_index_metadata`
+* destination index: `read`, `create_index`, `index`
+
+For more information, see <<security-privileges>> and <<built-in-roles>>.
+
 
 [[update-transform-desc]]
 ==== {api-description-title}

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -23,7 +23,7 @@ built-in roles and privileges:
 
 * `transform_admin`
 
-* `manage_transform`
+* `manage_transform` (the built-in `transform_admin` role has this privilege)
 * source index: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `index`
 


### PR DESCRIPTION
This PR updates the prerequisites of using transforms in the docs and uses a bulleted list instead of normal text.

Preview:

* [GET](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-transform.html)
* [GET stats](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-transform-stats.html)
* [PUT](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html)
* [Delete](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-transform.html)
* [Preview](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html)
* [Start](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/start-transform.html)
* [Stop](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/stop-transform.html)
* [Update](http://elasticsearch_54804.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-transform.html)