### PR TITLE
Add skip arbitrary_key to nodes.reload_secure_settings YAML test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
@@ -1,3 +1,6 @@
+setup:
+  - skip:
+      features: [arbitrary_key]
 ---
 "node_reload_secure_settings test wrong password":
   - skip:


### PR DESCRIPTION
The nodes reload_secure_settings test is missing the `setup.skip.arbitrary_key` header.
This change should also be backported to 7.7.

cc @elastic/es-clients