### PR TITLE
[DOCS] Document index alias swaps are atomic

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -258,7 +258,9 @@ indices that match this pattern are added/removed.
 
 It is an error to index to an alias which points to more than one index.
 
-It is also possible to swap an index with an alias in one operation:
+It is also possible to swap an index with an alias in one, atomic operation.
+This means there will be no period of downtime where the alias points to
+no index.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -259,8 +259,8 @@ indices that match this pattern are added/removed.
 It is an error to index to an alias which points to more than one index.
 
 It is also possible to swap an index with an alias in one, atomic operation.
-This means there will be no period of downtime where the alias points to
-no index.
+This means there will be no period of downtime where the alias points to no
+index.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Explicitly notes that index alias swaps are atomic in the update index alias API docs.

Relates to #51152