### PR TITLE
Remove InferenceConfigUpdate generic parameter

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUp
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
 
         private final String modelId;
         private final List<Map<String, Object>> objectsToInfer;
-        private final InferenceConfigUpdate<? extends InferenceConfig> update;
+        private final InferenceConfigUpdate update;
         private final boolean previouslyLicensed;
 
         public Request(String modelId, boolean previouslyLicensed) {
@@ -51,7 +50,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
 
         public Request(String modelId,
                        List<Map<String, Object>> objectsToInfer,
-                       InferenceConfigUpdate<? extends InferenceConfig> inferenceConfig,
+                       InferenceConfigUpdate inferenceConfig,
                        boolean previouslyLicensed) {
             this.modelId = ExceptionsHelper.requireNonNull(modelId, TrainedModelConfig.MODEL_ID);
             this.objectsToInfer = Collections.unmodifiableList(ExceptionsHelper.requireNonNull(objectsToInfer, "objects_to_infer"));
@@ -61,10 +60,10 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
 
         public Request(String modelId,
                        Map<String, Object> objectToInfer,
-                       InferenceConfigUpdate<? extends InferenceConfig> update,
+                       InferenceConfigUpdate update,
                        boolean previouslyLicensed) {
             this(modelId,
-                Arrays.asList(ExceptionsHelper.requireNonNull(objectToInfer, "objects_to_infer")),
+                Collections.singletonList(ExceptionsHelper.requireNonNull(objectToInfer, "objects_to_infer")),
                 update,
                 previouslyLicensed);
         }
@@ -74,7 +73,7 @@ public class InternalInferModelAction extends ActionType<InternalInferModelActio
             this.modelId = in.readString();
             this.objectsToInfer = Collections.unmodifiableList(in.readList(StreamInput::readMap));
             if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
-                this.update = (InferenceConfigUpdate<? extends InferenceConfig>)in.readNamedWriteable(InferenceConfigUpdate.class);
+                this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             } else {
                 InferenceConfig oldConfig = in.readNamedWriteable(InferenceConfig.class);
                 if (oldConfig instanceof RegressionConfig) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
@@ -24,7 +24,7 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.Classificat
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig.RESULTS_FIELD;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig.TOP_CLASSES_RESULTS_FIELD;
 
-public class ClassificationConfigUpdate implements InferenceConfigUpdate<ClassificationConfig> {
+public class ClassificationConfigUpdate implements InferenceConfigUpdate {
 
     public static final ParseField NAME = new ParseField("classification");
 
@@ -185,11 +185,19 @@ public class ClassificationConfigUpdate implements InferenceConfigUpdate<Classif
     }
 
     @Override
-    public ClassificationConfig apply(ClassificationConfig originalConfig) {
-        if (isNoop(originalConfig)) {
+    public InferenceConfig apply(InferenceConfig originalConfig) {
+        if (originalConfig instanceof ClassificationConfig == false) {
+            throw ExceptionsHelper.badRequestException(
+                "Inference config of type [{}] can not be updated with a inference request of type [{}]",
+                originalConfig.getName(),
+                getName());
+        }
+        ClassificationConfig classificationConfig = (ClassificationConfig)originalConfig;
+
+        if (isNoop(classificationConfig)) {
             return originalConfig;
         }
-        ClassificationConfig.Builder builder = new ClassificationConfig.Builder(originalConfig);
+        ClassificationConfig.Builder builder = new ClassificationConfig.Builder(classificationConfig);
         if (resultsField != null) {
             builder.setResultsField(resultsField);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigUpdate.java
@@ -9,9 +9,9 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
 
-public interface InferenceConfigUpdate<T extends InferenceConfig> extends NamedXContentObject, NamedWriteable {
+public interface InferenceConfigUpdate extends NamedXContentObject, NamedWriteable {
 
-    T apply(T originalConfig);
+    InferenceConfig apply(InferenceConfig originalConfig);
 
     InferenceConfig toConfig();
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdate.java
@@ -22,7 +22,7 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionC
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig.NUM_TOP_FEATURE_IMPORTANCE_VALUES;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig.RESULTS_FIELD;
 
-public class RegressionConfigUpdate implements InferenceConfigUpdate<RegressionConfig> {
+public class RegressionConfigUpdate implements InferenceConfigUpdate {
 
     public static final ParseField NAME = new ParseField("regression");
 
@@ -127,11 +127,19 @@ public class RegressionConfigUpdate implements InferenceConfigUpdate<RegressionC
     }
 
     @Override
-    public RegressionConfig apply(RegressionConfig originalConfig) {
-        if (isNoop(originalConfig)) {
+    public InferenceConfig apply(InferenceConfig originalConfig) {
+        if (originalConfig instanceof RegressionConfig == false) {
+            throw ExceptionsHelper.badRequestException(
+                "Inference config of type [{}] can not be updated with a inference request of type [{}]",
+                originalConfig.getName(),
+                getName());
+        }
+
+        RegressionConfig regressionConfig = (RegressionConfig)originalConfig;
+        if (isNoop(regressionConfig)) {
             return originalConfig;
         }
-        RegressionConfig.Builder builder = new RegressionConfig.Builder(originalConfig);
+        RegressionConfig.Builder builder = new RegressionConfig.Builder(regressionConfig);
         if (resultsField != null) {
             builder.setResultsField(resultsField);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -48,7 +48,6 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
 
         Response.Builder responseBuilder = Response.builder();
@@ -63,8 +62,6 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                     ex -> true);
                 request.getObjectsToInfer().forEach(stringObjectMap ->
                     typedChainTaskExecutor.add(chainedTask ->
-                        // The InferenceConfigUpdate here is unchecked, initially.
-                        // It gets checked when it is appliedTransportInternalInferModelAction.java
                         model.infer(stringObjectMap, request.getUpdate(), chainedTask)));
 
                 typedChainTaskExecutor.execute(ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Request;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction.Response;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.ml.inference.loadingservice.Model;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
@@ -54,7 +53,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
 
         Response.Builder responseBuilder = Response.builder();
 
-        ActionListener<Model<? extends InferenceConfig>> getModelListener = ActionListener.wrap(
+        ActionListener<Model> getModelListener = ActionListener.wrap(
             model -> {
                 TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor =
                     new TypedChainTaskExecutor<>(client.threadPool().executor(ThreadPool.Names.SAME),
@@ -65,7 +64,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                 request.getObjectsToInfer().forEach(stringObjectMap ->
                     typedChainTaskExecutor.add(chainedTask ->
                         // The InferenceConfigUpdate here is unchecked, initially.
-                        // It gets checked when it is applied
+                        // It gets checked when it is appliedTransportInternalInferModelAction.java
                         model.infer(stringObjectMap, request.getUpdate(), chainedTask)));
 
                 typedChainTaskExecutor.execute(ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -74,7 +74,7 @@ public class InferenceProcessor extends AbstractProcessor {
     private final String modelId;
 
     private final String targetField;
-    private final InferenceConfigUpdate<? extends InferenceConfig> inferenceConfig;
+    private final InferenceConfigUpdate inferenceConfig;
     private final Map<String, String> fieldMap;
     private final InferenceAuditor auditor;
     private volatile boolean previouslyLicensed;
@@ -85,7 +85,7 @@ public class InferenceProcessor extends AbstractProcessor {
                               String tag,
                               String targetField,
                               String modelId,
-                              InferenceConfigUpdate<? extends InferenceConfig> inferenceConfig,
+                              InferenceConfigUpdate inferenceConfig,
                               Map<String, String> fieldMap) {
         super(tag);
         this.client = ExceptionsHelper.requireNonNull(client, "client");
@@ -248,7 +248,7 @@ public class InferenceProcessor extends AbstractProcessor {
                     LoggingDeprecationHandler.INSTANCE.usedDeprecatedName(null, () -> null, FIELD_MAPPINGS, FIELD_MAP);
                 }
             }
-            InferenceConfigUpdate<? extends InferenceConfig> inferenceConfig =
+            InferenceConfigUpdate inferenceConfig =
                 inferenceConfigFromMap(ConfigurationUtils.readMap(TYPE, tag, config, INFERENCE_CONFIG));
 
             return new InferenceProcessor(client,
@@ -266,7 +266,7 @@ public class InferenceProcessor extends AbstractProcessor {
             this.maxIngestProcessors = maxIngestProcessors;
         }
 
-        InferenceConfigUpdate<? extends InferenceConfig> inferenceConfigFromMap(Map<String, Object> inferenceConfig) {
+        InferenceConfigUpdate inferenceConfigFromMap(Map<String, Object> inferenceConfig) {
             ExceptionsHelper.requireNonNull(inferenceConfig, INFERENCE_CONFIG);
             if (inferenceConfig.size() != 1) {
                 throw ExceptionsHelper.badRequestException("{} must be an object with one inference type mapped to an object.",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static org.elasticsearch.xpack.core.ml.job.messages.Messages.INFERENCE_WARNING_ALL_FIELDS_MISSING;
 
-public class LocalModel<T extends InferenceConfig> implements Model<T> {
+public class LocalModel<T extends InferenceConfig> implements Model {
 
     private final TrainedModelDefinition trainedModelDefinition;
     private final String modelId;
@@ -100,7 +100,7 @@ public class LocalModel<T extends InferenceConfig> implements Model<T> {
     }
 
     @Override
-    public void infer(Map<String, Object> fields, InferenceConfigUpdate<T> update, ActionListener<InferenceResults> listener) {
+    public void infer(Map<String, Object> fields, InferenceConfigUpdate update, ActionListener<InferenceResults> listener) {
         if (update.isSupported(this.inferenceConfig) == false) {
             listener.onFailure(ExceptionsHelper.badRequestException(
                 "Model [{}] has inference config of type [{}] which is not supported by inference request of type [{}]",

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static org.elasticsearch.xpack.core.ml.job.messages.Messages.INFERENCE_WARNING_ALL_FIELDS_MISSING;
 
-public class LocalModel<T extends InferenceConfig> implements Model {
+public class LocalModel implements Model {
 
     private final TrainedModelDefinition trainedModelDefinition;
     private final String modelId;
@@ -40,14 +40,14 @@ public class LocalModel<T extends InferenceConfig> implements Model {
     private final TrainedModelStatsService trainedModelStatsService;
     private volatile long persistenceQuotient = 100;
     private final LongAdder currentInferenceCount;
-    private final T inferenceConfig;
+    private final InferenceConfig inferenceConfig;
 
     public LocalModel(String modelId,
                       String nodeId,
                       TrainedModelDefinition trainedModelDefinition,
                       TrainedModelInput input,
                       Map<String, String> defaultFieldMap,
-                      T modelInferenceConfig,
+                      InferenceConfig modelInferenceConfig,
                       TrainedModelStatsService trainedModelStatsService ) {
         this.trainedModelDefinition = trainedModelDefinition;
         this.modelId = modelId;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
@@ -7,18 +7,17 @@ package org.elasticsearch.xpack.ml.inference.loadingservice;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
-import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.util.Map;
 
-public interface Model<T extends InferenceConfig> {
+public interface Model {
 
     String getResultsType();
 
-    void infer(Map<String, Object> fields, InferenceConfigUpdate<T> inferenceConfig, ActionListener<InferenceResults> listener);
+    void infer(Map<String, Object> fields, InferenceConfigUpdate inferenceConfig, ActionListener<InferenceResults> listener);
 
     String getModelId();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -88,7 +88,7 @@ public class ModelLoadingService implements ClusterStateListener {
     private final TrainedModelStatsService modelStatsService;
     private final Cache<String, LocalModel<? extends InferenceConfig>> localModelCache;
     private final Set<String> referencedModels = new HashSet<>();
-    private final Map<String, Queue<ActionListener<Model<? extends InferenceConfig>>>> loadingListeners = new HashMap<>();
+    private final Map<String, Queue<ActionListener<Model>>> loadingListeners = new HashMap<>();
     private final TrainedModelProvider provider;
     private final Set<String> shouldNotAudit;
     private final ThreadPool threadPool;
@@ -140,7 +140,7 @@ public class ModelLoadingService implements ClusterStateListener {
      * @param modelId the model to get
      * @param modelActionListener the listener to alert when the model has been retrieved.
      */
-    public void getModel(String modelId, ActionListener<Model<? extends InferenceConfig>> modelActionListener) {
+    public void getModel(String modelId, ActionListener<Model> modelActionListener) {
         LocalModel<? extends InferenceConfig> cachedModel = localModelCache.get(modelId);
         if (cachedModel != null) {
             modelActionListener.onResponse(cachedModel);
@@ -178,9 +178,9 @@ public class ModelLoadingService implements ClusterStateListener {
      * Returns true if the model is CURRENTLY being loaded and the listener was added to be notified when it is loaded
      * Returns false if the model is not loaded or actively being loaded
      */
-    private boolean loadModelIfNecessary(String modelId, ActionListener<Model<? extends InferenceConfig>> modelActionListener) {
+    private boolean loadModelIfNecessary(String modelId, ActionListener<Model> modelActionListener) {
         synchronized (loadingListeners) {
-            Model<? extends InferenceConfig> cachedModel = localModelCache.get(modelId);
+            Model cachedModel = localModelCache.get(modelId);
             if (cachedModel != null) {
                 modelActionListener.onResponse(cachedModel);
                 return true;
@@ -219,7 +219,7 @@ public class ModelLoadingService implements ClusterStateListener {
     }
 
     private void handleLoadSuccess(String modelId, TrainedModelConfig trainedModelConfig) throws IOException {
-        Queue<ActionListener<Model<? extends InferenceConfig>>> listeners;
+        Queue<ActionListener<Model>> listeners;
         trainedModelConfig.ensureParsedDefinition(namedXContentRegistry);
         InferenceConfig inferenceConfig = trainedModelConfig.getInferenceConfig() == null ?
             inferenceConfigFromTargetType(trainedModelConfig.getModelDefinition().getTrainedModel().targetType()) :
@@ -242,13 +242,13 @@ public class ModelLoadingService implements ClusterStateListener {
             localModelCache.put(modelId, loadedModel);
             shouldNotAudit.remove(modelId);
         } // synchronized (loadingListeners)
-        for (ActionListener<Model<? extends InferenceConfig>> listener = listeners.poll(); listener != null; listener = listeners.poll()) {
+        for (ActionListener<Model> listener = listeners.poll(); listener != null; listener = listeners.poll()) {
             listener.onResponse(loadedModel);
         }
     }
 
     private void handleLoadFailure(String modelId, Exception failure) {
-        Queue<ActionListener<Model<? extends InferenceConfig>>> listeners;
+        Queue<ActionListener<Model>> listeners;
         synchronized (loadingListeners) {
             listeners = loadingListeners.remove(modelId);
             if (listeners == null) {
@@ -257,7 +257,7 @@ public class ModelLoadingService implements ClusterStateListener {
         } // synchronized (loadingListeners)
         // If we failed to load and there were listeners present, that means that this model is referenced by a processor
         // Alert the listeners to the failure
-        for (ActionListener<Model<? extends InferenceConfig>> listener = listeners.poll(); listener != null; listener = listeners.poll()) {
+        for (ActionListener<Model> listener = listeners.poll(); listener != null; listener = listeners.poll()) {
             listener.onFailure(failure);
         }
     }
@@ -293,7 +293,7 @@ public class ModelLoadingService implements ClusterStateListener {
             return;
         }
         // The listeners still waiting for a model and we are canceling the load?
-        List<Tuple<String, List<ActionListener<Model<? extends InferenceConfig>>>>> drainWithFailure = new ArrayList<>();
+        List<Tuple<String, List<ActionListener<Model>>>> drainWithFailure = new ArrayList<>();
         Set<String> referencedModelsBeforeClusterState = null;
         Set<String> loadingModelBeforeClusterState = null;
         Set<String> removedModels = null;
@@ -336,11 +336,11 @@ public class ModelLoadingService implements ClusterStateListener {
                     referencedModels);
             }
         }
-        for (Tuple<String, List<ActionListener<Model<? extends InferenceConfig>>>> modelAndListeners : drainWithFailure) {
+        for (Tuple<String, List<ActionListener<Model>>> modelAndListeners : drainWithFailure) {
             final String msg = new ParameterizedMessage(
                 "Cancelling load of model [{}] as it is no longer referenced by a pipeline",
                 modelAndListeners.v1()).getFormat();
-            for (ActionListener<Model<? extends InferenceConfig>> listener : modelAndListeners.v2()) {
+            for (ActionListener<Model> listener : modelAndListeners.v2()) {
                 listener.onFailure(new ElasticsearchException(msg));
             }
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -11,13 +11,15 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.preprocessing.OneHotEncoding;
+import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.SingleValueInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PredictionFieldType;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdate;
@@ -28,8 +30,6 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedM
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.WeightedSum;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.Tree;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.TreeNode;
-import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.ml.inference.TrainedModelStatsService;
 import org.mockito.ArgumentMatcher;
@@ -63,7 +63,7 @@ public class LocalModelTests extends ESTestCase {
             .setTrainedModel(buildClassification(false))
             .build();
 
-        Model<ClassificationConfig> model = new LocalModel<>(modelId,
+        Model model = new LocalModel<>(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),
@@ -134,7 +134,7 @@ public class LocalModelTests extends ESTestCase {
             .setTrainedModel(buildClassification(true))
             .build();
 
-        Model<ClassificationConfig> model = new LocalModel<>(modelId,
+        Model model = new LocalModel<>(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),
@@ -189,7 +189,7 @@ public class LocalModelTests extends ESTestCase {
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildRegression())
             .build();
-        Model<RegressionConfig> model = new LocalModel<>("regression_model",
+        Model model = new LocalModel<>("regression_model",
             "test-node",
             trainedModelDefinition,
             new TrainedModelInput(inputFields),
@@ -215,7 +215,7 @@ public class LocalModelTests extends ESTestCase {
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildRegression())
             .build();
-        Model<RegressionConfig> model = new LocalModel<>(
+        Model model = new LocalModel<>(
             "regression_model",
             "test-node",
             trainedModelDefinition,
@@ -246,7 +246,7 @@ public class LocalModelTests extends ESTestCase {
             .setTrainedModel(buildClassification(false))
             .build();
 
-        Model<ClassificationConfig> model = new LocalModel<>(modelId,
+        Model model = new LocalModel<>(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),
@@ -276,16 +276,16 @@ public class LocalModelTests extends ESTestCase {
         }));
     }
 
-    private static <T extends InferenceConfig> SingleValueInferenceResults getSingleValue(Model<T> model,
+    private static <T extends InferenceConfig> SingleValueInferenceResults getSingleValue(Model model,
                                                                                           Map<String, Object> fields,
-                                                                                          InferenceConfigUpdate<T> config)
+                                                                                          InferenceConfigUpdate config)
         throws Exception {
         return (SingleValueInferenceResults)getInferenceResult(model, fields, config);
     }
 
-    private static <T extends InferenceConfig> InferenceResults getInferenceResult(Model<T> model,
+    private static <T extends InferenceConfig> InferenceResults getInferenceResult(Model model,
                                                                                    Map<String, Object> fields,
-                                                                                   InferenceConfigUpdate<T> config) throws Exception {
+                                                                                   InferenceConfigUpdate config) throws Exception {
         PlainActionFuture<InferenceResults> future = new PlainActionFuture<>();
         model.infer(fields, config, future);
         return future.get();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -63,7 +63,7 @@ public class LocalModelTests extends ESTestCase {
             .setTrainedModel(buildClassification(false))
             .build();
 
-        Model model = new LocalModel<>(modelId,
+        Model model = new LocalModel(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),
@@ -92,7 +92,7 @@ public class LocalModelTests extends ESTestCase {
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildClassification(true))
             .build();
-        model = new LocalModel<>(modelId,
+        model = new LocalModel(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),
@@ -134,7 +134,7 @@ public class LocalModelTests extends ESTestCase {
             .setTrainedModel(buildClassification(true))
             .build();
 
-        Model model = new LocalModel<>(modelId,
+        Model model = new LocalModel(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),
@@ -189,7 +189,7 @@ public class LocalModelTests extends ESTestCase {
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildRegression())
             .build();
-        Model model = new LocalModel<>("regression_model",
+        Model model = new LocalModel("regression_model",
             "test-node",
             trainedModelDefinition,
             new TrainedModelInput(inputFields),
@@ -215,7 +215,7 @@ public class LocalModelTests extends ESTestCase {
             .setPreProcessors(Arrays.asList(new OneHotEncoding("categorical", oneHotMap())))
             .setTrainedModel(buildRegression())
             .build();
-        Model model = new LocalModel<>(
+        Model model = new LocalModel(
             "regression_model",
             "test-node",
             trainedModelDefinition,
@@ -246,7 +246,7 @@ public class LocalModelTests extends ESTestCase {
             .setTrainedModel(buildClassification(false))
             .build();
 
-        Model model = new LocalModel<>(modelId,
+        Model model = new LocalModel(modelId,
             "test-node",
             definition,
             new TrainedModelInput(inputFields),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.ml.inference.TrainedModelStatsService;
@@ -122,7 +121,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         String[] modelIds = new String[]{model1, model2, model3};
         for(int i = 0; i < 10; i++) {
             String model = modelIds[i%3];
-            PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
             modelLoadingService.getModel(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
@@ -135,7 +134,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(model1, model2));
         for(int i = 0; i < 10; i++) {
             String model = modelIds[i%3];
-            PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
             modelLoadingService.getModel(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
@@ -178,7 +177,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for(int i = 0; i < 10; i++) {
             // Only reference models 1 and 2, so that cache is only invalidated once for model3 (after initial load)
             String model = modelIds[i%2];
-            PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
             modelLoadingService.getModel(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
@@ -198,7 +197,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         // Load model 3, should invalidate 1 and 2
         for(int i = 0; i < 10; i++) {
-            PlainActionFuture<Model<? extends InferenceConfig>> future3 = new PlainActionFuture<>();
+            PlainActionFuture<Model> future3 = new PlainActionFuture<>();
             modelLoadingService.getModel(model3, future3);
             assertThat(future3.get(), is(not(nullValue())));
         }
@@ -219,7 +218,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         // Load model 1, should invalidate 3
         for(int i = 0; i < 10; i++) {
-            PlainActionFuture<Model<? extends InferenceConfig>> future1 = new PlainActionFuture<>();
+            PlainActionFuture<Model> future1 = new PlainActionFuture<>();
             modelLoadingService.getModel(model1, future1);
             assertThat(future1.get(), is(not(nullValue())));
         }
@@ -233,7 +232,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         // Load model 2
         for(int i = 0; i < 10; i++) {
-            PlainActionFuture<Model<? extends InferenceConfig>> future2 = new PlainActionFuture<>();
+            PlainActionFuture<Model> future2 = new PlainActionFuture<>();
             modelLoadingService.getModel(model2, future2);
             assertThat(future2.get(), is(not(nullValue())));
         }
@@ -244,7 +243,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(model1, model2));
         for(int i = 0; i < 10; i++) {
             String model = modelIds[i%3];
-            PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
             modelLoadingService.getModel(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }
@@ -272,7 +271,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(false, model1));
 
         for(int i = 0; i < 10; i++) {
-            PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
             modelLoadingService.getModel(model1, future);
             assertThat(future.get(), is(not(nullValue())));
         }
@@ -295,7 +294,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             "test-node");
         modelLoadingService.clusterChanged(ingestChangedEvent(model));
 
-        PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+        PlainActionFuture<Model> future = new PlainActionFuture<>();
         modelLoadingService.getModel(model, future);
 
         try {
@@ -322,7 +321,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             Settings.EMPTY,
             "test-node");
 
-        PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+        PlainActionFuture<Model> future = new PlainActionFuture<>();
         modelLoadingService.getModel(model, future);
         try {
             future.get();
@@ -346,7 +345,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             "test-node");
 
         for(int i = 0; i < 3; i++) {
-            PlainActionFuture<Model<? extends InferenceConfig>> future = new PlainActionFuture<>();
+            PlainActionFuture<Model> future = new PlainActionFuture<>();
             modelLoadingService.getModel(model, future);
             assertThat(future.get(), is(not(nullValue())));
         }


### PR DESCRIPTION
The generic parameter causes complications as it is expected to be the same type as the generic parameter to `LocalModel<T extends InferenceConfig>` but because we must pass around bounded wildcard types the complier isn't able to show that the generic parameters are the same. This forces us to use unchecked types in certain places, which is ok as the subclasses of  `InferenceConfigUpdate` check the expected type when it is used. 

To simplify the code this change removes the generic type from `InferenceConfigUpdate` and we rely on checking checking the class type were appropriate. 