### PR TITLE
Enable searchable snapshots for release tests

### DIFF
--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'
@@ -39,4 +41,10 @@ task testJar(type: Jar) {
 
 artifacts {
   testArtifacts testJar
+}
+
+test {
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
+  }
 }


### PR DESCRIPTION
Our searchable snapshot unit tests have been failing in release builds due to the feature toggle not being enabled.

https://gradle-enterprise.elastic.co/s/thubipxlrt4my/tests/inzjkvfxeeuik-jku4cqj6y3o3c

This enables the feature flag for these unit tests when we are doing a non-snapshot build. Not sure if this is the correct fix to be honest but we do this for the rest tests already.