### PR TITLE
Fix test allocated processors test

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -210,12 +210,13 @@ public class ClusterStatsIT extends ESIntegTestCase {
     }
 
     public void testAllocatedProcessors() throws Exception {
-        // start one node with 7 processors.
-        internalCluster().startNode(Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 7).build());
+        // the node.processors setting is bounded above by Runtime#availableProcessors
+        final int nodeProcessors = randomIntBetween(1, Runtime.getRuntime().availableProcessors());
+        internalCluster().startNode(Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), nodeProcessors).build());
         waitForNodes(1);
 
         ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
-        assertThat(response.getNodesStats().getOs().getAllocatedProcessors(), equalTo(7));
+        assertThat(response.getNodesStats().getOs().getAllocatedProcessors(), equalTo(nodeProcessors));
     }
 
     public void testClusterStatusWhenStateNotRecovered() throws Exception {


### PR DESCRIPTION
This test tries to set the number of allocated processors to seven. That is fine, unless the test is running on a machine where  Runtime#availableProcessors is less than seven (typically when there are fewer than seven logical cores, but it can happen in various other ways related to CPU quotas in Docker containers with Docker-aware JVMs, etc.). This commit addresses this by randomizing the number of allocated processors, to a value that is less than or equal to the hard constraint on the number of allocated processors.

Relates #44894