### PR TITLE
Yaml test: Fixed bad indentation

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
@@ -10,7 +10,7 @@
         body:
           secure_settings_password: awrongpasswordhere
   - set:
-    nodes._arbitrary_key_: node_id
+      nodes._arbitrary_key_: node_id
 
   - is_true: nodes
   - is_true: cluster_name
@@ -24,7 +24,7 @@
       nodes.reload_secure_settings: {}
 
   - set:
-    nodes._arbitrary_key_: node_id
+      nodes._arbitrary_key_: node_id
 
   - is_true: nodes
   - is_true: cluster_name


### PR DESCRIPTION
The `nodes.reload_secure_settings` tests are failing in [clients-ci](https://clients-ci.elastic.co/) because the indentation of the `set` block is not correct.
This change should also be backported to `7.7`.

cc @elastic/es-clients 