### PR TITLE
Add explicit generation member to data streams

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
@@ -23,10 +23,12 @@
         name: "*"
   - match: { 0.name: simple-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
+  - match: { 0.generation: 1 }
   - length: { 0.indices: 1 }
   - match: { 0.indices.0.index_name: 'simple-data-stream1-000001' }
   - match: { 1.name: simple-data-stream2 }
   - match: { 1.timestamp_field: '@timestamp2' }
+  - match: { 0.generation: 1 }
   - length: { 1.indices: 1 }
   - match: { 1.indices.0.index_name: 'simple-data-stream2-000001' }
 
@@ -97,22 +99,27 @@
       indices.get_data_streams: {}
   - match: { 0.name: get-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
+  - match: { 0.generation: 1 }
   - match: { 1.name: get-data-stream2 }
   - match: { 1.timestamp_field: '@timestamp2' }
+  - match: { 1.generation: 1 }
 
   - do:
       indices.get_data_streams:
         name: get-data-stream1
   - match: { 0.name: get-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
+  - match: { 0.generation: 1 }
 
   - do:
       indices.get_data_streams:
         name: get-data-*
   - match: { 0.name: get-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
+  - match: { 0.generation: 1 }
   - match: { 1.name: get-data-stream2 }
   - match: { 1.timestamp_field: '@timestamp2' }
+  - match: { 1.generation: 1 }
 
   - do:
       indices.get_data_streams:
@@ -169,6 +176,7 @@
       indices.get_data_streams: {}
   - match: { 0.name: delete-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
+  - match: { 0.generation: 1 }
   - length: { 0.indices: 1 }
   - match: { 0.indices.0.index_name: 'delete-data-stream1-000001' }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamAction.java
@@ -178,7 +178,7 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
             MetadataCreateIndexService.validateIndexOrAliasName(request.name,
                 (s1, s2) -> new IllegalArgumentException("data_stream [" + s1 + "] " + s2));
 
-            String firstBackingIndexName = request.name + "-000001";
+            String firstBackingIndexName = DataStream.getBackingIndexName(request.name, 1);
             CreateIndexClusterStateUpdateRequest createIndexRequest =
                 new CreateIndexClusterStateUpdateRequest("initialize_data_stream", firstBackingIndexName, firstBackingIndexName)
                 .settings(Settings.builder().put("index.hidden", true).build());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -49,7 +49,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
     }
 
     public DataStream(String name, String timeStampField, List<Index> indices) {
-        this(name, timeStampField, indices, 1);
+        this(name, timeStampField, indices, indices.size());
     }
 
     public String getName() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.Index;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 public final class DataStream extends AbstractDiffable<DataStream> implements ToXContentObject {
@@ -38,11 +39,17 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
     private final String name;
     private final String timeStampField;
     private final List<Index> indices;
+    private long generation;
 
-    public DataStream(String name, String timeStampField, List<Index> indices) {
+    public DataStream(String name, String timeStampField, List<Index> indices, long generation) {
         this.name = name;
         this.timeStampField = timeStampField;
         this.indices = indices;
+        this.generation = generation;
+    }
+
+    public DataStream(String name, String timeStampField, List<Index> indices) {
+        this(name, timeStampField, indices, 1);
     }
 
     public String getName() {
@@ -57,8 +64,16 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         return indices;
     }
 
+    public long getGeneration() {
+        return generation;
+    }
+
+    public static String getBackingIndexName(String dataStreamName, long generation) {
+        return String.format(Locale.ROOT, "%s-%06d", dataStreamName, generation);
+    }
+
     public DataStream(StreamInput in) throws IOException {
-        this(in.readString(), in.readString(), in.readList(Index::new));
+        this(in.readString(), in.readString(), in.readList(Index::new), in.readVLong());
     }
 
     public static Diff<DataStream> readDiffFrom(StreamInput in) throws IOException {
@@ -70,20 +85,23 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         out.writeString(name);
         out.writeString(timeStampField);
         out.writeList(indices);
+        out.writeVLong(generation);
     }
 
     public static final ParseField NAME_FIELD = new ParseField("name");
     public static final ParseField TIMESTAMP_FIELD_FIELD = new ParseField("timestamp_field");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
+    public static final ParseField GENERATION_FIELD = new ParseField("generation");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStream, Void> PARSER = new ConstructingObjectParser<>("data_stream",
-        args -> new DataStream((String) args[0], (String) args[1], (List<Index>) args[2]));
+        args -> new DataStream((String) args[0], (String) args[1], (List<Index>) args[2], (Long) args[3]));
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), NAME_FIELD);
         PARSER.declareString(ConstructingObjectParser.constructorArg(), TIMESTAMP_FIELD_FIELD);
         PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> Index.fromXContent(p), INDICES_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), GENERATION_FIELD);
     }
 
     public static DataStream fromXContent(XContentParser parser) throws IOException {
@@ -96,6 +114,7 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         builder.field(NAME_FIELD.getPreferredName(), name);
         builder.field(TIMESTAMP_FIELD_FIELD.getPreferredName(), timeStampField);
         builder.field(INDICES_FIELD.getPreferredName(), indices);
+        builder.field(GENERATION_FIELD.getPreferredName(), generation);
         builder.endObject();
         return builder;
     }
