### PR TITLE
Fix S3 Blob Container Retries Test Range Handling (#55000)

### DIFF
--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -214,7 +214,6 @@ public class S3BlobContainerRetriesTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54995")
     public void testReadRangeBlobWithRetries() throws Exception {
         final int maxRetries = randomInt(5);
         final CountDown countDown = new CountDown(maxRetries + 1);
@@ -325,7 +324,6 @@ public class S3BlobContainerRetriesTests extends ESTestCase {
         assertThat(exception.getSuppressed().length, equalTo(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54981")
     public void testReadBlobWithPrematureConnectionClose() {
         final int maxRetries = randomInt(20);
         final BlobContainer blobContainer = createBlobContainer(maxRetries, null, null, null);
@@ -547,13 +545,13 @@ public class S3BlobContainerRetriesTests extends ESTestCase {
         if (rangeEnd.isPresent()) {
             // adapt range end to be compliant to https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
             final int effectiveRangeEnd = Math.min(rangeEnd.get(), bytes.length - 1);
-            length = effectiveRangeEnd - rangeStart;
+            length = effectiveRangeEnd - rangeStart + 1;
         } else {
-            length = bytes.length - rangeStart - 1;
+            length = bytes.length - rangeStart;
         }
         exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=utf-8");
         exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
-        final int bytesToSend = length == 0 ? 0 : randomIntBetween(0, length - 1);
+        final int bytesToSend = randomIntBetween(0, length - 1);
         if (bytesToSend > 0) {
             exchange.getResponseBody().write(bytes, rangeStart, bytesToSend);
         }


### PR DESCRIPTION
The ranges in HTTP headers are using inclusive values for start and end of the range.
The math we used was off in so far that start equals end for the range resulted in length `0`
instead of the correct value of `1`.
Closes #54981
Closes #54995

backport of #55000 