### PR TITLE
Remove pipline aggs from agg result tree (backport of #54716)

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregator.java
@@ -30,13 +30,11 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ArrayValuesSource.NumericArrayValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -50,9 +48,8 @@ final class MatrixStatsAggregator extends MetricsAggregator {
     ObjectArray<RunningStats> stats;
 
     MatrixStatsAggregator(String name, Map<String, ValuesSource.Numeric> valuesSources, SearchContext context,
-                                 Aggregator parent, MultiValueMode multiValueMode, List<PipelineAggregator> pipelineAggregators,
-                                 Map<String,Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                                 Aggregator parent, MultiValueMode multiValueMode, Map<String,Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         if (valuesSources != null && !valuesSources.isEmpty()) {
             this.valuesSources = new NumericArrayValuesSource(valuesSources, multiValueMode);
             stats = context.bigArrays().newObjectArray(1);

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ArrayValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 final class MatrixStatsAggregatorFactory extends ArrayValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -51,10 +49,9 @@ final class MatrixStatsAggregatorFactory extends ArrayValuesSourceAggregatorFact
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata)
         throws IOException {
-        return new MatrixStatsAggregator(name, null, searchContext, parent, multiValueMode, pipelineAggregators, metadata);
+        return new MatrixStatsAggregator(name, null, searchContext, parent, multiValueMode, metadata);
     }
 
     @Override
@@ -62,8 +59,7 @@ final class MatrixStatsAggregatorFactory extends ArrayValuesSourceAggregatorFact
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new MatrixStatsAggregator(name, valuesSources, searchContext, parent, multiValueMode, pipelineAggregators, metadata);
+        return new MatrixStatsAggregator(name, valuesSources, searchContext, parent, multiValueMode, metadata);
     }
 }

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregatorFactory.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/ArrayValuesSourceAggregatorFactory.java
@@ -23,12 +23,10 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public abstract class ArrayValuesSourceAggregatorFactory<VS extends ValuesSource>
@@ -48,7 +46,6 @@ public abstract class ArrayValuesSourceAggregatorFactory<VS extends ValuesSource
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         HashMap<String, VS> valuesSources = new HashMap<>();
 
@@ -59,22 +56,19 @@ public abstract class ArrayValuesSourceAggregatorFactory<VS extends ValuesSource
             }
         }
         if (valuesSources.isEmpty()) {
-            return createUnmapped(searchContext, parent, pipelineAggregators, metadata);
+            return createUnmapped(searchContext, parent, metadata);
         }
