### PR TITLE
[DOCS] Relocate "Remote Clusters" page

### DIFF
--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -55,11 +55,6 @@ The modules in this section are:
     Configure the transport networking layer, used internally by Elasticsearch
     to communicate between nodes.
 
-<<modules-remote-clusters, Remote clusters>>::
-
-    Remote clusters are used in features that work by connecting across clusters
-    on the transport layer.
-
 <<modules-cross-cluster-search, {ccs-cap}>>::
 
     {ccs-cap} enables executing search requests across more than one cluster
@@ -82,5 +77,3 @@ include::modules/node.asciidoc[]
 include::modules/threadpool.asciidoc[]
 
 include::modules/transport.asciidoc[]
-
-include::modules/remote-clusters.asciidoc[]

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -1,7 +1,7 @@
 [[modules-remote-clusters]]
 == Remote clusters
 
-The _remote clusters_ functionality enables you to establish uni-directional
+The _remote clusters_ functionality enables you to establish unidirectional
 connections to a remote cluster. Remote clusters are required for
 <<xpack-ccr,{ccr}>> and <<modules-cross-cluster-search,{ccs}>>.
 

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -1,17 +1,9 @@
 [[modules-remote-clusters]]
 == Remote clusters
 
-ifndef::include-xpack[]
-The _remote clusters_ module enables you to establish uni-directional
-connections to a remote cluster. This functionality is used in
-<<modules-cross-cluster-search,{ccs}>>.
-endif::[]
-ifdef::include-xpack[]
-The _remote clusters_ module enables you to establish uni-directional
-connections to a remote cluster. This functionality is used in
-<<xpack-ccr,{ccr}>> and
-<<modules-cross-cluster-search,{ccs}>>.
-endif::[]
+The _remote clusters_ functionality enables you to establish uni-directional
+connections to a remote cluster. Remote clusters are required for
+<<xpack-ccr,{ccr}>> and <<modules-cross-cluster-search,{ccs}>>.
 
 Remote cluster connections work by configuring a remote cluster and connecting
 to a limited number of nodes in that remote cluster. There are two modes for

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -87,6 +87,8 @@ include::setup/sysconfig.asciidoc[]
 
 include::setup/bootstrap-checks.asciidoc[]
 
+include::setup/bootstrap-checks-xes.asciidoc[]
+
 include::setup/starting.asciidoc[]
 
 include::setup/stopping.asciidoc[]
@@ -95,6 +97,6 @@ include::setup/add-nodes.asciidoc[]
 
 include::setup/restart-cluster.asciidoc[]
 
-include::setup/bootstrap-checks-xes.asciidoc[]
+include::modules/remote-clusters.asciidoc[]
 
 include::modules/plugins.asciidoc[]


### PR DESCRIPTION
As part of #53303, this relocates the [Remote Clusters](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-remote-clusters.html) documentation from the [Modules](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules.html) section to the [Set up Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/master/setup.html) section.

Supporting changes:
* Reorders the [Bootstrap checks for X-Pack section](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks-xpack.html) to immediately follow the [Bootstrap checks](https://www.elastic.co/guide/en/elasticsearch/reference/master/bootstrap-checks.html) chapter.
* Removes an outdated X-Pack `idef` from the [Remote Clusters](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-remote-clusters.html) intro.

