### PR TITLE
Move old jdk download tests to openjdk tests

### DIFF
--- a/buildSrc/src/test/java/org/elasticsearch/gradle/AdoptOpenJdkDownloadPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/AdoptOpenJdkDownloadPluginIT.java
@@ -25,11 +25,6 @@ import java.io.InputStream;
 public class AdoptOpenJdkDownloadPluginIT extends JdkDownloadPluginIT {
 
     @Override
-    public String oldJdkVersion() {
-        return "1+99";
-    }
-
-    @Override
     public String jdkVersion() {
         return "12.0.2+10";
     }
@@ -40,13 +35,9 @@ public class AdoptOpenJdkDownloadPluginIT extends JdkDownloadPluginIT {
     }
 
     @Override
-    protected String urlPath(final boolean isOld, final String platform, final String extension) {
+    protected String urlPath(final String version, final String platform, final String extension) {
         final String module = platform.equals("osx") ? "mac" : platform;
-        if (isOld) {
-            return "/adoptopenjdk/OpenJDK1U-jdk_x64_" + module + "_hotspot_1_99." + extension;
-        } else {
-            return "/adoptopenjdk/OpenJDK12U-jdk_x64_" + module + "_hotspot_12.0.2_10." + extension;
-        }
+        return "/adoptopenjdk/OpenJDK12U-jdk_x64_" + module + "_hotspot_12.0.2_10." + extension;
     }
 
     @Override

--- a/buildSrc/src/test/java/org/elasticsearch/gradle/OpenJdkDownloadPluginIT.java
+++ b/buildSrc/src/test/java/org/elasticsearch/gradle/OpenJdkDownloadPluginIT.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 
 public class OpenJdkDownloadPluginIT extends JdkDownloadPluginIT {
 
-    @Override
     public String oldJdkVersion() {
         return "1+99";
     }
@@ -40,7 +39,8 @@ public class OpenJdkDownloadPluginIT extends JdkDownloadPluginIT {
     }
 
     @Override
-    protected String urlPath(final boolean isOld, final String platform, final String extension) {
+    protected String urlPath(final String version, final String platform, final String extension) {
+        final boolean isOld = version.equals(oldJdkVersion());
         final String versionPath = isOld ? "jdk1/99" : "jdk12.0.1/123456789123456789123456789abcde/99";
         final String filename = "openjdk-" + (isOld ? "1" : "12.0.1") + "_" + platform + "-x64_bin." + extension;
         return "/java/GA/" + versionPath + "/GPL/" + filename;
@@ -51,6 +51,18 @@ public class OpenJdkDownloadPluginIT extends JdkDownloadPluginIT {
         try (InputStream stream = JdkDownloadPluginIT.class.getResourceAsStream("fake_openjdk_" + platform + "." + extension)) {
             return stream.readAllBytes();
         }
+    }
+
+    public final void testLinuxExtractionOldVersion() throws IOException {
+        assertExtraction("getLinuxJdk", "linux", "bin/java", jdkVendor(), oldJdkVersion());
+    }
+
+    public final void testDarwinExtractionOldVersion() throws IOException {
+        assertExtraction("getDarwinJdk", "osx", "Contents/Home/bin/java", jdkVendor(), oldJdkVersion());
+    }
+
+    public final void testWindowsExtractionOldVersion() throws IOException {
+        assertExtraction("getWindowsJdk", "windows", "bin/java", jdkVendor(), oldJdkVersion());
     }
 
 }


### PR DESCRIPTION
The "old jdk" tests are just testing support for downloading from oracle
prior to java 12.0.1, when oracle added a hash to the url. This commit
moves these tests into the openjdk tests (ie oracle download tests),
since adoptopenjdk does not have any change in behavior that needs to be
tested.