### PR TITLE
Refactor AuditTrail for TransportRequests instead of TransportMessage

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportGrantApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/TransportGrantApiKeyAction.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.CreateApiKeyResponse;
 import org.elasticsearch.xpack.core.security.action.GrantApiKeyAction;
@@ -69,11 +69,12 @@ public final class TransportGrantApiKeyAction extends HandledTransportAction<Gra
         }
     }
 
-    private void resolveAuthentication(GrantApiKeyRequest.Grant grant, TransportMessage message, ActionListener<Authentication> listener) {
+    private void resolveAuthentication(GrantApiKeyRequest.Grant grant, TransportRequest transportRequest,
+                                       ActionListener<Authentication> listener) {
         switch (grant.getType()) {
             case GrantApiKeyRequest.PASSWORD_GRANT_TYPE:
                 final UsernamePasswordToken token = new UsernamePasswordToken(grant.getUsername(), grant.getPassword());
-                authenticationService.authenticate(super.actionName, message, token, listener);
+                authenticationService.authenticate(super.actionName, transportRequest, token, listener);
                 return;
             case GrantApiKeyRequest.ACCESS_TOKEN_GRANT_TYPE:
                 tokenService.authenticateToken(grant.getAccessToken(), listener);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
@@ -7,7 +7,7 @@ package org.elasticsearch.xpack.security.audit;
 
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -24,35 +24,35 @@ public interface AuditTrail {
 
     void authenticationSuccess(String requestId, String realm, User user, RestRequest request);
 
-    void authenticationSuccess(String requestId, String realm, User user, String action, TransportMessage message);
+    void authenticationSuccess(String requestId, String realm, User user, String action, TransportRequest transportRequest);
 
-    void anonymousAccessDenied(String requestId, String action, TransportMessage message);
+    void anonymousAccessDenied(String requestId, String action, TransportRequest transportRequest);
 
     void anonymousAccessDenied(String requestId, RestRequest request);
 
     void authenticationFailed(String requestId, RestRequest request);
 
-    void authenticationFailed(String requestId, String action, TransportMessage message);
+    void authenticationFailed(String requestId, String action, TransportRequest transportRequest);
 
-    void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportMessage message);
+    void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportRequest transportRequest);
 
     void authenticationFailed(String requestId, AuthenticationToken token, RestRequest request);
 
-    void authenticationFailed(String requestId, String realm, AuthenticationToken token, String action, TransportMessage message);
+    void authenticationFailed(String requestId, String realm, AuthenticationToken token, String action, TransportRequest transportRequest);
 
     void authenticationFailed(String requestId, String realm, AuthenticationToken token, RestRequest request);
 
-    void accessGranted(String requestId, Authentication authentication, String action, TransportMessage message,
+    void accessGranted(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                        AuthorizationInfo authorizationInfo);
 
-    void accessDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+    void accessDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                       AuthorizationInfo authorizationInfo);
 
     void tamperedRequest(String requestId, RestRequest request);
 
-    void tamperedRequest(String requestId, String action, TransportMessage message);
+    void tamperedRequest(String requestId, String action, TransportRequest transportRequest);
 
-    void tamperedRequest(String requestId, User user, String action, TransportMessage request);
+    void tamperedRequest(String requestId, User user, String action, TransportRequest transportRequest);
 
     /**
      * The {@link #connectionGranted(InetAddress, String, SecurityIpFilterRule)} and
@@ -64,10 +64,10 @@ public interface AuditTrail {
 
     void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule);
 
-    void runAsGranted(String requestId, Authentication authentication, String action, TransportMessage message,
+    void runAsGranted(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                       AuthorizationInfo authorizationInfo);
 
-    void runAsDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+    void runAsDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                      AuthorizationInfo authorizationInfo);
 
     void runAsDenied(String requestId, Authentication authentication, RestRequest request,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.security.audit;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -55,10 +55,10 @@ public class AuditTrailService {
         public void authenticationSuccess(String requestId, String realm, User user, RestRequest request) {}
 
         @Override
-        public void authenticationSuccess(String requestId, String realm, User user, String action, TransportMessage message) {}
+        public void authenticationSuccess(String requestId, String realm, User user, String action, TransportRequest transportRequest) {}
 
         @Override
-        public void anonymousAccessDenied(String requestId, String action, TransportMessage message) {}
+        public void anonymousAccessDenied(String requestId, String action, TransportRequest transportRequest) {}
 
         @Override
         public void anonymousAccessDenied(String requestId, RestRequest request) {}
@@ -67,37 +67,37 @@ public class AuditTrailService {
         public void authenticationFailed(String requestId, RestRequest request) {}
 
         @Override
-        public void authenticationFailed(String requestId, String action, TransportMessage message) {}
+        public void authenticationFailed(String requestId, String action, TransportRequest transportRequest) {}
 
         @Override
-        public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportMessage message) {}
+        public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportRequest transportRequest) {}
 
         @Override
         public void authenticationFailed(String requestId, AuthenticationToken token, RestRequest request) {}
 
         @Override
         public void authenticationFailed(String requestId, String realm, AuthenticationToken token,
-                                         String action, TransportMessage message) {}
+                                         String action, TransportRequest transportRequest) {}
 
         @Override
         public void authenticationFailed(String requestId, String realm, AuthenticationToken token, RestRequest request) {}
 
         @Override
-        public void accessGranted(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void accessGranted(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                   AuthorizationInfo authorizationInfo) {}
 
         @Override
-        public void accessDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void accessDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                  AuthorizationInfo authorizationInfo) {}
 
         @Override
         public void tamperedRequest(String requestId, RestRequest request) {}
 
         @Override
-        public void tamperedRequest(String requestId, String action, TransportMessage message) {}
+        public void tamperedRequest(String requestId, String action, TransportRequest transportRequest) {}
 
         @Override
-        public void tamperedRequest(String requestId, User user, String action, TransportMessage request) {}
+        public void tamperedRequest(String requestId, User user, String action, TransportRequest transportRequest) {}
 
         @Override
         public void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {}
@@ -106,11 +106,11 @@ public class AuditTrailService {
         public void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {}
 
         @Override
-        public void runAsGranted(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void runAsGranted(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                  AuthorizationInfo authorizationInfo) {}
 
         @Override
-        public void runAsDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void runAsDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                 AuthorizationInfo authorizationInfo) {}
 
         @Override
@@ -148,16 +148,16 @@ public class AuditTrailService {
         }
 
         @Override
-        public void authenticationSuccess(String requestId, String realm, User user, String action, TransportMessage message) {
+        public void authenticationSuccess(String requestId, String realm, User user, String action, TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationSuccess(requestId, realm, user, action, message);
+                auditTrail.authenticationSuccess(requestId, realm, user, action, transportRequest);
             }
         }
 
         @Override
-        public void anonymousAccessDenied(String requestId, String action, TransportMessage message) {
+        public void anonymousAccessDenied(String requestId, String action, TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.anonymousAccessDenied(requestId, action, message);
+                auditTrail.anonymousAccessDenied(requestId, action, transportRequest);
             }
         }
 
@@ -176,24 +176,24 @@ public class AuditTrailService {
         }
 
         @Override
-        public void authenticationFailed(String requestId, String action, TransportMessage message) {
+        public void authenticationFailed(String requestId, String action, TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, action, message);
+                auditTrail.authenticationFailed(requestId, action, transportRequest);
             }
         }
 
         @Override
-        public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportMessage message) {
+        public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, token, action, message);
+                auditTrail.authenticationFailed(requestId, token, action, transportRequest);
             }
         }
 
         @Override
         public void authenticationFailed(String requestId, String realm, AuthenticationToken token, String action,
-                                         TransportMessage message) {
+                                         TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.authenticationFailed(requestId, realm, token, action, message);
+                auditTrail.authenticationFailed(requestId, realm, token, action, transportRequest);
             }
         }
 
@@ -212,7 +212,7 @@ public class AuditTrailService {
         }
 
         @Override
-        public void accessGranted(String requestId, Authentication authentication, String action, TransportMessage msg,
+        public void accessGranted(String requestId, Authentication authentication, String action, TransportRequest msg,
                                   AuthorizationInfo authorizationInfo) {
             for (AuditTrail auditTrail : auditTrails) {
                 auditTrail.accessGranted(requestId, authentication, action, msg, authorizationInfo);
@@ -220,10 +220,10 @@ public class AuditTrailService {
         }
 
         @Override
-        public void accessDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void accessDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                  AuthorizationInfo authorizationInfo) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.accessDenied(requestId, authentication, action, message, authorizationInfo);
+                auditTrail.accessDenied(requestId, authentication, action, transportRequest, authorizationInfo);
             }
         }
 
@@ -235,16 +235,16 @@ public class AuditTrailService {
         }
 
         @Override
-        public void tamperedRequest(String requestId, String action, TransportMessage message) {
+        public void tamperedRequest(String requestId, String action, TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.tamperedRequest(requestId, action, message);
+                auditTrail.tamperedRequest(requestId, action, transportRequest);
             }
         }
 
         @Override
-        public void tamperedRequest(String requestId, User user, String action, TransportMessage request) {
+        public void tamperedRequest(String requestId, User user, String action, TransportRequest transportRequest) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.tamperedRequest(requestId, user, action, request);
+                auditTrail.tamperedRequest(requestId, user, action, transportRequest);
             }
         }
 
@@ -263,18 +263,18 @@ public class AuditTrailService {
         }
 
         @Override
-        public void runAsGranted(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void runAsGranted(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                  AuthorizationInfo authorizationInfo) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.runAsGranted(requestId, authentication, action, message, authorizationInfo);
+                auditTrail.runAsGranted(requestId, authentication, action, transportRequest, authorizationInfo);
             }
         }
 
         @Override
-        public void runAsDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+        public void runAsDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                                 AuthorizationInfo authorizationInfo) {
             for (AuditTrail auditTrail : auditTrails) {
-                auditTrail.runAsDenied(requestId, authentication, action, message, authorizationInfo);
+                auditTrail.runAsDenied(requestId, authentication, action, transportRequest, authorizationInfo);
             }
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -33,7 +33,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
@@ -253,9 +253,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void authenticationSuccess(String requestId, String realm, User user, String action, TransportMessage message) {
+    public void authenticationSuccess(String requestId, String realm, User user, String action, TransportRequest transportRequest) {
         if (events.contains(AUTHENTICATION_SUCCESS)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(user), Optional.of(realm), Optional.empty(), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
@@ -263,10 +263,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .with(EVENT_ACTION_FIELD_NAME, "authentication_success")
                         .with(REALM_FIELD_NAME, realm)
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
                         .withPrincipal(user)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
@@ -277,18 +277,18 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void anonymousAccessDenied(String requestId, String action, TransportMessage message) {
+    public void anonymousAccessDenied(String requestId, String action, TransportRequest transportRequest) {
         if (events.contains(ANONYMOUS_ACCESS_DENIED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.empty(), Optional.empty(), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "anonymous_access_denied")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
@@ -317,9 +317,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportMessage message) {
+    public void authenticationFailed(String requestId, AuthenticationToken token, String action, TransportRequest transportRequest) {
         if (events.contains(AUTHENTICATION_FAILED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(token), Optional.empty(), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
@@ -327,9 +327,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
                         .with(ACTION_FIELD_NAME, action)
                         .with(PRINCIPAL_FIELD_NAME, token.principal())
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
@@ -357,18 +357,18 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void authenticationFailed(String requestId, String action, TransportMessage message) {
+    public void authenticationFailed(String requestId, String action, TransportRequest transportRequest) {
         if (events.contains(AUTHENTICATION_FAILED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.empty(), Optional.empty(), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "authentication_failed")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
@@ -398,9 +398,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void authenticationFailed(String requestId, String realm, AuthenticationToken token, String action, TransportMessage message) {
+    public void authenticationFailed(String requestId, String realm, AuthenticationToken token, String action,
+                                     TransportRequest transportRequest) {
         if (events.contains(REALM_AUTHENTICATION_FAILED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(token), Optional.of(realm), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
@@ -409,9 +410,9 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                         .with(REALM_FIELD_NAME, realm)
                         .with(PRINCIPAL_FIELD_NAME, token.principal())
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
@@ -442,7 +443,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void accessGranted(String requestId, Authentication authentication, String action, TransportMessage msg,
+    public void accessGranted(String requestId, Authentication authentication, String action, TransportRequest msg,
                               AuthorizationInfo authorizationInfo) {
         final User user = authentication.getUser();
         final boolean isSystem = SystemUser.is(user) || XPackUser.is(user);
@@ -509,20 +510,20 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void accessDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+    public void accessDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                              AuthorizationInfo authorizationInfo) {
         if (events.contains(ACCESS_DENIED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate().test(new AuditEventMetaInfo(Optional.of(authentication.getUser()),
                     Optional.of(effectiveRealmName(authentication)), Optional.of(authorizationInfo), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "access_denied")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
                         .withSubject(authentication)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .with(authorizationInfo.asMap())
                         .withOpaqueId(threadContext)
@@ -551,18 +552,18 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void tamperedRequest(String requestId, String action, TransportMessage message) {
+    public void tamperedRequest(String requestId, String action, TransportRequest transportRequest) {
         if (events.contains(TAMPERED_REQUEST)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.empty(), Optional.empty(), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "tampered_request")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
                         .withXForwardedFor(threadContext)
@@ -573,18 +574,18 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void tamperedRequest(String requestId, User user, String action, TransportMessage message) {
+    public void tamperedRequest(String requestId, User user, String action, TransportRequest transportRequest) {
         if (events.contains(TAMPERED_REQUEST)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate()
                     .test(new AuditEventMetaInfo(Optional.of(user), Optional.empty(), Optional.empty(), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "tampered_request")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .withPrincipal(user)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .withOpaqueId(threadContext)
@@ -632,20 +633,20 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void runAsGranted(String requestId, Authentication authentication, String action, TransportMessage message,
+    public void runAsGranted(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                              AuthorizationInfo authorizationInfo) {
         if (events.contains(RUN_AS_GRANTED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate().test(new AuditEventMetaInfo(Optional.of(authentication.getUser()),
                     Optional.of(effectiveRealmName(authentication)), Optional.of(authorizationInfo), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "run_as_granted")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
                         .withRunAsSubject(authentication)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .with(authorizationInfo.asMap())
                         .withOpaqueId(threadContext)
@@ -657,20 +658,20 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void runAsDenied(String requestId, Authentication authentication, String action, TransportMessage message,
+    public void runAsDenied(String requestId, Authentication authentication, String action, TransportRequest transportRequest,
                             AuthorizationInfo authorizationInfo) {
         if (events.contains(RUN_AS_DENIED)) {
-            final Optional<String[]> indices = indices(message);
+            final Optional<String[]> indices = indices(transportRequest);
             if (eventFilterPolicyRegistry.ignorePredicate().test(new AuditEventMetaInfo(Optional.of(authentication.getUser()),
                     Optional.of(effectiveRealmName(authentication)), Optional.of(authorizationInfo), indices)) == false) {
                 final StringMapMessage logEntry = new LogEntryBuilder()
                         .with(EVENT_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                         .with(EVENT_ACTION_FIELD_NAME, "run_as_denied")
                         .with(ACTION_FIELD_NAME, action)
-                        .with(REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                        .with(REQUEST_NAME_FIELD_NAME, transportRequest.getClass().getSimpleName())
                         .withRequestId(requestId)
                         .withRunAsSubject(authentication)
-                        .withRestOrTransportOrigin(message, threadContext)
+                        .withRestOrTransportOrigin(transportRequest, threadContext)
                         .with(INDICES_FIELD_NAME, indices.orElse(null))
                         .with(authorizationInfo.asMap())
                         .withOpaqueId(threadContext)
@@ -749,14 +750,14 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             return this;
         }
 
-        LogEntryBuilder withRestOrTransportOrigin(TransportMessage message, ThreadContext threadContext) {
+        LogEntryBuilder withRestOrTransportOrigin(TransportRequest transportRequest, ThreadContext threadContext) {
             assert LOCAL_ORIGIN_FIELD_VALUE.equals(logEntry.get(ORIGIN_TYPE_FIELD_NAME)); // this is the default
             final InetSocketAddress restAddress = RemoteHostHeader.restRemoteAddress(threadContext);
             if (restAddress != null) {
                 logEntry.with(ORIGIN_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                         .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(restAddress));
             } else {
-                final TransportAddress address = message.remoteAddress();
+                final TransportAddress address = transportRequest.remoteAddress();
                 if (address != null) {
                     logEntry.with(ORIGIN_TYPE_FIELD_NAME, TRANSPORT_ORIGIN_FIELD_VALUE)
                             .with(ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address.address()));
@@ -870,11 +871,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
 
-    private static Optional<String[]> indices(TransportMessage message) {
-        if (message instanceof IndicesRequest) {
-            final String[] indices = ((IndicesRequest) message).indices();
+    private static Optional<String[]> indices(TransportRequest transportRequest) {
+        if (transportRequest instanceof IndicesRequest) {
+            final String[] indices = ((IndicesRequest) transportRequest).indices();
             if (indices != null) {
-                return Optional.of(((IndicesRequest) message).indices());
+                return Optional.of(((IndicesRequest) transportRequest).indices());
             }
         }
         return Optional.empty();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -8,7 +8,7 @@ package org.elasticsearch.xpack.security.audit;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
@@ -35,7 +35,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     private AuditTrailService service;
 
     private AuthenticationToken token;
-    private TransportMessage message;
+    private TransportRequest request;
     private RestRequest restRequest;
     private XPackLicenseState licenseState;
     private boolean isAuditingAllowed;
@@ -52,17 +52,17 @@ public class AuditTrailServiceTests extends ESTestCase {
         isAuditingAllowed = randomBoolean();
         when(licenseState.isAuditingAllowed()).thenReturn(isAuditingAllowed);
         token = mock(AuthenticationToken.class);
-        message = mock(TransportMessage.class);
+        request = mock(TransportRequest.class);
         restRequest = mock(RestRequest.class);
     }
 
     public void testAuthenticationFailed() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().authenticationFailed(requestId, token, "_action", message);
+        service.get().authenticationFailed(requestId, token, "_action", request);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, token, "_action", message);
+                verify(auditTrail).authenticationFailed(requestId, token, "_action", request);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
@@ -71,11 +71,11 @@ public class AuditTrailServiceTests extends ESTestCase {
 
     public void testAuthenticationFailedNoToken() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().authenticationFailed(requestId, "_action", message);
+        service.get().authenticationFailed(requestId, "_action", request);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, "_action", message);
+                verify(auditTrail).authenticationFailed(requestId, "_action", request);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
@@ -110,11 +110,11 @@ public class AuditTrailServiceTests extends ESTestCase {
 
     public void testAuthenticationFailedRealm() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().authenticationFailed(requestId, "_realm", token, "_action", message);
+        service.get().authenticationFailed(requestId, "_realm", token, "_action", request);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationFailed(requestId, "_realm", token, "_action", message);
+                verify(auditTrail).authenticationFailed(requestId, "_realm", token, "_action", request);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
@@ -136,11 +136,11 @@ public class AuditTrailServiceTests extends ESTestCase {
 
     public void testAnonymousAccess() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().anonymousAccessDenied(requestId, "_action", message);
+        service.get().anonymousAccessDenied(requestId, "_action", request);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).anonymousAccessDenied(requestId, "_action", message);
+                verify(auditTrail).anonymousAccessDenied(requestId, "_action", request);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
@@ -153,11 +153,11 @@ public class AuditTrailServiceTests extends ESTestCase {
         AuthorizationInfo authzInfo =
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().accessGranted(requestId, authentication, "_action", message, authzInfo);
+        service.get().accessGranted(requestId, authentication, "_action", request, authzInfo);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).accessGranted(requestId, authentication, "_action", message, authzInfo);
+                verify(auditTrail).accessGranted(requestId, authentication, "_action", request, authzInfo);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
@@ -170,11 +170,11 @@ public class AuditTrailServiceTests extends ESTestCase {
         AuthorizationInfo authzInfo =
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().accessDenied(requestId, authentication, "_action", message, authzInfo);
+        service.get().accessDenied(requestId, authentication, "_action", request, authzInfo);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).accessDenied(requestId, authentication, "_action", message, authzInfo);
+                verify(auditTrail).accessDenied(requestId, authentication, "_action", request, authzInfo);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));
@@ -228,11 +228,11 @@ public class AuditTrailServiceTests extends ESTestCase {
         User user = new User("_username", "r1");
         String realm = "_realm";
         final String requestId = randomAlphaOfLengthBetween(6, 12);
-        service.get().authenticationSuccess(requestId, realm, user, "_action", message);
+        service.get().authenticationSuccess(requestId, realm, user, "_action", request);
         verify(licenseState).isAuditingAllowed();
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
-                verify(auditTrail).authenticationSuccess(requestId, realm, user, "_action", message);
+                verify(auditTrail).authenticationSuccess(requestId, realm, user, "_action", request);
             }
         } else {
             verifyZeroInteractions(auditTrails.toArray((Object[]) new AuditTrail[auditTrails.size()]));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -32,7 +32,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest.Builder;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.audit.logfile.CapturingLogger;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
@@ -259,18 +259,18 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testAnonymousAccessDeniedTransport() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
 
         final String requestId = randomRequestId();
-        auditTrail.anonymousAccessDenied(requestId, "_action", message);
+        auditTrail.anonymousAccessDenied(requestId, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
             .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "anonymous_access_denied")
             .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
             .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
-        indicesRequest(message, checkedFields, checkedArrayFields);
-        restOrTransportOrigin(message, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -282,7 +282,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "anonymous_access_denied")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.anonymousAccessDenied(requestId, "_action", message);
+        auditTrail.anonymousAccessDenied(requestId, "_action", request);
         assertEmptyLog(logger);
     }
 
@@ -323,20 +323,20 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
     public void testAuthenticationFailed() throws Exception {
         final AuthenticationToken mockToken = new MockToken();
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
 
         final String requestId = randomRequestId();
-        auditTrail.authenticationFailed(requestId, mockToken, "_action", message);
+        auditTrail.authenticationFailed(requestId, mockToken, "_action", request);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                      .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "authentication_failed")
                      .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
                      .put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, mockToken.principal())
-                     .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                     .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                      .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -348,24 +348,24 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "authentication_failed")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.authenticationFailed(requestId, new MockToken(), "_action", message);
+        auditTrail.authenticationFailed(requestId, new MockToken(), "_action", request);
         assertEmptyLog(logger);
     }
 
     public void testAuthenticationFailedNoToken() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
 
         final String requestId = randomRequestId();
-        auditTrail.authenticationFailed(requestId, "_action", message);
+        auditTrail.authenticationFailed(requestId, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                      .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "authentication_failed")
                      .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                     .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                     .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                      .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -377,7 +377,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "authentication_failed")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.authenticationFailed(requestId, "_action", message);
+        auditTrail.authenticationFailed(requestId, "_action", request);
         assertEmptyLog(logger);
     }
 
@@ -469,10 +469,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
 
     public void testAuthenticationFailedRealm() throws Exception {
         final AuthenticationToken mockToken = new MockToken();
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String realm = randomAlphaOfLengthBetween(1, 6);
         final String requestId = randomRequestId();
-        auditTrail.authenticationFailed(requestId, realm, mockToken, "_action", message);
+        auditTrail.authenticationFailed(requestId, realm, mockToken, "_action", request);
         assertEmptyLog(logger);
 
         // test enabled
@@ -481,7 +481,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                        .put("xpack.security.audit.logfile.events.include", "realm_authentication_failed")
                        .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.authenticationFailed(requestId, realm, mockToken, "_action", message);
+        auditTrail.authenticationFailed(requestId, realm, mockToken, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
@@ -489,10 +489,10 @@ public class LoggingAuditTrailTests extends ESTestCase {
                      .put(LoggingAuditTrail.REALM_FIELD_NAME, realm)
                      .put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, mockToken.principal())
                      .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                     .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                     .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                      .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -543,24 +543,24 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testAccessGranted() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
         final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
         final Authentication authentication = createAuthentication();
         final String requestId = randomRequestId();
 
-        auditTrail.accessGranted(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.accessGranted(requestId, authentication, "_action", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "access_granted")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedArrayFields.put(PRINCIPAL_ROLES_FIELD_NAME, (String[]) authorizationInfo.asMap().get(PRINCIPAL_ROLES_FIELD_NAME));
         subject(authentication, checkedFields);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -572,17 +572,17 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "access_granted")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.accessGranted(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.accessGranted(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
 
     public void testAccessGrantedInternalSystemAction() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
         final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
         final Authentication authentication = new Authentication(SystemUser.INSTANCE, new RealmRef("_reserved", "test", "foo"), null);
         final String requestId = randomRequestId();
-        auditTrail.accessGranted(requestId, authentication, "internal:_action", message, authorizationInfo);
+        auditTrail.accessGranted(requestId, authentication, "internal:_action", request, authorizationInfo);
         assertEmptyLog(logger);
 
         // test enabled
@@ -591,7 +591,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.include", "system_access_granted")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.accessGranted(requestId, authentication, "internal:_action", message, authorizationInfo);
+        auditTrail.accessGranted(requestId, authentication, "internal:_action", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
@@ -599,35 +599,35 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, SystemUser.INSTANCE.principal())
                 .put(LoggingAuditTrail.PRINCIPAL_REALM_FIELD_NAME, "_reserved")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "internal:_action")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedArrayFields.put(PRINCIPAL_ROLES_FIELD_NAME, (String[]) authorizationInfo.asMap().get(PRINCIPAL_ROLES_FIELD_NAME));
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
     }
 
     public void testAccessGrantedInternalSystemActionNonSystemUser() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
         final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
         final Authentication authentication = createAuthentication();
         final String requestId = randomRequestId();
 
-        auditTrail.accessGranted(requestId, authentication, "internal:_action", message, authorizationInfo);
+        auditTrail.accessGranted(requestId, authentication, "internal:_action", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
             .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "access_granted")
             .put(LoggingAuditTrail.ACTION_FIELD_NAME, "internal:_action")
-            .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+            .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
             .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedArrayFields.put(PRINCIPAL_ROLES_FIELD_NAME, (String[]) authorizationInfo.asMap().get(PRINCIPAL_ROLES_FIELD_NAME));
         subject(authentication, checkedFields);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -639,29 +639,29 @@ public class LoggingAuditTrailTests extends ESTestCase {
                     .put("xpack.security.audit.logfile.events.exclude", "access_granted")
                     .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.accessGranted(requestId, authentication, "internal:_action", message, authorizationInfo);
+        auditTrail.accessGranted(requestId, authentication, "internal:_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
 
     public void testAccessDenied() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
         final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
         final Authentication authentication = createAuthentication();
         final String requestId = randomRequestId();
 
-        auditTrail.accessDenied(requestId, authentication, "_action/bar", message, authorizationInfo);
+        auditTrail.accessDenied(requestId, authentication, "_action/bar", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "access_denied")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action/bar")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedArrayFields.put(PRINCIPAL_ROLES_FIELD_NAME, (String[]) authorizationInfo.asMap().get(PRINCIPAL_ROLES_FIELD_NAME));
         subject(authentication, checkedFields);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
 
@@ -674,7 +674,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "access_denied")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.accessDenied(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.accessDenied(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
 
@@ -720,19 +720,19 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testTamperedRequest() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
 
         final String requestId = randomRequestId();
-        auditTrail.tamperedRequest(requestId, "_action", message);
+        auditTrail.tamperedRequest(requestId, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "tampered_request")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -744,12 +744,12 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "tampered_request")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.tamperedRequest(requestId, "_action", message);
+        auditTrail.tamperedRequest(requestId, "_action", request);
         assertEmptyLog(logger);
     }
 
     public void testTamperedRequestWithUser() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final boolean runAs = randomBoolean();
         final User user;
         if (runAs) {
@@ -759,13 +759,13 @@ public class LoggingAuditTrailTests extends ESTestCase {
         }
 
         final String requestId = randomRequestId();
-        auditTrail.tamperedRequest(requestId, user, "_action", message);
+        auditTrail.tamperedRequest(requestId, user, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "tampered_request")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         if (runAs) {
             checkedFields.put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, "running_as");
@@ -773,8 +773,8 @@ public class LoggingAuditTrailTests extends ESTestCase {
         } else {
             checkedFields.put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, "_username");
         }
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -786,7 +786,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "tampered_request")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.tamperedRequest(requestId, user, "_action", message);
+        auditTrail.tamperedRequest(requestId, user, "_action", request);
         assertEmptyLog(logger);
     }
 
@@ -850,7 +850,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testRunAsGranted() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
         final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
         final Authentication authentication = new Authentication(
@@ -859,7 +859,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 new RealmRef("lookRealm", "up", "by"));
         final String requestId = randomRequestId();
 
-        auditTrail.runAsGranted(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.runAsGranted(requestId, authentication, "_action", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
@@ -869,11 +869,11 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put(LoggingAuditTrail.PRINCIPAL_RUN_AS_FIELD_NAME, "running as")
                 .put(LoggingAuditTrail.PRINCIPAL_RUN_AS_REALM_FIELD_NAME, "lookRealm")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedArrayFields.put(PRINCIPAL_ROLES_FIELD_NAME, (String[]) authorizationInfo.asMap().get(PRINCIPAL_ROLES_FIELD_NAME));
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -885,12 +885,12 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "run_as_granted")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.runAsGranted(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.runAsGranted(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
 
     public void testRunAsDenied() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
         final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
         final Authentication authentication = new Authentication(
@@ -899,7 +899,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 new RealmRef("lookRealm", "up", "by"));
         final String requestId = randomRequestId();
 
-        auditTrail.runAsDenied(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.runAsDenied(requestId, authentication, "_action", request, authorizationInfo);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
@@ -909,11 +909,11 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put(LoggingAuditTrail.PRINCIPAL_RUN_AS_FIELD_NAME, "running as")
                 .put(LoggingAuditTrail.PRINCIPAL_RUN_AS_REALM_FIELD_NAME, "lookRealm")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         checkedArrayFields.put(PRINCIPAL_ROLES_FIELD_NAME, (String[]) authorizationInfo.asMap().get(PRINCIPAL_ROLES_FIELD_NAME));
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -925,7 +925,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.exclude", "run_as_denied")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.runAsDenied(requestId, authentication, "_action", message, authorizationInfo);
+        auditTrail.runAsDenied(requestId, authentication, "_action", request, authorizationInfo);
         assertEmptyLog(logger);
     }
 
@@ -986,7 +986,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testAuthenticationSuccessTransport() throws Exception {
-        final TransportMessage message = randomBoolean() ? new MockMessage(threadContext) : new MockIndicesRequest(threadContext);
+        final TransportRequest request = randomBoolean() ? new MockRequest(threadContext) : new MockIndicesRequest(threadContext);
         final User user;
         if (randomBoolean()) {
             user = new User("running as", new String[] { "r2" }, new User("_username", new String[] { "r1" }));
@@ -997,7 +997,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         final String requestId = randomRequestId();
 
         // event by default disabled
-        auditTrail.authenticationSuccess(requestId, realm, user, "_action", message);
+        auditTrail.authenticationSuccess(requestId, realm, user, "_action", request);
         assertEmptyLog(logger);
 
         settings = Settings.builder()
@@ -1005,14 +1005,14 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 .put("xpack.security.audit.logfile.events.include", "authentication_success")
                 .build();
         auditTrail = new LoggingAuditTrail(settings, clusterService, logger, threadContext);
-        auditTrail.authenticationSuccess(requestId, realm, user, "_action", message);
+        auditTrail.authenticationSuccess(requestId, realm, user, "_action", request);
         final MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
         final MapBuilder<String, String[]> checkedArrayFields = new MapBuilder<>();
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                 .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "authentication_success")
                 .put(LoggingAuditTrail.ACTION_FIELD_NAME, "_action")
                 .put(LoggingAuditTrail.REALM_FIELD_NAME, realm)
-                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, message.getClass().getSimpleName())
+                .put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, request.getClass().getSimpleName())
                 .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         if (user.isRunAs()) {
             checkedFields.put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, "running as");
@@ -1020,8 +1020,8 @@ public class LoggingAuditTrailTests extends ESTestCase {
         } else {
             checkedFields.put(LoggingAuditTrail.PRINCIPAL_FIELD_NAME, "_username");
         }
-        restOrTransportOrigin(message, threadContext, checkedFields);
-        indicesRequest(message, checkedFields, checkedArrayFields);
+        restOrTransportOrigin(request, threadContext, checkedFields);
+        indicesRequest(request, checkedFields, checkedArrayFields);
         opaqueId(threadContext, checkedFields);
         forwardedFor(threadContext, checkedFields);
         assertMsg(logger, checkedFields.immutableMap(), checkedArrayFields.immutableMap());
@@ -1038,43 +1038,43 @@ public class LoggingAuditTrailTests extends ESTestCase {
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String realm = randomAlphaOfLengthBetween(1, 6);
         // transport messages without indices
-        final TransportMessage[] messages = new TransportMessage[] { new MockMessage(threadContext),
+        final TransportRequest[] requests = new TransportRequest[] { new MockRequest(threadContext),
                 new org.elasticsearch.action.MockIndicesRequest(IndicesOptions.strictExpandOpenAndForbidClosed(), new String[0]),
                 new org.elasticsearch.action.MockIndicesRequest(IndicesOptions.strictExpandOpenAndForbidClosed(), (String[]) null) };
         final List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
         int logEntriesCount = 1;
-        for (final TransportMessage message : messages) {
-            auditTrail.anonymousAccessDenied("_req_id", "_action", message);
+        for (final TransportRequest request : requests) {
+            auditTrail.anonymousAccessDenied("_req_id", "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.authenticationFailed("_req_id", new MockToken(), "_action", message);
+            auditTrail.authenticationFailed("_req_id", new MockToken(), "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.authenticationFailed("_req_id", "_action", message);
+            auditTrail.authenticationFailed("_req_id", "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.authenticationFailed("_req_id", realm, new MockToken(), "_action", message);
+            auditTrail.authenticationFailed("_req_id", realm, new MockToken(), "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.accessGranted("_req_id", createAuthentication(), "_action", message, authorizationInfo);
+            auditTrail.accessGranted("_req_id", createAuthentication(), "_action", request, authorizationInfo);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.accessDenied("_req_id", createAuthentication(), "_action", message, authorizationInfo);
+            auditTrail.accessDenied("_req_id", createAuthentication(), "_action", request, authorizationInfo);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.tamperedRequest("_req_id", "_action", message);
+            auditTrail.tamperedRequest("_req_id", "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.tamperedRequest("_req_id", user, "_action", message);
+            auditTrail.tamperedRequest("_req_id", user, "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.runAsGranted("_req_id", createAuthentication(), "_action", message, authorizationInfo);
+            auditTrail.runAsGranted("_req_id", createAuthentication(), "_action", request, authorizationInfo);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.runAsDenied("_req_id", createAuthentication(), "_action", message, authorizationInfo);
+            auditTrail.runAsDenied("_req_id", createAuthentication(), "_action", request, authorizationInfo);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
-            auditTrail.authenticationSuccess("_req_id", realm, user, "_action", message);
+            auditTrail.authenticationSuccess("_req_id", realm, user, "_action", request);
             assertThat(output.size(), is(logEntriesCount++));
             assertThat(output.get(logEntriesCount - 2), not(containsString("indices=")));
         }
@@ -1191,9 +1191,9 @@ public class LoggingAuditTrailTests extends ESTestCase {
         return new ClusterSettings(settings, new HashSet<>(settingsList));
     }
 
-    static class MockMessage extends TransportMessage {
+    static class MockRequest extends TransportRequest {
 
-        MockMessage(ThreadContext threadContext) throws IOException {
+        MockRequest(ThreadContext threadContext) throws IOException {
             if (randomBoolean()) {
                 if (randomBoolean()) {
                     remoteAddress(buildNewFakeTransportAddress());
@@ -1254,14 +1254,14 @@ public class LoggingAuditTrailTests extends ESTestCase {
         return randomBoolean() ? randomAlphaOfLengthBetween(8, 24) : AuditUtil.generateRequestId(threadContext);
     }
 
-    private static void restOrTransportOrigin(TransportMessage message, ThreadContext threadContext,
+    private static void restOrTransportOrigin(TransportRequest request, ThreadContext threadContext,
                                               MapBuilder<String, String> checkedFields) {
         final InetSocketAddress restAddress = RemoteHostHeader.restRemoteAddress(threadContext);
         if (restAddress != null) {
             checkedFields.put(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME, LoggingAuditTrail.REST_ORIGIN_FIELD_VALUE)
                     .put(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(restAddress));
         } else {
-            final TransportAddress address = message.remoteAddress();
+            final TransportAddress address = request.remoteAddress();
             if (address != null) {
                 checkedFields.put(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME, LoggingAuditTrail.TRANSPORT_ORIGIN_FIELD_VALUE)
                         .put(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address.address()));
@@ -1294,13 +1294,13 @@ public class LoggingAuditTrailTests extends ESTestCase {
         }
     }
 
-    private static void indicesRequest(TransportMessage message, MapBuilder<String, String> checkedFields,
+    private static void indicesRequest(TransportRequest request, MapBuilder<String, String> checkedFields,
                                        MapBuilder<String, String[]> checkedArrayFields) {
-        if (message instanceof IndicesRequest) {
+        if (request instanceof IndicesRequest) {
             checkedFields.put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, MockIndicesRequest.class.getSimpleName());
-            checkedArrayFields.put(LoggingAuditTrail.INDICES_FIELD_NAME, ((IndicesRequest) message).indices());
+            checkedArrayFields.put(LoggingAuditTrail.INDICES_FIELD_NAME, ((IndicesRequest) request).indices());
         } else {
-            checkedFields.put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, MockMessage.class.getSimpleName());
+            checkedFields.put(LoggingAuditTrail.REQUEST_NAME_FIELD_NAME, MockRequest.class.getSimpleName());
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -54,7 +54,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
@@ -143,7 +143,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     private static final String FIRST_REALM_NAME = "file_realm";
     private static final String FIRST_REALM_TYPE = "file";
     private AuthenticationService service;
-    private TransportMessage message;
+    private TransportRequest transportRequest;
     private RestRequest restRequest;
     private Realms realms;
     private Realm firstRealm;
@@ -169,9 +169,9 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         token = mock(AuthenticationToken.class);
         when(token.principal()).thenReturn(randomAlphaOfLength(5));
-        message = new InternalMessage();
+        transportRequest = new InternalRequest();
         remoteAddress = new InetSocketAddress(InetAddress.getLocalHost(), 100);
-        message.remoteAddress(new TransportAddress(remoteAddress));
+        transportRequest.remoteAddress(new TransportAddress(remoteAddress));
         restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withRemoteAddress(remoteAddress).build();
         threadContext = new ThreadContext(Settings.EMPTY);
 
@@ -259,7 +259,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(secondRealm.token(threadContext)).thenReturn(token);
 
         PlainActionFuture<Authentication> future = new PlainActionFuture<>();
-        Authenticator authenticator = service.createAuthenticator("_action", message, true, future);
+        Authenticator authenticator = service.createAuthenticator("_action", transportRequest, true, future);
         authenticator.extractToken((result) -> {
             assertThat(result, notNullValue());
             assertThat(result, is(token));
@@ -270,7 +270,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     public void testTokenMissing() throws Exception {
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
         PlainActionFuture<Authentication> future = new PlainActionFuture<>();
-        Authenticator authenticator = service.createAuthenticator("_action", message, true, future);
+        Authenticator authenticator = service.createAuthenticator("_action", transportRequest, true, future);
         authenticator.extractToken((token) -> {
             assertThat(token, nullValue());
             authenticator.handleNullToken();
@@ -278,7 +278,7 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, () -> future.actionGet());
         assertThat(e.getMessage(), containsString("missing authentication credentials"));
-        verify(auditTrail).anonymousAccessDenied(reqId, "_action", message);
+        verify(auditTrail).anonymousAccessDenied(reqId, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
     }
 
@@ -296,7 +296,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         final AtomicBoolean completed = new AtomicBoolean(false);
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -306,7 +306,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             setCompletedToTrue(completed);
         }, this::logAndFail));
         assertTrue(completed.get());
-        verify(auditTrail).authenticationFailed(reqId, firstRealm.name(), token, "_action", message);
+        verify(auditTrail).authenticationFailed(reqId, firstRealm.name(), token, "_action", transportRequest);
         verify(realms).asList();
         verifyNoMoreInteractions(realms);
     }
@@ -322,7 +322,7 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         // Authenticate against the normal chain. 1st Realm will be checked (and not pass) then 2nd realm will successfully authc
         final AtomicBoolean completed = new AtomicBoolean(false);
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -338,7 +338,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         // Authenticate against the smart chain.
         // "SecondRealm" will be at the top of the list and will successfully authc.
         // "FirstRealm" will not be used
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -349,8 +349,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             setCompletedToTrue(completed);
         }, this::logAndFail));
 
-        verify(auditTrail).authenticationFailed(reqId, firstRealm.name(), token, "_action", message);
-        verify(auditTrail, times(2)).authenticationSuccess(reqId, secondRealm.name(), user, "_action", message);
+        verify(auditTrail).authenticationFailed(reqId, firstRealm.name(), token, "_action", transportRequest);
+        verify(auditTrail, times(2)).authenticationSuccess(reqId, secondRealm.name(), user, "_action", transportRequest);
         verify(firstRealm, times(2)).name(); // used above one time
         verify(secondRealm, times(3)).name(); // used above one time
         verify(secondRealm, times(2)).type(); // used to create realm ref
@@ -370,7 +370,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         // This will authenticate against the smart chain.
         // "SecondRealm" will be at the top of the list but will no longer authenticate the user.
         // Then "FirstRealm" will be checked.
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -381,8 +381,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             setCompletedToTrue(completed);
         }, this::logAndFail));
 
-        verify(auditTrail, times(1)).authenticationFailed(reqId, SECOND_REALM_NAME, token, "_action", message);
-        verify(auditTrail, times(1)).authenticationSuccess(reqId, FIRST_REALM_NAME, user, "_action", message);
+        verify(auditTrail, times(1)).authenticationFailed(reqId, SECOND_REALM_NAME, token, "_action", transportRequest);
+        verify(auditTrail, times(1)).authenticationSuccess(reqId, FIRST_REALM_NAME, user, "_action", transportRequest);
         verify(secondRealm, times(3)).authenticate(eq(token), any(ActionListener.class)); // 2 from above + 1 more
         verify(firstRealm, times(2)).authenticate(eq(token), any(ActionListener.class)); // 1 from above + 1 more
     }
@@ -439,7 +439,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         final AtomicBoolean completed = new AtomicBoolean(false);
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -450,7 +450,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         assertTrue(completed.get());
 
         completed.set(false);
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -458,8 +458,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThreadContextContainsAuthentication(result);
             setCompletedToTrue(completed);
         }, this::logAndFail));
-        verify(auditTrail, times(2)).authenticationFailed(reqId, firstRealm.name(), token, "_action", message);
-        verify(auditTrail, times(2)).authenticationSuccess(reqId, secondRealm.name(), user, "_action", message);
+        verify(auditTrail, times(2)).authenticationFailed(reqId, firstRealm.name(), token, "_action", transportRequest);
+        verify(auditTrail, times(2)).authenticationSuccess(reqId, secondRealm.name(), user, "_action", transportRequest);
         verify(firstRealm, times(3)).name(); // used above one time
         verify(secondRealm, times(3)).name(); // used above one time
         verify(secondRealm, times(2)).type(); // used to create realm ref
@@ -481,14 +481,14 @@ public class AuthenticationServiceTests extends ESTestCase {
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         final AtomicBoolean completed = new AtomicBoolean(false);
-        service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+        service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
             assertThat(result, notNullValue());
             assertThat(result.getUser(), is(user));
             assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
             assertThreadContextContainsAuthentication(result);
             setCompletedToTrue(completed);
         }, this::logAndFail));
-        verify(auditTrail).authenticationSuccess(reqId, secondRealm.name(), user, "_action", message);
+        verify(auditTrail).authenticationSuccess(reqId, secondRealm.name(), user, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
         verify(firstRealm, never()).authenticate(eq(token), any(ActionListener.class));
         assertTrue(completed.get());
@@ -498,7 +498,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         final Authentication authentication = new Authentication(new User("_username", "r1"), new RealmRef("test", "cached", "foo"), null);
         authentication.writeToContext(threadContext);
 
-        Authentication result = authenticateBlocking("_action", message, null);
+        Authentication result = authenticateBlocking("_action", transportRequest, null);
 
         assertThat(result, notNullValue());
         assertThat(result, is(authentication));
@@ -535,7 +535,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(firstRealm.supports(token)).thenReturn(true);
         mockAuthenticate(firstRealm, token, user);
 
-        Authentication result = authenticateBlocking("_action", message, null);
+        Authentication result = authenticateBlocking("_action", transportRequest, null);
 
         assertThat(result, notNullValue());
         assertThat(result.getUser(), is(user));
@@ -554,13 +554,13 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(secondRealm.token(threadContext)).thenReturn(null);
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
         try {
-            authenticateBlocking("_action", message, null);
+            authenticateBlocking("_action", transportRequest, null);
             fail("expected an authentication exception when trying to authenticate an anonymous message");
         } catch (ElasticsearchSecurityException e) {
             // expected
             assertAuthenticationException(e);
         }
-        verify(auditTrail).anonymousAccessDenied(reqId, "_action", message);
+        verify(auditTrail).anonymousAccessDenied(reqId, "_action", transportRequest);
     }
 
     public void testAuthenticateRestAnonymous()  throws Exception {
@@ -582,7 +582,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(secondRealm.token(threadContext)).thenReturn(null);
         User user1 = new User("username", "r1", "r2");
 
-        Authentication result = authenticateBlocking("_action", message, user1);
+        Authentication result = authenticateBlocking("_action", transportRequest, user1);
         assertThat(result, notNullValue());
         assertThat(result.getUser(), sameInstance(user1));
         assertThat(result.getAuthenticationType(), is(AuthenticationType.INTERNAL));
@@ -598,8 +598,8 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(firstRealm, token, user);
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", message, fallback));
-        verify(auditTrail).authenticationFailed(reqId, token, "_action", message);
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, fallback));
+        verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
         assertAuthenticationException(e);
     }
@@ -623,9 +623,9 @@ public class AuthenticationServiceTests extends ESTestCase {
         final User user = new User("username", "r1", "r2");
         final Consumer<ActionListener<Authentication>> authenticate;
         if (randomBoolean()) {
-            authenticate = listener -> service.authenticate("_action", message, SystemUser.INSTANCE, listener);
+            authenticate = listener -> service.authenticate("_action", transportRequest, SystemUser.INSTANCE, listener);
         } else {
-            authenticate = listener -> service.authenticate("_action", message, true, listener);
+            authenticate = listener -> service.authenticate("_action", transportRequest, true, listener);
         }
         when(firstRealm.token(threadContext)).thenReturn(token);
         when(firstRealm.supports(token)).thenReturn(true);
@@ -640,7 +640,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             setCompletedToTrue(completed);
         }, this::logAndFail));
 
-        verify(auditTrail).authenticationSuccess(reqId, firstRealm.name(), user, "_action", message);
+        verify(auditTrail).authenticationSuccess(reqId, firstRealm.name(), user, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
         assertTrue(completed.get());
     }
@@ -674,7 +674,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         final SetOnce<Authentication> authRef = new SetOnce<>();
         final SetOnce<String> authHeaderRef = new SetOnce<>();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-            service.authenticate("_action", message, SystemUser.INSTANCE, ActionListener.wrap(authentication -> {
+            service.authenticate("_action", transportRequest, SystemUser.INSTANCE, ActionListener.wrap(authentication -> {
                     assertThat(authentication, notNullValue());
                     assertThat(authentication.getUser(), sameInstance(user1));
                     assertThat(authentication.getAuthenticationType(), is(AuthenticationType.REALM));
@@ -688,7 +688,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         reset(firstRealm);
 
         // checking authentication from the context
-        InternalMessage message1 = new InternalMessage();
+        InternalRequest message1 = new InternalRequest();
         ThreadPool threadPool1 = new TestThreadPool("testAutheticateTransportContextAndHeader1");
         try {
             ThreadContext threadContext1 = threadPool1.getThreadContext();
@@ -733,7 +733,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             service = new AuthenticationService(Settings.EMPTY, realms, auditTrailService,
                 new DefaultAuthenticationFailureHandler(Collections.emptyMap()), threadPool2, new AnonymousUser(Settings.EMPTY),
                 tokenService, apiKeyService);
-            service.authenticate("_action", new InternalMessage(), SystemUser.INSTANCE, ActionListener.wrap(result -> {
+            service.authenticate("_action", new InternalRequest(), SystemUser.INSTANCE, ActionListener.wrap(result -> {
                     assertThat(result, notNullValue());
                     assertThat(result.getUser(), equalTo(user1));
                     assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
@@ -747,7 +747,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     }
 
     public void testAuthenticateTamperedUser() throws Exception {
-        InternalMessage message = new InternalMessage();
+        InternalRequest message = new InternalRequest();
         threadContext.putHeader(AuthenticationField.AUTHENTICATION_KEY, "_signed_auth");
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
 
@@ -776,8 +776,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
             threadContext.putHeader("Authorization", "Bearer thisisaninvalidtoken");
             ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", message, null));
-            verify(auditTrail).anonymousAccessDenied(reqId, "_action", message);
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+            verify(auditTrail).anonymousAccessDenied(reqId, "_action", transportRequest);
             verifyNoMoreInteractions(auditTrail);
             assertAuthenticationException(e);
         }
@@ -806,8 +806,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
             threadContext.putHeader("Authorization", "ApiKey dGhpc2lzYW5pbnZhbGlkaWQ6dGhpc2lzYW5pbnZhbGlkc2VjcmV0");
             ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", message, null));
-            verify(auditTrail).anonymousAccessDenied(reqId, "_action", message);
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
+            verify(auditTrail).anonymousAccessDenied(reqId, "_action", transportRequest);
             verifyNoMoreInteractions(auditTrail);
             assertAuthenticationException(e);
         }
@@ -874,7 +874,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         service = new AuthenticationService(settings, realms, auditTrailService,
             new DefaultAuthenticationFailureHandler(Collections.emptyMap()),
             threadPool, anonymousUser, tokenService, apiKeyService);
-        InternalMessage message = new InternalMessage();
+        InternalRequest message = new InternalRequest();
 
         Authentication result = authenticateBlocking("_action", message, null);
         assertThat(result, notNullValue());
@@ -892,7 +892,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             new DefaultAuthenticationFailureHandler(Collections.emptyMap()),
             threadPool, anonymousUser, tokenService, apiKeyService);
 
-        InternalMessage message = new InternalMessage();
+        InternalRequest message = new InternalRequest();
 
         Authentication result = authenticateBlocking("_action", message, SystemUser.INSTANCE);
         assertThat(result, notNullValue());
@@ -905,11 +905,11 @@ public class AuthenticationServiceTests extends ESTestCase {
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
         when(firstRealm.token(threadContext)).thenThrow(authenticationError("realm doesn't like tokens"));
         try {
-            authenticateBlocking("_action", message, null);
+            authenticateBlocking("_action", transportRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like tokens"));
-            verify(auditTrail).authenticationFailed(reqId, "_action", message);
+            verify(auditTrail).authenticationFailed(reqId, "_action", transportRequest);
         }
     }
 
@@ -932,11 +932,11 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(secondRealm.supports(token)).thenThrow(authenticationError("realm doesn't like supports"));
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
         try {
-            authenticateBlocking("_action", message, null);
+            authenticateBlocking("_action", transportRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like supports"));
-            verify(auditTrail).authenticationFailed(reqId, token, "_action", message);
+            verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
         }
     }
 
@@ -976,7 +976,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(secondRealm, token, (terminateWithNoException) ? null : throwE, true);
 
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", message, null));
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
         if (terminateWithNoException) {
             assertThat(e.getMessage(), is("terminate authc process"));
             assertThat(e.getHeader("WWW-Authenticate"), contains(basicScheme));
@@ -993,8 +993,8 @@ public class AuthenticationServiceTests extends ESTestCase {
                 assertThat(e.getHeader("WWW-Authenticate"), contains(basicScheme));
             }
         }
-        verify(auditTrail).authenticationFailed(reqId, secondRealm.name(), token, "_action", message);
-        verify(auditTrail).authenticationFailed(reqId, token, "_action", message);
+        verify(auditTrail).authenticationFailed(reqId, secondRealm.name(), token, "_action", transportRequest);
+        verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
     }
 
@@ -1007,11 +1007,11 @@ public class AuthenticationServiceTests extends ESTestCase {
             .when(secondRealm).authenticate(eq(token), any(ActionListener.class));
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
         try {
-            authenticateBlocking("_action", message, null);
+            authenticateBlocking("_action", transportRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't like authenticate"));
-            verify(auditTrail).authenticationFailed(reqId, token, "_action", message);
+            verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
         }
     }
 
@@ -1045,11 +1045,11 @@ public class AuthenticationServiceTests extends ESTestCase {
         final String reqId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         try {
-            authenticateBlocking("_action", message, null);
+            authenticateBlocking("_action", transportRequest, null);
             fail("exception should bubble out");
         } catch (ElasticsearchException e) {
             assertThat(e.getMessage(), is("realm doesn't want to lookup"));
-            verify(auditTrail).authenticationFailed(reqId, token, "_action", message);
+            verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
         }
     }
 
@@ -1115,7 +1115,7 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         // we do not actually go async
         if (randomBoolean()) {
-            service.authenticate("_action", message, true, listener);
+            service.authenticate("_action", transportRequest, true, listener);
         } else {
             service.authenticate(restRequest, listener);
         }
@@ -1154,7 +1154,7 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         // call service asynchronously but it doesn't actually go async
         if (randomBoolean()) {
-            service.authenticate("_action", message, true, listener);
+            service.authenticate("_action", transportRequest, true, listener);
         } else {
             service.authenticate(restRequest, listener);
         }
@@ -1191,10 +1191,10 @@ public class AuthenticationServiceTests extends ESTestCase {
         mockAuthenticate(secondRealm, token, user);
 
         try {
-            authenticateBlocking("_action", message, null);
+            authenticateBlocking("_action", transportRequest, null);
             fail("exception should be thrown");
         } catch (ElasticsearchException e) {
-            verify(auditTrail).runAsDenied(eq(reqId), any(Authentication.class), eq("_action"), eq(message),
+            verify(auditTrail).runAsDenied(eq(reqId), any(Authentication.class), eq("_action"), eq(transportRequest),
                 eq(EmptyAuthorizationInfo.INSTANCE));
             verifyNoMoreInteractions(auditTrail);
         }
@@ -1217,8 +1217,8 @@ public class AuthenticationServiceTests extends ESTestCase {
         }).when(secondRealm).lookupUser(eq("run_as"), any(ActionListener.class));
         User fallback = randomBoolean() ? SystemUser.INSTANCE : null;
         ElasticsearchSecurityException e =
-                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", message, fallback));
-        verify(auditTrail).authenticationFailed(reqId, token, "_action", message);
+                expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, fallback));
+        verify(auditTrail).authenticationFailed(reqId, token, "_action", transportRequest);
         verifyNoMoreInteractions(auditTrail);
         assertAuthenticationException(e);
     }
@@ -1264,7 +1264,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         when(securityIndex.indexExists()).thenReturn(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", "Bearer " + token);
-            service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+            service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
                     assertThat(result, notNullValue());
                     assertThat(result.getUser(), is(user));
                     assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -1274,7 +1274,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 }, this::logAndFail));
         }
         assertTrue(completed.get());
-        verify(auditTrail).authenticationSuccess(anyString(), eq("realm"), eq(user), eq("_action"), same(message));
+        verify(auditTrail).authenticationSuccess(anyString(), eq("realm"), eq(user), eq("_action"), same(transportRequest));
         verifyNoMoreInteractions(auditTrail);
     }
 
@@ -1291,7 +1291,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         AtomicBoolean success = new AtomicBoolean(false);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", "Bearer " + Base64.getEncoder().encodeToString(randomBytes));
-            service.authenticate("_action", message, true, ActionListener.wrap(result -> {
+            service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
                 assertThat(result, notNullValue());
                 assertThat(result.getUser(), is(user));
                 assertThat(result.getLookedUpBy(), is(nullValue()));
@@ -1325,7 +1325,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         latch.await();
         if (success.get()) {
             final String realmName = firstRealm.name();
-            verify(auditTrail).authenticationSuccess(anyString(), eq(realmName), eq(user), eq("_action"), same(message));
+            verify(auditTrail).authenticationSuccess(anyString(), eq(realmName), eq(user), eq("_action"), same(transportRequest));
         }
         verifyNoMoreInteractions(auditTrail);
     }
@@ -1352,7 +1352,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", "Bearer " + token);
             ElasticsearchSecurityException e =
-                    expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", message, null));
+                    expectThrows(ElasticsearchSecurityException.class, () -> authenticateBlocking("_action", transportRequest, null));
             assertEquals(RestStatus.UNAUTHORIZED, e.status());
             assertEquals("token expired", e.getMessage());
         }
@@ -1363,7 +1363,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             final String invalidHeader = randomFrom("apikey", "apikey ", "apikey foo");
             threadContext.putHeader("Authorization", invalidHeader);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class,
-                () -> authenticateBlocking("_action", message, null));
+                () -> authenticateBlocking("_action", transportRequest, null));
             assertEquals(RestStatus.UNAUTHORIZED, e.status());
             assertThat(e.getMessage(), containsString("missing authentication credentials"));
         }
@@ -1403,7 +1403,7 @@ public class AuthenticationServiceTests extends ESTestCase {
 
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", headerValue);
-            final Authentication authentication = authenticateBlocking("_action", message, null);
+            final Authentication authentication = authenticateBlocking("_action", transportRequest, null);
             assertThat(authentication.getUser().principal(), is("johndoe"));
             assertThat(authentication.getAuthenticationType(), is(AuthenticationType.API_KEY));
         }
@@ -1444,14 +1444,14 @@ public class AuthenticationServiceTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.putHeader("Authorization", headerValue);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class,
-                () -> authenticateBlocking("_action", message, null));
+                () -> authenticateBlocking("_action", transportRequest, null));
             assertEquals(RestStatus.UNAUTHORIZED, e.status());
         }
     }
 
-    private static class InternalMessage extends TransportMessage {
+    private static class InternalRequest extends TransportRequest {
         @Override
-        public void writeTo(StreamOutput out) throws IOException {}
+        public void writeTo(StreamOutput out) {}
     }
 
     void assertThreadContextContainsAuthentication(Authentication authentication) throws IOException {
@@ -1503,12 +1503,12 @@ public class AuthenticationServiceTests extends ESTestCase {
         return future.actionGet();
     }
 
-    private Authentication authenticateBlocking(String action, TransportMessage message, User fallbackUser) {
+    private Authentication authenticateBlocking(String action, TransportRequest transportRequest, User fallbackUser) {
         PlainActionFuture<Authentication> future = new PlainActionFuture<>();
         if (fallbackUser == null) {
-            service.authenticate(action, message, true, future);
+            service.authenticate(action, transportRequest, true, future);
         } else {
-            service.authenticate(action, message, fallbackUser, future);
+            service.authenticate(action, transportRequest, fallbackUser, future);
         }
         return future.actionGet();
     }


### PR DESCRIPTION
This commit refactors the `AuditTrail` to use the `TransportRequest` as a parameter for all its audit methods, instead of the current `TransportMessage` super class.

The goal is to gain access to the `TransportRequest#parentTaskId` member, so that it can be audited. The `parentTaskId` is used internally when spawning tasks that handle transport requests. In this way tasks across nodes are related by the same parent task.

Relates https://github.com/elastic/elasticsearch/issues/52314