### PR TITLE
[DOCS] Relocate `transport` module content

### DIFF
--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -50,11 +50,6 @@ The modules in this section are:
 
     Information about the dedicated thread pools used in Elasticsearch.
 
-<<modules-transport,Transport>>::
-
-    Configure the transport networking layer, used internally by Elasticsearch
-    to communicate between nodes.
-
 <<modules-cross-cluster-search, {ccs-cap}>>::
 
     {ccs-cap} enables executing search requests across more than one cluster
@@ -75,5 +70,3 @@ include::modules/network.asciidoc[]
 include::modules/node.asciidoc[]
 
 include::modules/threadpool.asciidoc[]
-
-include::modules/transport.asciidoc[]

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -1,9 +1,9 @@
 [[modules-transport]]
-== Transport
+=== Transport
 
-The transport module is used for internal communication between nodes
+The transport networking layer is used for internal communication between nodes
 within the cluster. Each call that goes from one node to the other uses
-the transport module (for example, when an HTTP GET request is processed
+the transport layer (for example, when an HTTP GET request is processed
 by one node, and should actually be processed by another node that holds
 the data).
 
@@ -14,8 +14,8 @@ http://en.wikipedia.org/wiki/C10k_problem[C10k problem], as well as
 being the ideal solution for scatter (broadcast) / gather operations such
 as search in Elasticsearch.
 
-[float]
-=== Transport Settings
+[[transport-settings]]
+==== Transport settings
 
 The internal transport communicates over TCP. You can configure it with the
 following settings:
@@ -56,8 +56,8 @@ transport connections.
 It also uses the common
 <<modules-network,network settings>>.
 
-[float]
-==== Transport Profiles
+[[transport-profiles]]
+===== Transport profiles
 
 Elasticsearch allows you to bind to multiple ports on different interfaces by
 the use of transport profiles. See this example configuration
@@ -105,8 +105,8 @@ example above:
 * `tcp.send_buffer_size`: Configures the send buffer size of the socket
 * `tcp.receive_buffer_size`: Configures the receive buffer size of the socket
 
-[float]
-==== Long-lived idle connections
+[[long-lived-connections]]
+===== Long-lived idle connections
 
 Elasticsearch opens a number of long-lived TCP connections between each pair of
 nodes in the cluster, and some of these connections may be idle for an extended
@@ -119,11 +119,9 @@ and ensuring that the keepalive interval is shorter than any timeout that might
 cause idle connections to be closed, or by setting `transport.ping_schedule` if
 keepalives cannot be configured.
 
-[float]
-==== Transport Compression
 
-[float]
-===== Request Compression
+[[request-compression]]
+===== Request compression
 
 By default, the `transport.compress` setting is `false` and network-level
 request compression is disabled between nodes in the cluster. This default
@@ -138,8 +136,8 @@ request compression, you can set it on a per-remote cluster basis using the
 <<remote-cluster-settings,`cluster.remote.${cluster_alias}.transport.compress` setting>>.
 
 
-[float]
-===== Response Compression
+[[response-compression]]
+===== Response compression
 
 The compression settings do not configure compression for responses. {es} will
 compress a response if the inbound request was compressed--even when compression
@@ -147,10 +145,10 @@ is not enabled. Similarly, {es} will not compress a response if the inbound
 request was uncompressed--even when compression is enabled.
 
 
-[float]
-=== Transport Tracer
+[[transport-tracer]]
+==== Transport tracer
 
-The transport module has a dedicated tracer logger which, when activated, logs incoming and out going requests. The log can be dynamically activated
+The transport layer has a dedicated tracer logger which, when activated, logs incoming and out going requests. The log can be dynamically activated
 by setting the level of the `org.elasticsearch.transport.TransportService.tracer` logger to `TRACE`:
 
 [source,console]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -79,6 +79,8 @@ include::settings/sql-settings.asciidoc[]
 
 include::settings/transform-settings.asciidoc[]
 
+include::modules/transport.asciidoc[]
+
 include::settings/notification-settings.asciidoc[]
 
 include::setup/important-settings.asciidoc[]


### PR DESCRIPTION
Moves `transport` content from the [Modules][0] section to the
[Configuring Elasticsearch][1] section.

Supporting changes:
* Adds explicit anchors to several headings
* Changes several headings to sentence case
* Increments several headings
* Removes several unneeded `[float]` attributes
* Replaces `transport module` with `transport layer`

Relates to #53305

[0]: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules.html
[1]: https://www.elastic.co/guide/en/elasticsearch/reference/master/settings.html