### PR TITLE
Passthrough special characters in thread pool docs

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -16,7 +16,7 @@ There are several thread pools, but the important ones include:
 `search`::
     For count/search/suggest operations. Thread pool type is
     `fixed` with a size of `int((`<<node.processors,
-    `# of allocated processors`>>` * 3) / 2) + 1`, and queue_size of `1000`.
+    `# of allocated processors`>>`pass:[ * ]3) / 2) + 1`, and queue_size of `1000`.
 
 [[search-throttled]]`search_throttled`::
     For count/search/suggest/get operations on `search_throttled indices`.
@@ -34,44 +34,44 @@ There are several thread pools, but the important ones include:
 `write`::
     For single-document index/delete/update and bulk requests. Thread pool type
     is `fixed` with a size of <<node.processors, `# of allocated processors`>>,
-    queue_size of `200`. The maximum size for this pool is `1 + `
+    queue_size of `200`. The maximum size for this pool is `pass:[1 + ]`
     <<node.processors, `# of allocated processors`>>.
 
 `snapshot`::
     For snapshot/restore operations. Thread pool type is `scaling` with a
     keep-alive of `5m` and a max of `min(5, (`<<node.processors,
-    `# of allocated processors`>>`)/2)`.
+    `# of allocated processors`>>`) / 2)`.
 
 `warmer`::
     For segment warm-up operations. Thread pool type is `scaling` with a
     keep-alive of `5m` and a max of `min(5, (`<<node.processors,
-    `# of allocated processors`>>`)/2)`.
+    `# of allocated processors`>>`) / 2)`.
 
 `refresh`::
     For refresh operations. Thread pool type is `scaling` with a
     keep-alive of `5m` and a max of `min(10, (`<<node.processors,
-    `# of allocated processors`>>`)/2)`.
+    `# of allocated processors`>>`) / 2)`.
 
 `listener`::
     Mainly for java client executing of action when listener threaded is set to
     `true`. Thread pool type is `scaling` with a default max of
-    `min(10, (`<<node.processors, `# of allocated processors`>>`)/2)`.
+    `min(10, (`<<node.processors, `# of allocated processors`>>`) / 2)`.
 
 `fetch_shard_started`::
     For listing shard states.
     Thread pool type is `scaling` with keep-alive of `5m` and a default maximum
-    size of `2 * `<<node.processors, `# of allocated processors`>>.
+    size of `pass:[2 * ]`<<node.processors, `# of allocated processors`>>.
 
 `fetch_shard_store`::
     For listing shard stores.
     Thread pool type is `scaling` with keep-alive of `5m` and a default maximum
-    size of `2 * `<<node.processors, `# of allocated processors`>>.
+    size of `pass:[2 * ]`<<node.processors, `# of allocated processors`>>.
 
 `flush`::
     For <<indices-flush,flush>> and <<index-modules-translog, translog>> `fsync`
     operations. Thread pool type is `scaling` with a keep-alive of `5m` and a
     default maximum size of `min(5, (`<<node.processors,
-    `# of allocated processors`>>`)/2)`.
+    `# of allocated processors`>>`) / 2)`.
 
 `force_merge`::
     For <<indices-forcemerge,force merge>> operations.

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -34,8 +34,8 @@ There are several thread pools, but the important ones include:
 `write`::
     For single-document index/delete/update and bulk requests. Thread pool type
     is `fixed` with a size of <<node.processors, `# of allocated processors`>>,
-    queue_size of `200`. The maximum size for this pool is `pass:[1 + ]`
-    <<node.processors, `# of allocated processors`>>.
+    queue_size of `200`. The maximum size for this pool is 
+    `pass:[1 + ]`<<node.processors, `# of allocated processors`>>.
 
 `snapshot`::
     For snapshot/restore operations. Thread pool type is `scaling` with a


### PR DESCRIPTION
Some of these characters are special to Asciidoctor and they ruin the rendering on this page. Instead, we use a macro to passthrough these characters without Asciidoctor applying any subtitutions to them. This commit then addresses some rendering issues in the thread pool docs.

