### PR TITLE
No need to separate the docker images from 'Arch-tag'

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -28,17 +28,15 @@ dependencies {
 }
 
 ext.expansions = { architecture, oss, local ->
-  String base_image = null
+  String base_image = centos:7
   String tini_arch = null
   String classifier = null
   switch (architecture) {
     case "aarch64":
-      base_image = "arm64v8/centos:7"
       tini_arch = "arm64"
       classifier = "linux-aarch64"
       break;
     case "x64":
-      base_image = "amd64/centos:7"
       tini_arch = "amd64"
       classifier = "linux-x86_64"
       break;


### PR DESCRIPTION
The docker hub supports multi-arch： [centos:7](https://hub.docker.com/layers/centos/library/centos/7/images/sha256-fc5a0399d94336d15305d4d43754cd3c57808123cc67a578687748734af8f06b?context=explore)
It seems that there is no need to separate the docker images from
'Arch-tag'.
