### PR TITLE
Make feature usage version aware

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/ccr/CCRInfoTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/ccr/CCRInfoTransportAction.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ccr;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -76,6 +77,11 @@ public class CCRInfoTransportAction extends XPackInfoFeatureTransportAction {
             } else {
                 lastFollowTimeInMillis = null;
             }
+        }
+
+        @Override
+        public Version version() {
+            return Version.V_7_0_0;
         }
 
         public int getNumberOfFollowerIndices() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/ccr/CCRInfoTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/ccr/CCRInfoTransportAction.java
@@ -80,7 +80,7 @@ public class CCRInfoTransportAction extends XPackInfoFeatureTransportAction {
         }
 
         @Override
-        public Version version() {
+        public Version getMinimalSupportedVersion() {
             return Version.V_7_0_0;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.core;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
@@ -40,8 +39,6 @@ public interface XPackFeatureSet {
             this.available = available;
             this.enabled = enabled;
         }
-
-        public abstract Version getMinimalSupportedVersion();
 
         public String name() {
             return name;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,6 +40,8 @@ public interface XPackFeatureSet {
             this.available = available;
             this.enabled = enabled;
         }
+
+        public abstract Version version();
 
         public String name() {
             return name;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
@@ -6,9 +6,9 @@
 package org.elasticsearch.xpack.core;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
@@ -22,7 +22,7 @@ public interface XPackFeatureSet {
 
     boolean enabled();
 
-    abstract class Usage implements ToXContentObject, NamedWriteable {
+    abstract class Usage implements ToXContentObject, VersionedNamedWriteable {
 
         private static final String AVAILABLE_XFIELD = "available";
         private static final String ENABLED_XFIELD = "enabled";
@@ -41,7 +41,7 @@ public interface XPackFeatureSet {
             this.enabled = enabled;
         }
 
-        public abstract Version version();
+        public abstract Version getMinimalSupportedVersion();
 
         public String name() {
             return name;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -33,7 +33,7 @@ public class XPackUsageResponse extends ActionResponse {
 
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
-        // we can only wrote the usages with version the coordinating node is compatible with otherwise it will not know the named writeable
+        // we can only write the usages with version the coordinating node is compatible with otherwise it will not know the named writeable
         final List<XPackFeatureSet.Usage> usagesToWrite =
             usages.stream().filter(usage -> out.getVersion().onOrAfter(usage.version())).collect(Collectors.toUnmodifiableList());
         writeTo(out, usages);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -34,8 +34,10 @@ public class XPackUsageResponse extends ActionResponse {
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         // we can only write the usages with version the coordinating node is compatible with otherwise it will not know the named writeable
-        final List<XPackFeatureSet.Usage> usagesToWrite =
-            usages.stream().filter(usage -> out.getVersion().onOrAfter(usage.version())).collect(Collectors.toUnmodifiableList());
+        final List<XPackFeatureSet.Usage> usagesToWrite = usages
+            .stream()
+            .filter(usage -> out.getVersion().onOrAfter(usage.getMinimalSupportedVersion()))
+            .collect(Collectors.toUnmodifiableList());
         writeTo(out, usagesToWrite);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -12,18 +12,19 @@ import org.elasticsearch.xpack.core.XPackFeatureSet;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class XPackUsageResponse extends ActionResponse {
 
-    private List<XPackFeatureSet.Usage> usages;
+    private final List<XPackFeatureSet.Usage> usages;
 
-    public XPackUsageResponse(StreamInput in) throws IOException {
+    public XPackUsageResponse(final StreamInput in) throws IOException {
         usages = in.readNamedWriteableList(XPackFeatureSet.Usage.class);
     }
 
-    public XPackUsageResponse(List<XPackFeatureSet.Usage> usages) {
-        this.usages = usages;
+    public XPackUsageResponse(final List<XPackFeatureSet.Usage> usages) {
+        this.usages = Objects.requireNonNull(usages);
     }
 
     public List<XPackFeatureSet.Usage> getUsages() {
@@ -31,7 +32,7 @@ public class XPackUsageResponse extends ActionResponse {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
+    public void writeTo(final StreamOutput out) throws IOException {
         // we can only wrote the usages with version the coordinating node is compatible with otherwise it will not know the named writeable
         final List<XPackFeatureSet.Usage> usagesToWrite =
             usages.stream().filter(usage -> out.getVersion().onOrAfter(usage.version())).collect(Collectors.toUnmodifiableList());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -19,12 +19,12 @@ public class XPackUsageResponse extends ActionResponse {
 
     private final List<XPackFeatureSet.Usage> usages;
 
-    public XPackUsageResponse(final StreamInput in) throws IOException {
-        usages = in.readNamedWriteableList(XPackFeatureSet.Usage.class);
-    }
-
     public XPackUsageResponse(final List<XPackFeatureSet.Usage> usages) {
         this.usages = Objects.requireNonNull(usages);
+    }
+
+    public XPackUsageResponse(final StreamInput in) throws IOException {
+        usages = in.readNamedWriteableList(XPackFeatureSet.Usage.class);
     }
 
     public List<XPackFeatureSet.Usage> getUsages() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -36,7 +36,7 @@ public class XPackUsageResponse extends ActionResponse {
         // we can only write the usages with version the coordinating node is compatible with otherwise it will not know the named writeable
         final List<XPackFeatureSet.Usage> usagesToWrite =
             usages.stream().filter(usage -> out.getVersion().onOrAfter(usage.version())).collect(Collectors.toUnmodifiableList());
-        writeTo(out, usages);
+        writeTo(out, usagesToWrite);
     }
 
     private static void writeTo(final StreamOutput out, final List<XPackFeatureSet.Usage> usages) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageResponse.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,12 +19,7 @@ public class XPackUsageResponse extends ActionResponse {
     private List<XPackFeatureSet.Usage> usages;
 
     public XPackUsageResponse(StreamInput in) throws IOException {
-        super(in);
-        int size = in.readVInt();
-        usages = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            usages.add(in.readNamedWriteable(XPackFeatureSet.Usage.class));
-        }
+        usages = in.readNamedWriteableList(XPackFeatureSet.Usage.class);
     }
 
     public XPackUsageResponse(List<XPackFeatureSet.Usage> usages) {
@@ -41,10 +35,11 @@ public class XPackUsageResponse extends ActionResponse {
         // we can only wrote the usages with version the coordinating node is compatible with otherwise it will not know the named writeable
         final List<XPackFeatureSet.Usage> usagesToWrite =
             usages.stream().filter(usage -> out.getVersion().onOrAfter(usage.version())).collect(Collectors.toUnmodifiableList());
-        out.writeVInt(usagesToWrite.size());
-        for (XPackFeatureSet.Usage usageToWrite : usagesToWrite) {
-            out.writeNamedWriteable(usageToWrite);
-        }
+        writeTo(out, usages);
+    }
+
+    private static void writeTo(final StreamOutput out, final List<XPackFeatureSet.Usage> usages) throws IOException {
+        out.writeNamedWriteableList(usages);
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/AnalyticsFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/AnalyticsFeatureSetUsage.java
@@ -37,7 +37,7 @@ public class AnalyticsFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_4_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/AnalyticsFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/analytics/AnalyticsFeatureSetUsage.java
@@ -37,6 +37,11 @@ public class AnalyticsFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
+    public Version version() {
+        return Version.V_7_4_0;
+    }
+
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         if (out.getVersion().onOrAfter(Version.V_7_8_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/eql/EqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/eql/EqlFeatureSetUsage.java
@@ -51,7 +51,7 @@ public class EqlFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_7_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/eql/EqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/eql/EqlFeatureSetUsage.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.eql;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -16,7 +17,7 @@ import java.io.IOException;
 import java.util.Map;
 
 public class EqlFeatureSetUsage extends XPackFeatureSet.Usage {
-    
+
     private final Map<String, Object> stats;
 
     public EqlFeatureSetUsage(StreamInput in) throws IOException {
@@ -48,4 +49,10 @@ public class EqlFeatureSetUsage extends XPackFeatureSet.Usage {
         super.writeTo(out);
         out.writeMap(stats);
     }
+
+    @Override
+    public Version version() {
+        return Version.V_7_7_0;
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
@@ -25,7 +25,7 @@ public class FrozenIndicesFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.frozen;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -21,6 +22,11 @@ public class FrozenIndicesFeatureSetUsage extends XPackFeatureSet.Usage {
     public FrozenIndicesFeatureSetUsage(StreamInput input) throws IOException {
         super(input);
         numberOfFrozenIndices = input.readVInt();
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/GraphFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/GraphFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.graph;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
@@ -20,4 +21,10 @@ public class GraphFeatureSetUsage extends XPackFeatureSet.Usage {
     public GraphFeatureSetUsage(boolean available, boolean enabled) {
         super(XPackField.GRAPH, available, enabled);
     }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/GraphFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/GraphFeatureSetUsage.java
@@ -23,7 +23,7 @@ public class GraphFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -35,7 +35,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,6 +32,11 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
         if (input.readBoolean()) {
             policyStats = input.readList(PolicyStats::new);
         }
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logstash/LogstashFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logstash/LogstashFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.logstash;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
@@ -19,6 +20,11 @@ public class LogstashFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public LogstashFeatureSetUsage(boolean available, boolean enabled) {
         super(XPackField.LOGSTASH, available, enabled);
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logstash/LogstashFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/logstash/LogstashFeatureSetUsage.java
@@ -23,7 +23,7 @@ public class LogstashFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
@@ -70,6 +70,11 @@ public class MachineLearningFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
+    public Version version() {
+        return Version.V_7_0_0;
+    }
+
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(jobsUsage);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
@@ -70,7 +70,7 @@ public class MachineLearningFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.monitoring;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,6 +35,11 @@ public class MonitoringFeatureSetUsage extends XPackFeatureSet.Usage {
         super(XPackField.MONITORING, available, enabled);
         this.exporters = exporters;
         this.collectionEnabled = collectionEnabled;
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
     }
 
     public Map<String, Object> getExporters() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringFeatureSetUsage.java
@@ -38,7 +38,7 @@ public class MonitoringFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/RollupFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/RollupFeatureSetUsage.java
@@ -23,7 +23,7 @@ public class RollupFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/RollupFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/RollupFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.rollup;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
@@ -20,4 +21,10 @@ public class RollupFeatureSetUsage extends XPackFeatureSet.Usage {
     public RollupFeatureSetUsage(boolean available, boolean enabled) {
         super(XPackField.ROLLUP, available, enabled);
     }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -78,6 +78,11 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
+    public Version version() {
+        return Version.V_7_0_0;
+    }
+
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeMap(realmsUsage);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -78,7 +78,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SLMFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SLMFeatureSetUsage.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.slm;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,6 +36,11 @@ public class SLMFeatureSetUsage extends XPackFeatureSet.Usage {
     public SLMFeatureSetUsage(boolean available, boolean enabled, @Nullable SnapshotLifecycleStats slmStats) {
         super(XPackField.SNAPSHOT_LIFECYCLE, available, enabled);
         this.slmStats = slmStats;
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_5_0;
     }
 
     public SnapshotLifecycleStats getStats() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SLMFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SLMFeatureSetUsage.java
@@ -39,7 +39,7 @@ public class SLMFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_5_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsage.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.spatial;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
@@ -22,6 +23,11 @@ public class SpatialFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public SpatialFeatureSetUsage(StreamInput input) throws IOException {
         super(input);
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_4_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsage.java
@@ -26,7 +26,7 @@ public class SpatialFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_4_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/sql/SqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/sql/SqlFeatureSetUsage.java
@@ -31,7 +31,7 @@ public class SqlFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/sql/SqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/sql/SqlFeatureSetUsage.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.sql;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -16,7 +17,7 @@ import java.io.IOException;
 import java.util.Map;
 
 public class SqlFeatureSetUsage extends XPackFeatureSet.Usage {
-    
+
     private final Map<String, Object> stats;
 
     public SqlFeatureSetUsage(StreamInput in) throws IOException {
@@ -27,6 +28,11 @@ public class SqlFeatureSetUsage extends XPackFeatureSet.Usage {
     public SqlFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> stats) {
         super(XPackField.SQL, available, enabled);
         this.stats = stats;
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
     }
 
     public Map<String, Object> stats() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -39,7 +39,7 @@ public class TransformFeatureSetUsage extends Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_5_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.transform;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,6 +36,11 @@ public class TransformFeatureSetUsage extends Usage {
         super(XPackField.TRANSFORM, available, enabled);
         this.transformCountByState = Objects.requireNonNull(transformCountByState);
         this.accumulatedStats = Objects.requireNonNull(accumulatedStats);
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_5_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/vectors/VectorsFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/vectors/VectorsFeatureSetUsage.java
@@ -42,6 +42,11 @@ public class VectorsFeatureSetUsage extends XPackFeatureSet.Usage {
         out.writeVInt(avgDenseVectorDims);
     }
 
+    @Override
+    public Version version() {
+        return Version.V_7_3_0;
+    }
+
     public VectorsFeatureSetUsage(boolean available, boolean enabled, int numDenseVectorFields, int avgDenseVectorDims) {
         super(XPackField.VECTORS, available, enabled);
         this.numDenseVectorFields = numDenseVectorFields;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/vectors/VectorsFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/vectors/VectorsFeatureSetUsage.java
@@ -43,7 +43,7 @@ public class VectorsFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_3_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/votingonly/VotingOnlyNodeFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/votingonly/VotingOnlyNodeFeatureSetUsage.java
@@ -22,7 +22,7 @@ public class VotingOnlyNodeFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_3_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/votingonly/VotingOnlyNodeFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/votingonly/VotingOnlyNodeFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.votingonly;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
@@ -19,4 +20,10 @@ public class VotingOnlyNodeFeatureSetUsage extends XPackFeatureSet.Usage {
     public VotingOnlyNodeFeatureSetUsage(boolean available) {
         super(XPackField.VOTING_ONLY, available, true);
     }
+
+    @Override
+    public Version version() {
+        return Version.V_7_3_0;
+    }
+
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherFeatureSetUsage.java
@@ -30,7 +30,7 @@ public class WatcherFeatureSetUsage extends XPackFeatureSet.Usage {
     }
 
     @Override
-    public Version version() {
+    public Version getMinimalSupportedVersion() {
         return Version.V_7_0_0;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherFeatureSetUsage.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.watcher;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -26,6 +27,11 @@ public class WatcherFeatureSetUsage extends XPackFeatureSet.Usage {
     public WatcherFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> stats) {
         super(XPackField.WATCHER, available, enabled);
         this.stats = stats;
+    }
+
+    @Override
+    public Version version() {
+        return Version.V_7_0_0;
     }
 
     public Map<String, Object> stats() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/XPackUsageResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/XPackUsageResponseTests.java
@@ -52,7 +52,7 @@ public class XPackUsageResponseTests extends ESTestCase {
         }
 
         @Override
-        public Version version() {
+        public Version getMinimalSupportedVersion() {
             return oldVersion;
         }
 
@@ -69,7 +69,7 @@ public class XPackUsageResponseTests extends ESTestCase {
         }
 
         @Override
-        public Version version() {
+        public Version getMinimalSupportedVersion() {
             return newVersion;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/XPackUsageResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/XPackUsageResponseTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.xpack.core.XPackFeatureSet;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class XPackUsageResponseTests extends ESTestCase {
+
+    private static Version oldVersion;
+    private static Version newVersion;
+
+    @BeforeClass
+    public static void setVersion() {
+        oldVersion = VersionUtils.randomVersionBetween(
+            random(),
+            VersionUtils.getFirstVersion(),
+            VersionUtils.getPreviousVersion(VersionUtils.getPreviousMinorVersion())
+        );
+        newVersion = VersionUtils.randomVersionBetween(
+            random(),
+            VersionUtils.getPreviousMinorVersion(),
+            Version.CURRENT
+        );
+    }
+
+    public static class OldUsage extends XPackFeatureSet.Usage {
+
+        public OldUsage() {
+            super("old", randomBoolean(), randomBoolean());
+        }
+
+        public OldUsage(final StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public Version version() {
+            return oldVersion;
+        }
+
+    }
+
+    public static class NewUsage extends XPackFeatureSet.Usage {
+
+        public NewUsage() {
+            super("new", randomBoolean(), randomBoolean());
+        }
+
+        public NewUsage(final StreamInput in) throws IOException {
+            super(in);
+        }
+
+        @Override
+        public Version version() {
+            return newVersion;
+        }
+
+    }
+
+    public void testVersionDependentSerializationWriteToOldStream() throws IOException {
+        final XPackUsageResponse before = new XPackUsageResponse(List.of(new OldUsage(), new NewUsage()));
+        final BytesStreamOutput oldStream = new BytesStreamOutput();
+        oldStream.setVersion(VersionUtils.randomVersionBetween(random(), oldVersion, VersionUtils.getPreviousVersion(newVersion)));
+        before.writeTo(oldStream);
+
+        final NamedWriteableRegistry registry = new NamedWriteableRegistry(List.of(
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, "old", OldUsage::new),
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, "new", NewUsage::new)
+        ));
+
+        final StreamInput in = new NamedWriteableAwareStreamInput(oldStream.bytes().streamInput(), registry);
+        final XPackUsageResponse after = new XPackUsageResponse(in);
+        assertThat(after.getUsages(), hasSize(1));
+        assertThat(after.getUsages().get(0), instanceOf(OldUsage.class));
+    }
+
+    public void testVersionDependentSerializationWriteToNewStream() throws IOException {
+        final XPackUsageResponse before = new XPackUsageResponse(List.of(new OldUsage(), new NewUsage()));
+        final BytesStreamOutput newStream = new BytesStreamOutput();
+        newStream.setVersion(VersionUtils.randomVersionBetween(random(), newVersion, Version.CURRENT));
+        before.writeTo(newStream);
+
+        final NamedWriteableRegistry registry = new NamedWriteableRegistry(List.of(
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, "old", OldUsage::new),
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, "new", NewUsage::new)
+        ));
+
+        final StreamInput in = new NamedWriteableAwareStreamInput(newStream.bytes().streamInput(), registry);
+        final XPackUsageResponse after = new XPackUsageResponse(in);
+        assertThat(after.getUsages(), hasSize(2));
+        assertThat(after.getUsages().get(0), instanceOf(OldUsage.class));
+        assertThat(after.getUsages().get(1), instanceOf(NewUsage.class));
+    }
+
+}


### PR DESCRIPTION
Today we indiscriminately serialize these independent of the version on the stream, even though the other side might not understand a new feature set usage that we have added. For example, if we add feature set usage in 7.7 for EQL, in a mixed cluster context if a request is sent to an old coordinating node, but the master is a new version, then it would attempt to serialize the usage information for the new feature back to the old coordinating node, who will blow up on the unrecognized named writeable. This commit addresses this by making feature usage version aware, and only serializing those that the other side would understand.

Closes #44589 
Closes #55248