### PR TITLE
Fail sniff  process if no connections opened

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -304,14 +304,6 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
         }
     }
 
-    List<String> getSeedNodes() {
-        return configuredSeedNodes;
-    }
-
-    int getMaxConnections() {
-        return maxNumRemoteConnections;
-    }
-
     /* This class handles the _state response from the remote cluster when sniffing nodes to connect to */
     private class SniffClusterStateResponseHandler implements TransportResponseHandler<ClusterStateResponse> {
 
@@ -369,7 +361,12 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
             // since if we do it afterwards we might fail assertions that check if all high level connections are closed.
             // from a code correctness perspective we could also close it afterwards.
             IOUtils.closeWhileHandlingException(connection);
-            listener.onResponse(null);
+            int openConnections = connectionManager.size();
+            if (openConnections == 0) {
+                listener.onFailure(new IllegalStateException("Unable to open any connections to remote cluster [" + clusterAlias + "]"));
+            } else {
+                listener.onResponse(null);
+            }
         }
 
         @Override


### PR DESCRIPTION
Currently the remote cluster sniff connection process can succeed even
if no connections are opened. This commit fixes this by failing the
connection process if no connections are successfully opened.