### PR TITLE
[7.x] Use Decimal formatter for Numeric ValuesSourceTypes (#54366)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -75,6 +75,22 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             Number missing = docValueFormat.parseDouble(rawMissing.toString(), false, now);
             return MissingValues.replaceMissing((ValuesSource.Numeric) valuesSource, missing);
         }
+
+        @Override
+        public DocValueFormat getFormatter(String format, ZoneId tz) {
+            /* TODO: this silently ignores a timezone argument, whereas NumberFieldType#docValueFormat throws if given a time zone.
+                     Before we can solve this, we need to resolve https://github.com/elastic/elasticsearch/issues/47469 which deals
+                     with the fact that the same formatter is used for input and output values.  We want to support a use case in SQL
+                     (and elsewhere) that allows for passing a long value milliseconds since epoch into date aggregations.  In that case,
+                     the timezone is sensible as part of the bucket key format.
+             */
+            if (format == null) {
+                return DocValueFormat.RAW;
+            } else {
+                return new DocValueFormat.Decimal(format);
+            }
+
+        }
     },
     BYTES() {
         @Override


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use Decimal formatter for Numeric ValuesSourceTypes (#54366)