### PR TITLE
Wildcard field - add regex and fuzzy support

### DIFF
--- a/x-pack/plugin/wildcard/build.gradle
+++ b/x-pack/plugin/wildcard/build.gradle
@@ -19,6 +19,6 @@ integTest.enabled = false
 
 
 licenseHeaders {
-  additionalLicense 'RegExp', 'RegExp (BSD-like)', 'Copyright (c) 2001-2009 Anders Moeller'
+  additionalLicense 'REGEX', 'RegExp (BSD-like)', 'Copyright (c) 2001-2009 Anders Moeller'
   excludes << 'org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java'
 }

--- a/x-pack/plugin/wildcard/build.gradle
+++ b/x-pack/plugin/wildcard/build.gradle
@@ -16,3 +16,8 @@ dependencies {
 }
 
 integTest.enabled = false
+
+
+licenseHeaders {
+  excludes << 'org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java'
+}

--- a/x-pack/plugin/wildcard/build.gradle
+++ b/x-pack/plugin/wildcard/build.gradle
@@ -19,5 +19,6 @@ integTest.enabled = false
 
 
 licenseHeaders {
+  additionalLicense 'RegExp', 'RegExp (BSD-like)', 'Copyright (c) 2001-2009 Anders Moeller'
   excludes << 'org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java'
 }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java
