### PR TITLE
SQL: [Test] Add test for a fixed bug for string scalars on aggs (#55304)

### DIFF
--- a/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
+++ b/x-pack/plugin/sql/qa/src/main/resources/agg.csv-spec
@@ -435,6 +435,17 @@ null        |5.1415926535
 null        |4.1415926535
 ;
 
+aggregateWithStringScalars
+schema::gender:s|avg:s
+SELECT gender, REPLACE(CONVERT(AVG(salary), text), '.', ',') as "avg"
+FROM test_emp WHERE languages IS NOT NULL AND birth_date IS NOT NULL GROUP BY gender ORDER BY gender LIMIT 2;
+
+    gender     |      avg
+---------------+---------------
+null           |48760,5
+F              |51130,48
+;
+
 //
 // Grouping functions
 //


### PR DESCRIPTION
Added an integration test to validate behaviour of string scalars on top
of aggregate functions. The behaviour was fixed with #49570.

Relates to: #41597

(cherry picked from commit 35f964154850e3f02b6c7f9ca238da98ad83ebb3)
