### PR TITLE
Disable monitoring in ML multinode tests

### DIFF
--- a/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
+++ b/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
@@ -11,6 +11,7 @@ testClusters.integTest {
   testDistribution = 'DEFAULT'
   numberOfNodes = 3
   setting 'xpack.security.enabled', 'false'
+  setting 'xpack.monitoring.elasticsearch.collection.enabled', 'false'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -40,6 +40,7 @@ testClusters.integTest {
   testDistribution = 'DEFAULT'
 
   setting 'xpack.security.enabled', 'true'
+  setting 'xpack.monitoring.elasticsearch.collection.enabled', 'false'
   setting 'xpack.ml.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.security.authc.token.enabled', 'true'


### PR DESCRIPTION
Removing the deprecated "xpack.monitoring.enabled" setting introduced log spam and potentially some failures in ML tests. It's possible to use a different, non-deprecated setting to disable monitoring, so we do that here.

Relates #55420 
Relates #54816 