-        return doCreateInternal(valuesSources, searchContext, parent,
-                collectsFromSingleBucket, pipelineAggregators, metadata);
+        return doCreateInternal(valuesSources, searchContext, parent, collectsFromSingleBucket, metadata);
     }
 
     protected abstract Aggregator createUnmapped(SearchContext searchContext,
                                                     Aggregator parent,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException;
 
     protected abstract Aggregator doCreateInternal(Map<String, VS> valuesSources,
                                                     SearchContext searchContext,
                                                     Aggregator parent,
                                                     boolean collectsFromSingleBucket,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException;
 
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregatorFactory.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregatorFactory.java
@@ -26,14 +26,12 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Bytes.WithOrdinals;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class ChildrenAggregatorFactory extends ValuesSourceAggregatorFactory<WithOrdinals> {
@@ -56,12 +54,11 @@ public class ChildrenAggregatorFactory extends ValuesSourceAggregatorFactory<Wit
     }
 
     @Override
-    protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metadata) {
+    protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        return new NonCollectingAggregator(name, searchContext, parent, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
-                return new InternalChildren(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+                return new InternalChildren(name, 0, buildEmptySubAggregations(), metadata());
             }
         };
     }
@@ -70,13 +67,12 @@ public class ChildrenAggregatorFactory extends ValuesSourceAggregatorFactory<Wit
     protected Aggregator doCreateInternal(WithOrdinals valuesSource,
                                           SearchContext searchContext, Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
 
         long maxOrd = valuesSource.globalMaxOrd(searchContext.searcher());
         if (collectsFromSingleBucket) {
             return new ParentToChildrenAggregator(name, factories, searchContext, parent, childFilter,
-                parentFilter, valuesSource, maxOrd, pipelineAggregators, metadata);
+                parentFilter, valuesSource, maxOrd, metadata);
         } else {
             return asMultiBucketAggregator(this, searchContext, parent);
         }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregator.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregator.java
@@ -24,12 +24,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,19 +40,18 @@ public class ChildrenToParentAggregator extends ParentJoinAggregator {
     public ChildrenToParentAggregator(String name, AggregatorFactories factories,
             SearchContext context, Aggregator parent, Query childFilter,
             Query parentFilter, ValuesSource.Bytes.WithOrdinals valuesSource,
-            long maxOrd, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, childFilter, parentFilter, valuesSource, maxOrd, pipelineAggregators, metadata);
+            long maxOrd, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, childFilter, parentFilter, valuesSource, maxOrd, metadata);
     }
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
         return new InternalParent(name, bucketDocCount(owningBucketOrdinal),
-                bucketAggregations(owningBucketOrdinal), pipelineAggregators(), metadata());
+                bucketAggregations(owningBucketOrdinal), metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalParent(name, 0, buildEmptySubAggregations(), pipelineAggregators(),
-                metadata());
+        return new InternalParent(name, 0, buildEmptySubAggregations(), metadata());
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/InternalChildren.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/InternalChildren.java
@@ -22,19 +22,16 @@ package org.elasticsearch.join.aggregations;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
  * Results of the {@link ParentToChildrenAggregator}.
  */
 public class InternalChildren extends InternalSingleBucketAggregation implements Children {
-    public InternalChildren(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, aggregations, pipelineAggregators, metadata);
+    public InternalChildren(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
+        super(name, docCount, aggregations, metadata);
     }
 
     /**
@@ -51,6 +48,6 @@ public class InternalChildren extends InternalSingleBucketAggregation implements
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalChildren(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalChildren(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/InternalParent.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/InternalParent.java
@@ -22,19 +22,16 @@ package org.elasticsearch.join.aggregations;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
  * Results of the {@link ChildrenToParentAggregator}.
  */
 public class InternalParent extends InternalSingleBucketAggregation implements Parent {
-    public InternalParent(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, aggregations, pipelineAggregators, metadata);
+    public InternalParent(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
+        super(name, docCount, aggregations, metadata);
     }
 
     /**
@@ -51,6 +48,6 @@ public class InternalParent extends InternalSingleBucketAggregation implements P
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalParent(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalParent(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregatorFactory.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentAggregatorFactory.java
@@ -26,14 +26,12 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Bytes.WithOrdinals;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class ParentAggregatorFactory extends ValuesSourceAggregatorFactory<WithOrdinals> {
@@ -57,11 +55,11 @@ public class ParentAggregatorFactory extends ValuesSourceAggregatorFactory<WithO
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metadata) {
+                                        Map<String, Object> metadata) throws IOException {
+        return new NonCollectingAggregator(name, searchContext, parent, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
-                return new InternalParent(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+                return new InternalParent(name, 0, buildEmptySubAggregations(), metadata());
             }
         };
     }
@@ -70,13 +68,12 @@ public class ParentAggregatorFactory extends ValuesSourceAggregatorFactory<WithO
     protected Aggregator doCreateInternal(WithOrdinals valuesSource,
                                           SearchContext searchContext, Aggregator children,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
 
         long maxOrd = valuesSource.globalMaxOrd(searchContext.searcher());
         if (collectsFromSingleBucket) {
             return new ChildrenToParentAggregator(name, factories, searchContext, children, childFilter,
-                parentFilter, valuesSource, maxOrd, pipelineAggregators, metadata);
+                parentFilter, valuesSource, maxOrd, metadata);
         } else {
             return asMultiBucketAggregator(this, searchContext, children);
         }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentJoinAggregator.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentJoinAggregator.java
@@ -24,8 +24,8 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
-import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.lease.Releasables;
@@ -37,12 +37,10 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -73,9 +71,8 @@ public abstract class ParentJoinAggregator extends BucketsAggregator implements 
                                     Query outFilter,
                                     ValuesSource.Bytes.WithOrdinals valuesSource,
                                     long maxOrd,
-                                    List<PipelineAggregator> pipelineAggregators,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
 
         if (maxOrd > Integer.MAX_VALUE) {
             throw new IllegalStateException("the number of parent [" + maxOrd + "] + is greater than the allowed limit " +

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregator.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregator.java
@@ -23,12 +23,10 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class ParentToChildrenAggregator extends ParentJoinAggregator {
@@ -38,19 +36,18 @@ public class ParentToChildrenAggregator extends ParentJoinAggregator {
     public ParentToChildrenAggregator(String name, AggregatorFactories factories,
             SearchContext context, Aggregator parent, Query childFilter,
             Query parentFilter, ValuesSource.Bytes.WithOrdinals valuesSource,
-            long maxOrd, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, parentFilter, childFilter, valuesSource, maxOrd, pipelineAggregators, metadata);
+            long maxOrd, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, parentFilter, childFilter, valuesSource, maxOrd, metadata);
     }
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
         return new InternalChildren(name, bucketDocCount(owningBucketOrdinal),
-                bucketAggregations(owningBucketOrdinal), pipelineAggregators(), metadata());
+                bucketAggregations(owningBucketOrdinal), metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalChildren(name, 0, buildEmptySubAggregations(), pipelineAggregators(),
-                metadata());
+        return new InternalChildren(name, 0, buildEmptySubAggregations(), metadata());
     }
 }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalChildrenTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalChildrenTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,8 +44,8 @@ public class InternalChildrenTests extends InternalSingleBucketAggregationTestCa
 
     @Override
     protected InternalChildren createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalChildren(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalChildren(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalParentTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalParentTests.java
@@ -19,10 +19,6 @@
 
 package org.elasticsearch.join.aggregations;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry.Entry;
@@ -30,7 +26,10 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class InternalParentTests extends InternalSingleBucketAggregationTestCase<InternalParent> {
 
@@ -44,8 +43,8 @@ public class InternalParentTests extends InternalSingleBucketAggregationTestCase
 
     @Override
     protected InternalParent createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalParent(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalParent(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.SearchShardTarget;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SearchContext.Lifetime;
 import org.elasticsearch.search.query.QueryPhaseExecutionException;
@@ -53,7 +52,6 @@ public abstract class AggregatorBase extends Aggregator {
     protected BucketCollector collectableSubAggregators;
 
     private Map<String, Aggregator> subAggregatorbyName;
-    private final List<PipelineAggregator> pipelineAggregators;
     private final CircuitBreakerService breakerService;
     private long requestBytesUsed;
 
@@ -67,9 +65,8 @@ public abstract class AggregatorBase extends Aggregator {
      * @param metadata              The metadata associated with this aggregator
      */
     protected AggregatorBase(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Map<String, Object> metadata) throws IOException {
         this.name = name;
-        this.pipelineAggregators = pipelineAggregators;
         this.metadata = metadata;
         this.parent = parent;
         this.context = context;
@@ -150,10 +147,6 @@ public abstract class AggregatorBase extends Aggregator {
 
     public Map<String, Object> metadata() {
         return this.metadata;
-    }
-
-    public List<PipelineAggregator> pipelineAggregators() {
-        return this.pipelineAggregators;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -223,13 +223,6 @@ public class AggregatorFactories {
         return factories.length;
     }
 
-    /**
-     * @return the number of pipeline aggregator factories
-     */
-    public int countPipelineAggregators() {
-        return pipelineAggregatorFactories.size();
-    }
-
     public static class Builder implements Writeable, ToXContentObject {
         private final Set<String> names = new HashSet<>();
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -26,12 +26,10 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SearchContext.Lifetime;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public abstract class AggregatorFactory {
@@ -201,7 +199,6 @@ public abstract class AggregatorFactory {
     protected abstract Aggregator createInternal(SearchContext searchContext,
                                                     Aggregator parent,
                                                     boolean collectsFromSingleBucket,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException;
 
     /**
@@ -222,7 +219,7 @@ public abstract class AggregatorFactory {
      * @return The created aggregator
      */
     public final Aggregator create(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket) throws IOException {
-        return createInternal(searchContext, parent, collectsFromSingleBucket, this.factories.createPipelineAggregators(), this.metadata);
+        return createInternal(searchContext, parent, collectsFromSingleBucket, this.metadata);
     }
 
     public AggregatorFactory getParent() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -147,7 +146,6 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
 
     protected final Map<String, Object> metadata;
 
-    private final List<PipelineAggregator> pipelineAggregators;
     private List<PipelineAggregator> pipelineAggregatorsForBwcSerialization;
 
     /**
@@ -157,20 +155,6 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
      */
     protected InternalAggregation(String name, Map<String, Object> metadata) {
         this.name = name;
-        this.pipelineAggregators = emptyList();
-        this.metadata = metadata;
-    }
-
-    /**
-     * Constructs an aggregation result with a given name.
-     *
-     * @param name The name of the aggregation.
-     * @deprecated pipelines are being removed from the aggregation tree. Use the other ctor.
-     */
-    @Deprecated
-    protected InternalAggregation(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        this.name = name;
-        this.pipelineAggregators = pipelineAggregators;
         this.metadata = metadata;
     }
 
@@ -191,7 +175,6 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
     protected InternalAggregation(StreamInput in) throws IOException {
         name = in.readString();
         metadata = in.readMap();
-        pipelineAggregators = emptyList();
         if (in.getVersion().before(Version.V_7_8_0)) {
             in.readNamedWriteableList(PipelineAggregator.class);
         }
@@ -311,14 +294,6 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
     }
 
     /**
-     * @deprecated soon to be removed because it is not longer needed
-     */
-    @Deprecated
-    public List<PipelineAggregator> pipelineAggregators() {
-        return pipelineAggregators;
-    }
-
-    /**
      * The {@linkplain PipelineAggregator}s sent to older versions of Elasticsearch.
      * @deprecated only use these for serializing to older Elasticsearch versions
      */
@@ -353,7 +328,7 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, metadata, pipelineAggregators);
+        return Objects.hash(name, metadata);
     }
 
     @Override
@@ -365,7 +340,6 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
 
         InternalAggregation other = (InternalAggregation) obj;
         return Objects.equals(name, other.name) &&
-                Objects.equals(pipelineAggregators, other.pipelineAggregators) &&
                 Objects.equals(metadata, other.metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 
 import java.io.IOException;
@@ -39,14 +38,6 @@ public abstract class InternalMultiBucketAggregation<A extends InternalMultiBuck
 
     public InternalMultiBucketAggregation(String name, Map<String, Object> metadata) {
         super(name, metadata);
-    }
-
-    /**
-     * @deprecated being removed
-     */
-    @Deprecated
-    public InternalMultiBucketAggregation(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/NonCollectingAggregator.java
@@ -20,11 +20,9 @@
 package org.elasticsearch.search.aggregations;
 
 import org.apache.lucene.index.LeafReaderContext;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,13 +32,13 @@ import java.util.Map;
 public abstract class NonCollectingAggregator extends AggregatorBase {
 
     protected NonCollectingAggregator(String name, SearchContext context, Aggregator parent, AggregatorFactories subFactories,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, subFactories, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, subFactories, context, parent, metadata);
     }
 
     protected NonCollectingAggregator(String name, SearchContext context, Aggregator parent,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        this(name, context, parent, AggregatorFactories.EMPTY, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        this(name, context, parent, AggregatorFactories.EMPTY, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortOrder;
@@ -35,7 +34,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.function.IntConsumer;
 
@@ -46,8 +44,8 @@ public abstract class BucketsAggregator extends AggregatorBase {
     private IntArray docCounts;
 
     public BucketsAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
         bigArrays = context.bigArrays();
         docCounts = bigArrays.newIntArray(1, true);
         if (context.aggregations() != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferableBucketAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferableBucketAggregator.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.MultiBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -37,8 +36,8 @@ public abstract class DeferableBucketAggregator extends BucketsAggregator {
     private DeferringBucketCollector recordingWrapper;
 
     protected DeferableBucketAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 
@@ -53,8 +52,8 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
      * @param aggregations  The already built sub-aggregations that are associated with the bucket.
      */
     protected InternalSingleBucketAggregation(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        super(name, metadata);
         this.docCount = docCount;
         this.aggregations = aggregations;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -129,9 +128,8 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
     private final String separator;
 
     public AdjacencyMatrixAggregator(String name, AggregatorFactories factories, String separator, String[] keys,
-            Weight[] filters, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            Weight[] filters, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
         this.separator = separator;
         this.keys = keys;
         this.filters = filters;
@@ -210,13 +208,13 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
                 pos++;
             }
         }
-        return new InternalAdjacencyMatrix(name, buckets, pipelineAggregators(), metadata());
+        return new InternalAdjacencyMatrix(name, buckets, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         List<InternalAdjacencyMatrix.InternalBucket> buckets = new ArrayList<>(0);
-        return new InternalAdjacencyMatrix(name, buckets, pipelineAggregators(), metadata());
+        return new InternalAdjacencyMatrix(name, buckets, metadata());
     }
 
     final long bucketOrd(long owningBucketOrdinal, int filterOrd) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorFactory.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregator.KeyedFilter;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -61,10 +60,8 @@ public class AdjacencyMatrixAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
-        return new AdjacencyMatrixAggregator(name, factories, separator, keys, weights, searchContext, parent,
-                pipelineAggregators, metadata);
+        return new AdjacencyMatrixAggregator(name, factories, separator, keys, weights, searchContext, parent, metadata);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -120,9 +119,8 @@ public class InternalAdjacencyMatrix
     private final List<InternalBucket> buckets;
     private Map<String, InternalBucket> bucketMap;
 
-    public InternalAdjacencyMatrix(String name, List<InternalBucket> buckets,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+    public InternalAdjacencyMatrix(String name, List<InternalBucket> buckets, Map<String, Object> metadata) {
+        super(name, metadata);
         this.buckets = buckets;
     }
 
@@ -155,7 +153,7 @@ public class InternalAdjacencyMatrix
 
     @Override
     public InternalAdjacencyMatrix create(List<InternalBucket> buckets) {
-        return new InternalAdjacencyMatrix(this.name, buckets, this.pipelineAggregators(), this.metadata);
+        return new InternalAdjacencyMatrix(this.name, buckets, this.metadata);
     }
 
     @Override
@@ -206,8 +204,7 @@ public class InternalAdjacencyMatrix
         }
         Collections.sort(reducedBuckets, Comparator.comparing(InternalBucket::getKey));
 
-        InternalAdjacencyMatrix reduced = new InternalAdjacencyMatrix(name, reducedBuckets, pipelineAggregators(),
-                getMetadata());
+        InternalAdjacencyMatrix reduced = new InternalAdjacencyMatrix(name, reducedBuckets, getMetadata());
 
         return reduced;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationFactory.java
@@ -23,11 +23,9 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class CompositeAggregationFactory extends AggregatorFactory {
@@ -46,8 +44,7 @@ class CompositeAggregationFactory extends AggregatorFactory {
 
     @Override
     protected Aggregator createInternal(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        return new CompositeAggregator(name, factories, searchContext, parent, pipelineAggregators, metadata,
-            size, sources, afterKey);
+                                        Map<String, Object> metadata) throws IOException {
+        return new CompositeAggregator(name, factories, searchContext, parent, metadata, size, sources, afterKey);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -53,7 +53,6 @@ import org.elasticsearch.search.aggregations.MultiBucketCollector;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.geogrid.CellIdSource;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.searchafter.SearchAfterBuilder;
@@ -89,9 +88,9 @@ final class CompositeAggregator extends BucketsAggregator {
     private boolean earlyTerminated;
 
     CompositeAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
-                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
+                        Map<String, Object> metadata,
                         int size, CompositeValuesSourceConfig[] sourceConfigs, CompositeKey rawAfterKey) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         this.size = size;
         this.sourceNames = Arrays.stream(sourceConfigs).map(CompositeValuesSourceConfig::name).collect(Collectors.toList());
         this.reverseMuls = Arrays.stream(sourceConfigs).mapToInt(CompositeValuesSourceConfig::reverseMul).toArray();
@@ -153,13 +152,13 @@ final class CompositeAggregator extends BucketsAggregator {
         }
         CompositeKey lastBucket = num > 0 ? buckets[num-1].getRawKey() : null;
         return new InternalComposite(name, size, sourceNames, formats, Arrays.asList(buckets), lastBucket, reverseMuls,
-            earlyTerminated, pipelineAggregators(), metadata());
+            earlyTerminated, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         return new InternalComposite(name, size, sourceNames, formats, Collections.emptyList(), null, reverseMuls,
-            false, pipelineAggregators(), metadata());
+            false, metadata());
     }
 
     private void finishLeaf() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.KeyComparable;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -58,8 +57,8 @@ public class InternalComposite
 
     InternalComposite(String name, int size, List<String> sourceNames, List<DocValueFormat> formats,
                       List<InternalBucket> buckets, CompositeKey afterKey, int[] reverseMuls, boolean earlyTerminated,
-                      List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+                      Map<String, Object> metadata) {
+        super(name, metadata);
         this.sourceNames = sourceNames;
         this.formats = formats;
         this.buckets = buckets;
@@ -131,7 +130,7 @@ public class InternalComposite
          * to be able to retrieve the next page even if all buckets have been filtered.
          */
         return new InternalComposite(name, size, sourceNames, formats, newBuckets, afterKey,
-            reverseMuls, earlyTerminated, pipelineAggregators(), getMetadata());
+            reverseMuls, earlyTerminated, getMetadata());
     }
 
     @Override
@@ -222,7 +221,7 @@ public class InternalComposite
             lastKey = lastBucket.getRawKey();
         }
         return new InternalComposite(name, size, sourceNames, reducedFormats, result, lastKey, reverseMuls,
-            earlyTerminated, pipelineAggregators(), metadata);
+            earlyTerminated, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregator.java
@@ -29,11 +29,9 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -48,9 +46,9 @@ public class FilterAggregator extends BucketsAggregator implements SingleBucketA
                             Supplier<Weight> filter,
                             AggregatorFactories factories,
                             SearchContext context,
-                            Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+                            Aggregator parent,
                             Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         this.filter = filter;
     }
 
@@ -71,13 +69,12 @@ public class FilterAggregator extends BucketsAggregator implements SingleBucketA
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
-        return new InternalFilter(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), pipelineAggregators(),
-                metadata());
+        return new InternalFilter(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalFilter(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+        return new InternalFilter(name, 0, buildEmptySubAggregations(), metadata());
     }
 }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorFactory.java
@@ -29,11 +29,9 @@ import org.elasticsearch.search.aggregations.AggregationInitializationException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class FilterAggregatorFactory extends AggregatorFactory {
@@ -72,9 +70,8 @@ public class FilterAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
-        return new FilterAggregator(name, () -> this.getWeight(), factories, searchContext, parent, pipelineAggregators, metadata);
+        return new FilterAggregator(name, () -> this.getWeight(), factories, searchContext, parent, metadata);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -123,9 +122,8 @@ public class FiltersAggregator extends BucketsAggregator {
     private final int totalNumKeys;
 
     public FiltersAggregator(String name, AggregatorFactories factories, String[] keys, Supplier<Weight[]> filters, boolean keyed,
-            String otherBucketKey, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            String otherBucketKey, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
         this.keyed = keyed;
         this.keys = keys;
         this.filters = filters;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorFactory.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -89,10 +88,9 @@ public class FiltersAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         return new FiltersAggregator(name, factories, keys, () -> getWeights(searchContext), keyed,
-            otherBucket ? otherBucketKey : null, searchContext, parent, pipelineAggregators, metadata);
+            otherBucket ? otherBucketKey : null, searchContext, parent, metadata);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
@@ -22,16 +22,13 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class InternalFilter extends InternalSingleBucketAggregation implements Filter {
-    InternalFilter(String name, long docCount, InternalAggregations subAggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, subAggregations, pipelineAggregators, metadata);
+    InternalFilter(String name, long docCount, InternalAggregations subAggregations, Map<String, Object> metadata) {
+        super(name, docCount, subAggregations, metadata);
     }
 
     /**
@@ -48,6 +45,6 @@ public class InternalFilter extends InternalSingleBucketAggregation implements F
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalFilter(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalFilter(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregator.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -49,8 +48,8 @@ public abstract class GeoGridAggregator<T extends InternalGeoGrid> extends Bucke
 
     GeoGridAggregator(String name, AggregatorFactories factories, CellIdSource valuesSource,
                       int requiredSize, int shardSize, SearchContext aggregationContext,
-                      Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, aggregationContext, parent, pipelineAggregators, metadata);
+                      Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, aggregationContext, parent, metadata);
         this.valuesSource = valuesSource;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregator.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -35,10 +34,8 @@ public class GeoHashGridAggregator extends GeoGridAggregator<InternalGeoHashGrid
 
     GeoHashGridAggregator(String name, AggregatorFactories factories, CellIdSource valuesSource,
                           int requiredSize, int shardSize, SearchContext aggregationContext,
-                          Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                          Map<String, Object> metadata) throws IOException {
-        super(name, factories, valuesSource, requiredSize, shardSize, aggregationContext, parent,
-            pipelineAggregators, metadata);
+                          Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, valuesSource, requiredSize, shardSize, aggregationContext, parent, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregatorFactory.java
@@ -27,14 +27,12 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -60,10 +58,9 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory<
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         final InternalAggregation aggregation = new InternalGeoHashGrid(name, requiredSize, emptyList(), metadata);
-        return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metadata) {
+        return new NonCollectingAggregator(name, searchContext, parent, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
                 return aggregation;
@@ -76,13 +73,12 @@ public class GeoHashGridAggregatorFactory extends ValuesSourceAggregatorFactory<
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
         }
         CellIdSource cellIdSource = new CellIdSource(valuesSource, precision, geoBoundingBox, Geohash::longEncode);
         return new GeoHashGridAggregator(name, factories, cellIdSource, requiredSize, shardSize,
-            searchContext, parent, pipelineAggregators, metadata);
+            searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregator.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -36,10 +35,8 @@ public class GeoTileGridAggregator extends GeoGridAggregator<InternalGeoTileGrid
 
     GeoTileGridAggregator(String name, AggregatorFactories factories, CellIdSource valuesSource,
                           int requiredSize, int shardSize, SearchContext aggregationContext,
-                          Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                          Map<String, Object> metadata) throws IOException {
-        super(name, factories, valuesSource, requiredSize, shardSize, aggregationContext, parent,
-            pipelineAggregators, metadata);
+                          Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, valuesSource, requiredSize, shardSize, aggregationContext, parent, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregatorFactory.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -34,7 +33,6 @@ import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
@@ -58,10 +56,9 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory<
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         final InternalAggregation aggregation = new InternalGeoTileGrid(name, requiredSize, Collections.emptyList(), metadata);
-        return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metadata) {
+        return new NonCollectingAggregator(name, searchContext, parent, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
                 return aggregation;
@@ -74,13 +71,12 @@ public class GeoTileGridAggregatorFactory extends ValuesSourceAggregatorFactory<
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
         }
         CellIdSource cellIdSource = new CellIdSource(valuesSource, precision, geoBoundingBox, GeoTileUtils::longEncode);
         return new GeoTileGridAggregator(name, factories, cellIdSource, requiredSize, shardSize,
-            searchContext, parent, pipelineAggregators, metadata);
+            searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -25,18 +25,16 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class GlobalAggregator extends BucketsAggregator implements SingleBucketAggregator {
 
     public GlobalAggregator(String name, AggregatorFactories subFactories, SearchContext aggregationContext,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, subFactories, aggregationContext, null, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, subFactories, aggregationContext, null, metadata);
     }
 
     @Override
@@ -54,8 +52,7 @@ public class GlobalAggregator extends BucketsAggregator implements SingleBucketA
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
         assert owningBucketOrdinal == 0 : "global aggregator can only be a top level aggregator";
-        return new InternalGlobal(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), pipelineAggregators(),
-                metadata());
+        return new InternalGlobal(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregatorFactory.java
@@ -24,11 +24,9 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class GlobalAggregatorFactory extends AggregatorFactory {
@@ -45,7 +43,6 @@ public class GlobalAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         if (parent != null) {
             throw new AggregationExecutionException("Aggregation [" + parent.name() + "] cannot have a global " + "sub-aggregation [" + name
@@ -54,6 +51,6 @@ public class GlobalAggregatorFactory extends AggregatorFactory {
         if (collectsFromSingleBucket == false) {
             throw new IllegalStateException();
         }
-        return new GlobalAggregator(name, factories, searchContext, pipelineAggregators, metadata);
+        return new GlobalAggregator(name, factories, searchContext, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobal.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobal.java
@@ -21,10 +21,8 @@ package org.elasticsearch.search.aggregations.bucket.global;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -32,9 +30,8 @@ import java.util.Map;
  * regardless the query.
  */
 public class InternalGlobal extends InternalSingleBucketAggregation implements Global {
-    InternalGlobal(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, aggregations, pipelineAggregators, metadata);
+    InternalGlobal(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
+        super(name, docCount, aggregations, metadata);
     }
 
     /**
@@ -51,6 +48,6 @@ public class InternalGlobal extends InternalSingleBucketAggregation implements G
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalGlobal(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalGlobal(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.aggregations.bucket.DeferableBucketAggregator;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.MergingBucketsDeferringCollector;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -66,9 +65,9 @@ class AutoDateHistogramAggregator extends DeferableBucketAggregator {
 
     AutoDateHistogramAggregator(String name, AggregatorFactories factories, int numBuckets, RoundingInfo[] roundingInfos,
             @Nullable ValuesSource.Numeric valuesSource, DocValueFormat formatter, SearchContext aggregationContext, Aggregator parent,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, aggregationContext, parent, pipelineAggregators, metadata);
+        super(name, factories, aggregationContext, parent, metadata);
         this.targetBuckets = numBuckets;
         this.valuesSource = valuesSource;
         this.formatter = formatter;
@@ -185,16 +184,14 @@ class AutoDateHistogramAggregator extends DeferableBucketAggregator {
         InternalAutoDateHistogram.BucketInfo emptyBucketInfo = new InternalAutoDateHistogram.BucketInfo(roundingInfos, roundingIdx,
                 buildEmptySubAggregations());
 
-        return new InternalAutoDateHistogram(name, buckets, targetBuckets, emptyBucketInfo,
-            formatter, pipelineAggregators(), metadata(), 1);
+        return new InternalAutoDateHistogram(name, buckets, targetBuckets, emptyBucketInfo, formatter, metadata(), 1);
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         InternalAutoDateHistogram.BucketInfo emptyBucketInfo = new InternalAutoDateHistogram.BucketInfo(roundingInfos, roundingIdx,
                 buildEmptySubAggregations());
-        return new InternalAutoDateHistogram(name, Collections.emptyList(), targetBuckets, emptyBucketInfo, formatter,
-                pipelineAggregators(), metadata(), 1);
+        return new InternalAutoDateHistogram(name, Collections.emptyList(), targetBuckets, emptyBucketInfo, formatter, metadata(), 1);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorFactory.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -32,7 +31,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public final class AutoDateHistogramAggregatorFactory
@@ -59,28 +57,25 @@ public final class AutoDateHistogramAggregatorFactory
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
         }
-        return createAggregator(valuesSource, searchContext, parent, pipelineAggregators, metadata);
+        return createAggregator(valuesSource, searchContext, parent, metadata);
     }
 
     private Aggregator createAggregator(ValuesSource.Numeric valuesSource,
                                             SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         return new AutoDateHistogramAggregator(name, factories, numBuckets, roundingInfos,
-            valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
+            valuesSource, config.format(), searchContext, parent, metadata);
     }
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return createAggregator(null, searchContext, parent, pipelineAggregators, metadata);
+        return createAggregator(null, searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -34,7 +34,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -68,9 +67,9 @@ class DateHistogramAggregator extends BucketsAggregator {
             BucketOrder order, boolean keyed,
             long minDocCount, @Nullable ExtendedBounds extendedBounds, @Nullable ValuesSource.Numeric valuesSource,
             DocValueFormat formatter, SearchContext aggregationContext,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, aggregationContext, parent, pipelineAggregators, metadata);
+        super(name, factories, aggregationContext, parent, metadata);
         this.rounding = rounding;
         this.shardRounding = shardRounding;
         this.order = order;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
@@ -26,18 +26,15 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.BucketOrder;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
-public final class DateHistogramAggregatorFactory
-        extends ValuesSourceAggregatorFactory<ValuesSource> {
+public final class DateHistogramAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
 
     private final BucketOrder order;
     private final boolean keyed;
@@ -78,20 +75,19 @@ public final class DateHistogramAggregatorFactory
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
         }
         if (valuesSource instanceof ValuesSource.Numeric) {
-            return createAggregator((ValuesSource.Numeric) valuesSource, searchContext, parent, pipelineAggregators, metadata);
+            return createAggregator((ValuesSource.Numeric) valuesSource, searchContext, parent, metadata);
         } else if (valuesSource instanceof ValuesSource.Range) {
             ValuesSource.Range rangeValueSource = (ValuesSource.Range) valuesSource;
             if (rangeValueSource.rangeType() != RangeType.DATE) {
                 throw new IllegalArgumentException("Expected date range type but found range type [" + rangeValueSource.rangeType().name
                     + "]");
             }
-            return createRangeAggregator((ValuesSource.Range) valuesSource, searchContext, parent, pipelineAggregators, metadata);
+            return createRangeAggregator((ValuesSource.Range) valuesSource, searchContext, parent, metadata);
         }
         else {
             throw new IllegalArgumentException("Expected one of [Date, Range] values source, found ["
@@ -100,26 +96,23 @@ public final class DateHistogramAggregatorFactory
     }
 
     private Aggregator createAggregator(ValuesSource.Numeric valuesSource, SearchContext searchContext,
-                                        Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
+                                        Aggregator parent, Map<String, Object> metadata) throws IOException {
         return new DateHistogramAggregator(name, factories, rounding, shardRounding, order, keyed, minDocCount, extendedBounds,
-                valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
+                valuesSource, config.format(), searchContext, parent, metadata);
     }
 
     private Aggregator createRangeAggregator(ValuesSource.Range valuesSource,
                                              SearchContext searchContext,
                                              Aggregator parent,
-                                             List<PipelineAggregator> pipelineAggregators,
                                              Map<String, Object> metadata) throws IOException {
         return new DateRangeHistogramAggregator(name, factories, rounding, shardRounding, order, keyed, minDocCount, extendedBounds,
-            valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
+            valuesSource, config.format(), searchContext, parent, metadata);
     }
 
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return createAggregator(null, searchContext, parent, pipelineAggregators, metadata);
+        return createAggregator(null, searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -71,10 +70,9 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
                                  BucketOrder order, boolean keyed,
                                  long minDocCount, @Nullable ExtendedBounds extendedBounds, @Nullable ValuesSource.Range valuesSource,
                                  DocValueFormat formatter, SearchContext aggregationContext,
-                                 Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                                 Map<String, Object> metadata) throws IOException {
+                                 Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, aggregationContext, parent, pipelineAggregators, metadata);
+        super(name, factories, aggregationContext, parent, metadata);
         this.rounding = rounding;
         this.shardRounding = shardRounding;
         this.order = order;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
@@ -24,14 +24,12 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.BucketOrder;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -87,14 +85,13 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
         }
         if (valuesSource instanceof ValuesSource.Numeric) {
             return new NumericHistogramAggregator(name, factories, interval, offset, order, keyed, minDocCount, minBound, maxBound,
-                (ValuesSource.Numeric) valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
+                (ValuesSource.Numeric) valuesSource, config.format(), searchContext, parent, metadata);
         } else if (valuesSource instanceof ValuesSource.Range) {
             ValuesSource.Range rangeValueSource = (ValuesSource.Range) valuesSource;
             if (rangeValueSource.rangeType().isNumeric() == false) {
@@ -102,8 +99,7 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
                     + rangeValueSource.rangeType().name + "]");
             }
             return new RangeHistogramAggregator(name, factories, interval, offset, order, keyed, minDocCount, minBound, maxBound,
-                (ValuesSource.Range) valuesSource, config.format(), searchContext, parent, pipelineAggregators,
-                metadata);
+                (ValuesSource.Range) valuesSource, config.format(), searchContext, parent, metadata);
         }
         else {
             throw new IllegalArgumentException("Expected one of [Numeric, Range] values source, found ["
@@ -114,9 +110,8 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         return new NumericHistogramAggregator(name, factories, interval, offset, order, keyed, minDocCount, minBound, maxBound,
-            null, config.format(), searchContext, parent, pipelineAggregators, metadata);
+            null, config.format(), searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.KeyComparable;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -200,8 +199,8 @@ public final class InternalAutoDateHistogram extends
     private long bucketInnerInterval;
 
     InternalAutoDateHistogram(String name, List<Bucket> buckets, int targetBuckets, BucketInfo emptyBucketInfo, DocValueFormat formatter,
-                              List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata, long bucketInnerInterval) {
-        super(name, pipelineAggregators, metadata);
+                              Map<String, Object> metadata, long bucketInnerInterval) {
+        super(name, metadata);
         this.buckets = buckets;
         this.bucketInfo = emptyBucketInfo;
         this.format = formatter;
@@ -259,7 +258,7 @@ public final class InternalAutoDateHistogram extends
 
     @Override
     public InternalAutoDateHistogram create(List<Bucket> buckets) {
-        return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, pipelineAggregators(), metadata, 1);
+        return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, metadata, 1);
     }
 
     @Override
@@ -517,7 +516,7 @@ public final class InternalAutoDateHistogram extends
                 this.bucketInfo.emptySubAggregations);
 
         return new InternalAutoDateHistogram(getName(), reducedBucketsResult.buckets, targetBuckets, bucketInfo, format,
-                pipelineAggregators(), getMetadata(), reducedBucketsResult.innerInterval);
+                getMetadata(), reducedBucketsResult.innerInterval);
     }
 
     private BucketReduceResult maybeMergeConsecutiveBuckets(BucketReduceResult reducedBucketsResult,
@@ -594,7 +593,7 @@ public final class InternalAutoDateHistogram extends
             buckets2.add((Bucket) b);
         }
         buckets2 = Collections.unmodifiableList(buckets2);
-        return new InternalAutoDateHistogram(name, buckets2, targetBuckets, bucketInfo, format, pipelineAggregators(), getMetadata(), 1);
+        return new InternalAutoDateHistogram(name, buckets2, targetBuckets, bucketInfo, format, getMetadata(), 1);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregator.java
@@ -35,7 +35,6 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram.EmptyBucketInfo;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -66,10 +65,9 @@ class NumericHistogramAggregator extends BucketsAggregator {
     NumericHistogramAggregator(String name, AggregatorFactories factories, double interval, double offset,
                                BucketOrder order, boolean keyed, long minDocCount, double minBound, double maxBound,
                                @Nullable ValuesSource.Numeric valuesSource, DocValueFormat formatter,
-                               SearchContext context, Aggregator parent,
-                               List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+                               SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         if (interval <= 0) {
             throw new IllegalArgumentException("interval must be positive, got: " + interval);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java
@@ -36,7 +36,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -60,10 +59,9 @@ public class RangeHistogramAggregator extends BucketsAggregator {
     RangeHistogramAggregator(String name, AggregatorFactories factories, double interval, double offset,
                              BucketOrder order, boolean keyed, long minDocCount, double minBound, double maxBound,
                              @Nullable ValuesSource.Range valuesSource, DocValueFormat formatter,
-                             SearchContext context, Aggregator parent,
-                             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+                             SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         if (interval <= 0) {
             throw new IllegalArgumentException("interval must be positive, got: " + interval);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
@@ -21,16 +21,13 @@ package org.elasticsearch.search.aggregations.bucket.missing;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class InternalMissing extends InternalSingleBucketAggregation implements Missing {
-    InternalMissing(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, aggregations, pipelineAggregators, metadata);
+    InternalMissing(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
+        super(name, docCount, aggregations, metadata);
     }
 
     /**
@@ -47,6 +44,6 @@ public class InternalMissing extends InternalSingleBucketAggregation implements 
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalMissing(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalMissing(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregator.java
@@ -27,12 +27,10 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class MissingAggregator extends BucketsAggregator implements SingleBucketAggregator {
@@ -40,9 +38,8 @@ public class MissingAggregator extends BucketsAggregator implements SingleBucket
     private final ValuesSource valuesSource;
 
     public MissingAggregator(String name, AggregatorFactories factories, ValuesSource valuesSource,
-            SearchContext aggregationContext, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
-        super(name, factories, aggregationContext, parent, pipelineAggregators, metadata);
+            SearchContext aggregationContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, aggregationContext, parent, metadata);
         this.valuesSource = valuesSource;
     }
 
@@ -72,13 +69,12 @@ public class MissingAggregator extends BucketsAggregator implements SingleBucket
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
-        return new InternalMissing(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal),
-                pipelineAggregators(), metadata());
+        return new InternalMissing(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalMissing(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+        return new InternalMissing(name, 0, buildEmptySubAggregations(), metadata());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class MissingAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
@@ -43,9 +41,8 @@ public class MissingAggregatorFactory extends ValuesSourceAggregatorFactory<Valu
     @Override
     protected MissingAggregator createUnmapped(SearchContext searchContext,
                                                 Aggregator parent,
-                                                List<PipelineAggregator> pipelineAggregators,
                                                 Map<String, Object> metadata) throws IOException {
-        return new MissingAggregator(name, factories, null, searchContext, parent, pipelineAggregators, metadata);
+        return new MissingAggregator(name, factories, null, searchContext, parent, metadata);
     }
 
     @Override
@@ -53,9 +50,8 @@ public class MissingAggregatorFactory extends ValuesSourceAggregatorFactory<Valu
                                                     SearchContext searchContext,
                                                     Aggregator parent,
                                                     boolean collectsFromSingleBucket,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException {
-        return new MissingAggregator(name, factories, valuesSource, searchContext, parent, pipelineAggregators, metadata);
+        return new MissingAggregator(name, factories, valuesSource, searchContext, parent, metadata);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNested.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNested.java
@@ -21,19 +21,16 @@ package org.elasticsearch.search.aggregations.bucket.nested;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
  * Result of the {@link NestedAggregator}.
  */
 public class InternalNested extends InternalSingleBucketAggregation implements Nested {
-    InternalNested(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, aggregations, pipelineAggregators, metadata);
+    InternalNested(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
+        super(name, docCount, aggregations, metadata);
     }
 
     /**
@@ -50,6 +47,6 @@ public class InternalNested extends InternalSingleBucketAggregation implements N
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalNested(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalNested(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNested.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNested.java
@@ -21,19 +21,16 @@ package org.elasticsearch.search.aggregations.bucket.nested;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
  * Result of the {@link ReverseNestedAggregator}.
  */
 public class InternalReverseNested extends InternalSingleBucketAggregation implements ReverseNested {
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, docCount, aggregations, pipelineAggregators, metadata);
+    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata) {
+        super(name, docCount, aggregations, metadata);
     }
 
     /**
@@ -50,6 +47,6 @@ public class InternalReverseNested extends InternalSingleBucketAggregation imple
 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalReverseNested(name, docCount, subAggregations, pipelineAggregators(), getMetadata());
+        return new InternalReverseNested(name, docCount, subAggregations, getMetadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -42,11 +42,9 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class NestedAggregator extends BucketsAggregator implements SingleBucketAggregator {
@@ -61,9 +59,8 @@ public class NestedAggregator extends BucketsAggregator implements SingleBucketA
 
     NestedAggregator(String name, AggregatorFactories factories, ObjectMapper parentObjectMapper, ObjectMapper childObjectMapper,
                      SearchContext context, Aggregator parentAggregator,
-                     List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
-                     boolean collectsFromSingleBucket) throws IOException {
-        super(name, factories, context, parentAggregator, pipelineAggregators, metadata);
+                     Map<String, Object> metadata, boolean collectsFromSingleBucket) throws IOException {
+        super(name, factories, context, parentAggregator, metadata);
 
         Query parentFilter = parentObjectMapper != null ? parentObjectMapper.nestedTypeFilter()
             : Queries.newNonNestedFilter(context.mapperService().getIndexSettings().getIndexVersionCreated());
@@ -126,13 +123,12 @@ public class NestedAggregator extends BucketsAggregator implements SingleBucketA
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
-        return new InternalNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal),
-                pipelineAggregators(), metadata());
+        return new InternalNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metadata());
     }
 
         @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalNested(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+        return new InternalNested(name, 0, buildEmptySubAggregations(), metadata());
     }
 
     class BufferingNestedLeafBucketCollector extends LeafBucketCollectorBase {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorFactory.java
@@ -26,11 +26,9 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class NestedAggregatorFactory extends AggregatorFactory {
@@ -50,13 +48,12 @@ public class NestedAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         if (childObjectMapper == null) {
-            return new Unmapped(name, searchContext, parent, pipelineAggregators, metadata);
+            return new Unmapped(name, searchContext, parent, metadata);
         }
         return new NestedAggregator(name, factories, parentObjectMapper, childObjectMapper, searchContext, parent,
-            pipelineAggregators, metadata, collectsFromSingleBucket);
+            metadata, collectsFromSingleBucket);
     }
 
     private static final class Unmapped extends NonCollectingAggregator {
@@ -64,14 +61,13 @@ public class NestedAggregatorFactory extends AggregatorFactory {
         Unmapped(String name,
                     SearchContext context,
                     Aggregator parent,
-                    List<PipelineAggregator> pipelineAggregators,
                     Map<String, Object> metadata) throws IOException {
-            super(name, context, parent, pipelineAggregators, metadata);
+            super(name, context, parent, metadata);
         }
 
         @Override
         public InternalAggregation buildEmptyAggregation() {
-            return new InternalNested(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+            return new InternalNested(name, 0, buildEmptySubAggregations(), metadata());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregator.java
@@ -35,11 +35,9 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class ReverseNestedAggregator extends BucketsAggregator implements SingleBucketAggregator {
@@ -50,9 +48,9 @@ public class ReverseNestedAggregator extends BucketsAggregator implements Single
     private final BitSetProducer parentBitsetProducer;
 
     public ReverseNestedAggregator(String name, AggregatorFactories factories, ObjectMapper objectMapper,
-            SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata)
+            SearchContext context, Aggregator parent, Map<String, Object> metadata)
             throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         if (objectMapper == null) {
             parentFilter = Queries.newNonNestedFilter(context.mapperService().getIndexSettings().getIndexVersionCreated());
         } else {
@@ -94,13 +92,12 @@ public class ReverseNestedAggregator extends BucketsAggregator implements Single
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
-        return new InternalReverseNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal),
-                pipelineAggregators(), metadata());
+        return new InternalReverseNested(name, bucketDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal), metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalReverseNested(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+        return new InternalReverseNested(name, 0, buildEmptySubAggregations(), metadata());
     }
 
     Query getParentFilter() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorFactory.java
@@ -26,11 +26,9 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class ReverseNestedAggregatorFactory extends AggregatorFactory {
@@ -51,13 +49,12 @@ public class ReverseNestedAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         if (unmapped) {
-            return new Unmapped(name, searchContext, parent, pipelineAggregators, metadata);
+            return new Unmapped(name, searchContext, parent, metadata);
         } else {
             return new ReverseNestedAggregator(name, factories, parentObjectMapper,
-                searchContext, parent, pipelineAggregators, metadata);
+                searchContext, parent, metadata);
         }
     }
 
@@ -66,14 +63,13 @@ public class ReverseNestedAggregatorFactory extends AggregatorFactory {
         Unmapped(String name,
                     SearchContext context,
                     Aggregator parent,
-                    List<PipelineAggregator> pipelineAggregators,
                     Map<String, Object> metadata) throws IOException {
-            super(name, context, parent, pipelineAggregators, metadata);
+            super(name, context, parent, metadata);
         }
 
         @Override
         public InternalAggregation buildEmptyAggregation() {
-            return new InternalReverseNested(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+            return new InternalReverseNested(name, 0, buildEmptySubAggregations(), metadata());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeAggregatorFactory.java
@@ -25,7 +25,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Unmapped;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -33,7 +32,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class AbstractRangeAggregatorFactory<R extends Range> extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -60,9 +58,8 @@ public class AbstractRangeAggregatorFactory<R extends Range> extends ValuesSourc
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new Unmapped<>(name, ranges, keyed, config.format(), searchContext, parent, rangeFactory, pipelineAggregators, metadata);
+        return new Unmapped<>(name, ranges, keyed, config.format(), searchContext, parent, rangeFactory, metadata);
     }
 
     @Override
@@ -70,10 +67,9 @@ public class AbstractRangeAggregatorFactory<R extends Range> extends ValuesSourc
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         return new RangeAggregator(name, factories, valuesSource, config.format(), rangeFactory, ranges, keyed, searchContext, parent,
-                pipelineAggregators, metadata);
+                metadata);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -80,9 +79,8 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
     public BinaryRangeAggregator(String name, AggregatorFactories factories,
             ValuesSource.Bytes valuesSource, DocValueFormat format,
             List<Range> ranges, boolean keyed, SearchContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.format = format;
         this.keyed = keyed;
@@ -337,11 +335,11 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
                     ranges[i].key, ranges[i].from, ranges[i].to,
                     bucketDocCount(bucketOrd), bucketAggregations(bucketOrd)));
         }
-        return new InternalBinaryRange(name, format, keyed, buckets, pipelineAggregators(), metadata());
+        return new InternalBinaryRange(name, format, keyed, buckets, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalBinaryRange(name, format, keyed, emptyList(), pipelineAggregators(), metadata());
+        return new InternalBinaryRange(name, format, keyed, emptyList(), metadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorFactory.java
@@ -22,7 +22,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -50,21 +49,18 @@ public class BinaryRangeAggregatorFactory
     }
 
     @Override
-    protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators,
-                                        Map<String, Object> metadata) throws IOException {
+    protected Aggregator createUnmapped(SearchContext searchContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
         return new BinaryRangeAggregator(name, factories, null, config.format(),
-                ranges, keyed, searchContext, parent, pipelineAggregators, metadata);
+                ranges, keyed, searchContext, parent, metadata);
     }
 
     @Override
     protected Aggregator doCreateInternal(ValuesSource.Bytes valuesSource,
                                           SearchContext searchContext, Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
         return new BinaryRangeAggregator(name, factories, valuesSource, config.format(),
-                ranges, keyed, searchContext, parent, pipelineAggregators, metadata);
+                ranges, keyed, searchContext, parent, metadata);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceRangeAggregatorFactory.java
@@ -33,14 +33,12 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder.Range;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class GeoDistanceRangeAggregatorFactory
@@ -67,10 +65,9 @@ public class GeoDistanceRangeAggregatorFactory
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         return new RangeAggregator.Unmapped<>(name, ranges, keyed, config.format(), searchContext, parent,
-            rangeFactory, pipelineAggregators, metadata);
+            rangeFactory, metadata);
     }
 
     @Override
@@ -78,12 +75,10 @@ public class GeoDistanceRangeAggregatorFactory
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         DistanceSource distanceSource = new DistanceSource(valuesSource, distanceType, origin, unit);
         return new RangeAggregator(name, factories, distanceSource, config.format(), rangeFactory, ranges, keyed, searchContext,
-                parent,
-                pipelineAggregators, metadata);
+                parent, metadata);
     }
 
     private static class DistanceSource extends ValuesSource.Numeric {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -192,9 +191,8 @@ public final class InternalBinaryRange
     protected final boolean keyed;
     private final List<Bucket> buckets;
 
-    public InternalBinaryRange(String name, DocValueFormat format, boolean keyed, List<Bucket> buckets,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+    public InternalBinaryRange(String name, DocValueFormat format, boolean keyed, List<Bucket> buckets, Map<String, Object> metadata) {
+        super(name, metadata);
         this.format = format;
         this.keyed = keyed;
         this.buckets = buckets;
@@ -229,7 +227,7 @@ public final class InternalBinaryRange
 
     @Override
     public InternalBinaryRange create(List<Bucket> buckets) {
-        return new InternalBinaryRange(name, format, keyed, buckets, pipelineAggregators(), metadata);
+        return new InternalBinaryRange(name, format, keyed, buckets, metadata);
     }
 
     @Override
@@ -262,7 +260,7 @@ public final class InternalBinaryRange
             buckets.add(new Bucket(format, keyed, b.key, b.from, b.to, docCounts[i],
                     InternalAggregations.reduce(Arrays.asList(aggs[i]), reduceContext)));
         }
-        return new InternalBinaryRange(name, format, keyed, buckets, pipelineAggregators(), metadata);
+        return new InternalBinaryRange(name, format, keyed, buckets, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -227,9 +226,9 @@ public class RangeAggregator extends BucketsAggregator {
 
     public RangeAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, DocValueFormat format,
             InternalRange.Factory rangeFactory, Range[] ranges, boolean keyed, SearchContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         assert valuesSource != null;
         this.valuesSource = valuesSource;
         this.format = format;
@@ -363,10 +362,10 @@ public class RangeAggregator extends BucketsAggregator {
         private final DocValueFormat format;
 
         public Unmapped(String name, R[] ranges, boolean keyed, DocValueFormat format, SearchContext context, Aggregator parent,
-                InternalRange.Factory factory, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata)
+                InternalRange.Factory factory, Map<String, Object> metadata)
                 throws IOException {
 
-            super(name, context, parent, pipelineAggregators, metadata);
+            super(name, context, parent, metadata);
             this.ranges = ranges;
             this.keyed = keyed;
             this.format = format;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregatorFactory.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.sampler.SamplerAggregator.ExecutionMode;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -35,7 +34,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
@@ -58,11 +56,10 @@ public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory<
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
 
         if (valuesSource instanceof ValuesSource.Numeric) {
-            return new DiversifiedNumericSamplerAggregator(name, shardSize, factories, searchContext, parent, pipelineAggregators, metadata,
+            return new DiversifiedNumericSamplerAggregator(name, shardSize, factories, searchContext, parent, metadata,
                     (Numeric) valuesSource, maxDocsPerValue);
         }
 
@@ -80,8 +77,7 @@ public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory<
             if ((execution.needsGlobalOrdinals()) && (!(valuesSource instanceof ValuesSource.Bytes.WithOrdinals))) {
                 execution = ExecutionMode.MAP;
             }
-            return execution.create(name, factories, shardSize, maxDocsPerValue, valuesSource, searchContext, parent, pipelineAggregators,
-                    metadata);
+            return execution.create(name, factories, shardSize, maxDocsPerValue, valuesSource, searchContext, parent, metadata);
         }
 
         throw new AggregationExecutionException("Sampler aggregation cannot be applied to field [" + config.fieldContext().field()
@@ -91,11 +87,10 @@ public class DiversifiedAggregatorFactory extends ValuesSourceAggregatorFactory<
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        final UnmappedSampler aggregation = new UnmappedSampler(name, pipelineAggregators, metadata);
+        final UnmappedSampler aggregation = new UnmappedSampler(name, metadata);
 
-        return new NonCollectingAggregator(name, searchContext, parent, factories, pipelineAggregators, metadata) {
+        return new NonCollectingAggregator(name, searchContext, parent, factories, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
                 return aggregation;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
@@ -31,12 +31,10 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -50,10 +48,10 @@ public class DiversifiedBytesHashSamplerAggregator extends SamplerAggregator {
     private int maxDocsPerValue;
 
     DiversifiedBytesHashSamplerAggregator(String name, int shardSize, AggregatorFactories factories,
-            SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
+            SearchContext context, Aggregator parent, Map<String, Object> metadata,
             ValuesSource valuesSource,
             int maxDocsPerValue) throws IOException {
-        super(name, shardSize, factories, context, parent, pipelineAggregators, metadata);
+        super(name, shardSize, factories, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.maxDocsPerValue = maxDocsPerValue;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
@@ -33,12 +33,10 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -49,9 +47,9 @@ public class DiversifiedMapSamplerAggregator extends SamplerAggregator {
     private BytesRefHash bucketOrds;
 
     DiversifiedMapSamplerAggregator(String name, int shardSize, AggregatorFactories factories,
-            SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
+            SearchContext context, Aggregator parent, Map<String, Object> metadata,
             ValuesSource valuesSource, int maxDocsPerValue) throws IOException {
-        super(name, shardSize, factories, context, parent, pipelineAggregators, metadata);
+        super(name, shardSize, factories, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.maxDocsPerValue = maxDocsPerValue;
         // Need to use super class shardSize since it is limited to maxDoc

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -45,9 +43,9 @@ public class DiversifiedNumericSamplerAggregator extends SamplerAggregator {
     private int maxDocsPerValue;
 
     DiversifiedNumericSamplerAggregator(String name, int shardSize, AggregatorFactories factories,
-            SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
+            SearchContext context, Aggregator parent, Map<String, Object> metadata,
             ValuesSource.Numeric valuesSource, int maxDocsPerValue) throws IOException {
-        super(name, shardSize, factories, context, parent, pipelineAggregators, metadata);
+        super(name, shardSize, factories, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.maxDocsPerValue = maxDocsPerValue;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
@@ -31,12 +31,10 @@ import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -46,9 +44,9 @@ public class DiversifiedOrdinalsSamplerAggregator extends SamplerAggregator {
     private int maxDocsPerValue;
 
     DiversifiedOrdinalsSamplerAggregator(String name, int shardSize, AggregatorFactories factories,
-            SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
+            SearchContext context, Aggregator parent, Map<String, Object> metadata,
             ValuesSource.Bytes.WithOrdinals.FieldData valuesSource, int maxDocsPerValue) throws IOException {
-        super(name, shardSize, factories, context, parent, pipelineAggregators, metadata);
+        super(name, shardSize, factories, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.maxDocsPerValue = maxDocsPerValue;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
@@ -21,10 +21,8 @@ package org.elasticsearch.search.aggregations.bucket.sampler;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class InternalSampler extends InternalSingleBucketAggregation implements Sampler {
@@ -32,9 +30,8 @@ public class InternalSampler extends InternalSingleBucketAggregation implements 
     // InternalSampler and UnmappedSampler share the same parser name, so we use this when identifying the aggregation type
     public static final String PARSER_NAME = "sampler";
 
-    InternalSampler(String name, long docCount, InternalAggregations subAggregations, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) {
-        super(name, docCount, subAggregations, pipelineAggregators, metadata);
+    InternalSampler(String name, long docCount, InternalAggregations subAggregations, Map<String, Object> metadata) {
+        super(name, docCount, subAggregations, metadata);
     }
 
     /**
@@ -57,6 +54,6 @@ public class InternalSampler extends InternalSingleBucketAggregation implements 
     @Override
     protected InternalSingleBucketAggregation newAggregation(String name, long docCount,
             InternalAggregations subAggregations) {
-        return new InternalSampler(name, docCount, subAggregations, pipelineAggregators(), metadata);
+        return new InternalSampler(name, docCount, subAggregations, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
@@ -33,13 +33,11 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferableBucketAggregator;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,10 +64,9 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, int shardSize, int maxDocsPerValue, ValuesSource valuesSource,
-                    SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                    Map<String, Object> metadata) throws IOException {
+                    SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-                return new DiversifiedMapSamplerAggregator(name, shardSize, factories, context, parent, pipelineAggregators, metadata,
+                return new DiversifiedMapSamplerAggregator(name, shardSize, factories, context, parent, metadata,
                         valuesSource,
                         maxDocsPerValue);
             }
@@ -84,11 +81,9 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, int shardSize, int maxDocsPerValue, ValuesSource valuesSource,
-                    SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                    Map<String, Object> metadata) throws IOException {
+                    SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
 
-                return new DiversifiedBytesHashSamplerAggregator(name, shardSize, factories, context, parent, pipelineAggregators,
-                        metadata,
+                return new DiversifiedBytesHashSamplerAggregator(name, shardSize, factories, context, parent, metadata,
                         valuesSource,
                         maxDocsPerValue);
             }
@@ -103,9 +98,8 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
 
             @Override
             Aggregator create(String name, AggregatorFactories factories, int shardSize, int maxDocsPerValue, ValuesSource valuesSource,
-                    SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                    Map<String, Object> metadata) throws IOException {
-                return new DiversifiedOrdinalsSamplerAggregator(name, shardSize, factories, context, parent, pipelineAggregators, metadata,
+                    SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+                return new DiversifiedOrdinalsSamplerAggregator(name, shardSize, factories, context, parent, metadata,
                         (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, maxDocsPerValue);
             }
 
@@ -132,8 +126,7 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
         }
 
         abstract Aggregator create(String name, AggregatorFactories factories, int shardSize, int maxDocsPerValue,
-                ValuesSource valuesSource, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                Map<String, Object> metadata) throws IOException;
+                ValuesSource valuesSource, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException;
 
         abstract boolean needsGlobalOrdinals();
 
@@ -148,8 +141,8 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
     protected BestDocsDeferringCollector bdd;
 
     SamplerAggregator(String name, int shardSize, AggregatorFactories factories, SearchContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
         // Make sure we do not allow size > maxDoc, to prevent accidental OOM
         this.shardSize = Math.min(shardSize, context.searcher().getIndexReader().maxDoc());
     }
@@ -174,13 +167,12 @@ public class SamplerAggregator extends DeferableBucketAggregator implements Sing
     public InternalAggregation buildAggregation(long owningBucketOrdinal) throws IOException {
         runDeferredCollections(owningBucketOrdinal);
         return new InternalSampler(name, bdd == null ? 0 : bdd.getDocCount(owningBucketOrdinal), bucketAggregations(owningBucketOrdinal),
-                pipelineAggregators(),
                 metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalSampler(name, 0, buildEmptySubAggregations(), pipelineAggregators(), metadata());
+        return new InternalSampler(name, 0, buildEmptySubAggregations(), metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorFactory.java
@@ -23,11 +23,9 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class SamplerAggregatorFactory extends AggregatorFactory {
@@ -44,9 +42,8 @@ public class SamplerAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
-        return new SamplerAggregator(name, shardSize, factories, searchContext, parent, pipelineAggregators, metadata);
+        return new SamplerAggregator(name, shardSize, factories, searchContext, parent, metadata);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/UnmappedSampler.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/UnmappedSampler.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,8 +31,8 @@ import java.util.Map;
 public class UnmappedSampler extends InternalSampler {
     public static final String NAME = "unmapped_sampler";
 
-    UnmappedSampler(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, 0, InternalAggregations.EMPTY, pipelineAggregators, metadata);
+    UnmappedSampler(String name, Map<String, Object> metadata) {
+        super(name, 0, InternalAggregations.EMPTY, metadata);
     }
 
     /**
@@ -50,7 +49,7 @@ public class UnmappedSampler extends InternalSampler {
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
-        return new UnmappedSampler(name, pipelineAggregators(), metadata);
+        return new UnmappedSampler(name, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/GlobalOrdinalsSignificantTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/GlobalOrdinalsSignificantTermsAggregator.java
@@ -30,14 +30,12 @@ import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.bucket.terms.GlobalOrdinalsStringTermsAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -62,10 +60,9 @@ public class GlobalOrdinalsSignificantTermsAggregator extends GlobalOrdinalsStri
                                                     boolean forceRemapGlobalOrds,
                                                     SignificanceHeuristic significanceHeuristic,
                                                     SignificantTermsAggregatorFactory termsAggFactory,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException {
         super(name, factories, valuesSource, null, format, bucketCountThresholds, includeExclude, context, parent,
-            forceRemapGlobalOrds, SubAggCollectionMode.BREADTH_FIRST, false, pipelineAggregators, metadata);
+            forceRemapGlobalOrds, SubAggCollectionMode.BREADTH_FIRST, false, metadata);
         this.significanceHeuristic = significanceHeuristic;
         this.termsAggFactory = termsAggFactory;
         this.numCollectedDocs = 0;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTermsAggregator.java
@@ -29,14 +29,12 @@ import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTermsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -46,11 +44,10 @@ public class SignificantLongTermsAggregator extends LongTermsAggregator {
     public SignificantLongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource,
             DocValueFormat format, BucketCountThresholds bucketCountThresholds, SearchContext context, Aggregator parent,
             SignificanceHeuristic significanceHeuristic, SignificantTermsAggregatorFactory termsAggFactory,
-            IncludeExclude.LongFilter includeExclude,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            IncludeExclude.LongFilter includeExclude, Map<String, Object> metadata) throws IOException {
 
         super(name, factories, valuesSource, format, null, bucketCountThresholds, context, parent,
-                SubAggCollectionMode.BREADTH_FIRST, false, includeExclude, pipelineAggregators, metadata);
+                SubAggCollectionMode.BREADTH_FIRST, false, includeExclude, metadata);
         this.significanceHeuristic = significanceHeuristic;
         this.termsAggFactory = termsAggFactory;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsAggregator.java
@@ -30,14 +30,12 @@ import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTermsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -54,10 +52,10 @@ public class SignificantStringTermsAggregator extends StringTermsAggregator {
     public SignificantStringTermsAggregator(String name, AggregatorFactories factories, ValuesSource valuesSource, DocValueFormat format,
             BucketCountThresholds bucketCountThresholds, IncludeExclude.StringFilter includeExclude, SearchContext aggregationContext,
             Aggregator parent, SignificanceHeuristic significanceHeuristic, SignificantTermsAggregatorFactory termsAggFactory,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Map<String, Object> metadata) throws IOException {
 
         super(name, factories, valuesSource, null, format, bucketCountThresholds, includeExclude, aggregationContext, parent,
-                SubAggCollectionMode.BREADTH_FIRST, false, pipelineAggregators, metadata);
+                SubAggCollectionMode.BREADTH_FIRST, false, metadata);
         this.significanceHeuristic = significanceHeuristic;
         this.termsAggFactory = termsAggFactory;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -49,14 +49,12 @@ import org.elasticsearch.search.aggregations.bucket.significant.heuristics.Signi
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource>
@@ -164,11 +162,10 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         final InternalAggregation aggregation = new UnmappedSignificantTerms(name, bucketCountThresholds.getRequiredSize(),
                 bucketCountThresholds.getMinDocCount(), metadata);
-        return new NonCollectingAggregator(name, searchContext, parent, pipelineAggregators, metadata) {
+        return new NonCollectingAggregator(name, searchContext, parent, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
                 return aggregation;
@@ -181,7 +178,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
@@ -226,7 +222,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
             }
 
             return execution.create(name, factories, valuesSource, format, bucketCountThresholds, includeExclude, searchContext, parent,
-                    significanceHeuristic, this, pipelineAggregators, metadata);
+                    significanceHeuristic, this, metadata);
         }
 
         if ((includeExclude != null) && (includeExclude.isRegexBased())) {
@@ -245,8 +241,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                 longFilter = includeExclude.convertToLongFilter(config.format());
             }
             return new SignificantLongTermsAggregator(name, factories, (ValuesSource.Numeric) valuesSource, config.format(),
-                    bucketCountThresholds, searchContext, parent, significanceHeuristic, this, longFilter, pipelineAggregators,
-                    metadata);
+                    bucketCountThresholds, searchContext, parent, significanceHeuristic, this, longFilter, metadata);
         }
 
         throw new AggregationExecutionException("significant_terms aggregation cannot be applied to field ["
@@ -268,12 +263,11 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                               Aggregator parent,
                               SignificanceHeuristic significanceHeuristic,
                               SignificantTermsAggregatorFactory termsAggregatorFactory,
-                              List<PipelineAggregator> pipelineAggregators,
                               Map<String, Object> metadata) throws IOException {
 
                 final IncludeExclude.StringFilter filter = includeExclude == null ? null : includeExclude.convertToStringFilter(format);
                 return new SignificantStringTermsAggregator(name, factories, valuesSource, format, bucketCountThresholds, filter,
-                        aggregationContext, parent, significanceHeuristic, termsAggregatorFactory, pipelineAggregators, metadata);
+                        aggregationContext, parent, significanceHeuristic, termsAggregatorFactory, metadata);
 
             }
 
@@ -291,7 +285,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                               Aggregator parent,
                               SignificanceHeuristic significanceHeuristic,
                               SignificantTermsAggregatorFactory termsAggregatorFactory,
-                              List<PipelineAggregator> pipelineAggregators,
                               Map<String, Object> metadata) throws IOException {
 
                 final IncludeExclude.OrdinalsFilter filter = includeExclude == null ? null : includeExclude.convertToOrdinalsFilter(format);
@@ -309,8 +302,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                 }
                 return new GlobalOrdinalsSignificantTermsAggregator(name, factories,
                         (ValuesSource.Bytes.WithOrdinals.FieldData) valuesSource, format, bucketCountThresholds, filter,
-                        aggregationContext, parent, remapGlobalOrd, significanceHeuristic, termsAggregatorFactory, pipelineAggregators,
-                        metadata);
+                        aggregationContext, parent, remapGlobalOrd, significanceHeuristic, termsAggregatorFactory, metadata);
 
             }
         };
@@ -343,7 +335,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                                    Aggregator parent,
                                    SignificanceHeuristic significanceHeuristic,
                                    SignificantTermsAggregatorFactory termsAggregatorFactory,
-                                   List<PipelineAggregator> pipelineAggregators,
                                    Map<String, Object> metadata) throws IOException;
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregator.java
@@ -41,7 +41,6 @@ import org.elasticsearch.search.aggregations.bucket.significant.heuristics.Signi
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude.StringFilter;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
@@ -72,12 +71,12 @@ public class SignificantTextAggregator extends BucketsAggregator {
 
 
     public SignificantTextAggregator(String name, AggregatorFactories factories,
-            SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+            SearchContext context, Aggregator parent,
             BucketCountThresholds bucketCountThresholds, IncludeExclude.StringFilter includeExclude,
             SignificanceHeuristic significanceHeuristic, SignificantTextAggregatorFactory termsAggFactory,
             String fieldName, String [] sourceFieldNames, boolean filterDuplicateText,
             Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
         this.bucketCountThresholds = bucketCountThresholds;
         this.includeExclude = includeExclude;
         this.significanceHeuristic = significanceHeuristic;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorFactory.java
@@ -43,11 +43,9 @@ import org.elasticsearch.search.aggregations.bucket.significant.heuristics.Signi
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class SignificantTextAggregatorFactory extends AggregatorFactory
@@ -165,8 +163,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory
 
     @Override
     protected Aggregator createInternal(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata)
-            throws IOException {
+                                        Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
         }
@@ -191,7 +188,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory
         IncludeExclude.StringFilter incExcFilter = includeExclude == null ? null:
             includeExclude.convertToStringFilter(DocValueFormat.RAW);
 
-        return new SignificantTextAggregator(name, factories, searchContext, parent, pipelineAggregators, bucketCountThresholds,
+        return new SignificantTextAggregator(name, factories, searchContext, parent, bucketCountThresholds,
                 incExcFilter, significanceHeuristic, this, indexedFieldName, sourceFieldNames, filterDuplicateText, metadata);
 
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractRareTermsAggregator.java
@@ -29,12 +29,10 @@ import org.elasticsearch.search.aggregations.bucket.DeferableBucketAggregator;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.MergingBucketsDeferringCollector;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -53,10 +51,9 @@ public abstract class AbstractRareTermsAggregator<T extends ValuesSource,
     final SetBackedScalingCuckooFilter filter;
 
     AbstractRareTermsAggregator(String name, AggregatorFactories factories, SearchContext context,
-                                Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                                Map<String, Object> metadata, long maxDocCount, double precision,
+                                Aggregator parent, Map<String, Object> metadata, long maxDocCount, double precision,
                                 DocValueFormat format, T valuesSource, U includeExclude) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+        super(name, factories, context, parent, metadata);
 
         // We seed the rng with the ShardID so results are deterministic and don't change randomly
         this.filter = new SetBackedScalingCuckooFilter(10000, new Random(context.indexShard().shardId().hashCode()), precision);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractStringTermsAggregator.java
@@ -24,11 +24,9 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -39,8 +37,8 @@ abstract class AbstractStringTermsAggregator extends TermsAggregator {
 
     AbstractStringTermsAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
             BucketOrder order, DocValueFormat format, BucketCountThresholds bucketCountThresholds, SubAggCollectionMode subAggCollectMode,
-            boolean showTermDocCountError, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, bucketCountThresholds, order, format, subAggCollectMode, pipelineAggregators, metadata);
+            boolean showTermDocCountError, Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, bucketCountThresholds, order, format, subAggCollectMode, metadata);
         this.showTermDocCountError = showTermDocCountError;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsAggregator.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.BucketOrder;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.internal.SearchContext;
@@ -41,9 +40,9 @@ public class DoubleTermsAggregator extends LongTermsAggregator {
     DoubleTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, DocValueFormat format,
             BucketOrder order, BucketCountThresholds bucketCountThresholds, SearchContext aggregationContext, Aggregator parent,
             SubAggCollectionMode collectionMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Map<String, Object> metadata) throws IOException {
         super(name, factories, valuesSource, format, order, bucketCountThresholds, aggregationContext, parent, collectionMode,
-                showTermDocCountError, longFilter, pipelineAggregators, metadata);
+                showTermDocCountError, longFilter, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -41,13 +41,11 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.function.LongUnaryOperator;
 
@@ -88,10 +86,8 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                                                boolean remapGlobalOrds,
                                                SubAggCollectionMode collectionMode,
                                                boolean showTermDocCountError,
-                                               List<PipelineAggregator> pipelineAggregators,
                                                Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, order, format, bucketCountThresholds, collectionMode, showTermDocCountError,
-            pipelineAggregators, metadata);
+        super(name, factories, context, parent, order, format, bucketCountThresholds, collectionMode, showTermDocCountError, metadata);
         this.valuesSource = valuesSource;
         this.includeExclude = includeExclude;
         final IndexReader reader = context.searcher().getIndexReader();
@@ -312,10 +308,9 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                        boolean forceDenseMode,
                        SubAggCollectionMode collectionMode,
                        boolean showTermDocCountError,
-                       List<PipelineAggregator> pipelineAggregators,
                        Map<String, Object> metadata) throws IOException {
             super(name, factories, valuesSource, order, format, bucketCountThresholds, null,
-                context, parent, forceDenseMode, collectionMode, showTermDocCountError, pipelineAggregators, metadata);
+                context, parent, forceDenseMode, collectionMode, showTermDocCountError, metadata);
             assert factories == null || factories.countAggregators() == 0;
             this.segmentDocCounts = context.bigArrays().newIntArray(1, true);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,10 +51,9 @@ public abstract class InternalMappedRareTerms<A extends InternalRareTerms<A, B>,
 
     protected final Logger logger = LogManager.getLogger(getClass());
 
-    InternalMappedRareTerms(String name, BucketOrder order, List<PipelineAggregator> pipelineAggregators,
-                            Map<String, Object> metadata, DocValueFormat format,
+    InternalMappedRareTerms(String name, BucketOrder order, Map<String, Object> metadata, DocValueFormat format,
                             List<B> buckets, long maxDocCount, SetBackedScalingCuckooFilter filter) {
-        super(name, order, maxDocCount, pipelineAggregators, metadata);
+        super(name, order, maxDocCount, metadata);
         this.format = format;
         this.buckets = buckets;
         this.filter = filter;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.KeyComparable;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -122,9 +121,8 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
     protected final BucketOrder order;
     protected final long maxDocCount;
 
-    protected InternalRareTerms(String name, BucketOrder order, long maxDocCount,
-                            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+    protected InternalRareTerms(String name, BucketOrder order, long maxDocCount, Map<String, Object> metadata) {
+        super(name, metadata);
         this.order = order;
         this.maxDocCount = maxDocCount;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTerms.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -100,10 +99,9 @@ public class LongRareTerms extends InternalMappedRareTerms<LongRareTerms, LongRa
         }
     }
 
-    LongRareTerms(String name, BucketOrder order, List<PipelineAggregator> pipelineAggregators,
-                  Map<String, Object> metadata, DocValueFormat format,
+    LongRareTerms(String name, BucketOrder order, Map<String, Object> metadata, DocValueFormat format,
                   List<LongRareTerms.Bucket> buckets, long maxDocCount, SetBackedScalingCuckooFilter filter) {
-        super(name, order, pipelineAggregators, metadata, format, buckets, maxDocCount, filter);
+        super(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 
     /**
@@ -120,7 +118,7 @@ public class LongRareTerms extends InternalMappedRareTerms<LongRareTerms, LongRa
 
     @Override
     public LongRareTerms create(List<LongRareTerms.Bucket> buckets) {
-        return new LongRareTerms(name, order, pipelineAggregators(), metadata, format, buckets, maxDocCount, filter);
+        return new LongRareTerms(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 
     @Override
@@ -130,8 +128,7 @@ public class LongRareTerms extends InternalMappedRareTerms<LongRareTerms, LongRa
 
     @Override
     protected LongRareTerms createWithFilter(String name, List<LongRareTerms.Bucket> buckets, SetBackedScalingCuckooFilter filter) {
-        return new LongRareTerms(name, order, pipelineAggregators(), getMetadata(), format,
-            buckets, maxDocCount, filter);
+        return new LongRareTerms(name, order, getMetadata(), format, buckets, maxDocCount, filter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsAggregator.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -49,10 +48,8 @@ public class LongRareTermsAggregator extends AbstractRareTermsAggregator<ValuesS
 
     LongRareTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, DocValueFormat format,
                                    SearchContext aggregationContext, Aggregator parent, IncludeExclude.LongFilter longFilter,
-                                   int maxDocCount, double precision, List<PipelineAggregator> pipelineAggregators,
-                                   Map<String, Object> metadata) throws IOException {
-        super(name, factories, aggregationContext, parent, pipelineAggregators, metadata, maxDocCount, precision,
-            format, valuesSource, longFilter);
+                                   int maxDocCount, double precision, Map<String, Object> metadata) throws IOException {
+        super(name, factories, aggregationContext, parent, metadata, maxDocCount, precision, format, valuesSource, longFilter);
         this.bucketOrds = new LongHash(1, aggregationContext.bigArrays());
     }
 
@@ -151,12 +148,12 @@ public class LongRareTermsAggregator extends AbstractRareTermsAggregator<ValuesS
         }
 
         CollectionUtil.introSort(buckets, ORDER.comparator());
-        return new LongRareTerms(name, ORDER, pipelineAggregators(), metadata(), format, buckets, maxDocCount, filter);
+        return new LongRareTerms(name, ORDER, metadata(), format, buckets, maxDocCount, filter);
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new LongRareTerms(name, ORDER, pipelineAggregators(), metadata(), format, emptyList(), 0, filter);
+        return new LongRareTerms(name, ORDER, metadata(), format, emptyList(), 0, filter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -32,13 +32,11 @@ import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude.LongFilter;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
@@ -53,9 +51,8 @@ public class LongTermsAggregator extends TermsAggregator {
     public LongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, DocValueFormat format,
             BucketOrder order, BucketCountThresholds bucketCountThresholds, SearchContext aggregationContext, Aggregator parent,
             SubAggCollectionMode subAggCollectMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, aggregationContext, parent, bucketCountThresholds, order, format, subAggCollectMode, pipelineAggregators,
-                metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, factories, aggregationContext, parent, bucketCountThresholds, order, format, subAggCollectMode, metadata);
         this.valuesSource = valuesSource;
         this.showTermDocCountError = showTermDocCountError;
         this.longFilter = longFilter;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorFactory.java
@@ -29,14 +29,12 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
@@ -58,10 +56,9 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<Va
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        final InternalAggregation aggregation = new UnmappedRareTerms(name, pipelineAggregators, metadata);
-        return new NonCollectingAggregator(name, searchContext, parent, factories, pipelineAggregators, metadata) {
+        final InternalAggregation aggregation = new UnmappedRareTerms(name, metadata);
+        return new NonCollectingAggregator(name, searchContext, parent, factories, metadata) {
             @Override
             public InternalAggregation buildEmptyAggregation() {
                 return aggregation;
@@ -74,7 +71,6 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<Va
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
@@ -90,7 +86,7 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<Va
             }
 
             return execution.create(name, factories, valuesSource, format,
-                includeExclude, searchContext, parent, pipelineAggregators, metadata, maxDocCount, precision);
+                includeExclude, searchContext, parent, metadata, maxDocCount, precision);
         }
 
         if ((includeExclude != null) && (includeExclude.isRegexBased())) {
@@ -108,7 +104,7 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<Va
                 longFilter = includeExclude.convertToLongFilter(config.format());
             }
             return new LongRareTermsAggregator(name, factories, (ValuesSource.Numeric) valuesSource, config.format(),
-                searchContext, parent, longFilter, maxDocCount, precision, pipelineAggregators, metadata);
+                searchContext, parent, longFilter, maxDocCount, precision, metadata);
         }
 
         throw new AggregationExecutionException("RareTerms aggregation cannot be applied to field [" + config.fieldContext().field()
@@ -123,12 +119,11 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<Va
             Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource,
                               DocValueFormat format, IncludeExclude includeExclude,
                               SearchContext context, Aggregator parent,
-                              List<PipelineAggregator> pipelineAggregators,
                               Map<String, Object> metadata, long maxDocCount, double precision)
                 throws IOException {
                 final IncludeExclude.StringFilter filter = includeExclude == null ? null : includeExclude.convertToStringFilter(format);
                 return new StringRareTermsAggregator(name, factories, (ValuesSource.Bytes) valuesSource, format, filter,
-                    context, parent, pipelineAggregators, metadata, maxDocCount, precision);
+                    context, parent, metadata, maxDocCount, precision);
             }
 
             @Override
@@ -155,8 +150,7 @@ public class RareTermsAggregatorFactory extends ValuesSourceAggregatorFactory<Va
 
         abstract Aggregator create(String name, AggregatorFactories factories, ValuesSource valuesSource,
                                    DocValueFormat format, IncludeExclude includeExclude,
-                                   SearchContext context, Aggregator parent,
-                                   List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata,
+                                   SearchContext context, Aggregator parent, Map<String, Object> metadata,
                                    long maxDocCount, double precision)
             throws IOException;
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTerms.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -102,10 +101,9 @@ public class StringRareTerms extends InternalMappedRareTerms<StringRareTerms, St
         }
     }
 
-    StringRareTerms(String name, BucketOrder order, List<PipelineAggregator> pipelineAggregators,
-                           Map<String, Object> metadata, DocValueFormat format,
+    StringRareTerms(String name, BucketOrder order, Map<String, Object> metadata, DocValueFormat format,
                            List<StringRareTerms.Bucket> buckets, long maxDocCount, SetBackedScalingCuckooFilter filter) {
-        super(name, order, pipelineAggregators, metadata, format, buckets, maxDocCount, filter);
+        super(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 
     /**
@@ -122,7 +120,7 @@ public class StringRareTerms extends InternalMappedRareTerms<StringRareTerms, St
 
     @Override
     public StringRareTerms create(List<StringRareTerms.Bucket> buckets) {
-        return new StringRareTerms(name, order, pipelineAggregators(), metadata, format, buckets, maxDocCount, filter);
+        return new StringRareTerms(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 
     @Override
@@ -133,8 +131,7 @@ public class StringRareTerms extends InternalMappedRareTerms<StringRareTerms, St
     @Override
     protected StringRareTerms createWithFilter(String name, List<StringRareTerms.Bucket> buckets,
                                                SetBackedScalingCuckooFilter filterFilter) {
-        return new StringRareTerms(name, order, pipelineAggregators(), metadata, format,
-            buckets, maxDocCount, filterFilter);
+        return new StringRareTerms(name, order, metadata, format, buckets, maxDocCount, filterFilter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsAggregator.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -50,9 +49,9 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator<Value
 
     StringRareTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Bytes valuesSource,
                                      DocValueFormat format,  IncludeExclude.StringFilter stringFilter,
-                                     SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+                                     SearchContext context, Aggregator parent,
                                      Map<String, Object> metadata, long maxDocCount, double precision) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata, maxDocCount, precision, format, valuesSource, stringFilter);
+        super(name, factories, context, parent, metadata, maxDocCount, precision, format, valuesSource, stringFilter);
         this.bucketOrds = new BytesRefHash(1, context.bigArrays());
     }
 
@@ -156,12 +155,12 @@ public class StringRareTermsAggregator extends AbstractRareTermsAggregator<Value
         }
 
         CollectionUtil.introSort(buckets, ORDER.comparator());
-        return new StringRareTerms(name, ORDER, pipelineAggregators(), metadata(), format, buckets, maxDocCount, filter);
+        return new StringRareTerms(name, ORDER, metadata(), format, buckets, maxDocCount, filter);
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new StringRareTerms(name, LongRareTermsAggregator.ORDER, pipelineAggregators(), metadata(), format, emptyList(), 0, filter);
+        return new StringRareTerms(name, LongRareTermsAggregator.ORDER, metadata(), format, emptyList(), 0, filter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -33,13 +33,11 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalOrder;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -55,10 +53,9 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
             BucketOrder order, DocValueFormat format, BucketCountThresholds bucketCountThresholds,
             IncludeExclude.StringFilter includeExclude, SearchContext context,
             Aggregator parent, SubAggCollectionMode collectionMode, boolean showTermDocCountError,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Map<String, Object> metadata) throws IOException {
 
-        super(name, factories, context, parent, order, format, bucketCountThresholds, collectionMode, showTermDocCountError,
-                pipelineAggregators, metadata);
+        super(name, factories, context, parent, order, format, bucketCountThresholds, collectionMode, showTermDocCountError, metadata);
         this.valuesSource = valuesSource;
         this.includeExclude = includeExclude;
         bucketOrds = new BytesRefHash(1, context.bigArrays());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregator.java
@@ -34,14 +34,12 @@ import org.elasticsearch.search.aggregations.InternalOrder.Aggregation;
 import org.elasticsearch.search.aggregations.InternalOrder.CompoundOrder;
 import org.elasticsearch.search.aggregations.bucket.DeferableBucketAggregator;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -180,8 +178,8 @@ public abstract class TermsAggregator extends DeferableBucketAggregator {
 
     public TermsAggregator(String name, AggregatorFactories factories, SearchContext context, Aggregator parent,
             BucketCountThresholds bucketCountThresholds, BucketOrder order, DocValueFormat format, SubAggCollectionMode collectMode,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, factories, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, factories, context, parent, metadata);
         this.bucketCountThresholds = bucketCountThresholds;
         this.order = order;
         partiallyBuiltBucketComparator = order == null ? null : order.partiallyBuiltBucketComparator(b -> b.bucketOrd, this);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedRareTerms.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -46,8 +45,8 @@ public class UnmappedRareTerms extends InternalRareTerms<UnmappedRareTerms, Unma
         }
     }
 
-    UnmappedRareTerms(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, LongRareTermsAggregator.ORDER, 0, pipelineAggregators, metadata);
+    UnmappedRareTerms(String name, Map<String, Object> metadata) {
+        super(name, LongRareTermsAggregator.ORDER, 0, metadata);
     }
 
     /**
@@ -74,7 +73,7 @@ public class UnmappedRareTerms extends InternalRareTerms<UnmappedRareTerms, Unma
 
     @Override
     public UnmappedRareTerms create(List<UnmappedRareTerms.Bucket> buckets) {
-        return new UnmappedRareTerms(name, pipelineAggregators(), metadata);
+        return new UnmappedRareTerms(name, metadata);
     }
 
     @Override
@@ -94,7 +93,7 @@ public class UnmappedRareTerms extends InternalRareTerms<UnmappedRareTerms, Unma
 
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
-        return new UnmappedRareTerms(name, pipelineAggregators(), metadata);
+        return new UnmappedRareTerms(name, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -33,12 +33,10 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
@@ -56,8 +54,8 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
 
     AbstractHDRPercentilesAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
             double[] keys, int numberOfSignificantValueDigits, boolean keyed, DocValueFormat formatter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.keyed = keyed;
         this.format = formatter;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,9 +38,8 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     final boolean keyed;
 
     AbstractInternalTDigestPercentiles(String name, double[] keys, TDigestState state, boolean keyed, DocValueFormat formatter,
-            List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+        super(name, metadata);
         this.keys = keys;
         this.state = state;
         this.keyed = keyed;
@@ -96,11 +94,11 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
             }
             merged.add(percentiles.state);
         }
-        return createReduced(getName(), keys, merged, keyed, pipelineAggregators(), getMetadata());
+        return createReduced(getName(), keys, merged, keyed, getMetadata());
     }
 
     protected abstract AbstractInternalTDigestPercentiles createReduced(String name, double[] keys, TDigestState merged, boolean keyed,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata);
+            Map<String, Object> metadata);
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -32,12 +32,10 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
@@ -55,8 +53,8 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
 
     AbstractTDigestPercentilesAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
             double[] keys, double compression, boolean keyed, DocValueFormat formatter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.keyed = keyed;
         this.formatter = formatter;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class AvgAggregator extends NumericMetricsAggregator.SingleValue {
@@ -48,8 +46,8 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     DocValueFormat format;
 
     AvgAggregator(String name, ValuesSource.Numeric valuesSource, DocValueFormat formatter, SearchContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.format = formatter;
         if (valuesSource != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class AvgAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -44,9 +42,8 @@ class AvgAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new AvgAggregator(name, null, config.format(), searchContext, parent, pipelineAggregators, metadata);
+        return new AvgAggregator(name, null, config.format(), searchContext, parent, metadata);
     }
 
     @Override
@@ -54,8 +51,7 @@ class AvgAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new AvgAggregator(name, valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
+        return new AvgAggregator(name, valuesSource, config.format(), searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -40,12 +40,10 @@ import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -67,9 +65,8 @@ class CardinalityAggregator extends NumericMetricsAggregator.SingleValue {
                             int precision,
                             SearchContext context,
                             Aggregator parent,
-                            List<PipelineAggregator> pipelineAggregators,
                             Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.precision = precision;
         this.counts = valuesSource == null ? null : new HyperLogLogPlusPlus(precision, context.bigArrays(), 1);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
@@ -50,9 +48,8 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new CardinalityAggregator(name, null, precision(), searchContext, parent, pipelineAggregators, metadata);
+        return new CardinalityAggregator(name, null, precision(), searchContext, parent, metadata);
     }
 
     @Override
@@ -60,10 +57,8 @@ class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new CardinalityAggregator(name, valuesSource, precision(), searchContext, parent, pipelineAggregators,
-                metadata);
+        return new CardinalityAggregator(name, valuesSource, precision(), searchContext, parent, metadata);
     }
 
     private int precision() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -31,12 +31,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
@@ -56,10 +54,8 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
     DoubleArray compensationOfSqrs;
 
     ExtendedStatsAggregator(String name, ValuesSource.Numeric valuesSource, DocValueFormat formatter,
-            SearchContext context, Aggregator parent, double sigma, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata)
-            throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            SearchContext context, Aggregator parent, double sigma, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.format = formatter;
         this.sigma = sigma;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -52,10 +50,8 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory<Value
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new ExtendedStatsAggregator(name, null, config.format(), searchContext,
-            parent, sigma, pipelineAggregators, metadata);
+        return new ExtendedStatsAggregator(name, null, config.format(), searchContext, parent, sigma, metadata);
     }
 
     @Override
@@ -63,9 +59,8 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory<Value
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         return new ExtendedStatsAggregator(name, valuesSource, config.format(), searchContext,
-            parent, sigma, pipelineAggregators, metadata);
+            parent, sigma, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 final class GeoBoundsAggregator extends MetricsAggregator {
@@ -52,9 +50,8 @@ final class GeoBoundsAggregator extends MetricsAggregator {
     DoubleArray negRights;
 
     GeoBoundsAggregator(String name, SearchContext aggregationContext, Aggregator parent,
-            ValuesSource.GeoPoint valuesSource, boolean wrapLongitude, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
-        super(name, aggregationContext, parent, pipelineAggregators, metadata);
+            ValuesSource.GeoPoint valuesSource, boolean wrapLongitude, Map<String, Object> metadata) throws IOException {
+        super(name, aggregationContext, parent, metadata);
         this.valuesSource = valuesSource;
         this.wrapLongitude = wrapLongitude;
         if (valuesSource != null) {
@@ -153,15 +150,13 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         double posRight = posRights.get(owningBucketOrdinal);
         double negLeft = negLefts.get(owningBucketOrdinal);
         double negRight = negRights.get(owningBucketOrdinal);
-        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude,
-            pipelineAggregators(), metadata());
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         return new InternalGeoBounds(name, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
-            Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude,
-            pipelineAggregators(), metadata());
+            Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
@@ -51,9 +49,8 @@ class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSou
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new GeoBoundsAggregator(name, searchContext, parent, null, wrapLongitude, pipelineAggregators, metadata);
+        return new GeoBoundsAggregator(name, searchContext, parent, null, wrapLongitude, metadata);
     }
 
     @Override
@@ -61,8 +58,7 @@ class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSou
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new GeoBoundsAggregator(name, searchContext, parent, valuesSource, wrapLongitude, pipelineAggregators, metadata);
+        return new GeoBoundsAggregator(name, searchContext, parent, valuesSource, wrapLongitude, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,9 +45,8 @@ final class GeoCentroidAggregator extends MetricsAggregator {
     private LongArray counts;
 
     GeoCentroidAggregator(String name, SearchContext context, Aggregator parent,
-                                    ValuesSource.GeoPoint valuesSource, List<PipelineAggregator> pipelineAggregators,
-                                    Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                                    ValuesSource.GeoPoint valuesSource, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final BigArrays bigArrays = context.bigArrays();
@@ -120,12 +117,12 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         final GeoPoint bucketCentroid = (bucketCount > 0)
                 ? new GeoPoint(latSum.get(bucket) / bucketCount, lonSum.get(bucket) / bucketCount)
                 : null;
-        return new InternalGeoCentroid(name, bucketCentroid , bucketCount, pipelineAggregators(), metadata());
+        return new InternalGeoCentroid(name, bucketCentroid , bucketCount, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoCentroid(name, null, 0L, pipelineAggregators(), metadata());
+        return new InternalGeoCentroid(name, null, 0L, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.GeoPoint> {
@@ -47,9 +45,8 @@ class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new GeoCentroidAggregator(name, searchContext, parent, null, pipelineAggregators, metadata);
+        return new GeoCentroidAggregator(name, searchContext, parent, null, metadata);
     }
 
     @Override
@@ -57,8 +54,7 @@ class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new GeoCentroidAggregator(name, searchContext, parent, valuesSource, pipelineAggregators, metadata);
+        return new GeoCentroidAggregator(name, searchContext, parent, valuesSource, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregator.java
@@ -22,21 +22,18 @@ import org.HdrHistogram.DoubleHistogram;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class HDRPercentileRanksAggregator extends AbstractHDRPercentilesAggregator {
 
     HDRPercentileRanksAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
             double[] percents, int numberOfSignificantValueDigits, boolean keyed, DocValueFormat format,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, format, pipelineAggregators,
-                metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, format, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregator.java
@@ -22,21 +22,17 @@ import org.HdrHistogram.DoubleHistogram;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class HDRPercentilesAggregator extends AbstractHDRPercentilesAggregator {
 
     HDRPercentilesAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent, double[] percents,
-            int numberOfSignificantValueDigits, boolean keyed, DocValueFormat formatter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, formatter,
-                pipelineAggregators, metadata);
+            int numberOfSignificantValueDigits, boolean keyed, DocValueFormat formatter, Map<String, Object> metadata) throws IOException {
+        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, formatter, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,9 +41,8 @@ public class InternalGeoBounds extends InternalAggregation implements GeoBounds 
     final boolean wrapLongitude;
 
     InternalGeoBounds(String name, double top, double bottom, double posLeft, double posRight,
-                      double negLeft, double negRight, boolean wrapLongitude,
-                      List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+                      double negLeft, double negRight, boolean wrapLongitude, Map<String, Object> metadata) {
+        super(name, metadata);
         this.top = top;
         this.bottom = bottom;
         this.posLeft = posLeft;
@@ -115,8 +113,7 @@ public class InternalGeoBounds extends InternalAggregation implements GeoBounds 
                 negRight = bounds.negRight;
             }
         }
-        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, pipelineAggregators(),
-                getMetadata());
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, getMetadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -54,9 +53,8 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
         return GeoEncodingUtils.decodeLongitude((int) (encodedLatLon & 0xFFFFFFFFL));
     }
 
-    InternalGeoCentroid(String name, GeoPoint centroid, long count, List<PipelineAggregator>
-            pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+    InternalGeoCentroid(String name, GeoPoint centroid, long count, Map<String, Object> metadata) {
+        super(name, metadata);
         assert (centroid == null) == (count == 0);
         this.centroid = centroid;
         assert count >= 0;
@@ -132,7 +130,7 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
             }
         }
         final GeoPoint result = (Double.isNaN(lonSum)) ? null : new GeoPoint(latSum/totalCount, lonSum/totalCount);
-        return new InternalGeoCentroid(name, result, totalCount, pipelineAggregators(), getMetadata());
+        return new InternalGeoCentroid(name, result, totalCount, getMetadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalNumericMetricsAggregation.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
@@ -81,14 +80,6 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
         }
 
         /**
-         * @deprecated prefer the other ctor, the pipeline aggregators aren't used
-         */
-        @Deprecated
-        protected MultiValue(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-            super(name, pipelineAggregators, metadata);
-        }
-
-        /**
          * Read from a stream.
          */
         protected MultiValue(StreamInput in) throws IOException {
@@ -122,14 +113,6 @@ public abstract class InternalNumericMetricsAggregation extends InternalAggregat
     }
 
     private InternalNumericMetricsAggregation(String name, Map<String, Object> metadata) {
-        super(name, metadata);
-    }
-
-    /**
-     * @deprecated prefer the other ctor, the pipeline aggregators aren't used
-     */
-    @Deprecated
-    private InternalNumericMetricsAggregation(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
         super(name, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,14 +42,13 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
     final Script reduceScript;
     private final List<Object> aggregations;
 
-    InternalScriptedMetric(String name, Object aggregation, Script reduceScript, List<PipelineAggregator> pipelineAggregators,
-                                  Map<String, Object> metadata) {
-        this(name, Collections.singletonList(aggregation), reduceScript, pipelineAggregators, metadata);
+    InternalScriptedMetric(String name, Object aggregation, Script reduceScript, Map<String, Object> metadata) {
+        this(name, Collections.singletonList(aggregation), reduceScript, metadata);
     }
 
-    private InternalScriptedMetric(String name, List<Object> aggregations, Script reduceScript,
-                                   List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+
+    private InternalScriptedMetric(String name, List<Object> aggregations, Script reduceScript, Map<String, Object> metadata) {
+        super(name, metadata);
         this.aggregations = aggregations;
         this.reduceScript = reduceScript;
     }
@@ -133,8 +131,7 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
             // until we hit the final reduce phase.
             aggregation = aggregationObjects;
         }
-        return new InternalScriptedMetric(firstAggregation.getName(), aggregation, firstAggregation.reduceScript, pipelineAggregators(),
-                getMetadata());
+        return new InternalScriptedMetric(firstAggregation.getName(), aggregation, firstAggregation.reduceScript, getMetadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
@@ -20,19 +20,17 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPercentiles implements PercentileRanks {
     public static final String NAME = "tdigest_percentile_ranks";
 
     InternalTDigestPercentileRanks(String name, double[] cdfValues, TDigestState state, boolean keyed, DocValueFormat formatter,
-                                    List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, cdfValues, state, keyed, formatter, pipelineAggregators, metadata);
+                                   Map<String, Object> metadata) {
+        super(name, cdfValues, state, keyed, formatter, metadata);
     }
 
     /**
@@ -69,8 +67,8 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
 
     @Override
     protected AbstractInternalTDigestPercentiles createReduced(String name, double[] keys, TDigestState merged, boolean keyed,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalTDigestPercentileRanks(name, keys, merged, keyed, format, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalTDigestPercentileRanks(name, keys, merged, keyed, format, metadata);
     }
 
     static double percentileRank(TDigestState state, double value) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -20,19 +20,17 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentiles implements Percentiles {
     public static final String NAME = "tdigest_percentiles";
 
     InternalTDigestPercentiles(String name, double[] percents, TDigestState state, boolean keyed, DocValueFormat formatter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, percents, state, keyed, formatter, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        super(name, percents, state, keyed, formatter, metadata);
     }
 
     /**
@@ -69,8 +67,8 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
 
     @Override
     protected AbstractInternalTDigestPercentiles createReduced(String name, double[] keys, TDigestState merged, boolean keyed,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalTDigestPercentiles(name, keys, merged, keyed, format, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalTDigestPercentiles(name, keys, merged, keyed, format, metadata);
     }
 
     public static class Iter implements Iterator<Percentile> {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -49,8 +48,8 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
     private SearchHits searchHits;
 
     public InternalTopHits(String name, int from, int size, TopDocsAndMaxScore topDocs, SearchHits searchHits,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        super(name, metadata);
         this.from = from;
         this.size = size;
         this.topDocs = topDocs;
@@ -160,7 +159,7 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
         assert reducedTopDocs.totalHits.relation == Relation.EQUAL_TO;
         return new InternalTopHits(name, this.from, this.size,
             new TopDocsAndMaxScore(reducedTopDocs, maxScore),
-            new SearchHits(hits, reducedTopDocs.totalHits, maxScore), pipelineAggregators(), getMetadata());
+            new SearchHits(hits, reducedTopDocs.totalHits, maxScore), getMetadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -36,13 +36,11 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -62,9 +60,8 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
                     ValuesSourceConfig<ValuesSource.Numeric> config,
                     ValuesSource.Numeric valuesSource,
                     SearchContext context,
-                    Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                    Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                    Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             maxes = context.bigArrays().newDoubleArray(1, false);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class MaxAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -44,9 +42,8 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new MaxAggregator(name, config, null, searchContext, parent, pipelineAggregators, metadata);
+        return new MaxAggregator(name, config, null, searchContext, parent, metadata);
     }
 
     @Override
@@ -54,8 +51,7 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new MaxAggregator(name, config, valuesSource, searchContext, parent, pipelineAggregators, metadata);
+        return new MaxAggregator(name, config, valuesSource, searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
@@ -31,12 +31,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -54,13 +52,12 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
     MedianAbsoluteDeviationAggregator(String name,
                                              SearchContext context,
                                              Aggregator parent,
-                                             List<PipelineAggregator> pipelineAggregators,
                                              Map<String, Object> metadata,
                                              @Nullable ValuesSource.Numeric valuesSource,
                                              DocValueFormat format,
                                              double compression) throws IOException {
 
-        super(name, context, parent, pipelineAggregators, metadata);
+        super(name, context, parent, metadata);
 
         this.valuesSource = valuesSource;
         this.format = Objects.requireNonNull(format);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class MedianAbsoluteDeviationAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -52,14 +50,11 @@ public class MedianAbsoluteDeviationAggregatorFactory extends ValuesSourceAggreg
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-
         return new MedianAbsoluteDeviationAggregator(
             name,
             searchContext,
             parent,
-            pipelineAggregators,
             metadata,
             null,
             config.format(),
@@ -72,14 +67,11 @@ public class MedianAbsoluteDeviationAggregatorFactory extends ValuesSourceAggreg
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-
         return new MedianAbsoluteDeviationAggregator(
             name,
             searchContext,
             parent,
-            pipelineAggregators,
             metadata,
             valuesSource,
             config.format(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MetricsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MetricsAggregator.java
@@ -22,17 +22,13 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorBase;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public abstract class MetricsAggregator extends AggregatorBase {
-
-    protected MetricsAggregator(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata) throws IOException {
-        super(name, AggregatorFactories.EMPTY, context, parent, pipelineAggregators, metadata);
+    protected MetricsAggregator(String name, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, AggregatorFactories.EMPTY, context, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -40,13 +40,11 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -66,9 +64,8 @@ class MinAggregator extends NumericMetricsAggregator.SingleValue {
                     ValuesSource.Numeric valuesSource,
                     SearchContext context,
                     Aggregator parent,
-                    List<PipelineAggregator> pipelineAggregators,
                     Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             mins = context.bigArrays().newDoubleArray(1, false);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class MinAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -44,9 +42,8 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new MinAggregator(name, config, null, searchContext, parent, pipelineAggregators, metadata);
+        return new MinAggregator(name, config, null, searchContext, parent, metadata);
     }
 
     @Override
@@ -54,8 +51,7 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new MinAggregator(name, config, valuesSource, searchContext, parent, pipelineAggregators, metadata);
+        return new MinAggregator(name, config, valuesSource, searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NumericMetricsAggregator.java
@@ -20,26 +20,23 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Comparators;
 import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public abstract class NumericMetricsAggregator extends MetricsAggregator {
 
     private NumericMetricsAggregator(String name, SearchContext context, Aggregator parent,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
     }
 
     public abstract static class SingleValue extends NumericMetricsAggregator {
 
-        protected SingleValue(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                Map<String, Object> metadata) throws IOException {
-            super(name, context, parent, pipelineAggregators, metadata);
+        protected SingleValue(String name, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+            super(name, context, parent, metadata);
         }
 
         public abstract double metric(long owningBucketOrd);
@@ -56,9 +53,8 @@ public abstract class NumericMetricsAggregator extends MetricsAggregator {
 
     public abstract static class MultiValue extends NumericMetricsAggregator {
 
-        protected MultiValue(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                Map<String, Object> metadata) throws IOException {
-            super(name, context, parent, pipelineAggregators, metadata);
+        protected MultiValue(String name, SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+            super(name, context, parent, metadata);
         }
 
         public abstract boolean hasMetric(String name);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class PercentileRanksAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
@@ -57,11 +55,10 @@ class PercentileRanksAggregatorFactory extends ValuesSourceAggregatorFactory<Val
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                         Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
 
         return percentilesConfig.createPercentileRanksAggregator(name, null, searchContext, parent, percents, keyed,
-                config.format(), pipelineAggregators, metadata);
+                config.format(), metadata);
     }
 
     @Override
@@ -69,9 +66,8 @@ class PercentileRanksAggregatorFactory extends ValuesSourceAggregatorFactory<Val
                                           SearchContext searchContext,
                                           Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
         return percentilesConfig.createPercentileRanksAggregator(name, valuesSource, searchContext, parent, percents, keyed,
-            config.format(), pipelineAggregators, metadata);
+            config.format(), metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregatorFactory.java
@@ -23,14 +23,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,11 +54,10 @@ class PercentilesAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                         Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
 
         return percentilesConfig.createPercentilesAggregator(name, null, searchContext, parent, percents, keyed,
-            config.format(), pipelineAggregators, metadata);
+            config.format(), metadata);
     }
 
     @Override
@@ -68,10 +65,9 @@ class PercentilesAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
                                           SearchContext searchContext,
                                           Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
 
         return percentilesConfig.createPercentilesAggregator(name, valuesSource, searchContext, parent, percents, keyed,
-                config.format(), pipelineAggregators, metadata);
+                config.format(), metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
@@ -26,12 +26,10 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,13 +69,11 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
 
     abstract Aggregator createPercentilesAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
                                                     double[] values, boolean keyed, DocValueFormat formatter,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException;
 
     abstract Aggregator createPercentileRanksAggregator(String name, ValuesSource valuesSource, SearchContext context,
                                                         Aggregator parent, double[] values, boolean keyed,
-                                                        DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators,
-                                                        Map<String, Object> metadata) throws IOException;
+                                                        DocValueFormat formatter, Map<String, Object> metadata) throws IOException;
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
@@ -130,19 +126,16 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         @Override
         Aggregator createPercentilesAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
                                                double[] values, boolean keyed, DocValueFormat formatter,
-                                               List<PipelineAggregator> pipelineAggregators,
                                                Map<String, Object> metadata) throws IOException {
-            return new TDigestPercentilesAggregator(name, valuesSource, context, parent, values, compression, keyed, formatter,
-                pipelineAggregators, metadata);
+            return new TDigestPercentilesAggregator(name, valuesSource, context, parent, values, compression, keyed, formatter, metadata);
         }
 
         @Override
         Aggregator createPercentileRanksAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
                                                    double[] values, boolean keyed, DocValueFormat formatter,
-                                                   List<PipelineAggregator> pipelineAggregators,
                                                    Map<String, Object> metadata) throws IOException {
             return new TDigestPercentileRanksAggregator(name, valuesSource, context, parent, values, compression, keyed,
-                formatter, pipelineAggregators, metadata);
+                formatter, metadata);
         }
 
         @Override
@@ -206,19 +199,17 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         @Override
         Aggregator createPercentilesAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
                                                double[] values, boolean keyed, DocValueFormat formatter,
-                                               List<PipelineAggregator> pipelineAggregators,
                                                Map<String, Object> metadata) throws IOException {
             return new HDRPercentilesAggregator(name, valuesSource, context, parent, values, numberOfSignificantValueDigits, keyed,
-                formatter, pipelineAggregators, metadata);
+                formatter, metadata);
         }
 
         @Override
         Aggregator createPercentileRanksAggregator(String name, ValuesSource valuesSource, SearchContext context, Aggregator parent,
                                                    double[] values, boolean keyed, DocValueFormat formatter,
-                                                   List<PipelineAggregator> pipelineAggregators,
                                                    Map<String, Object> metadata) throws IOException {
             return new HDRPercentileRanksAggregator(name, valuesSource, context, parent, values, numberOfSignificantValueDigits, keyed,
-                formatter, pipelineAggregators, metadata);
+                formatter, metadata);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
@@ -29,11 +29,9 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class ScriptedMetricAggregator extends MetricsAggregator {
@@ -50,9 +48,8 @@ class ScriptedMetricAggregator extends MetricsAggregator {
                                 Map<String, Object> aggState,
                                 SearchContext context,
                                 Aggregator parent,
-                                List<PipelineAggregator> pipelineAggregators,
                                 Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+        super(name, context, parent, metadata);
         this.aggState = aggState;
         this.mapScript = mapScript;
         this.combineScript = combineScript;
@@ -93,13 +90,12 @@ class ScriptedMetricAggregator extends MetricsAggregator {
         } else {
             aggregation = aggState;
         }
-        return new InternalScriptedMetric(name, aggregation, reduceScript, pipelineAggregators(),
-                metadata());
+        return new InternalScriptedMetric(name, aggregation, reduceScript, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalScriptedMetric(name, null, reduceScript, pipelineAggregators(), metadata());
+        return new InternalScriptedMetric(name, null, reduceScript, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
@@ -19,15 +19,14 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptedMetricAggContexts;
 import org.elasticsearch.search.SearchParseException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -72,7 +71,6 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         if (collectsFromSingleBucket == false) {
             return asMultiBucketAggregator(this, searchContext, parent);
@@ -99,8 +97,7 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
             CollectionUtils.ensureNoSelfReferences(aggState, "Scripted metric aggs init script");
         }
         return new ScriptedMetricAggregator(name, mapScript,
-                combineScript, reduceScript, aggState, searchContext, parent,
-                pipelineAggregators, metadata);
+                combineScript, reduceScript, aggState, searchContext, parent, metadata);
     }
 
     private static Script deepCopyScript(Script script, SearchContext context, Map<String, Object> aggParams) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class StatsAggregator extends NumericMetricsAggregator.MultiValue {
@@ -51,9 +49,8 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
 
 
     StatsAggregator(String name, ValuesSource.Numeric valuesSource, DocValueFormat format,
-                        SearchContext context, Aggregator parent,
-                        List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                        SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             final BigArrays bigArrays = context.bigArrays();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class StatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -48,10 +46,9 @@ class StatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata)
             throws IOException {
-        return new StatsAggregator(name, null, config.format(), searchContext, parent, pipelineAggregators, metadata);
+        return new StatsAggregator(name, null, config.format(), searchContext, parent, metadata);
     }
 
     @Override
@@ -59,8 +56,7 @@ class StatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new StatsAggregator(name, valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
-    }
+        return new StatsAggregator(name, valuesSource, config.format(), searchContext, parent, metadata);
+            }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -29,12 +29,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class SumAggregator extends NumericMetricsAggregator.SingleValue {
@@ -46,8 +44,8 @@ class SumAggregator extends NumericMetricsAggregator.SingleValue {
     private DoubleArray compensations;
 
     SumAggregator(String name, ValuesSource.Numeric valuesSource, DocValueFormat formatter, SearchContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.format = formatter;
         if (valuesSource != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -31,7 +30,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class SumAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Numeric> {
@@ -48,10 +46,9 @@ class SumAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata)
             throws IOException {
-        return new SumAggregator(name, null, config.format(), searchContext, parent, pipelineAggregators, metadata);
+        return new SumAggregator(name, null, config.format(), searchContext, parent, metadata);
     }
 
     @Override
@@ -59,8 +56,7 @@ class SumAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Nu
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new SumAggregator(name, valuesSource, config.format(), searchContext, parent, pipelineAggregators, metadata);
+        return new SumAggregator(name, valuesSource, config.format(), searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
@@ -21,12 +21,10 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggregator {
@@ -39,9 +37,8 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
                                         double compression,
                                         boolean keyed,
                                         DocValueFormat formatter,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
-        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, pipelineAggregators, metadata);
+        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, metadata);
     }
 
     @Override
@@ -50,14 +47,13 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
         if (state == null) {
             return buildEmptyAggregation();
         } else {
-            return new InternalTDigestPercentileRanks(name, keys, state, keyed, formatter, pipelineAggregators(), metadata());
+            return new InternalTDigestPercentileRanks(name, keys, state, keyed, formatter, metadata());
         }
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTDigestPercentileRanks(name, keys, new TDigestState(compression), keyed,
-            formatter, pipelineAggregators(), metadata());
+        return new InternalTDigestPercentileRanks(name, keys, new TDigestState(compression), keyed, formatter, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
@@ -21,12 +21,10 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator {
@@ -39,9 +37,8 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
                                     double compression,
                                     boolean keyed,
                                     DocValueFormat formatter,
-                                    List<PipelineAggregator> pipelineAggregators,
                                     Map<String, Object> metadata) throws IOException {
-        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, pipelineAggregators, metadata);
+        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, metadata);
     }
 
     @Override
@@ -50,7 +47,7 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
         if (state == null) {
             return buildEmptyAggregation();
         } else {
-            return new InternalTDigestPercentiles(name, keys, state, keyed, formatter, pipelineAggregators(), metadata());
+            return new InternalTDigestPercentiles(name, keys, state, keyed, formatter, metadata());
         }
     }
 
@@ -66,7 +63,6 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTDigestPercentiles(name, keys, new TDigestState(compression), keyed,
-            formatter, pipelineAggregators(), metadata());
+        return new InternalTDigestPercentiles(name, keys, new TDigestState(compression), keyed, formatter, metadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregator.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import com.carrotsearch.hppc.LongObjectHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.FieldDoc;
@@ -47,7 +48,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.internal.SearchContext;
@@ -56,7 +56,6 @@ import org.elasticsearch.search.rescore.RescoreContext;
 import org.elasticsearch.search.sort.SortAndFormats;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class TopHitsAggregator extends MetricsAggregator {
@@ -78,8 +77,8 @@ class TopHitsAggregator extends MetricsAggregator {
     private final LongObjectPagedHashMap<Collectors> topDocsCollectors;
 
     TopHitsAggregator(FetchPhase fetchPhase, SubSearchContext subSearchContext, String name, SearchContext context,
-            Aggregator parent, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+            Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.fetchPhase = fetchPhase;
         topDocsCollectors = new LongObjectPagedHashMap<>(1, context.bigArrays());
         this.subSearchContext = subSearchContext;
@@ -204,7 +203,7 @@ class TopHitsAggregator extends MetricsAggregator {
             }
         }
         return new InternalTopHits(name, subSearchContext.from(), subSearchContext.size(), topDocsAndMaxScore, fetchResult.hits(),
-                pipelineAggregators(), metadata());
+                metadata());
     }
 
     @Override
@@ -217,7 +216,7 @@ class TopHitsAggregator extends MetricsAggregator {
             topDocs = Lucene.EMPTY_TOP_DOCS;
         }
         return new InternalTopHits(name, subSearchContext.from(), subSearchContext.size(), new TopDocsAndMaxScore(topDocs, Float.NaN),
-                SearchHits.empty(), pipelineAggregators(), metadata());
+                SearchHits.empty(), metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorFactory.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext.FieldAndFormat;
@@ -90,7 +89,6 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         SubSearchContext subSearchContext = new SubSearchContext(searchContext);
         subSearchContext.parsedQuery(searchContext.parsedQuery());
@@ -118,8 +116,7 @@ class TopHitsAggregatorFactory extends AggregatorFactory {
         if (highlightBuilder != null) {
             subSearchContext.highlight(highlightBuilder.build(searchContext.getQueryShardContext()));
         }
-        return new TopHitsAggregator(searchContext.fetchPhase(), subSearchContext, name, searchContext, parent,
-                pipelineAggregators, metadata);
+        return new TopHitsAggregator(searchContext.fetchPhase(), subSearchContext, name, searchContext, parent, metadata);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -27,12 +27,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -49,10 +47,8 @@ class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
     LongArray counts;
 
     ValueCountAggregator(String name, ValuesSource valuesSource,
-            SearchContext aggregationContext, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata)
-            throws IOException {
-        super(name, aggregationContext, parent, pipelineAggregators, metadata);
+            SearchContext aggregationContext, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, aggregationContext, parent, metadata);
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
             counts = context.bigArrays().newLongArray(1, true);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorFactory.java
@@ -23,18 +23,15 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class ValueCountAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
-
     ValueCountAggregatorFactory(String name, ValuesSourceConfig<ValuesSource> config, QueryShardContext queryShardContext,
             AggregatorFactory parent, AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metadata) throws IOException {
         super(name, config, queryShardContext, parent, subFactoriesBuilder, metadata);
@@ -43,9 +40,8 @@ class ValueCountAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSo
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new ValueCountAggregator(name, null, searchContext, parent, pipelineAggregators, metadata);
+        return new ValueCountAggregator(name, null, searchContext, parent, metadata);
     }
 
     @Override
@@ -53,8 +49,7 @@ class ValueCountAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSo
                                             SearchContext searchContext,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new ValueCountAggregator(name, valuesSource, searchContext, parent, pipelineAggregators, metadata);
+        return new ValueCountAggregator(name, valuesSource, searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
@@ -30,12 +30,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.search.aggregations.metrics.WeightedAvgAggregationBuilder.VALUE_FIELD;
@@ -52,9 +50,8 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
     private DocValueFormat format;
 
     WeightedAvgAggregator(String name, MultiValuesSource.NumericMultiValuesSource valuesSources, DocValueFormat format,
-                            SearchContext context, Aggregator parent,
-                            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                            SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSources = valuesSources;
         this.format = format;
         if (valuesSources != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregatorFactory.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource.Numeric;
@@ -32,7 +31,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class WeightedAvgAggregatorFactory extends MultiValuesSourceAggregatorFactory<Numeric> {
@@ -47,9 +45,8 @@ class WeightedAvgAggregatorFactory extends MultiValuesSourceAggregatorFactory<Nu
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new WeightedAvgAggregator(name, null, format, searchContext, parent, pipelineAggregators, metadata);
+        return new WeightedAvgAggregator(name, null, format, searchContext, parent, metadata);
     }
 
     @Override
@@ -58,13 +55,12 @@ class WeightedAvgAggregatorFactory extends MultiValuesSourceAggregatorFactory<Nu
                                             DocValueFormat format,
                                             Aggregator parent,
                                             boolean collectsFromSingleBucket,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
         MultiValuesSource.NumericMultiValuesSource numericMultiVS
             = new MultiValuesSource.NumericMultiValuesSource(configs, queryShardContext);
         if (numericMultiVS.areValuesSourcesEmpty()) {
-            return createUnmapped(searchContext, parent, pipelineAggregators, metadata);
+            return createUnmapped(searchContext, parent, metadata);
         }
-        return new WeightedAvgAggregator(name, numericMultiVS, format, searchContext, parent, pipelineAggregators, metadata);
+        return new WeightedAvgAggregator(name, numericMultiVS, format, searchContext, parent, metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregatorFactory.java
@@ -24,11 +24,9 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public abstract class MultiValuesSourceAggregatorFactory<VS extends ValuesSource>
@@ -50,21 +48,16 @@ public abstract class MultiValuesSourceAggregatorFactory<VS extends ValuesSource
     public Aggregator createInternal(SearchContext searchContext,
                                         Aggregator parent,
                                         boolean collectsFromSingleBucket,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
-
-        return doCreateInternal(searchContext, configs, format, parent,
-            collectsFromSingleBucket, pipelineAggregators, metadata);
+        return doCreateInternal(searchContext, configs, format, parent, collectsFromSingleBucket, metadata);
     }
 
     protected abstract Aggregator createUnmapped(SearchContext searchContext,
                                                     Aggregator parent,
-                                                    List<PipelineAggregator> pipelineAggregators,
                                                     Map<String, Object> metadata) throws IOException;
 
     protected abstract Aggregator doCreateInternal(SearchContext searchContext, Map<String, ValuesSourceConfig<VS>> configs,
                                                    DocValueFormat format, Aggregator parent, boolean collectsFromSingleBucket,
-                                                   List<PipelineAggregator> pipelineAggregators,
                                                    Map<String, Object> metadata) throws IOException;
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregatorFactory.java
@@ -23,11 +23,9 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource> extends AggregatorFactory {
@@ -42,12 +40,12 @@ public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource> ext
 
     @Override
     public Aggregator createInternal(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket,
-                                     List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+                                     Map<String, Object> metadata) throws IOException {
         VS vs = config.toValuesSource(queryShardContext, this::resolveMissingAny);
         if (vs == null) {
-            return createUnmapped(searchContext, parent, pipelineAggregators, metadata);
+            return createUnmapped(searchContext, parent, metadata);
         }
-        return doCreateInternal(vs, searchContext, parent, collectsFromSingleBucket, pipelineAggregators, metadata);
+        return doCreateInternal(vs, searchContext, parent, collectsFromSingleBucket, metadata);
     }
 
     /**
@@ -67,14 +65,12 @@ public abstract class ValuesSourceAggregatorFactory<VS extends ValuesSource> ext
 
     protected abstract Aggregator createUnmapped(SearchContext searchContext,
                                                  Aggregator parent,
-                                                 List<PipelineAggregator> pipelineAggregators,
                                                  Map<String, Object> metadata) throws IOException;
 
     protected abstract Aggregator doCreateInternal(VS valuesSource,
                                                    SearchContext searchContext,
                                                    Aggregator parent,
                                                    boolean collectsFromSingleBucket,
-                                                   List<PipelineAggregator> pipelineAggregators,
                                                    Map<String, Object> metadata) throws IOException;
 
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/TestAggregatorFactory.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/TestAggregatorFactory.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -48,7 +47,7 @@ public class TestAggregatorFactory extends AggregatorFactory {
     }
 
     @Override
-    protected Aggregator createInternal(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket, List list,
+    protected Aggregator createInternal(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket,
                                         Map metadata) throws IOException {
         return aggregator;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -21,17 +21,14 @@ package org.elasticsearch.search.aggregations.bucket.adjacency;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
-import static java.util.Collections.emptyList;
 
 public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregationTestCase<InternalAdjacencyMatrix> {
 
@@ -75,7 +72,7 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
             int docCount = randomIntBetween(0, 1000);
             buckets.add(new InternalAdjacencyMatrix.InternalBucket(key, docCount, aggregations));
         }
-        return new InternalAdjacencyMatrix(name, buckets, emptyList(), metadata);
+        return new InternalAdjacencyMatrix(name, buckets, metadata);
     }
 
     @Override
@@ -111,7 +108,6 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
     protected InternalAdjacencyMatrix mutateInstance(InternalAdjacencyMatrix instance) {
         String name = instance.getName();
         List<InternalAdjacencyMatrix.InternalBucket> buckets = instance.getBuckets();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 2)) {
         case 0:
@@ -133,6 +129,6 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalAdjacencyMatrix(name, buckets, pipelineAggregators, metadata);
+        return new InternalAdjacencyMatrix(name, buckets, metadata);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -170,8 +170,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         }
         Collections.sort(buckets, (o1, o2) -> o1.compareKey(o2));
         CompositeKey lastBucket = buckets.size() > 0 ? buckets.get(buckets.size()-1).getRawKey() : null;
-        return new InternalComposite(name, size, sourceNames, formats, buckets, lastBucket, reverseMuls, randomBoolean(),
-            Collections.emptyList(), metadata);
+        return new InternalComposite(name, size, sourceNames, formats, buckets, lastBucket, reverseMuls, randomBoolean(), metadata);
     }
 
     @Override
@@ -207,7 +206,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         }
         CompositeKey lastBucket = buckets.size() > 0 ? buckets.get(buckets.size()-1).getRawKey() : null;
         return new InternalComposite(instance.getName(), instance.getSize(), sourceNames, formats, buckets, lastBucket, reverseMuls,
-            randomBoolean(), instance.pipelineAggregators(), metadata);
+            randomBoolean(), metadata);
     }
 
     @Override
@@ -255,7 +254,7 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         InternalComposite mapped = createTestInstance(randomAlphaOfLength(10), emptyMap(), InternalAggregations.EMPTY);
         List<DocValueFormat> rawFormats = formats.stream().map(f -> DocValueFormat.RAW).collect(toList());
         InternalComposite unmapped = new InternalComposite(mapped.getName(), mapped.getSize(), sourceNames,
-                rawFormats, emptyList(), null, reverseMuls, true, emptyList(), emptyMap());
+                rawFormats, emptyList(), null, reverseMuls, true, emptyMap());
         List<InternalAggregation> toReduce = Arrays.asList(unmapped, mapped);
         Collections.shuffle(toReduce, random());
         InternalComposite finalReduce = (InternalComposite) unmapped.reduce(toReduce, emptyReduceContextBuilder().forFinalReduction());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
 import java.util.Map;
@@ -31,8 +30,8 @@ import java.util.Map;
 public class InternalFilterTests extends InternalSingleBucketAggregationTestCase<InternalFilter> {
     @Override
     protected InternalFilter createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalFilter(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalFilter(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobalTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobalTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
 import java.util.Map;
@@ -31,8 +30,8 @@ import java.util.Map;
 public class InternalGlobalTests extends InternalSingleBucketAggregationTestCase<InternalGlobal> {
     @Override
     protected InternalGlobal createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalGlobal(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalGlobal(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalAutoDateHistogram.BucketInfo;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
 import java.time.Instant;
@@ -43,7 +42,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.equalTo;
 
 public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregationTestCase<InternalAutoDateHistogram> {
@@ -85,7 +83,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
         }
         InternalAggregations subAggregations = new InternalAggregations(Collections.emptyList());
         BucketInfo bucketInfo = new BucketInfo(roundingInfos, roundingIndex, subAggregations);
-        return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, emptyList(), metadata, 1);
+        return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, metadata, 1);
     }
 
     /*
@@ -249,7 +247,6 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
         List<InternalAutoDateHistogram.Bucket> buckets = instance.getBuckets();
         int targetBuckets = instance.getTargetBuckets();
         BucketInfo bucketInfo = instance.getBucketInfo();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
         case 0:
@@ -275,6 +272,6 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, pipelineAggregators, metadata, 1);
+        return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, metadata, 1);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
 import java.util.Map;
@@ -31,8 +30,8 @@ import java.util.Map;
 public class InternalMissingTests extends InternalSingleBucketAggregationTestCase<InternalMissing> {
     @Override
     protected InternalMissing createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalMissing(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalMissing(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,8 +32,8 @@ import java.util.Map;
 public class InternalNestedTests extends InternalSingleBucketAggregationTestCase<InternalNested> {
     @Override
     protected InternalNested createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalNested(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalNested(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,8 +32,8 @@ import java.util.Map;
 public class InternalReverseNestedTests extends InternalSingleBucketAggregationTestCase<InternalReverseNested> {
     @Override
     protected InternalReverseNested createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalReverseNested(name, docCount, aggregations, pipelineAggregators, metadata);
+            Map<String, Object> metadata) {
+        return new InternalReverseNested(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,8 +32,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Collections.emptyList;
 
 public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBinaryRange> {
 
@@ -86,7 +83,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
             final String key = (i == nullKey) ? null: randomAlphaOfLength(10);
             buckets.add(new InternalBinaryRange.Bucket(format, keyed, key, ranges.get(i).v1(), ranges.get(i).v2(), docCount, aggregations));
         }
-        return new InternalBinaryRange(name, format, keyed, buckets, emptyList(), metadata);
+        return new InternalBinaryRange(name, format, keyed, buckets, metadata);
     }
 
     @Override
@@ -131,7 +128,6 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
         DocValueFormat format = instance.format;
         boolean keyed = instance.keyed;
         List<InternalBinaryRange.Bucket> buckets = instance.getBuckets();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
         case 0:
@@ -156,7 +152,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalBinaryRange(name, format, keyed, buckets, pipelineAggregators, metadata);
+        return new InternalBinaryRange(name, format, keyed, buckets, metadata);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSamplerTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
 import java.util.Map;
@@ -30,8 +29,8 @@ import java.util.Map;
 public class InternalSamplerTests extends InternalSingleBucketAggregationTestCase<InternalSampler> {
     @Override
     protected InternalSampler createTestInstance(String name, long docCount, InternalAggregations aggregations,
-                                                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalSampler(name, docCount, aggregations, pipelineAggregators, metadata);
+                                                 Map<String, Object> metadata) {
+        return new InternalSampler(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
@@ -21,14 +21,12 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.closeTo;
 
 public class InternalGeoBoundsTests extends InternalAggregationTestCase<InternalGeoBounds> {
@@ -40,8 +38,7 @@ public class InternalGeoBoundsTests extends InternalAggregationTestCase<Internal
         double top = frequently() ? randomDouble() : Double.NEGATIVE_INFINITY;
         InternalGeoBounds geo = new InternalGeoBounds(name,
             top, randomDouble(), randomDouble(), randomDouble(),
-            randomDouble(), randomDouble(), randomBoolean(),
-            emptyList(), metadata);
+            randomDouble(), randomDouble(), randomBoolean(), metadata);
         return geo;
     }
 
@@ -113,7 +110,6 @@ public class InternalGeoBoundsTests extends InternalAggregationTestCase<Internal
         double negLeft = instance.negLeft;
         double negRight = instance.negRight;
         boolean wrapLongitude = instance.wrapLongitude;
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 8)) {
         case 0:
@@ -155,6 +151,6 @@ public class InternalGeoBoundsTests extends InternalAggregationTestCase<Internal
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, pipelineAggregators, metadata);
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, metadata);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -22,7 +22,6 @@ import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
 
@@ -47,7 +46,7 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         if (count == 0) {
             centroid = null;
         }
-        return new InternalGeoCentroid(name, centroid, count, Collections.emptyList(), Collections.emptyMap());
+        return new InternalGeoCentroid(name, centroid, count, Collections.emptyMap());
     }
 
     @Override
@@ -88,7 +87,6 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         String name = instance.getName();
         GeoPoint centroid = instance.centroid();
         long count = instance.count();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 2)) {
         case 0:
@@ -127,6 +125,6 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalGeoCentroid(name, centroid, count, pipelineAggregators, metadata);
+        return new InternalGeoCentroid(name, centroid, count, metadata);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
 import java.io.IOException;
@@ -42,8 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-
-import static java.util.Collections.emptyList;
 
 public class InternalScriptedMetricTests extends InternalAggregationTestCase<InternalScriptedMetric> {
 
@@ -84,7 +81,7 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
             reduceScript = new Script(ScriptType.INLINE, MockScriptEngine.NAME, REDUCE_SCRIPT_NAME, params);
         }
         Object randomValue = randomValue(valueTypes, 0);
-        return new InternalScriptedMetric(name, randomValue, reduceScript, emptyList(), metadata);
+        return new InternalScriptedMetric(name, randomValue, reduceScript, metadata);
     }
 
     @SuppressWarnings("unchecked")
@@ -127,7 +124,6 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
     protected void assertReduced(InternalScriptedMetric reduced, List<InternalScriptedMetric> inputs) {
         InternalScriptedMetric firstAgg = inputs.get(0);
         assertEquals(firstAgg.getName(), reduced.getName());
-        assertEquals(firstAgg.pipelineAggregators(), reduced.pipelineAggregators());
         assertEquals(firstAgg.getMetadata(), reduced.getMetadata());
         if (hasReduceScript) {
             assertEquals(inputs.size(), reduced.aggregation());
@@ -200,7 +196,6 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         String name = instance.getName();
         Object value = instance.aggregation();
         Script reduceScript = instance.reduceScript;
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
         case 0:
@@ -238,6 +233,6 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalScriptedMetric(name, value, reduceScript, pipelineAggregators, metadata);
+        return new InternalScriptedMetric(name, value, reduceScript, metadata);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
@@ -21,14 +21,11 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Collections.emptyList;
 
 public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRanksTestCase<InternalTDigestPercentileRanks> {
 
@@ -39,7 +36,7 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
         Arrays.stream(values).forEach(state::add);
 
         assertEquals(state.centroidCount(), values.length);
-        return new InternalTDigestPercentileRanks(name, percents, state, keyed, format, emptyList(), metadata);
+        return new InternalTDigestPercentileRanks(name, percents, state, keyed, format, metadata);
     }
 
     @Override
@@ -82,7 +79,6 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
         TDigestState state = instance.state;
         boolean keyed = instance.keyed;
         DocValueFormat formatter = instance.formatter();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 4)) {
         case 0:
@@ -115,6 +111,6 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalTDigestPercentileRanks(name, percents, state, keyed, formatter, pipelineAggregators, metadata);
+        return new InternalTDigestPercentileRanks(name, percents, state, keyed, formatter, metadata);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
@@ -21,19 +21,11 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
-import org.elasticsearch.search.aggregations.metrics.ParsedTDigestPercentiles;
-import org.elasticsearch.search.aggregations.metrics.TDigestState;
-import org.elasticsearch.search.aggregations.metrics.InternalPercentilesTestCase;
-import org.elasticsearch.search.aggregations.metrics.ParsedPercentiles;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Collections.emptyList;
 
 public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase<InternalTDigestPercentiles> {
 
@@ -45,7 +37,7 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
         Arrays.stream(values).forEach(state::add);
 
         assertEquals(state.centroidCount(), values.length);
-        return new InternalTDigestPercentiles(name, percents, state, keyed, format, emptyList(), metadata);
+        return new InternalTDigestPercentiles(name, percents, state, keyed, format, metadata);
     }
 
     @Override
@@ -83,7 +75,6 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
         TDigestState state = instance.state;
         boolean keyed = instance.keyed;
         DocValueFormat formatter = instance.formatter();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 4)) {
         case 0:
@@ -116,6 +107,6 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalTDigestPercentiles(name, percents, state, keyed, formatter, pipelineAggregators, metadata);
+        return new InternalTDigestPercentiles(name, percents, state, keyed, formatter, metadata);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.NotEqualMessageBuilder;
@@ -49,8 +48,8 @@ import org.elasticsearch.test.NotEqualMessageBuilder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -60,7 +59,6 @@ import java.util.Set;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 
 public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTopHits> {
@@ -132,7 +130,7 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         // Lucene's TopDocs initializes the maxScore to Float.NaN, if there is no maxScore
         TopDocsAndMaxScore topDocsAndMaxScore = new TopDocsAndMaxScore(topDocs, maxScore == Float.NEGATIVE_INFINITY ? Float.NaN : maxScore);
 
-        return new InternalTopHits(name, from, requestedSize, topDocsAndMaxScore, searchHits, emptyList(), metadata);
+        return new InternalTopHits(name, from, requestedSize, topDocsAndMaxScore, searchHits, metadata);
     }
 
     /**
@@ -332,7 +330,6 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         int size = instance.getSize();
         TopDocsAndMaxScore topDocs = instance.getTopDocs();
         SearchHits searchHits = instance.getHits();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 5)) {
         case 0:
@@ -363,6 +360,6 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalTopHits(name, from, size, topDocs, searchHits, pipelineAggregators, metadata);
+        return new InternalTopHits(name, from, size, topDocs, searchHits, metadata);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/InternalSingleBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/InternalSingleBucketAggregationTestCase.java
@@ -27,7 +27,6 @@ import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregat
 import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalMax;
 import org.elasticsearch.search.aggregations.metrics.InternalMin;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
 import java.io.IOException;
@@ -37,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -68,15 +66,14 @@ public abstract class InternalSingleBucketAggregationTestCase<T extends Internal
         };
     }
 
-    protected abstract T createTestInstance(String name, long docCount, InternalAggregations aggregations,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata);
+    protected abstract T createTestInstance(String name, long docCount, InternalAggregations aggregations, Map<String, Object> metadata);
     protected abstract void extraAssertReduced(T reduced, List<T> inputs);
 
     @Override
     protected final T createTestInstance(String name, Map<String, Object> metadata) {
         // we shouldn't use the full long range here since we sum doc count on reduce, and don't want to overflow the long range there
         long docCount = between(0, Integer.MAX_VALUE);
-        return createTestInstance(name, docCount, subAggregationsSupplier.get(), emptyList(), metadata);
+        return createTestInstance(name, docCount, subAggregationsSupplier.get(), metadata);
     }
 
     @Override
@@ -84,7 +81,6 @@ public abstract class InternalSingleBucketAggregationTestCase<T extends Internal
         String name = instance.getName();
         long docCount = instance.getDocCount();
         InternalAggregations aggregations = instance.getAggregations();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
         case 0:
@@ -109,7 +105,7 @@ public abstract class InternalSingleBucketAggregationTestCase<T extends Internal
             metadata.put(randomAlphaOfLength(15), randomInt());
             break;
         }
-        return createTestInstance(name, docCount, aggregations, pipelineAggregators, metadata);
+        return createTestInstance(name, docCount, aggregations, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregator.java
@@ -21,12 +21,10 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class BoxplotAggregator extends NumericMetricsAggregator.MultiValue {
@@ -37,9 +35,8 @@ public class BoxplotAggregator extends NumericMetricsAggregator.MultiValue {
     protected final double compression;
 
     BoxplotAggregator(String name, ValuesSource valuesSource, DocValueFormat formatter, double compression,
-                      SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                      Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                      SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.valuesSource = valuesSource;
         this.format = formatter;
         this.compression = compression;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorFactory.java
@@ -10,14 +10,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 public class BoxplotAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource> {
@@ -38,11 +36,9 @@ public class BoxplotAggregatorFactory extends ValuesSourceAggregatorFactory<Valu
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                         Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata)
         throws IOException {
-        return new BoxplotAggregator(name, null, config.format(), compression, searchContext, parent,
-            pipelineAggregators, metadata);
+        return new BoxplotAggregator(name, null, config.format(), compression, searchContext, parent, metadata);
     }
 
     @Override
@@ -50,10 +46,8 @@ public class BoxplotAggregatorFactory extends ValuesSourceAggregatorFactory<Valu
                                           SearchContext searchContext,
                                           Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
-        return new BoxplotAggregator(name, valuesSource, config.format(), compression, searchContext, parent,
-            pipelineAggregators, metadata);
+        return new BoxplotAggregator(name, valuesSource, config.format(), compression, searchContext, parent, metadata);
     }
 
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -64,9 +63,8 @@ public class InternalStringStats extends InternalAggregation {
     public InternalStringStats(String name, long count, long totalLength, int minLength, int maxLength,
                                Map<String, Long> charOccurences, boolean showDistribution,
                                DocValueFormat formatter,
-                               List<PipelineAggregator> pipelineAggregators,
                                Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+        super(name, metadata);
         this.format = formatter;
         this.showDistribution = showDistribution;
         this.count = count;
@@ -213,7 +211,7 @@ public class InternalStringStats extends InternalAggregation {
         }
 
         return new InternalStringStats(name, count, totalLength, minLength, maxLength, occurs,
-            showDistribution, format, pipelineAggregators(), getMetadata());
+            showDistribution, format, getMetadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
@@ -19,14 +19,12 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -51,9 +49,8 @@ public class StringStatsAggregator extends MetricsAggregator {
     Map<Character, LongArray> charOccurrences;
 
     StringStatsAggregator(String name, boolean showDistribution, ValuesSource.Bytes valuesSource, DocValueFormat format,
-                          SearchContext context, Aggregator parent,
-                          List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                          SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent, metadata);
         this.showDistribution = showDistribution;
         this.valuesSource = valuesSource;
         if (valuesSource != null) {
@@ -154,15 +151,14 @@ public class StringStatsAggregator extends MetricsAggregator {
 
         return new InternalStringStats(name, count.get(bucket), totalLength.get(bucket),
             minLength.get(bucket), maxLength.get(bucket), occurrences, showDistribution,
-            format, pipelineAggregators(), metadata());
+            format, metadata());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         return new InternalStringStats(name,
             0, 0, Integer.MAX_VALUE, Integer.MIN_VALUE,
-            Collections.emptyMap(), showDistribution, format,
-            pipelineAggregators(), metadata());
+            Collections.emptyMap(), showDistribution, format, metadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorFactory.java
@@ -10,14 +10,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class StringStatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesSource.Bytes> {
@@ -36,10 +34,8 @@ class StringStatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                             Aggregator parent,
-                                            List<PipelineAggregator> pipelineAggregators,
                                             Map<String, Object> metadata) throws IOException {
-        return new StringStatsAggregator(name, showDistribution,null, config.format(), searchContext, parent,
-                                         pipelineAggregators, metadata);
+        return new StringStatsAggregator(name, showDistribution,null, config.format(), searchContext, parent, metadata);
     }
 
     @Override
@@ -47,10 +43,8 @@ class StringStatsAggregatorFactory extends ValuesSourceAggregatorFactory<ValuesS
                                           SearchContext searchContext,
                                           Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
-        return new StringStatsAggregator(name, showDistribution, valuesSource, config.format(), searchContext, parent,
-                                         pipelineAggregators, metadata);
+        return new StringStatsAggregator(name, showDistribution, valuesSource, config.format(), searchContext, parent, metadata);
     }
 
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.sort.SortValue;
 
@@ -37,8 +36,8 @@ public class InternalTopMetrics extends InternalNumericMetricsAggregation.MultiV
     private final List<TopMetric> topMetrics;
 
     public InternalTopMetrics(String name, @Nullable SortOrder sortOrder, List<String> metricNames,
-            int size, List<TopMetric> topMetrics, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        super(name, pipelineAggregators, metadata);
+            int size, List<TopMetric> topMetrics, Map<String, Object> metadata) {
+        super(name, metadata);
         this.sortOrder = sortOrder;
         this.metricNames = metricNames;
         /*
@@ -48,9 +47,8 @@ public class InternalTopMetrics extends InternalNumericMetricsAggregation.MultiV
         this.topMetrics = topMetrics;
     }
 
-    static InternalTopMetrics buildEmptyAggregation(String name, List<String> metricNames,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) {
-        return new InternalTopMetrics(name, SortOrder.ASC, metricNames, 0, emptyList(), pipelineAggregators, metadata);
+    static InternalTopMetrics buildEmptyAggregation(String name, List<String> metricNames, Map<String, Object> metadata) {
+        return new InternalTopMetrics(name, SortOrder.ASC, metricNames, 0, emptyList(), metadata);
     }
 
     /**
@@ -124,7 +122,7 @@ public class InternalTopMetrics extends InternalNumericMetricsAggregation.MultiV
                 queue.updateTop();
             }
         }
-        return new InternalTopMetrics(getName(), sortOrder, metricNames, size, merged, pipelineAggregators(), getMetadata());
+        return new InternalTopMetrics(getName(), sortOrder, metricNames, size, merged, getMetadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregator.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.BucketedSort;
@@ -58,10 +57,9 @@ class TopMetricsAggregator extends NumericMetricsAggregator.MultiValue {
     private final BucketedSort sort;
     private final Metrics metrics;
 
-    TopMetricsAggregator(String name, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metadata, int size,
+    TopMetricsAggregator(String name, SearchContext context, Aggregator parent, Map<String, Object> metadata, int size,
             SortBuilder<?> sort, List<MetricSource> metricSources) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+        super(name, context, parent, metadata);
         this.size = size;
         metrics = new Metrics(size, context.getQueryShardContext().bigArrays(), metricSources);
         /*
@@ -127,12 +125,12 @@ class TopMetricsAggregator extends NumericMetricsAggregator.MultiValue {
     public InternalAggregation buildAggregation(long bucket) throws IOException {
         List<InternalTopMetrics.TopMetric> topMetrics = sort.getValues(bucket, metrics.resultBuilder(sort.getFormat()));
         assert topMetrics.size() <= size;
-        return new InternalTopMetrics(name, sort.getOrder(), metrics.names(), size, topMetrics, pipelineAggregators(), metadata());
+        return new InternalTopMetrics(name, sort.getOrder(), metrics.names(), size, topMetrics, metadata());
     }
 
     @Override
     public InternalTopMetrics buildEmptyAggregation() {
-        return InternalTopMetrics.buildEmptyAggregation(name, metrics.names(), pipelineAggregators(), metadata());
+        return InternalTopMetrics.buildEmptyAggregation(name, metrics.names(), metadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorFactory.java
@@ -12,7 +12,6 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -50,7 +49,7 @@ public class TopMetricsAggregatorFactory extends AggregatorFactory {
 
     @Override
     protected TopMetricsAggregator createInternal(SearchContext searchContext, Aggregator parent, boolean collectsFromSingleBucket,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
+            Map<String, Object> metadata) throws IOException {
         int maxBucketSize = MAX_BUCKET_SIZE.get(searchContext.getQueryShardContext().getIndexSettings().getSettings());
         if (size > maxBucketSize) {
             throw new IllegalArgumentException("[top_metrics.size] must not be more than [" + maxBucketSize + "] but was [" + size
@@ -64,7 +63,6 @@ public class TopMetricsAggregatorFactory extends AggregatorFactory {
                     return new TopMetricsAggregator.MetricSource(config.getFieldName(), resolved.format(),
                             resolved.toValuesSource(searchContext.getQueryShardContext()));
                 }).collect(toList());
-        return new TopMetricsAggregator(name, searchContext, parent, pipelineAggregators, metadata, size,
-                sortBuilders.get(0), metricSources);
+        return new TopMetricsAggregator(name, searchContext, parent, metadata, size, sortBuilders.get(0), metricSources);
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/PairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/PairedTTestAggregator.java
@@ -16,12 +16,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.analytics.ttest.TTestAggregationBuilder.A_FIELD;
@@ -31,9 +29,8 @@ public class PairedTTestAggregator extends TTestAggregator<PairedTTestState> {
     private TTestStatsBuilder statsBuilder;
 
     PairedTTestAggregator(String name, MultiValuesSource.NumericMultiValuesSource valuesSources, int tails, DocValueFormat format,
-                          SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
-                         Map<String, Object> metadata) throws IOException {
-        super(name, valuesSources, tails, format, context, parent, pipelineAggregators, metadata);
+                          SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, valuesSources, tails, format, context, parent, metadata);
         statsBuilder = new TTestStatsBuilder(context.bigArrays());
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregator.java
@@ -11,12 +11,10 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 
@@ -28,9 +26,8 @@ public abstract class TTestAggregator<T extends TTestState> extends NumericMetri
     private DocValueFormat format;
 
     TTestAggregator(String name, MultiValuesSource.NumericMultiValuesSource valuesSources, int tails, DocValueFormat format,
-                    SearchContext context, Aggregator parent,
-                    List<PipelineAggregator> pipelineAggregators, Map<String, Object> metadata) throws IOException {
-        super(name, context, parent, pipelineAggregators, metadata);
+                    SearchContext context, Aggregator parent, Map<String, Object> metadata) throws IOException {
+        super(name, context, parent,  metadata);
         this.valuesSources = valuesSources;
         this.tails = tails;
         this.format = format;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorFactory.java
@@ -11,7 +11,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -19,7 +18,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 class TTestAggregatorFactory extends MultiValuesSourceAggregatorFactory<ValuesSource.Numeric>{
@@ -39,15 +37,14 @@ class TTestAggregatorFactory extends MultiValuesSourceAggregatorFactory<ValuesSo
     @Override
     protected Aggregator createUnmapped(SearchContext searchContext,
                                         Aggregator parent,
-                                        List<PipelineAggregator> pipelineAggregators,
                                         Map<String, Object> metadata) throws IOException {
         switch (testType) {
             case PAIRED:
-                return new PairedTTestAggregator(name, null, tails, format, searchContext, parent, pipelineAggregators, metadata);
+                return new PairedTTestAggregator(name, null, tails, format, searchContext, parent, metadata);
             case HOMOSCEDASTIC:
-                return new UnpairedTTestAggregator(name, null, tails, true, format, searchContext, parent, pipelineAggregators, metadata);
+                return new UnpairedTTestAggregator(name, null, tails, true, format, searchContext, parent, metadata);
             case HETEROSCEDASTIC:
-                return new UnpairedTTestAggregator(name, null, tails, false, format, searchContext, parent, pipelineAggregators, metadata);
+                return new UnpairedTTestAggregator(name, null, tails, false, format, searchContext, parent, metadata);
             default:
                 throw new IllegalArgumentException("Unsupported t-test type " + testType);
         }
@@ -59,22 +56,19 @@ class TTestAggregatorFactory extends MultiValuesSourceAggregatorFactory<ValuesSo
                                           DocValueFormat format,
                                           Aggregator parent,
                                           boolean collectsFromSingleBucket,
-                                          List<PipelineAggregator> pipelineAggregators,
                                           Map<String, Object> metadata) throws IOException {
         MultiValuesSource.NumericMultiValuesSource numericMultiVS
             = new MultiValuesSource.NumericMultiValuesSource(configs, queryShardContext);
         if (numericMultiVS.areValuesSourcesEmpty()) {
-            return createUnmapped(searchContext, parent, pipelineAggregators, metadata);
+            return createUnmapped(searchContext, parent, metadata);
         }
         switch (testType) {
             case PAIRED:
-                return new PairedTTestAggregator(name, numericMultiVS, tails, format, searchContext, parent, pipelineAggregators, metadata);
+                return new PairedTTestAggregator(name, numericMultiVS, tails, format, searchContext, parent, metadata);
             case HOMOSCEDASTIC:
-                return new UnpairedTTestAggregator(name, numericMultiVS, tails, true, format, searchContext, parent, pipelineAggregators,
-                    metadata);
+                return new UnpairedTTestAggregator(name, numericMultiVS, tails, true, format, searchContext, parent, metadata);
             case HETEROSCEDASTIC:
-                return new UnpairedTTestAggregator(name, numericMultiVS, tails, false, format, searchContext, parent, pipelineAggregators,
-                    metadata);
+                return new UnpairedTTestAggregator(name, numericMultiVS, tails, false, format, searchContext, parent, metadata);
             default:
                 throw new IllegalArgumentException("Unsupported t-test type " + testType);
         }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
@@ -15,12 +15,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.MultiValuesSource;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.analytics.ttest.TTestAggregationBuilder.A_FIELD;
@@ -32,9 +30,9 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
     private final boolean homoscedastic;
 
     UnpairedTTestAggregator(String name, MultiValuesSource.NumericMultiValuesSource valuesSources, int tails, boolean homoscedastic,
-                            DocValueFormat format, SearchContext context, Aggregator parent, List<PipelineAggregator> pipelineAggregators,
+                            DocValueFormat format, SearchContext context, Aggregator parent,
                             Map<String, Object> metadata) throws IOException {
-        super(name, valuesSources, tails, format, context, parent, pipelineAggregators, metadata);
+        super(name, valuesSources, tails, format, context, parent, metadata);
         BigArrays bigArrays = context.bigArrays();
         a = new TTestStatsBuilder(bigArrays);
         b = new TTestStatsBuilder(bigArrays);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -40,7 +39,7 @@ public class InternalStringStatsTests extends InternalAggregationTestCase<Intern
     @Override
     protected InternalStringStats createTestInstance(String name, Map<String, Object> metadata) {
         if (randomBoolean()) {
-            return new InternalStringStats(name, 0, 0, 0, 0, emptyMap(), randomBoolean(), DocValueFormat.RAW, emptyList(), metadata);
+            return new InternalStringStats(name, 0, 0, 0, 0, emptyMap(), randomBoolean(), DocValueFormat.RAW, metadata);
         }
         /*
          * Pick random count and length that are *much* less than
@@ -52,8 +51,7 @@ public class InternalStringStatsTests extends InternalAggregationTestCase<Intern
         long totalLength = randomLongBetween(0, count * 10);
         return new InternalStringStats(name, count, totalLength,
                 between(0, Integer.MAX_VALUE), between(0, Integer.MAX_VALUE), randomCharOccurrences(),
-                randomBoolean(), DocValueFormat.RAW,
-                emptyList(), metadata);
+                randomBoolean(), DocValueFormat.RAW, metadata);
     };
 
     @Override
@@ -89,7 +87,7 @@ public class InternalStringStatsTests extends InternalAggregationTestCase<Intern
              break;
          }
         return new InternalStringStats(name, count, totalLength, minLength, maxLength, charOccurrences, showDistribution,
-                DocValueFormat.RAW, instance.pipelineAggregators(), instance.getMetadata());
+                DocValueFormat.RAW, instance.getMetadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsReduceTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsReduceTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
@@ -82,7 +81,7 @@ public class InternalTopMetricsReduceTests extends ESTestCase {
     }
 
     private InternalTopMetrics buildEmpty() {
-        return InternalTopMetrics.buildEmptyAggregation("test", singletonList("test"), emptyList(), null);
+        return InternalTopMetrics.buildEmptyAggregation("test", singletonList("test"), null);
     }
 
     private InternalTopMetrics buildFilled(int size, InternalTopMetrics.TopMetric... metrics) {
@@ -90,7 +89,7 @@ public class InternalTopMetricsReduceTests extends ESTestCase {
     }
 
     private InternalTopMetrics buildFilled(SortOrder sortOrder, int size, InternalTopMetrics.TopMetric... metrics) {
-        return new InternalTopMetrics("test", sortOrder, singletonList("test"), size, Arrays.asList(metrics), emptyList(), null);
+        return new InternalTopMetrics("test", sortOrder, singletonList("test"), size, Arrays.asList(metrics), null);
     }
 
     private InternalTopMetrics.TopMetric top(SortValue sortValue, double metricValue) {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -34,7 +34,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -58,7 +57,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
 
     public void testEmptyIsNotMapped() {
         InternalTopMetrics empty = InternalTopMetrics.buildEmptyAggregation(
-                randomAlphaOfLength(5), randomMetricNames(between(1, 5)), emptyList(), null);
+                randomAlphaOfLength(5), randomMetricNames(between(1, 5)), null);
         assertFalse(empty.isMapped());
     }
 
@@ -70,7 +69,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     public void testToXContentDoubleSortValue() throws IOException {
         List<InternalTopMetrics.TopMetric> top = singletonList(
                 new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricOneDouble)));
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -92,7 +91,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         SortValue sortValue = SortValue.from(ZonedDateTime.parse("2007-12-03T10:15:30Z").toInstant().toEpochMilli());
         List<InternalTopMetrics.TopMetric> top = singletonList(new InternalTopMetrics.TopMetric(
                 strictDateTime(), sortValue, singletonList(metricOneDouble)));
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -113,7 +112,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     public void testToXContentLongMetricValue() throws IOException {
         List<InternalTopMetrics.TopMetric> top = singletonList(
                 new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricOneLong)));
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -136,7 +135,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 strictDateTime(), SortValue.from(ZonedDateTime.parse("2007-12-03T10:15:30Z").toInstant().toEpochMilli()));
         List<InternalTopMetrics.TopMetric> top = singletonList(
                 new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricValue)));
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, emptyList(), null);
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 1, top, null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -157,7 +156,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
     public void testToXContentManyMetrics() throws IOException {
         List<InternalTopMetrics.TopMetric> top = singletonList(new InternalTopMetrics.TopMetric(
                 DocValueFormat.RAW, SortValue.from(1.0), Arrays.asList(metricOneDouble, metricOneLong, metricOneDouble)));
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, Arrays.asList("foo", "bar", "baz"), 1, top, emptyList(), null);
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, Arrays.asList("foo", "bar", "baz"), 1, top, null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -181,7 +180,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         List<InternalTopMetrics.TopMetric> top = Arrays.asList(
                 new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(1.0), singletonList(metricOneDouble)),
                 new InternalTopMetrics.TopMetric(DocValueFormat.RAW, SortValue.from(2.0), singletonList(metricOneLong)));
-        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 2, top, emptyList(), null);
+        InternalTopMetrics tm = new InternalTopMetrics("test", sortOrder, singletonList("test"), 2, top, null);
         assertThat(Strings.toString(tm, true, true), equalTo(
                 "{\n" +
                 "  \"test\" : {\n" +
@@ -226,7 +225,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         List<String> metricNames = randomMetricNames(metricCount);
         int size = between(1, 100);
         List<InternalTopMetrics.TopMetric> topMetrics = randomTopMetrics(randomDocValueFormat, between(0, size), metricCount);
-        return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics, emptyList(), metadata);
+        return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics, metadata);
     }
 
     @Override
@@ -260,8 +259,7 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
         default:
             throw new IllegalArgumentException("bad mutation");
         }
-        return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics,
-                instance.pipelineAggregators(), instance.getMetadata());
+        return new InternalTopMetrics(name, sortOrder, metricNames, size, topMetrics, instance.getMetadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
@@ -90,7 +89,6 @@ public class InternalTTestTests extends InternalAggregationTestCase<InternalTTes
             throw new IllegalStateException(ex);
         }
         DocValueFormat formatter = instance.format();
-        List<PipelineAggregator> pipelineAggregators = instance.pipelineAggregators();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 2)) {
             case 0:

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/CancellingAggregationBuilder.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/CancellingAggregationBuilder.java
@@ -19,11 +19,9 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -86,7 +84,6 @@ public class CancellingAggregationBuilder extends AbstractAggregationBuilder<Can
             protected Aggregator createInternal(SearchContext searchContext,
                                                 Aggregator parent,
                                                 boolean collectsFromSingleBucket,
-                                                List<PipelineAggregator> pipelineAggregators,
                                                 Map<String, Object> metadata) throws IOException {
                 while (searchContext.isCancelled() == false) {
                     try {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestMultiValueAggregation.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestMultiValueAggregation.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 class TestMultiValueAggregation extends InternalNumericMetricsAggregation.MultiValue {
@@ -22,7 +21,7 @@ class TestMultiValueAggregation extends InternalNumericMetricsAggregation.MultiV
     private final Map<String, Double> values;
 
     TestMultiValueAggregation(String name, Map<String, Double> values) {
-        super(name, emptyList(), emptyMap());
+        super(name, emptyMap());
         this.values = values;
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestSingleValueAggregation.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestSingleValueAggregation.java
@@ -12,7 +12,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import java.io.IOException;
 import java.util.List;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 public class TestSingleValueAggregation extends InternalAggregation {
@@ -21,7 +20,7 @@ public class TestSingleValueAggregation extends InternalAggregation {
     private final Object value;
 
     TestSingleValueAggregation(String name, List<String> path, Object value) {
-        super(name, emptyList(), emptyMap());
+        super(name, emptyMap());
         this.path = path;
         this.value = value;
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
@@ -69,7 +69,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
         TopHitsAggExtractor extractor = randomTopHitsAggExtractor();
 
         TotalHits totalHits = new TotalHits(0, TotalHits.Relation.EQUAL_TO);
-        Aggregation agg = new InternalTopHits(extractor.name(), 0, 0, null, new SearchHits(null, totalHits, 0.0f), null, null);
+        Aggregation agg = new InternalTopHits(extractor.name(), 0, 0, null, new SearchHits(null, totalHits, 0.0f), null);
         Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
         assertNull(extractor.extract(bucket));
     }
@@ -78,7 +78,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
         TopHitsAggExtractor extractor = new TopHitsAggExtractor("topHitsAgg", DataTypes.KEYWORD, UTC);
 
         String value = "Str_Value";
-        Aggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null, null);
+        Aggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null);
         Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
         assertEquals(value, extractor.extract(bucket));
     }
@@ -88,7 +88,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
         TopHitsAggExtractor extractor = new TopHitsAggExtractor("topHitsAgg", DataTypes.DATETIME, zoneId);
 
         long value = 123456789L;
-        Aggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null, null);
+        Aggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null);
         Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
         assertEquals(DateUtils.asDateTime(value, zoneId), extractor.extract(bucket));
     }


### PR DESCRIPTION
This removes pipeline aggregators from the aggregation result tree
except for a single field used for backwards compatibility with pre-7.8
versions of Elasticsearch. That field isn't populated unless we are
serializing to pre-7.8 Elasticsearch. So, good news! We no longer build
pipeline aggregators on the data node. Most of the time.
