### PR TITLE
Fixes for IntelliJ IDEA 2020.1 support

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -38,6 +38,12 @@ if (System.getProperty('idea.active') == 'true') {
     }
   }
 
+  tasks.register('buildDependencyArtifacts') {
+    group = 'ide'
+    description = 'Builds artifacts needed as dependency for IDE modules'
+    dependsOn ':client:rest-high-level:shadowJar'
+  }
+
   idea {
     project {
       vcs = 'Git'
@@ -49,7 +55,7 @@ if (System.getProperty('idea.active') == 'true') {
           testRunner = 'choose_per_test'
         }
         taskTriggers {
-          afterSync tasks.named('configureIdeaGradleJvm')
+          afterSync tasks.named('configureIdeaGradleJvm'), tasks.named('buildDependencyArtifacts')
         }
         codeStyle {
           java {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.rest-test'
 archivesBaseName = 'x-pack'
 
 dependencies {
-  testCompile project(xpackModule('core'))
+  testCompile project(xpackModule('core')) // this redundant dependency is here to make IntelliJ happy
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'elasticsearch.rest-test'
 archivesBaseName = 'x-pack'
 
 dependencies {
+  testCompile project(xpackModule('core'))
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 

--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
   testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 


### PR DESCRIPTION
Some changes in how IntelliJ 2020.1 resolved dependencies caused some build failures in the IDE due to missing dependencies in QA projects. This makes those dependencies explicit to workaround the problem.

Additionally, I noticed that on a clean import the build will fail due to the HLRC shadow jar not having been built (our wildfly qa tests depend on this). So now and import will run the task to build that jar ensuring it's always available even if you haven't manually built it already.