### PR TITLE
[DOCS] Add maintenance releases to upgrade table

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -9,7 +9,9 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * Between minor versions
 * From 5.6 to 6.8
 * From 6.8 to {version}
-* Between {minor-version} versions
+ifeval::[ "{version}" != "{minor-version}.0" ]
+* From any version since {minor-version}.0 to {version}
+endif::[]
 
 
 The following table shows the recommended upgrade paths to {version}.

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -9,14 +9,20 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * Between minor versions
 * From 5.6 to 6.8
 * From 6.8 to {version}
+* Between {minor-version} versions
 
 
 The following table shows the recommended upgrade paths to {version}.
 
-[cols="<1m,3",options="header",]
+[cols="<1,3",options="header",]
 |====
 |Upgrade from   
-|Recommended upgrade path  to {version}
+|Recommended upgrade path to {version}
+
+ifeval::[ "{version}" != "{minor-version}.0" ]
+|A previous {minor-version} version (e.g., {minor-version}.0)
+|<<rolling-upgrades,Rolling upgrade>> to {version}
+endif::[]
 
 |7.0–7.5
 |<<rolling-upgrades,Rolling upgrade>> to {version}

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -34,6 +34,7 @@ Rolling upgrades are supported:
 * Between minor versions
 * {stack-ref-68}/upgrading-elastic-stack.html[From 5.6 to 6.8]
 * From 6.8 to {version}
+* Between {minor-version} versions
 
 Upgrading directly to {version} from 6.7 or earlier requires a
 <<restart-upgrade, full cluster restart>>.

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -34,7 +34,9 @@ Rolling upgrades are supported:
 * Between minor versions
 * {stack-ref-68}/upgrading-elastic-stack.html[From 5.6 to 6.8]
 * From 6.8 to {version}
-* Between {minor-version} versions
+ifeval::[ "{version}" != "{minor-version}.0" ]
+* From any version since {minor-version}.0 to {version}
+endif::[]
 
 Upgrading directly to {version} from 6.7 or earlier requires a
 <<restart-upgrade, full cluster restart>>.


### PR DESCRIPTION
Updates the supported upgrade path table in [Upgrade Elasticsearch][0]
to include maintenance releases. For example, this covers upgrading
from 7.6.0 to 7.6.2.

The new table row only displays for releases greater than n.x.0. For
example, the new row will display for the 7.7.1 release but not the
7.7.0 release.

This PR targets 7.6 as that's the latest branch that will display the new row.
However, I plan to port to 7.7, 7.x, and master.

Preview: http://docs__maint-rel-upgrade-76.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/setup-upgrade.html

Closes #53787

[0]: https://www.elastic.co/guide/en/elasticsearch/reference/master/setup-upgrade.html