### PR TITLE
Set minimal support version of DataStreamMetadata to 7.7.0

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -94,7 +94,7 @@ public class DataStreamMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_0_0;
+        return Version.V_7_7_0;
     }
 
     @Override


### PR DESCRIPTION
, which is to what it is set in the 7.x branch.