### PR TITLE
[DOCS] Removes transform performance note

### DIFF
--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -64,10 +64,13 @@ creates a new index that is dedicated to the transformed data.
 [[transform-performance]]
 ==== Performance considerations
 
-{transforms-cap} perform search aggregations on the source 
-indices then index the results into the destination index. Therefore, a 
-{transform} never takes less time than the cumulated duration of the 
-aggregation that it performs and the indexing process.
+{transforms-cap} perform search aggregations on the source indices then index
+the results into the destination index. Therefore, a {transform} never takes
+less time than the cumulated duration of the aggregation and the indexing
+process. 
+
+If your {transform} must process a lot of historic data, it has high resource
+usage initially--particularly during the first checkpoint.
 
 For better performance, make sure that your search aggregations and queries are 
 optimized and that your {transform} is processing only necessary data.

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -66,8 +66,7 @@ creates a new index that is dedicated to the transformed data.
 
 {transforms-cap} perform search aggregations on the source indices then index
 the results into the destination index. Therefore, a {transform} never takes
-less time than the cumulated duration of the aggregation and the indexing
-process. 
+less time or uses less resources than the aggregation and indexing processes. 
 
 If your {transform} must process a lot of historic data, it has high resource
 usage initially--particularly during the first checkpoint.

--- a/docs/reference/transform/overview.asciidoc
+++ b/docs/reference/transform/overview.asciidoc
@@ -71,8 +71,3 @@ aggregation that it performs and the indexing process.
 
 For better performance, make sure that your search aggregations and queries are 
 optimized and that your {transform} is processing only necessary data.
-
-NOTE: When you use <<search-aggregations-bucket-datehistogram-aggregation>>, the 
-queries are not considered optimal as they run through a significant amount of 
-data. For this reason, {transforms} performing date histogram aggregations take 
-longer to run.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/54254

This PR removes an out-dated note from the transform performance documentation (https://www.elastic.co/guide/en/elasticsearch/reference/master/transform-overview.html#transform-performance).

Preview: http://elasticsearch_55177.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-overview.html