### PR TITLE
[7.7][ML] Mark task as completed when DFA job is stopped while reinde…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -223,6 +223,7 @@ public class DataFrameAnalyticsManager {
                 if (error instanceof TaskCancelledException && task.isStopping()) {
                     LOGGER.debug(new ParameterizedMessage("[{}] Caught task cancelled exception while task is stopping",
                         config.getId()), error);
+                    task.markAsCompleted();
                 } else {
                     task.setFailed(ExceptionsHelper.unwrapCause(error).getMessage());
                 }


### PR DESCRIPTION
…xing (#55286)

After #54650 we catch `TaskCancelledException` when we wait for
reindexing to complete as it may be thrown. However, when that happens
we do not mark the task as completed. This results in the stop request
never returning and the failures we saw in #55068.

Closes #55068

Backport of #55286
