### PR TITLE
Add runner settings to remote debug configuration in IntelliJ

### DIFF
--- a/.idea/runConfigurations/Debug_Elasticsearch.xml
+++ b/.idea/runConfigurations/Debug_Elasticsearch.xml
@@ -6,6 +6,10 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="5005" />
     <option name="AUTO_RESTART" value="true" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5005" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>


### PR DESCRIPTION
When remote run configuration is executed in IntelliJ Community edition, it
automatically adds the RunnedSettings section. This section doesn't seem to have
any negative effect on the Ultimate Edition.
