### PR TITLE
Bump minimum version for component template CRUD test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 "Basic CRUD":
+  - skip:
+      version: " - 7.7.99"
+      reason: "index/component template v2 API unavailable before 7.8"
 
   - do:
       cluster.put_component_template:


### PR DESCRIPTION
These tests do CRUD for component templates, however, for 7.7 some changes weren't backported in the
`_doc` wrapping/unwrapping done for the APIs, this can cause test failures.

This bumps the minimum version for these tests to 7.8, which is okay because component templates are
hidden behind a flag and have no compatibility guarantees for 7.7.

Relates to #53101
