### PR TITLE
Make windows JAVA_HOME handling consistent with linux (#55261)

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -36,13 +36,16 @@ if "%1" == "nojava" (
    exit /b
 )
 
-if defined JAVA_HOME (
-  set JAVA="%JAVA_HOME%\bin\java.exe"
-  set JAVA_TYPE=JAVA_HOME
-) else (
+rem compariing to empty string makes this equivalent to bash -v check on env var
+rem and allows to effectively force use of the bundled jdk when launching ES
+rem by setting JAVA_HOME=
+if "%JAVA_HOME%" == "" (
   set JAVA="%ES_HOME%\jdk\bin\java.exe"
   set JAVA_HOME="%ES_HOME%\jdk"
   set JAVA_TYPE=bundled jdk
+) else (
+  set JAVA="%JAVA_HOME%\bin\java.exe"
+  set JAVA_TYPE=JAVA_HOME
 )
 
 if not exist !JAVA! (

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -243,6 +243,18 @@ public class ArchiveTests extends PackagingTestCase {
         });
     }
 
+    public void test54ForceBundledJdkEmptyJavaHome() throws Exception {
+        assumeThat(distribution().hasJdk, is(true));
+        // cleanup from previous test
+        rm(installation.config("elasticsearch.keystore"));
+
+        sh.getEnv().put("JAVA_HOME", "");
+
+        startElasticsearch();
+        ServerUtils.runElasticsearchTests();
+        stopElasticsearch();
+    }
+
     public void test70CustomPathConfAndJvmOptions() throws Exception {
 
         final Path tempConf = getTempDir().resolve("esconf-alternate");


### PR DESCRIPTION
In bash, checking for whether an env variable exists uses the -z test,
against a stringified env var, so that the test is actually whether the
env var is empty, but not necessarily undefined. We use this to test
whether JAVA_HOME is set, to determine whether the bundled jdk should be
used. In windows, this test is an actual "undefined" check. This commit
brings the behavior on two systems in sync, opting to allow for an empty
JAVA_HOME in windows to indicate the bundled jdk should be used.

closes #55134