### PR TITLE
[7.7] Allow different source sets from forbiddenApis (#54731)

### DIFF
--- a/distribution/archives/darwin-tar/build.gradle
+++ b/distribution/archives/darwin-tar/build.gradle
@@ -1,2 +1,0 @@
-// This file is intentionally blank. All configuration of the
-// distribution is done in the parent project.


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Allow different source sets from forbiddenApis (#54731)