### PR TITLE
Only one of azure key or token can be specified in 3rd party tests

### DIFF
--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -52,8 +52,6 @@ if (!azureAccount && !azureKey && !azureContainer && !azureBasePath && !azureSas
   azureSasToken = ''
   useFixture = true
 
-} else if (!azureAccount || !azureKey || !azureContainer || !azureBasePath || !azureSasToken) {
-  throw new IllegalArgumentException("not all options specified to run against external Azure service are present")
 }
 
 if (useFixture) {
@@ -78,8 +76,12 @@ testClusters.integTest {
   }
 
   keystore 'azure.client.searchable_snapshots.account', azureAccount
-  keystore 'azure.client.searchable_snapshots.key', azureKey
-  keystore 'azure.client.searchable_snapshots.sas_token', azureSasToken
+  if (azureKey != null && azureKey.isEmpty() == false) {
+    keystore 'azure.client.searchable_snapshots.key', azureKey
+  }
+  if (azureSasToken != null && azureSasToken.isEmpty() == false) {
+    keystore 'azure.client.searchable_snapshots.sas_token', azureSasToken
+  }
 
   setting 'xpack.license.self_generated.type', 'trial'
 


### PR DESCRIPTION
#54803 introduces more QA tests for Azure storage service, but they fail the build is one of the key or token is missing. It should instead work like `repository-azure:qa` tests.