### PR TITLE
Adjust versions after searchable snapshots has been backported to `7.x`

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteAction.java
@@ -50,7 +50,7 @@ public class DeleteAction implements LifecycleAction {
     }
 
     public DeleteAction(StreamInput in) throws IOException {
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             this.deleteSearchableSnapshot = in.readBoolean();
         } else {
             this.deleteSearchableSnapshot = true;
@@ -59,7 +59,7 @@ public class DeleteAction implements LifecycleAction {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeBoolean(deleteSearchableSnapshot);
         }
     }

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/test/resources/rest-api-spec/test/clear_cache.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/test/resources/rest-api-spec/test/clear_cache.yml
@@ -67,8 +67,8 @@ teardown:
 ---
 "Clear searchable snapshots cache":
   - skip:
-      version: " - 7.99.99"
-      reason:  searchable snapshots introduced in 8.0
+      version: " - 7.7.99"
+      reason:  searchable snapshots introduced in 7.8.0
 
   - do:
       catch: missing

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/test/resources/rest-api-spec/test/stats.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/test/resources/rest-api-spec/test/stats.yml
@@ -66,8 +66,8 @@ teardown:
 ---
 "Tests searchable snapshots stats":
   - skip:
-      version: " - 7.99.99"
-      reason:  searchable snapshots introduced in 8.0
+      version: " - 7.7.99"
+      reason:  searchable snapshots introduced in 7.8.0
 
   - do:
       catch: missing


### PR DESCRIPTION
This commit adjusts some versions on `master` now searchable snapshots has been backported to `7.x` in #54825.