### PR TITLE
Mark cluster component template APIs as experimental

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
       "description":"Deletes a component template"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
       "description":"Returns one or more component templates"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
       "description":"Creates or updates a component template"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {


### PR DESCRIPTION
This commit marks the cluster component template APIs
as experimental. They are behind a feature flag
and not yet stable.
