### PR TITLE
[ML] fix bugs with prediction field value settings

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfig.java
@@ -214,6 +214,7 @@ public class ClassificationConfig implements LenientlyParsedInferenceConfig, Str
             this.topClassesResultsField = config.topClassesResultsField;
             this.resultsField = config.resultsField;
             this.numTopFeatureImportanceValues = config.numTopFeatureImportanceValues;
+            this.predictionFieldType = config.predictionFieldType;
         }
 
         public Builder setNumTopClasses(Integer numTopClasses) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdate.java
@@ -262,9 +262,13 @@ public class ClassificationConfigUpdate implements InferenceConfigUpdate {
             return this;
         }
 
-        private Builder setPredictionFieldType(String predictionFieldType) {
-            this.predictionFieldType = PredictionFieldType.fromString(predictionFieldType);
+        public Builder setPredictionFieldType(PredictionFieldType predictionFieldtype) {
+            this.predictionFieldType = predictionFieldtype;
             return this;
+        }
+
+        private Builder setPredictionFieldType(String predictionFieldType) {
+            return setPredictionFieldType(PredictionFieldType.fromString(predictionFieldType));
         }
 
         public ClassificationConfigUpdate build() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldType.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -57,7 +58,7 @@ public enum PredictionFieldType implements Writeable {
                 }
                 return areClose(value, 1.0D);
             case NUMBER:
-                if (stringRep == null) {
+                if (Strings.isNullOrEmpty(stringRep)) {
                     return value;
                 }
                 // Quick check to verify that the string rep is LIKELY a number

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldType.java
@@ -57,6 +57,19 @@ public enum PredictionFieldType implements Writeable {
                 }
                 return areClose(value, 1.0D);
             case NUMBER:
+                if (stringRep == null) {
+                    return value;
+                }
+                // Quick check to verify that the string rep is LIKELY a number
+                // Still handles the case where it throws and then returns the underlying value
+                if (stringRep.charAt(0) == '-' || Character.isDigit(stringRep.charAt(0))) {
+                    try {
+                        return Long.parseLong(stringRep);
+                    } catch (NumberFormatException nfe) {
+                        return value;
+                    }
+                }
+                return value;
             default:
                 return value;
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InternalInferModelActionRequestTests.java
@@ -45,8 +45,8 @@ public class InternalInferModelActionRequestTests extends AbstractBWCWireSeriali
     }
 
     private static InferenceConfigUpdate randomInferenceConfigUpdate() {
-        return randomFrom(RegressionConfigUpdateTests.randomRegressionConfig(),
-            ClassificationConfigUpdateTests.randomClassificationConfig());
+        return randomFrom(RegressionConfigUpdateTests.randomRegressionConfigUpdate(),
+            ClassificationConfigUpdateTests.randomClassificationConfigUpdate());
     }
 
     private static Map<String, Object> randomMap() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ClassificationConfigUpdateTests.java
@@ -16,11 +16,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigTests.randomClassificationConfig;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ClassificationConfigUpdateTests extends AbstractBWCSerializationTestCase<ClassificationConfigUpdate> {
 
-    public static ClassificationConfigUpdate randomClassificationConfig() {
+    public static ClassificationConfigUpdate randomClassificationConfigUpdate() {
         return new ClassificationConfigUpdate(randomBoolean() ? null : randomIntBetween(-1, 10),
             randomBoolean() ? null : randomAlphaOfLength(10),
             randomBoolean() ? null : randomAlphaOfLength(10),
@@ -49,9 +50,33 @@ public class ClassificationConfigUpdateTests extends AbstractBWCSerializationTes
         assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
     }
 
+    public void testApply() {
+        ClassificationConfig originalConfig = randomClassificationConfig();
+
+        assertThat(originalConfig, equalTo(ClassificationConfigUpdate.EMPTY_PARAMS.apply(originalConfig)));
+
+        assertThat(new ClassificationConfig.Builder(originalConfig).setNumTopClasses(5).build(),
+            equalTo(new ClassificationConfigUpdate.Builder().setNumTopClasses(5).build().apply(originalConfig)));
+        assertThat(new ClassificationConfig.Builder()
+            .setNumTopClasses(5)
+            .setNumTopFeatureImportanceValues(1)
+            .setPredictionFieldType(PredictionFieldType.BOOLEAN)
+            .setResultsField("foo")
+            .setTopClassesResultsField("bar").build(),
+            equalTo(new ClassificationConfigUpdate.Builder()
+                .setNumTopClasses(5)
+                .setNumTopFeatureImportanceValues(1)
+                .setPredictionFieldType(PredictionFieldType.BOOLEAN)
+                .setResultsField("foo")
+                .setTopClassesResultsField("bar")
+                .build()
+                .apply(originalConfig)
+            ));
+    }
+
     @Override
     protected ClassificationConfigUpdate createTestInstance() {
-        return randomClassificationConfig();
+        return randomClassificationConfigUpdate();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldTypeTests.java
@@ -38,6 +38,7 @@ public class PredictionFieldTypeTests extends ESTestCase {
             is(nullValue()));
         assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, "foo"), equalTo(1.0));
         assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, null), equalTo(1.0));
+        assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, ""), equalTo(1.0));
         long expected = randomLong();
         assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, String.valueOf(expected)), equalTo(expected));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PredictionFieldTypeTests.java
