### PR TITLE
[DOCS] EQL: Note array values are not supported.

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -31,7 +31,6 @@ source string.
 between(file.path, "system32\\\\", ".exe")   // returns "cmd"
 between(file.path, "workspace\\\\", ".exe")  // returns ""
 
-
 // Greedy matching defaults to false.
 between(file.path, "\\\\", "\\\\", false)  // returns "Windows"
 // Sets greedy matching to true
@@ -74,8 +73,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the first array item only.
 --
 
 `<left>`::
@@ -92,8 +89,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-<<array,Array values>> are not supported.
 --
 
 `<right>`::
@@ -110,8 +105,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-<<array,Array values>> are not supported.
 --
 
 `<greedy_matching>`::
@@ -152,10 +145,6 @@ endsWith(file.name, ".dll")               // returns false
 endsWith("regsvr32.exe", file.extension)  // returns true
 endsWith("ntdll.dll", file.name)          // returns false
 
-// file.name = [ "ntdll.dll", "regsvr32.exe" ]
-endsWith(file.name, ".dll")               // returns true
-endsWith(file.name, ".exe")               // returns false
-
 // null handling
 endsWith("regsvr32.exe", null)            // returns null
 endsWith("", null)                        // returns null 
@@ -185,8 +174,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the first array item only.
 --
 
 `<substring>`::
@@ -250,8 +237,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-<<array,Array values>> are not supported.
 --
 
 *Returns:* integer or `null`
@@ -282,10 +267,6 @@ startsWith(process.name, "explorer")    // returns false
 startsWith("regsvr32.exe", process.name) // returns true
 startsWith("explorer.exe", process.name) // returns false
 
-// process.name = [ "explorer.exe", "regsvr32.exe" ]
-startsWith(process.name, "explorer")    // returns true
-startsWith(process.name, "regsvr32")    // returns false
-
 // null handling
 startsWith("regsvr32.exe", null)        // returns null
 startsWith("", null)                    // returns null 
@@ -315,8 +296,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the first array item only.
 --
 
 `<substring>`::

--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -30,3 +30,13 @@ queries that contain:
 * {eql-ref}/pipes.html[Pipes]
 
 * {eql-ref}/sequences.html[Sequences]
+
+[discrete]
+[[eql-array-values]]
+=== Array values
+
+EQL in {es} does not support <<array,array field values>>.
+
+In {es}, field mappings do not indicate whether a field contains array values or
+the order of array values. Using array field values may cause unexpected search
+results.


### PR DESCRIPTION
Adds a section to the EQL limitations docs noting that array
values are not supported.

Also removes references to array values from the EQL functions
documentation.

Relates to #54970.