### PR TITLE
[DOCS] EQL: Remove case sensitivity from function docs

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -131,8 +131,7 @@ If `true`, matching is case-sensitive. Defaults to `false`.
 [[eql-fn-endswith]]
 === `endsWith`
 
-Returns `true` if a source string ends with a provided substring. Matching is
-case insensitive.
+Returns `true` if a source string ends with a provided substring.
 
 [%collapsible]
 ====
@@ -140,7 +139,6 @@ case insensitive.
 [source,eql]
 ----
 endsWith("regsvr32.exe", ".exe")          // returns true
-endsWith("regsvr32.exe", ".EXE")          // returns true
 endsWith("regsvr32.exe", ".dll")          // returns false
 endsWith("", "")                          // returns true
 
@@ -261,8 +259,7 @@ field datatypes:
 [[eql-fn-startswith]]
 === `startsWith`
 
-Returns `true` if a source string begins with a provided substring. Matching is
-case insensitive.
+Returns `true` if a source string begins with a provided substring.
 
 [%collapsible]
 ====
@@ -270,7 +267,6 @@ case insensitive.
 [source,eql]
 ----
 startsWith("regsvr32.exe", "regsvr32")  // returns true
-startsWith("regsvr32.exe", "RegSvr32")  // returns true
 startsWith("regsvr32.exe", "explorer")  // returns false
 startsWith("", "")                      // returns true
 


### PR DESCRIPTION
Per #54411, we plan to handle case sensitivity via a parameter for the
EQL search API (with the possible exception of the `between` function).

This removes references and examples related to case sensitivity from
the EQL functions docs.