### PR TITLE
Allow terms agg to default to depth first

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -102,10 +102,10 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 if (valuesSource instanceof ValuesSource.Bytes.WithOrdinals == false) {
                     execution = ExecutionMode.MAP;
                 }
-                final long maxOrd = execution == ExecutionMode.GLOBAL_ORDINALS ? getMaxOrd(valuesSource, context.searcher()) : -1;
                 if (execution == null) {
                     execution = ExecutionMode.GLOBAL_ORDINALS;
                 }
+                final long maxOrd = execution == ExecutionMode.GLOBAL_ORDINALS ? getMaxOrd(valuesSource, context.searcher()) : -1;
                 if (subAggCollectMode == null) {
                     subAggCollectMode = SubAggCollectionMode.DEPTH_FIRST;
                     // TODO can we remove concept of AggregatorFactories.EMPTY?


### PR DESCRIPTION
If you didn't explictly set `global_ordinals` execution mode we were
never collecting the information that we needed to select `depth_first`
based on the request so we were always defaulting to `breadth_first`.
This fixes it so we collect the information. So we *can* make the choice.
