### PR TITLE
SQL: Implement scripting inside aggs

### DIFF
--- a/docs/reference/sql/functions/aggs.asciidoc
+++ b/docs/reference/sql/functions/aggs.asciidoc
@@ -397,6 +397,16 @@ https://en.wikipedia.org/wiki/Kurtosis[Quantify] the shape of the distribution o
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggKurtosis]
 --------------------------------------------------
 
+[NOTE]
+====
+`KURTOSIS` cannot be used on top of scalar functions but only directly on a field. So, for example, the following is
+not allowed and an error is returned:
+[source, sql]
+---------------------------------------
+ SELECT KURTOSIS(salary), gender FROM emp GROUP BY gender
+---------------------------------------
+====
+
 [[sql-functions-aggs-mad]]
 ==== `MAD`
 
@@ -500,6 +510,16 @@ https://en.wikipedia.org/wiki/Skewness[Quantify] the asymmetric distribution of 
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggSkewness]
 --------------------------------------------------
+
+[NOTE]
+====
+`SKEWNESS` cannot be used on top of scalar functions but only directly on a field. So, for example, the following is
+not allowed and an error is returned:
+[source, sql]
+---------------------------------------
+ SELECT SKEWNESS(salary), gender FROM emp GROUP BY gender
+---------------------------------------
+====
 
 [[sql-functions-aggs-stddev-pop]]
 ==== `STDDEV_POP`

--- a/docs/reference/sql/functions/aggs.asciidoc
+++ b/docs/reference/sql/functions/aggs.asciidoc
@@ -32,6 +32,11 @@ AVG(numeric_field) <1>
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggAvg]
 --------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggAvgScalars]
+--------------------------------------------------
+
 [[sql-functions-aggs-count]]
 ==== `COUNT`
 
@@ -82,6 +87,10 @@ COUNT(ALL field_name) <1>
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggCountAll]
 --------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggCountAllScalars]
+--------------------------------------------------
 
 [[sql-functions-aggs-count-distinct]]
 ==== `COUNT(DISTINCT)`
@@ -103,6 +112,11 @@ COUNT(DISTINCT field_name) <1>
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggCountDistinct]
+--------------------------------------------------
+
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggCountDistinctScalars]
 --------------------------------------------------
 
 [[sql-functions-aggs-first]]
@@ -192,6 +206,11 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[firstWithTwoArgsAndGroupBy]
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[firstValueWithTwoArgsAndGroupBy]
+--------------------------------------------------------------------------
+
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[firstValueWithTwoArgsAndGroupByScalars]
 --------------------------------------------------------------------------
 
 [NOTE]
@@ -289,6 +308,11 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[lastWithTwoArgsAndGroupBy]
 include-tagged::{sql-specs}/docs/docs.csv-spec[lastValueWithTwoArgsAndGroupBy]
 -------------------------------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+-------------------------------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[lastValueWithTwoArgsAndGroupByScalars]
+-------------------------------------------------------------------------
+
 [NOTE]
 `LAST` cannot be used in `HAVING` clause.
 [NOTE]
@@ -315,6 +339,11 @@ MAX(field_name) <1>
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggMax]
+--------------------------------------------------
+
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggMaxScalars]
 --------------------------------------------------
 
 [NOTE]
@@ -367,6 +396,11 @@ SUM(field_name) <1>
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggSum]
+--------------------------------------------------
+
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggSumScalars]
 --------------------------------------------------
 
 [[sql-functions-aggs-statistics]]
@@ -431,6 +465,11 @@ https://en.wikipedia.org/wiki/Median_absolute_deviation[Measure] the variability
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggMad]
 --------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggMadScalars]
+--------------------------------------------------
+
 [[sql-functions-aggs-percentile]]
 ==== `PERCENTILE`
 
@@ -459,6 +498,11 @@ of input values in the field `field_name`.
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggPercentile]
 --------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggPercentileScalars]
+--------------------------------------------------
+
 [[sql-functions-aggs-percentile-rank]]
 ==== `PERCENTILE_RANK`
 
@@ -485,6 +529,11 @@ of input values in the field `field_name`.
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggPercentileRank]
+--------------------------------------------------
+
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggPercentileRankScalars]
 --------------------------------------------------
 
 [[sql-functions-aggs-skewness]]
@@ -545,6 +594,11 @@ Returns the https://en.wikipedia.org/wiki/Standard_deviations[population standar
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggStddevPop]
 --------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggStddevPopScalars]
+--------------------------------------------------
+
 [[sql-functions-aggs-sum-squares]]
 ==== `SUM_OF_SQUARES`
 
@@ -569,6 +623,11 @@ Returns the https://en.wikipedia.org/wiki/Total_sum_of_squares[sum of squares] o
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggSumOfSquares]
 --------------------------------------------------
 
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggSumOfSquaresScalars]
+--------------------------------------------------
+
 [[sql-functions-aggs-var-pop]]
 ==== `VAR_POP`
 
@@ -591,4 +650,10 @@ Returns the https://en.wikipedia.org/wiki/Variance[population variance] of input
 ["source","sql",subs="attributes,macros"]
 --------------------------------------------------
 include-tagged::{sql-specs}/docs/docs.csv-spec[aggVarPop]
+--------------------------------------------------
+
+
+["source","sql",subs="attributes,macros"]
+--------------------------------------------------
+include-tagged::{sql-specs}/docs/docs.csv-spec[aggVarPopScalars]
 --------------------------------------------------

--- a/docs/reference/sql/functions/aggs.asciidoc
+++ b/docs/reference/sql/functions/aggs.asciidoc
@@ -399,11 +399,11 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[aggKurtosis]
 
 [NOTE]
 ====
-`KURTOSIS` cannot be used on top of scalar functions but only directly on a field. So, for example, the following is
-not allowed and an error is returned:
+`KURTOSIS` cannot be used on top of scalar functions or operators but only directly on a field. So, for example,
+the following is not allowed and an error is returned:
 [source, sql]
 ---------------------------------------
- SELECT KURTOSIS(salary), gender FROM emp GROUP BY gender
+ SELECT KURTOSIS(salary / 12.0), gender FROM emp GROUP BY gender
 ---------------------------------------
 ====
 
@@ -517,7 +517,7 @@ include-tagged::{sql-specs}/docs/docs.csv-spec[aggSkewness]
 not allowed and an error is returned:
 [source, sql]
 ---------------------------------------
- SELECT SKEWNESS(salary), gender FROM emp GROUP BY gender
+ SELECT SKEWNESS(ROUND(salary / 12.0, 2), gender FROM emp GROUP BY gender
 ---------------------------------------
 ====
 

--- a/docs/reference/sql/limitations.asciidoc
+++ b/docs/reference/sql/limitations.asciidoc
@@ -130,12 +130,6 @@ SELECT age, MAX(salary) - MIN(salary) AS diff FROM test GROUP BY age ORDER BY di
 --------------------------------------------------
 
 [float]
-=== Using aggregation functions on top of scalar functions
-
-Aggregation functions like <<sql-functions-aggs-min,`MIN`>>, <<sql-functions-aggs-max,`MAX`>>, etc. can only be used
-directly on fields, and so queries like `SELECT MAX(abs(age)) FROM test` are not possible.
-
-[float]
 === Using a sub-select
 
 Using sub-selects (`SELECT X FROM (SELECT Y)`) is **supported to a small degree**: any sub-select that can be "flattened" into a single

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Scripts.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Scripts.java
@@ -66,13 +66,6 @@ public final class Scripts {
                 DataTypes.BOOLEAN);
     }
 
