### PR TITLE
Ignore ILM indices in the TerminalPolicyStep

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -134,8 +134,15 @@ class IndexLifecycleRunner {
                 markPolicyDoesNotExist(policy, indexMetadata.getIndex(), lifecycleState);
                 return;
             } else {
+                Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(lifecycleState);
+                if (TerminalPolicyStep.KEY.equals(currentStepKey)) {
+                    // This index is a leftover from before we halted execution on the final phase
+                    // instead of going to the completed phase, so it's okay to ignore this index
+                    // for now
+                    return;
+                }
                 logger.error("current step [{}] for index [{}] with policy [{}] is not recognized",
-                    LifecycleExecutionState.getCurrentStepKey(lifecycleState), index, policy);
+                    currentStepKey, index, policy);
                 return;
             }
         }
@@ -263,8 +270,15 @@ class IndexLifecycleRunner {
             return;
         }
         if (currentStep == null) {
+            Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(lifecycleState);
+            if (TerminalPolicyStep.KEY.equals(currentStepKey)) {
+                // This index is a leftover from before we halted execution on the final phase
+                // instead of going to the completed phase, so it's okay to ignore this index
+                // for now
+                return;
+            }
             logger.warn("current step [{}] for index [{}] with policy [{}] is not recognized",
-                LifecycleExecutionState.getCurrentStepKey(lifecycleState), index, policy);
+                currentStepKey, index, policy);
             return;
         }
 
@@ -323,8 +337,15 @@ class IndexLifecycleRunner {
                 markPolicyDoesNotExist(policy, indexMetadata.getIndex(), lifecycleState);
                 return;
             } else {
+                Step.StepKey currentStepKey = LifecycleExecutionState.getCurrentStepKey(lifecycleState);
+                if (TerminalPolicyStep.KEY.equals(currentStepKey)) {
+                    // This index is a leftover from before we halted execution on the final phase
+                    // instead of going to the completed phase, so it's okay to ignore this index
+                    // for now
+                    return;
+                }
                 logger.error("current step [{}] for index [{}] with policy [{}] is not recognized",
-                    LifecycleExecutionState.getCurrentStepKey(lifecycleState), index, policy);
+                    currentStepKey, index, policy);
                 return;
             }
         }


### PR DESCRIPTION
Prior to the change in #51631 indices were moved to the `TerminalPolicyStep` when their ILM actions
had completed. Once we switched ILM to stop in the last policy configured, these steps because
inaccessible from the policy's perspective. This meant that indices upgraded from ES prior to 7.7.0
could see the following error spammed in their logs every 10 minutes (by default) for every index in
this state:

```
[2020-04-14T15:52:23,764][ERROR][o.e.x.i.IndexLifecycleRunner] [midgar] current step [{"phase":"completed","action":"completed","name":"completed"}] for index [foo] with policy [full] is not recognized
```

This changes the runner to ignore these steps, which is what is desired anyway since the index is
already in the terminal phase.
