### PR TITLE
SLM PUT: add precision on date math support in indices parameter

### DIFF
--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -67,7 +67,8 @@ If `true`, cluster states are included in snapshots. Defaults to `false`.
 
 `indices`::
 (Optional, array of strings)
-Array of index names or wildcard pattern of index names included in snapshots.
+Array of index names or wildcard pattern of index names included in snapshots. It
+supports <<date-math-index-names,date math>> expressions.
 ====
 
 `name`::


### PR DESCRIPTION
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
Yes

It was not clear for me that `indices` parameter supports date math expression.

I think it may be worth to add the precision in the documentation.