### PR TITLE
Add validation to feature set usage name

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackFeatureSet.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public interface XPackFeatureSet {
 
@@ -35,6 +36,10 @@ public interface XPackFeatureSet {
         }
 
         public Usage(String name, boolean available, boolean enabled) {
+            Objects.requireNonNull(name);
+            if (name.isEmpty()) {
+                throw new IllegalArgumentException("name must not be empty");
+            }
             this.name = name;
             this.available = available;
             this.enabled = enabled;


### PR DESCRIPTION
We do not validate the name is not null, and not empty. Even though it never should be, we had a build failure where it appears that somehow this did happen. We add some validation here, in case this really is happening, we will have a more clear indication where this is coming from, and of course, validation that name fits the implicit assumptions that it is not null and not empty.

