### PR TITLE
[7.x] Add allowed warnings to index template composition tests (#54916)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -2,7 +2,8 @@
 "Component and index template composition":
   - skip:
       version: " - 7.7.99"
-      reason: "itv2 is available in 7.8+"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
       cluster.put_component_template:
@@ -35,6 +36,8 @@
                 is_write_index: true
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [foo, bar-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -86,9 +89,12 @@
 "Index template priority":
   - skip:
       version: " - 7.7.99"
-      reason: "itv2 is available in 7.8+"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [foo, bar-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -100,6 +106,8 @@
           priority: 400
 
   - do:
+      allowed_warnings:
+        - "index template [another-template] has index patterns [bar-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [another-template] will take precedence during new index creation"
       indices.put_index_template:
         name: another-template
         body:
@@ -124,7 +132,8 @@
 "Component template only composition":
   - skip:
       version: " - 7.7.99"
-      reason: "itv2 is available in 7.8+"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
       cluster.put_component_template:
@@ -145,6 +154,8 @@
                   type: keyword
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [baz*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -166,9 +177,12 @@
 "Index template without component templates":
   - skip:
       version: " - 7.7.99"
-      reason: "itv2 is available in 7.8+"
+      reason: "index template v2 API unavailable before 7.8"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [eggplant] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add allowed warnings to index template composition tests (#54916)