### PR TITLE
Remove version guards in JoinRequest serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -60,11 +60,7 @@ public class JoinRequest extends TransportRequest {
     public JoinRequest(StreamInput in) throws IOException {
         super(in);
         sourceNode = new DiscoveryNode(in);
-        if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
-            minimumTerm = in.readLong();
-        } else {
-            minimumTerm = 0L;
-        }
+        minimumTerm = in.readLong();
         optionalJoin = Optional.ofNullable(in.readOptionalWriteable(Join::new));
     }
 
@@ -72,9 +68,7 @@ public class JoinRequest extends TransportRequest {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         sourceNode.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_7_7_0)) {
-            out.writeLong(minimumTerm);
-        }
+        out.writeLong(minimumTerm);
         out.writeOptionalWriteable(optionalJoin.orElse(null));
     }
 


### PR DESCRIPTION
8.0 nodes never speak to nodes before 7.7 so these version guards are
unnecessary.