@@ -1,12 +1,3 @@
-package org.elasticsearch.xpack.wildcard.mapper;
-
-import org.apache.lucene.util.automaton.Automata;
-import org.apache.lucene.util.automaton.Automaton;
-import org.apache.lucene.util.automaton.AutomatonProvider;
-import org.apache.lucene.util.automaton.MinimizationOperations;
-import org.apache.lucene.util.automaton.Operations;
-import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
-
 /*
  * dk.brics.automaton
  * 
@@ -36,7 +27,14 @@ import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package org.elasticsearch.xpack.wildcard.mapper;
 
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.AutomatonProvider;
+import org.apache.lucene.util.automaton.MinimizationOperations;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/ApproximateRegExp.java
@@ -1,0 +1,602 @@
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.AutomatonProvider;
+import org.apache.lucene.util.automaton.MinimizationOperations;
+import org.apache.lucene.util.automaton.Operations;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+
+/*
+ * dk.brics.automaton
+ * 
+ * Copyright (c) 2001-2009 Anders Moeller
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 
+ * This class is a fork of Lucene's RegExp class and is used to create a very simplified
+ * form of automaton that is used to extract ngrams used in accelerating searches on
+ * the wildcard field.
+ * Any non-concrete expressions in the regex e.g. ".*" are converted into a special marker character
+ * used in {@link NGramAutomaton} to denote sections of the automaton that are unparseable 
+ * 
+ *
+ */
+public class ApproximateRegExp {
+  
+  enum Kind {
+    REGEXP_UNION, REGEXP_CONCATENATION, REGEXP_INTERSECTION, REGEXP_OPTIONAL, REGEXP_REPEAT, REGEXP_REPEAT_MIN, 
+    REGEXP_REPEAT_MINMAX, REGEXP_COMPLEMENT, REGEXP_CHAR, REGEXP_CHAR_RANGE, REGEXP_ANYCHAR, REGEXP_EMPTY, 
+    REGEXP_STRING, REGEXP_ANYSTRING, REGEXP_AUTOMATON, REGEXP_INTERVAL
+  }
+  
+  /**
+   * Syntax flag, enables intersection (<tt>&amp;</tt>).
+   */
+  public static final int INTERSECTION = 0x0001;
+  
+  /**
+   * Syntax flag, enables complement (<tt>~</tt>).
+   */
+  public static final int COMPLEMENT = 0x0002;
+  
+  /**
+   * Syntax flag, enables empty language (<tt>#</tt>).
+   */
+  public static final int EMPTY = 0x0004;
+  
+  /**
+   * Syntax flag, enables anystring (<tt>@</tt>).
+   */
+  public static final int ANYSTRING = 0x0008;
+  
+  /**
+   * Syntax flag, enables named automata (<tt>&lt;</tt>identifier<tt>&gt;</tt>).
+   */
+  public static final int AUTOMATON = 0x0010;
+  
+  /**
+   * Syntax flag, enables numerical intervals (
+   * <tt>&lt;<i>n</i>-<i>m</i>&gt;</tt>).
+   */
+  public static final int INTERVAL = 0x0020;
+  
+  /**
+   * Syntax flag, enables all optional regexp syntax.
+   */
+  public static final int ALL = 0xffff;
+  
+  /**
+   * Syntax flag, enables no optional regexp syntax.
+   */
+  public static final int NONE = 0x0000;
+
+  private final String originalString;
+  Kind kind;
+  ApproximateRegExp exp1, exp2;
+  String s;
+  int c;
+  int min, max, digits;
+  int from, to;
+  
+  int flags;
+  int pos;
+  
+  ApproximateRegExp() {
+    this.originalString = null;
+  }
+  
+  /**
+   * Constructs new <code>RegExp</code> from a string. Same as
+   * <code>RegExp(s, ALL)</code>.
+   * 
+   * @param s regexp string
+   * @exception IllegalArgumentException if an error occurred while parsing the
+   *              regular expression
+   */
+  public ApproximateRegExp(String s) throws IllegalArgumentException {
+    this(s, ALL);
+  }
+  
+  /**
+   * Constructs new <code>RegExp</code> from a string.
+   * 
+   * @param s regexp string
+   * @param syntax_flags boolean 'or' of optional syntax constructs to be
+   *          enabled
+   * @exception IllegalArgumentException if an error occurred while parsing the
+   *              regular expression
+   */
+  public ApproximateRegExp(String s, int syntax_flags) throws IllegalArgumentException {
+    originalString = s;
+    flags = syntax_flags;
+    ApproximateRegExp e;
+    if (s.length() == 0) e = makeString("");
+    else {
+      e = parseUnionExp();
+      if (pos < originalString.length()) throw new IllegalArgumentException(
+          "end-of-string expected at position " + pos);
+    }
+    kind = e.kind;
+    exp1 = e.exp1;
+    exp2 = e.exp2;
+    this.s = e.s;
+    c = e.c;
+    min = e.min;
+    max = e.max;
+    digits = e.digits;
+    from = e.from;
+    to = e.to;
+  }
+
+  /**
+   * Constructs new <code>Automaton</code> from this <code>RegExp</code>. Same
+   * as <code>toAutomaton(null)</code> (empty automaton map).
+   */
+  public Automaton toAutomaton() {
+    return toAutomaton(null, null, Operations.DEFAULT_MAX_DETERMINIZED_STATES);
+  }
+
+  /**
+   * Constructs new <code>Automaton</code> from this <code>RegExp</code>. The
+   * constructed automaton is minimal and deterministic and has no transitions
+   * to dead states.
+   * 
+   * @param maxDeterminizedStates maximum number of states in the resulting
+   *   automata.  If the automata would need more than this many states
+   *   TooComplextToDeterminizeException is thrown.  Higher number require more
+   *   space but can process more complex regexes.
+   * @exception IllegalArgumentException if this regular expression uses a named
+   *              identifier that is not available from the automaton provider
+   * @exception TooComplexToDeterminizeException if determinizing this regexp
+   *   requires more than maxDeterminizedStates states
+   */
+  public Automaton toAutomaton(int maxDeterminizedStates)
+      throws IllegalArgumentException, TooComplexToDeterminizeException {
+    return toAutomaton(null, null, maxDeterminizedStates);
+  }
+
+  
+  private Automaton toAutomaton(Map<String,Automaton> automata,
+      AutomatonProvider automaton_provider, int maxDeterminizedStates)
+      throws IllegalArgumentException, TooComplexToDeterminizeException {
+      return toAutomatonInternal(automata, automaton_provider,
+        maxDeterminizedStates);
+  }
+  
+  private Automaton toAutomatonInternal(Map<String,Automaton> automata,
+      AutomatonProvider automaton_provider, int maxDeterminizedStates)
+      throws IllegalArgumentException {
+    List<Automaton> list;
+    Automaton a = null;
+    switch (kind) {
+      case REGEXP_UNION:
+        list = new ArrayList<>();
+        findLeaves(exp1, Kind.REGEXP_UNION, list, automata, automaton_provider,
+          maxDeterminizedStates);
+        findLeaves(exp2, Kind.REGEXP_UNION, list, automata, automaton_provider,
+          maxDeterminizedStates);
+        a = Operations.union(list);
+        a = MinimizationOperations.minimize(a, maxDeterminizedStates);
+        break;
+      case REGEXP_CONCATENATION:
+        list = new ArrayList<>();
+        findLeaves(exp1, Kind.REGEXP_CONCATENATION, list, automata,
+            automaton_provider, maxDeterminizedStates);
+        findLeaves(exp2, Kind.REGEXP_CONCATENATION, list, automata,
+            automaton_provider, maxDeterminizedStates);
+        a = Operations.concatenate(list);
+        a = MinimizationOperations.minimize(a, maxDeterminizedStates);
+        break;
+      case REGEXP_INTERSECTION:
+        a = Operations.intersection(
+            exp1.toAutomatonInternal(
+              automata, automaton_provider, maxDeterminizedStates),
+            exp2.toAutomatonInternal(
+              automata, automaton_provider, maxDeterminizedStates));
+        a = MinimizationOperations.minimize(a, maxDeterminizedStates);
+        break;
+      case REGEXP_OPTIONAL:
+      case REGEXP_REPEAT:
+      case REGEXP_REPEAT_MIN:
+      case REGEXP_REPEAT_MINMAX:
+      case REGEXP_COMPLEMENT:
+      case REGEXP_CHAR_RANGE:
+      case REGEXP_ANYSTRING:
+      case REGEXP_ANYCHAR:
+      case REGEXP_INTERVAL:
+        a = Automata.makeString(NGramAutomaton.INVALID_CHAR_STRING);
+        break;
+      case REGEXP_EMPTY:
+        a = Automata.makeEmpty();
+        break;
+      case REGEXP_STRING:
+        a = Automata.makeString(s);
+        break;
+      case REGEXP_CHAR:
+          a = Automata.makeChar(c);
+          break;
+      case REGEXP_AUTOMATON:
+        Automaton aa = null;
+        if (automata != null) {
+          aa = automata.get(s);
+        }
+        if (aa == null && automaton_provider != null) {
+          try {
+            aa = automaton_provider.getAutomaton(s);
+          } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+          }
+        }
+        if (aa == null) {
+          throw new IllegalArgumentException("'" + s + "' not found");
+        }
+        a = aa;
+        break;
+    }
+    return a;
+  }
+  
+  private void findLeaves(ApproximateRegExp exp, Kind kind, List<Automaton> list,
+      Map<String,Automaton> automata, AutomatonProvider automaton_provider,
+      int maxDeterminizedStates) {
+    if (exp.kind == kind) {
+      findLeaves(exp.exp1, kind, list, automata, automaton_provider,
+        maxDeterminizedStates);
+      findLeaves(exp.exp2, kind, list, automata, automaton_provider,
+        maxDeterminizedStates);
+    } else {
+      list.add(exp.toAutomatonInternal(automata, automaton_provider, 
+        maxDeterminizedStates));
+    }
+  }
+
+  /**
+   * The string that was used to construct the regex.  Compare to toString.
+   */
+  public String getOriginalString() {
+    return originalString;
+  }
+
+  static ApproximateRegExp makeUnion(ApproximateRegExp exp1, ApproximateRegExp exp2) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_UNION;
+    r.exp1 = exp1;
+    r.exp2 = exp2;
+    return r;
+  }
+  
+  static ApproximateRegExp makeConcatenation(ApproximateRegExp exp1, ApproximateRegExp exp2) {
+    if ((exp1.kind == Kind.REGEXP_CHAR || exp1.kind == Kind.REGEXP_STRING)
+        && (exp2.kind == Kind.REGEXP_CHAR || exp2.kind == Kind.REGEXP_STRING)) return makeString(
+        exp1, exp2);
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_CONCATENATION;
+    if (exp1.kind == Kind.REGEXP_CONCATENATION
+        && (exp1.exp2.kind == Kind.REGEXP_CHAR || exp1.exp2.kind == Kind.REGEXP_STRING)
+        && (exp2.kind == Kind.REGEXP_CHAR || exp2.kind == Kind.REGEXP_STRING)) {
+      r.exp1 = exp1.exp1;
+      r.exp2 = makeString(exp1.exp2, exp2);
+    } else if ((exp1.kind == Kind.REGEXP_CHAR || exp1.kind == Kind.REGEXP_STRING)
+        && exp2.kind == Kind.REGEXP_CONCATENATION
+        && (exp2.exp1.kind == Kind.REGEXP_CHAR || exp2.exp1.kind == Kind.REGEXP_STRING)) {
+      r.exp1 = makeString(exp1, exp2.exp1);
+      r.exp2 = exp2.exp2;
+    } else {
+      r.exp1 = exp1;
+      r.exp2 = exp2;
+    }
+    return r;
+  }
+  
+  static private ApproximateRegExp makeString(ApproximateRegExp exp1, ApproximateRegExp exp2) {
+    StringBuilder b = new StringBuilder();
+    if (exp1.kind == Kind.REGEXP_STRING) b.append(exp1.s);
+    else b.appendCodePoint(exp1.c);
+    if (exp2.kind == Kind.REGEXP_STRING) b.append(exp2.s);
+    else b.appendCodePoint(exp2.c);
+    return makeString(b.toString());
+  }
+  
+  static ApproximateRegExp makeIntersection(ApproximateRegExp exp1, ApproximateRegExp exp2) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_INTERSECTION;
+    r.exp1 = exp1;
+    r.exp2 = exp2;
+    return r;
+  }
+  
+  static ApproximateRegExp makeOptional(ApproximateRegExp exp) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_OPTIONAL;
+    r.exp1 = exp;
+    return r;
+  }
+  
+  static ApproximateRegExp makeRepeat(ApproximateRegExp exp) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_REPEAT;
+    r.exp1 = exp;
+    return r;
+  }
+  
+  static ApproximateRegExp makeRepeat(ApproximateRegExp exp, int min) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_REPEAT_MIN;
+    r.exp1 = exp;
+    r.min = min;
+    return r;
+  }
+  
+  static ApproximateRegExp makeRepeat(ApproximateRegExp exp, int min, int max) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_REPEAT_MINMAX;
+    r.exp1 = exp;
+    r.min = min;
+    r.max = max;
+    return r;
+  }
+  
+  static ApproximateRegExp makeComplement(ApproximateRegExp exp) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_COMPLEMENT;
+    r.exp1 = exp;
+    return r;
+  }
+  
+  static ApproximateRegExp makeChar(int c) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_CHAR;
+    r.c = c;
+    return r;
+  }
+  
+  static ApproximateRegExp makeCharRange(int from, int to) {
+    if (from > to) 
+      throw new IllegalArgumentException("invalid range: from (" + from + ") cannot be > to (" + to + ")");
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_CHAR_RANGE;
+    r.from = from;
+    r.to = to;
+    return r;
+  }
+  
+  static ApproximateRegExp makeAnyChar() {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_ANYCHAR;
+    return r;
+  }
+  
+  static ApproximateRegExp makeEmpty() {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_EMPTY;
+    return r;
+  }
+  
+  static ApproximateRegExp makeString(String s) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_STRING;
+    r.s = s;
+    return r;
+  }
+  
+  static ApproximateRegExp makeAnyString() {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_ANYSTRING;
+    return r;
+  }
+  
+  static ApproximateRegExp makeAutomaton(String s) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_AUTOMATON;
+    r.s = s;
+    return r;
+  }
+  
+  static ApproximateRegExp makeInterval(int min, int max, int digits) {
+    ApproximateRegExp r = new ApproximateRegExp();
+    r.kind = Kind.REGEXP_INTERVAL;
+    r.min = min;
+    r.max = max;
+    r.digits = digits;
+    return r;
+  }
+  
+  private boolean peek(String s) {
+    return more() && s.indexOf(originalString.codePointAt(pos)) != -1;
+  }
+  
+  private boolean match(int c) {
+    if (pos >= originalString.length()) return false;
+    if (originalString.codePointAt(pos) == c) {
+      pos += Character.charCount(c);
+      return true;
+    }
+    return false;
+  }
+  
+  private boolean more() {
+    return pos < originalString.length();
+  }
+  
+  private int next() throws IllegalArgumentException {
+    if (!more()) throw new IllegalArgumentException("unexpected end-of-string");
+    int ch = originalString.codePointAt(pos);
+    pos += Character.charCount(ch);
+    return ch;
+  }
+  
+  private boolean check(int flag) {
+    return (flags & flag) != 0;
+  }
+  
+  final ApproximateRegExp parseUnionExp() throws IllegalArgumentException {
+    ApproximateRegExp e = parseInterExp();
+    if (match('|')) e = makeUnion(e, parseUnionExp());
+    return e;
+  }
+  
+  final ApproximateRegExp parseInterExp() throws IllegalArgumentException {
+    ApproximateRegExp e = parseConcatExp();
+    if (check(INTERSECTION) && match('&')) e = makeIntersection(e,
+        parseInterExp());
+    return e;
+  }
+  
+  final ApproximateRegExp parseConcatExp() throws IllegalArgumentException {
+    ApproximateRegExp e = parseRepeatExp();
+    if (more() && !peek(")|") && (!check(INTERSECTION) || !peek("&"))) e = makeConcatenation(
+        e, parseConcatExp());
+    return e;
+  }
+  
+  final ApproximateRegExp parseRepeatExp() throws IllegalArgumentException {
+    ApproximateRegExp e = parseComplExp();
+    while (peek("?*+{")) {
+      if (match('?')) e = makeOptional(e);
+      else if (match('*')) e = makeRepeat(e);
+      else if (match('+')) e = makeRepeat(e, 1);
+      else if (match('{')) {
+        int start = pos;
+        while (peek("0123456789"))
+          next();
+        if (start == pos) throw new IllegalArgumentException(
+            "integer expected at position " + pos);
+        int n = Integer.parseInt(originalString.substring(start, pos));
+        int m = -1;
+        if (match(',')) {
+          start = pos;
+          while (peek("0123456789"))
+            next();
+          if (start != pos) m = Integer.parseInt(
+            originalString.substring(start, pos));
+        } else m = n;
+        if (!match('}')) throw new IllegalArgumentException(
+            "expected '}' at position " + pos);
+        if (m == -1) e = makeRepeat(e, n);
+        else e = makeRepeat(e, n, m);
+      }
+    }
+    return e;
+  }
+  
+  final ApproximateRegExp parseComplExp() throws IllegalArgumentException {
+    if (check(COMPLEMENT) && match('~')) return makeComplement(parseComplExp());
+    else return parseCharClassExp();
+  }
+  
+  final ApproximateRegExp parseCharClassExp() throws IllegalArgumentException {
+    if (match('[')) {
+      boolean negate = false;
+      if (match('^')) negate = true;
+      ApproximateRegExp e = parseCharClasses();
+      if (negate) e = makeIntersection(makeAnyChar(), makeComplement(e));
+      if (!match(']')) throw new IllegalArgumentException(
+          "expected ']' at position " + pos);
+      return e;
+    } else return parseSimpleExp();
+  }
+  
+  final ApproximateRegExp parseCharClasses() throws IllegalArgumentException {
+    ApproximateRegExp e = parseCharClass();
+    while (more() && !peek("]"))
+      e = makeUnion(e, parseCharClass());
+    return e;
+  }
+  
+  final ApproximateRegExp parseCharClass() throws IllegalArgumentException {
+    int c = parseCharExp();
+    if (match('-')) return makeCharRange(c, parseCharExp());
+    else return makeChar(c);
+  }
+  
+  final ApproximateRegExp parseSimpleExp() throws IllegalArgumentException {
+    if (match('.')) return makeAnyChar();
+    else if (check(EMPTY) && match('#')) return makeEmpty();
+    else if (check(ANYSTRING) && match('@')) return makeAnyString();
+    else if (match('"')) {
+      int start = pos;
+      while (more() && !peek("\""))
+        next();
+      if (!match('"')) throw new IllegalArgumentException(
+          "expected '\"' at position " + pos);
+      return makeString(originalString.substring(start, pos - 1));
+    } else if (match('(')) {
+      if (match(')')) return makeString("");
+      ApproximateRegExp e = parseUnionExp();
+      if (!match(')')) throw new IllegalArgumentException(
+          "expected ')' at position " + pos);
+      return e;
+    } else if ((check(AUTOMATON) || check(INTERVAL)) && match('<')) {
+      int start = pos;
+      while (more() && !peek(">"))
+        next();
+      if (!match('>')) throw new IllegalArgumentException(
+          "expected '>' at position " + pos);
+      String s = originalString.substring(start, pos - 1);
+      int i = s.indexOf('-');
+      if (i == -1) {
+        if (!check(AUTOMATON)) throw new IllegalArgumentException(
+            "interval syntax error at position " + (pos - 1));
+        return makeAutomaton(s);
+      } else {
+        if (!check(INTERVAL)) throw new IllegalArgumentException(
+            "illegal identifier at position " + (pos - 1));
+        try {
+          if (i == 0 || i == s.length() - 1 || i != s.lastIndexOf('-')) throw new NumberFormatException();
+          String smin = s.substring(0, i);
+          String smax = s.substring(i + 1, s.length());
+          int imin = Integer.parseInt(smin);
+          int imax = Integer.parseInt(smax);
+          int digits;
+          if (smin.length() == smax.length()) digits = smin.length();
+          else digits = 0;
+          if (imin > imax) {
+            int t = imin;
+            imin = imax;
+            imax = t;
+          }
+          return makeInterval(imin, imax, digits);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(
+              "interval syntax error at position " + (pos - 1));
+        }
+      }
+    } else return makeChar(parseCharExp());
+  }
+  
+  final int parseCharExp() throws IllegalArgumentException {
+    match('\\');
+    return next();
+  }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -92,8 +92,11 @@ public class AutomatonQueryOnBinaryDv extends Query {
 
     @Override
     public boolean equals(Object obj) {
-        AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
-        return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern);
+        if (obj instanceof AutomatonQueryOnBinaryDv) {
+            AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
+            return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern);            
+        }
+        return false;
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/AutomatonQueryOnBinaryDv.java
@@ -92,11 +92,11 @@ public class AutomatonQueryOnBinaryDv extends Query {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof AutomatonQueryOnBinaryDv) {
-            AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
-            return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern);            
-        }
-        return false;
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+          }        
+        AutomatonQueryOnBinaryDv other = (AutomatonQueryOnBinaryDv) obj;
+        return Objects.equals(field, other.field)  && Objects.equals(matchPattern, other.matchPattern);            
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/ExpressionToFilterTransformer.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/ExpressionToFilterTransformer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery.Builder;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Expression;
+
+/**
+ * Transforms expressions to filters.
+ */
+public class ExpressionToFilterTransformer implements Expression.Transformer<String, Query> {
+    private final String ngramField;
+
+    public ExpressionToFilterTransformer(String ngramField) {
+        this.ngramField = ngramField;
+    }
+
+    @Override
+    public Query alwaysTrue() {
+        throw new IllegalArgumentException("Can't transform always true into a filter.");
+    }
+
+    @Override
+    public Query alwaysFalse() {
+        throw new IllegalArgumentException("Can't transform always false into a filter.");
+    }
+
+    @Override
+    public Query leaf(String t) {
+        return new TermQuery(new Term(ngramField, t));
+    }
+
+    @Override
+    public Query and(Set<Query> js) {
+        Builder and = new BooleanQuery.Builder();        
+        for (Query j : js) {
+            and.add(j, Occur.MUST);
+        }
+        return and.build();
+    }
+
+    @Override
+    public Query or(Set<Query> js) {
+        // Array containing all terms if this is contains only term filters
+        boolean allTermFilters = true;
+        List<BytesRef> allTerms = null;
+        Builder filter = new BooleanQuery.Builder();        
+        for (Query j : js) {
+            filter.add(j, Occur.SHOULD);
+            if (allTermFilters) {
+                allTermFilters = j instanceof TermQuery;
+                if (allTermFilters) {
+                    if (allTerms == null) {
+                        allTerms = new ArrayList<>(js.size());
+                    }
+                    allTerms.add(((TermQuery) j).getTerm().bytes());
+                }
+            }
+        }
+        if (!allTermFilters) {
+            return filter.build();
+        }
+        return new TermInSetQuery(ngramField, allTerms);
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramApproximationSettings.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramApproximationSettings.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.wildcard.mapper;
+
+
+import java.util.Locale;
+
+public class NGramApproximationSettings {
+    private int maxExpand = 4;
+    private int maxStatesTraced = 10000;
+    private int maxDeterminizedStates = 20000;
+    private int maxNgramsExtracted = 100;
+    private int maxInspect = Integer.MAX_VALUE;
+    private boolean caseSensitive = false;
+    private Locale locale = Locale.ROOT;
+    private boolean rejectUnaccelerated = false;
+
+    public int getMaxExpand() {
+        return maxExpand;
+    }
+
+    public void setMaxExpand(int maxExpand) {
+        this.maxExpand = maxExpand;
+    }
+
+    public int getMaxStatesTraced() {
+        return maxStatesTraced;
+    }
+
+    public void setMaxStatesTraced(int maxStatesTraced) {
+        this.maxStatesTraced = maxStatesTraced;
+    }
+
+    public int getMaxDeterminizedStates() {
+        return maxDeterminizedStates;
+    }
+
+    public void setMaxDeterminizedStates(int maxDeterminizedStates) {
+        this.maxDeterminizedStates = maxDeterminizedStates;
+    }
+
+    public int getMaxNgramsExtracted() {
+        return maxNgramsExtracted;
+    }
+
+    public void setMaxNgramsExtracted(int maxNgramsExtracted) {
+        this.maxNgramsExtracted = maxNgramsExtracted;
+    }
+
+    public int getMaxInspect() {
+        return maxInspect;
+    }
+
+    public void setMaxInspect(int maxInspect) {
+        this.maxInspect = maxInspect;
+    }
+
+    public boolean getCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
+    }
+
+    public boolean getRejectUnaccelerated() {
+        return rejectUnaccelerated;
+    }
+
+    public void setRejectUnaccelerated(boolean rejectUnaccelerated) {
+        this.rejectUnaccelerated = rejectUnaccelerated;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (caseSensitive ? 1231 : 1237);
+        result = prime * result + ((locale == null) ? 0 : locale.hashCode());
+        result = prime * result + maxDeterminizedStates;
+        result = prime * result + maxExpand;
+        result = prime * result + maxInspect;
+        result = prime * result + maxNgramsExtracted;
+        result = prime * result + maxStatesTraced;
+        result = prime * result + (rejectUnaccelerated ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NGramApproximationSettings other = (NGramApproximationSettings) obj;
+        if (caseSensitive != other.caseSensitive)
+            return false;
+        if (locale == null) {
+            if (other.locale != null)
+                return false;
+        } else if (!locale.equals(other.locale))
+            return false;
+        if (maxDeterminizedStates != other.maxDeterminizedStates)
+            return false;
+        if (maxExpand != other.maxExpand)
+            return false;
+        if (maxInspect != other.maxInspect)
+            return false;
+        if (maxNgramsExtracted != other.maxNgramsExtracted)
+            return false;
+        if (maxStatesTraced != other.maxStatesTraced)
+            return false;
+        if (rejectUnaccelerated != other.rejectUnaccelerated)
+            return false;
+        return true;
+    }
+}    
+

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
@@ -158,7 +158,7 @@ public class NGramAutomaton {
         int statesTraced = 0;
         Transition transition = new Transition();
         int currentTransitions = 0;
-        while (!leftToProcess.isEmpty()) {
+        while (false == leftToProcess.isEmpty()) {
             if (statesTraced >= maxStatesTraced) {
                 throw new AutomatonTooComplexException();
             }

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Transition;
+import org.elasticsearch.xpack.wildcard.mapper.regex.And;
+import org.elasticsearch.xpack.wildcard.mapper.regex.AutomatonTooComplexException;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Expression;
+import org.elasticsearch.xpack.wildcard.mapper.regex.ExpressionSource;
+import org.elasticsearch.xpack.wildcard.mapper.regex.False;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Leaf;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Or;
+import org.elasticsearch.xpack.wildcard.mapper.regex.True;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A finite automaton who's transitions are ngrams that must be in the string or
+ * ngrams we can't check for. Not thread safe one bit.
+ */
+public class NGramAutomaton {
+    private final Automaton source;
+    private final int gramSize;
+    private final int maxExpand;
+    private final int maxStatesTraced;
+    private final int maxTransitions;
+    private final List<NGramState> initialStates = new ArrayList<>();
+    private final List<NGramState> acceptStates = new ArrayList<>();
+    private final Map<NGramState, NGramState> states = new HashMap<>();
+
+    /**
+     * Build it.
+     * @param source automaton to convert into an ngram automaton
+     * @param gramSize size of the grams to extract
+     * @param maxExpand Maximum size of range transitions to expand into single
+     *            transitions. Its roughly analogous to the number of character
+     *            in a character class before it is considered a wildcard for
+     *            optimization purposes.
+     * @param maxStatesTraced maximum number of states traced during automaton
+     *            functions. Higher number allow more complex automata to be
+     *            converted to ngram expressions at the cost of more time.
+     */
+    public NGramAutomaton(Automaton source, int gramSize, int maxExpand, int maxStatesTraced, int maxTransitions) {
+        this.source = source;
+        this.gramSize = gramSize;
+        this.maxExpand = maxExpand;
+        this.maxStatesTraced = maxStatesTraced;
+        this.maxTransitions = maxTransitions;
+        if (source.getNumStates() == 0) {
+            return;
+        }
+        // Build the initial states using the first gramSize transitions
+        int[] codePoints = new int[gramSize - 1];
+        buildInitial(codePoints, 0, 0);
+        traceRemainingStates();
+    }
+
+    /**
+     * Returns <a href="http://www.research.att.com/sw/tools/graphviz/"
+     * target="_top">Graphviz Dot</a> representation of this automaton.
+     */
+    public String toDot() {
+        StringBuilder b = new StringBuilder("digraph Automaton {\n");
+        b.append("  rankdir = LR;\n");
+        b.append("  initial [shape=plaintext,label=\"\"];\n");
+        for (NGramState state : states.keySet()) {
+            b.append("  ").append(state.dotName());
+            if (acceptStates.contains(state)) {
+                b.append(" [shape=doublecircle,label=\"").append(state).append("\"];\n");
+            } else {
+                b.append(" [shape=circle,label=\"").append(state).append("\"];\n");
+            }
+            if (state.initial) {
+                b.append("  initial -> ").append(state.dotName()).append("\n");
+            }
+            for (NGramTransition transition : state.outgoingTransitions) {
+                b.append("  ").append(transition).append("\n");
+            }
+        }
+        return b.append("}\n").toString();
+    }
+
+    /**
+     * Convert this automaton into an expression of ngrams that must be found
+     * for the entire automaton to match. The automaton isn't simplified so you
+     * probably should call {@link Expression#simplify()} on it.
+     */
+    public Expression<String> expression() {
+        return Or.fromExpressionSources(acceptStates);
+    }
+
+    /**
+     * Recursively walk transitions building the prefixes for the initial state.
+     *
+     * @param codePoints work array holding codePoints
+     * @param offset offset into work array/depth in tree
+     * @param currentState current source state
+     * @return true to continue, false if we hit a dead end
+     */
+    private boolean buildInitial(int[] codePoints, int offset, int currentState) {
+        if (source.isAccept(currentState)) {
+            // Hit an accept state before finishing a trigram - meaning you
+            // could match this without using any of the trigrams we might find
+            // later. In that case we just give up.
+            initialStates.clear();
+            states.clear();
+            return false;
+        }
+        if (offset == gramSize - 1) {
+            // We've walked deeply enough to find an initial state.
+            NGramState state = new NGramState(currentState, new String(codePoints, 0, gramSize - 1), true);
+            // Only add one copy of each state - if we've already seen this
+            // state just ignore it.
+            if (states.containsKey(state)) {
+                return true;
+            }
+            initialStates.add(state);
+            states.put(state, state);
+            return true;
+        }
+        // TODO build fewer of these
+        Transition transition = new Transition();
+        int totalLeavingState = source.initTransition(currentState, transition);
+        for (int currentLeavingState = 0; currentLeavingState < totalLeavingState; currentLeavingState++) {
+            source.getNextTransition(transition);
+            int min, max;
+            if (transition.max - transition.min >= maxExpand) {
+                // Consider this transition useless.
+                min = 0;
+                max = 0;
+            } else {
+                min = transition.min;
+                max = transition.max;
+            }
+            for (int c = min; c <= max; c++) {
+                codePoints[offset] = c;
+                if (!buildInitial(codePoints, offset + 1, transition.dest)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void traceRemainingStates() {
+        LinkedList<NGramState> leftToProcess = new LinkedList<NGramState>();
+        leftToProcess.addAll(initialStates);
+        int[] codePoint = new int[1];
+        int statesTraced = 0;
+        Transition transition = new Transition();
+        int currentTransitions = 0;
+        while (!leftToProcess.isEmpty()) {
+            if (statesTraced >= maxStatesTraced) {
+                throw new AutomatonTooComplexException();
+            }
+            statesTraced++;
+            NGramState from = leftToProcess.pop();
+            if (acceptStates.contains(from)) {
+                // Any transitions out of accept states aren't interesting for
+                // finding required ngrams
+                continue;
+            }
+            int totalLeavingState = source.initTransition(from.sourceState, transition);
+            if (currentTransitions >= maxTransitions) {
+                acceptStates.add(from);
+                continue;
+            }
+            for (int currentLeavingState = 0; currentLeavingState < totalLeavingState; currentLeavingState++) {
+                source.getNextTransition(transition);
+                int min, max;
+                if (transition.max - transition.min >= maxExpand) {
+                    // Consider this transition useless.
+                    min = 0;
+                    max = 0;
+                } else {
+                    min = transition.min;
+                    max = transition.max;
+                }
+                for (int c = min; c <= max; c++) {
+                    codePoint[0] = c;
+                    String ngram = from.prefix + new String(codePoint, 0, 1);
+                    NGramState next = buildOrFind(leftToProcess, transition.dest, ngram.substring(1));
+                    // Transitions containing an invalid character contain no
+                    // prefix.
+                    if (ngram.indexOf(0) >= 0) {
+                        ngram = null;
+                    }
+                    if (currentTransitions >= maxTransitions) {
+                        acceptStates.add(from);
+                        continue;
+                    }
+                    currentTransitions++;
+                    NGramTransition ngramTransition = new NGramTransition(from, next, ngram);
+                    from.outgoingTransitions.add(ngramTransition);
+                    ngramTransition.to.incomingTransitions.add(ngramTransition);
+                }
+            }
+        }
+    }
+
+    private NGramState buildOrFind(LinkedList<NGramState> leftToProcess, int sourceState, String prefix) {
+        NGramState built = new NGramState(sourceState, prefix, false);
+        NGramState found = states.get(built);
+        if (found != null) {
+            return found;
+        }
+        if (source.isAccept(sourceState)) {
+            acceptStates.add(built);
+        }
+        states.put(built, built);
+        leftToProcess.add(built);
+        return built;
+    }
+
+    /**
+     * State in the ngram graph. Equals and hashcode only use the sourceState
+     * and prefix.
+     */
+    private static class NGramState implements ExpressionSource<String> {
+        /**
+         * We use the 0 char to stand in for code points we can't match.
+         */
+        private static final String INVALID_CHAR = new String(new int[] { 0 }, 0, 1);
+        /**
+         * We print code points we can't match as double underscores.
+         */
+        private static final String INVALID_PRINT_CHAR = "__";
+
+        /**
+         * State in the source automaton.
+         */
+        private final int sourceState;
+        /**
+         * Prefix of the ngram transitions that come from this state.
+         */
+        private final String prefix;
+        /**
+         * Is this an initial state? Initial states are potential starts of the
+         * regex and thus all incoming transitions are not required.
+         */
+        private final boolean initial;
+        /**
+         * Transitions leading from this state.
+         */
+        private final List<NGramTransition> outgoingTransitions = new ArrayList<>();
+        /**
+         * Transitions coming into this state.
+         */
+        private final List<NGramTransition> incomingTransitions = new ArrayList<>();
+        /**
+         * Lazily initialized expression matching all strings incoming to this
+         * state.
+         */
+        private Expression<String> expression;
+        /**
+         * Is this state in the path being turned into an expression.
+         */
+        private boolean inPath = false;
+
+        private NGramState(int sourceState, String prefix, boolean initial) {
+            this.sourceState = sourceState;
+            this.prefix = prefix;
+            this.initial = initial;
+        }
+
+        @Override
+        public String toString() {
+            return "(" + prettyPrefix() + ", " + sourceState + ")";
+        }
+
+        public String dotName() {
+            // Spaces become ___ because __ was taken by null.
+            return prettyPrefix().replace(" ", "___").replace("`", "_bt_")
+                    .replace("^", "_caret_").replace("|", "_pipe_")
+                    .replace("{", "_lcb_").replace("}", "_rcb_")
+                    .replace("=", "_eq_") + sourceState;
+        }
+
+        public String prettyPrefix() {
+            return prefix.replace(INVALID_CHAR, INVALID_PRINT_CHAR);
+        }
+
+        @Override
+        public Expression<String> expression() {
+            if (expression == null) {
+                if (initial) {
+                    expression = True.instance();
+                } else {
+                    inPath = true;
+                    expression = Or.fromExpressionSources(incomingTransitions);
+                    inPath = false;
+                }
+            }
+            return expression;
+        }
+
+        // Equals and hashcode from Eclipse.
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
+            result = prime * result + sourceState;
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            NGramState other = (NGramState) obj;
+            if (prefix == null) {
+                if (other.prefix != null)
+                    return false;
+            } else if (!prefix.equals(other.prefix))
+                return false;
+            if (sourceState != other.sourceState)
+                return false;
+            return true;
+        }
+    }
+
+    private static class NGramTransition implements ExpressionSource<String> {
+        private final NGramState from;
+        private final NGramState to;
+        private final String ngram;
+
+        private NGramTransition(NGramState from, NGramState to, String ngram) {
+            this.from = from;
+            this.to = to;
+            this.ngram = ngram;
+        }
+
+        @Override
+        public Expression<String> expression() {
+            if (from.inPath) {
+                return False.<String>instance();
+            }
+            if (ngram == null) {
+                return from.expression();
+            }
+            //Set.of fails if these 2 elements are equal so test first
+            Expression<String> a = from.expression();
+            Expression<String> b = new Leaf<>(ngram);
+            if(a.equals(b)) {
+                return new And<>(Set.of(a));
+            }
+            return new And<>(Set.of(a, b));
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder b = new StringBuilder();
+            b.append(from.dotName()).append(" -> ").append(to.dotName());
+            if (ngram != null) {
+                b.append(" [label=\"" + ngram.replace(" ", "_") + "\"]");
+            }
+            return b.toString();
+        }
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
@@ -28,6 +28,14 @@ import java.util.Set;
  * ngrams we can't check for. Not thread safe one bit.
  */
 public class NGramAutomaton {
+    /**
+     * We use the 1 char to stand in for code points we can't match.
+     * We don't use 0 because that is reserved in the NGram index for 
+     * denoting value starts and ends.
+     */
+    public static final char INVALID_CHAR = 1;
+    public static final String INVALID_CHAR_STRING = new String(new int[] { INVALID_CHAR }, 0, 1);    
+    
     private final Automaton source;
     private final int gramSize;
     private final int maxExpand;
@@ -135,8 +143,8 @@ public class NGramAutomaton {
             int min, max;
             if (transition.max - transition.min >= maxExpand) {
                 // Consider this transition useless.
-                min = NGramState.INVALID_CHAR;
-                max = NGramState.INVALID_CHAR;
+                min = INVALID_CHAR;
+                max = INVALID_CHAR;
             } else {
                 min = transition.min;
                 max = transition.max;
@@ -179,8 +187,8 @@ public class NGramAutomaton {
                 int min, max;
                 if (transition.max - transition.min >= maxExpand) {
                     // Consider this transition useless.
-                    min = NGramState.INVALID_CHAR;
-                    max = NGramState.INVALID_CHAR;
+                    min = INVALID_CHAR;
+                    max = INVALID_CHAR;
                 } else {
                     min = transition.min;
                     max = transition.max;
@@ -191,7 +199,7 @@ public class NGramAutomaton {
                     NGramState next = buildOrFind(leftToProcess, transition.dest, ngram.substring(1));
                     // Transitions containing an invalid character contain no
                     // prefix.
-                    if (ngram.indexOf(NGramState.INVALID_CHAR) >= 0) {
+                    if (ngram.indexOf(INVALID_CHAR) >= 0) {
                         ngram = null;
                     }
                     if (currentTransitions >= maxTransitions) {
@@ -227,13 +235,7 @@ public class NGramAutomaton {
      */
     private static class NGramState implements ExpressionSource<String> {
         
-        /**
-         * We use the 1 char to stand in for code points we can't match.
-         * We don't use 0 because that is reserved in the NGram index for 
-         * denoting value starts and ends.
-         */
-        public static final char INVALID_CHAR = 1;
-        private static final String INVALID_CHAR_STRING = new String(new int[] { INVALID_CHAR }, 0, 1);
+
         /**
          * We print code points we can't match as double underscores.
          */

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomaton.java
@@ -135,8 +135,8 @@ public class NGramAutomaton {
             int min, max;
             if (transition.max - transition.min >= maxExpand) {
                 // Consider this transition useless.
-                min = 0;
-                max = 0;
+                min = NGramState.INVALID_CHAR;
+                max = NGramState.INVALID_CHAR;
             } else {
                 min = transition.min;
                 max = transition.max;
@@ -179,8 +179,8 @@ public class NGramAutomaton {
                 int min, max;
                 if (transition.max - transition.min >= maxExpand) {
                     // Consider this transition useless.
-                    min = 0;
-                    max = 0;
+                    min = NGramState.INVALID_CHAR;
+                    max = NGramState.INVALID_CHAR;
                 } else {
                     min = transition.min;
                     max = transition.max;
@@ -191,7 +191,7 @@ public class NGramAutomaton {
                     NGramState next = buildOrFind(leftToProcess, transition.dest, ngram.substring(1));
                     // Transitions containing an invalid character contain no
                     // prefix.
-                    if (ngram.indexOf(0) >= 0) {
+                    if (ngram.indexOf(NGramState.INVALID_CHAR) >= 0) {
                         ngram = null;
                     }
                     if (currentTransitions >= maxTransitions) {
@@ -226,10 +226,14 @@ public class NGramAutomaton {
      * and prefix.
      */
     private static class NGramState implements ExpressionSource<String> {
+        
         /**
-         * We use the 0 char to stand in for code points we can't match.
+         * We use the 1 char to stand in for code points we can't match.
+         * We don't use 0 because that is reserved in the NGram index for 
+         * denoting value starts and ends.
          */
-        private static final String INVALID_CHAR = new String(new int[] { 0 }, 0, 1);
+        public static final char INVALID_CHAR = 1;
+        private static final String INVALID_CHAR_STRING = new String(new int[] { INVALID_CHAR }, 0, 1);
         /**
          * We print code points we can't match as double underscores.
          */
@@ -286,7 +290,7 @@ public class NGramAutomaton {
         }
 
         public String prettyPrefix() {
-            return prefix.replace(INVALID_CHAR, INVALID_PRINT_CHAR);
+            return prefix.replace(INVALID_CHAR_STRING, INVALID_PRINT_CHAR);
         }
 
         @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractor.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import org.apache.lucene.util.automaton.Automaton;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Expression;
+import org.elasticsearch.xpack.wildcard.mapper.regex.True;
+
+/**
+ * Extracts ngrams from automatons.
+ */
+public class NGramExtractor {
+    private final int gramSize;
+    private final int maxExpand;
+    private final int maxStatesTraced;
+    private final int maxNgrams;
+
+    /**
+     * Build it.
+     *
+     * @param gramSize size of the ngram. The "n" in ngram.
+     * @param maxExpand Maximum size of range transitions to expand into single
+     *            transitions. Its roughly analogous to the number of characters
+     *            in a character class before it is considered a wildcard for
+     *            optimization purposes.
+     * @param maxStatesTraced maximum number of states traced during automaton
+     *            functions. Higher number allow more complex automata to be
+     *            converted to ngram expressions at the cost of more time.
+     * @param maxNgrams the maximum number of ngrams extracted from the regex.
+     *            If more could be exracted from the regex they are ignored.
+     */
+    public NGramExtractor(int gramSize, int maxExpand, int maxStatesTraced, int maxNgrams) {
+        this.gramSize = gramSize;
+        this.maxExpand = maxExpand;
+        this.maxStatesTraced = maxStatesTraced;
+        this.maxNgrams = maxNgrams;
+    }
+
+    /**
+     * Extract an Expression containing ngrams from an automaton.
+     */
+    public Expression<String> extract(Automaton automaton) {
+        if (automaton.isAccept(0)) {
+            return True.<String> instance();
+        }
+        return new NGramAutomaton(automaton, gramSize, maxExpand, maxStatesTraced, maxNgrams).expression().simplify();
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/UnableToAccelerateRegexException.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/UnableToAccelerateRegexException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import java.util.Locale;
+
+/**
+ * Thrown when the filter is unable to accelerate a regex and
+ * rejectUnaccelerated is set.
+ */
+public class UnableToAccelerateRegexException extends RuntimeException {
+    public UnableToAccelerateRegexException(String regex, int gramSize, String ngramField) {
+        super(String.format(Locale.ROOT, "Unable to accelerate \"%s\" with %s sized grams stored in %s", regex, gramSize, ngramField));
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -252,15 +252,8 @@ public class WildcardFieldMapper extends FieldMapper {
                 // TODO always lower case the ngram index and value? Could help with 
                 // a) speed (less ngram variations to explore on disk) and 
                 // b) use less disk space
-                String openStart = TOKEN_START_OR_END_CHAR + ".*";
-                if (ngramPattern.startsWith(openStart)) {
-                    //".*" causes too many imagined beginnings in the Automaton to trace through.
-                    //Rewrite to cut to the concrete path after .* to extract required ngrams
-                    // TODO ideally we would trim the automaton paths rather than the regex string
-                    ngramPattern = ngramPattern.substring(openStart.length());
-                }
                 Automaton automaton = regex.toAutomaton(maxDeterminizedStates);
-                RegExp ngramRegex =new RegExp(ngramPattern, flags);
+                ApproximateRegExp ngramRegex =new ApproximateRegExp(ngramPattern, flags);
                 Automaton ngramAutomaton = ngramRegex.toAutomaton(maxDeterminizedStates);
                 return automatonToQuery(ngramPattern, value, ngramAutomaton, automaton);
             } catch (AutomatonTooComplexException e) {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -8,10 +8,8 @@
 package org.elasticsearch.xpack.wildcard.mapper;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.ngram.NGramTokenizer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -21,18 +21,22 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.MultiTermQuery.RewriteMethod;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.automaton.Automaton;
-import org.elasticsearch.ElasticsearchParseException;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -59,15 +63,18 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.wildcard.mapper.regex.AutomatonTooComplexException;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Expression;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.index.mapper.TypeParsers.parseField;
+import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /**
  * A {@link FieldMapper} for indexing fields with ngrams for efficient wildcard matching
@@ -202,6 +209,9 @@ public class WildcardFieldMapper extends FieldMapper {
 
      public static final class WildcardFieldType extends MappedFieldType {
 
+        // Currently these settings are not tweakable by end users, however, they are pretty advanced settings so may never be.
+        private NGramApproximationSettings settings = new NGramApproximationSettings();
+
         public WildcardFieldType() {
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
@@ -216,218 +226,106 @@ public class WildcardFieldMapper extends FieldMapper {
             return result;
         }
 
-        // Holds parsed information about the wildcard pattern
-        static class PatternStructure {
-            boolean openStart, openEnd, hasSymbols;
-            int lastGap =0;
-            int wildcardCharCount, wildcardStringCount;
-            String[] fragments;
-            Integer []  precedingGapSizes;
-            final String pattern;
-
-            @SuppressWarnings("fallthrough") // Intentionally uses fallthrough mirroring implementation in Lucene's WildcardQuery
-            PatternStructure (String wildcardText) {
-                this.pattern = wildcardText;
-                ArrayList<String> fragmentList = new ArrayList<>();
-                ArrayList<Integer> precedingGapSizeList = new ArrayList<>();
-                StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < wildcardText.length();) {
-                    final int c = wildcardText.codePointAt(i);
-                    int length = Character.charCount(c);
-                    switch (c) {
-                    case WildcardQuery.WILDCARD_STRING:
-                        if (i == 0) {
-                            openStart = true;
-                        }
-                        openEnd = true;
-                        hasSymbols = true;
-                        wildcardStringCount++;
-
-                        if (sb.length() > 0) {
-                            precedingGapSizeList.add(lastGap);
-                            fragmentList.add(sb.toString());
-                            sb = new StringBuilder();
-                        }
-                        lastGap = Integer.MAX_VALUE;
-                        break;
-                    case WildcardQuery.WILDCARD_CHAR:
-                        if (i == 0) {
-                            openStart = true;
-                        }
-                        hasSymbols = true;
-                        wildcardCharCount++;
-                        openEnd = true;
-                        if (sb.length() > 0) {
-                            precedingGapSizeList.add(lastGap);
-                            fragmentList.add(sb.toString());
-                            sb = new StringBuilder();
-                            lastGap = 0;
-                        }
-
-                        if (lastGap != Integer.MAX_VALUE) {
-                            lastGap++;
-                        }
-                        break;
-                    case WildcardQuery.WILDCARD_ESCAPE:
-                        // add the next codepoint instead, if it exists
-                        if (i + length < wildcardText.length()) {
-                            final int nextChar = wildcardText.codePointAt(i + length);
-                            length += Character.charCount(nextChar);
-                            sb.append(Character.toChars(nextChar));
-                            openEnd = false;
-                            break;
-                        } // else fallthru, lenient parsing with a trailing \
-                    default:
-                        openEnd = false;
-                        sb.append(Character.toChars(c));
-                    }
-                    i += length;
-                }
-                if (sb.length() > 0) {
-                    precedingGapSizeList.add(lastGap);
-                    fragmentList.add(sb.toString());
-                    lastGap = 0;
-                }
-                fragments = fragmentList.toArray(new String[0]);
-                precedingGapSizes = precedingGapSizeList.toArray(new Integer[0]);
-
-            }
-
-            public boolean needsVerification() {
-                // Return true if term queries are not enough evidence
-                if (fragments.length == 1 && wildcardCharCount == 0) {
-                    // The one case where we don't need verification is when
-                    // we have a single fragment and no ? characters
-                    return false;
-                }
-                return true;
-            }
-
-            // Returns number of positions for last gap (Integer.MAX means unlimited gap)
-            public int getPrecedingGapSize(int fragmentNum) {
-                return precedingGapSizes[fragmentNum];
-            }
-
-            public boolean isMatchAll() {
-                return fragments.length == 0 && wildcardStringCount >0 && wildcardCharCount ==0;
-            }
-
-            @Override
-            public int hashCode() {
-                return pattern.hashCode();
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                PatternStructure other = (PatternStructure) obj;
-                return pattern.equals(other.pattern);
-            }
-
-
-        }
-
 
         @Override
         public Query wildcardQuery(String wildcardPattern, RewriteMethod method, QueryShardContext context) {
-            PatternStructure patternStructure = new PatternStructure(wildcardPattern);
-            ArrayList<String> tokens = new ArrayList<>();
-
-            for (int i = 0; i < patternStructure.fragments.length; i++) {
-                String fragment = patternStructure.fragments[i];
-                int fLength = fragment.length();
-                if (fLength == 0) {
-                    continue;
-                }
-
-                // Add any start/end of string character
-                if (i == 0 && patternStructure.openStart == false) {
-                    // Start-of-string anchored (is not a leading wildcard)
-                    fragment = TOKEN_START_OR_END_CHAR + fragment;
-                }
-                if (patternStructure.openEnd == false && i == patternStructure.fragments.length - 1) {
-                    // End-of-string anchored (is not a trailing wildcard)
-                    fragment = fragment + TOKEN_START_OR_END_CHAR + TOKEN_START_OR_END_CHAR;
-                }
-                if (fragment.codePointCount(0, fragment.length()) <= NGRAM_SIZE) {
-                    tokens.add(fragment);
-                } else {
-                    // Break fragment into multiple Ngrams
-                    TokenStream tokenizer = WILDCARD_ANALYZER.tokenStream(name(), fragment);
-                    CharTermAttribute termAtt = tokenizer.addAttribute(CharTermAttribute.class);
-                    String lastUnusedToken = null;
-                    try {
-                        tokenizer.reset();
-                        boolean takeThis = true;
-                        // minimise number of terms searched - eg for "12345" and 3grams we only need terms
-                        // `123` and `345` - no need to search for 234. We take every other ngram.
-                        while (tokenizer.incrementToken()) {
-                            String tokenValue = termAtt.toString();
-                            if (takeThis) {
-                                tokens.add(tokenValue);
-                            } else {
-                                lastUnusedToken = tokenValue;
-                            }
-                            // alternate
-                            takeThis = !takeThis;
-                        }
-                        if (lastUnusedToken != null) {
-                            // given `cake` and 3 grams the loop above would output only `cak` and we need to add trailing
-                            // `ake` to complete the logic.
-                            tokens.add(lastUnusedToken);
-                        }
-                        tokenizer.end();
-                        tokenizer.close();
-                    } catch (IOException ioe) {
-                        throw new ElasticsearchParseException("Error parsing wildcard query pattern fragment [" + fragment + "]");
-                    }
-                }
+            
+            Automaton dvAutomaton = WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
+            
+            //Unlike the doc values, ngram index has extra string-start and end characters. 
+            String ngramWildcardPattern = TOKEN_START_OR_END_CHAR + wildcardPattern 
+                    + TOKEN_START_OR_END_CHAR + TOKEN_START_OR_END_CHAR;            
+            Automaton ngramAutomaton = WildcardQuery.toAutomaton(new Term(name(), ngramWildcardPattern));
+            return automatonToQuery(wildcardPattern, wildcardPattern, ngramAutomaton, dvAutomaton);
+        }
+        
+        @Override
+        public Query regexpQuery(String value, int flags, int maxDeterminizedStates, RewriteMethod method, QueryShardContext context) {
+            if (context.allowExpensiveQueries() == false) {
+                throw new ElasticsearchException("[regexp] queries cannot be executed when '" +
+                        ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
             }
-
-            if (patternStructure.isMatchAll()) {
-                return new MatchAllDocsQuery();
+            failIfNotIndexed();
+            RegExp regex =new RegExp(value, flags);
+            try {
+                // TODO always lower case the ngram index and value? Could help with 
+                // a) speed (less ngram variations to explore on disk) and 
+                // b) use less disk space
+                Automaton automaton = regex.toAutomaton(maxDeterminizedStates);
+                return automatonToQuery(value, automaton);
+            } catch (AutomatonTooComplexException e) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT,
+                        "Regex /%s/ too complex for maxStatesTraced setting [%s].  Use a simpler regex or raise maxStatesTraced.", regex,
+                        settings.getMaxStatesTraced()), e);
             }
-            BooleanQuery approximation = createApproximationQuery(tokens);
-            if (approximation.clauses().size() > 1 || patternStructure.needsVerification()) {
+            
+        }
+        
+
+        @Override
+        public Query fuzzyQuery(Object value, Fuzziness fuzziness, int prefixLength, int maxExpansions,
+                boolean transpositions, QueryShardContext context) {            
+            if (context.allowExpensiveQueries() == false) {
+                throw new ElasticsearchException("[fuzzy] queries cannot be executed when '" +
+                        ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
+            }
+            failIfNotIndexed();
+            String searchTerm = BytesRefs.toString(value);
+            FuzzyQuery fq = new FuzzyQuery(new Term(name(), searchTerm),
+                    fuzziness.asDistance(searchTerm), prefixLength, maxExpansions, transpositions);
+
+            
+            String ngramFuzzyPattern = TOKEN_START_OR_END_CHAR + searchTerm + TOKEN_START_OR_END_CHAR + TOKEN_START_OR_END_CHAR;            
+            
+            FuzzyQuery ngramFq = new FuzzyQuery(new Term(name(), ngramFuzzyPattern),
+                    fuzziness.asDistance(searchTerm), prefixLength + 1, maxExpansions, transpositions);
+
+            // I'm assuming (perhaps incorrectly) that these are logically ORed...
+            CompiledAutomaton[] ngramAutomata = ngramFq.getAutomata();
+            CompiledAutomaton[] automata = fq.getAutomata();
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            assert ngramAutomata.length == automata.length;
+            for (int i=0; i<automata.length;i++) {
+                Query ngramQuery = automatonToQuery(ngramFuzzyPattern, searchTerm, ngramAutomata[i].automaton, automata[i].automaton);
+                builder.add(ngramQuery, Occur.SHOULD);                                
+            }
+            return builder.build();
+        }
+
+        protected Query automatonToQuery(String value, Automaton automaton) {
+            return automatonToQuery(value,  value, automaton, automaton);
+        }
+
+        // The ngram and dv values can differ - null chars added to string beginning and ends in ngram index and used by
+        // wildcard query expressions.
+        protected Query automatonToQuery(String ngramValue, String dvValue, Automaton ngramAutomaton, Automaton dvAutomaton) {
+            Query ngramApproximation;
+            Expression<String> expression = new NGramExtractor(NGRAM_SIZE, settings.getMaxExpand(), settings.getMaxStatesTraced(),
+                    settings.getMaxNgramsExtracted()).extract(ngramAutomaton).simplify();
+            if (expression.alwaysTrue()) {
+                if (settings.getRejectUnaccelerated()) {
+                    throw new UnableToAccelerateRegexException(ngramValue, NGRAM_SIZE, name());
+                }
+                ngramApproximation = new MatchAllDocsQuery();
+            } else if (expression.alwaysFalse()) {
+                // Not sure what regex expression would cause this branch but cover it anyway.
+                ngramApproximation = new MatchNoDocsQuery();
+            } else {
+                ngramApproximation = expression.transform(new ExpressionToFilterTransformer(name()));
+            }
+            //TODO - skip every other ngram in long strings
+            //TODO - don't generate terms not in index.
+            //TODO - prefer rare ngrams when pruning
+
+            AutomatonQueryOnBinaryDv verifyingQuery = new AutomatonQueryOnBinaryDv(name(), dvValue, dvAutomaton);
+            if (ngramApproximation != null && !(ngramApproximation instanceof MatchAllDocsQuery)) {
+                // We can accelerate execution with the ngram query
                 BooleanQuery.Builder verifyingBuilder = new BooleanQuery.Builder();
-                verifyingBuilder.add(new BooleanClause(approximation, Occur.MUST));
-                Automaton automaton = WildcardQuery.toAutomaton(new Term(name(), wildcardPattern));
-                verifyingBuilder.add(new BooleanClause(new AutomatonQueryOnBinaryDv(name(), wildcardPattern, automaton), Occur.MUST));
+                verifyingBuilder.add(new BooleanClause(ngramApproximation, Occur.MUST));
+                verifyingBuilder.add(new BooleanClause(verifyingQuery, Occur.MUST));
                 return verifyingBuilder.build();
             }
-            return approximation;
-        }
-
-        private BooleanQuery createApproximationQuery(ArrayList<String> tokens) {
-            BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
-            if (tokens.size() <= MAX_CLAUSES_IN_APPROXIMATION_QUERY) {
-                for (String token : tokens) {
-                    addClause(token, bqBuilder);
-                }
-                return bqBuilder.build();
-            }
-            // Thin out the number of clauses using a selection spread evenly across the range
-            float step = (float) (tokens.size() - 1) / (float) (MAX_CLAUSES_IN_APPROXIMATION_QUERY - 1); // set step size
-            for (int i = 0; i < MAX_CLAUSES_IN_APPROXIMATION_QUERY; i++) {
-                addClause(tokens.get(Math.round(step * i)), bqBuilder); // add each element of a position which is a multiple of step
-            }
-            // TODO we can be smarter about pruning here. e.g.
-            // * Avoid wildcard queries if there are sufficient numbers of other terms that are full 3grams that are cheaper term queries
-            // * We can select terms on their scarcity rather than even spreads across the search string.
-
-            return bqBuilder.build();
-        }
-
-        private void addClause(String token, BooleanQuery.Builder bqBuilder) {
-            assert token.codePointCount(0, token.length()) <= NGRAM_SIZE;
-            if (token.codePointCount(0, token.length()) == NGRAM_SIZE) {
-                TermQuery tq = new TermQuery(new Term(name(), token));
-                bqBuilder.add(new BooleanClause(tq, Occur.MUST));
-            } else {
-                WildcardQuery wq = new WildcardQuery(new Term(name(), token + "*"));
-                wq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
-                bqBuilder.add(new BooleanClause(wq, Occur.MUST));
-            }
-
+            return verifyingQuery;
         }
 
         @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -255,7 +255,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 // a) speed (less ngram variations to explore on disk) and 
                 // b) use less disk space
                 String openStart = TOKEN_START_OR_END_CHAR + ".*";
-                if(ngramPattern.startsWith(openStart)){
+                if (ngramPattern.startsWith(openStart)) {
                     //".*" causes too many imagined beginnings in the Automaton to trace through.
                     //Rewrite to cut to the concrete path after .* to extract required ngrams
                     // TODO ideally we would trim the automaton paths rather than the regex string

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/AbstractCompositeExpression.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/AbstractCompositeExpression.java
@@ -112,6 +112,7 @@ public abstract class AbstractCompositeExpression<T> implements Expression<T> {
         case 1:
             return newComponentsBuilder.get(0);
         default:
+            // intentional fall-through
         }
         Expression<T> commonExtracted = extractCommon(changed ? newComponentsBuilder : components);
         if (commonExtracted != null) {

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/AbstractCompositeExpression.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/AbstractCompositeExpression.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+import org.elasticsearch.common.util.set.Sets;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Abstract parent for composite expressions like And and Or.
+ */
+public abstract class AbstractCompositeExpression<T> implements Expression<T> {
+    private static final int MAX_COMPONENT_STRING_LENGTH = 1000;
+    private static final int MAX_COMPONENTS_SIZE_FOR_TO_STRING = 10;
+    private final Set<Expression<T>> components;
+    private boolean simplified;
+    private String toString = null;
+
+    public AbstractCompositeExpression(Set<Expression<T>> components) {
+        this.components = components;
+    }
+
+    /**
+     * Transform the components of this composite expression.  Used by subclasses when implementing transform.
+     * @param transformer transformer to use
+     * @return result of transforming components
+     */
+    protected <J> Set<J> transformComponents(Expression.Transformer<T, J> transformer) {
+        Set<J> builder = new HashSet<>();
+        for (Expression<T> component : components) {
+            builder.add(component.transform(transformer));
+        }
+        return Collections.unmodifiableSet(builder);
+    }
+
+    /**
+     * Build an expression of this type with a list of components. Used in
+     * simplification.
+     */
+    protected abstract AbstractCompositeExpression<T> newFrom(Set<Expression<T>> components);
+
+    /**
+     * Does this component of this expression affect the outcome of the overall
+     * expression? For example the TRUE in (TRUE AND foo) doesn't effect the
+     * expression and can be simplified away.
+     */
+    protected abstract boolean doesNotAffectOutcome(Expression<T> expression);
+
+    /**
+     * Does this component force the expression to a certain value? For example
+     * the FALSE in (FALSE and foo) forces the whole expression to FALSE.
+     */
+    protected abstract Expression<T> componentForcesOutcome(Expression<T> expression);
+
+    protected abstract String toStringJoiner();
+
+    @Override
+    public boolean alwaysFalse() {
+        return false;
+    }
+
+    @Override
+    public boolean alwaysTrue() {
+        return false;
+    }
+
+    @Override
+    public Expression<T> simplify() {
+        if (simplified) {
+            return this;
+        }
+        Iterator<Expression<T>> componentsItr = components.iterator();
+        List<Expression<T>> newComponentsBuilder = null;
+        boolean changed = false;
+        while (componentsItr.hasNext()) {
+            Expression<T> expression = componentsItr.next();
+            Expression<T> simplified = expression.simplify();
+            changed |= expression != simplified;
+            if (doesNotAffectOutcome(simplified)) {
+                changed |= true;
+                continue;
+            }
+            Expression<T> forcedOutcome = componentForcesOutcome(simplified);
+            if (forcedOutcome != null) {
+                return forcedOutcome;
+            }
+            if (newComponentsBuilder == null) {
+                newComponentsBuilder = new ArrayList<>(components.size());
+            }
+            if (simplified.getClass() == getClass()) {
+                changed |= true;
+                newComponentsBuilder.addAll(((AbstractCompositeExpression<T>) simplified).components);
+                continue;
+            }
+            newComponentsBuilder.add(simplified);
+        }
+        if (newComponentsBuilder == null) {
+            // Nothing left in the expression!
+            return True.instance();
+        }
+        switch (newComponentsBuilder.size()) {
+        case 0:
+            return True.instance();
+        case 1:
+            return newComponentsBuilder.get(0);
+        default:
+        }
+        Expression<T> commonExtracted = extractCommon(changed ? newComponentsBuilder : components);
+        if (commonExtracted != null) {
+            return commonExtracted;
+        }
+
+        if (!changed) {
+            this.simplified = true;
+            return this;
+        }
+        AbstractCompositeExpression<T> result = newFrom(changed ? Set.copyOf(newComponentsBuilder) : components);
+        result.simplified = true;
+        return result;
+    }
+
+    private Expression<T> extractCommon(Iterable<Expression<T>> newComponents) {
+        // Are all composite subexpressions of the same type?
+        boolean allCompositesOfSameType = true;
+        // Are all the non-composite subexpressions of this type the same?
+        boolean nonCompositesAreSame = true;
+        // First non-composite subexpression.
+        Expression<T> firstNonComposite = null;
+        // If all composite subexpressions are of the same type then what is that type?
+        Class<?> compositesClass = null;
+        for (Expression<T> current : newComponents) {
+            if (current.isComposite()) {
+                if (compositesClass == null) {
+                    compositesClass = current.getClass();
+                } else {
+                    allCompositesOfSameType &= compositesClass == current.getClass();
+                }
+            } else {
+                if (firstNonComposite == null) {
+                    firstNonComposite = current;
+                } else {
+                    nonCompositesAreSame &= firstNonComposite.equals(current);
+                }
+            }
+        }
+
+        if (firstNonComposite == null) {
+            // Everything is composite and they are all of the same type.
+            if (allCompositesOfSameType) {
+                // If this component is composed of composite components we can
+                // attempt to factor out any equivalent parts
+                AbstractCompositeExpression<T> first = (AbstractCompositeExpression<T>) newComponents.iterator().next();
+                Set<Expression<T>> sharedComponents = null;
+                for (Expression<T> component : first.components) {
+                    boolean shared = true;
+                    Iterator<Expression<T>> current = newComponents.iterator();
+                    while (shared && current.hasNext()) {
+                        shared &= ((AbstractCompositeExpression<T>) current.next()).components.contains(component);
+                    }
+                    if (shared) {
+                        if (sharedComponents == null) {
+                            sharedComponents = new HashSet<>();
+                        }
+                        sharedComponents.add(component);
+                    }
+                }
+                if (sharedComponents != null) {
+                    // Build all the subcomponents with the common part extracted
+                    Set<Expression<T>> extractedComponents = new HashSet<>();
+                    AbstractCompositeExpression<T> composite = null;
+                    for (Expression<T> component : newComponents) {
+                        composite = (AbstractCompositeExpression<T>) component;
+                        extractedComponents.add(composite.newFrom(Set.copyOf(Sets.difference(composite.components, sharedComponents)))
+                                .simplify());
+                    }
+                    sharedComponents.add(newFrom(Collections.unmodifiableSet(extractedComponents)).simplify());
+                    return composite.newFrom(Collections.unmodifiableSet(sharedComponents)).simplify();
+                }
+            }
+        } else {
+            if (allCompositesOfSameType && nonCompositesAreSame && canFactorOut(newComponents, firstNonComposite)) {
+                Set<Expression<T>> sharedComponents = new HashSet<>();
+                sharedComponents.add(firstNonComposite);
+                AbstractCompositeExpression<T> composite = null;
+                Set<Expression<T>> extractedComponents = new HashSet<>();
+                for (Expression<T> component : newComponents) {
+                    if (!component.isComposite()) {
+                        continue;
+                    }
+                    composite = (AbstractCompositeExpression<T>) component;
+                    extractedComponents.add(composite.newFrom(Collections.unmodifiableSet((
+                            Sets.difference(composite.components, sharedComponents))))
+                            .simplify());
+                }
+                // In the rare case that there aren't any composites but all the
+                // non-composits are the same we should just return that
+                // non-composite
+                if (composite == null) {
+                    return firstNonComposite;
+                }
+                // Add True to represent the extracted common component
+                extractedComponents.add(True.<T>instance());
+                sharedComponents.add(newFrom(Collections.unmodifiableSet(extractedComponents)).simplify());
+                return composite.newFrom(Collections.unmodifiableSet(sharedComponents)).simplify();
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Can we factor commonComposite out of all subexpressions?
+     */
+    private boolean canFactorOut(Iterable<Expression<T>> subexpressions, Expression<T> commonComposite) {
+        for (Expression<T> current : subexpressions) {
+            if (!current.equals(commonComposite)) {
+                if (!current.isComposite()) {
+                    return false;
+                }
+                AbstractCompositeExpression<T> composite = (AbstractCompositeExpression<T>) current;
+                if (!composite.components.contains(commonComposite)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isComposite() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        if (toString != null) {
+            return toString;
+        }
+        if (components.size() > MAX_COMPONENTS_SIZE_FOR_TO_STRING) {
+            toString = "(lots of " + toStringJoiner() + "s)";
+            return toString;
+        }
+        StringBuilder b = new StringBuilder();
+        b.append('(');
+        boolean first = true;
+        for (Expression<T> component: components) {
+            if (first) {
+                first = false;
+            } else {
+                b.append(toStringJoiner());
+            }
+            b.append(component.toString());
+        }
+        b.append(')');
+        if (b.length() > MAX_COMPONENT_STRING_LENGTH) {
+            toString = "TOO_BIG";
+        } else {
+            toString = b.toString();
+        }
+        return toString;
+    }
+
+    @Override
+    public int hashCode() {
+        return components.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        @SuppressWarnings("rawtypes")
+        AbstractCompositeExpression other = (AbstractCompositeExpression) obj;
+        return components.equals(other.components);
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/And.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/And.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+import java.util.Set;
+
+/**
+ * Conjunction.
+ */
+public final class And<T> extends AbstractCompositeExpression<T> {
+    public And(Set<Expression<T>> components) {
+        super(components);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public And(Expression<T>... components) {
+        this(Set.of(components));
+    }
+
+    @Override
+    protected boolean doesNotAffectOutcome(Expression<T> expression) {
+        return expression.alwaysTrue();
+    }
+
+    @Override
+    protected Expression<T> componentForcesOutcome(Expression<T> expression) {
+        if (expression.alwaysFalse()) {
+            return expression;
+        }
+        return null;
+    }
+
+    @Override
+    protected AbstractCompositeExpression<T> newFrom(Set<Expression<T>> components) {
+        return new And<>(components);
+    }
+
+    @Override
+    protected String toStringJoiner() {
+        return " AND ";
+    }
+
+    @Override
+    public <J> J transform(Expression.Transformer<T, J> transformer) {
+        return transformer.and(transformComponents(transformer));
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/AutomatonTooComplexException.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/AutomatonTooComplexException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+/**
+ * Thrown when the automaton is too complex to convert to ngrams (as measured by
+ * maxExpand).
+ */
+public class AutomatonTooComplexException extends IllegalArgumentException {
+    /**
+     * Build it.
+     */
+    public AutomatonTooComplexException() {
+        super("The supplied automaton is too complex to extract ngrams");
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/Expression.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/Expression.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+import java.util.Set;
+
+/**
+ * Immutable representation of some logic. Expressions can be simplified and
+ * transformed. Simplifying expressions eliminates extraneous terms and factors
+ * out common terms.  Transformation allows client code to convert the expression
+ * to some other (maybe evaluable) form.
+ *
+ * @param <T> type stored in leaves
+ */
+public interface Expression<T> {
+    /**
+     * Returns a simplified copy of this expression. If the simplification
+     * didn't change anything then returns this.
+     */
+    Expression<T> simplify();
+
+    /**
+     * Is this node in the expression always true? Note that this only
+     * represents _this_ node of the expression. To know if the entire
+     * expression is always true of false first {@link Expression#simplify()}
+     * it.
+     */
+    boolean alwaysTrue();
+
+    /**
+     * Is this node in the expression always false? Note that this only
+     * represents _this_ node of the expression. To know if the entire
+     * expression is always true of false first {@link Expression#simplify()}
+     * it.
+     */
+    boolean alwaysFalse();
+
+    /**
+     * Is this expression made of many subexpressions?
+     */
+    boolean isComposite();
+
+    /**
+     * Transform this expression into another form.
+     *
+     * @param <J> result of the transformation.
+     */
+    <J> J transform(Transformer<T, J> transformer);
+
+    /**
+     * Transformer for expression components.
+     *
+     * @param <T> type stored in leaves
+     * @param <J> result of the transformation.
+     */
+    interface Transformer<T, J> {
+        /**
+         * Transform an expression that is always true.
+         */
+        J alwaysTrue();
+
+        /**
+         * Transform an expression that is always false.
+         */
+        J alwaysFalse();
+
+        /**
+         * Transform a leaf expression.
+         *
+         * @param t data stored in the leaf
+         * @return result of the transform
+         */
+        J leaf(T t);
+
+        /**
+         * Transform an and expression.
+         *
+         * @param js transformed sub-expressions
+         * @return result of the transform
+         */
+        J and(Set<J> js);
+
+        /**
+         * Transform an or expression.
+         *
+         * @param js transformed sub-expressions
+         * @return result of the transform
+         */
+        J or(Set<J> js);
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/ExpressionSource.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/ExpressionSource.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+/**
+ * Type that can be expressed as an expression.
+ *
+ * @param <T> type stored in leaves
+ */
+public interface ExpressionSource<T> {
+    /**
+     * This expressed as an expression. The result might not be simplified so
+     * call simplify on it if you need it simplified.
+     */
+    Expression<T> expression();
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/False.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/False.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+/**
+ * Always false.
+ */
+public class False<T> implements Expression<T> {
+    private static final False<Object> TRUE = new False<>();
+
+    /**
+     * There is only one false.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> False<T> instance() {
+        return (False<T>) TRUE;
+    }
+
+    private False() {
+        // Only one instance
+    }
+
+    public String toString() {
+        return "FALSE";
+    }
+
+    @Override
+    public Expression<T> simplify() {
+        return this;
+    }
+
+    @Override
+    public boolean alwaysTrue() {
+        return false;
+    }
+
+    @Override
+    public boolean alwaysFalse() {
+        return true;
+    }
+
+    @Override
+    public boolean isComposite() {
+        return false;
+    }
+
+    @Override
+    public <J> J transform(Expression.Transformer<T, J> transformer) {
+        return transformer.alwaysFalse();
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/Leaf.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/Leaf.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A leaf expression.
+ */
+public final class Leaf<T> implements Expression<T> {
+    @SafeVarargs
+    public static final <T> Set<Expression<T>> leaves(T... ts) {
+        Set<Expression<T>> builder = new HashSet<>();
+        for (T t : ts) {
+            builder.add(new Leaf<T>(t));
+        }
+        return Collections.unmodifiableSet(builder);
+    }
+
+    private final T t;
+    private int hashCode;
+
+    public Leaf(T t) {
+        if (t == null) {
+            throw new IllegalArgumentException("Leaf value cannot be null");
+        }
+        this.t = t;
+    }
+
+    public String toString() {
+        return t.toString();
+    }
+
+    @Override
+    public Expression<T> simplify() {
+        return this;
+    }
+
+    @Override
+    public boolean alwaysTrue() {
+        return false;
+    }
+
+    @Override
+    public boolean alwaysFalse() {
+        return false;
+    }
+
+    @Override
+    public boolean isComposite() {
+        return false;
+    }
+
+    @Override
+    public <J> J transform(Expression.Transformer<T, J> transformer) {
+        return transformer.leaf(t);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == 0) {
+            hashCode = t.hashCode();
+        }
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        @SuppressWarnings("rawtypes")
+        Leaf other = (Leaf) obj;
+        return t.equals(other.t);
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/Or.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/Or.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * Disjunction.
+ */
+public final class Or<T> extends AbstractCompositeExpression<T> {
+    public static <T> Expression<T> fromExpressionSources(List<? extends ExpressionSource<T>> sources) {
+        switch (sources.size()) {
+        case 0:
+            return True.instance();
+        case 1:
+            return sources.get(0).expression();
+        default:
+            Set<Expression<T>> or = new HashSet<>();
+            for (ExpressionSource<T> source : sources) {
+                or.add(source.expression());
+            }
+            return new Or<>(Collections.unmodifiableSet(or)).simplify();
+        }
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public Or(Expression<T>... components) {
+        this(Set.of(components));
+    }
+
+    public Or(Set<Expression<T>> components) {
+        super(components);
+    }
+
+    @Override
+    protected boolean doesNotAffectOutcome(Expression<T> expression) {
+        return expression.alwaysFalse();
+    }
+
+    @Override
+    protected Expression<T> componentForcesOutcome(Expression<T> expression) {
+        if (expression.alwaysTrue()) {
+            return expression;
+        }
+        return null;
+    }
+
+    @Override
+    protected AbstractCompositeExpression<T> newFrom(Set<Expression<T>> components) {
+        return new Or<>(components);
+    }
+
+    @Override
+    protected String toStringJoiner() {
+        return " OR ";
+    }
+
+    @Override
+    public <J> J transform(Expression.Transformer<T, J> transformer) {
+        return transformer.or(transformComponents(transformer));
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/RegexTooComplexException.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/RegexTooComplexException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+
+/**
+ * Wraps Lucene's XTooComplexToDeterminizeException to be serializable to be
+ * thrown over the wire.
+ */
+public class RegexTooComplexException extends RuntimeException {
+
+    public RegexTooComplexException(TooComplexToDeterminizeException e) {
+        super(e.getMessage());
+    }
+}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/True.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/regex/True.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper.regex;
+
+/**
+ * Always true.
+ */
+public class True<T> implements Expression<T> {
+    private static final True<Object> TRUE = new True<>();
+
+    /**
+     * There is only one True.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> True<T> instance() {
+        return (True<T>) TRUE;
+    }
+
+    private True() {
+        // Only one copy
+    }
+
+    public String toString() {
+        return "TRUE";
+    }
+
+    @Override
+    public Expression<T> simplify() {
+        return this;
+    }
+
+    @Override
+    public boolean alwaysTrue() {
+        return true;
+    }
+
+    @Override
+    public boolean alwaysFalse() {
+        return false;
+    }
+
+    @Override
+    public boolean isComposite() {
+        return false;
+    }
+
+    @Override
+    public <J> J transform(Expression.Transformer<T, J> transformer) {
+        return transformer.alwaysTrue();
+    }
+}

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/ExpressionTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/ExpressionTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.wildcard.mapper.regex.And;
+import org.elasticsearch.xpack.wildcard.mapper.regex.False;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Leaf;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Or;
+import org.elasticsearch.xpack.wildcard.mapper.regex.True;
+
+public class ExpressionTests extends ESTestCase {
+    private final Leaf<String> foo = new Leaf<>("foo");
+    private final Leaf<String> bar = new Leaf<>("bar");
+    private final Leaf<String> baz = new Leaf<>("baz");
+
+    public void testSimple() {
+        assertEquals(True.instance(), True.instance());
+        assertEquals(True.instance().hashCode(), True.instance().hashCode());
+        assertEquals(False.instance(), False.instance());
+        assertEquals(False.instance().hashCode(), False.instance().hashCode());
+        assertNotEquals(True.instance(), False.instance());
+        assertNotEquals(False.instance(), True.instance());
+
+        Leaf<String> leaf = new Leaf<>("foo");
+        assertEquals(leaf, leaf);
+        assertNotEquals(True.instance(), leaf);
+        assertNotEquals(False.instance(), leaf);
+    }
+
+    public void testExtract() {
+        assertEquals(new And<>(foo, new Or<>(bar, baz)),
+                new Or<>(
+                        new And<>(foo, bar),
+                        new And<>(foo, baz)
+                ).simplify());
+    }
+
+    public void testExtractToEmpty() {
+        assertEquals(new And<>(foo, bar),
+                new Or<>(
+                        new And<>(foo, bar),
+                        new And<>(foo, bar, baz)
+                ).simplify());
+    }
+
+    public void testExtractSingle() {
+        assertEquals(foo,
+                new Or<>(
+                        new And<>(foo, bar),
+                        foo
+                ).simplify());
+    }
+
+    public void testExtractDuplicates() {
+        assertEquals(foo, new Or<>(foo, new And<>(foo)).simplify());
+    }
+}

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
@@ -5,8 +5,6 @@
  */
 package org.elasticsearch.xpack.wildcard.mapper;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.AutomatonTestUtil;
 import org.apache.lucene.util.automaton.RegExp;

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
@@ -103,7 +103,8 @@ public class NGramAutomatonTest extends ESTestCase {
     }
 
     // The pgTrgmExample methods below test examples from the slides at
-    // http://www.pgcon.org/2012/schedule/attachments/248_Alexander%20Korotkov%20-%20Index%20support%20for%20regular%20expression%20search.pdf
+    // http://www.pgcon.org/2012/schedule/attachments/
+    //    248_Alexander%20Korotkov%20-%20Index%20support%20for%20regular%20expression%20search.pdf
     @Test
     public void pgTrgmExample1() {
         assertTrigramExpression("a(b+|c+)d", new Or<String>(

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.AutomatonTestUtil;
+import org.apache.lucene.util.automaton.RegExp;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.wildcard.mapper.regex.And;
+import org.elasticsearch.xpack.wildcard.mapper.regex.AutomatonTooComplexException;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Expression;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Leaf;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Or;
+import org.elasticsearch.xpack.wildcard.mapper.regex.True;
+import org.junit.Test;
+
+import static org.elasticsearch.xpack.wildcard.mapper.regex.Leaf.leaves;
+
+public class NGramAutomatonTest extends ESTestCase {
+    @Test
+    public void simple() {
+        assertTrigramExpression("cat", new Leaf<>("cat"));
+    }
+
+    @Test
+    public void options() {
+        assertTrigramExpression("(cat)|(dog)|(cow)", new Or<String>(leaves("cat", "dog", "cow")));
+    }
+
+    @Test
+    public void leadingWildcard() {
+        assertTrigramExpression(".*cat", new Leaf<>("cat"));
+    }
+
+    @Test
+    public void followingWildcard() {
+        assertTrigramExpression("cat.*", new Leaf<>("cat"));
+    }
+
+    @Test
+    public void initialCharClassExpanded() {
+        assertTrigramExpression("[abcd]oop", new And<String>(new Or<String>(leaves("aoo", "boo", "coo", "doo")), new Leaf<>("oop")));
+    }
+
+    @Test
+    public void initialCharClassSkipped() {
+        assertTrigramExpression("[abcde]oop", new Leaf<String>("oop"));
+    }
+
+    @Test
+    public void followingCharClassExpanded() {
+        assertTrigramExpression("oop[abcd]", new And<String>(
+                new Leaf<>("oop"),
+                new Or<String>(leaves("opa", "opb", "opc", "opd"))));
+    }
+
+    @Test
+    public void followingCharClassSkipped() {
+        assertTrigramExpression("oop[abcde]", new Leaf<String>("oop"));
+    }
+
+    @Test
+    public void shortCircuit() {
+        assertTrigramExpression("a|(lopi)", True.<String> instance());
+    }
+
+    @Test
+    public void optional() {
+        assertTrigramExpression("(a|[j-t])lopi", new And<String>(leaves("lop", "opi")));
+    }
+
+    @Test
+    public void loop() {
+        assertTrigramExpression("ab(cdef)*gh", new Or<String>(
+                new And<String>(leaves("abc", "bcd", "cde", "def", "efg", "fgh")),
+                new And<String>(leaves("abg", "bgh"))));
+    }
+
+    @Test
+    public void converge() {
+        assertTrigramExpression("(ajdef)|(cdef)", new And<String>(
+                new Or<String>(
+                        new And<String>(leaves("ajd", "jde")),
+                        new Leaf<>("cde")),
+                        new Leaf<>("def")));
+    }
+
+    @Test
+    public void complex() {
+        assertTrigramExpression("h[efas] te.*me", new And<String>(
+                new Or<String>(
+                        new And<String>(leaves("ha ", "a t")),
+                        new And<String>(leaves("he ", "e t")),
+                        new And<String>(leaves("hf ", "f t")),
+                        new And<String>(leaves("hs ", "s t"))),
+                new Leaf<>(" te")));
+    }
+
+    // The pgTrgmExample methods below test examples from the slides at
+    // http://www.pgcon.org/2012/schedule/attachments/248_Alexander%20Korotkov%20-%20Index%20support%20for%20regular%20expression%20search.pdf
+    @Test
+    public void pgTrgmExample1() {
+        assertTrigramExpression("a(b+|c+)d", new Or<String>(
+                new Leaf<>("abd"),
+                new And<String>(leaves("abb", "bbd")),
+                new Leaf<>("acd"),
+                new And<String>(leaves("acc", "ccd"))));
+    }
+
+    @Test
+    public void pgTrgmExample2() {
+        assertTrigramExpression("(abc|cba)def", new And<String>(
+                new Leaf<>("def"), new Or<String>(
+                        new And<String>(leaves("abc", "bcd", "cde")),
+                        new And<String>(leaves("cba", "bad", "ade")))));
+    }
+
+    @Test
+    public void pgTrgmExample3() {
+        assertTrigramExpression("abc+de", new And<String>(
+                new Leaf<>("abc"),
+                new Leaf<>("cde"),
+                new Or<String>(
+                        new Leaf<>("bcd"),
+                        new And<String>(leaves("bcc", "ccd")))));
+    }
+
+    @Test
+    public void pgTrgmExample4() {
+        assertTrigramExpression("(abc*)+de", new Or<String>(
+                new And<String>(leaves("abd", "bde")),
+                new And<String>(
+                        new Leaf<>("abc"),
+                        new Leaf<>("cde"),
+                        new Or<String>(
+                                new Leaf<>("bcd"),
+                                new And<String>(leaves("bcc", "ccd"))))));
+    }
+
+    @Test
+    public void pgTrgmExample5() {
+        assertTrigramExpression("ab(cd)*ef", new Or<String>(
+                new And<String>(leaves("abe", "bef")),
+                new And<String>(leaves("abc", "bcd", "cde", "def"))));
+    }
+
+    /**
+     * Automatons that would take too long to process are aborted.
+     */
+//    @Test(expected=AutomatonTooComplexException.class)
+    public void tooManyStates() {
+        // TODO I'm not sure how to reliably trigger this without really high maxTransitions.  Maybe its not possible?
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            b.append("[efas]+");
+        }
+        assertTrigramExpression(b.toString(), null /*ignored*/);
+    }
+
+    /**
+     * This would periodically fail when we were removing cycles rather
+     * preventing them from being added to the expression.
+     */
+    @Test
+    public void bigramFailsSometimes() {
+        assertExpression("te.*me", 2, new And<String>(leaves("te", "me")));
+    }
+
+    @Test(expected=TooComplexToDeterminizeException.class)
+    public void tooBig() {
+        assertTrigramExpression("\\[\\[(Datei|File|Bild|Image):[^]]*alt=[^]|}]{50,200}",
+                null /* ignored */);
+    }
+
+    @Test(expected=TooComplexToDeterminizeException.class)
+    public void tooBigToo() {
+        assertTrigramExpression("[^]]*alt=[^]\\|}]{80,}",
+                null /* ignored */);
+    }
+
+    @Test
+    public void huge() {
+        assertTrigramExpression("[ac]*a[de]{50,80}", null);
+    }
+
+    @Test
+    @Repeat(iterations=100)
+    public void randomRegexp() {
+        // Some of the regex strings don't actually compile so just retry until we get a good one.
+        String str;
+        while (true) {
+            try {
+                str = AutomatonTestUtil.randomRegexp(random());
+                new RegExp(str);
+                break;
+            } catch (Exception e) {
+                // retry now
+            }
+        }
+        assertTrigramExpression(str, null);
+    }
+
+    /**
+     * Tests that building the automaton doesn't blow up in unexpected ways.
+     */
+    @Test
+    @Repeat(iterations=100)
+    public void randomAutomaton() {
+        Automaton automaton = AutomatonTestUtil.randomAutomaton(random());
+        NGramAutomaton ngramAutomaton;
+        try {
+            ngramAutomaton = new NGramAutomaton(automaton, between(2, 7), 4, 10000, 500);
+        } catch (AutomatonTooComplexException e) {
+            // This is fine - some automata are genuinely too complex to ngramify.
+            return;
+        }
+        Expression<String> expression = ngramAutomaton.expression();
+        expression = expression.simplify();
+    }
+
+    /**
+     * Asserts that the provided regex extracts the expected expression when
+     * configured to extract trigrams. Uses 4 as maxExpand just because I had to
+     * pick something and 4 seemed pretty good.
+     */
+    private void assertTrigramExpression(String regex, Expression<String> expected) {
+        assertExpression(regex, 3, expected);
+    }
+
+    /**
+     * Asserts that the provided regex extracts the expected expression when
+     * configured to extract ngrams. Uses 4 as maxExpand just because I had to
+     * pick something and 4 seemed pretty good.
+     */
+    private void assertExpression(String regex, int gramSize, Expression<String> expected) {
+//         System.err.println(regex);
+        Automaton automaton = new RegExp(regex).toAutomaton(20000);
+//         System.err.println(automaton.toDot());
+        NGramAutomaton ngramAutomaton = new NGramAutomaton(automaton, gramSize, 4, 10000, 100);
+//         System.err.println(ngramAutomaton.toDot());
+        Expression<String> expression = ngramAutomaton.expression();
+//         System.err.println(expression);
+        expression = expression.simplify();
+//         System.err.println(expression);
+        if (expected != null) {
+            // Null means skip the test here.
+            assertEquals(expected, expression);
+        }
+    }
+}

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTest.java
@@ -157,7 +157,6 @@ public class NGramAutomatonTest extends ESTestCase {
         assertTrigramExpression("[ac]*a[de]{50,80}", null);
     }
 
-    @Repeat(iterations=100)
     public void testRandomRegexp() {
         // Some of the regex strings don't actually compile so just retry until we get a good one.
         String str;
@@ -176,7 +175,6 @@ public class NGramAutomatonTest extends ESTestCase {
     /**
      * Tests that building the automaton doesn't blow up in unexpected ways.
      */
-    @Repeat(iterations=100)
     public void testRandomAutomaton() {
         Automaton automaton = AutomatonTestUtil.randomAutomaton(random());
         NGramAutomaton ngramAutomaton;

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramAutomatonTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.wildcard.mapper.regex.True;
 
 import static org.elasticsearch.xpack.wildcard.mapper.regex.Leaf.leaves;
 
-public class NGramAutomatonTest extends ESTestCase {
+public class NGramAutomatonTests extends ESTestCase {
     public void testSimple() {
         assertTrigramExpression("cat", new Leaf<>("cat"));
     }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractorTest.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.wildcard.mapper;
+
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.wildcard.mapper.regex.And;
+import org.elasticsearch.xpack.wildcard.mapper.regex.Leaf;
+import org.elasticsearch.xpack.wildcard.mapper.regex.True;
+import org.junit.Test;
+
+import static org.elasticsearch.xpack.wildcard.mapper.regex.Leaf.leaves;
+
+public class NGramExtractorTest extends ESTestCase {
+    @Test
+    public void simple() {
+        NGramExtractor gram = new NGramExtractor(3, 4, 10000, 100);
+        Automaton automaton = new RegExp("hero of legend").toAutomaton();
+        assertEquals(
+                new And<String>(leaves("her", "ero", "ro ", "o o", " of",
+                        "of ", "f l", " le", "leg", "ege", "gen", "end")),
+                gram.extract(automaton));
+        automaton = new RegExp("").toAutomaton();
+        assertEquals(True.<String> instance(), gram.extract(automaton));
+        automaton = new RegExp(".*").toAutomaton();
+        assertEquals(True.<String> instance(), gram.extract(automaton));
+        automaton = new RegExp("he").toAutomaton();
+        assertEquals(True.<String> instance(), gram.extract(automaton));
+        automaton = new RegExp("her").toAutomaton();
+        assertEquals(new Leaf<>("her"), gram.extract(automaton));
+    }
+
+    @Test
+    public void maxNgrams() {
+        NGramExtractor gram = new NGramExtractor(3, 4, 10000, 3);
+        Automaton automaton = new RegExp("hero of legend").toAutomaton();
+        assertEquals(
+                new And<String>(leaves("her", "ero", "ro ")),
+                gram.extract(automaton));
+    }
+}

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractorTest.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractorTest.java
@@ -11,13 +11,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.wildcard.mapper.regex.And;
 import org.elasticsearch.xpack.wildcard.mapper.regex.Leaf;
 import org.elasticsearch.xpack.wildcard.mapper.regex.True;
-import org.junit.Test;
 
 import static org.elasticsearch.xpack.wildcard.mapper.regex.Leaf.leaves;
 
 public class NGramExtractorTest extends ESTestCase {
-    @Test
-    public void simple() {
+    public void testSimple() {
         NGramExtractor gram = new NGramExtractor(3, 4, 10000, 100);
         Automaton automaton = new RegExp("hero of legend").toAutomaton();
         assertEquals(
@@ -34,8 +32,7 @@ public class NGramExtractorTest extends ESTestCase {
         assertEquals(new Leaf<>("her"), gram.extract(automaton));
     }
 
-    @Test
-    public void maxNgrams() {
+    public void testMaxNgrams() {
         NGramExtractor gram = new NGramExtractor(3, 4, 10000, 3);
         Automaton automaton = new RegExp("hero of legend").toAutomaton();
         assertEquals(

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractorTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/NGramExtractorTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.xpack.wildcard.mapper.regex.True;
 
 import static org.elasticsearch.xpack.wildcard.mapper.regex.Leaf.leaves;
 
-public class NGramExtractorTest extends ESTestCase {
+public class NGramExtractorTests extends ESTestCase {
     public void testSimple() {
         NGramExtractor gram = new NGramExtractor(3, 4, 10000, 100);
         Automaton automaton = new RegExp("hero of legend").toAutomaton();

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -332,9 +332,9 @@ public class WildcardFieldMapperTests extends ESTestCase {
         RegExp regex = new RegExp(result.toString());
         Automaton automaton = regex.toAutomaton();
         ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automaton);
-        byte[] bytes = randomValue.getBytes();
+        BytesRef br = new BytesRef(randomValue);
         assertTrue("[" + result.toString() + "]should match [" + randomValue + "]" + substitutionPoint + "-" + substitutionLength + "/"
-                + randomValue.length(), bytesMatcher.run(bytes, 0, bytes.length));
+                + randomValue.length(), bytesMatcher.run(br.bytes, br.offset, br.length));
         return result.toString();
     }
 

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -261,7 +261,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
         // automatons and this would cause many transitions. Some of the expressions below would just throw 
         // in the towel and revert to "match all".
         String regexes[] = { ".*/etc/passw.*", ".*etc/passwd HTTP.*", ".*/etc/passwd.*", "/etc/passwd.*", 
-            ".*ietcipasswd.*", ".*jetcjpasswd.*", ".*\\.c", ".a", "b"};
+            ".*ietcipasswd.*", ".*jetcjpasswd.*", ".*\\.c", ".a", "b", "a.*bcgcgc", "a.*bcg(cg|ab)c"};
         for (String regex : regexes) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(regex, 0, 20000, null, MOCK_QSC);
             assertTrue(regex+" pattern not accelerated", wildcardFieldQuery instanceof BooleanQuery);

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -297,7 +297,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
         
         // Modify the middle...
         String replacementPart = randomValue.substring(substitutionPoint, substitutionPoint+substitutionLength);
-        int mutation = randomIntBetween(0, 8);
+        int mutation = randomIntBetween(0, 10);
         switch (mutation) {
         case 0:
             // OR with random alpha of same length
@@ -338,7 +338,14 @@ public class WildcardFieldMapperTests extends ESTestCase {
             // NOT a character - replace all b's with "not a"
             result.append(replacementPart.replaceAll("b", "[^a]"));
             break;
-
+        case 9:
+            // Make whole part repeatable 1 or more times
+            result.append("(" + replacementPart +")+");
+            break;
+        case 10:
+            // Make whole part repeatable 0 or more times
+            result.append("(" + replacementPart +")?");
+            break;
         default:
             break;
         }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -261,7 +261,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
         // automatons and this would cause many transitions. Some of the expressions below would just throw 
         // in the towel and revert to "match all".
         String regexes[] = { ".*/etc/passw.*", ".*etc/passwd HTTP.*", ".*/etc/passwd.*", "/etc/passwd.*", 
-            ".*ietcipasswd.*", ".*jetcjpasswd.*"};
+            ".*ietcipasswd.*", ".*jetcjpasswd.*", ".*\\.c", ".a", "b"};
         for (String regex : regexes) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(regex, 0, 20000, null, MOCK_QSC);
             assertTrue(regex+" pattern not accelerated", wildcardFieldQuery instanceof BooleanQuery);
@@ -270,7 +270,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
     
     public void testWildcardAcceleration() throws IOException {
         // All of these patterns should be accelerated. 
-        String patterns[] = { "*foobar", "foobar*", "foo*bar", "foo?bar", "?foo*bar?"};
+        String patterns[] = { "*foobar", "foobar*", "foo*bar", "foo?bar", "?foo*bar?", "*c"};
         for (String pattern : patterns) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().wildcardQuery(pattern, null, MOCK_QSC);
             assertTrue(wildcardFieldQuery instanceof BooleanQuery);

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -264,7 +264,7 @@ public class WildcardFieldMapperTests extends ESTestCase {
             ".*ietcipasswd.*", ".*jetcjpasswd.*"};
         for (String regex : regexes) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(regex, 0, 20000, null, MOCK_QSC);
-            assertTrue(wildcardFieldQuery instanceof BooleanQuery);
+            assertTrue(regex+" pattern not accelerated", wildcardFieldQuery instanceof BooleanQuery);
         }
     }    
     


### PR DESCRIPTION
First cut at extracting ngrams from automata for the approximation query. This means regex, wildcard, prefix and fuzzy all share the same logic for extracting ngram acceleration queries. Added tests for equivalence for same search results on keyword fields (all exactly the same but for fuzzy queries currently).
