### PR TITLE
Remove deprecated third-party methods from tests (#55255)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/LicenseIT.java
@@ -49,9 +49,9 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.not;
 
 public class LicenseIT extends ESRestHighLevelClientTestCase {
 
@@ -168,9 +168,9 @@ public class LicenseIT extends ESRestHighLevelClientTestCase {
     private static void assertNotEmptyAcknowledgeMessages(Map<String, String[]> acknowledgeMessages) {
         assertThat(acknowledgeMessages.entrySet(), not(empty()));
         for (Map.Entry<String, String[]> entry : acknowledgeMessages.entrySet()) {
-            assertThat(entry.getKey(), not(isEmptyOrNullString()));
+            assertThat(entry.getKey(), not(emptyOrNullString()));
             for (String message : entry.getValue()) {
-                assertThat(message, not(isEmptyOrNullString()));
+                assertThat(message, not(emptyOrNullString()));
             }
         }
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -99,6 +99,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirs
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
@@ -1234,7 +1235,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         FieldCapabilitiesResponse response = execute(request,
             highLevelClient()::fieldCaps, highLevelClient()::fieldCapsAsync);
 
-        assertEquals(new String[] {"index1", "index2"}, response.getIndices());
+        assertThat(response.getIndices(), arrayContaining("index1", "index2"));
 
         // Check the capabilities for the 'rating' field.
         assertTrue(response.get().containsKey("rating"));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/core/BroadcastResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/core/BroadcastResponseTests.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
 
 public class BroadcastResponseTests extends AbstractResponseTestCase<org.elasticsearch.action.support.broadcast.BroadcastResponse,
     BroadcastResponse> {
@@ -80,7 +80,7 @@ public class BroadcastResponseTests extends AbstractResponseTestCase<org.elastic
         if (clientInstance.shards().failed() > 0) {
             final DefaultShardOperationFailedException groupedFailure = clientInstance.shards().failures().iterator().next();
             assertThat(groupedFailure.index(), equalTo(index));
-            assertThat(groupedFailure.shardId(), isIn(shardIds));
+            assertThat(groupedFailure.shardId(), in(shardIds));
             assertThat(groupedFailure.reason(), containsString("reason=retention lease with ID [" + id + "] not found"));
         }
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/RollupDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/RollupDocumentationIT.java
@@ -80,7 +80,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.oneOf;
 
 public class RollupDocumentationIT extends ESRestHighLevelClientTestCase {
 
@@ -429,7 +429,7 @@ public class RollupDocumentationIT extends ESRestHighLevelClientTestCase {
         ClusterHealthRequest healthRequest = new ClusterHealthRequest(config.getRollupIndex()).waitForYellowStatus();
         ClusterHealthResponse healthResponse = client.cluster().health(healthRequest, RequestOptions.DEFAULT);
         assertFalse(healthResponse.isTimedOut());
-        assertThat(healthResponse.getStatus(), isOneOf(ClusterHealthStatus.YELLOW, ClusterHealthStatus.GREEN));
+        assertThat(healthResponse.getStatus(), oneOf(ClusterHealthStatus.YELLOW, ClusterHealthStatus.GREEN));
 
         // Now that the job is created, we should have a rollup index with metadata.
         // We can test out the caps API now.
@@ -546,7 +546,7 @@ public class RollupDocumentationIT extends ESRestHighLevelClientTestCase {
         ClusterHealthRequest healthRequest = new ClusterHealthRequest(config.getRollupIndex()).waitForYellowStatus();
         ClusterHealthResponse healthResponse = client.cluster().health(healthRequest, RequestOptions.DEFAULT);
         assertFalse(healthResponse.isTimedOut());
-        assertThat(healthResponse.getStatus(), isOneOf(ClusterHealthStatus.YELLOW, ClusterHealthStatus.GREEN));
+        assertThat(healthResponse.getStatus(), oneOf(ClusterHealthStatus.YELLOW, ClusterHealthStatus.GREEN));
 
         // Now that the job is created, we should have a rollup index with metadata.
         // We can test out the caps API now.

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SecurityDocumentationIT.java
@@ -133,8 +133,8 @@ import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -491,7 +491,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(mappings.size(), is(2));
             for (ExpressionRoleMapping roleMapping : mappings) {
                 assertThat(roleMapping.isEnabled(), is(true));
-                assertThat(roleMapping.getName(), isIn(new String[]{"mapping-example-1", "mapping-example-2"}));
+                assertThat(roleMapping.getName(), in(new String[]{"mapping-example-1", "mapping-example-2"}));
                 if (roleMapping.getName().equals("mapping-example-1")) {
                     assertThat(roleMapping.getMetadata(), equalTo(Collections.emptyMap()));
                     assertThat(roleMapping.getExpression(), equalTo(rules1));
@@ -516,7 +516,7 @@ public class SecurityDocumentationIT extends ESRestHighLevelClientTestCase {
             assertThat(mappings.size(), is(2));
             for (ExpressionRoleMapping roleMapping : mappings) {
                 assertThat(roleMapping.isEnabled(), is(true));
-                assertThat(roleMapping.getName(), isIn(new String[]{"mapping-example-1", "mapping-example-2"}));
+                assertThat(roleMapping.getName(), in(new String[]{"mapping-example-1", "mapping-example-2"}));
                 if (roleMapping.getName().equals("mapping-example-1")) {
                     assertThat(roleMapping.getMetadata(), equalTo(Collections.emptyMap()));
                     assertThat(roleMapping.getExpression(), equalTo(rules1));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/ReloadAnalyzersResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/ReloadAnalyzersResponseTests.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
 
 public class ReloadAnalyzersResponseTests
         extends AbstractResponseTestCase<org.elasticsearch.xpack.core.action.ReloadAnalyzersResponse, ReloadAnalyzersResponse> {
@@ -94,7 +94,7 @@ public class ReloadAnalyzersResponseTests
         if (clientInstance.shards().failed() > 0) {
             final DefaultShardOperationFailedException groupedFailure = clientInstance.shards().failures().iterator().next();
             assertThat(groupedFailure.index(), equalTo(index));
-            assertThat(groupedFailure.shardId(), isIn(shardIds));
+            assertThat(groupedFailure.shardId(), in(shardIds));
             assertThat(groupedFailure.reason(), containsString("reason=retention lease with ID [" + id + "] not found"));
         }
         Map<String, ReloadDetails> serverDetails = serverTestInstance.getReloadDetails();

--- a/client/rest/src/test/java/org/elasticsearch/client/HeapBufferedAsyncResponseConsumerTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/HeapBufferedAsyncResponseConsumerTests.java
@@ -135,7 +135,7 @@ public class HeapBufferedAsyncResponseConsumerTests extends RestClientTestCase {
                 return contentLength.get();
             }
         };
-        contentLength.set(randomLong(bufferLimit));
+        contentLength.set(randomLongBetween(0L, bufferLimit));
         consumer.onEntityEnclosed(entity, ContentType.APPLICATION_JSON);
 
         contentLength.set(randomLongBetween(bufferLimit + 1, MAX_TEST_BUFFER_SIZE));

--- a/libs/x-content/src/test/java/org/elasticsearch/common/ParseFieldTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/ParseFieldTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.test.ESTestCase;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 
 public class ParseFieldTests extends ESTestCase {
     public void testParse() {

--- a/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/XContentParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/common/xcontent/XContentParserTests.java
@@ -41,8 +41,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
@@ -208,7 +208,7 @@ public class XContentParserTests extends ESTestCase {
             assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
             assertThat(parser.currentName(), equalTo("foo"));
             token = parser.nextToken();
-            assertThat(token, isIn(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_NUMBER)));
+            assertThat(token, in(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_NUMBER)));
             assertFalse(parser.isBooleanValue());
             if (token.equals(XContentParser.Token.VALUE_STRING)) {
                 expectThrows(IllegalArgumentException.class, parser::booleanValue);
@@ -220,7 +220,7 @@ public class XContentParserTests extends ESTestCase {
             assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
             assertThat(parser.currentName(), equalTo("bar"));
             token = parser.nextToken();
-            assertThat(token, isIn(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_NUMBER)));
+            assertThat(token, in(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_NUMBER)));
             assertFalse(parser.isBooleanValue());
             if (token.equals(XContentParser.Token.VALUE_STRING)) {
                 expectThrows(IllegalArgumentException.class, parser::booleanValue);
@@ -241,7 +241,7 @@ public class XContentParserTests extends ESTestCase {
             assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
             assertThat(parser.currentName(), equalTo("foo"));
             token = parser.nextToken();
-            assertThat(token, isIn(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_BOOLEAN)));
+            assertThat(token, in(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_BOOLEAN)));
             assertTrue(parser.isBooleanValue());
             assertFalse(parser.booleanValue());
 
@@ -249,7 +249,7 @@ public class XContentParserTests extends ESTestCase {
             assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
             assertThat(parser.currentName(), equalTo("bar"));
             token = parser.nextToken();
-            assertThat(token, isIn(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_BOOLEAN)));
+            assertThat(token, in(Arrays.asList(XContentParser.Token.VALUE_STRING, XContentParser.Token.VALUE_BOOLEAN)));
             assertTrue(parser.isBooleanValue());
             assertTrue(parser.booleanValue());
         }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
@@ -43,8 +43,8 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 
 public class MustacheTests extends ESTestCase {
@@ -384,7 +384,7 @@ public class MustacheTests extends ESTestCase {
     }
 
     private TemplateScript.Factory compile(String script) {
-        assertThat("cannot compile null or empty script", script, not(isEmptyOrNullString()));
+        assertThat("cannot compile null or empty script", script, not(emptyOrNullString()));
         return engine.compile(null, script, TemplateScript.CONTEXT, Collections.emptyMap());
     }
 }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapperTests.java
@@ -70,12 +70,12 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasProperty;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.collection.IsArrayContainingInAnyOrder.arrayContainingInAnyOrder;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 public class SearchAsYouTypeFieldMapperTests extends ESSingleNodeTestCase {

--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
@@ -41,12 +41,12 @@ import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocumen
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 public class AttachmentProcessorTests extends ESTestCase {
 

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
@@ -42,10 +42,10 @@ import java.util.Map;
 
 import static org.elasticsearch.repositories.azure.AzureStorageService.blobNameFromUri;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -58,8 +58,8 @@ public class AzureStorageServiceTests extends ESTestCase {
         final Map<String, AzureStorageSettings> loadedSettings = AzureStorageSettings.load(settings);
         assertThat(loadedSettings.keySet(), containsInAnyOrder("azure1","azure2","azure3","default"));
 
-        assertThat(loadedSettings.get("azure1").getEndpointSuffix(), isEmptyString());
-        assertThat(loadedSettings.get("azure2").getEndpointSuffix(), isEmptyString());
+        assertThat(loadedSettings.get("azure1").getEndpointSuffix(), is(emptyString()));
+        assertThat(loadedSettings.get("azure2").getEndpointSuffix(), is(emptyString()));
         assertThat(loadedSettings.get("azure3").getEndpointSuffix(), equalTo("my_endpoint_suffix"));
     }
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -30,8 +30,8 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.nullValue;
 
 public class S3ClientSettingsTests extends ESTestCase {
@@ -41,12 +41,12 @@ public class S3ClientSettingsTests extends ESTestCase {
 
         final S3ClientSettings defaultSettings = settings.get("default");
         assertThat(defaultSettings.credentials, nullValue());
-        assertThat(defaultSettings.endpoint, isEmptyString());
+        assertThat(defaultSettings.endpoint, is(emptyString()));
         assertThat(defaultSettings.protocol, is(Protocol.HTTPS));
-        assertThat(defaultSettings.proxyHost, isEmptyString());
+        assertThat(defaultSettings.proxyHost, is(emptyString()));
         assertThat(defaultSettings.proxyPort, is(80));
-        assertThat(defaultSettings.proxyUsername, isEmptyString());
-        assertThat(defaultSettings.proxyPassword, isEmptyString());
+        assertThat(defaultSettings.proxyUsername, is(emptyString()));
+        assertThat(defaultSettings.proxyPassword, is(emptyString()));
         assertThat(defaultSettings.readTimeoutMillis, is(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT));
         assertThat(defaultSettings.maxRetries, is(ClientConfiguration.DEFAULT_RETRY_POLICY.getMaxErrorRetry()));
         assertThat(defaultSettings.throttleRetries, is(ClientConfiguration.DEFAULT_THROTTLE_RETRIES));

--- a/qa/evil-tests/src/test/java/org/elasticsearch/cli/EvilCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/cli/EvilCommandTests.java
@@ -26,7 +26,8 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
 
 public class EvilCommandTests extends ESTestCase {
 
@@ -62,7 +63,7 @@ public class EvilCommandTests extends ESTestCase {
             // ensure that we dump the stack trace too
             assertThat(output, containsString("\tat org.elasticsearch.cli.EvilCommandTests$1.close"));
         } else {
-            assertThat(output, isEmptyString());
+            assertThat(output, is(emptyString()));
         }
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -51,7 +51,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
@@ -76,7 +76,7 @@ public class ArchiveTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
         final Result r = bin.pluginTool.run("list");
 
-        assertThat(r.stdout, isEmptyString());
+        assertThat(r.stdout, emptyString());
     }
 
     public void test30MissingBundledJdk() throws Exception {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -59,8 +59,8 @@ import static org.elasticsearch.cluster.routing.allocation.decider.EnableAllocat
 import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
@@ -278,7 +278,7 @@ public class RecoveryIT extends AbstractRollingTestCase {
                     String xpath = "routing_table.indices." + index + ".shards.0.node";
                     @SuppressWarnings("unchecked") List<String> assignedNodes = (List<String>) XContentMapValues.extractValue(xpath, state);
                     assertNotNull(state.toString(), assignedNodes);
-                    assertThat(state.toString(), newNode, isIn(assignedNodes));
+                    assertThat(state.toString(), newNode, in(assignedNodes));
                 }, 60, TimeUnit.SECONDS);
                 ensureGreen(index);
                 client().performRequest(new Request("POST", index + "/_refresh"));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -62,8 +62,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.startsWith;
 
 /**
@@ -980,7 +981,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             }
             for (Decision d : result.getCanAllocateDecision().getDecisions()) {
                 if (d.type() == Decision.Type.NO) {
-                    assertThat(d.label(), isOneOf("filter", "same_shard"));
+                    assertThat(d.label(), is(oneOf("filter", "same_shard")));
                 }
                 assertNotNull(d.getExplanation());
             }
@@ -1253,10 +1254,10 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
                     assertNotEquals("delayed", parser.currentName()); // we should never display "delayed" from unassigned info
                     if (parser.currentName().equals("last_allocation_status")) {
                         parser.nextToken();
-                        assertThat(parser.text(), isOneOf(AllocationDecision.NO.toString(),
+                        assertThat(parser.text(), is(oneOf(AllocationDecision.NO.toString(),
                             AllocationDecision.NO_VALID_SHARD_COPY.toString(),
                             AllocationDecision.AWAITING_INFO.toString(),
-                            AllocationDecision.NO_ATTEMPT.toString()));
+                            AllocationDecision.NO_ATTEMPT.toString())));
                     }
                 }
             }

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -58,7 +58,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class BulkIntegrationIT extends ESIntegTestCase {
     @Override
@@ -183,7 +184,7 @@ public class BulkIntegrationIT extends ESIntegTestCase {
                         IndexResponse response = client().prepareIndex(index, "_doc").setId(id)
                             .setSource(Collections.singletonMap("f" + randomIntBetween(1, 10), randomNonNegativeLong()),
                                 XContentType.JSON).get();
-                        assertThat(response.getResult(), isOneOf(CREATED, UPDATED));
+                        assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));
                         logger.info("--> index id={} seq_no={}", response.getId(), response.getSeqNo());
                     } catch (ElasticsearchException ignore) {
                         logger.info("--> fail to index id={}", id);

--- a/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -39,8 +39,8 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 
 public class ClusterBlockTests extends ESTestCase {
 
@@ -162,7 +162,7 @@ public class ClusterBlockTests extends ESTestCase {
         }
 
         assertThat(builder.build().indices().get("index").size(), equalTo(clusterBlocks.length));
-        assertThat(builder.build().getIndexBlockWithId("index", blockId), isOneOf(clusterBlocks));
+        assertThat(builder.build().getIndexBlockWithId("index", blockId), is(oneOf(clusterBlocks)));
         assertThat(builder.build().getIndexBlockWithId("index", randomValueOtherThan(blockId, ESTestCase::randomInt)), nullValue());
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -50,7 +50,8 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPA
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
 
 public class AutoExpandReplicasTests extends ESTestCase {
 
@@ -168,7 +169,7 @@ public class AutoExpandReplicasTests extends ESTestCase {
                 postTable = state.routingTable().index("index").shard(0);
 
                 assertTrue("not all shards started in " + state.toString(), postTable.allShardsStarted());
-                assertThat(postTable.toString(), postTable.getAllAllocationIds(), everyItem(isIn(preTable.getAllAllocationIds())));
+                assertThat(postTable.toString(), postTable.getAllAllocationIds(), everyItem(is(in(preTable.getAllAllocationIds()))));
             } else {
                 // fake an election where conflicting nodes are removed and readded
                 state = ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes()).masterNodeId(null).build()).build();
@@ -193,7 +194,7 @@ public class AutoExpandReplicasTests extends ESTestCase {
             Set<String> unchangedAllocationIds = preTable.getShards().stream().filter(shr -> unchangedNodeIds.contains(shr.currentNodeId()))
                 .map(shr -> shr.allocationId().getId()).collect(Collectors.toSet());
 
-            assertThat(postTable.toString(), unchangedAllocationIds, everyItem(isIn(postTable.getAllAllocationIds())));
+            assertThat(postTable.toString(), unchangedAllocationIds, everyItem(is(in(postTable.getAllAllocationIds()))));
 
             postTable.getShards().forEach(
                 shardRouting -> {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -78,7 +78,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
@@ -304,7 +305,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         Set<String> newHistoryUUIds = Stream.of(shardStats)
             .map(shard -> shard.getCommitStats().getUserData().get(Engine.HISTORY_UUID_KEY)).collect(Collectors.toSet());
-        assertThat(newHistoryUUIds, everyItem(not(isIn(historyUUIDs))));
+        assertThat(newHistoryUUIds, everyItem(is(not(in(historyUUIDs)))));
         assertThat(newHistoryUUIds, hasSize(1));
     }
 
@@ -539,7 +540,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             Set<String> selectedPartition = replicasSide1.contains(newPrimaryNode) ? replicasSide1 : replicasSide2;
             assertThat(shardRoutingTable.activeShards(), hasSize(selectedPartition.size()));
             for (ShardRouting activeShard : shardRoutingTable.activeShards()) {
-                assertThat(state.getRoutingNodes().node(activeShard.currentNodeId()).node().getName(), isIn(selectedPartition));
+                assertThat(state.getRoutingNodes().node(activeShard.currentNodeId()).node().getName(), is(in(selectedPartition)));
             }
             assertThat(state.metadata().index("test").inSyncAllocationIds(shardId.id()), hasSize(numberOfReplicas + 1));
         }, 1, TimeUnit.MINUTES);

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/FilterPathTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/FilterPathTests.java
@@ -26,9 +26,9 @@ import java.util.Set;
 
 import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -49,7 +49,7 @@ public class FilterPathTests extends ESTestCase {
         FilterPath next = filterPath.getNext();
         assertNotNull(next);
         assertThat(next.matches(), is(true));
-        assertThat(next.getSegment(), isEmptyString());
+        assertThat(next.getSegment(), is(emptyString()));
         assertSame(next, FilterPath.EMPTY);
     }
 
@@ -73,7 +73,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
     }
 
@@ -102,7 +102,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
     }
 
@@ -148,7 +148,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
 
         input = "w\\.0\\.0\\.t";
@@ -165,7 +165,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
 
 
@@ -187,7 +187,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
     }
 
@@ -231,7 +231,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
     }
 
@@ -271,7 +271,7 @@ public class FilterPathTests extends ESTestCase {
         next = next.getNext();
         assertNotNull(next);
         assertThat(next.matches(), is(true));
-        assertThat(next.getSegment(), isEmptyString());
+        assertThat(next.getSegment(), is(emptyString()));
         assertSame(next, FilterPath.EMPTY);
     }
 
@@ -301,7 +301,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
     }
 
@@ -337,7 +337,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
 
         // test.dot\.ted
@@ -354,7 +354,7 @@ public class FilterPathTests extends ESTestCase {
         filterPath = filterPath.getNext();
         assertNotNull(filterPath);
         assertThat(filterPath.matches(), is(true));
-        assertThat(filterPath.getSegment(), isEmptyString());
+        assertThat(filterPath.getSegment(), is(emptyString()));
         assertSame(filterPath, FilterPath.EMPTY);
     }
 }

--- a/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -75,10 +75,10 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.oneOf;
 
 /**
  * Tests various cluster operations (e.g., indexing) during disruptions.
@@ -170,7 +170,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                                 }
 
                                 IndexResponse response = indexRequestBuilder.get(timeout);
-                                assertThat(response.getResult(), isOneOf(CREATED, UPDATED));
+                                assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));
                                 ackedDocs.put(id, node);
                                 logger.trace("[{}] indexed id [{}] through node [{}], response [{}]", name, id, node, response);
                             } catch (ElasticsearchException e) {
@@ -478,7 +478,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                         IndexResponse response = client().prepareIndex(index, "_doc", id)
                             .setSource(Collections.singletonMap("f" + randomIntBetween(1, 10), randomNonNegativeLong()), XContentType.JSON)
                             .get();
-                        assertThat(response.getResult(), isOneOf(CREATED, UPDATED));
+                        assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));
                         logger.info("--> index id={} seq_no={}", response.getId(), response.getSeqNo());
                         ackedDocs.add(response.getId());
                     } catch (ElasticsearchException ignore) {
@@ -504,7 +504,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
             IndexShard shard = indicesService.getShardOrNull(shardRouting.shardId());
             Set<String> docs = IndexShardTestCase.getShardDocUIDs(shard);
             assertThat("shard [" + shard.routingEntry() + "] docIds [" + docs + "] vs " + " acked docIds [" + ackedDocs + "]",
-                ackedDocs, everyItem(isIn(docs)));
+                ackedDocs, everyItem(is(in(docs))));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -209,7 +209,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -1655,7 +1655,7 @@ public class InternalEngineTests extends EngineTestCase {
                     Translog.Operation op = ops.get(seqno);
                     if (op != null) {
                         assertThat(op, instanceOf(Translog.Index.class));
-                        assertThat(msg, ((Translog.Index) op).id(), isIn(liveDocs));
+                        assertThat(msg, ((Translog.Index) op).id(), is(in(liveDocs)));
                         assertEquals(msg, ((Translog.Index) op).source(), B_1);
                     }
                 } else {
@@ -1744,7 +1744,7 @@ public class InternalEngineTests extends EngineTestCase {
                     Translog.Operation op = ops.get(seqno);
                     if (op != null) {
                         assertThat(op, instanceOf(Translog.Index.class));
-                        assertThat(msg, ((Translog.Index) op).id(), isIn(liveDocs));
+                        assertThat(msg, ((Translog.Index) op).id(), is(in(liveDocs)));
                     }
                 } else {
                     Translog.Operation op = ops.get(seqno);

--- a/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -83,8 +83,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 
@@ -786,7 +786,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
                 while (done.get() == false) {
                     try {
                         List<DocIdSeqNoAndSource> exposedDocs = EngineTestCase.getDocIds(getEngine(randomFrom(replicas)), randomBoolean());
-                        assertThat(docsBelowGlobalCheckpoint, everyItem(isIn(exposedDocs)));
+                        assertThat(docsBelowGlobalCheckpoint, everyItem(is(in(exposedDocs))));
                         assertThat(randomFrom(replicas).getLocalCheckpoint(), greaterThanOrEqualTo(initDocs - 1L));
                     } catch (AlreadyClosedException ignored) {
                         // replica swaps engine during rollback

--- a/server/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerTests.java
@@ -38,7 +38,8 @@ import java.util.stream.IntStream;
 
 import static org.elasticsearch.index.seqno.LocalCheckpointTracker.BIT_SET_SIZE;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class LocalCheckpointTrackerTests extends ESTestCase {
 
@@ -202,7 +203,7 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         assertThat(tracker.getProcessedCheckpoint(), equalTo(unFinishedSeq - 1L));
         tracker.markSeqNoAsProcessed(unFinishedSeq);
         assertThat(tracker.getProcessedCheckpoint(), equalTo(maxOps - 1L));
-        assertThat(tracker.processedSeqNo.size(), isOneOf(0, 1));
+        assertThat(tracker.processedSeqNo.size(), is(oneOf(0, 1)));
         if (tracker.processedSeqNo.size() == 1) {
             assertThat(tracker.processedSeqNo.keys().iterator().next().value, equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
         }
@@ -256,7 +257,7 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         assertThat(tracker.getProcessedCheckpoint(), equalTo(maxOps - 1L));
         assertThat(tracker.hasProcessed(unFinishedSeq), equalTo(true));
         assertThat(tracker.hasProcessed(randomLongBetween(maxOps, Long.MAX_VALUE)), equalTo(false));
-        assertThat(tracker.processedSeqNo.size(), isOneOf(0, 1));
+        assertThat(tracker.processedSeqNo.size(), is(oneOf(0, 1)));
         if (tracker.processedSeqNo.size() == 1) {
             assertThat(tracker.processedSeqNo.keys().iterator().next().value, equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
         }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -185,14 +185,15 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.isIn;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
 
 /**
@@ -663,7 +664,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 new IndexShardRoutingTable.Builder(indexShard.shardId()).addShard(primaryRouting).build()
             );
             latch.await();
-            assertThat(indexShard.getActiveOperationsCount(), isOneOf(0, IndexShard.OPERATIONS_BLOCKED));
+            assertThat(indexShard.getActiveOperationsCount(), is(oneOf(0, IndexShard.OPERATIONS_BLOCKED)));
             if (randomBoolean()) {
                 assertBusy(() -> assertEquals(0, indexShard.getActiveOperationsCount()));
             }
@@ -3788,7 +3789,7 @@ public class IndexShardTests extends IndexShardTestCase {
                     List<String> exposedDocIds = EngineTestCase.getDocIds(getEngine(shard), rarely())
                         .stream().map(DocIdSeqNoAndSource::getId).collect(Collectors.toList());
                     assertThat("every operations before the global checkpoint must be reserved",
-                        docBelowGlobalCheckpoint, everyItem(isIn(exposedDocIds)));
+                        docBelowGlobalCheckpoint, everyItem(is(in(exposedDocIds))));
                 } catch (AlreadyClosedException ignored) {
                     hitClosedExceptions++;
                 } catch (IOException e) {

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -80,6 +80,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
+import static org.hamcrest.Matchers.arrayContaining;
 
 /**
  * Tests how {@linkplain RefreshListeners} interacts with {@linkplain InternalEngine}.
@@ -348,7 +349,7 @@ public class RefreshListenersTests extends ESTestCase {
                             assertEquals(iteration, getResult.version());
                             org.apache.lucene.document.Document document =
                                     getResult.docIdAndVersion().reader.document(getResult.docIdAndVersion().docId);
-                            assertEquals(new String[] {testFieldValue}, document.getValues("test"));
+                            assertThat(document.getValues("test"), arrayContaining(testFieldValue));
                         }
                     } catch (Exception t) {
                         throw new RuntimeException("failure on the [" + iteration + "] iteration of thread [" + threadId + "]", t);

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -133,9 +133,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -2976,7 +2976,7 @@ public class TranslogTests extends ESTestCase {
                 assertThat(snapshot.totalOperations(), equalTo(expectedSnapshotOps));
                 Translog.Operation op;
                 while ((op = snapshot.next()) != null) {
-                    assertThat(Tuple.tuple(op.seqNo(), op.primaryTerm()), isIn(seenSeqNos));
+                    assertThat(Tuple.tuple(op.seqNo(), op.primaryTerm()), is(in(seenSeqNos)));
                     readFromSnapshot++;
                 }
                 readFromSnapshot += snapshot.skippedOperations();

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -39,10 +39,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 
 public class FsProbeTests extends ESTestCase {
@@ -83,9 +84,9 @@ public class FsProbeTests extends ESTestCase {
 
             for (FsInfo.Path path : stats) {
                 assertNotNull(path);
-                assertThat(path.getPath(), not(isEmptyOrNullString()));
-                assertThat(path.getMount(), not(isEmptyOrNullString()));
-                assertThat(path.getType(), not(isEmptyOrNullString()));
+                assertThat(path.getPath(), is(not(emptyOrNullString())));
+                assertThat(path.getMount(), is(not(emptyOrNullString())));
+                assertThat(path.getType(), is(not(emptyOrNullString())));
                 assertThat(path.total, greaterThan(0L));
                 assertThat(path.free, greaterThan(0L));
                 assertThat(path.available, greaterThan(0L));

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfilerIT.java
@@ -42,9 +42,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.search.profile.query.RandomQueryGenerator.randomQueryBuilder;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 
@@ -96,7 +97,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                     }
 
                     CollectorResult result = searchProfiles.getCollectorResult();
-                    assertThat(result.getName(), not(isEmptyOrNullString()));
+                    assertThat(result.getName(), is(not(emptyOrNullString())));
                     assertThat(result.getTime(), greaterThan(0L));
                 }
             }
@@ -234,7 +235,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -299,7 +300,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -349,7 +350,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -401,7 +402,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -448,7 +449,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -495,7 +496,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -541,7 +542,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }
@@ -596,7 +597,7 @@ public class QueryProfilerIT extends ESIntegTestCase {
                 }
 
                 CollectorResult result = searchProfiles.getCollectorResult();
-                assertThat(result.getName(), not(isEmptyOrNullString()));
+                assertThat(result.getName(), is(not(emptyOrNullString())));
                 assertThat(result.getTime(), greaterThan(0L));
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
@@ -44,7 +44,8 @@ import static org.elasticsearch.geometry.utils.Geohash.addNeighborsAtLevel;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.search.suggest.completion.CategoryContextMappingTests.assertContextSuggestFields;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
 
 public class GeoContextMappingTests extends ESSingleNodeTestCase {
 
@@ -275,7 +276,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         locations.add("ezs42e");
         addNeighborsAtLevel("ezs42e", GeoContextMapping.DEFAULT_PRECISION, locations);
         for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
-            assertThat(internalQueryContext.context, isIn(locations));
+            assertThat(internalQueryContext.context, is(in(locations)));
             assertThat(internalQueryContext.boost, equalTo(1));
             assertThat(internalQueryContext.isPrefix, equalTo(false));
         }
@@ -294,7 +295,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         locations.add("wh0n94");
         addNeighborsAtLevel("wh0n94", GeoContextMapping.DEFAULT_PRECISION, locations);
         for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
-            assertThat(internalQueryContext.context, isIn(locations));
+            assertThat(internalQueryContext.context, is(in(locations)));
             assertThat(internalQueryContext.boost, equalTo(1));
             assertThat(internalQueryContext.isPrefix, equalTo(false));
         }
@@ -322,7 +323,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
         locations.add("wh0");
         addNeighborsAtLevel("wh0", 3, locations);
         for (ContextMapping.InternalQueryContext internalQueryContext : internalQueryContexts) {
-            assertThat(internalQueryContext.context, isIn(locations));
+            assertThat(internalQueryContext.context, is(in(locations)));
             assertThat(internalQueryContext.boost, equalTo(10));
             assertThat(internalQueryContext.isPrefix, equalTo(internalQueryContext.context.length() < GeoContextMapping.DEFAULT_PRECISION));
         }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -74,7 +74,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matcher;
-import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 
@@ -564,7 +564,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             assertTrue(connectedNodeIds + " should be a quorum of " + lastCommittedConfiguration,
                 lastCommittedConfiguration.hasQuorum(connectedNodeIds));
             assertThat("leader " + leader.getLocalNode() + " should be part of voting configuration " + lastCommittedConfiguration,
-                lastCommittedConfiguration.getNodeIds(), IsCollectionContaining.hasItem(leader.getLocalNode().getId()));
+                lastCommittedConfiguration.getNodeIds(), Matchers.hasItem(leader.getLocalNode().getId()));
 
             assertThat("no reconfiguration is in progress",
                 lastAcceptedState.getLastCommittedConfiguration(), equalTo(lastAcceptedState.getLastAcceptedConfiguration()));

--- a/test/framework/src/main/java/org/elasticsearch/common/logging/JsonLogsIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/logging/JsonLogsIntegTestCase.java
@@ -29,8 +29,9 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 /**
@@ -72,11 +73,11 @@ public abstract class JsonLogsIntegTestCase extends ESRestTestCase {
         try (Stream<JsonLogLine> stream = JsonLogsStream.from(openReader(getLogFile()))) {
             stream.limit(LINES_TO_CHECK)
                   .forEach(jsonLogLine -> {
-                      assertThat(jsonLogLine.type(), not(isEmptyOrNullString()));
-                      assertThat(jsonLogLine.timestamp(), not(isEmptyOrNullString()));
-                      assertThat(jsonLogLine.level(), not(isEmptyOrNullString()));
-                      assertThat(jsonLogLine.component(), not(isEmptyOrNullString()));
-                      assertThat(jsonLogLine.message(), not(isEmptyOrNullString()));
+                      assertThat(jsonLogLine.type(), is(not(emptyOrNullString())));
+                      assertThat(jsonLogLine.timestamp(), is(not(emptyOrNullString())));
+                      assertThat(jsonLogLine.level(), is(not(emptyOrNullString())));
+                      assertThat(jsonLogLine.component(), is(not(emptyOrNullString())));
+                      assertThat(jsonLogLine.message(), is(not(emptyOrNullString())));
 
                       // all lines should have the same nodeName and clusterName
                       assertThat(jsonLogLine.nodeName(), nodeNameMatcher());

--- a/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
@@ -39,9 +39,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.core.Is.is;
 
 public class DeterministicTaskQueueTests extends ESTestCase {
@@ -57,7 +57,7 @@ public class DeterministicTaskQueueTests extends ESTestCase {
 
         assertTrue(taskQueue.hasRunnableTasks());
         taskQueue.runRandomTask();
-        assertThat(strings, contains(isOneOf("foo", "bar")));
+        assertThat(strings, contains(oneOf("foo", "bar")));
 
         assertTrue(taskQueue.hasRunnableTasks());
         taskQueue.runRandomTask();

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ObjectPathTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ObjectPathTests.java
@@ -34,9 +34,10 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 
 public class ObjectPathTests extends ESTestCase {
 
@@ -216,7 +217,7 @@ public class ObjectPathTests extends ESTestCase {
             final Object object = objectPath.evaluate("metadata.templates.template_2._arbitrary_key_");
             assertThat(object, instanceOf(String.class));
             final String key = (String) object;
-            assertThat(key, isOneOf("field2", "field3"));
+            assertThat(key, is(oneOf("field2", "field3")));
         }
 
         {

--- a/test/logger-usage/src/test/java/org/elasticsearch/test/loggerusage/ESLoggerUsageTests.java
+++ b/test/logger-usage/src/test/java/org/elasticsearch/test/loggerusage/ESLoggerUsageTests.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.common.SuppressLoggerChecks;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.loggerusage.ESLoggerUsageChecker.WrongLoggerUsage;
-import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,7 +38,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.oneOf;
 
 public class ESLoggerUsageTests extends ESTestCase {
 
@@ -73,13 +74,13 @@ public class ESLoggerUsageTests extends ESTestCase {
                 if (method.isVarArgs()) {
                     assertEquals(2, paramLength);
                     assertEquals(String.class, method.getParameterTypes()[markerOffset]);
-                    assertThat(method.getParameterTypes()[markerOffset + 1], Matchers.<Class<?>>isOneOf(Object[].class, Supplier[].class));
+                    assertThat(method.getParameterTypes()[markerOffset + 1], is(oneOf(Object[].class, Supplier[].class)));
                 } else {
-                    assertThat(method.getParameterTypes()[markerOffset], Matchers.<Class<?>>isOneOf(Message.class, MessageSupplier.class,
-                        CharSequence.class, Object.class, String.class, Supplier.class));
+                    assertThat(method.getParameterTypes()[markerOffset], is(oneOf(Message.class, MessageSupplier.class,
+                        CharSequence.class, Object.class, String.class, Supplier.class)));
 
                     if (paramLength == 2) {
-                        assertThat(method.getParameterTypes()[markerOffset + 1], Matchers.<Class<?>>isOneOf(Throwable.class, Object.class));
+                        assertThat(method.getParameterTypes()[markerOffset + 1], is(oneOf(Throwable.class, Object.class)));
                         if (method.getParameterTypes()[markerOffset + 1].equals(Object.class)) {
                             assertEquals(String.class, method.getParameterTypes()[markerOffset]);
                         }
@@ -102,7 +103,7 @@ public class ESLoggerUsageTests extends ESTestCase {
         for (Constructor<?> constructor : ParameterizedMessage.class.getConstructors()) {
             assertThat(constructor.getParameterTypes().length, greaterThanOrEqualTo(2));
             assertEquals(String.class, constructor.getParameterTypes()[0]);
-            assertThat(constructor.getParameterTypes()[1], Matchers.<Class<?>>isOneOf(String[].class, Object[].class, Object.class));
+            assertThat(constructor.getParameterTypes()[1], is(oneOf(String[].class, Object[].class, Object.class)));
 
             if (constructor.getParameterTypes().length > 2) {
                 assertEquals(3, constructor.getParameterTypes().length);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/util/ExpandedIdsMatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/util/ExpandedIdsMatcherTests.java
@@ -13,7 +13,8 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class ExpandedIdsMatcherTests extends ESTestCase {
 
@@ -72,8 +73,8 @@ public class ExpandedIdsMatcherTests extends ESTestCase {
         assertThat(requiredMatches.unmatchedIds(), hasSize(4));
         requiredMatches.filterMatchedIds(Arrays.asList("foo","baz"));
         assertThat(requiredMatches.unmatchedIds(), hasSize(2));
-        assertThat(requiredMatches.unmatchedIds().get(0), isOneOf("bar", "wild*"));
-        assertThat(requiredMatches.unmatchedIds().get(1), isOneOf("bar", "wild*"));
+        assertThat(requiredMatches.unmatchedIds().get(0), is(oneOf("bar", "wild*")));
+        assertThat(requiredMatches.unmatchedIds().get(1), is(oneOf("bar", "wild*")));
     }
 
     public void testMatchingResourceIds_allowNoMatch() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/MetricConfigSerializingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/job/MetricConfigSerializingTests.java
@@ -21,7 +21,8 @@ import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -77,7 +78,7 @@ public class MetricConfigSerializingTests extends AbstractSerializingTestCase<Me
         MetricConfig config = new MetricConfig("my_field", singletonList("max"));
         config.validateMappings(responseMap, e);
         assertThat("The field referenced by a metric group must be a [numeric] or [date] type," +
-            " but found [keyword] for field [my_field]", isIn(e.validationErrors()));
+            " but found [keyword] for field [my_field]", is(in(e.validationErrors())));
     }
 
     public void testValidateFieldMatchingNotAggregatable() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/SSLConfigurationTests.java
@@ -24,9 +24,9 @@ import java.util.Arrays;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -340,7 +340,7 @@ public class SSLConfigurationTests extends ESTestCase {
         X509Certificate[] defaultAcceptedIssuers = new DefaultJDKTrustConfig(null).createTrustManager(null)
             .getAcceptedIssuers();
         assertEquals(keyConfAcceptedIssuers.length + defaultAcceptedIssuers.length, trustConfAcceptedIssuers.length);
-        assertThat(Arrays.asList(keyConfAcceptedIssuers), everyItem(isIn(trustConfAcceptedIssuers)));
-        assertThat(Arrays.asList(defaultAcceptedIssuers), everyItem(isIn(trustConfAcceptedIssuers)));
+        assertThat(Arrays.asList(keyConfAcceptedIssuers), everyItem(is(in(trustConfAcceptedIssuers))));
+        assertThat(Arrays.asList(defaultAcceptedIssuers), everyItem(is(in(trustConfAcceptedIssuers))));
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -38,7 +38,8 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 /**
  * An integration test for detection rules
@@ -225,7 +226,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         assertThat(records.size(), equalTo(2));
         for (AnomalyRecord record : records) {
             assertThat(record.getTimestamp().getTime(), equalTo(secondAnomalyTime));
-            assertThat(record.getOverFieldValue(), isOneOf("111.111.111.111", "222.222.222.222"));
+            assertThat(record.getOverFieldValue(), is(oneOf("111.111.111.111", "222.222.222.222")));
         }
 
         closeJob(job.getId());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -91,7 +91,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
@@ -322,7 +322,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         List<Calendar> updatedCalendars = getCalendars(null);
         assertEquals(5, updatedCalendars.size());
         for (Calendar cal: updatedCalendars) {
-            assertThat("bar", not(isIn(cal.getJobIds())));
+            assertThat("bar", is(not(in(cal.getJobIds()))));
         }
 
         Calendar catFoo = getCalendar("cat foo calendar");
@@ -344,8 +344,8 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         updatedCalendars = getCalendars(null);
         assertEquals(5, updatedCalendars.size());
         for (Calendar cal: updatedCalendars) {
-            assertThat("bar", not(isIn(cal.getJobIds())));
-            assertThat("cat", not(isIn(cal.getJobIds())));
+            assertThat("bar", is(not(in(cal.getJobIds()))));
+            assertThat("cat", is(not(in(cal.getJobIds()))));
         }
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -75,15 +75,15 @@ import static org.elasticsearch.threadpool.ThreadPool.Names.WRITE;
 import static org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.TEMPLATE_VERSION;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.oneOf;
 
 public class MonitoringIT extends ESSingleNodeTestCase {
 
@@ -264,15 +264,15 @@ public class MonitoringIT extends ESSingleNodeTestCase {
 
         final String index = (String) document.get("_index");
         assertThat(index, containsString(".monitoring-" + expectedSystem.getSystem() + "-" + TEMPLATE_VERSION + "-"));
-        assertThat((String) document.get("_id"), not(isEmptyOrNullString()));
+        assertThat((String) document.get("_id"), is(not(emptyOrNullString())));
 
         final Map<String, Object> source = (Map<String, Object>) document.get("_source");
         assertThat(source, notNullValue());
-        assertThat((String) source.get("cluster_uuid"), not(isEmptyOrNullString()));
+        assertThat((String) source.get("cluster_uuid"), is(not(emptyOrNullString())));
         assertThat(source.get("type"), equalTo(expectedType));
 
         final String timestamp = (String) source.get("timestamp");
-        assertThat(timestamp, not(isEmptyOrNullString()));
+        assertThat(timestamp, is(not(emptyOrNullString())));
 
         assertThat(((Number) source.get("interval_ms")).longValue(), equalTo(interval.getMillis()));
 
@@ -305,7 +305,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         assertThat(sourceNode.get("transport_address"),equalTo(node.getAddress().toString()));
         assertThat(sourceNode.get("ip"), equalTo(node.getAddress().getAddress()));
         assertThat(sourceNode.get("name"), equalTo(node.getName()));
-        assertThat((String) sourceNode.get("timestamp"), not(isEmptyOrNullString()));
+        assertThat((String) sourceNode.get("timestamp"), is(not(emptyOrNullString())));
     }
 
     /**
@@ -317,24 +317,24 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         final Map<String, Object> source = (Map<String, Object>) document.get("_source");
         assertEquals(12, source.size());
 
-        assertThat((String) source.get("cluster_name"), not(isEmptyOrNullString()));
+        assertThat((String) source.get("cluster_name"), is(not(emptyOrNullString())));
         assertThat(source.get("version"), equalTo(Version.CURRENT.toString()));
 
         final Map<String, Object> license = (Map<String, Object>) source.get("license");
         assertThat(license, notNullValue());
-        assertThat((String) license.get(License.Fields.ISSUER), not(isEmptyOrNullString()));
-        assertThat((String) license.get(License.Fields.ISSUED_TO), not(isEmptyOrNullString()));
+        assertThat((String) license.get(License.Fields.ISSUER), is(not(emptyOrNullString())));
+        assertThat((String) license.get(License.Fields.ISSUED_TO), is(not(emptyOrNullString())));
         assertThat((Long) license.get(License.Fields.ISSUE_DATE_IN_MILLIS), greaterThan(0L));
         assertThat((Integer) license.get(License.Fields.MAX_NODES), greaterThan(0));
 
         String uid = (String) license.get("uid");
-        assertThat(uid, not(isEmptyOrNullString()));
+        assertThat(uid, is(not(emptyOrNullString())));
 
         String type = (String) license.get("type");
-        assertThat(type, not(isEmptyOrNullString()));
+        assertThat(type, is(not(emptyOrNullString())));
 
         String status = (String) license.get(License.Fields.STATUS);
-        assertThat(status, not(isEmptyOrNullString()));
+        assertThat(status, is(not(emptyOrNullString())));
 
         if ("basic".equals(license.get("type")) == false) {
             Long expiryDate = (Long) license.get(License.Fields.EXPIRY_DATE_IN_MILLIS);
@@ -342,7 +342,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         }
 
         Boolean clusterNeedsTLS = (Boolean) license.get("cluster_needs_tls");
-        assertThat(clusterNeedsTLS, isOneOf(true, null));
+        assertThat(clusterNeedsTLS, is(oneOf(true, null)));
 
         final Map<String, Object> clusterStats = (Map<String, Object>) source.get("cluster_stats");
         assertThat(clusterStats, notNullValue());
@@ -427,10 +427,10 @@ public class MonitoringIT extends ESSingleNodeTestCase {
         // particular field values checked in the index stats tests
         final Map<String, Object> indexStats = (Map<String, Object>) source.get(IndexStatsMonitoringDoc.TYPE);
         assertEquals(7, indexStats.size());
-        assertThat((String) indexStats.get("index"), not(isEmptyOrNullString()));
-        assertThat((String) indexStats.get("uuid"), not(isEmptyOrNullString()));
+        assertThat((String) indexStats.get("index"), is(not(emptyOrNullString())));
+        assertThat((String) indexStats.get("uuid"), is(not(emptyOrNullString())));
         assertThat(indexStats.get("created"), notNullValue());
-        assertThat((String) indexStats.get("status"), not(isEmptyOrNullString()));
+        assertThat((String) indexStats.get("status"), is(not(emptyOrNullString())));
         assertThat(indexStats.get("shards"), notNullValue());
         final Map<String, Object> shards = (Map<String, Object>) indexStats.get("shards");
         assertEquals(11, shards.size());

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateGenerateToolTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.xpack.security.cli.CertificateGenerateTool.CertificateI
 import org.elasticsearch.xpack.security.cli.CertificateGenerateTool.Name;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 import org.elasticsearch.xpack.core.ssl.PemUtils;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.BeforeClass;
 
@@ -74,10 +73,12 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.test.TestMatchers.pathExists;
+import static org.elasticsearch.test.FileMatchers.pathExists;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -342,7 +343,7 @@ public class CertificateGenerateToolTests extends ESTestCase {
                     assertSubjAltNames(subjAltNames, certInfo);
                 }
                 if (pkcs12Password != null) {
-                    assertThat(p12, pathExists(p12));
+                    assertThat(p12, pathExists());
                     try (InputStream in = Files.newInputStream(p12)) {
                         final KeyStore ks = KeyStore.getInstance("PKCS12");
                         ks.load(in, pkcs12Password);
@@ -353,7 +354,7 @@ public class CertificateGenerateToolTests extends ESTestCase {
                         assertThat(key, notNullValue());
                     }
                 } else {
-                    assertThat(p12, not(pathExists(p12)));
+                    assertThat(p12, not(pathExists()));
                 }
             }
         }
@@ -493,7 +494,7 @@ public class CertificateGenerateToolTests extends ESTestCase {
                 DLTaggedObject taggedName = (DLTaggedObject) seq.getObjectAt(1);
                 assertThat(taggedName.getTagNo(), equalTo(0));
                 assertThat(taggedName.getObject(), instanceOf(ASN1String.class));
-                assertThat(taggedName.getObject().toString(), Matchers.isIn(certInfo.commonNames));
+                assertThat(taggedName.getObject().toString(), is(in(certInfo.commonNames)));
             } else {
                 fail("unknown general name with tag " + generalName.getTagNo());
             }

--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertificateToolTests.java
@@ -39,7 +39,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
-import org.elasticsearch.test.TestMatchers;
 import org.elasticsearch.xpack.security.cli.CertificateTool.CAInfo;
 import org.elasticsearch.xpack.security.cli.CertificateTool.CertificateAuthorityCommand;
 import org.elasticsearch.xpack.security.cli.CertificateTool.CertificateCommand;
@@ -90,10 +89,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.FileMatchers.pathExists;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 /**
@@ -400,7 +402,7 @@ public class CertificateToolTests extends ESTestCase {
                             GeneralNames.fromExtensions(x509CertHolder.getExtensions(), Extension.subjectAlternativeName);
                     assertSubjAltNames(subjAltNames, certInfo);
                 }
-                assertThat(p12, Matchers.not(TestMatchers.pathExists(p12)));
+                assertThat(p12, Matchers.not(pathExists()));
             }
         }
     }
@@ -586,7 +588,7 @@ public class CertificateToolTests extends ESTestCase {
         );
         caCommand.execute(terminal, caOptions, env);
 
-        assertThat(caFile, TestMatchers.pathExists(caFile));
+        assertThat(caFile, pathExists());
 
         final GenerateCertificateCommand gen1Command = new PathAwareGenerateCertificateCommand(caFile, node1File);
         final OptionSet gen1Options = gen1Command.getParser().parse(
@@ -601,7 +603,7 @@ public class CertificateToolTests extends ESTestCase {
                 "-name", "node01");
         gen1Command.execute(terminal, gen1Options, env);
 
-        assertThat(node1File, TestMatchers.pathExists(node1File));
+        assertThat(node1File, pathExists());
 
         final GenerateCertificateCommand gen2Command = new PathAwareGenerateCertificateCommand(caFile, node2File);
         final OptionSet gen2Options = gen2Command.getParser().parse(
@@ -616,7 +618,7 @@ public class CertificateToolTests extends ESTestCase {
                 "-name", "node02");
         gen2Command.execute(terminal, gen2Options, env);
 
-        assertThat(node2File, TestMatchers.pathExists(node2File));
+        assertThat(node2File, pathExists());
 
         // Node 3 uses an auto generated CA, and therefore should not be trusted by the other nodes.
         final GenerateCertificateCommand gen3Command = new PathAwareGenerateCertificateCommand(null, node3File);
@@ -630,7 +632,7 @@ public class CertificateToolTests extends ESTestCase {
                 "-ip", node3Ip);
         gen3Command.execute(terminal, gen3Options, env);
 
-        assertThat(node3File, TestMatchers.pathExists(node3File));
+        assertThat(node3File, pathExists());
 
         final KeyStore node1KeyStore = CertParsingUtils.readKeyStore(node1File, "PKCS12", node1Password.toCharArray());
         final KeyStore node2KeyStore = CertParsingUtils.readKeyStore(node2File, "PKCS12", node2Password.toCharArray());
@@ -702,16 +704,16 @@ public class CertificateToolTests extends ESTestCase {
         terminal.addSecretInput(node1Password);
         gen1Command.execute(terminal, gen1Options, env);
 
-        assertThat(pkcs12Zip, TestMatchers.pathExists(pkcs12Zip));
+        assertThat(pkcs12Zip, pathExists());
 
         FileSystem zip1FS = FileSystems.newFileSystem(new URI("jar:" + pkcs12Zip.toUri()), Collections.emptyMap());
         Path zip1Root = zip1FS.getPath("/");
 
         final Path caP12 = zip1Root.resolve("ca/ca.p12");
-        assertThat(caP12, TestMatchers.pathExists(caP12));
+        assertThat(caP12, pathExists());
 
         final Path node1P12 = zip1Root.resolve("node01/node01.p12");
-        assertThat(node1P12, TestMatchers.pathExists(node1P12));
+        assertThat(node1P12, pathExists());
 
         final GenerateCertificateCommand gen2Command = new PathAwareGenerateCertificateCommand(caP12, pemZip);
         final OptionSet gen2Options = gen2Command.getParser().parse(
@@ -727,18 +729,18 @@ public class CertificateToolTests extends ESTestCase {
         terminal.addSecretInput(caPassword);
         gen2Command.execute(terminal, gen2Options, env);
 
-        assertThat(pemZip, TestMatchers.pathExists(pemZip));
+        assertThat(pemZip, pathExists());
 
         FileSystem zip2FS = FileSystems.newFileSystem(new URI("jar:" + pemZip.toUri()), Collections.emptyMap());
         Path zip2Root = zip2FS.getPath("/");
 
         final Path ca2 = zip2Root.resolve("ca/ca.p12");
-        assertThat(ca2, Matchers.not(TestMatchers.pathExists(ca2)));
+        assertThat(ca2, Matchers.not(pathExists()));
 
         final Path node2Cert = zip2Root.resolve("node02/node02.crt");
-        assertThat(node2Cert, TestMatchers.pathExists(node2Cert));
+        assertThat(node2Cert, pathExists());
         final Path node2Key = zip2Root.resolve("node02/node02.key");
-        assertThat(node2Key, TestMatchers.pathExists(node2Key));
+        assertThat(node2Key, pathExists());
 
         final KeyStore node1KeyStore = CertParsingUtils.readKeyStore(node1P12, "PKCS12", node1Password.toCharArray());
         final KeyStore node1TrustStore = node1KeyStore;
@@ -862,7 +864,7 @@ public class CertificateToolTests extends ESTestCase {
                 assertThat(seq.getObjectAt(1), instanceOf(ASN1TaggedObject.class));
                 ASN1TaggedObject tagged = (ASN1TaggedObject) seq.getObjectAt(1);
                 assertThat(tagged.getObject(), instanceOf(ASN1String.class));
-                assertThat(tagged.getObject().toString(), Matchers.isIn(certInfo.commonNames));
+                assertThat(tagged.getObject().toString(), is(in(certInfo.commonNames)));
             } else {
                 fail("unknown general name with tag " + generalName.getTagNo());
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -72,8 +72,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.core.security.index.RestrictedIndicesNames.SECURITY_MAIN_ALIAS;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 /**
  * Base class to run tests against a cluster with X-Pack installed and security enabled.

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest.Metric.PLUGINS;
 import static org.elasticsearch.test.SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * A test that starts a single node with security enabled. This test case allows for customization

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -64,8 +64,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -295,7 +295,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         Set<String> expectedKeyIds = Sets.newHashSet(createdApiKeys.get(0).getId(), createdApiKeys.get(1).getId());
         boolean apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover = false;
         for (ApiKey apiKey : getApiKeyResponseListener.get().getApiKeyInfos()) {
-            assertThat(apiKey.getId(), isIn(expectedKeyIds));
+            assertThat(apiKey.getId(), is(in(expectedKeyIds)));
             if (apiKey.getId().equals(createdApiKeys.get(0).getId())) {
                 // has been invalidated but not yet deleted by ExpiredApiKeysRemover
                 assertThat(apiKey.isInvalidated(), is(true));
@@ -328,7 +328,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         expectedKeyIds = Sets.newHashSet(createdApiKeys.get(1).getId());
         apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover = false;
         for (ApiKey apiKey : getApiKeyResponseListener.get().getApiKeyInfos()) {
-            assertThat(apiKey.getId(), isIn(expectedKeyIds));
+            assertThat(apiKey.getId(), is(in(expectedKeyIds)));
             if (apiKey.getId().equals(createdApiKeys.get(1).getId())) {
                 // has been invalidated but not yet deleted by ExpiredApiKeysRemover
                 assertThat(apiKey.isInvalidated(), is(true));
@@ -412,7 +412,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 createdApiKeys.get(3).getId());
         boolean apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover = false;
         for (ApiKey apiKey : getApiKeyResponseListener.get().getApiKeyInfos()) {
-            assertThat(apiKey.getId(), isIn(expectedKeyIds));
+            assertThat(apiKey.getId(), is(in(expectedKeyIds)));
             if (apiKey.getId().equals(createdApiKeys.get(0).getId())) {
                 // has been expired, not invalidated
                 assertTrue(apiKey.getExpiration().isBefore(Instant.now()));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -109,9 +109,9 @@ import static org.elasticsearch.xpack.security.authc.TokenServiceTests.mockGetTo
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -1515,7 +1515,7 @@ public class AuthenticationServiceTests extends ESTestCase {
 
     private String expectAuditRequestId() {
         String reqId = AuditUtil.extractRequestId(threadContext);
-        assertThat(reqId, not(isEmptyOrNullString()));
+        assertThat(reqId, is(not(emptyOrNullString())));
         return reqId;
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapUserSearchSessionFactoryTests.java
@@ -44,8 +44,8 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
@@ -529,7 +529,7 @@ public class LdapUserSearchSessionFactoryTests extends LdapTestCase {
                 TestEnvironment.newEnvironment(globalSettings), new ThreadContext(globalSettings));
         try (LdapUserSearchSessionFactory searchSessionFactory = getLdapUserSearchSessionFactory(config, sslService, threadPool)) {
             assertThat(searchSessionFactory.bindCredentials, notNullValue());
-            assertThat(searchSessionFactory.bindCredentials.getBindDN(), isEmptyString());
+            assertThat(searchSessionFactory.bindCredentials.getBindDN(), is(emptyString()));
         }
         assertDeprecationWarnings(config.identifier(), false, useLegacyBindPassword);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
@@ -29,7 +29,7 @@ import static org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import static org.elasticsearch.test.SecurityTestsUtils.assertAuthorizationExceptionDefaultUsers;
 import static org.elasticsearch.test.SecurityTestsUtils.assertThrowsAuthorizationExceptionDefaultUsers;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoSearchHits;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.number.OrderingComparison.greaterThan;

--- a/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvTestUtils.java
+++ b/x-pack/plugin/sql/qa/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/CsvTestUtils.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -91,7 +91,7 @@ public final class CsvTestUtils {
 
             String sch = schema;
             if (header.contains(":")) {
-                assertThat("Cannot declare schema both individually and inside the header", sch, isEmptyOrNullString());
+                assertThat("Cannot declare schema both individually and inside the header", sch, is(emptyOrNullString()));
                 sch = header;
             }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/AccountsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/AccountsTests.java
@@ -15,8 +15,8 @@ import java.util.HashSet;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.oneOf;
 import static org.mockito.Mockito.mock;
 
 public class AccountsTests extends ESTestCase {
@@ -82,7 +82,7 @@ public class AccountsTests extends ESTestCase {
         assertThat(account.name(), equalTo("account2"));
         account = service.getAccount(null);
         assertThat(account, notNullValue());
-        assertThat(account.name(), isOneOf("account1", "account2"));
+        assertThat(account.name(), is(oneOf("account1", "account2")));
     }
 
     public void testMultipleAccountsUnknownDefault() throws Exception {

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MlMigrationFullClusterRestartIT.java
@@ -38,7 +38,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.emptyOrNullString;
 
 public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
@@ -172,7 +173,7 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
 
             assertEquals(jobId, XContentMapValues.extractValue("job_id", jobStats.get(0)));
             assertEquals("opened", XContentMapValues.extractValue("state", jobStats.get(0)));
-            assertThat((String) XContentMapValues.extractValue("assignment_explanation", jobStats.get(0)), isEmptyOrNullString());
+            assertThat((String) XContentMapValues.extractValue("assignment_explanation", jobStats.get(0)), is(emptyOrNullString()));
             assertNotNull(XContentMapValues.extractValue("node", jobStats.get(0)));
         }, 30, TimeUnit.SECONDS);
     }
@@ -188,7 +189,7 @@ public class MlMigrationFullClusterRestartIT extends AbstractFullClusterRestartT
 
             assertEquals(datafeedId, XContentMapValues.extractValue("datafeed_id", datafeedStats.get(0)));
             assertEquals("started", XContentMapValues.extractValue("state", datafeedStats.get(0)));
-            assertThat((String) XContentMapValues.extractValue("assignment_explanation", datafeedStats.get(0)), isEmptyOrNullString());
+            assertThat((String) XContentMapValues.extractValue("assignment_explanation", datafeedStats.get(0)), is(emptyOrNullString()));
             assertNotNull(XContentMapValues.extractValue("node", datafeedStats.get(0)));
         }, 30, TimeUnit.SECONDS);
     }

--- a/x-pack/qa/multi-node/src/test/java/org/elasticsearch/multi_node/RollupIT.java
+++ b/x-pack/qa/multi-node/src/test/java/org/elasticsearch/multi_node/RollupIT.java
@@ -34,7 +34,8 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.test.SecuritySettingsSourceField.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.oneOf;
 
 public class RollupIT extends ESRestTestCase {
 
@@ -207,7 +208,7 @@ public class RollupIT extends ESRestTestCase {
         Map<String, Object> getRollupJobResponse = toMap(client().performRequest(getRollupJobRequest));
         Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
         if (job != null) {
-            assertThat(ObjectPath.eval("status.job_state", job), isOneOf(states));
+            assertThat(ObjectPath.eval("status.job_state", job), is(oneOf(states)));
         }
 
         // check that the rollup job is started using the Tasks API
@@ -219,7 +220,7 @@ public class RollupIT extends ESRestTestCase {
         Map<String, Object> taskResponseNode = (Map<String, Object>) taskResponseNodes.values().iterator().next();
         Map<String, Object> taskResponseTasks = (Map<String, Object>) taskResponseNode.get("tasks");
         Map<String, Object> taskResponseStatus = (Map<String, Object>) taskResponseTasks.values().iterator().next();
-        assertThat(ObjectPath.eval("status.job_state", taskResponseStatus), isOneOf(states));
+        assertThat(ObjectPath.eval("status.job_state", taskResponseStatus), is(oneOf(states)));
 
         // check that the rollup job is started using the Cluster State API
         final Request clusterStateRequest = new Request("GET", "_cluster/state/metadata");
@@ -233,7 +234,7 @@ public class RollupIT extends ESRestTestCase {
 
                 final String jobStateField = "task.xpack/rollup/job.state.job_state";
                 assertThat("Expected field [" + jobStateField + "] to be started or indexing in " + task.get("id"),
-                    ObjectPath.eval(jobStateField, task), isOneOf(states));
+                    ObjectPath.eval(jobStateField, task), is(oneOf(states)));
                 break;
             }
         }
@@ -251,7 +252,7 @@ public class RollupIT extends ESRestTestCase {
 
             Map<String, Object> job = getJob(getRollupJobResponse, rollupJob);
             if (job != null) {
-                assertThat(ObjectPath.eval("status.job_state", job), isOneOf(expectedStates));
+                assertThat(ObjectPath.eval("status.job_state", job), is(oneOf(expectedStates)));
             }
         }, 30L, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
I've noticed that a lot of our tests are using deprecated static methods
from the Hamcrest matchers. While this is not a big deal in any
objective sense, it seems like a small good thing to reduce compilation
warnings and be ready for a new release of the matcher library if we
need to upgrade. I've also switched a few other methods in tests that
have drop-in replacements.