### PR TITLE
[DOCS] Adds tranform node to list of default types

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -16,7 +16,7 @@ requests to the appropriate node.
 By default, a node is all of the following types: master-eligible, data, ingest,
 and (if available) machine learning and transform.
 
-TIP: As the cluster grows and in particular if you have large {ml} jobs and
+TIP: As the cluster grows and in particular if you have large {ml} jobs or
 {ctransforms}, consider separating dedicated master-eligible nodes from
 dedicated data nodes, {ml} nodes, and {transform} nodes.
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -16,9 +16,9 @@ requests to the appropriate node.
 By default, a node is all of the following types: master-eligible, data, ingest,
 and (if available) machine learning and transform.
 
-TIP: As the cluster grows and in particular if you have large {ml} jobs,
-consider separating dedicated master-eligible nodes from dedicated data nodes
-and dedicated {ml} nodes.
+TIP: As the cluster grows and in particular if you have large {ml} jobs and
+{ctransforms}, consider separating dedicated master-eligible nodes from
+dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 <<master-node,Master-eligible node>>::
 

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -14,7 +14,7 @@ All nodes know about all the other nodes in the cluster and can forward client
 requests to the appropriate node.
 
 By default, a node is all of the following types: master-eligible, data, ingest,
-and machine learning (if available).
+and (if available) machine learning and transform.
 
 TIP: As the cluster grows and in particular if you have large {ml} jobs,
 consider separating dedicated master-eligible nodes from dedicated data nodes


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/52712

This PR updates the node module (https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-node.html) to clarify that all nodes are transform nodes by default.

Preview: http://elasticsearch_54850.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-node.html