### PR TITLE
Re-add origin url information to publish POM files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,14 +65,6 @@ if (VersionProperties.elasticsearch.toString().endsWith('-SNAPSHOT')) {
 }
 String elasticLicenseUrl = "https://raw.githubusercontent.com/elastic/elasticsearch/${licenseCommit}/licenses/ELASTIC-LICENSE.txt"
 
-configure(allprojects - project(':distribution:archives:integ-test-zip')) {
-  project.pluginManager.withPlugin('nebula.maven-base-publish') {
-    if (project.pluginManager.hasPlugin('elasticsearch.build') == false) {
-      throw new GradleException("Project ${path} publishes a pom but doesn't apply the build plugin.")
-    }
-  }
-}
-
 subprojects {
   // Default to the apache license
   project.ext.licenseName = 'The Apache Software License, Version 2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,14 @@ if (VersionProperties.elasticsearch.toString().endsWith('-SNAPSHOT')) {
 }
 String elasticLicenseUrl = "https://raw.githubusercontent.com/elastic/elasticsearch/${licenseCommit}/licenses/ELASTIC-LICENSE.txt"
 
+configure(allprojects - project(':distribution:archives:integ-test-zip')) {
+  project.pluginManager.withPlugin('nebula.maven-base-publish') {
+    if (project.pluginManager.hasPlugin('elasticsearch.build') == false) {
+      throw new GradleException("Project ${path} publishes a pom but doesn't apply the build plugin.")
+    }
+  }
+}
+
 subprojects {
   // Default to the apache license
   project.ext.licenseName = 'The Apache Software License, Version 2.0'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -158,7 +158,6 @@ if (project == rootProject) {
 if (project != rootProject) {
   apply plugin: 'elasticsearch.build'
   apply plugin: 'nebula.maven-base-publish'
-  apply plugin: 'nebula.maven-scm'
 
   // groovydoc succeeds, but has some weird internal exception...
   groovydoc.enabled = false

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -354,18 +354,6 @@ class BuildPlugin implements Plugin<Project> {
 
     /**Configuration generation of maven poms. */
     static void configurePomGeneration(Project project) {
-        // Add git origin info to generated POM files
-        project.pluginManager.withPlugin('nebula.maven-base-publish') {
-            PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
-            MavenPublication nebulaPublication = (MavenPublication) publishing.publications.getByName('nebula')
-            nebulaPublication.pom.withXml { XmlProvider xml ->
-                Node root = xml.asNode()
-                root.appendNode('url', PluginBuildPlugin.urlFromOrigin(BuildParams.gitOrigin))
-                Node scmNode = root.appendNode('scm')
-                scmNode.appendNode('url', BuildParams.gitOrigin)
-            }
-        }
-
         project.plugins.withType(MavenPublishPlugin).whenPluginAdded {
             TaskProvider generatePomTask = project.tasks.register("generatePom") { Task task ->
                 task.dependsOn 'generatePomFileForNebulaPublication'
@@ -387,6 +375,7 @@ class BuildPlugin implements Plugin<Project> {
                 shadow.component(publication)
                 // Workaround for https://github.com/johnrengelman/shadow/issues/334
                 // Here we manually add any project dependencies in the "shadow" configuration to our generated POM
+                publication.pom.withXml(this.&addScmInfo)
                 publication.pom.withXml { xml ->
                     Node dependenciesNode = (xml.asNode().get('dependencies') as NodeList).get(0) as Node
                     project.configurations.getByName(ShadowBasePlugin.CONFIGURATION_NAME).allDependencies.each { dependency ->
@@ -402,6 +391,20 @@ class BuildPlugin implements Plugin<Project> {
                 generatePomTask.configure({ Task t -> t.dependsOn = ['generatePomFileForShadowPublication'] } as Action<Task>)
             }
         }
+
+        // Add git origin info to generated POM files
+        project.pluginManager.withPlugin('nebula.maven-base-publish') {
+            PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+            MavenPublication nebulaPublication = (MavenPublication) publishing.publications.getByName('nebula')
+            nebulaPublication.pom.withXml(this.&addScmInfo)
+        }
+    }
+
+    private static void addScmInfo(XmlProvider xml) {
+        Node root = xml.asNode()
+        root.appendNode('url', PluginBuildPlugin.urlFromOrigin(BuildParams.gitOrigin))
+        Node scmNode = root.appendNode('scm')
+        scmNode.appendNode('url', BuildParams.gitOrigin)
     }
 
     /**

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -28,6 +28,7 @@ import org.apache.commons.io.IOUtils
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin
 import org.elasticsearch.gradle.info.JavaHome
+import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 import org.elasticsearch.gradle.precommit.DependencyLicensesTask
 import org.elasticsearch.gradle.precommit.PrecommitTasks
 import org.elasticsearch.gradle.test.ErrorReportingTestListener
@@ -42,6 +43,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
@@ -352,6 +354,18 @@ class BuildPlugin implements Plugin<Project> {
 
     /**Configuration generation of maven poms. */
     static void configurePomGeneration(Project project) {
+        // Add git origin info to generated POM files
+        project.pluginManager.withPlugin('nebula.maven-base-publish') {
+            PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+            MavenPublication nebulaPublication = (MavenPublication) publishing.publications.getByName('nebula')
+            nebulaPublication.pom.withXml { XmlProvider xml ->
+                Node root = xml.asNode()
+                root.appendNode('url', PluginBuildPlugin.urlFromOrigin(BuildParams.gitOrigin))
+                Node scmNode = root.appendNode('scm')
+                scmNode.appendNode('url', BuildParams.gitOrigin)
+            }
+        }
+
         project.plugins.withType(MavenPublishPlugin).whenPluginAdded {
             TaskProvider generatePomTask = project.tasks.register("generatePom") { Task task ->
                 task.dependsOn 'generatePomFileForNebulaPublication'

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -23,7 +23,6 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'elasticsearch.rest-resources'
 

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -20,7 +20,6 @@ import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
  */
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -18,7 +18,6 @@
  */
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -349,7 +349,6 @@ configure(subprojects.findAll { it.name == 'integ-test-zip' }) {
   // The integ-test-distribution is published to maven
   BuildPlugin.configurePomGeneration(project)
   apply plugin: 'nebula.maven-base-publish'
-  apply plugin: 'nebula.maven-scm'
 
   // make the pom file name use elasticsearch instead of the project name
   archivesBaseName = "elasticsearch${it.name.contains('oss') ? '-oss' : ''}"

--- a/libs/cli/build.gradle
+++ b/libs/cli/build.gradle
@@ -19,7 +19,6 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.optional-base'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 dependencies {
   compile 'net.sf.jopt-simple:jopt-simple:5.0.2'

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -19,7 +19,6 @@
 
 apply plugin: 'nebula.optional-base'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 dependencies {
   // This dependency is used only by :libs:core for null-checking interop with other tools

--- a/libs/geo/build.gradle
+++ b/libs/geo/build.gradle
@@ -19,7 +19,6 @@
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 dependencies {
   testCompile(project(":test:framework")) {

--- a/libs/nio/build.gradle
+++ b/libs/nio/build.gradle
@@ -17,7 +17,6 @@
  * under the License.
  */
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 dependencies {
   compile project(':libs:elasticsearch-core')

--- a/libs/secure-sm/build.gradle
+++ b/libs/secure-sm/build.gradle
@@ -17,7 +17,6 @@
  * under the License.
  */
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 dependencies {
   // do not add non-test compile dependencies to secure-sm without a good reason to do so

--- a/libs/ssl-config/build.gradle
+++ b/libs/ssl-config/build.gradle
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-apply plugin: "nebula.maven-scm"
+apply plugin: "nebula.maven-base-publish"
 
 dependencies {
   compile project(':libs:elasticsearch-core')

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -19,7 +19,6 @@
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 dependencies {
   compile project(':libs:elasticsearch-core')

--- a/modules/lang-painless/spi/build.gradle
+++ b/modules/lang-painless/spi/build.gradle
@@ -19,7 +19,6 @@
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 group = 'org.elasticsearch.plugin'
 archivesBaseName = 'elasticsearch-scripting-painless-spi'

--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -18,7 +18,7 @@ import org.elasticsearch.gradle.info.BuildParams
  * specific language governing permissions and limitations
  * under the License.
  */
-apply plugin: "nebula.maven-scm"
+apply plugin: "nebula.maven-base-publish"
 
 esplugin {
   description 'The nio transport.'

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 apply plugin: 'elasticsearch.rest-resources'
 
 test.enabled = false

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -22,7 +22,6 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.optional-base'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 publishing {
   publications {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -24,7 +24,6 @@ subprojects {
   group = 'org.elasticsearch.test'
   apply plugin: 'elasticsearch.build'
   apply plugin: 'nebula.maven-base-publish'
-  apply plugin: 'nebula.maven-scm'
 
   // TODO: should we have licenses for our test deps?
   dependencyLicenses.enabled = false

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -6,7 +6,6 @@ import java.nio.file.Paths
 
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 
 archivesBaseName = 'x-pack-core'
 

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -1,7 +1,7 @@
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'
-apply plugin: 'nebula.maven-scm'
+apply plugin: 'nebula.maven-base-publish'
 esplugin {
   name 'x-pack-identity-provider'
   description 'Elasticsearch Expanded Pack Plugin - Identity Provider'

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -1,7 +1,7 @@
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'
-apply plugin: 'nebula.maven-scm'
+apply plugin: 'nebula.maven-base-publish'
 esplugin {
   name 'x-pack-security'
   description 'Elasticsearch Expanded Pack Plugin - Security'

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
-apply plugin: 'nebula.maven-scm'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 description = 'JDBC driver for Elasticsearch'


### PR DESCRIPTION
Some unintentional fallout from #54611 was that we lost some of the SCM information we add to our generated POM files. Turns out, this is required in order to publish artifacts to Maven Central, which has caused the most recent release to fail. This PR removes the use of the nebula plugin, and instead adds this logic to our `BuildPlugin`.