### PR TITLE
[7.x] [ML] inference only persist if there are stats (#54752)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceStats.java
@@ -31,7 +31,7 @@ public class InferenceStats implements ToXContentObject, Writeable {
     public static final ParseField NODE_ID = new ParseField("node_id");
     public static final ParseField FAILURE_COUNT = new ParseField("failure_count");
     public static final ParseField TYPE = new ParseField("type");
-    public static final ParseField TIMESTAMP = new ParseField("time_stamp");
+    public static final ParseField TIMESTAMP = new ParseField("timestamp");
 
     public static final ConstructingObjectParser<InferenceStats, Void> PARSER = new ConstructingObjectParser<>(
         NAME,
@@ -125,6 +125,10 @@ public class InferenceStats implements ToXContentObject, Writeable {
 
     public Instant getTimeStamp() {
         return timeStamp;
+    }
+
+    public boolean hasStats() {
+        return missingAllFieldsCount > 0 || inferenceCount > 0 || failureCount > 0;
     }
 
     @Override
@@ -221,16 +225,19 @@ public class InferenceStats implements ToXContentObject, Writeable {
             return this;
         }
 
-        public void incMissingFields() {
+        public Accumulator incMissingFields() {
             this.missingFieldsAccumulator.increment();
+            return this;
         }
 
-        public void incInference() {
+        public Accumulator incInference() {
             this.inferenceAccumulator.increment();
+            return this;
         }
 
-        public void incFailure() {
+        public Accumulator incFailure() {
             this.failureCountAccumulator.increment();
+            return this;
         }
 
         public InferenceStats currentStats() {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/InferenceIngestIT.java
@@ -96,7 +96,6 @@ public class InferenceIngestIT extends ESRestTestCase {
         assertThat(EntityUtils.toString(searchResponse.getEntity()), containsString("\"value\":10"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54786")
     public void testPipelineIngest() throws Exception {
 
         client().performRequest(putPipeline("simple_classification_pipeline", CLASSIFICATION_PIPELINE));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -110,14 +110,14 @@ public class LocalModel<T extends InferenceConfig> implements Model<T> {
             return;
         }
         try {
-            statsAccumulator.get().incInference();
+            statsAccumulator.updateAndGet(InferenceStats.Accumulator::incInference);
             currentInferenceCount.increment();
 
             Model.mapFieldsIfNecessary(fields, defaultFieldMap);
 
             boolean shouldPersistStats = ((currentInferenceCount.sum() + 1) % persistenceQuotient == 0);
             if (fieldNames.stream().allMatch(f -> MapHelper.dig(f, fields) == null)) {
-                statsAccumulator.get().incMissingFields();
+                statsAccumulator.updateAndGet(InferenceStats.Accumulator::incMissingFields);
                 if (shouldPersistStats) {
                     persistStats();
                 }
@@ -130,7 +130,7 @@ public class LocalModel<T extends InferenceConfig> implements Model<T> {
             }
             listener.onResponse(inferenceResults);
         } catch (Exception e) {
-            statsAccumulator.get().incFailure();
+            statsAccumulator.updateAndGet(InferenceStats.Accumulator::incFailure);
             listener.onFailure(e);
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.Numbers;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
@@ -551,7 +552,9 @@ public class TrainedModelProvider {
             failures == null ? 0L : Double.valueOf(failures.getValue()).longValue(),
             modelId,
             null,
-            timeStamp == null ? Instant.now() : Instant.ofEpochMilli(Double.valueOf(timeStamp.getValue()).longValue())
+            timeStamp == null || (Numbers.isValidDouble(timeStamp.getValue()) == false) ?
+                Instant.now() :
+                Instant.ofEpochMilli(Double.valueOf(timeStamp.getValue()).longValue())
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -46,7 +46,6 @@ import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
 import org.junit.After;
 import org.junit.Before;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -62,7 +61,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
@@ -140,12 +138,6 @@ public class ModelLoadingServiceTests extends ESTestCase {
             assertThat(future.get(), is(not(nullValue())));
         }
 
-        verify(trainedModelStatsService, times(1)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
-            @Override
-            public boolean matches(final Object o) {
-                return ((InferenceStats)o).getModelId().equals(model3);
-            }
-        }));
         verify(trainedModelProvider, times(1)).getTrainedModel(eq(model1), eq(true), any());
         verify(trainedModelProvider, times(1)).getTrainedModel(eq(model2), eq(true), any());
         // It is not referenced, so called eagerly
@@ -192,24 +184,6 @@ public class ModelLoadingServiceTests extends ESTestCase {
         verify(trainedModelProvider, atMost(2)).getTrainedModel(eq(model2), eq(true), any());
         // Only loaded requested once on the initial load from the change event
         verify(trainedModelProvider, times(1)).getTrainedModel(eq(model3), eq(true), any());
-        verify(trainedModelStatsService, atMost(2)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
-            @Override
-            public boolean matches(final Object o) {
-                return ((InferenceStats)o).getModelId().equals(model1);
-            }
-        }));
-        verify(trainedModelStatsService, atMost(2)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
-            @Override
-            public boolean matches(final Object o) {
-                return ((InferenceStats)o).getModelId().equals(model2);
-            }
-        }));
-        verify(trainedModelStatsService, times(1)).queueStats(argThat(new ArgumentMatcher<InferenceStats>() {
-            @Override
-            public boolean matches(final Object o) {
-                return ((InferenceStats)o).getModelId().equals(model3);
-            }
-        }));
 
         // Load model 3, should invalidate 1
         for(int i = 0; i < 10; i++) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] inference only persist if there are stats (#54752)