### PR TITLE
Remove guard around atomic move supported check

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -279,9 +279,7 @@ public final class NodeEnvironment  implements Closeable {
             applySegmentInfosTrace(settings);
             assertCanWrite();
 
-            if (DiscoveryNode.isMasterNode(settings) || DiscoveryNode.isDataNode(settings)) {
-                ensureAtomicMoveSupported(nodePaths);
-            }
+            ensureAtomicMoveSupported(nodePaths);
 
             if (upgradeLegacyNodeFolders(logger, settings, environment, nodeLock)) {
                 assertCanWrite();


### PR DESCRIPTION
We use to allow non-data/non-master nodes to not have a persistent data path via the undocumented node.local_storage setting. We recently removed this setting, but left behind was a guard around a check that the data paths support atomic moves. This commit unguards this check, so that all nodes are required to have persistent storage that supports atomic move operations.

Relates #54381 
