### PR TITLE
[7.x] Advise a simpler curator migration (#54457)

### DIFF
--- a/docs/reference/ilm/ilm-with-existing-indices.asciidoc
+++ b/docs/reference/ilm/ilm-with-existing-indices.asciidoc
@@ -3,13 +3,14 @@
 [[ilm-with-existing-indices]]
 == Manage existing indices
 
+NOTE:  If migrating from Curator, ensure you are running Curator version 5.7 or greater
+so that Curator will ignore ILM managed indices.
+
 While it is recommended to use {ilm-init} to manage the index lifecycle from
 start to finish, it may be useful to use {ilm-init} with existing indices,
-particularly when transitioning from an alternative method of managing the index
-lifecycle such as Curator, or when migrating from daily indices to
-rollover-based indices. Such use cases are fully supported, but there are some
-configuration differences from when {ilm-init} can manage the complete index
-lifecycle.
+for example, when migrating from daily indices to rollover-based indices. 
+Such use cases are fully supported, but there are some configuration differences 
+from when {ilm-init} can manage the complete index lifecycle.
 
 This section describes strategies to leverage {ilm-init} for existing periodic
 indices when migrating to fully {ilm-init}-manged indices, which can be done in


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Advise a simpler curator migration (#54457)