### PR TITLE
Remove Redundant Cluster State during Snapshot INIT + Master Failover (#54420)

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -567,12 +567,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         }
 
         @Override
-        public void onFailure(Exception e) {
-            e.addSuppressed(this.e);
+        public void onFailure(@Nullable Exception e) {
             if (snapshotCreated) {
-                cleanupAfterError(e);
+                cleanupAfterError(ExceptionsHelper.useOrSuppress(e, this.e));
             } else {
-                userCreateSnapshotListener.onFailure(e);
+                userCreateSnapshotListener.onFailure(ExceptionsHelper.useOrSuppress(e, this.e));
             }
         }
 
@@ -1179,7 +1178,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     endingSnapshots.remove(snapshot);
                 }
                 if (listener != null) {
-                    listener.onResponse(snapshotInfo);
+                    listener.onFailure(null);
                 }
             }
         });


### PR DESCRIPTION
* Remove Redundant Cluster State during Snapshot INIT + Master Failover

Similar to #54395 we know that a snapshot in INIT state has not
written anything to the repository yet. If we see one from a master
failover, there is no point in moving it to ABORTED before removing it
from the cluster state in a subsequent CS update.
Instead, we can simply remove its job from the CS the first time
we see it on master failover and be done with it.

backport of #54420

Note: for the backport we need to keep the cleanup code because in a mixed cluster containing 6.x we could have still written data to the repo on INIT so we set the flag for the cleanup to true on the bwc path