### PR TITLE
Remove the object format for indices_boost.

### DIFF
--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -52,3 +52,8 @@ deprecated in 7.6, and are now removed in 8.x. The form
 `cosineSimilarity(query, doc['field'])` is replaced by
 `cosineSimilarity(query, 'field')`.
 
+[float]
+==== Object format for `indices_boost`
+The `indices_boost` option in the search request used to accept the boosts
+both as an object and as an array. The object format has been deprecated since
+5.2 and is now removed in 8.0.

--- a/docs/reference/search/request/index-boost.asciidoc
+++ b/docs/reference/search/request/index-boost.asciidoc
@@ -11,15 +11,15 @@ deprecated[5.2.0, This format is deprecated. Please use array format instead.]
 --------------------------------------------------
 GET /_search
 {
-    "indices_boost" : {
-        "index1" : 1.4,
-        "index2" : 1.3
-    }
+    "indices_boost" : [
+        { "index1" : 1.4 },
+        { "index2" : 1.3 }
+    ]
 }
 --------------------------------------------------
-// TEST[setup:index_boost warning:Object format in indices_boost is deprecated, please use array format instead]
+// TEST[setup:index_boost]
 
-You can also specify it as an array to control the order of boosts.
+Index aliases and wildcard expressions can also be used:
 
 [source,console]
 --------------------------------------------------
@@ -33,6 +33,5 @@ GET /_search
 --------------------------------------------------
 // TEST[continued]
 
-This is important when you use aliases or wildcard expression.
-If multiple matches are found, the first match will be used.
-For example, if an index is included in both `alias1` and `index*`, boost value of `1.4` is applied.
+If multiple matches are found, the first match will be used. For example, if an
+index is included in both `alias1` and `index*`, boost value of `1.4` is applied.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/40_indices_boost.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/40_indices_boost.yml
@@ -33,38 +33,7 @@ setup:
         index: [test_1, test_2]
 
 ---
-"Indices boost using object":
-  - skip:
-      features: "warnings"
-
-  - do:
-      warnings:
-        - 'Object format in indices_boost is deprecated, please use array format instead'
-      search:
-        rest_total_hits_as_int: true
-        index: _all
-        body:
-          indices_boost: {test_1: 2.0, test_2: 1.0}
-
-  - match: { hits.total: 2 }
-  - match: { hits.hits.0._index: test_1 }
-  - match: { hits.hits.1._index: test_2 }
-
-  - do:
-      warnings:
-        - 'Object format in indices_boost is deprecated, please use array format instead'
-      search:
-        rest_total_hits_as_int: true
-        index: _all
-        body:
-          indices_boost: {test_1: 1.0, test_2: 2.0}
-
-  - match: { hits.total: 2 }
-  - match: { hits.hits.0._index: test_2 }
-  - match: { hits.hits.1._index: test_1 }
-
----
-"Indices boost using array":
+"Basic indices boost":
   - do:
       search:
         rest_total_hits_as_int: true
@@ -88,7 +57,7 @@ setup:
   - match: { hits.hits.1._index: test_1 }
 
 ---
-"Indices boost using array with alias":
+"Indices boost with alias":
   - do:
       search:
         rest_total_hits_as_int: true
@@ -112,7 +81,7 @@ setup:
   - match: { hits.hits.1._index: test_1 }
 
 ---
-"Indices boost using array with wildcard":
+"Indices boost with wildcard":
   - do:
       search:
         rest_total_hits_as_int: true
@@ -136,7 +105,7 @@ setup:
   - match: { hits.hits.1._index: test_1 }
 
 ---
-"Indices boost using array multiple match":
+"Indices boost multiple match":
   - do:
       search:
         rest_total_hits_as_int: true

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1076,19 +1076,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         scriptFields.add(new ScriptField(parser));
                     }
-                } else if (INDICES_BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    deprecationLogger.deprecated(
-                        "Object format in indices_boost is deprecated, please use array format instead");
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                        if (token == XContentParser.Token.FIELD_NAME) {
-                            currentFieldName = parser.currentName();
-                        } else if (token.isValue()) {
-                            indexBoosts.add(new IndexBoost(currentFieldName, parser.floatValue()));
-                        } else {
-                            throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token +
-                                " in [" + currentFieldName + "].", parser.getTokenLocation());
-                        }
-                    }
                 } else if (AGGREGATIONS_FIELD.match(currentFieldName, parser.getDeprecationHandler())
                         || AGGS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     aggregations = AggregatorFactories.parseAggregators(parser);

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -377,17 +377,6 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
 
     public void testParseIndicesBoost() throws IOException {
         {
-            String restContent = " { \"indices_boost\": {\"foo\": 1.0, \"bar\": 2.0}}";
-            try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
-                assertEquals(2, searchSourceBuilder.indexBoosts().size());
-                assertEquals(new SearchSourceBuilder.IndexBoost("foo", 1.0f), searchSourceBuilder.indexBoosts().get(0));
-                assertEquals(new SearchSourceBuilder.IndexBoost("bar", 2.0f), searchSourceBuilder.indexBoosts().get(1));
-                assertWarnings("Object format in indices_boost is deprecated, please use array format instead");
-            }
-        }
-
-        {
             String restContent = "{" +
                 "    \"indices_boost\" : [\n" +
                 "        { \"foo\" : 1.0 },\n" +


### PR DESCRIPTION
This format has been deprecated since version 5.2.