### PR TITLE
Remove Unused Snapshot Status Values

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -427,9 +427,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         STARTED((byte) 1, false),
         SUCCESS((byte) 2, true),
         FAILED((byte) 3, true),
-        ABORTED((byte) 4, false),
-        MISSING((byte) 5, true),
-        WAITING((byte) 6, false);
+        ABORTED((byte) 4, false);
 
         private final byte value;
 
@@ -460,10 +458,6 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                     return FAILED;
                 case 4:
                     return ABORTED;
-                case 5:
-                    return MISSING;
-                case 6:
-                    return WAITING;
                 default:
                     throw new IllegalArgumentException("No snapshot state for value [" + value + "]");
             }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -716,7 +716,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                                 new Snapshot(randomName("repo"), new SnapshotId(randomName("snap"), UUIDs.randomBase64UUID())),
                                 randomBoolean(),
                                 randomBoolean(),
-                                SnapshotsInProgress.State.fromValue((byte) randomIntBetween(0, 6)),
+                                randomFrom(SnapshotsInProgress.State.values()),
                                 Collections.emptyList(),
                                 Math.abs(randomLong()),
                                 (long) randomIntBetween(0, 1000),


### PR DESCRIPTION
This is a left-over from before #41940 when we used the same status enum for the shards
and the snapshots overall. The two removed values were never used on the shard level
so we can simply remove them here without BwC implications.
