### PR TITLE
[DOCS] Document `max_concurrent_searches` default

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -13,6 +13,7 @@ There are several thread pools, but the important ones include:
     For generic operations (for example, background node discovery).
     Thread pool type is `scaling`.
 
+[[search-threadpool]]
 `search`::
     For count/search/suggest operations. Thread pool type is
     `fixed` with a size of `int((`<<node.processors,

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -78,7 +78,8 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `max_concurrent_searches`::
 (Optional, integer)
-Maximum number of concurrent searches the multi search API can execute.
+Maximum number of concurrent searches the multi search API can execute. Defaults
+to +max(1, (# of <<data-node,data nodes>> * min(# of <<node.processors,allocated processors>>, 10)))+.
 
 `max_concurrent_shard_requests`::
 +

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -79,7 +79,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 `max_concurrent_searches`::
 (Optional, integer)
 Maximum number of concurrent searches the multi search API can execute. Defaults
-to +max(1, (# of <<data-node,data nodes>> * min(# of <<node.processors,allocated processors>>, 10)))+.
+to +max(1, (# of <<data-node,data nodes>> * min(<<search-threadpool,search thread pool size>>, 10)))+.
 
 `max_concurrent_shard_requests`::
 +


### PR DESCRIPTION
Documents the default value for the multi search API's `max_concurrent_searches`
query parameter.

Closes #55033