### PR TITLE
Remove mentions of data science plugin

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
@@ -150,7 +150,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
 
     private static <T> ContextParser<String, T> checkLicense(ContextParser<String, T> realParser) {
         return (parser, name) -> {
-            if (getLicenseState().isDataScienceAllowed() == false) {
+            if (getLicenseState().isAnalyticsAllowed() == false) {
                 throw LicenseUtils.newComplianceException(XPackField.ANALYTICS);
             }
             return realParser.parse(parser, name);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportAction.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportAction.java
@@ -31,7 +31,7 @@ public class AnalyticsInfoTransportAction extends XPackInfoFeatureTransportActio
 
     @Override
     public boolean available() {
-        return licenseState.isDataScienceAllowed();
+        return licenseState.isAnalyticsAllowed();
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/AnalyticsUsageTransportAction.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/action/AnalyticsUsageTransportAction.java
@@ -45,7 +45,7 @@ public class AnalyticsUsageTransportAction extends XPackUsageFeatureTransportAct
     @Override
     protected void masterOperation(Task task, XPackUsageRequest request, ClusterState state,
                                    ActionListener<XPackUsageFeatureResponse> listener) {
-        boolean available = licenseState.isDataScienceAllowed();
+        boolean available = licenseState.isAnalyticsAllowed();
         if (available) {
             AnalyticsStatsAction.Request statsRequest = new AnalyticsStatsAction.Request();
             statsRequest.setParentTask(clusterService.localNode().getId(), task.getId());

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsInfoTransportActionTests.java
@@ -59,7 +59,7 @@ public class AnalyticsInfoTransportActionTests extends ESTestCase {
         AnalyticsInfoTransportAction featureSet = new AnalyticsInfoTransportAction(
             mock(TransportService.class), mock(ActionFilters.class), licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isDataScienceAllowed()).thenReturn(available);
+        when(licenseState.isAnalyticsAllowed()).thenReturn(available);
         assertThat(featureSet.available(), is(available));
         Client client = mockClient();
         AnalyticsUsageTransportAction usageAction = new AnalyticsUsageTransportAction(mock(TransportService.class), clusterService, null,
@@ -85,7 +85,7 @@ public class AnalyticsInfoTransportActionTests extends ESTestCase {
         assertThat(featureSet.enabled(), is(true));
         assertTrue(featureSet.enabled());
         boolean available = randomBoolean();
-        when(licenseState.isDataScienceAllowed()).thenReturn(available);
+        when(licenseState.isAnalyticsAllowed()).thenReturn(available);
         Client client = mockClient();
         AnalyticsUsageTransportAction usageAction = new AnalyticsUsageTransportAction(mock(TransportService.class),
             clusterService, null, mock(ActionFilters.class), null, licenseState, client);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -598,7 +598,7 @@ public class XPackLicenseState {
         return allowForAllLicenses();
     }
 
-    public boolean isDataScienceAllowed() {
+    public boolean isAnalyticsAllowed() {
         return allowForAllLicenses();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -77,7 +77,7 @@ public class XPackLicenseState {
             "Stopping/Deleting existing transforms continue to function."
         });
         messages.put(XPackField.ANALYTICS, new String[] {
-            "Aggregations provided by Data Science plugin are no longer usable."
+            "Aggregations provided by Analytics plugin are no longer usable."
         });
         messages.put(XPackField.CCR, new String[]{
             "Creating new follower indices will be blocked",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -492,7 +492,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.FROZEN_INDICES, FrozenIndicesFeatureSetUsage::new),
             // Spatial
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SPATIAL, SpatialFeatureSetUsage::new),
-            // data science
+            // Analytics
             new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ANALYTICS, AnalyticsFeatureSetUsage::new)
         );
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -50,7 +50,7 @@ public final class XPackField {
     public static final String FROZEN_INDICES = "frozen_indices";
     /** Name constant for spatial features. */
     public static final String SPATIAL = "spatial";
-    /** Name constant for the data science plugin. */
+    /** Name constant for the analytics plugin. */
     public static final String ANALYTICS = "analytics";
     /** Name constant for the enrich plugin. */
     public static final String ENRICH = "enrich";


### PR DESCRIPTION
Trivial change that removes all remaining mentions of data science plugin that
was renamed into analytics plugin.

Follow up for #54847
