### PR TITLE
Backport: enable feature enabled flags for java integration tests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -333,6 +333,10 @@ task integTest(type: Test) {
   mustRunAfter test
 
   include '**/*IT.class'
+  if (org.elasticsearch.gradle.info.BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.itv2_feature_enabled', 'true'
+    systemProperty 'es.datastreams_feature_enabled', 'true'
+  }
 }
 
 check.dependsOn integTest


### PR DESCRIPTION
Backport of: #55373

Enabled data streams and itv2 feature enabled system properties in server module's integ test task.

PR #54726 added java integration tests for data streams, so this is why these system properties
need to be enabled when running release build.