### PR TITLE
Mute testSearchableSnapshotAction in TimeSeriesLifecycleActions tests

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -1549,6 +1549,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         assertBusy(() -> assertFalse("expected " + index + " to be deleted by ILM", indexExists(index)));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/55050")
     public void testSearchableSnapshotAction() throws Exception {
         String snapshotRepo = createSnapshotRepo();
         createNewSingletonPolicy("cold", new SearchableSnapshotAction(snapshotRepo));


### PR DESCRIPTION
Details in #55050
