### PR TITLE
[Docs]Adds ip_range datatype to core datatypes range list

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -13,7 +13,7 @@ string::         <<text,`text`>>, <<keyword,`keyword`>> and <<wildcard,`wildcard
 <<date_nanos>>:: `date_nanos`
 <<boolean>>::    `boolean`
 <<binary>>::     `binary`
-<<range>>::      `integer_range`, `float_range`, `long_range`, `double_range`, `date_range`
+<<range>>::      `integer_range`, `float_range`, `long_range`, `double_range`, `date_range`, `ip_range`
 
 [float]
 === Complex datatypes


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
Adds the `ip_range` datatype to the [Core datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html#_core_datatypes) range list. 

@FrankHassanabad noticed it was missing.

[Preview](http://elasticsearch_55446.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/mapping-types.html)
