### PR TITLE
[TEST] Allow kb or mb for data frame analytics memory estimate

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/explain_data_frame_analytics.yml
@@ -126,9 +126,9 @@
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
   - match:
-      memory_estimation.expected_memory_without_disk: / \dkb /
+      memory_estimation.expected_memory_without_disk: / \d[km]b /
   - match:
-      memory_estimation.expected_memory_with_disk: / \dkb /
+      memory_estimation.expected_memory_with_disk: / \d[km]b /
   - length: { field_selection: 2 }
   - match: { field_selection.0.name: "x" }
   - match: { field_selection.0.mapping_types: ["float"] }
@@ -156,9 +156,9 @@
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
   - match:
-      memory_estimation.expected_memory_without_disk: / \dkb /
+      memory_estimation.expected_memory_without_disk: / \d[km]b /
   - match:
-      memory_estimation.expected_memory_with_disk: / \dkb /
+      memory_estimation.expected_memory_with_disk: / \d[km]b /
 
   - do:
       index:
@@ -173,9 +173,9 @@
           source: { index: "index-source" }
           analysis: { outlier_detection: {} }
   - match:
-      memory_estimation.expected_memory_without_disk: / \dkb /
+      memory_estimation.expected_memory_without_disk: / \d[km]b /
   - match:
-      memory_estimation.expected_memory_with_disk: / \dkb /
+      memory_estimation.expected_memory_with_disk: / \d[km]b /
 
 ---
 "Test field_selection given body":


### PR DESCRIPTION
This change is to support the switch from kb to mb being made in
https://github.com/elastic/ml-cpp/pull/1126