### PR TITLE
Fix VectorsFeatureSetUsage serialization in BWC mode

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/vectors/VectorsFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/vectors/VectorsFeatureSetUsage.java
@@ -37,7 +37,7 @@ public class VectorsFeatureSetUsage extends XPackFeatureSet.Usage {
         out.writeVInt(numDenseVectorFields);
         // Older versions recorded the number of sparse vector fields.
         if (out.getVersion().before(Version.V_8_0_0)) {
-            out.writeInt(0);
+            out.writeVInt(0);
         }
         out.writeVInt(avgDenseVectorDims);
     }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/100_analytics_usage.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/100_analytics_usage.yml
@@ -19,8 +19,8 @@ setup:
 ---
 "Basic test for usage stats on analytics indices":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/55378"
+      version: " - 7.7.99"
+      reason:  "stats are not working in earlier versions"
   - do:
       xpack.info: {}
   - match: { features.analytics.available: true }


### PR DESCRIPTION
While communicating with an earlier version of elasticsearch,
VectorsFeatureSetUsage is using writeInt instead of writeVInt that 7.x version
is expecting. This commit fixes the issue.

Fixes #55378
