### PR TITLE
Mute data stream YML tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Create data stream":
   - skip:
-      version: " - 7.7.99"
-      reason: available only in 7.8+
+      version: " - 7.99.99"
+      reason:  "enable in 7.8+ after backporting https://github.com/elastic/elasticsearch/pull/55342 (Add explicit generation attribute)"
 
   - do:
       indices.create_data_stream:
@@ -78,8 +78,8 @@
 ---
 "Get data stream":
   - skip:
-      version: " - 7.7.99"
-      reason: available only in 7.8+
+      version: " - 7.99.99"
+      reason:  "enable in 7.8+ after backporting https://github.com/elastic/elasticsearch/pull/55342 (Add explicit generation attribute)"
 
   - do:
       indices.create_data_stream:
@@ -147,8 +147,8 @@
 ---
 "Delete data stream with backing indices":
   - skip:
-      version: " - 7.7.99"
-      reason: available only in 7.8+
+      version: " - 7.99.99"
+      reason:  "enable in 7.8+ after backporting https://github.com/elastic/elasticsearch/pull/55342 (Add explicit generation attribute)"
 
   - do:
       indices.create_data_stream:


### PR DESCRIPTION
The BWC tests will fail until https://github.com/elastic/elasticsearch/pull/55342 is backported.
