### PR TITLE
Exclude JDK Contents/MacOS directory on Darwin

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -409,6 +409,9 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       return copySpec {
         from project.jdks."bundled_${platform}_${architecture}"
         exclude "demo/**"
+        if ("darwin".equals(platform)) {
+          exclude "Contents/MacOS"
+        }
         eachFile { FileCopyDetails details ->
           if (details.relativePath.segments[-2] == 'bin' || details.relativePath.segments[-1] == 'jspawnhelper') {
             details.mode = 0755

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -409,6 +409,10 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       return copySpec {
         from project.jdks."bundled_${platform}_${architecture}"
         exclude "demo/**"
+        /*
+         * The Contents/MacOS directory interferes with notarization, and is unused by our distribution, so we exclude
+         * it from the build.
+         */
         if ("darwin".equals(platform)) {
           exclude "Contents/MacOS"
         }


### PR DESCRIPTION
This directory interferes with notarization and removing it before we notarize allows us to have a properly notarized distribution. Conceptually, this directory is only needed when building a distribution to be installed by Installer (a so-called "pkg"). Since we are not building such distributions, and this directory interferes with notarization, we choose to exclude it here. We do this here, rather than in our notarization process, to ensure that what we run through CI for testing is also what we ship to the world.
