### PR TITLE
[DOCS] Changes kibana_user to kibana_admin in DFA API prerequisites

### DIFF
--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -25,7 +25,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
-* `kibana_user` (UI only)
+* `kibana_admin` (UI only)
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -26,7 +26,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
-* `kibana_user` (UI only)
+* `kibana_admin` (UI only)
 
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -24,7 +24,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
 
 * `machine_learning_admin`
-* `kibana_user` (UI only)
+* `kibana_admin` (UI only)
 
 
 * source index: `read`, `view_index_metadata`

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -24,7 +24,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles and privileges:
 
 * `machine_learning_admin`
-* `kibana_user` (UI only)
+* `kibana_admin` (UI only)
 
 
 * source index: `read`, `view_index_metadata`

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -28,7 +28,7 @@ If the {es} {security-features} are enabled, you must have the following
 built-in roles or equivalent privileges:
 
 * `machine_learning_admin`
-* `kibana_user` (UI only)
+* `kibana_admin` (UI only)
   
 For more information, see <<security-privileges>> and <<built-in-roles>>.
 


### PR DESCRIPTION
The role `kibana_user` has been deprecated in favor of `kibana_admin`. This PR changes the `kibana_user` prerequisite to `kibana_admin` in the data frame analytics API documentation.