### PR TITLE
Deprecate local parameter for get field mapping request (#55014)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/IndicesRequestConverters.java
@@ -227,7 +227,6 @@ final class IndicesRequestConverters {
         RequestConverters.Params parameters = new RequestConverters.Params();
         parameters.withIndicesOptions(getFieldMappingsRequest.indicesOptions());
         parameters.withIncludeDefaults(getFieldMappingsRequest.includeDefaults());
-        parameters.withLocal(getFieldMappingsRequest.local());
         request.addParameters(parameters.asMap());
         return request;
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetFieldMappingsRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/indices/GetFieldMappingsRequest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Strings;
 /** Request the mappings of specific fields */
 public class GetFieldMappingsRequest implements Validatable {
 
+    @Deprecated
     private boolean local = false;
 
     private String[] fields = Strings.EMPTY_ARRAY;
@@ -40,11 +41,13 @@ public class GetFieldMappingsRequest implements Validatable {
      * Indicate whether the receiving node should operate based on local index information or forward requests,
      * where needed, to other nodes. If running locally, request will not raise errors if running locally &amp; missing indices.
      */
+    @Deprecated
     public GetFieldMappingsRequest local(boolean local) {
         this.local = local;
         return this;
     }
 
+    @Deprecated
     public boolean local() {
         return local;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesRequestConvertersTests.java
@@ -359,7 +359,6 @@ public class IndicesRequestConvertersTests extends ESTestCase {
         Map<String, String> expectedParams = new HashMap<>();
         RequestConvertersTests.setRandomIndicesOptions(getFieldMappingsRequest::indicesOptions, getFieldMappingsRequest::indicesOptions,
             expectedParams);
-        RequestConvertersTests.setRandomLocal(getFieldMappingsRequest::local, expectedParams);
 
         Request request = IndicesRequestConverters.getFieldMapping(getFieldMappingsRequest);
         StringJoiner endpoint = new StringJoiner("/", "/", "");

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -709,7 +709,6 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
         // end::get-field-mappings-request-local
 
         {
-
             // tag::get-field-mappings-execute
             GetFieldMappingsResponse response =
                 client.indices().getFieldMapping(request, RequestOptions.DEFAULT);

--- a/docs/java-rest/high-level/indices/get_field_mappings.asciidoc
+++ b/docs/java-rest/high-level/indices/get_field_mappings.asciidoc
@@ -34,7 +34,8 @@ how wildcard expressions are expanded
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-local]
 --------------------------------------------------
-<1> The `local` flag (defaults to `false`) controls whether the aliases need
+<1> deprecated:[7.8.0, This parameter is a no-op and field mappings are always retrieved locally]
+The `local` flag (defaults to `false`) controls whether the aliases need
 to be looked up in the local cluster state or in the cluster state held by
 the elected master node
 

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -50,7 +50,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 (Optional, boolean) If `true`, the response includes default mapping values.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+`local`::
+deprecated:[7.8.0, This parameter is a no-op and field mappings are always retrieved locally]
+(Optional, boolean) If `true`, the request retrieves information from the local
+node only. Defaults to `false`, which means information is retrieved from
+the master node.
 
 
 [[get-field-mapping-api-example]]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_field_mapping/10_basic.yml
@@ -52,3 +52,20 @@ setup:
 
   - match: {test_index.mappings.text.mapping.text.type:     text}
   - match: {test_index.mappings.text.mapping.text.analyzer: default}
+
+---
+"Get field mapping with local is deprecated":
+
+  - skip:
+      features: ["warnings", "node_selector"]
+
+  - do:
+      node_selector:
+        version: "7.8.0 - "
+      warnings:
+        - "Use [local] in get field mapping requests is deprecated. The parameter will be removed in the next major version"
+      indices.get_field_mapping:
+        fields: text
+        local: true
+
+  - match: {test_index.mappings.text.mapping.text.type:     text}

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetFieldMappingAction.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetadata;
@@ -47,8 +48,8 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 public class RestGetFieldMappingAction extends BaseRestHandler {
 
-    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(
-        LogManager.getLogger(RestGetFieldMappingAction.class));
+    private static final Logger logger = LogManager.getLogger(RestGetFieldMappingAction.class);
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal] Using include_type_name in get " +
         "field mapping requests is deprecated. The parameter will be removed in the next major version.";
 
@@ -85,6 +86,12 @@ public class RestGetFieldMappingAction extends BaseRestHandler {
         GetFieldMappingsRequest getMappingsRequest = new GetFieldMappingsRequest();
         getMappingsRequest.indices(indices).types(types).fields(fields).includeDefaults(request.paramAsBoolean("include_defaults", false));
         getMappingsRequest.indicesOptions(IndicesOptions.fromRequest(request, getMappingsRequest.indicesOptions()));
+
+        if (request.hasParam("local")) {
+            deprecationLogger.deprecatedAndMaybeLog("get_field_mapping_local",
+                "Use [local] in get field mapping requests is deprecated. "
+                    + "The parameter will be removed in the next major version");
+        }
         getMappingsRequest.local(request.paramAsBoolean("local", getMappingsRequest.local()));
         return channel ->
                 client.admin().indices().getFieldMappings(getMappingsRequest, new RestBuilderListener<GetFieldMappingsResponse>(channel) {


### PR DESCRIPTION
The usage of local parameter for GetFieldMappingRequest has been removed from the underlying transport action since v2.0.

This PR deprecates the parameter from rest layer. It will be removed in next major version.