### PR TITLE
Add allowed warnings to index template composition tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -3,6 +3,7 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
       cluster.put_component_template:
@@ -35,6 +36,8 @@
                 is_write_index: true
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [foo, bar-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -87,8 +90,11 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [foo, bar-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -100,6 +106,8 @@
           priority: 400
 
   - do:
+      allowed_warnings:
+        - "index template [another-template] has index patterns [bar-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [another-template] will take precedence during new index creation"
       indices.put_index_template:
         name: another-template
         body:
@@ -125,6 +133,7 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
       cluster.put_component_template:
@@ -145,6 +154,8 @@
                   type: keyword
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [baz*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -167,8 +178,11 @@
   - skip:
       version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [eggplant] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:


### PR DESCRIPTION
We occasionally add a global template for our YAML tests, and this can cause warnings for these
template tests. This commit adds these warnings so they don't cause test failures.

Resolves #54822
