### PR TITLE
Fix creating filtered alias using now in a date_nanos range query failed (#54785)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
@@ -84,8 +84,8 @@
 ---
 "Can create filtered alias with a date_nanos range query":
   - skip:
-      version: " - 7.99.99"
-      reason: "skipping older version until backport"
+      version: " - 7.7.99"
+      reason: "Fix was introduced in 7.8.0"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/10_basic.yml
@@ -80,3 +80,30 @@
         index: test_index
         name: test_alias
   - match: {test_index.aliases.test_alias: { 'is_write_index': true }}
+
+---
+"Can create filtered alias with a date_nanos range query":
+  - skip:
+      version: " - 7.99.99"
+      reason: "skipping older version until backport"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            properties:
+              date_nanos_field:
+                type: date_nanos
+
+  - do:
+      indices.put_alias:
+        index: test_index
+        name: test_alias
+        body: {"filter": {"range": {"date_nanos_field": {"gt": "now-7d/d"}}}}
+
+  - do:
+      indices.get_alias:
+        index: test_index
+        name: test_alias
+  - match: {test_index.aliases.test_alias: {"filter": {"range": {"date_nanos_field": {"gt": "now-7d/d"}}}}}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -149,10 +149,10 @@ public class MetadataIndexAliasesService {
                             }
                             indices.put(action.getIndex(), indexService);
                         }
-                        // the context is only used for validation so it's fine to pass fake values for the shard id and the current
-                        // timestamp
-                        aliasValidator.validateAliasFilter(alias, filter, indexService.newQueryShardContext(0, null, () -> 0L, null),
-                                xContentRegistry);
+                        // the context is only used for validation so it's fine to pass fake values for the shard id,
+                        // but the current timestamp should be set to real value as we may use `now` in a filtered alias
+                        aliasValidator.validateAliasFilter(alias, filter, indexService.newQueryShardContext(0, null,
+                            () -> System.currentTimeMillis(), null), xContentRegistry);
                     }
                 };
                 if (action.apply(newAliasValidator, metadata, index)) {


### PR DESCRIPTION
Modify the value of nowInMillis in queryShardContext to current timestamp, because the
value will be used lately when validating the filtered alias which uses now in a date_nanos
range query.

Backport of #54785