### PR TITLE
Use LTS version of Ubuntu in Dockerfiles

### DIFF
--- a/test/fixtures/azure-fixture/Dockerfile
+++ b/test/fixtures/azure-fixture/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-12-jre-headless
+RUN apt-get install -qqy openjdk-11-jre-headless
 ENTRYPOINT exec java -classpath "/fixture/shared/*" fixture.azure.AzureHttpFixture 0.0.0.0 8091 container
 EXPOSE 8091

--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-12-jre-headless
+RUN apt-get install -qqy openjdk-11-jre-headless
 
 ARG port
 ARG bucket

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
 RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-12-jre-headless
+RUN apt-get install -qqy openjdk-11-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/x-pack/test/smb-fixture/Dockerfile
+++ b/x-pack/test/smb-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 RUN apt-get update -qqy && apt-get install -qqy samba ldap-utils
 ADD . /fixture
 RUN chmod +x /fixture/src/main/resources/provision/installsmb.sh

--- a/x-pack/test/smb-fixture/Dockerfile
+++ b/x-pack/test/smb-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 RUN apt-get update -qqy && apt-get install -qqy samba ldap-utils
 ADD . /fixture
 RUN chmod +x /fixture/src/main/resources/provision/installsmb.sh


### PR DESCRIPTION
We have some Dockerfiles that reference Ubuntu 19.04, which is not an LTS
version and has now appears to have been retired from the Ubuntu repositories.
Switch to 18.04, which is the current long-term support version. This
also requires a switch from OpenJDK 12 to 11.

I didn't change `smb-fixture` as that would have requried changes to the code that the container runs.