### PR TITLE
[DOCS] Correct URL for searchable snapshot API specs

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.clear_cache": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-clear-cache.html"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-clear-cache.html"
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.mount": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-mount-snapshot.html"
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-api-stats.html"
     },
     "stability": "experimental",
     "url": {


### PR DESCRIPTION
The JSON specs for the following APIs link to docs pages that don't exist:

* Mount snapshot API
* Clear cache API
* Searchable snapshot statistics API

This can cause doc build errors for ES client docs, such as the Elasticsearch-JS client.

This updates those links so downstream clients have a valid link.

Link to related broken docs build: https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/14790/console