### PR TITLE
Add pom validation

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -120,6 +120,7 @@ dependencies {
   compile 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
   compile 'de.thetaphi:forbiddenapis:2.7'
   compile 'com.avast.gradle:gradle-docker-compose-plugin:0.8.12'
+  compile 'org.apache.maven:maven-model:3.6.2'
   compileOnly "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
   testCompile "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
   testCompile "junit:junit:${props.getProperty('junit')}"

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -377,7 +377,10 @@ class BuildPlugin implements Plugin<Project> {
                 // Here we manually add any project dependencies in the "shadow" configuration to our generated POM
                 publication.pom.withXml(this.&addScmInfo)
                 publication.pom.withXml { xml ->
-                    Node dependenciesNode = (xml.asNode().get('dependencies') as NodeList).get(0) as Node
+                    Node root = xml.asNode();
+                    root.appendNode('name', project.name)
+                    root.appendNode('description', project.description)
+                    Node dependenciesNode = (root.get('dependencies') as NodeList).get(0) as Node
                     project.configurations.getByName(ShadowBasePlugin.CONFIGURATION_NAME).allDependencies.each { dependency ->
                         if (dependency instanceof ProjectDependency) {
                             def dependencyNode = dependenciesNode.appendNode('dependency')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -100,11 +100,20 @@ class PrecommitTasks {
             }
         }
 
-        return project.tasks.register('precommit') {
+        TaskProvider precommit = project.tasks.register('precommit') {
             group = JavaBasePlugin.VERIFICATION_GROUP
             description = 'Runs all non-test checks.'
             dependsOn = precommitTasks
         }
+
+        // not all jar projects produce a pom (we don't ship all jars), so a pom validation
+        // task is only added on some projects, and thus we can't always have a task
+        // here to add to precommit tasks explicitly. Instead, we apply our internal
+        // pom validation plugin after the precommit task is created and let the
+        // plugin add the task if necessary
+        project.plugins.apply(PomValidationPlugin)
+
+        return precommit
     }
 
     static TaskProvider configureTestingConventions(Project project) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationPlugin.java
@@ -38,10 +38,11 @@ public class PomValidationPlugin implements Plugin<Project> {
             PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
             publishing.getPublications().all(publication -> {
                 String publicationName = Util.capitalize(publication.getName());
-                TaskProvider<PomValidationTask> validateTask =
-                    project.getTasks().register("validate" + publicationName + "Pom", PomValidationTask.class);
+                TaskProvider<PomValidationTask> validateTask = project.getTasks()
+                    .register("validate" + publicationName + "Pom", PomValidationTask.class);
                 validateTask.configure(task -> {
-                    GenerateMavenPom generateMavenPom = project.getTasks().withType(GenerateMavenPom.class)
+                    GenerateMavenPom generateMavenPom = project.getTasks()
+                        .withType(GenerateMavenPom.class)
                         .getByName("generatePomFileFor" + publicationName + "Publication");
                     task.dependsOn(generateMavenPom);
                     task.getPomFile().fileValue(generateMavenPom.getDestination());

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationPlugin.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.precommit;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
+import org.gradle.api.tasks.TaskProvider;
+
+/**
+ * Adds pom validation to every pom generation task.
+ */
+public class PomValidationPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getTasks().withType(GenerateMavenPom.class, generateMavenPom -> {
+            String taskname = "validate" + generateMavenPom.getName().substring("generate".length());
+            TaskProvider<PomValidationTask> validateTask = project.getTasks().register(taskname, PomValidationTask.class);
+            validateTask.configure(task -> {
+                task.dependsOn(generateMavenPom);
+                task.getPomFile().fileValue(generateMavenPom.getDestination());
+            });
+            project.getTasks().named("precommit").configure(precommit -> {
+                precommit.dependsOn(validateTask);
+            });
+        });
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationPlugin.java
@@ -38,9 +38,7 @@ public class PomValidationPlugin implements Plugin<Project> {
                 task.dependsOn(generateMavenPom);
                 task.getPomFile().fileValue(generateMavenPom.getDestination());
             });
-            project.getTasks().named("precommit").configure(precommit -> {
-                precommit.dependsOn(validateTask);
-            });
+            project.getTasks().named("precommit").configure(precommit -> { precommit.dependsOn(validateTask); });
         });
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationTask.java
@@ -21,7 +21,6 @@ package org.elasticsearch.gradle.precommit;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationTask.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.precommit;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.FileReader;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public class PomValidationTask extends DefaultTask {
+
+    private final RegularFileProperty pomFile = getProject().getObjects().fileProperty();
+
+    private boolean foundError;
+
+    @InputFile
+    public RegularFileProperty getPomFile() {
+        return pomFile;
+    }
+
+    @TaskAction
+    public void checkPom() throws Exception {
+        MavenXpp3Reader reader = new MavenXpp3Reader();
+        Model model = reader.read(new FileReader(pomFile.getAsFile().get()));
+
+        validateString("groupId", model.getGroupId());
+        validateString("artifactId", model.getArtifactId());
+        validateString("version", model.getVersion());
+        validateString("name", model.getName());
+        validateString("description", model.getDescription());
+        validateString("url", model.getUrl());
+
+        validateCollection("licenses", model.getLicenses(), v -> {
+            validateString("licenses.name", v.getName());
+            validateString("licenses.url", v.getUrl());
+        });
+
+        validateCollection("developers", model.getDevelopers(), v -> {
+            validateString("developers.name", v.getName());
+            validateString("developers.url", v.getUrl());
+        });
+
+        validateNonNull("scm", model.getScm(), () ->
+            validateString("scm.url", model.getScm().getUrl())
+        );
+
+        if (foundError) {
+            throw new GradleException("Pom file [" + pomFile.getAsFile().get() + "] failed validation");
+        }
+    }
+
+    private void logError(String element, String message) {
+        foundError = true;
+        getLogger().error("{} {} in [{}]", element, message, pomFile.getAsFile().get());
+    }
+
+    private <T> void validateNonEmpty(String element, T value, Predicate<T> isEmpty) {
+        if (isEmpty.test(value)) {
+            logError(element, "is empty");
+        }
+    }
+
+    private <T> void validateNonNull(String element, T value, Runnable validator) {
+        if (value == null) {
+            logError(element, "is missing");
+        } else {
+            validator.run();
+        }
+    }
+
+    private void validateString(String element, String value) {
+        validateNonNull(element, value, () ->
+            validateNonEmpty(element, value, String::isBlank)
+        );
+    }
+
+    private <T> void validateCollection(String element, Collection<T> value, Consumer<T> validator) {
+        validateNonNull(element, value, () -> {
+            validateNonEmpty(element, value, Collection::isEmpty);
+            value.forEach(validator);
+        });
+
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/PomValidationTask.java
@@ -65,9 +65,7 @@ public class PomValidationTask extends DefaultTask {
             validateString("developers.url", v.getUrl());
         });
 
-        validateNonNull("scm", model.getScm(), () ->
-            validateString("scm.url", model.getScm().getUrl())
-        );
+        validateNonNull("scm", model.getScm(), () -> validateString("scm.url", model.getScm().getUrl()));
 
         if (foundError) {
             throw new GradleException("Pom file [" + pomFile.getAsFile().get() + "] failed validation");
@@ -94,9 +92,7 @@ public class PomValidationTask extends DefaultTask {
     }
 
     private void validateString(String element, String value) {
-        validateNonNull(element, value, () ->
-            validateNonEmpty(element, value, String::isBlank)
-        );
+        validateNonNull(element, value, () -> validateNonEmpty(element, value, String::isBlank));
     }
 
     private <T> void validateCollection(String element, Collection<T> value, Consumer<T> validator) {

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -22,20 +22,12 @@ import org.elasticsearch.gradle.info.BuildParams
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.rest-test'
-apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'elasticsearch.rest-resources'
 
 group = 'org.elasticsearch.client'
 archivesBaseName = 'elasticsearch-rest-high-level-client'
-
-publishing {
-  publications {
-    nebula {
-      artifactId = archivesBaseName
-    }
-  }
-}
 
 restResources {
   //we need to copy the yaml spec so we can check naming (see RestHighlevelClientTests#testApiNamingConventions)


### PR DESCRIPTION
The pom files for our published artifacts are sent to maven central
during Elastic's release process, but we may not found out until then
that we have inadvertently broken the pom structure, as has happened
several times before. This commit adds validation of the pom file
specifically for the rules required by maven central.