### PR TITLE
value_count Aggregation optimization

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -21,7 +21,9 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleDocValuesField;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -108,6 +110,38 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         Map<String, ScriptEngine> engines = Collections.singletonMap(scriptEngine.getType(), scriptEngine);
 
         return new ScriptService(Settings.EMPTY, engines, ScriptModule.CORE_CONTEXTS);
+    }
+
+
+    public void testGeoField() throws IOException {
+        testCase(new MatchAllDocsQuery(), ValueType.GEOPOINT, iw -> {
+            for (int i = 0; i < 10; i++) {
+                Document document = new Document();
+                document.add(new LatLonDocValuesField("field", 10, 10));
+                iw.addDocument(document);
+            }
+        }, count -> assertEquals(10L, count.getValue()));
+    }
+
+    public void testDoubleField() throws IOException {
+        testCase(new MatchAllDocsQuery(), ValueType.DOUBLE, iw -> {
+            for (int i = 0; i < 15; i++) {
+                Document document = new Document();
+                document.add(new DoubleDocValuesField(FIELD_NAME, 23D));
+                iw.addDocument(document);
+            }
+        }, count -> assertEquals(15L, count.getValue()));
+    }
+
+    public void testKeyWordField() throws IOException {
+        testCase(new MatchAllDocsQuery(), ValueType.STRING, iw -> {
+            for (int i = 0; i < 20; i++) {
+                Document document = new Document();
+                document.add(new SortedSetDocValuesField(FIELD_NAME, new BytesRef("stringValue")));
+                document.add(new SortedSetDocValuesField(FIELD_NAME, new BytesRef("string11Value")));
+                iw.addDocument(document);
+            }
+        }, count -> assertEquals(40L, count.getValue()));
     }
 
     public void testNoDocs() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -78,8 +78,8 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
     private static final String FIELD_NAME = "field";
 
-    /** Script to return the {@code _value} provided by aggs framework. */
-    private static final String VALUE_SCRIPT = "_value";
+    private static final String STRING_VALUE_SCRIPT = "string_value";
+    private static final String NUMBER_VALUE_SCRIPT = "number_value";
     private static final String SINGLE_SCRIPT = "single";
 
     @Override
@@ -101,7 +101,8 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     protected ScriptService getMockScriptService() {
         Map<String, Function<Map<String, Object>, Object>> scripts = new HashMap<>();
 
-        scripts.put(VALUE_SCRIPT, vars -> (Double.valueOf((String) vars.get("_value")) + 1));
+        scripts.put(STRING_VALUE_SCRIPT, vars -> (Double.valueOf((String) vars.get("_value")) + 1));
+        scripts.put(NUMBER_VALUE_SCRIPT, vars -> (((Number) vars.get("_value")).doubleValue() + 1));
         scripts.put(SINGLE_SCRIPT, vars -> 1);
 
         MockScriptEngine scriptEngine = new MockScriptEngine(MockScriptEngine.NAME,
@@ -273,7 +274,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     public void testValueScriptNumber() throws IOException {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name")
             .field(FIELD_NAME)
-            .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, Collections.emptyMap()));
+            .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, NUMBER_VALUE_SCRIPT, Collections.emptyMap()));
 
         MappedFieldType fieldType = createMappedFieldType(ValueType.NUMERIC);
         fieldType.setName(FIELD_NAME);
@@ -322,7 +323,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     public void testValueScriptString() throws IOException {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name")
             .field(FIELD_NAME)
-            .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, Collections.emptyMap()));
+            .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, STRING_VALUE_SCRIPT, Collections.emptyMap()));
 
         MappedFieldType fieldType = createMappedFieldType(ValueType.STRING);
         fieldType.setName(FIELD_NAME);


### PR DESCRIPTION
We found some problems during the test.

Data: 200Million docs， 1 shard，0 replica。


Hit | avg | sum | value_count
-- | -- | -- | --
20k | 38ms | 33ms | 63ms
200k | 127ms | 125ms | 334ms
2Million | 789ms | 729ms | 3.176s
20Million | 4.2s | 3.239s | 22.787s
200Million(100%) | 21s | 22s | 154.917s


The performance of avg, sum and other is very close when performing statistics, but the performance of value_count has always been poor, even not on an order of magnitude. Based on some common-sense knowledge, we think that value_count and sum are similar operations, and the time consumed should be the same. Therefore, we have discussed the agg of value_count.

The principle of counting in es is to traverse the field of each document. If the field is an ordinary value, the count value is increased by 1. If it is an array type, the count value is increased by n. However, the problem lies in traversing each document and taking out the field, which changes from disk to an object in the Java language. We summarize its current problems with Elasticsearch as:

- Number cast to string overhead, and GC problems caused by a large number of strings
- After the number type is converted to string, sorting and other unnecessary operations are performed


Here is the proof of type conversion overhead.

```
// Java long to string source code, getChars is very time-consuming.
public static String toString(long i) {
        int size = stringSize(i);
        if (COMPACT_STRINGS) {
            byte[] buf = new byte[size];
            getChars(i, size, buf);
            return new String(buf, LATIN1);
        } else {
            byte[] buf = new byte[size * 2];
            StringUTF16.getChars(i, size, buf);
            return new String(buf, UTF16);
        }
}   
```


test type | average | min | max | sum
-- | -- | -- | -- | --
double->long | 32.2ns | 28ns | 0.024ms | 3.22s
long->double | 31.9ns | 28ns | 0.036ms | 3.19s
long->String | 163.8ns | 93ns | 1921ms | 16.3s



https://github.com/elastic/elasticsearch/issues/36752 The program heat map shows that the toString time is particularly serious. 

## optimization

Our optimization code is actually very simple. It is to manage different types separately, instead of uniformly converting to string unified processing. We added type identification in ValueCountAggregator, and made special treatment for number and geopoint types to cancel their type conversion. Because the string type is reduced and the string constant is reduced, the improvement effect is very obvious.

## result



Hit | avg | sum |  value_countdouble before| value_countdouble after| value_countkeyword before | value_countkeyword after | value_countgeo_point before | value_countgeo_point after
-- | -- | -- | -- | -- | -- | -- | -- | --
20k | 38ms | 33ms | 63ms | 26ms | 30ms | 30ms | 38ms | 15ms
200k | 127ms | 125ms | 334ms | 78ms | 116ms | 99s | 278ms | 31ms
2Million | 789ms | 729ms | 3.176s | 439ms | 348ms | 386ms | 3.365s | 178ms
20Million | 4.2s | 3.239s | 22.787s | 2.7s | 2.5s | 2.6s | 25.192s | 1.278s
200Million(100%) | 21s | 22s | 154.917s | 18.99s | 19s | 20s | 168.971s | 9.093s

- The results are more in line with common sense. valuecount is about the same as avg, sum, etc., or even lower than these. Previously, valuecount was much larger than avg and sum, and it was not even an order of magnitude when the amount of data was large.
- When calculating numeric types such as double and long, the performance is improved by about 8 to 9 times; when calculating the geo_point type, the performance is improved by 18 to 20 times.







