### PR TITLE
[DOCS] Collapse nested objects in graph-explore-api

### DIFF
--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -30,6 +30,7 @@ enable you to _spider out_ from one more vertices of interest. You can exclude
 vertices that have already been returned.
 
 [float]
+[role="child_attributes"]
 === Request Body
 
 query::
@@ -72,6 +73,9 @@ graph as vertices. For example:
 ]
 --------------------------------------------------
 
+.Options for `vertices`
+[%collapsible%open]
+======
 field::: Identifies a field in the documents of interest.
 include::: Identifies the terms of interest that form the starting points
 from which you want to spider out. You do not have to specify a seed query
@@ -93,6 +97,7 @@ shard_min_doc_count:::
 This advanced setting controls how many documents on a particular shard have
 to contain a pair of terms before the connection is returned for global
 consideration. Defaults to 2.
+======
 
 connections::
 Specifies or more fields from which you want to extract terms that are
@@ -114,6 +119,9 @@ explore additional relationships in the data. Each level of nesting is
 considered a _hop_, and proximity within the graph is often described in
 terms of _hop depth_.
 
+.Options for `connections`
+[%collapsible%open]
+======
 query:::
 An optional _guiding query_ that constrains the Graph API as it
 explores connected terms. For example, you might want to direct the Graph
@@ -133,9 +141,13 @@ Contains the fields you are interested in. For example:
   }
 ]
 --------------------------------------------------
+======
 
 controls:: Direct the Graph API how to build the graph.
 
+.Options for `controls`
+[%collapsible%open]
+======
 use_significance:::
 The `use_significance` flag filters associated terms so only those that are
 significantly associated with your query are included. For information about
@@ -168,6 +180,7 @@ a maximum number of documents per value for that field. For example:
   "max_docs_per_value": 500
 }
 --------------------------------------------------
+======
 
 // [float]
 // === Authorization
@@ -279,7 +292,7 @@ not a global count for all documents in the index).
 
 The default settings are configured to remove noisy data and
 get the "big picture" from your data. This example shows how to specify
-additional parameters to influence how the graph is built. 
+additional parameters to influence how the graph is built.
 
 For tips on tuning the settings for more detailed forensic evaluation where
 every document could be of interest, see the

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -75,7 +75,7 @@ graph as vertices. For example:
 ]
 --------------------------------------------------
 +
-.Options for `vertices`
+.Properties for `vertices`
 [%collapsible%open]
 ======
 field::: Identifies a field in the documents of interest.
@@ -121,7 +121,7 @@ explore additional relationships in the data. Each level of nesting is
 considered a _hop_, and proximity within the graph is often described in
 terms of _hop depth_.
 +
-.Options for `connections`
+.Properties for `connections`
 [%collapsible%open]
 ======
 query:::
@@ -147,7 +147,7 @@ Contains the fields you are interested in. For example:
 
 controls:: Direct the Graph API how to build the graph.
 +
-.Options for `controls`
+.Properties for `controls`
 [%collapsible%open]
 ======
 use_significance:::

--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -30,8 +30,10 @@ enable you to _spider out_ from one more vertices of interest. You can exclude
 vertices that have already been returned.
 
 [float]
-[role="child_attributes"]
 === Request Body
+
+[role="child_attributes"]
+====
 
 query::
 A seed query that identifies the documents of interest. Can be any valid
@@ -72,7 +74,7 @@ graph as vertices. For example:
     }
 ]
 --------------------------------------------------
-
++
 .Options for `vertices`
 [%collapsible%open]
 ======
@@ -118,7 +120,7 @@ NOTE: Connections can be nested inside the `connections` object to
 explore additional relationships in the data. Each level of nesting is
 considered a _hop_, and proximity within the graph is often described in
 terms of _hop depth_.
-
++
 .Options for `connections`
 [%collapsible%open]
 ======
@@ -144,7 +146,7 @@ Contains the fields you are interested in. For example:
 ======
 
 controls:: Direct the Graph API how to build the graph.
-
++
 .Options for `controls`
 [%collapsible%open]
 ======
@@ -181,6 +183,7 @@ a maximum number of documents per value for that field. For example:
 }
 --------------------------------------------------
 ======
+====
 
 // [float]
 // === Authorization


### PR DESCRIPTION
**Summary**
Collapsible docs for graph explore api document as mentioned in https://github.com/elastic/elasticsearch/issues/54667
Uses changes in https://github.com/elastic/docs/pull/1786

**Tests**
Ran  `./gradlew -p docs check` tests pass.

Closes #54667