### PR TITLE
Use LTS version of Ubuntu in Dockerfiles

### DIFF
--- a/test/fixtures/azure-fixture/Dockerfile
+++ b/test/fixtures/azure-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 RUN apt-get update -qqy
 RUN apt-get install -qqy openjdk-12-jre-headless
 ENTRYPOINT exec java -classpath "/fixture/shared/*" fixture.azure.AzureHttpFixture 0.0.0.0 8091 container

--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
 RUN apt-get update -qqy
 RUN apt-get install -qqy openjdk-12-jre-headless

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
 RUN apt-get update -qqy
 RUN apt-get install -qqy openjdk-12-jre-headless

--- a/x-pack/test/smb-fixture/Dockerfile
+++ b/x-pack/test/smb-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 RUN apt-get update -qqy && apt-get install -qqy samba ldap-utils
 ADD . /fixture
 RUN chmod +x /fixture/src/main/resources/provision/installsmb.sh


### PR DESCRIPTION
We have some Dockerfiles that reference Ubuntu 19.04, which is not an LTS version and has now appears to have been retired from the Ubuntu repositories. Switch to 18.04, which is the current long-term support version. Also change a usage of 16.04 to 18.04, for consistency.