### PR TITLE
Rebooted master-ineligibles should not bootstrap

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -106,10 +106,14 @@ public class CoordinationStateTestCluster {
 
         void reboot() {
             if (localNode.isMasterNode() == false && rarely()) {
-                // master-ineligible nodes can't be trusted to persist the cluster state properly
-                persistedState = new InMemoryPersistedState(0L,
-                    clusterState(0L, 0L, localNode, CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
-                        CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG, 0L));
+                // master-ineligible nodes can't be trusted to persist the cluster state properly, but will not lose the fact that they
+                // were bootstrapped
+                final CoordinationMetadata.VotingConfiguration votingConfiguration
+                    = persistedState.getLastAcceptedState().getLastAcceptedConfiguration().isEmpty()
+                        ? CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG
+                        : CoordinationMetadata.VotingConfiguration.MUST_JOIN_ELECTED_MASTER;
+                persistedState
+                    = new InMemoryPersistedState(0L, clusterState(0L, 0L, localNode, votingConfiguration, votingConfiguration, 0L));
             }
 
             final Set<DiscoveryNodeRole> roles = new HashSet<>(localNode.getRoles());


### PR DESCRIPTION
In #55298 we saw a failure of `CoordinationStateTests#testSafety` in which a
single master-eligible node is bootstrapped, then rebooted as a
master-ineligible node (losing its persistent state) and then rebooted as a
master-eligible node and bootstrapped again.

This happens because this test loses too much of the persistent state; in fact
once bootstrapped the node would not allow itself to be bootstrapped again.
This commit adjusts the test logic to reflect this.

Closes #55298