### PR TITLE
Add documentation about path prefix

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/documentation/RestClientDocumentation.java
@@ -197,6 +197,13 @@ public class RestClientDocumentation {
                 });
             //end::rest-client-init-client-config-callback
         }
+        {
+            //tag::rest-client-init-client-config-reverse-proxy
+            RestClientBuilder builder = RestClient.builder(
+                new HttpHost("proxy", 9000, "http"))
+                .setPathPrefix("/elastic"); // <1>
+            //end::rest-client-init-client-config-reverse-proxy
+        }
 
         {
             //tag::rest-client-sync

--- a/docs/java-rest/low-level/usage.asciidoc
+++ b/docs/java-rest/low-level/usage.asciidoc
@@ -206,6 +206,12 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-init-reques
 https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html[`org.apache.http.client.config.RequestConfig.Builder`]
  allows to set)
 
+[[java-rest-low-usage-initialization-proxy]]
+==== Using a proxy
+
+When running Elasticsearch behind a proxy, you will need to configure the
+low level REST client this way:
+
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-init-client-config-callback]
@@ -215,6 +221,14 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-init-client
 http://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html[`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`]
  allows to set)
 
+If you are running Elasticsearch behind a reverse proxy which has a path
+prefix, you will need to configure the low level REST client this way:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-init-client-config-reverse-proxy]
+--------------------------------------------------
+<1> Set the path prefix to use to access Elasticsearch
 
 [[java-rest-low-usage-requests]]
 === Performing requests
@@ -339,9 +353,9 @@ translate to the execution of that request being cancelled, which needs to be
 specifically implemented in the API itself.
 
 The use of the `Cancellable` instance is optional and you can safely ignore this
-if you don't need it. A typical usecase for this would be using this together with 
+if you don't need it. A typical usecase for this would be using this together with
 frameworks like Rx Java or the Kotlin's `suspendCancellableCoRoutine`. Cancelling
-no longer needed requests is a good way to avoid putting unnecessary 
+no longer needed requests is a good way to avoid putting unnecessary
 load on Elasticsearch.
 
 ["source","java",subs="attributes,callouts,macros"]


### PR DESCRIPTION
When using a reverse proxy, developers might need to define a path prefix.
This appears to be not documented.

See related discussions:

* https://discuss.elastic.co/t/resthighlevelclient-accessing-an-elastic-http-endpoint-behind-reverse-proxy/117306
* https://discuss.elastic.co/t/elesticsearch-rest-http-request-through-redirected-url/227478
* https://discuss.elastic.co/t/java-high-level-rest-client-including-a-basepath-to-request-urls/217533
