### PR TITLE
Mute GCS Retry Tests on JDK8 (#55372)

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -51,6 +51,7 @@ import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.threeten.bp.Duration;
 
 import java.io.IOException;
@@ -98,6 +99,11 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends ESTestCase {
         assertThat(httpServer, notNullValue());
         InetSocketAddress address = httpServer.getAddress();
         return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+    }
+
+    @BeforeClass
+    public static void skipJava8() {
+        GoogleCloudStorageBlobStoreRepositoryTests.assumeNotJava8();
     }
 
     @Before

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.ESMockAPIBasedRepositoryIntegTestCase;
+import org.junit.BeforeClass;
 import org.threeten.bp.Duration;
 
 import java.io.IOException;
@@ -69,11 +70,16 @@ import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CL
 @SuppressForbidden(reason = "this test uses a HttpServer to emulate a Google Cloud Storage endpoint")
 public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTestCase {
 
-    private static void assumeNotJava8() {
+    public static void assumeNotJava8() {
         assumeFalse("This test is flaky on jdk8 - we suspect a JDK bug to trigger some assertion in the HttpServer implementation used " +
             "to emulate the server side logic of Google Cloud Storage. See https://bugs.openjdk.java.net/browse/JDK-8180754, " +
             "https://github.com/elastic/elasticsearch/pull/51933 and https://github.com/elastic/elasticsearch/issues/52906 " +
             "for more background on this issue.", JavaVersion.current().equals(JavaVersion.parse("8")));
+    }
+
+    @BeforeClass
+    public static void skipJava8() {
+        assumeNotJava8();
     }
 
     @Override
@@ -123,7 +129,6 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     }
 
     public void testDeleteSingleItem() {
-        assumeNotJava8();
         final String repoName = createRepository(randomName());
         final RepositoriesService repositoriesService = internalCluster().getMasterNodeInstance(RepositoriesService.class);
         final BlobStoreRepository repository = (BlobStoreRepository) repositoriesService.repository(repoName);
@@ -170,62 +175,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         assertEquals("failed to parse value [101mb] for setting [chunk_size], must be <= [100mb]", e.getMessage());
     }
 
-    @Override
-    public void testSnapshotAndRestore() throws Exception {
-        assumeNotJava8();
-        super.testSnapshotAndRestore();
-    }
-
-    @Override
-    public void testList() throws IOException {
-        assumeNotJava8();
-        super.testList();
-    }
-
-    @Override
-    public void testIndicesDeletedFromRepository() throws Exception {
-        assumeNotJava8();
-        super.testIndicesDeletedFromRepository();
-    }
-
-    @Override
-    public void testDeleteBlobs() throws IOException {
-        assumeNotJava8();
-        super.testDeleteBlobs();
-    }
-
-    @Override
-    public void testWriteRead() throws IOException {
-        assumeNotJava8();
-        super.testWriteRead();
-    }
-
-    @Override
-    public void testReadNonExistingPath() throws IOException {
-        assumeNotJava8();
-        super.testReadNonExistingPath();
-    }
-
-    @Override
-    public void testContainerCreationAndDeletion() throws IOException {
-        assumeNotJava8();
-        super.testContainerCreationAndDeletion();
-    }
-
-    @Override
-    public void testMultipleSnapshotAndRollback() throws Exception {
-        assumeNotJava8();
-        super.testMultipleSnapshotAndRollback();
-    }
-
-    @Override
-    public void testSnapshotWithLargeSegmentFiles() throws Exception {
-        assumeNotJava8();
-        super.testSnapshotWithLargeSegmentFiles();
-    }
-
     public void testWriteReadLarge() throws IOException {
-        assumeNotJava8();
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             byte[] data = randomBytes(GoogleCloudStorageBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE + 1);


### PR DESCRIPTION
Same as #53119 but for the retries tests.
Closes #55317

backport of #55372 