### PR TITLE
[DOCS] Add tip for upgrade assistant to upgrade docs

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -11,6 +11,17 @@ process so upgrading does not interrupt service. Rolling upgrades are supported:
 * From 6.8 to {prev-major-version}
 * From {prev-major-version} to {version}
 
+[TIP]
+====
+For rolling upgrades between major versions (e.g., 5.6 to 6.8), we recommend
+using the {kibana-ref}/upgrade-assistant.html[Kibana Upgrade Assistant].
+
+The upgrade assistant identifies deprecated settings in your cluster and guides
+you through the process of resolving issues, including reindexing.
+
+We also recommend checking your <<deprecation-logging,deprecation logs>> for any
+other functionality that may have changed.
+====
 
 The following table shows the recommended upgrade paths to {version}.
 


### PR DESCRIPTION
Our upgrade docs don't mention the upgrade assistant, which can be
helpful when migrating across major versions. The docs also don't
mention deprecation logs, which can highlight other functionality that
may change between versions.

This adds a related tip admonition to the upgrade docs.