@@ -38,6 +38,8 @@ public class PredictionFieldTypeTests extends ESTestCase {
             is(nullValue()));
         assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, "foo"), equalTo(1.0));
         assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, null), equalTo(1.0));
+        long expected = randomLong();
+        assertThat(PredictionFieldType.NUMBER.transformPredictedValue(1.0, String.valueOf(expected)), equalTo(expected));
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RegressionConfigUpdateTests.java
@@ -16,11 +16,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests.randomRegressionConfig;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RegressionConfigUpdateTests extends AbstractBWCSerializationTestCase<RegressionConfigUpdate> {
 
-    public static RegressionConfigUpdate randomRegressionConfig() {
+    public static RegressionConfigUpdate randomRegressionConfigUpdate() {
         return new RegressionConfigUpdate(randomBoolean() ? null : randomAlphaOfLength(10),
             randomBoolean() ? null : randomIntBetween(0, 10));
     }
@@ -40,9 +41,28 @@ public class RegressionConfigUpdateTests extends AbstractBWCSerializationTestCas
         assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
     }
 
+    public void testApply() {
+        RegressionConfig originalConfig = randomRegressionConfig();
+
+        assertThat(originalConfig, equalTo(RegressionConfigUpdate.EMPTY_PARAMS.apply(originalConfig)));
+
+        assertThat(new RegressionConfig.Builder(originalConfig).setNumTopFeatureImportanceValues(5).build(),
+            equalTo(new RegressionConfigUpdate.Builder().setNumTopFeatureImportanceValues(5).build().apply(originalConfig)));
+        assertThat(new RegressionConfig.Builder()
+                .setNumTopFeatureImportanceValues(1)
+                .setResultsField("foo")
+                .build(),
+            equalTo(new RegressionConfigUpdate.Builder()
+                .setNumTopFeatureImportanceValues(1)
+                .setResultsField("foo")
+                .build()
+                .apply(originalConfig)
+            ));
+    }
+
     @Override
     protected RegressionConfigUpdate createTestInstance() {
-        return randomRegressionConfig();
+        return randomRegressionConfigUpdate();
     }
 
     @Override


### PR DESCRIPTION
This fixes two unreleased bugs:

1. Prediction value type of `number` might show unexpected classes

Analytics created models may have class labels like `1, 5, 10` (or some collection of discrete, whole numbers). These labels are passed to the inference model config in the `classification_labels` field.

When the predicted value format is `numeric` it should attempt to see if the classification labels are provided and are numeric. If so, use those. If not, use the underlying value.

2. When supplying an update overwrite, inference was losing the default prediction field value. This is because it was not copied over in the copy ctor in the ClassificationConfig.Builder class. 

closes #55332 