### PR TITLE
Parent breaker makes nodes fail to join the cluster.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -135,7 +135,7 @@ public class JoinHelper {
             });
 
         transportService.registerRequestHandler(VALIDATE_JOIN_ACTION_NAME,
-            ThreadPool.Names.GENERIC, ValidateJoinRequest::new,
+            ThreadPool.Names.GENERIC, false, false, ValidateJoinRequest::new,
             (request, channel, task) -> {
                 final ClusterState localState = currentStateSupplier.get();
                 if (localState.metadata().clusterUUIDCommitted() &&


### PR DESCRIPTION
Node will get lost and fail to join cluster again if its memory is consumed a lot due to some expensive operations, such as big aggregations.  When the majority of nodes encounter this situation, cluster will be unavailable. It's because  _internal:cluster/coordination/join/validate_ action has been rejected by parent circuit breaker as the memory usage reaches up to 90%.

![image](https://user-images.githubusercontent.com/4607177/79757830-2d118780-834f-11ea-8571-be269f1d337e.png)

All actions in the cluster coordination layer can trip the circuit breaker except this validation action. This PR fixed this issue by ignoring validation action from circuit breaker checking.