### PR TITLE
Added note about snapshot versions

### DIFF
--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -60,7 +60,11 @@ index. This means that snapshots can only be restored to versions of
 Conversely, snapshots of indices created in 1.x **cannot** be restored to 5.x
 or 6.x, snapshots of indices created in 2.x **cannot** be restored to 6.x
 or 7.x, and snapshots of indices created in 5.x **cannot** be restored to 7.x
-or 8.x. This also applies to snapshots taken on newer versions of {es}. For example, snapshots taken in 7.6.0 **cannot** be restored to 7.5.0.
+or 8.x.
+
+We do not recommend restoring snapshots from later {es} versions in earlier
+versions. In some cases, the snapshots cannot be restored. For example, a
+snapshot taken in 7.6.0 cannot be restored to 7.5.0.
 
 Each snapshot can contain indices created in various versions of {es},
 and when restoring a snapshot it must be possible to restore all of the indices
@@ -88,5 +92,4 @@ include::take-snapshot.asciidoc[]
 include::restore-snapshot.asciidoc[]
 include::monitor-snapshot-restore.asciidoc[]
 include::../slm/index.asciidoc[]
-
 

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -60,7 +60,7 @@ index. This means that snapshots can only be restored to versions of
 Conversely, snapshots of indices created in 1.x **cannot** be restored to 5.x
 or 6.x, snapshots of indices created in 2.x **cannot** be restored to 6.x
 or 7.x, and snapshots of indices created in 5.x **cannot** be restored to 7.x
-or 8.x.
+or 8.x. This also applies to snapshots taken on newer versions of {es}. For example, snapshots taken in 7.6.0 **cannot** be restored to 7.5.0.
 
 Each snapshot can contain indices created in various versions of {es},
 and when restoring a snapshot it must be possible to restore all of the indices


### PR DESCRIPTION
It is not possible to restore snapshots taken on newer versions into clusters running lower versions. For example, a snapshot created in a 7.6.0 cluster cannot be restored on a 7.5.0 cluster. This should be documented.
