### PR TITLE
Add log line that will help debug item failures during multi search request

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -213,6 +213,7 @@ public class TransportGetDataFrameAnalyticsStatsAction
             multiSearchResponse -> {
                 for (MultiSearchResponse.Item itemResponse : multiSearchResponse.getResponses()) {
                     if (itemResponse.isFailure()) {
+                        logger.error("Item failure during multi search: " + itemResponse.getFailureMessage(), itemResponse.getFailure());
                         listener.onFailure(ExceptionsHelper.serverError(itemResponse.getFailureMessage(), itemResponse.getFailure()));
                         return;
                     } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
@@ -213,7 +214,10 @@ public class TransportGetDataFrameAnalyticsStatsAction
             multiSearchResponse -> {
                 for (MultiSearchResponse.Item itemResponse : multiSearchResponse.getResponses()) {
                     if (itemResponse.isFailure()) {
-                        logger.error("Item failure during multi search: " + itemResponse.getFailureMessage(), itemResponse.getFailure());
+                        logger.error(
+                            new ParameterizedMessage(
+                                "[{}] Item failure encountered during multi search: {}", configId, itemResponse.getFailureMessage()),
+                            itemResponse.getFailure());
                         listener.onFailure(ExceptionsHelper.serverError(itemResponse.getFailureMessage(), itemResponse.getFailure()));
                         return;
                     } else {


### PR DESCRIPTION
Currently when multi search request fails, there is no indication of what actually did go wrong in the logs:
```
Error Message
org.elasticsearch.ElasticsearchException: all shards failed
Stacktrace
org.elasticsearch.ElasticsearchException: all shards failed
	at __randomizedtesting.SeedInfo.seed([32E4FC497E7E3A70:D129B2593F4A7614]:0)
	at org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper.serverError(ExceptionsHelper.java:55)
	at org.elasticsearch.xpack.ml.action.TransportGetDataFrameAnalyticsStatsAction.lambda$searchStats$8(TransportGetDataFrameAnalyticsStatsAction.java:216)
```

This PR adds a log line that should reveal the root cause of an item failure.

Relates https://github.com/elastic/elasticsearch/issues/55221