@@ -107,11 +126,12 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         DataStream that = (DataStream) o;
         return name.equals(that.name) &&
             timeStampField.equals(that.timeStampField) &&
-            indices.equals(that.indices);
+            indices.equals(that.indices) &&
+            generation == that.generation;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, timeStampField, indices);
+        return Objects.hash(name, timeStampField, indices, generation);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.metadata.DataStream.getBackingIndexName;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_HIDDEN_SETTING;
 
 /**
@@ -268,8 +269,7 @@ public interface IndexAbstraction {
             this.dataStream = dataStream;
             this.dataStreamIndices = List.copyOf(dataStreamIndices);
             this.writeIndex =  dataStreamIndices.stream()
-                .filter(index -> index.getIndex().getName().equals(
-                    org.elasticsearch.cluster.metadata.DataStream.getBackingIndexName(dataStream.getName(), dataStream.getGeneration())))
+                .filter(index -> index.getIndex().getName().equals(getBackingIndexName(dataStream.getName(), dataStream.getGeneration())))
                 .findFirst()
                 .orElse(null);
             assert writeIndex != null;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -268,11 +268,8 @@ public interface IndexAbstraction {
         public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream, List<IndexMetadata> dataStreamIndices) {
             this.dataStream = dataStream;
             this.dataStreamIndices = List.copyOf(dataStreamIndices);
-            this.writeIndex =  dataStreamIndices.stream()
-                .filter(index -> index.getIndex().getName().equals(getBackingIndexName(dataStream.getName(), dataStream.getGeneration())))
-                .findFirst()
-                .orElse(null);
-            assert writeIndex != null;
+            this.writeIndex =  dataStreamIndices.get(dataStreamIndices.size() - 1);
+            assert writeIndex.getIndex().getName().equals(getBackingIndexName(dataStream.getName(), dataStream.getGeneration()));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -264,12 +264,15 @@ public interface IndexAbstraction {
         private final List<IndexMetadata> dataStreamIndices;
         private final IndexMetadata writeIndex;
 
-        public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream,
-                          List<IndexMetadata> dataStreamIndices, IndexMetadata writeIndex) {
+        public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream, List<IndexMetadata> dataStreamIndices) {
             this.dataStream = dataStream;
             this.dataStreamIndices = List.copyOf(dataStreamIndices);
-            this.writeIndex = writeIndex;
-            assert dataStreamIndices.contains(writeIndex);
+            this.writeIndex =  dataStreamIndices.stream()
+                .filter(index -> index.getIndex().getName().equals(
+                    org.elasticsearch.cluster.metadata.DataStream.getBackingIndexName(dataStream.getName(), dataStream.getGeneration())))
+                .findFirst()
+                .orElse(null);
+            assert writeIndex != null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1382,7 +1382,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                     assert backingIndices.isEmpty() == false;
                     assert backingIndices.contains(null) == false;
 
-                    IndexMetadata writeIndex = backingIndices.get(backingIndices.size() - 1);
                     IndexAbstraction existing = indicesLookup.put(dataStream.getName(),
                         new IndexAbstraction.DataStream(dataStream, backingIndices));
                     if (existing != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1384,7 +1384,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
                     IndexMetadata writeIndex = backingIndices.get(backingIndices.size() - 1);
                     IndexAbstraction existing = indicesLookup.put(dataStream.getName(),
-                        new IndexAbstraction.DataStream(dataStream, backingIndices, writeIndex));
+                        new IndexAbstraction.DataStream(dataStream, backingIndices));
                     if (existing != null) {
                         throw new IllegalStateException("data stream [" + dataStream.getName() +
                             "] conflicts with existing " + existing.getType().getDisplayName() + " [" + existing.getName() + "]");

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamRequestTests.java
@@ -81,8 +81,9 @@ public class CreateDataStreamRequestTests extends AbstractWireSerializingTestCas
         ClusterState newState = CreateDataStreamAction.TransportAction.createDataStream(metadataCreateIndexService, cs, req);
         assertThat(newState.metadata().dataStreams().size(), equalTo(1));
         assertThat(newState.metadata().dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
-        assertThat(newState.metadata().index(dataStreamName + "-000001"), notNullValue());
-        assertThat(newState.metadata().index(dataStreamName + "-000001").getSettings().get("index.hidden"), equalTo("true"));
+        assertThat(newState.metadata().index(DataStream.getBackingIndexName(dataStreamName, 1)), notNullValue());
+        assertThat(newState.metadata().index(DataStream.getBackingIndexName(dataStreamName, 1)).getSettings().get("index.hidden"),
+            equalTo("true"));
     }
 
     public void testCreateDuplicateDataStream() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -40,7 +40,11 @@ public class DataStreamTests extends AbstractSerializingTestCase<DataStream> {
     }
 
     public static DataStream randomInstance() {
-        return new DataStream(randomAlphaOfLength(10), randomAlphaOfLength(10), randomIndexInstances());
+        List<Index> indices = randomIndexInstances();
+        long generation = randomLongBetween(1, 128);
+        String dataStreamName = randomAlphaOfLength(10);
+        indices.add(new Index(DataStream.getBackingIndexName(dataStreamName, generation), UUIDs.randomBase64UUID(random())));
+        return new DataStream(dataStreamName, randomAlphaOfLength(10), indices, generation);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1769,7 +1769,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(index1, false)
             .put(index2, false)
-            .put(new DataStream(dataStreamName, "ts", List.of(index1.getIndex(), index2.getIndex())));
+            .put(new DataStream(dataStreamName, "ts", List.of(index1.getIndex(), index2.getIndex()), 2));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
 
         {

--- a/server/src/test/java/org/elasticsearch/indices/DataStreamIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/DataStreamIT.java
@@ -138,14 +138,14 @@ public class DataStreamIT extends ESIntegTestCase {
             IndexRequest indexRequest = new IndexRequest(dataStreamName).source("{}", XContentType.JSON)
                 .opType(DocWriteRequest.OpType.CREATE);
             IndexResponse indexResponse = client().index(indexRequest).actionGet();
-            assertThat(indexResponse.getIndex(), equalTo(dataStreamName + "-000001"));
+            assertThat(indexResponse.getIndex(), equalTo(DataStream.getBackingIndexName(dataStreamName, 1)));
         }
         {
             BulkRequest bulkRequest = new BulkRequest()
                 .add(new IndexRequest(dataStreamName).source("{}", XContentType.JSON)
                     .opType(DocWriteRequest.OpType.CREATE));
             BulkResponse bulkItemResponses  = client().bulk(bulkRequest).actionGet();
-            assertThat(bulkItemResponses.getItems()[0].getIndex(), equalTo(dataStreamName + "-000001"));
+            assertThat(bulkItemResponses.getItems()[0].getIndex(), equalTo(DataStream.getBackingIndexName(dataStreamName, 1)));
         }
 
         DeleteDataStreamAction.Request deleteDataStreamRequest = new DeleteDataStreamAction.Request("*");
@@ -169,7 +169,7 @@ public class DataStreamIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().search(searchRequest).actionGet();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(expectedNumHits));
         Arrays.stream(searchResponse.getHits().getHits()).forEach(hit -> {
-            assertThat(hit.getIndex(), equalTo(dataStream + "-000001"));
+            assertThat(hit.getIndex(), equalTo(DataStream.getBackingIndexName(dataStream, 1)));
         });
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DataStreamTestHelper.java
@@ -20,10 +20,9 @@
 package org.elasticsearch.cluster;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.test.ESTestCase;
-
-import java.util.Locale;
 
 public final class DataStreamTestHelper {
 
@@ -32,7 +31,7 @@ public final class DataStreamTestHelper {
     }
 
     public static IndexMetadata.Builder createBackingIndex(String dataStreamName, int generation) {
-        return IndexMetadata.builder(String.format(Locale.ROOT, "%s-%06d", dataStreamName, generation))
+        return IndexMetadata.builder(DataStream.getBackingIndexName(dataStreamName, generation))
             .settings(ESTestCase.settings(Version.CURRENT).put("index.hidden", true))
             .numberOfShards(1)
             .numberOfReplicas(1);


### PR DESCRIPTION
Adds an explicit `generation` attribute to data streams. The current write index is derived from the generation and the data stream validates that it contains a backing index corresponding to its generation.

Also DRYs up the logic for naming backing indices for data streams.

Related to #53100 
