### PR TITLE
Fix Broken Math in S3 Retries Tests (#54952)

### DIFF
--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -551,7 +551,7 @@ public class S3BlobContainerRetriesTests extends ESTestCase {
         }
         exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=utf-8");
         exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
-        final int bytesToSend = randomIntBetween(0, length - 1);
+        final int bytesToSend = length == 0 ? 0 : randomIntBetween(0, length - 1);
         if (bytesToSend > 0) {
             exchange.getResponseBody().write(bytes, rangeStart, bytesToSend);
         }


### PR DESCRIPTION
If we run into `length == 0` we trip an assertion in `randomIntBetween(0, length -1)`.

backport of #54952 