### PR TITLE
[DOCS] Remove text fields from classification dependent variables

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -128,7 +128,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=class-assignment-objective]
 include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 The data type of the field must be numeric (`integer`, `short`, `long`, `byte`), 
-categorical (`ip`, `keyword`, `text`), or boolean.
+categorical (`ip` or `keyword`), or boolean.
 
 `eta`::::
 (Optional, double) 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/53876
This PR removes `text` from the list of supported dependent variable data types for classification.

NOTE: Since https://github.com/elastic/elasticsearch/pull/53874 does not seem to be backported to 7.6 (i.e. text fields are still supported in that version with binary classification), I think we should add a breaking change in 7.x and 7.7 documentation.

Preview: http://elasticsearch_54849.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html