### PR TITLE
Move Watcher config out of RestResourcesPlugin

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/rest/RestResourcesPlugin.java
@@ -89,7 +89,7 @@ public class RestResourcesPlugin implements Plugin<Project> {
 
         // tests
         Configuration testConfig = project.getConfigurations().create("restTestConfig");
-        Configuration xpackTestConfig = project.getConfigurations().create("restXpackTest");
+        Configuration xpackTestConfig = project.getConfigurations().create("restXpackTestConfig");
         project.getConfigurations().create("restTests");
         project.getConfigurations().create("restXpackTests");
         Provider<CopyRestTestsTask> copyRestYamlTestTask = project.getTasks()
@@ -108,10 +108,6 @@ public class RestResourcesPlugin implements Plugin<Project> {
                         .project(Map.of("path", ":x-pack:plugin", "configuration", "restXpackTests"));
                     project.getDependencies().add(task.xpackConfig.getName(), restXPackTestdependency);
                     task.dependsOn(task.xpackConfig);
-                    // watcher
-                    Dependency restWatcherTests = project.getDependencies()
-                        .project(Map.of("path", ":x-pack:plugin:watcher:qa:rest", "configuration", "restXpackTests"));
-                    project.getDependencies().add(task.xpackConfig.getName(), restWatcherTests);
                 } else {
                     Dependency dependency = project.getDependencies()
                         .create("org.elasticsearch:rest-api-spec:" + VersionProperties.getElasticsearch());

--- a/x-pack/plugin/watcher/qa/with-security/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-security/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'elasticsearch.rest-test'
 dependencies {
   testCompile project(':x-pack:qa')
   testCompile project(path: ':x-pack:plugin:watcher:qa:rest', configuration: 'testArtifacts')
+  restXpackTestConfig project(path: ':x-pack:plugin:watcher:qa:rest', configuration: 'restXpackTests')
 }
 
 restResources {


### PR DESCRIPTION
This commit moves Watcher out of the general purpose RestResourcesPlugin
and declares the cross project test resource dependency explicitly.
This (explicit dependencies) should be the general model for one-off 
cases such as this. 

The name of the x-pack configuration has also been updated to better match
the non-x-pack variant. 

related #53620 
