### PR TITLE
Fix scripted metric in ccs (backport of #54776)

### DIFF
--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
@@ -196,6 +196,44 @@
   - match: { aggregations.cluster.buckets.1.animal.buckets.1.s.value: 0 }
   - match: { aggregations.cluster.buckets.1.average_sum.value: 1 }
 
+  # scripted_metric
+  - do:
+      search:
+        index: test_index,my_remote_cluster:test_index
+        body:
+          seq_no_primary_term: true
+          aggs:
+            cluster:
+              terms:
+                field: f1.keyword
+              aggs:
+                animal_length:
+                  scripted_metric:
+                    init_script: |
+                      state.sum = 0
+                    map_script: |
+                      state.sum += doc['animal.keyword'].value.length()
+                    combine_script: |
+                      state.sum
+                    reduce_script: |
+                      long sum = 0;
+                      for (s in states) {
+                        sum += s;
+                      }
+                      return sum
+  - match: { num_reduce_phases: 3 }
+  - match: {_clusters.total: 2}
+  - match: {_clusters.successful: 2}
+  - match: {_clusters.skipped: 0}
+  - match: { _shards.total: 5 }
+  - match: { hits.total.value: 11 }
+  - length: { aggregations.cluster.buckets: 2 }
+  - match: { aggregations.cluster.buckets.0.key: "remote_cluster" }
+  - match: { aggregations.cluster.buckets.0.doc_count: 6 }
+  - match: { aggregations.cluster.buckets.0.animal_length.value: 34 }
+  - match: { aggregations.cluster.buckets.1.key: "local_cluster" }
+  - match: { aggregations.cluster.buckets.1.animal_length.value: 15 }
+
 ---
 "Add transient remote cluster based on the preset cluster":
   - do:

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -132,7 +132,7 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         if (hasReduceScript) {
             assertEquals(inputs.size(), reduced.aggregation());
         } else {
-            assertEquals(inputs.size(), ((List<Object>) reduced.aggregation()).size());
+            assertEquals(inputs.size(), ((List<?>) reduced.aggregation()).size());
         }
     }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
@@ -42,8 +42,16 @@ public class InternalStringStatsTests extends InternalAggregationTestCase<Intern
         if (randomBoolean()) {
             return new InternalStringStats(name, 0, 0, 0, 0, emptyMap(), randomBoolean(), DocValueFormat.RAW, emptyList(), metadata);
         }
-        return new InternalStringStats(name, randomLongBetween(1, Long.MAX_VALUE),
-                randomNonNegativeLong(), between(0, Integer.MAX_VALUE), between(0, Integer.MAX_VALUE), randomCharOccurrences(),
+        /*
+         * Pick random count and length that are *much* less than
+         * Long.MAX_VALUE because reduction adds them together and sometimes
+         * serializes them and that serialization would fail if the sum has
+         * wrapped to a negative number.
+         */
+        long count = randomLongBetween(1, Integer.MAX_VALUE);
+        long totalLength = randomLongBetween(0, count * 10);
+        return new InternalStringStats(name, count, totalLength,
+                between(0, Integer.MAX_VALUE), between(0, Integer.MAX_VALUE), randomCharOccurrences(),
                 randomBoolean(), DocValueFormat.RAW,
                 emptyList(), metadata);
     };


### PR DESCRIPTION
`scripted_metric` did not work with cross cluster search because it
assumed that you'd never perform a partial reduction, serialize the
results, and then perform a final reduction. That
serialized-after-partial-reduction step was broken.

This is also required to support #54758.
