### PR TITLE
Add migration notes for local parameter deprecation (#55014)

### DIFF
--- a/docs/reference/migration/migrate_7_8.asciidoc
+++ b/docs/reference/migration/migrate_7_8.asciidoc
@@ -19,6 +19,16 @@ coming[7.8.0]
 //end::notable-breaking-changes[]
 
 [discrete]
+[[breaking_78_api_changes]]
+=== API changes
+
+[discrete]
+==== Deprecation of `local` parameter for get field mapping API
+
+The `local` parameter is a no-op and field mappings are always retrieved locally.
+As of 7.8, this parameter is deprecated and will be removed in next major version.
+
+[discrete]
 [[breaking_78_mappings_changes]]
 === Mappings changes
 


### PR DESCRIPTION
This is a follow-up for #55099 to add migration notes about the deprecation of local parameter for get field mapping API.