-    public static ScriptTemplate isNotNullCardinality(ScriptTemplate script) {
-        return new ScriptTemplate(formatTemplate(
-                format(Locale.ROOT, "{ql}.isNotNull(%s)", script.template())),
-                script.params(),
-                DataTypes.BOOLEAN);
-    }
-
     public static ScriptTemplate nullSafeSort(ScriptTemplate script) {
         String methodName = script.outputType().isNumeric() ? "nullSafeSortNumeric" : "nullSafeSortString";
         return new ScriptTemplate(formatTemplate(

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Scripts.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/script/Scripts.java
@@ -66,6 +66,13 @@ public final class Scripts {
                 DataTypes.BOOLEAN);
     }
 
+    public static ScriptTemplate isNotNullCardinality(ScriptTemplate script) {
+        return new ScriptTemplate(formatTemplate(
+                format(Locale.ROOT, "{ql}.isNotNull(%s)", script.template())),
+                script.params(),
+                DataTypes.BOOLEAN);
+    }
+
     public static ScriptTemplate nullSafeSort(ScriptTemplate script) {
         String methodName = script.outputType().isNumeric() ? "nullSafeSortNumeric" : "nullSafeSortString";
         return new ScriptTemplate(formatTemplate(

--- a/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
@@ -958,6 +958,7 @@ FROM test_emp GROUP BY gender ORDER BY gender;
 ;
 
 aggregatesWithScalarsAndGroupByOrderByAgg
+schema::max:d|gender:s
 SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",
 gender
 FROM test_emp GROUP BY gender ORDER BY max DESC;
@@ -967,6 +968,17 @@ FROM test_emp GROUP BY gender ORDER BY max DESC;
 155409.30000000002|F
 151745.40000000002|M
 132335.1          |null
+;
+
+aggregatesWithScalarsAndGroupByOrderByAggWithoutProjection
+schema::gender:s
+SELECT gender FROM test_emp GROUP BY gender ORDER BY MAX(salary % 100) DESC;
+
+    gender
+---------------
+M
+null
+F
 ;
 
 topHitsWithScalars

--- a/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
@@ -996,6 +996,34 @@ GROUP BY gender HAVING max > 152000 or min > 24000 ORDER BY gender;
 151745.40000000002|24110.25       |M
 ;
 
+aggregateFunctionsWithScalarsAndGroupByAndHaving_ComplexExpressions
+schema::max:d|min:d|gender:s
+SELECT ABS((MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) + 123) / -100) AS "max",
+cos(MIN(CASE WHEN (salary - 20) > 50000 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) % 100) AS "min",
+gender
+FROM test_emp
+GROUP BY gender HAVING (max / 10) + 10 > 165  OR ABS(min * -100) > 60 ORDER BY gender;
+
+       max        |        min        |    gender
+------------------+-------------------+---------------
+1555.323          |0.1887687166044111 |F
+1518.6840000000002|-0.6783938504738453|M
+;
+
+aggregateFunctionsWithScalarsAndGroupByAndHaving_CombinedFields
+schema::min:d|max:d|gender:s
+SELECT MIN(ABS(salary * (languages / - 20.0))) AS "min",
+MAX(salary / ((languages / 3.0) + 1)) AS "max",
+gender
+FROM test_emp
+GROUP BY gender HAVING (min::long) / 120 > 12 OR ROUND(max) / 10 > 5200 ORDER BY gender;
+
+      min      |      max      |    gender
+---------------+---------------+---------------
+2436.75        |55287.75       |null
+1401.75        |52508.25       |M
+;
+
 aggregateFunctionsWithScalarsAndGroupByAndHavingConvertedToStats
 schema::max:d|min:d|gender:s
 SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",

--- a/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
@@ -899,3 +899,156 @@ SELECT gender, MAD(salary) AS mad FROM test_emp GROUP BY gender HAVING mad > 100
 null           |10789.0        
 F              |12719.0         
 ;
+
+
+// aggregates with scalars
+aggregateFunctionsWithScalars
+SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",
+MIN(CASE WHEN (salary - 20) > 50000 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "min",
+AVG(cos(salary * 1.2) + 100 * (salary / 5)) AS "avg",
+SUM(-salary / 0.765 + sin((salary + 12345) / 12)) AS "sum",
+MAD(abs(salary / -0.813) / 2 + (12345 * (salary % 10))) AS "mad"
+FROM test_emp;
+
+       max        |      min      |       avg       |       sum        |       mad
+------------------+---------------+-----------------+------------------+-----------------
+155409.30000000002|23532.72       |964937.9295477575|-6307004.517507723|30811.76199261993
+;
+
+countWithScalars
+schema::cnt1:l|cnt2:l
+SELECT count(DISTINCT CASE WHEN (languages - 1) > 3 THEN (languages + 3) * 1.2 ELSE (languages - 1) * 2.7 END) AS "cnt1",
+count(CASE WHEN (languages - 2) > 2 THEN (languages + 5) * 1.2 ELSE ((languages / 0.87) - 11) * 2.7 END) AS "cnt2"
+FROM test_emp;
+
+   cnt1   |  cnt2
+----------+-------
+5         | 90
+;
+
+aggregateFunctionsWithScalarsAndGroupBy
+schema::max:d|min:d|avg:d|sum:d|mad:d|gender:s
+SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",
+MIN(CASE WHEN (salary - 20) > 50000 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "min",
+AVG(cos(salary * 1.2) + 100 * (salary / 5)) AS "avg",
+SUM(-salary / 0.765 + sin((salary + 12345) / 12)) AS "sum",
+MAD(abs(salary / -0.813) / 2 + (12345 * (salary % 10))) AS "mad",
+gender
+FROM test_emp GROUP BY gender ORDER BY gender;
+
+       max        |      min      |       avg        |        sum        |       mad       |    gender
+------------------+---------------+------------------+-------------------+-----------------+---------------
+132335.1          |23532.72       |975179.5463883684 |-637388.2516376646 |33398.4963099631 |null
+155409.30000000002|24139.08       |1009778.6217005679|-2178038.0602625553|24031.90651906518|F
+151745.40000000002|24110.25       |937180.7539433916 |-3491578.2056075027|32956.9126691267 |M
+;
+
+countWithScalarsAndGroupBy
+schema::cnt1:l|cnt2:l|gender:s
+SELECT count(DISTINCT CASE WHEN (languages - 1) > 3 THEN (languages + 3) * 1.2 ELSE (languages - 1) * 2.7 END) AS "cnt1",
+count(CASE WHEN (languages - 2) > 2 THEN (languages + 5) * 1.2 ELSE ((languages / 0.87) - 11) * 2.7 END) AS "cnt2",
+gender
+FROM test_emp GROUP BY gender ORDER BY gender;
+
+     cnt1      |     cnt2      |    gender
+---------------+---------------+---------------
+4              |10             |null
+5              |30             |F
+5              |50             |M
+;
+
+aggregatesWithScalarsAndGroupByOrderByAgg
+SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",
+gender
+FROM test_emp GROUP BY gender ORDER BY max DESC;
+
+       max        |    gender
+------------------+---------------
+155409.30000000002|F
+151745.40000000002|M
+132335.1          |null
+;
+
+topHitsWithScalars
+schema::first:s|last:s|gender:s
+SELECT FIRST(concat('aa_', substring(first_name, 3, 10)), birth_date) AS first,
+LAST(concat('bb_', substring(last_name, 4, 8)), birth_date) AS last,
+gender
+FROM test_emp GROUP BY gender ORDER By gender;
+
+     first     |     last      |    gender
+---------------+---------------+---------------
+aa_llian       |bb_kki         |null
+aa_mant        |bb_zuma        |F
+aa_mzi         |bb_ton         |M
+;
+
+aggregateFunctionsWithScalarsAndGroupByAndHaving
+schema::max:d|min:d|gender:s
+SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",
+MIN(CASE WHEN (salary - 20) > 50000 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "min",
+gender FROM test_emp
+GROUP BY gender HAVING max > 152000 or min > 24000 ORDER BY gender;
+
+       max        |      min      |    gender
+------------------+---------------+---------------
+155409.30000000002|24139.08       |F
+151745.40000000002|24110.25       |M
+;
+
+aggregateFunctionsWithScalarsAndGroupByAndHavingConvertedToStats
+schema::max:d|min:d|gender:s
+SELECT MAX(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "max",
+MIN(CASE WHEN (salary - 10) > 70000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "min",
+gender FROM test_emp
+GROUP BY gender HAVING max > 155000 or min > 36000 ORDER BY gender;
+
+       max        |       min        |    gender
+------------------+------------------+---------------
+155409.30000000002|36803.700000000004|F
+151745.40000000002|36720.0           |M
+;
+
+percentileAggregateFunctionsWithScalars
+schema::percentile:d|percentile_rank:d|gender:s
+SELECT PERCENTILE(CASE WHEN (salary / 2) > 10000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END, 80) AS "percentile",
+PERCENTILE_RANK(CASE WHEN (salary - 20) > 50000 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END, 40000) AS "percentile_rank",
+gender FROM test_emp
+GROUP BY gender ORDER BY gender;
+
+   percentile    | percentile_rank  |    gender
+-----------------+------------------+---------------
+86857.79999999999|32.69659025378865 |null
+94042.92000000001|37.03569653103581 |F
+87348.36         |44.337514210592246|M
+;
+
+extendedStatsAggregateFunctionsWithScalars
+schema::stddev_pop:d|sum_of_squares:d|var_pop:d|gender:s
+SELECT STDDEV_POP(CASE WHEN (salary / 2) > 10000 THEN (salary + 12345) * 1.2 ELSE (salary - 12345) * 2.7 END) AS "stddev_pop",
+SUM_OF_SQUARES(CASE WHEN (salary - 20) > 50000 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "sum_of_squares",
+VAR_POP(CASE WHEN (salary - 20) % 1000 > 200 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "var_pop",
+gender FROM test_emp
+GROUP BY gender ORDER BY gender;
+
+    stddev_pop    |   sum_of_squares    |      var_pop       |    gender
+------------------+---------------------+--------------------+---------------
+16752.73244172422 |3.06310583829007E10  |3.460331137445282E8 |null
+17427.462400181845|1.148127725047658E11 |3.1723426960671306E8|F
+15702.798665784752|1.5882243113919238E11|2.529402043805585E8 |M
+;
+
+extendedStatsAggregateFunctionsWithScalarAndSameArg
+schema::stddev_pop:d|sum_of_squares:d|var_pop:d|gender:s
+SELECT STDDEV_POP(CASE WHEN (salary - 20) % 1000 > 200 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "stddev_pop",
+SUM_OF_SQUARES(CASE WHEN (salary - 20) % 1000 > 200 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "sum_of_squares",
+VAR_POP(CASE WHEN (salary - 20) % 1000 > 200 THEN (salary * 1.2) - 1234 ELSE (salary - 20) * 0.93 END) AS "var_pop",
+gender FROM test_emp
+GROUP BY gender ORDER BY gender;
+
+    stddev_pop    |   sum_of_squares    |      var_pop       |    gender
+------------------+---------------------+--------------------+---------------
+18601.965319409886|3.4461553130896095E10|3.460331137445282E8 |null
+17811.071545718776|1.2151168881502939E11|3.1723426960671306E8|F
+15904.093950318531|1.699198993070239E11 |2.529402043805585E8 |M
+;

--- a/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/docs/docs.csv-spec
@@ -1133,13 +1133,25 @@ Georgi         |Facello        |10001
 ///////////////////////////////
 
 aggAvg
+schema::avg:d
 // tag::aggAvg
 SELECT AVG(salary) AS avg FROM emp;
 
-      avg:d      
+      avg
 ---------------
-48248.55          
+48248.55
 // end::aggAvg
+;
+
+aggAvgScalars
+schema::avg:d
+// tag::aggAvgScalars
+SELECT AVG(salary / 12.0) AS avg FROM emp;
+
+      avg
+---------------
+4020.7125
+// end::aggAvgScalars
 ;
 
 aggCountStar
@@ -1162,15 +1174,35 @@ SELECT COUNT(ALL last_name) AS count_all, COUNT(DISTINCT last_name) count_distin
 // end::aggCountAll
 ;
 
+aggCountAllScalars
+// tag::aggCountAllScalars
+SELECT COUNT(ALL CASE WHEN languages IS NULL THEN -1 ELSE languages END) AS count_all, COUNT(DISTINCT CASE WHEN languages IS NULL THEN -1 ELSE languages END) count_distinct FROM emp;
+
+   count_all   |  count_distinct
+---------------+---------------
+100            |6
+
+// end::aggCountAllScalars
+;
+
 aggCountDistinct
 // tag::aggCountDistinct
-
 SELECT COUNT(DISTINCT hire_date) unique_hires, COUNT(hire_date) AS hires FROM emp;
 
   unique_hires  |     hires
 ----------------+---------------
 99              |100
 // end::aggCountDistinct
+;
+
+aggCountDistinctScalars
+// tag::aggCountDistinctScalars
+SELECT COUNT(DISTINCT DATE_TRUNC('YEAR', hire_date)) unique_hires, COUNT(DATE_TRUNC('YEAR', hire_date)) AS hires FROM emp;
+
+ unique_hires  |     hires
+---------------+---------------
+14             |100
+// end::aggCountDistinctScalars
 ;
 
 firstWithOneArg
@@ -1237,6 +1269,19 @@ F             |   Sumant
 M             |   Remzi
 
 // end::firstValueWithTwoArgsAndGroupBy
+;
+
+firstValueWithTwoArgsAndGroupByScalars
+schema::gender:s|first:s
+// tag::firstValueWithTwoArgsAndGroupByScalars
+SELECT gender, FIRST_VALUE(SUBSTRING(first_name, 2, 6), birth_date) AS "first" FROM emp GROUP BY gender ORDER BY gender;
+
+    gender     |     first
+---------------+---------------
+null           |illian
+F              |umant
+M              |emzi
+// end::firstValueWithTwoArgsAndGroupByScalars
 ;
 
 lastWithOneArg
@@ -1307,6 +1352,18 @@ M          |   Hilari
 // end::lastValueWithTwoArgsAndGroupBy
 ;
 
+lastValueWithTwoArgsAndGroupByScalars
+schema::gender:s|last:s
+// tag::lastValueWithTwoArgsAndGroupByScalars
+SELECT gender, LAST_VALUE(SUBSTRING(first_name, 3, 8), birth_date) AS "last" FROM emp GROUP BY gender ORDER BY gender;
+
+    gender     |     last
+---------------+---------------
+null           |erhardt
+F              |ldiodio
+M              |lari
+// end::lastValueWithTwoArgsAndGroupByScalars
+;
 
 aggMax
 // tag::aggMax
@@ -1316,6 +1373,17 @@ SELECT MAX(salary) AS max FROM emp;
 ---------------
 74999               
 // end::aggMax
+;
+
+aggMaxScalars
+schema::max:d
+// tag::aggMaxScalars
+SELECT MAX(ABS(salary / -12.0)) AS max FROM emp;
+
+       max
+-----------------
+6249.916666666667
+// end::aggMaxScalars
 ;
 
 aggMin
@@ -1328,6 +1396,17 @@ SELECT MIN(salary) AS min FROM emp;
 // end::aggMin
 ;
 
+aggMinScalars
+schema::min:d
+// tag::aggMinScalars
+SELECT MIN(ABS(salary / 12.0)) AS min FROM emp;
+
+       min
+------------------
+2110.3333333333335
+// end::aggMinScalars
+;
+
 aggSum
 // tag::aggSum
 SELECT SUM(salary) AS sum FROM emp;
@@ -1336,6 +1415,17 @@ SELECT SUM(salary) AS sum FROM emp;
 ---------------
 4824855
 // end::aggSum
+;
+
+aggSumScalars
+schema::sum:d
+// tag::aggSumScalars
+SELECT ROUND(SUM(salary / 12.0), 1) AS sum FROM emp;
+
+      sum
+---------------
+402071.3
+// end::aggSumScalars
 ;
 
 aggKurtosis
@@ -1358,6 +1448,17 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, AVG(salary) AS avg, MAD(salary) A
 // end::aggMad
 ;
 
+aggMadScalars
+schema::min:d|max:d|avg:d|mad:d
+// tag::aggMadScalars
+SELECT MIN(salary / 12.0) AS min, MAX(salary / 12.0) AS max, AVG(salary/ 12.0) AS avg, MAD(salary / 12.0) AS mad FROM emp;
+
+       min        |       max       |      avg      |       mad
+------------------+-----------------+---------------+-----------------
+2110.3333333333335|6249.916666666667|4020.7125      |841.3750000000002
+// end::aggMadScalars
+;
+
 aggPercentile
 // tag::aggPercentile
 SELECT languages, PERCENTILE(salary, 95) AS "95th" FROM emp 
@@ -1374,6 +1475,23 @@ null           |74999.0
 // end::aggPercentile
 ;
 
+aggPercentileScalars
+schema::languages:i|95th:d
+// tag::aggPercentileScalars
+SELECT languages, PERCENTILE(salary / 12.0, 95) AS "95th" FROM emp
+       GROUP BY languages;
+
+   languages   |       95th
+---------------+------------------
+null           |6249.916666666667
+1              |6065.875
+2              |5993.725
+3              |6136.520833333332
+4              |6009.633333333332
+5              |5089.3083333333325
+// end::aggPercentileScalars
+;
+
 aggPercentileRank
 // tag::aggPercentileRank
 SELECT languages, PERCENTILE_RANK(salary, 65000) AS rank FROM emp GROUP BY languages;
@@ -1387,6 +1505,22 @@ null           |73.65766569962062
 4              |85.70446389643493
 5              |100.0      
 // end::aggPercentileRank
+;
+
+aggPercentileRankScalars
+schema::languages:i|rank:d
+// tag::aggPercentileRankScalars
+SELECT languages, PERCENTILE_RANK(salary/12, 5000) AS rank FROM emp GROUP BY languages;
+
+   languages   |       rank
+---------------+------------------
+null           |66.91240875912409
+1              |66.70766707667076
+2              |84.13266895048271
+3              |61.052992625621684
+4              |76.55646443990001
+5              |94.00696864111498
+// end::aggPercentileRankScalars
 ;
 
 aggSkewness
@@ -1410,6 +1544,17 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, STDDEV_POP(salary) AS stddev
 // end::aggStddevPop
 ;
 
+aggStddevPopScalars
+schema::min:d|max:d|stddev:d
+// tag::aggStddevPopScalars
+SELECT MIN(salary / 12.0) AS min, MAX(salary / 12.0) AS max, STDDEV_POP(salary / 12.0) AS stddev FROM emp;
+
+       min        |       max       |     stddev
+------------------+-----------------+-----------------
+2110.3333333333335|6249.916666666667|1147.093791898986
+// end::aggStddevPopScalars
+;
+
 
 aggSumOfSquares
 // tag::aggSumOfSquares
@@ -1422,6 +1567,16 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, SUM_OF_SQUARES(salary) AS sumsq
 // end::aggSumOfSquares
 ;
 
+aggSumOfSquaresScalars
+schema::min:d|max:d|sumsq:d
+// tag::aggSumOfSquaresScalars
+SELECT MIN(salary / 24.0) AS min, MAX(salary / 24.0) AS max, SUM_OF_SQUARES(salary / 24.0) AS sumsq FROM emp;
+
+       min        |       max        |       sumsq
+------------------+------------------+-------------------
+1055.1666666666667|3124.9583333333335|4.370488293767361E8
+// end::aggSumOfSquaresScalars
+;
 
 aggVarPop
 // tag::aggVarPop
@@ -1433,6 +1588,17 @@ SELECT MIN(salary) AS min, MAX(salary) AS max, VAR_POP(salary) AS varpop FROM em
 // end::aggVarPop
 ;
 
+aggVarPopScalars
+schema::min:d|max:d|varpop:d
+// tag::aggVarPopScalars
+SELECT MIN(salary / 24.0) AS min, MAX(salary / 24.0) AS max, VAR_POP(salary / 24.0) AS varpop FROM emp;
+
+       min        |       max        |      varpop
+------------------+------------------+------------------
+1055.1666666666667|3124.9583333333335|328956.04185329855
+
+// end::aggVarPopScalars
+;
 
 ///////////////////////////////
 //

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -59,6 +59,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.geo.StDistance;
 import org.elasticsearch.xpack.sql.expression.literal.geo.GeoShape;
 import org.elasticsearch.xpack.sql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.sql.querydsl.agg.AggFilter;
+import org.elasticsearch.xpack.sql.querydsl.agg.AggTarget;
 import org.elasticsearch.xpack.sql.querydsl.agg.AndAggFilter;
 import org.elasticsearch.xpack.sql.querydsl.agg.AvgAgg;
 import org.elasticsearch.xpack.sql.querydsl.agg.CardinalityAgg;
@@ -256,15 +257,15 @@ final class QueryTranslator {
         return e.foldable() || e instanceof FieldAttribute;
     }
 
-    private static Object asFieldOrLiteralOrScript(AggregateFunction af) {
+    private static AggTarget asFieldOrLiteralOrScript(AggregateFunction af) {
         return asFieldOrLiteralOrScript(af, af.field());
     }
 
-    private static Object asFieldOrLiteralOrScript(AggregateFunction af, Expression e) {
+    private static AggTarget asFieldOrLiteralOrScript(AggregateFunction af, Expression e) {
         if (e == null) {
             return null;
         }
-        return isFieldOrLiteral(e) ? field(af, e) : ((ScalarFunction) e).asScript();
+        return isFieldOrLiteral(e) ? AggTarget.of(field(af, e)) : AggTarget.of(((ScalarFunction) e).asScript());
     }
 
     // TODO: see whether escaping is needed

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -612,7 +612,7 @@ final class QueryTranslator {
 
         @Override
         protected LeafAgg toAgg(String id, MatrixStats m) {
-            if (isFieldOrLiteral(m)) {
+            if (isFieldOrLiteral(m.field())) {
                 return new MatrixStatsAgg(id, singletonList(field(m, m.field())));
             }
             throw new SqlIllegalArgumentException(

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -59,7 +59,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.geo.StDistance;
 import org.elasticsearch.xpack.sql.expression.literal.geo.GeoShape;
 import org.elasticsearch.xpack.sql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.sql.querydsl.agg.AggFilter;
-import org.elasticsearch.xpack.sql.querydsl.agg.AggTarget;
+import org.elasticsearch.xpack.sql.querydsl.agg.AggSource;
 import org.elasticsearch.xpack.sql.querydsl.agg.AndAggFilter;
 import org.elasticsearch.xpack.sql.querydsl.agg.AvgAgg;
 import org.elasticsearch.xpack.sql.querydsl.agg.CardinalityAgg;
@@ -257,15 +257,15 @@ final class QueryTranslator {
         return e.foldable() || e instanceof FieldAttribute;
     }
 
-    private static AggTarget asFieldOrLiteralOrScript(AggregateFunction af) {
+    private static AggSource asFieldOrLiteralOrScript(AggregateFunction af) {
         return asFieldOrLiteralOrScript(af, af.field());
     }
 
-    private static AggTarget asFieldOrLiteralOrScript(AggregateFunction af, Expression e) {
+    private static AggSource asFieldOrLiteralOrScript(AggregateFunction af, Expression e) {
         if (e == null) {
             return null;
         }
-        return isFieldOrLiteral(e) ? AggTarget.of(field(af, e)) : AggTarget.of(((ScalarFunction) e).asScript());
+        return isFieldOrLiteral(e) ? AggSource.of(field(af, e)) : AggSource.of(((ScalarFunction) e).asScript());
     }
 
     // TODO: see whether escaping is needed

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -5,14 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.planner;
 
-import static java.util.Collections.singletonList;
-import static org.elasticsearch.xpack.ql.expression.Expressions.id;
-import static org.elasticsearch.xpack.ql.expression.Foldables.valueOf;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.search.sort.SortOrder;
@@ -86,6 +78,14 @@ import org.elasticsearch.xpack.sql.querydsl.agg.SumAgg;
 import org.elasticsearch.xpack.sql.querydsl.agg.TopHitsAgg;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeConverter;
 import org.elasticsearch.xpack.sql.util.Check;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.xpack.ql.expression.Expressions.id;
+import static org.elasticsearch.xpack.ql.expression.Foldables.valueOf;
 
 final class QueryTranslator {
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -617,7 +617,7 @@ final class QueryTranslator {
                 return new MatrixStatsAgg(id, singletonList(field(m, m.field())));
             }
             throw new SqlIllegalArgumentException(
-                "Cannot use scalar functions or operators: [{}] in matrix stats " + "aggregate functions [KURTOSIS] and [SKEWNESS]",
+                "Cannot use scalar functions or operators: [{}] in aggregate functions [KURTOSIS] and [SKEWNESS]",
                 m.field().toString()
             );
         }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Agg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Agg.java
@@ -16,25 +16,25 @@ import static java.lang.String.format;
 public abstract class Agg {
 
     private final String id;
-    private final AggTarget target;
+    private final AggSource source;
 
-    Agg(String id, AggTarget target) {
+    Agg(String id, AggSource source) {
         this.id = id;
-        Objects.requireNonNull(target, "AggTarget must not be null");
-        this.target = target;
+        Objects.requireNonNull(source, "AggSource must not be null");
+        this.source = source;
     }
 
     public String id() {
         return id;
     }
 
-    public AggTarget target() {
-        return target;
+    public AggSource source() {
+        return source;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id) + target.hashCode();
+        return Objects.hash(id) + source.hashCode();
     }
 
     @Override
@@ -49,11 +49,11 @@ public abstract class Agg {
 
         Agg other = (Agg) obj;
         return Objects.equals(id, other.id)
-            && Objects.equals(target, other.target);
+            && Objects.equals(source, other.source);
     }
 
     @Override
     public String toString() {
-        return format(Locale.ROOT, "%s(%s)", getClass().getSimpleName(), target.toString());
+        return format(Locale.ROOT, "%s(%s)", getClass().getSimpleName(), source.toString());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Agg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Agg.java
@@ -5,9 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
-import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
-import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
-
 import java.util.Locale;
 import java.util.Objects;
 
@@ -19,37 +16,25 @@ import static java.lang.String.format;
 public abstract class Agg {
 
     private final String id;
-    private final String fieldName;
-    private final ScriptTemplate scriptTemplate;
+    private final AggTarget target;
 
-    Agg(String id, Object fieldOrScript) {
+    Agg(String id, AggTarget target) {
         this.id = id;
-        if (fieldOrScript instanceof String) {
-            this.fieldName = (String) fieldOrScript;
-            this.scriptTemplate = null;
-        } else if (fieldOrScript instanceof ScriptTemplate) {
-            this.fieldName = null;
-            this.scriptTemplate = (ScriptTemplate) fieldOrScript;
-        } else {
-            throw new SqlIllegalArgumentException("Argument of an aggregate function should be String or ScriptTemplate");
-        }
+        Objects.requireNonNull(target, "AggTarget must not be null");
+        this.target = target;
     }
 
     public String id() {
         return id;
     }
 
-    protected String fieldName() {
-        return fieldName;
-    }
-
-    public ScriptTemplate scriptTemplate() {
-        return scriptTemplate;
+    public AggTarget target() {
+        return target;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, fieldName, scriptTemplate);
+        return Objects.hash(id) + target.hashCode();
     }
 
     @Override
@@ -64,12 +49,11 @@ public abstract class Agg {
 
         Agg other = (Agg) obj;
         return Objects.equals(id, other.id)
-            && Objects.equals(fieldName, other.fieldName)
-            && Objects.equals(scriptTemplate, other.scriptTemplate);
+            && Objects.equals(target, other.target);
     }
 
     @Override
     public String toString() {
-        return format(Locale.ROOT, "%s(%s)", getClass().getSimpleName(), fieldName != null ? fieldName : scriptTemplate.toString());
+        return format(Locale.ROOT, "%s(%s)", getClass().getSimpleName(), target.toString());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Agg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Agg.java
@@ -19,8 +19,8 @@ public abstract class Agg {
     private final AggSource source;
 
     Agg(String id, AggSource source) {
-        this.id = id;
         Objects.requireNonNull(source, "AggSource must not be null");
+        this.id = id;
         this.source = source;
     }
 
@@ -34,7 +34,7 @@ public abstract class Agg {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id) + source.hashCode();
+        return Objects.hash(id, source);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AggSource.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AggSource.java
@@ -10,22 +10,22 @@ import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 
 import java.util.Objects;
 
-public class AggTarget {
+public class AggSource {
 
     private final String fieldName;
     private final ScriptTemplate script;
 
-    private AggTarget(String fieldName, ScriptTemplate script) {
+    private AggSource(String fieldName, ScriptTemplate script) {
         this.fieldName = fieldName;
         this.script = script;
     }
 
-    public static AggTarget of(String fieldName) {
-        return new AggTarget(fieldName, null);
+    public static AggSource of(String fieldName) {
+        return new AggSource(fieldName, null);
     }
 
-    public static AggTarget of(ScriptTemplate script) {
-        return new AggTarget(null, script);
+    public static AggSource of(ScriptTemplate script) {
+        return new AggSource(null, script);
     }
 
     @SuppressWarnings("rawtypes")
@@ -59,8 +59,8 @@ public class AggTarget {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AggTarget aggTarget = (AggTarget) o;
-        return Objects.equals(fieldName, aggTarget.fieldName) && Objects.equals(script, aggTarget.script);
+        AggSource aggSource = (AggSource) o;
+        return Objects.equals(fieldName, aggSource.fieldName) && Objects.equals(script, aggSource.script);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AggTarget.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AggTarget.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.querydsl.agg;
+
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
+import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
+
+import java.util.Objects;
+
+public class AggTarget {
+
+    private final String fieldName;
+    private final ScriptTemplate script;
+
+    private AggTarget(String fieldName, ScriptTemplate script) {
+        this.fieldName = fieldName;
+        this.script = script;
+    }
+
+    public static AggTarget of(String fieldName) {
+        return new AggTarget(fieldName, null);
+    }
+
+    public static AggTarget of(ScriptTemplate script) {
+        return new AggTarget(null, script);
+    }
+
+    @SuppressWarnings("rawtypes")
+    ValuesSourceAggregationBuilder with(ValuesSourceAggregationBuilder aggBuilder) {
+        if (fieldName != null) {
+            return aggBuilder.field(fieldName);
+        }
+        else {
+            return aggBuilder.script(script.toPainless());
+        }
+    }
+
+    public String fieldName() {
+        return fieldName;
+    }
+
+    public ScriptTemplate script() {
+        return script;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, script);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AggTarget aggTarget = (AggTarget) o;
+        return Objects.equals(fieldName, aggTarget.fieldName) && Objects.equals(script, aggTarget.script);
+    }
+
+    @Override
+    public String toString() {
+        return fieldName != null ? fieldName : script.toString();
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
@@ -9,7 +9,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
-import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
@@ -40,7 +39,7 @@ public class Aggs {
 
     public static final String ROOT_GROUP_NAME = "groupby";
 
-    public static final GroupByKey IMPLICIT_GROUP_KEY = new GroupByKey(ROOT_GROUP_NAME, StringUtils.EMPTY, null, null) {
+    public static final GroupByKey IMPLICIT_GROUP_KEY = new GroupByKey(ROOT_GROUP_NAME, AggTarget.of(StringUtils.EMPTY), null) {
 
         @Override
         public CompositeValuesSourceBuilder<?> createSourceBuilder() {
@@ -48,7 +47,7 @@ public class Aggs {
         }
 
         @Override
-        protected GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction) {
+        protected GroupByKey copy(String id, AggTarget target, Direction direction) {
             return this;
         }
     };

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
@@ -39,7 +39,7 @@ public class Aggs {
 
     public static final String ROOT_GROUP_NAME = "groupby";
 
-    public static final GroupByKey IMPLICIT_GROUP_KEY = new GroupByKey(ROOT_GROUP_NAME, AggTarget.of(StringUtils.EMPTY), null) {
+    public static final GroupByKey IMPLICIT_GROUP_KEY = new GroupByKey(ROOT_GROUP_NAME, AggSource.of(StringUtils.EMPTY), null) {
 
         @Override
         public CompositeValuesSourceBuilder<?> createSourceBuilder() {
@@ -47,7 +47,7 @@ public class Aggs {
         }
 
         @Override
-        protected GroupByKey copy(String id, AggTarget target, Direction direction) {
+        protected GroupByKey copy(String id, AggSource source, Direction direction) {
             return this;
         }
     };

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
@@ -5,6 +5,15 @@
  */
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
@@ -13,15 +22,6 @@ import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-
-import static java.util.Collections.emptyList;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
 
 /**
  * SQL Aggregations associated with a query.

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/Aggs.java
@@ -5,15 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
-import static java.util.Collections.emptyList;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeValuesSourceBuilder;
@@ -22,6 +13,15 @@ import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 import org.elasticsearch.xpack.ql.util.StringUtils;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
 
 /**
  * SQL Aggregations associated with a query.

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AvgAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AvgAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 
 public class AvgAgg extends LeafAgg {
 
-    public AvgAgg(String id, AggTarget target) {
-        super(id, target);
+    public AvgAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(avg(id()));
+        return addAggSource(avg(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AvgAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AvgAgg.java
@@ -11,8 +11,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 
 public class AvgAgg extends LeafAgg {
 
-    public AvgAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public AvgAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AvgAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/AvgAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 
 public class AvgAgg extends LeafAgg {
 
-    public AvgAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public AvgAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return avg(id()).field(fieldName());
+        return addFieldOrScript(avg(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/CardinalityAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/CardinalityAgg.java
@@ -11,8 +11,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.cardinal
 
 public class CardinalityAgg extends LeafAgg {
 
-    public CardinalityAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public CardinalityAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/CardinalityAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/CardinalityAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.cardinal
 
 public class CardinalityAgg extends LeafAgg {
 
-    public CardinalityAgg(String id, AggTarget target) {
-        super(id, target);
+    public CardinalityAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(cardinality(id()));
+        return addAggSource(cardinality(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/CardinalityAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/CardinalityAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.cardinal
 
 public class CardinalityAgg extends LeafAgg {
 
-    public CardinalityAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public CardinalityAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return cardinality(id()).field(fieldName());
+        return addFieldOrScript(cardinality(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/ExtendedStatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/ExtendedStatsAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.extended
 
 public class ExtendedStatsAgg extends LeafAgg {
 
-    public ExtendedStatsAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public ExtendedStatsAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return extendedStats(id()).field(fieldName());
+        return addFieldOrScript(extendedStats(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/ExtendedStatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/ExtendedStatsAgg.java
@@ -11,8 +11,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.extended
 
 public class ExtendedStatsAgg extends LeafAgg {
 
-    public ExtendedStatsAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public ExtendedStatsAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/ExtendedStatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/ExtendedStatsAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.extended
 
 public class ExtendedStatsAgg extends LeafAgg {
 
-    public ExtendedStatsAgg(String id, AggTarget target) {
-        super(id, target);
+    public ExtendedStatsAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(extendedStats(id()));
+        return addAggSource(extendedStats(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/FilterExistsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/FilterExistsAgg.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.sql.querydsl.agg;
 
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.xpack.ql.expression.gen.script.Scripts;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 
@@ -15,12 +16,16 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
  */
 public class FilterExistsAgg extends LeafAgg {
 
-    public FilterExistsAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public FilterExistsAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return filter(id(), QueryBuilders.existsQuery(fieldName()));
+        if (fieldName() != null) {
+            return filter(id(), QueryBuilders.existsQuery(fieldName()));
+        } else {
+            return filter(id(), QueryBuilders.scriptQuery(Scripts.isNotNullCardinality(scriptTemplate()).toPainless()));
+        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/FilterExistsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/FilterExistsAgg.java
@@ -21,16 +21,16 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.Scripts.formatTem
  */
 public class FilterExistsAgg extends LeafAgg {
 
-    public FilterExistsAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public FilterExistsAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        if (fieldName() != null) {
-            return filter(id(), QueryBuilders.existsQuery(fieldName()));
+        if (target().fieldName() != null) {
+            return filter(id(), QueryBuilders.existsQuery(target().fieldName()));
         } else {
-            return filter(id(), QueryBuilders.scriptQuery(wrapWithIsNotNull(scriptTemplate()).toPainless()));
+            return filter(id(), QueryBuilders.scriptQuery(wrapWithIsNotNull(target().script()).toPainless()));
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/FilterExistsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/FilterExistsAgg.java
@@ -21,16 +21,16 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.Scripts.formatTem
  */
 public class FilterExistsAgg extends LeafAgg {
 
-    public FilterExistsAgg(String id, AggTarget target) {
-        super(id, target);
+    public FilterExistsAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        if (target().fieldName() != null) {
-            return filter(id(), QueryBuilders.existsQuery(target().fieldName()));
+        if (source().fieldName() != null) {
+            return filter(id(), QueryBuilders.existsQuery(source().fieldName()));
         } else {
-            return filter(id(), QueryBuilders.scriptQuery(wrapWithIsNotNull(target().script()).toPainless()));
+            return filter(id(), QueryBuilders.scriptQuery(wrapWithIsNotNull(source().script()).toPainless()));
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
@@ -25,24 +25,24 @@ public class GroupByDateHistogram extends GroupByKey {
     private final ZoneId zoneId;
 
     public GroupByDateHistogram(String id, String fieldName, long fixedInterval, ZoneId zoneId) {
-        this(id, AggTarget.of(fieldName), null, fixedInterval, null, zoneId);
+        this(id, AggSource.of(fieldName), null, fixedInterval, null, zoneId);
     }
 
     public GroupByDateHistogram(String id, ScriptTemplate script, long fixedInterval, ZoneId zoneId) {
-        this(id, AggTarget.of(script), null, fixedInterval, null, zoneId);
+        this(id, AggSource.of(script), null, fixedInterval, null, zoneId);
     }
     
     public GroupByDateHistogram(String id, String fieldName, String calendarInterval, ZoneId zoneId) {
-        this(id, AggTarget.of(fieldName), null, -1L, calendarInterval, zoneId);
+        this(id, AggSource.of(fieldName), null, -1L, calendarInterval, zoneId);
     }
     
     public GroupByDateHistogram(String id, ScriptTemplate script, String calendarInterval, ZoneId zoneId) {
-        this(id, AggTarget.of(script), null, -1L, calendarInterval, zoneId);
+        this(id, AggSource.of(script), null, -1L, calendarInterval, zoneId);
     }
 
-    private GroupByDateHistogram(String id, AggTarget target, Direction direction, long fixedInterval,
-            String calendarInterval, ZoneId zoneId) {
-        super(id, target, direction);
+    private GroupByDateHistogram(String id, AggSource source, Direction direction, long fixedInterval,
+                                 String calendarInterval, ZoneId zoneId) {
+        super(id, source, direction);
         if (fixedInterval <= 0 && (calendarInterval == null || calendarInterval.isBlank())) {
             throw new SqlIllegalArgumentException("Either fixed interval or calendar interval needs to be specified");
         }
@@ -64,8 +64,8 @@ public class GroupByDateHistogram extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, AggTarget target, Direction direction) {
-        return new GroupByDateHistogram(id, target(), direction, fixedInterval, calendarInterval, zoneId);
+    protected GroupByKey copy(String id, AggSource source, Direction direction) {
+        return new GroupByDateHistogram(id, source(), direction, fixedInterval, calendarInterval, zoneId);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByDateHistogram.java
@@ -25,24 +25,24 @@ public class GroupByDateHistogram extends GroupByKey {
     private final ZoneId zoneId;
 
     public GroupByDateHistogram(String id, String fieldName, long fixedInterval, ZoneId zoneId) {
-        this(id, fieldName, null, null, fixedInterval, null, zoneId);
+        this(id, AggTarget.of(fieldName), null, fixedInterval, null, zoneId);
     }
 
     public GroupByDateHistogram(String id, ScriptTemplate script, long fixedInterval, ZoneId zoneId) {
-        this(id, null, script, null, fixedInterval, null, zoneId);
+        this(id, AggTarget.of(script), null, fixedInterval, null, zoneId);
     }
     
     public GroupByDateHistogram(String id, String fieldName, String calendarInterval, ZoneId zoneId) {
-        this(id, fieldName, null, null, -1L, calendarInterval, zoneId);
+        this(id, AggTarget.of(fieldName), null, -1L, calendarInterval, zoneId);
     }
     
     public GroupByDateHistogram(String id, ScriptTemplate script, String calendarInterval, ZoneId zoneId) {
-        this(id, null, script, null, -1L, calendarInterval, zoneId);
+        this(id, AggTarget.of(script), null, -1L, calendarInterval, zoneId);
     }
 
-    private GroupByDateHistogram(String id, String fieldName, ScriptTemplate script, Direction direction, long fixedInterval,
+    private GroupByDateHistogram(String id, AggTarget target, Direction direction, long fixedInterval,
             String calendarInterval, ZoneId zoneId) {
-        super(id, fieldName, script, direction);
+        super(id, target, direction);
         if (fixedInterval <= 0 && (calendarInterval == null || calendarInterval.isBlank())) {
             throw new SqlIllegalArgumentException("Either fixed interval or calendar interval needs to be specified");
         }
@@ -64,8 +64,8 @@ public class GroupByDateHistogram extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction) {
-        return new GroupByDateHistogram(id, fieldName, script, direction, fixedInterval, calendarInterval, zoneId);
+    protected GroupByKey copy(String id, AggTarget target, Direction direction) {
+        return new GroupByDateHistogram(id, target(), direction, fixedInterval, calendarInterval, zoneId);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
@@ -26,15 +26,19 @@ public abstract class GroupByKey extends Agg {
 
     protected final Direction direction;
 
-    protected GroupByKey(String id, String fieldName, ScriptTemplate scriptTemplate, Direction direction) {
-        super(id, fieldName != null ? fieldName : scriptTemplate);
+    protected GroupByKey(String id, AggTarget target, Direction direction) {
+        super(id, target);
         // ASC is the default order of CompositeValueSource
         this.direction = direction == null ? Direction.ASC : direction;
     }
 
+    public ScriptTemplate script() {
+        return target().script();
+    }
+
     public final CompositeValuesSourceBuilder<?> asValueSource() {
         CompositeValuesSourceBuilder<?> builder = createSourceBuilder();
-        ScriptTemplate script = scriptTemplate();
+        ScriptTemplate script = target().script();
         if (script != null) {
             builder.script(script.toPainless());
             if (script.outputType().isInteger()) {
@@ -57,7 +61,7 @@ public abstract class GroupByKey extends Agg {
         }
         // field based
         else {
-            builder.field(fieldName());
+            builder.field(target().fieldName());
         }
         return builder.order(direction.asOrder())
                .missingBucket(true);
@@ -65,20 +69,29 @@ public abstract class GroupByKey extends Agg {
 
     protected abstract CompositeValuesSourceBuilder<?> createSourceBuilder();
 
-    protected abstract GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction);
+    protected abstract GroupByKey copy(String id, AggTarget target, Direction direction);
 
     public GroupByKey with(Direction direction) {
-        return this.direction == direction ? this : copy(id(), fieldName(), scriptTemplate(), direction);
+        return this.direction == direction ? this : copy(id(), target(), direction);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id(), fieldName(), scriptTemplate(), direction);
+        return Objects.hash(super.hashCode(), direction);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj)
-                && Objects.equals(direction, ((GroupByKey) obj).direction);
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (super.equals(o) == false) {
+            return false;
+        }
+        GroupByKey that = (GroupByKey) o;
+        return direction == that.direction;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
@@ -25,18 +25,16 @@ import static org.elasticsearch.xpack.sql.type.SqlDataTypes.TIME;
 public abstract class GroupByKey extends Agg {
 
     protected final Direction direction;
-    private final ScriptTemplate script;
 
-    protected GroupByKey(String id, String fieldName, ScriptTemplate script, Direction direction) {
-        super(id, fieldName);
+    protected GroupByKey(String id, String fieldName, ScriptTemplate scriptTemplate, Direction direction) {
+        super(id, fieldName != null ? fieldName : scriptTemplate);
         // ASC is the default order of CompositeValueSource
         this.direction = direction == null ? Direction.ASC : direction;
-        this.script = script;
     }
 
     public final CompositeValuesSourceBuilder<?> asValueSource() {
         CompositeValuesSourceBuilder<?> builder = createSourceBuilder();
-        
+        ScriptTemplate script = scriptTemplate();
         if (script != null) {
             builder.script(script.toPainless());
             if (script.outputType().isInteger()) {
@@ -70,22 +68,17 @@ public abstract class GroupByKey extends Agg {
     protected abstract GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction);
 
     public GroupByKey with(Direction direction) {
-        return this.direction == direction ? this : copy(id(), fieldName(), script, direction);
-    }
-
-    public ScriptTemplate script() {
-        return script;
+        return this.direction == direction ? this : copy(id(), fieldName(), scriptTemplate(), direction);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id(), fieldName(), script, direction);
+        return Objects.hash(id(), fieldName(), scriptTemplate(), direction);
     }
 
     @Override
     public boolean equals(Object obj) {
         return super.equals(obj)
-                && Objects.equals(script, ((GroupByKey) obj).script)
                 && Objects.equals(direction, ((GroupByKey) obj).direction);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByKey.java
@@ -26,19 +26,19 @@ public abstract class GroupByKey extends Agg {
 
     protected final Direction direction;
 
-    protected GroupByKey(String id, AggTarget target, Direction direction) {
-        super(id, target);
+    protected GroupByKey(String id, AggSource source, Direction direction) {
+        super(id, source);
         // ASC is the default order of CompositeValueSource
         this.direction = direction == null ? Direction.ASC : direction;
     }
 
     public ScriptTemplate script() {
-        return target().script();
+        return source().script();
     }
 
     public final CompositeValuesSourceBuilder<?> asValueSource() {
         CompositeValuesSourceBuilder<?> builder = createSourceBuilder();
-        ScriptTemplate script = target().script();
+        ScriptTemplate script = source().script();
         if (script != null) {
             builder.script(script.toPainless());
             if (script.outputType().isInteger()) {
@@ -61,7 +61,7 @@ public abstract class GroupByKey extends Agg {
         }
         // field based
         else {
-            builder.field(target().fieldName());
+            builder.field(source().fieldName());
         }
         return builder.order(direction.asOrder())
                .missingBucket(true);
@@ -69,10 +69,10 @@ public abstract class GroupByKey extends Agg {
 
     protected abstract CompositeValuesSourceBuilder<?> createSourceBuilder();
 
-    protected abstract GroupByKey copy(String id, AggTarget target, Direction direction);
+    protected abstract GroupByKey copy(String id, AggSource source, Direction direction);
 
     public GroupByKey with(Direction direction) {
-        return this.direction == direction ? this : copy(id(), target(), direction);
+        return this.direction == direction ? this : copy(id(), source(), direction);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByNumericHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByNumericHistogram.java
@@ -20,15 +20,15 @@ public class GroupByNumericHistogram extends GroupByKey {
     private final double interval;
 
     public GroupByNumericHistogram(String id, String fieldName, double interval) {
-        this(id, AggTarget.of(fieldName), null, interval);
+        this(id, AggSource.of(fieldName), null, interval);
     }
 
     public GroupByNumericHistogram(String id, ScriptTemplate script, double interval) {
-        this(id, AggTarget.of(script), null, interval);
+        this(id, AggSource.of(script), null, interval);
     }
 
-    private GroupByNumericHistogram(String id, AggTarget aggTarget, Direction direction, double interval) {
-        super(id, aggTarget, direction);
+    private GroupByNumericHistogram(String id, AggSource aggSource, Direction direction, double interval) {
+        super(id, aggSource, direction);
         this.interval = interval;
     }
 
@@ -39,8 +39,8 @@ public class GroupByNumericHistogram extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, AggTarget target, Direction direction) {
-        return new GroupByNumericHistogram(id, target(), direction, interval);
+    protected GroupByKey copy(String id, AggSource source, Direction direction) {
+        return new GroupByNumericHistogram(id, source(), direction, interval);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByNumericHistogram.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByNumericHistogram.java
@@ -20,15 +20,15 @@ public class GroupByNumericHistogram extends GroupByKey {
     private final double interval;
 
     public GroupByNumericHistogram(String id, String fieldName, double interval) {
-        this(id, fieldName, null, null, interval);
+        this(id, AggTarget.of(fieldName), null, interval);
     }
 
     public GroupByNumericHistogram(String id, ScriptTemplate script, double interval) {
-        this(id, null, script, null, interval);
+        this(id, AggTarget.of(script), null, interval);
     }
 
-    private GroupByNumericHistogram(String id, String fieldName, ScriptTemplate script, Direction direction, double interval) {
-        super(id, fieldName, script, direction);
+    private GroupByNumericHistogram(String id, AggTarget aggTarget, Direction direction, double interval) {
+        super(id, aggTarget, direction);
         this.interval = interval;
     }
 
@@ -39,8 +39,8 @@ public class GroupByNumericHistogram extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction) {
-        return new GroupByNumericHistogram(id, fieldName, script, direction, interval);
+    protected GroupByKey copy(String id, AggTarget target, Direction direction) {
+        return new GroupByNumericHistogram(id, target(), direction, interval);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByValue.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByValue.java
@@ -16,15 +16,15 @@ import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 public class GroupByValue extends GroupByKey {
 
     public GroupByValue(String id, String fieldName) {
-        this(id, fieldName, null, null);
+        this(id, AggTarget.of(fieldName), null);
     }
 
     public GroupByValue(String id, ScriptTemplate script) {
-        this(id, null, script, null);
+        this(id, AggTarget.of(script), null);
     }
 
-    private GroupByValue(String id, String fieldName, ScriptTemplate script, Direction direction) {
-        super(id, fieldName, script, direction);
+    private GroupByValue(String id, AggTarget target, Direction direction) {
+        super(id, target, direction);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class GroupByValue extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, String fieldName, ScriptTemplate script, Direction direction) {
-        return new GroupByValue(id, fieldName, script, direction);
+    protected GroupByKey copy(String id, AggTarget target, Direction direction) {
+        return new GroupByValue(id, target(), direction);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByValue.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/GroupByValue.java
@@ -16,15 +16,15 @@ import org.elasticsearch.xpack.ql.querydsl.container.Sort.Direction;
 public class GroupByValue extends GroupByKey {
 
     public GroupByValue(String id, String fieldName) {
-        this(id, AggTarget.of(fieldName), null);
+        this(id, AggSource.of(fieldName), null);
     }
 
     public GroupByValue(String id, ScriptTemplate script) {
-        this(id, AggTarget.of(script), null);
+        this(id, AggSource.of(script), null);
     }
 
-    private GroupByValue(String id, AggTarget target, Direction direction) {
-        super(id, target, direction);
+    private GroupByValue(String id, AggSource source, Direction direction) {
+        super(id, source, direction);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class GroupByValue extends GroupByKey {
     }
 
     @Override
-    protected GroupByKey copy(String id, AggTarget target, Direction direction) {
-        return new GroupByValue(id, target(), direction);
+    protected GroupByKey copy(String id, AggSource source, Direction direction) {
+        return new GroupByValue(id, source(), direction);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/LeafAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/LeafAgg.java
@@ -10,18 +10,14 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuil
 
 public abstract class LeafAgg extends Agg {
 
-    LeafAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    LeafAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     abstract AggregationBuilder toBuilder();
 
     @SuppressWarnings("rawtypes")
     protected ValuesSourceAggregationBuilder addFieldOrScript(ValuesSourceAggregationBuilder builder) {
-        if (fieldName() != null) {
-            return builder.field(fieldName());
-        } else {
-            return builder.script(scriptTemplate().toPainless());
-        }
+        return target().with(builder);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/LeafAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/LeafAgg.java
@@ -6,12 +6,22 @@
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 
 public abstract class LeafAgg extends Agg {
 
-    LeafAgg(String id, String fieldName) {
-        super(id, fieldName);
+    LeafAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     abstract AggregationBuilder toBuilder();
+
+    @SuppressWarnings("rawtypes")
+    protected ValuesSourceAggregationBuilder addFieldOrScript(ValuesSourceAggregationBuilder builder) {
+        if (fieldName() != null) {
+            return builder.field(fieldName());
+        } else {
+            return builder.script(scriptTemplate().toPainless());
+        }
+    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/LeafAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/LeafAgg.java
@@ -10,14 +10,14 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuil
 
 public abstract class LeafAgg extends Agg {
 
-    LeafAgg(String id, AggTarget target) {
-        super(id, target);
+    LeafAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     abstract AggregationBuilder toBuilder();
 
     @SuppressWarnings("rawtypes")
-    protected ValuesSourceAggregationBuilder addFieldOrScript(ValuesSourceAggregationBuilder builder) {
-        return target().with(builder);
+    protected ValuesSourceAggregationBuilder addAggSource(ValuesSourceAggregationBuilder builder) {
+        return source().with(builder);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MatrixStatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MatrixStatsAgg.java
@@ -16,7 +16,7 @@ public class MatrixStatsAgg extends LeafAgg {
     private final List<String> fields;
 
     public MatrixStatsAgg(String id, List<String> fields) {
-        super(id, AggTarget.of("<multi-field>"));
+        super(id, AggSource.of("<multi-field>"));
         this.fields = fields;
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MatrixStatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MatrixStatsAgg.java
@@ -16,7 +16,7 @@ public class MatrixStatsAgg extends LeafAgg {
     private final List<String> fields;
 
     public MatrixStatsAgg(String id, List<String> fields) {
-        super(id, "<multi-field>");
+        super(id, AggTarget.of("<multi-field>"));
         this.fields = fields;
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MaxAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MaxAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 
 public class MaxAgg extends LeafAgg {
 
-    public MaxAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public MaxAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return max(id()).field(fieldName());
+        return addFieldOrScript(max(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MaxAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MaxAgg.java
@@ -11,8 +11,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 
 public class MaxAgg extends LeafAgg {
 
-    public MaxAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public MaxAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MaxAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MaxAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 
 public class MaxAgg extends LeafAgg {
 
-    public MaxAgg(String id, AggTarget target) {
-        super(id, target);
+    public MaxAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(max(id()));
+        return addAggSource(max(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MedianAbsoluteDeviationAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MedianAbsoluteDeviationAgg.java
@@ -12,12 +12,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.medianAb
 
 public class MedianAbsoluteDeviationAgg extends LeafAgg {
 
-    public MedianAbsoluteDeviationAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public MedianAbsoluteDeviationAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return medianAbsoluteDeviation(id()).field(fieldName());
+        return addFieldOrScript(medianAbsoluteDeviation(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MedianAbsoluteDeviationAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MedianAbsoluteDeviationAgg.java
@@ -12,8 +12,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.medianAb
 
 public class MedianAbsoluteDeviationAgg extends LeafAgg {
 
-    public MedianAbsoluteDeviationAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public MedianAbsoluteDeviationAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MedianAbsoluteDeviationAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MedianAbsoluteDeviationAgg.java
@@ -12,12 +12,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.medianAb
 
 public class MedianAbsoluteDeviationAgg extends LeafAgg {
 
-    public MedianAbsoluteDeviationAgg(String id, AggTarget target) {
-        super(id, target);
+    public MedianAbsoluteDeviationAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(medianAbsoluteDeviation(id()));
+        return addAggSource(medianAbsoluteDeviation(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MinAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MinAgg.java
@@ -11,8 +11,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 
 public class MinAgg extends LeafAgg {
 
-    public MinAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public MinAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MinAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MinAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 
 public class MinAgg extends LeafAgg {
 
-    public MinAgg(String id, AggTarget target) {
-        super(id, target);
+    public MinAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(min(id()));
+        return addAggSource(min(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MinAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/MinAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 
 public class MinAgg extends LeafAgg {
 
-    public MinAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public MinAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return min(id()).field(fieldName());
+        return addFieldOrScript(min(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentileRanksAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentileRanksAgg.java
@@ -15,18 +15,13 @@ public class PercentileRanksAgg extends LeafAgg {
 
     private final List<Double> values;
 
-    public PercentileRanksAgg(String id, String fieldName, List<Double> values) {
-        super(id, fieldName);
+    public PercentileRanksAgg(String id, Object fieldOrScript, List<Double> values) {
+        super(id, fieldOrScript);
         this.values = values;
-    }
-
-    public List<Double> percents() {
-        return values;
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return percentileRanks(id(), values.stream().mapToDouble(Double::doubleValue).toArray())
-                .field(fieldName());
+        return addFieldOrScript(percentileRanks(id(), values.stream().mapToDouble(Double::doubleValue).toArray()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentileRanksAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentileRanksAgg.java
@@ -15,8 +15,8 @@ public class PercentileRanksAgg extends LeafAgg {
 
     private final List<Double> values;
 
-    public PercentileRanksAgg(String id, Object fieldOrScript, List<Double> values) {
-        super(id, fieldOrScript);
+    public PercentileRanksAgg(String id, AggTarget target, List<Double> values) {
+        super(id, target);
         this.values = values;
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentileRanksAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentileRanksAgg.java
@@ -15,13 +15,13 @@ public class PercentileRanksAgg extends LeafAgg {
 
     private final List<Double> values;
 
-    public PercentileRanksAgg(String id, AggTarget target, List<Double> values) {
-        super(id, target);
+    public PercentileRanksAgg(String id, AggSource source, List<Double> values) {
+        super(id, source);
         this.values = values;
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(percentileRanks(id(), values.stream().mapToDouble(Double::doubleValue).toArray()));
+        return addAggSource(percentileRanks(id(), values.stream().mapToDouble(Double::doubleValue).toArray()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentilesAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentilesAgg.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
 
 import java.util.List;
 
@@ -15,20 +16,15 @@ public class PercentilesAgg extends LeafAgg {
 
     private final List<Double> percents;
 
-    public PercentilesAgg(String id, String fieldName, List<Double> percents) {
-        super(id, fieldName);
+    public PercentilesAgg(String id, Object fieldOrScript, List<Double> percents) {
+        super(id, fieldOrScript);
         this.percents = percents;
-    }
-
-    public List<Double> percents() {
-        return percents;
     }
 
     @Override
     AggregationBuilder toBuilder() {
         // TODO: look at keyed
-        return percentiles(id())
-                .field(fieldName())
-                .percentiles(percents.stream().mapToDouble(Double::doubleValue).toArray());
+        PercentilesAggregationBuilder builder = (PercentilesAggregationBuilder) addFieldOrScript(percentiles(id()));
+        return builder.percentiles(percents.stream().mapToDouble(Double::doubleValue).toArray());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentilesAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentilesAgg.java
@@ -16,8 +16,8 @@ public class PercentilesAgg extends LeafAgg {
 
     private final List<Double> percents;
 
-    public PercentilesAgg(String id, Object fieldOrScript, List<Double> percents) {
-        super(id, fieldOrScript);
+    public PercentilesAgg(String id, AggTarget target, List<Double> percents) {
+        super(id, target);
         this.percents = percents;
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentilesAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/PercentilesAgg.java
@@ -16,15 +16,15 @@ public class PercentilesAgg extends LeafAgg {
 
     private final List<Double> percents;
 
-    public PercentilesAgg(String id, AggTarget target, List<Double> percents) {
-        super(id, target);
+    public PercentilesAgg(String id, AggSource source, List<Double> percents) {
+        super(id, source);
         this.percents = percents;
     }
 
     @Override
     AggregationBuilder toBuilder() {
         // TODO: look at keyed
-        PercentilesAggregationBuilder builder = (PercentilesAggregationBuilder) addFieldOrScript(percentiles(id()));
+        PercentilesAggregationBuilder builder = (PercentilesAggregationBuilder) addAggSource(percentiles(id()));
         return builder.percentiles(percents.stream().mapToDouble(Double::doubleValue).toArray());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/StatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/StatsAgg.java
@@ -11,8 +11,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 
 public class StatsAgg extends LeafAgg {
 
-    public StatsAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public StatsAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/StatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/StatsAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 
 public class StatsAgg extends LeafAgg {
 
-    public StatsAgg(String id, AggTarget target) {
-        super(id, target);
+    public StatsAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(stats(id()));
+        return addAggSource(stats(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/StatsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/StatsAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 
 public class StatsAgg extends LeafAgg {
 
-    public StatsAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public StatsAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return stats(id()).field(fieldName());
+        return addFieldOrScript(stats(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/SumAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/SumAgg.java
@@ -11,11 +11,11 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 
 public class SumAgg extends LeafAgg {
 
-    public SumAgg(String id, String fieldName) {
-        super(id, fieldName);
+    public SumAgg(String id, Object fieldOrScript) {
+        super(id, fieldOrScript);
     }
 
     @Override AggregationBuilder toBuilder() {
-        return sum(id()).field(fieldName());
+        return addFieldOrScript(sum(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/SumAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/SumAgg.java
@@ -11,11 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 
 public class SumAgg extends LeafAgg {
 
-    public SumAgg(String id, Object fieldOrScript) {
-        super(id, fieldOrScript);
+    public SumAgg(String id, AggTarget target) {
+        super(id, target);
     }
 
-    @Override AggregationBuilder toBuilder() {
+    @Override
+    AggregationBuilder toBuilder() {
         return addFieldOrScript(sum(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/SumAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/SumAgg.java
@@ -11,12 +11,12 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 
 public class SumAgg extends LeafAgg {
 
-    public SumAgg(String id, AggTarget target) {
-        super(id, target);
+    public SumAgg(String id, AggSource source) {
+        super(id, source);
     }
 
     @Override
     AggregationBuilder toBuilder() {
-        return addFieldOrScript(sum(id()));
+        return addAggSource(sum(id()));
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/TopHitsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/TopHitsAgg.java
@@ -11,10 +11,8 @@ import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.xpack.ql.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.ql.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
 
 import java.util.ArrayList;
@@ -26,34 +24,22 @@ import static org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing.LAST;
 
 public class TopHitsAgg extends LeafAgg {
 
-    private final String sortField;
-    private final ScriptTemplate sortScriptTemplate;
+    private final AggTarget sortTarget;
     private final SortOrder sortOrder;
     private final DataType fieldDataType;
     private final DataType sortFieldDataType;
 
     public TopHitsAgg(
         String id,
-        Object fieldOrScript,
+        AggTarget target,
         DataType fieldDataType,
-        Object sortFieldOrScript,
+        AggTarget sortTarget,
         DataType sortFieldDataType,
         SortOrder sortOrder
     ) {
-        super(id, fieldOrScript);
-        if (sortFieldOrScript == null) {
-            this.sortField = null;
-            this.sortScriptTemplate = null;
-        } else if (sortFieldOrScript instanceof String) {
-            this.sortField = (String) sortFieldOrScript;
-            this.sortScriptTemplate = null;
-        } else if (sortFieldOrScript instanceof ScriptTemplate) {
-            this.sortField = null;
-            this.sortScriptTemplate = (ScriptTemplate) sortFieldOrScript;
-        } else {
-            throw new SqlIllegalArgumentException("sorting argument of TopHits aggregation should be String or ScriptTemplate");
-        }
+        super(id, target);
         this.fieldDataType = fieldDataType;
+        this.sortTarget = sortTarget;
         this.sortOrder = sortOrder;
         this.sortFieldDataType = sortFieldDataType;
     }
@@ -62,30 +48,34 @@ public class TopHitsAgg extends LeafAgg {
     AggregationBuilder toBuilder() {
         // Sort missing values (NULLs) as last to get the first/last non-null value
         List<SortBuilder<?>> sortBuilderList = new ArrayList<>(2);
-        if (sortField != null) {
-            sortBuilderList.add(
-                new FieldSortBuilder(sortField).order(sortOrder).missing(LAST.position()).unmappedType(sortFieldDataType.esType())
-            );
-        } else if (sortScriptTemplate != null) {
-            sortBuilderList.add(
-                new ScriptSortBuilder(
-                    Scripts.nullSafeSort(sortScriptTemplate).toPainless(),
-                    sortScriptTemplate.outputType().isNumeric()
-                        ? ScriptSortBuilder.ScriptSortType.NUMBER
-                        : ScriptSortBuilder.ScriptSortType.STRING
-                ).order(sortOrder)
-            );
+        if (sortTarget != null) {
+            if (sortTarget.fieldName() != null) {
+                sortBuilderList.add(
+                    new FieldSortBuilder(sortTarget.fieldName()).order(sortOrder)
+                        .missing(LAST.position())
+                        .unmappedType(sortFieldDataType.esType())
+                );
+            } else if (sortTarget.script() != null) {
+                sortBuilderList.add(
+                    new ScriptSortBuilder(
+                        Scripts.nullSafeSort(sortTarget.script()).toPainless(),
+                        sortTarget.script().outputType().isNumeric()
+                            ? ScriptSortBuilder.ScriptSortType.NUMBER
+                            : ScriptSortBuilder.ScriptSortType.STRING
+                    ).order(sortOrder)
+                );
+            }
         }
 
-        if (fieldName() != null) {
+        if (target().fieldName() != null) {
             sortBuilderList.add(
-                new FieldSortBuilder(fieldName()).order(sortOrder).missing(LAST.position()).unmappedType(fieldDataType.esType())
+                new FieldSortBuilder(target().fieldName()).order(sortOrder).missing(LAST.position()).unmappedType(fieldDataType.esType())
             );
         } else {
             sortBuilderList.add(
                 new ScriptSortBuilder(
-                    Scripts.nullSafeSort(scriptTemplate()).toPainless(),
-                    scriptTemplate().outputType().isNumeric()
+                    Scripts.nullSafeSort(target().script()).toPainless(),
+                    target().script().outputType().isNumeric()
                         ? ScriptSortBuilder.ScriptSortType.NUMBER
                         : ScriptSortBuilder.ScriptSortType.STRING
                 ).order(sortOrder)
@@ -93,11 +83,16 @@ public class TopHitsAgg extends LeafAgg {
         }
 
         TopHitsAggregationBuilder builder = topHits(id());
-        if (fieldName() != null) {
-            return builder.docValueField(fieldName(), SqlDataTypes.format(fieldDataType)).sorts(sortBuilderList).size(1);
+        if (target().fieldName() != null) {
+            return builder.docValueField(target().fieldName(), SqlDataTypes.format(fieldDataType)).sorts(sortBuilderList).size(1);
         } else {
-            return builder.scriptField(id(), scriptTemplate().toPainless()).sorts(sortBuilderList).size(1);
+            return builder.scriptField(id(), target().script().toPainless()).sorts(sortBuilderList).size(1);
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), sortTarget, sortOrder, fieldDataType, sortFieldDataType);
     }
 
     @Override
@@ -108,18 +103,13 @@ public class TopHitsAgg extends LeafAgg {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
+        if (super.equals(o) == false) {
             return false;
         }
         TopHitsAgg that = (TopHitsAgg) o;
-        return Objects.equals(sortField, that.sortField)
-            && Objects.equals(sortScriptTemplate, that.sortScriptTemplate)
-            && sortOrder == that.sortOrder
-            && fieldDataType == that.fieldDataType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), sortField, sortScriptTemplate, sortOrder, fieldDataType);
+        return Objects.equals(sortTarget, that.sortTarget) &&
+                sortOrder==that.sortOrder &&
+                Objects.equals(fieldDataType, that.fieldDataType) &&
+                Objects.equals(sortFieldDataType, that.sortFieldDataType);
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/TopHitsAgg.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/agg/TopHitsAgg.java
@@ -5,13 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.querydsl.agg;
 
-import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
-import static org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing.LAST;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -23,6 +16,13 @@ import org.elasticsearch.xpack.ql.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.type.SqlDataTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
+import static org.elasticsearch.xpack.ql.querydsl.container.Sort.Missing.LAST;
 
 public class TopHitsAgg extends LeafAgg {
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -6,16 +6,13 @@
 package org.elasticsearch.xpack.sql.analysis.analyzer;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.ql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.type.EsField;
-import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolverTests;
 import org.elasticsearch.xpack.sql.expression.function.SqlFunctionRegistry;
-import org.elasticsearch.xpack.sql.expression.function.aggregate.MatrixStatsEnclosed;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.Round;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.Truncate;
 import org.elasticsearch.xpack.sql.expression.function.scalar.string.Char;
@@ -39,12 +36,12 @@ import static org.elasticsearch.xpack.ql.type.DataTypes.KEYWORD;
 import static org.elasticsearch.xpack.ql.type.DataTypes.OBJECT;
 import static org.elasticsearch.xpack.sql.types.SqlTypesTests.loadMapping;
 
-
 public class VerifierErrorMessagesTests extends ESTestCase {
 
-    private SqlParser parser = new SqlParser();
-    private IndexResolution indexResolution = IndexResolution.valid(new EsIndex("test",
-            loadMapping("mapping-multi-field-with-nested.json")));
+    private final SqlParser parser = new SqlParser();
+    private final IndexResolution indexResolution = IndexResolution.valid(
+        new EsIndex("test", loadMapping("mapping-multi-field-with-nested.json"))
+    );
 
     private String error(String sql) {
         return error(indexResolution, sql);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -6,13 +6,16 @@
 package org.elasticsearch.xpack.sql.analysis.analyzer;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.type.EsField;
+import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolverTests;
 import org.elasticsearch.xpack.sql.expression.function.SqlFunctionRegistry;
+import org.elasticsearch.xpack.sql.expression.function.aggregate.MatrixStatsEnclosed;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.Round;
 import org.elasticsearch.xpack.sql.expression.function.scalar.math.Truncate;
 import org.elasticsearch.xpack.sql.expression.function.scalar.string.Char;
@@ -1097,5 +1100,12 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     public void testPivotValuesWithMultipleDifferencesThanColumn() {
         assertEquals("1:81: Literal ['bla'] of type [keyword] does not match type [boolean] of PIVOT column [bool]",
                 error("SELECT * FROM (SELECT int, keyword, bool FROM test) " + "PIVOT(AVG(int) FOR bool IN ('bla', true))"));
+    }
+
+    public void testErrorMessageForMatrixStatsWithScalars() {
+        assertEquals("1:17: [KURTOSIS()] cannot be used on top of operators or scalars",
+                error("SELECT KURTOSIS(ABS(int * 10.123)) FROM test"));
+        assertEquals("1:17: [SKEWNESS()] cannot be used on top of operators or scalars",
+                error("SELECT SKEWNESS(ABS(int * 10.123)) FROM test"));
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/SourceGeneratorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/SourceGeneratorTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.xpack.ql.querydsl.query.MatchQuery;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
 import org.elasticsearch.xpack.sql.expression.function.Score;
-import org.elasticsearch.xpack.sql.querydsl.agg.AggTarget;
+import org.elasticsearch.xpack.sql.querydsl.agg.AggSource;
 import org.elasticsearch.xpack.sql.querydsl.agg.AvgAgg;
 import org.elasticsearch.xpack.sql.querydsl.agg.GroupByValue;
 import org.elasticsearch.xpack.sql.querydsl.container.QueryContainer;
@@ -134,7 +134,7 @@ public class SourceGeneratorTests extends ESTestCase {
     public void testNoSortIfAgg() {
         QueryContainer container = new QueryContainer()
                 .addGroups(singletonList(new GroupByValue("group_id", "group_column")))
-                .addAgg("group_id", new AvgAgg("agg_id", AggTarget.of("avg_column")));
+                .addAgg("group_id", new AvgAgg("agg_id", AggSource.of("avg_column")));
         SearchSourceBuilder sourceBuilder = SourceGenerator.sourceBuilder(container, null, randomIntBetween(1, 10));
         assertNull(sourceBuilder.sorts());
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/SourceGeneratorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/SourceGeneratorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.ql.querydsl.query.MatchQuery;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
 import org.elasticsearch.xpack.sql.expression.function.Score;
+import org.elasticsearch.xpack.sql.querydsl.agg.AggTarget;
 import org.elasticsearch.xpack.sql.querydsl.agg.AvgAgg;
 import org.elasticsearch.xpack.sql.querydsl.agg.GroupByValue;
 import org.elasticsearch.xpack.sql.querydsl.container.QueryContainer;
@@ -133,7 +134,7 @@ public class SourceGeneratorTests extends ESTestCase {
     public void testNoSortIfAgg() {
         QueryContainer container = new QueryContainer()
                 .addGroups(singletonList(new GroupByValue("group_id", "group_column")))
-                .addAgg("group_id", new AvgAgg("agg_id", "avg_column"));
+                .addAgg("group_id", new AvgAgg("agg_id", AggTarget.of("avg_column")));
         SearchSourceBuilder sourceBuilder = SourceGenerator.sourceBuilder(container, null, randomIntBetween(1, 10));
         assertNull(sourceBuilder.sorts());
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -91,7 +91,6 @@ import org.elasticsearch.xpack.sql.querydsl.agg.GroupByDateHistogram;
 import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.types.SqlTypesTests;
 import org.elasticsearch.xpack.sql.util.DateUtils;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 public class QueryTranslatorTests extends ESTestCase {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -592,7 +592,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertFalse(condition.foldable());
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals("InternalSqlScriptUtils.caseFunction([InternalSqlScriptUtils.regex(InternalQlScriptUtils.docValue("
                 + "doc,params.v0),params.v1),params.v2,InternalSqlScriptUtils.regex(InternalQlScriptUtils.docValue(" +
                      "doc,params.v3),params.v4),params.v5,params.v6])",
@@ -864,7 +864,7 @@ public class QueryTranslatorTests extends ESTestCase {
 
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals(
                 "InternalSqlScriptUtils.round(InternalSqlScriptUtils.dateTimeChrono(InternalQlScriptUtils.docValue(doc,params.v0), "
                 + "params.v1, params.v2),params.v3)",
@@ -889,7 +889,7 @@ public class QueryTranslatorTests extends ESTestCase {
 
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals(
                 "InternalSqlScriptUtils.round(InternalSqlScriptUtils.dateTimeChrono(InternalQlScriptUtils.docValue(doc,params.v0), "
                 + "params.v1, params.v2),params.v3)",
@@ -1022,7 +1022,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertFalse(condition.foldable());
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals(
                 "InternalSqlScriptUtils.coalesce([InternalQlScriptUtils.docValue(doc,params.v0),params.v1])",
             scriptTemplate.toString());
@@ -1036,7 +1036,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertFalse(condition.foldable());
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals(
                 "InternalSqlScriptUtils.nullif(InternalQlScriptUtils.docValue(doc,params.v0),params.v1)",
             scriptTemplate.toString());
@@ -1050,7 +1050,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertFalse(condition.foldable());
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals("InternalSqlScriptUtils.caseFunction([InternalQlScriptUtils.gt(InternalQlScriptUtils.docValue(" + ""
                 + "doc,params.v0),params.v1),params.v2,InternalQlScriptUtils.gt(InternalQlScriptUtils.docValue(doc,params.v3)," +
                 "params.v4),params.v5,params.v6])",
@@ -1065,7 +1065,7 @@ public class QueryTranslatorTests extends ESTestCase {
         assertFalse(condition.foldable());
         GroupingContext groupingContext = QueryFolder.FoldAggregate.groupBy(((Aggregate) p).groupings());
         assertNotNull(groupingContext);
-        ScriptTemplate scriptTemplate = groupingContext.tail.scriptTemplate();
+        ScriptTemplate scriptTemplate = groupingContext.tail.script();
         assertEquals("InternalSqlScriptUtils.caseFunction([InternalQlScriptUtils.gt("  +
                 "InternalQlScriptUtils.docValue(doc,params.v0),params.v1),params.v2,params.v3])",
             scriptTemplate.toString());

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -5,30 +5,6 @@
  */
 package org.elasticsearch.xpack.sql.planner;
 
-import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
-import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
-import static org.elasticsearch.xpack.ql.type.DataTypes.DOUBLE;
-import static org.elasticsearch.xpack.ql.type.DataTypes.INTEGER;
-import static org.elasticsearch.xpack.ql.type.DataTypes.KEYWORD;
-import static org.elasticsearch.xpack.ql.type.DataTypes.LONG;
-import static org.elasticsearch.xpack.ql.type.DataTypes.TEXT;
-import static org.elasticsearch.xpack.sql.expression.function.scalar.math.MathProcessor.MathOperation.E;
-import static org.elasticsearch.xpack.sql.expression.function.scalar.math.MathProcessor.MathOperation.PI;
-import static org.elasticsearch.xpack.sql.planner.QueryTranslator.DATE_FORMAT;
-import static org.elasticsearch.xpack.sql.planner.QueryTranslator.TIME_FORMAT;
-import static org.elasticsearch.xpack.sql.type.SqlDataTypes.DATE;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.startsWith;
-
-import java.time.ZonedDateTime;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Stream;
-
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -92,6 +68,30 @@ import org.elasticsearch.xpack.sql.stats.Metrics;
 import org.elasticsearch.xpack.sql.types.SqlTypesTests;
 import org.elasticsearch.xpack.sql.util.DateUtils;
 import org.junit.BeforeClass;
+
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
+import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
+import static org.elasticsearch.xpack.ql.type.DataTypes.DOUBLE;
+import static org.elasticsearch.xpack.ql.type.DataTypes.INTEGER;
+import static org.elasticsearch.xpack.ql.type.DataTypes.KEYWORD;
+import static org.elasticsearch.xpack.ql.type.DataTypes.LONG;
+import static org.elasticsearch.xpack.ql.type.DataTypes.TEXT;
+import static org.elasticsearch.xpack.sql.expression.function.scalar.math.MathProcessor.MathOperation.E;
+import static org.elasticsearch.xpack.sql.expression.function.scalar.math.MathProcessor.MathOperation.PI;
+import static org.elasticsearch.xpack.sql.planner.QueryTranslator.DATE_FORMAT;
+import static org.elasticsearch.xpack.sql.planner.QueryTranslator.TIME_FORMAT;
+import static org.elasticsearch.xpack.sql.type.SqlDataTypes.DATE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 
 public class QueryTranslatorTests extends ESTestCase {
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -1830,7 +1830,7 @@ public class QueryTranslatorTests extends ESTestCase {
                     () -> optimizeAndPlan("SELECT " + aggFunction + "(int * 10.123) FROM test")
                 );
                 assertEquals(
-                    "Cannot use scalar functions or operators: [int * 10.123] in matrix stats aggregate functions " +
+                    "Cannot use scalar functions or operators: [int * 10.123] in aggregate functions " +
                     "[KURTOSIS] and [SKEWNESS]", siae.getMessage()
                 );
             }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.TermsQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.WildcardQuery;
 import org.elasticsearch.xpack.ql.type.EsField;
-import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Verifier;
@@ -1819,22 +1818,6 @@ public class QueryTranslatorTests extends ESTestCase {
         assertThat(eqe.queryContainer().toString().replaceAll("\\s+", ""), containsString(
                 "\"script\":{\"source\":\"InternalQlScriptUtils.nullSafeFilter(InternalQlScriptUtils.gt(params.a0,params.v0))\","
                 + "\"lang\":\"painless\",\"params\":{\"v0\":0}}"));
-    }
-
-    public void testErrorMessageForMatrixStatsWithScalars() {
-        for (FunctionDefinition fd : sqlFunctionRegistry.listFunctions()) {
-            String aggFunction = fd.name();
-            if (MatrixStatsEnclosed.class.isAssignableFrom(fd.clazz())) {
-                SqlIllegalArgumentException siae = expectThrows(
-                    SqlIllegalArgumentException.class,
-                    () -> optimizeAndPlan("SELECT " + aggFunction + "(int * 10.123) FROM test")
-                );
-                assertEquals(
-                    "Cannot use scalar functions or operators: [int * 10.123] in aggregate functions " +
-                    "[KURTOSIS] and [SKEWNESS]", siae.getMessage()
-                );
-            }
-        }
     }
 
     public void testScriptsInsideAggregateFunctions() {


### PR DESCRIPTION
Implement the use of scalar functions inside aggregate functions.
This allows for complex expressions inside aggregations, with or without
GROUBY as well as with or without a HAVING clause. e.g.:

```
SELECT MAX(CASE WHEN a IS NULL then -1 ELSE abs(a * 10) + 1 END) AS max, b
FROM test
GROUP BY b
HAVING MAX(CASE WHEN a IS NULL then -1 ELSE abs(a * 10) + 1 END) > 5
```

Scalar functions are still not allowed for `KURTOSIS` and `SKEWNESS` as
this is currently not implemented on the Elasticsearch side.

Fixes: #29980
Fixes: #36865
Fixes: #37271
