### PR TITLE
Fix docker image build error on Arm64

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -235,6 +235,7 @@ subprojects { Project subProject ->
     }
 
     exportDockerImageTask.dependsOn(parent.tasks.getByName(buildTaskName))
+    exportDockerImageTask.onlyIf { Architecture.current().name().toLowerCase().equals(architecture) }
 
     artifacts.add('default', file(tarFile)) {
       type 'tar'


### PR DESCRIPTION
When build docker images on Arm64, elasticsearch will export images no matter whether docker images exists or not.
So it would fail to export x86-images on Arm64:
```
> Task :distribution:docker:docker-export:exportDockerImage FAILED
FAILURE: Build failed with an exception.
* What went wrong:
A problem was found with the configuration of task ':distribution:docker:docker-export:exportDockerImage' (type 'LoggedExec').
> File '/home/yuqi/elasticsearch/distribution/docker/build/markers/buildDockerImage.marker' specified for property '$1' does not exist.
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```

This commit leverages 'onlyIF{}' to export images by Architecture-detection.

