### PR TITLE
Provide index->data stream lookup

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -67,6 +67,12 @@ public interface IndexAbstraction {
     IndexMetadata getWriteIndex();
 
     /**
+     * @return the data stream to which this index belongs or <code>null</code> if this is not a concrete index or
+     * if it is a concrete index that does not belong to a data stream.
+     */
+    @Nullable DataStream getDataStream();
+
+    /**
      * @return whether this index abstraction is hidden or not
      */
     boolean isHidden();
@@ -113,9 +119,15 @@ public interface IndexAbstraction {
     class Index implements IndexAbstraction {
 
         private final IndexMetadata concreteIndex;
+        private final DataStream dataStream;
+
+        public Index(IndexMetadata indexMetadata, DataStream dataStream) {
+            this.concreteIndex = indexMetadata;
+            this.dataStream = dataStream;
+        }
 
         public Index(IndexMetadata indexMetadata) {
-            this.concreteIndex = indexMetadata;
+            this(indexMetadata, null);
         }
 
         @Override
@@ -136,6 +148,11 @@ public interface IndexAbstraction {
         @Override
         public IndexMetadata getWriteIndex() {
             return concreteIndex;
+        }
+
+        @Override
+        public DataStream getDataStream() {
+            return dataStream;
         }
 
         @Override
@@ -179,6 +196,12 @@ public interface IndexAbstraction {
         @Nullable
         public IndexMetadata getWriteIndex() {
             return writeIndex.get();
+        }
+
+        @Override
+        public DataStream getDataStream() {
+            // aliases may not be part of a data stream
+            return null;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -939,7 +940,7 @@ public class MetadataTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("data stream [" + dataStreamName + "] conflicts with existing index or alias"));
     }
 
-    public void testBuilderRejectsDataStreamWithConflictingBackingIndices() {
+    public void testBuilderRejectsDataStreamWithBackingIndicesThatConflictWithIndex() {
         final String dataStreamName = "my-data-stream";
         final String conflictingIndex = dataStreamName + "-000001";
         Metadata.Builder b = Metadata.builder()
@@ -952,7 +953,24 @@ public class MetadataTests extends ESTestCase {
 
         IllegalStateException e = expectThrows(IllegalStateException.class, b::build);
         assertThat(e.getMessage(), containsString("data stream [" + dataStreamName +
-            "] could create backing indices that conflict with 1 existing index(s) or alias(s) including '" + conflictingIndex + "'"));
+            "] could create backing indices that conflict with 1 existing index(s) including '" + conflictingIndex + "'"));
+    }
+
+    public void testBuilderRejectsDataStreamWithBackingIndicesThatConflictWithAlias() {
+        final String dataStreamName = "my-data-stream";
+        final String conflictingAlias = dataStreamName + "-000001";
+        Metadata.Builder b = Metadata.builder()
+            .put(IndexMetadata.builder("foo")
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .putAlias(AliasMetadata.builder(conflictingAlias).build())
+                .build(), false)
+            .put(new DataStream(dataStreamName, "ts", Collections.emptyList()));
+
+        IllegalStateException e = expectThrows(IllegalStateException.class, b::build);
+        assertThat(e.getMessage(), containsString("data stream [" + dataStreamName +
+            "] could create backing indices that conflict with 1 existing alias(s) including '" + conflictingAlias + "'"));
     }
 
     public void testBuilderForDataStreamWithRandomlyNumberedBackingIndices() {
@@ -976,6 +994,54 @@ public class MetadataTests extends ESTestCase {
         Metadata metadata = b.build();
         assertThat(metadata.dataStreams().size(), equalTo(1));
         assertThat(metadata.dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
+    }
+
+    public void testIndicesLookupRecordsDataStreamForBackingIndices() {
+        // create some indices that do not back a data stream
+        final List<Index> indices = new ArrayList<>();
+        final int numIndices = randomIntBetween(2, 5);
+        int lastIndexNum = randomIntBetween(9, 50);
+        Metadata.Builder b = Metadata.builder();
+        for (int k = 1; k <= numIndices; k++) {
+            IndexMetadata im = IndexMetadata.builder(String.format(Locale.ROOT, "%s-%06d", "index", lastIndexNum))
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+            b.put(im, false);
+            indices.add(im.getIndex());
+            lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
+        }
+
+        // create some backing indices for a data stream
+        final String dataStreamName = "my-data-stream";
+        final List<Index> backingIndices = new ArrayList<>();
+        final int numBackingIndices = randomIntBetween(2, 5);
+        int lastBackingIndexNum = randomIntBetween(9, 50);
+        for (int k = 1; k <= numBackingIndices; k++) {
+            IndexMetadata im = IndexMetadata.builder(String.format(Locale.ROOT, "%s-%06d", dataStreamName, lastBackingIndexNum))
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+            b.put(im, false);
+            backingIndices.add(im.getIndex());
+            lastBackingIndexNum = randomIntBetween(lastBackingIndexNum + 1, lastBackingIndexNum + 50);
+        }
+        b.put(new DataStream(dataStreamName, "ts", backingIndices));
+        Metadata metadata = b.build();
+
+        SortedMap<String, IndexAbstraction> indicesLookup = metadata.getIndicesLookup();
+        assertThat(indicesLookup.size(), equalTo(indices.size() + backingIndices.size() + 1));
+        for (Index index : indices) {
+            assertTrue(indicesLookup.containsKey(index.getName()));
+            assertNull(indicesLookup.get(index.getName()).getDataStream());
+        }
+        for (Index index : backingIndices) {
+            assertTrue(indicesLookup.containsKey(index.getName()));
+            assertNotNull(indicesLookup.get(index.getName()).getDataStream());
+            assertThat(indicesLookup.get(index.getName()).getDataStream().getName(), equalTo(dataStreamName));
+        }
     }
 
     public void testSerialization() throws IOException {


### PR DESCRIPTION
This addresses the concerns raised here https://github.com/elastic/elasticsearch/pull/54848#issuecomment-610389994 and provides bidirectional lookup of backing indices to data streams and data streams to backing indices without maintaining the information in separate places.

If acceptable, it should probably be merged after https://github.com/elastic/elasticsearch/pull/54726 so the anonymous `IndexAbstraction` implementation in `Metadata.Builder::buildIndexAbstractionsLookup` can be replaced with the actual `IndexAbstraction.DataStream` class in that PR.
