### PR TITLE
[ML] Return assigned node in start/open job/datafeed response

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/MachineLearningClient.java
@@ -108,6 +108,7 @@ import org.elasticsearch.client.ml.RevertModelSnapshotRequest;
 import org.elasticsearch.client.ml.RevertModelSnapshotResponse;
 import org.elasticsearch.client.ml.SetUpgradeModeRequest;
 import org.elasticsearch.client.ml.StartDataFrameAnalyticsRequest;
+import org.elasticsearch.client.ml.StartDataFrameAnalyticsResponse;
 import org.elasticsearch.client.ml.StartDatafeedRequest;
 import org.elasticsearch.client.ml.StartDatafeedResponse;
 import org.elasticsearch.client.ml.StopDataFrameAnalyticsRequest;
@@ -2138,12 +2139,12 @@ public final class MachineLearningClient {
      * @return action acknowledgement
      * @throws IOException when there is a serialization issue sending the request or receiving the response
      */
-    public AcknowledgedResponse startDataFrameAnalytics(StartDataFrameAnalyticsRequest request,
-                                                        RequestOptions options) throws IOException {
+    public StartDataFrameAnalyticsResponse startDataFrameAnalytics(StartDataFrameAnalyticsRequest request,
+                                                                   RequestOptions options) throws IOException {
         return restHighLevelClient.performRequestAndParseEntity(request,
             MLRequestConverters::startDataFrameAnalytics,
             options,
-            AcknowledgedResponse::fromXContent,
+            StartDataFrameAnalyticsResponse::fromXContent,
             Collections.emptySet());
     }
 
@@ -2160,11 +2161,11 @@ public final class MachineLearningClient {
      * @return cancellable that may be used to cancel the request
      */
     public Cancellable startDataFrameAnalyticsAsync(StartDataFrameAnalyticsRequest request, RequestOptions options,
-                                                    ActionListener<AcknowledgedResponse> listener) {
+                                                    ActionListener<StartDataFrameAnalyticsResponse> listener) {
         return restHighLevelClient.performRequestAsyncAndParseEntity(request,
             MLRequestConverters::startDataFrameAnalytics,
             options,
-            AcknowledgedResponse::fromXContent,
+            StartDataFrameAnalyticsResponse::fromXContent,
             listener,
             Collections.emptySet());
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/OpenJobResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/OpenJobResponse.java
@@ -44,8 +44,8 @@ public class OpenJobResponse implements ToXContentObject {
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), NODE);
     }
 
-    private boolean opened;
-    private String node;
+    private final boolean opened;
+    private final String node;
 
     OpenJobResponse(boolean opened, String node) {
         this.opened = opened;
@@ -88,13 +88,13 @@ public class OpenJobResponse implements ToXContentObject {
         }
 
         OpenJobResponse that = (OpenJobResponse) other;
-        return isOpened() == that.isOpened()
+        return opened == that.opened
             && Objects.equals(node, that.node);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isOpened(), node);
+        return Objects.hash(opened, node);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDataFrameAnalyticsResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDataFrameAnalyticsResponse.java
@@ -18,9 +18,9 @@
  */
 package org.elasticsearch.client.ml;
 
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -28,41 +28,32 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Response indicating if the Machine Learning Job is now opened or not
+ * Response indicating if the Machine Learning Datafeed is now started or not
  */
-public class OpenJobResponse implements ToXContentObject {
+public class StartDataFrameAnalyticsResponse extends AcknowledgedResponse {
 
-    private static final ParseField OPENED = new ParseField("opened");
     private static final ParseField NODE = new ParseField("node");
 
-    public static final ConstructingObjectParser<OpenJobResponse, Void> PARSER =
-        new ConstructingObjectParser<>("open_job_response", true,
-            (a) -> new OpenJobResponse((Boolean) a[0], (String) a[1]));
+    public static final ConstructingObjectParser<StartDataFrameAnalyticsResponse, Void> PARSER =
+        new ConstructingObjectParser<>(
+            "start_data_frame_analytics_response",
+            true,
+            (a) -> new StartDataFrameAnalyticsResponse((Boolean) a[0], (String) a[1]));
 
     static {
-        PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), OPENED);
+        declareAcknowledgedField(PARSER);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), NODE);
     }
 
-    private boolean opened;
-    private String node;
+    private final String node;
 
-    OpenJobResponse(boolean opened, String node) {
-        this.opened = opened;
+    public StartDataFrameAnalyticsResponse(boolean acknowledged, String node) {
+        super(acknowledged);
         this.node = node;
     }
 
-    public static OpenJobResponse fromXContent(XContentParser parser) throws IOException {
+    public static StartDataFrameAnalyticsResponse fromXContent(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
-    }
-
-    /**
-     * Has the job opened or not
-     *
-     * @return boolean value indicating the job opened status
-     */
-    public boolean isOpened() {
-        return opened;
     }
 
     /**
@@ -87,24 +78,20 @@ public class OpenJobResponse implements ToXContentObject {
             return false;
         }
 
-        OpenJobResponse that = (OpenJobResponse) other;
-        return isOpened() == that.isOpened()
+        StartDataFrameAnalyticsResponse that = (StartDataFrameAnalyticsResponse) other;
+        return isAcknowledged() == that.isAcknowledged()
             && Objects.equals(node, that.node);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isOpened(), node);
+        return Objects.hash(isAcknowledged(), node);
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-        builder.field(OPENED.getPreferredName(), opened);
+    public void addCustomFields(XContentBuilder builder, Params params) throws IOException {
         if (node != null) {
             builder.field(NODE.getPreferredName(), node);
         }
-        builder.endObject();
-        return builder;
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
@@ -90,13 +90,13 @@ public class StartDatafeedResponse implements ToXContentObject {
         }
 
         StartDatafeedResponse that = (StartDatafeedResponse) other;
-        return isStarted() == that.isStarted()
+        return started == started
             && Objects.equals(node, that.node);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isStarted(), node);
+        return Objects.hash(started, node);
     }
 
     @Override

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/StartDatafeedResponse.java
@@ -33,21 +33,25 @@ import java.util.Objects;
 public class StartDatafeedResponse implements ToXContentObject {
 
     private static final ParseField STARTED = new ParseField("started");
+    private static final ParseField NODE = new ParseField("node");
 
     public static final ConstructingObjectParser<StartDatafeedResponse, Void> PARSER =
         new ConstructingObjectParser<>(
             "start_datafeed_response",
             true,
-            (a) -> new StartDatafeedResponse((Boolean)a[0]));
+            (a) -> new StartDatafeedResponse((Boolean) a[0], (String) a[1]));
 
     static {
         PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), STARTED);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), NODE);
     }
 
     private final boolean started;
+    private final String node;
 
-    public StartDatafeedResponse(boolean started) {
+    public StartDatafeedResponse(boolean started, String node) {
         this.started = started;
+        this.node = node;
     }
 
     public static StartDatafeedResponse fromXContent(XContentParser parser) throws IOException {
@@ -63,6 +67,18 @@ public class StartDatafeedResponse implements ToXContentObject {
         return started;
     }
 
+    /**
+     * The node that the datafeed was assigned to
+     *
+     * @return The ID of a node if the datafeed was assigned to a node.  If an empty string is returned
+     *         it means the datafeed was allowed to open lazily and has not yet been assigned to a node.
+     *         If <code>null</code> is returned it means the server version is too old to return node
+     *         information.
+     */
+    public String getNode() {
+        return node;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) {
@@ -74,18 +90,22 @@ public class StartDatafeedResponse implements ToXContentObject {
         }
 
         StartDatafeedResponse that = (StartDatafeedResponse) other;
-        return isStarted() == that.isStarted();
+        return isStarted() == that.isStarted()
+            && Objects.equals(node, that.node);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isStarted());
+        return Objects.hash(isStarted(), node);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(STARTED.getPreferredName(), started);
+        if (node != null) {
+            builder.field(NODE.getPreferredName(), node);
+        }
         builder.endObject();
         return builder;
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MlClientDocumentationIT.java
@@ -122,6 +122,7 @@ import org.elasticsearch.client.ml.RevertModelSnapshotRequest;
 import org.elasticsearch.client.ml.RevertModelSnapshotResponse;
 import org.elasticsearch.client.ml.SetUpgradeModeRequest;
 import org.elasticsearch.client.ml.StartDataFrameAnalyticsRequest;
+import org.elasticsearch.client.ml.StartDataFrameAnalyticsResponse;
 import org.elasticsearch.client.ml.StartDatafeedRequest;
 import org.elasticsearch.client.ml.StartDatafeedResponse;
 import org.elasticsearch.client.ml.StopDataFrameAnalyticsRequest;
@@ -232,6 +233,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
@@ -461,7 +463,10 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
 
             // tag::open-job-response
             boolean isOpened = openJobResponse.isOpened(); // <1>
+            String node = openJobResponse.getNode(); // <2>
             // end::open-job-response
+
+            assertThat(node, notNullValue());
         }
         {
             // tag::open-job-execute-listener
@@ -1011,11 +1016,14 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // tag::start-datafeed-execute
             StartDatafeedResponse response = client.machineLearning().startDatafeed(request, RequestOptions.DEFAULT);
             // end::start-datafeed-execute
+
             // tag::start-datafeed-response
             boolean started = response.isStarted(); // <1>
+            String node = response.getNode(); // <2>
             // end::start-datafeed-response
 
             assertTrue(started);
+            assertThat(node, notNullValue());
         }
         {
             StartDatafeedRequest request = new StartDatafeedRequest(datafeedId);
@@ -3131,14 +3139,16 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             // end::start-data-frame-analytics-request
 
             // tag::start-data-frame-analytics-execute
-            AcknowledgedResponse response = client.machineLearning().startDataFrameAnalytics(request, RequestOptions.DEFAULT);
+            StartDataFrameAnalyticsResponse response = client.machineLearning().startDataFrameAnalytics(request, RequestOptions.DEFAULT);
             // end::start-data-frame-analytics-execute
 
             // tag::start-data-frame-analytics-response
             boolean acknowledged = response.isAcknowledged();
+            String node = response.getNode(); // <1>
             // end::start-data-frame-analytics-response
 
             assertThat(acknowledged, is(true));
+            assertThat(node, notNullValue());
         }
         assertBusy(
             () -> assertThat(getAnalyticsState(DF_ANALYTICS_CONFIG.getId()), equalTo(DataFrameAnalyticsState.STOPPED)),
@@ -3147,9 +3157,9 @@ public class MlClientDocumentationIT extends ESRestHighLevelClientTestCase {
             StartDataFrameAnalyticsRequest request = new StartDataFrameAnalyticsRequest("my-analytics-config");
 
             // tag::start-data-frame-analytics-execute-listener
-            ActionListener<AcknowledgedResponse> listener = new ActionListener<>() {
+            ActionListener<StartDataFrameAnalyticsResponse> listener = new ActionListener<>() {
                 @Override
-                public void onResponse(AcknowledgedResponse response) {
+                public void onResponse(StartDataFrameAnalyticsResponse response) {
                     // <1>
                 }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/StartDataFrameAnalyticsResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/StartDataFrameAnalyticsResponseTests.java
@@ -23,17 +23,17 @@ import org.elasticsearch.test.AbstractXContentTestCase;
 
 import java.io.IOException;
 
-public class OpenJobResponseTests extends AbstractXContentTestCase<OpenJobResponse> {
+public class StartDataFrameAnalyticsResponseTests extends AbstractXContentTestCase<StartDataFrameAnalyticsResponse> {
 
     @Override
-    protected OpenJobResponse createTestInstance() {
+    protected StartDataFrameAnalyticsResponse createTestInstance() {
         String node = randomFrom("", randomAlphaOfLength(10), null);
-        return new OpenJobResponse(randomBoolean(), node);
+        return new StartDataFrameAnalyticsResponse(randomBoolean(), node);
     }
 
     @Override
-    protected OpenJobResponse doParseInstance(XContentParser parser) throws IOException {
-        return OpenJobResponse.fromXContent(parser);
+    protected StartDataFrameAnalyticsResponse doParseInstance(XContentParser parser) throws IOException {
+        return StartDataFrameAnalyticsResponse.fromXContent(parser);
     }
 
     @Override

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/StartDatafeedResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/StartDatafeedResponseTests.java
@@ -27,7 +27,8 @@ public class StartDatafeedResponseTests extends AbstractXContentTestCase<StartDa
 
     @Override
     protected StartDatafeedResponse createTestInstance() {
-        return new StartDatafeedResponse(randomBoolean());
+        String node = randomFrom("", randomAlphaOfLength(10), null);
+        return new StartDatafeedResponse(randomBoolean(), node);
     }
 
     @Override

--- a/docs/java-rest/high-level/ml/open-job.asciidoc
+++ b/docs/java-rest/high-level/ml/open-job.asciidoc
@@ -30,7 +30,12 @@ execution should wait for the job to be opened.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-response]
 --------------------------------------------------
-<1> `isOpened()` from the +{response}+ indicates if the job was successfully
-opened or not.
+<1> `isOpened()` from the +{response}+ is always `true` if the job was
+opened successfully. (An exception would be thrown instead if the job
+was not opened successfully.)
+<2> `getNode()` returns the node that the job was assigned to. If the
+job is allowed to open lazily and has not yet been assigned to a node
+then an empty string is returned. If `getNode()` returns `null` then
+the server is an old version that does not return node information.
 
 include::../execution.asciidoc[]

--- a/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
+++ b/docs/java-rest/high-level/ml/start-data-frame-analytics.asciidoc
@@ -24,6 +24,15 @@ include-tagged::{doc-tests-file}[{api}-request]
 include::../execution.asciidoc[]
 
 [id="{upid}-{api}-response"]
-==== Response
+==== Start {dfanalytics-job} response
 
 The returned +{response}+ object acknowledges the {dfanalytics-job} has started.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> `getNode()` returns the node that the job was assigned to. If the
+job is allowed to open lazily and has not yet been assigned to a node
+then an empty string is returned. If `getNode()` returns `null` then
+the server is an old version that does not return node information.

--- a/docs/java-rest/high-level/ml/start-datafeed.asciidoc
+++ b/docs/java-rest/high-level/ml/start-datafeed.asciidoc
@@ -5,13 +5,13 @@
 --
 [role="xpack"]
 [id="{upid}-{api}"]
-=== Start datafeed API
+=== Start {dfeed} API
 
-Starts a {ml} datafeed in the cluster. It accepts a +{request}+ object and
+Starts a {ml} {dfeed} in the cluster. It accepts a +{request}+ object and
 responds with a +{response}+ object.
 
 [id="{upid}-{api}-request"]
-==== Start datafeed request
+==== Start {dfeed} request
 
 A +{request}+ object is created referencing a non-null `datafeedId`.
 All other fields are optional for the request.
@@ -30,14 +30,29 @@ The following arguments are optional.
 --------------------------------------------------
 include-tagged::{doc-tests-file}[{api}-request-options]
 --------------------------------------------------
-<1> Set when the datafeed should end, the value is exclusive.
+<1> Set when the {dfeed} should end, the value is exclusive.
 May be an epoch seconds, epoch millis or an ISO 8601 string.
 "now" is a special value that indicates the current time.
-If you do not specify an end time, the datafeed runs continuously.
-<2> Set when the datafeed should start, the value is inclusive.
+If you do not specify an end time, the {dfeed} runs continuously.
+<2> Set when the {dfeed} should start, the value is inclusive.
 May be an epoch seconds, epoch millis or an ISO 8601 string.
-If you do not specify a start time and the datafeed is associated with a new job,
+If you do not specify a start time and the {dfeed} is associated with a new job,
 the analysis starts from the earliest time for which data is available.
 <3> Set the timeout for the request
+
+[id="{upid}-{api}-response"]
+==== Start {dfeed} response
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests-file}[{api}-response]
+--------------------------------------------------
+<1> `isStarted()` from the +{response}+ is always `true` if the {dfeed} was
+started successfully. (An exception would be thrown instead if the {dfeed}
+was not started successfully.)
+<2> `getNode()` returns the node that the {dfeed} was assigned to. If the
+{dfeed} is allowed to open lazily and has not yet been assigned to a node
+then an empty string is returned. If `getNode()` returns `null` then
+the server is an old version that does not return node information.
 
 include::../execution.asciidoc[]

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -51,12 +51,12 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 ==== {api-response-body-title}
 
 `node`::
-  (string) The ID of the node that the job was opened on, or an empty string
-  if the job is allowed to open lazily and has not yet been assigned to a node.
+  (string) The ID of the node that the job was opened on. If the job is allowed to 
+open lazily and has not yet been assigned to a node, this value is an empty string.
 
 `opened`::
-  (boolean) For a success response this is always `true`. On failure an
-  exception will be returned instead.
+  (boolean) For a successful response, this value is always `true`. On failure, an
+  exception is returned instead.
 
 [[ml-open-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -47,6 +47,17 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
   (Optional, time) Controls the time to wait until a job has opened. The default
   value is 30 minutes.
 
+[[ml-open-job-response-body]]
+==== {api-response-body-title}
+
+`node`::
+  (string) The ID of the node that the job was opened on, or an empty string
+  if the job is allowed to open lazily and has not yet been assigned to a node.
+
+`opened`::
+  (boolean) For a success response this is always `true`. On failure an
+  exception will be returned instead.
+
 [[ml-open-job-example]]
 ==== {api-examples-title}
 
@@ -64,6 +75,7 @@ When the job opens, you receive the following results:
 [source,console-result]
 ----
 {
-  "opened": true
+  "opened" : true,
+  "node" : "node-1"
 }
 ----

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -96,13 +96,13 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 ==== {api-response-body-title}
 
 `node`::
-  (string) The ID of the node that the {dfeed} was started on, or an empty
-  string if the {dfeed} is allowed to open lazily and has not yet been
-  assigned to a node.
+  (string) The ID of the node that the {dfeed} was started on.
+If the {dfeed} is allowed to open lazily and has not yet been
+  assigned to a node, this value is an empty string.
 
 `started`::
-  (boolean) For a success response this is always `true`. On failure an
-  exception will be returned instead.
+  (boolean) For a successful response, this value is always `true`. On failure, an
+  exception is returned instead.
 
 [[ml-start-datafeed-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -92,6 +92,18 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
   (Optional, time) Controls the amount of time to wait until a {dfeed} starts.
   The default value is 20 seconds.
 
+[[ml-start-datafeed-response-body]]
+==== {api-response-body-title}
+
+`node`::
+  (string) The ID of the node that the {dfeed} was started on, or an empty
+  string if the {dfeed} is allowed to open lazily and has not yet been
+  assigned to a node.
+
+`started`::
+  (boolean) For a success response this is always `true`. On failure an
+  exception will be returned instead.
+
 [[ml-start-datafeed-example]]
 ==== {api-examples-title}
 
@@ -109,6 +121,7 @@ When the {dfeed} starts, you receive the following results:
 [source,console-result]
 ----
 {
-  "started": true
+  "started" : true,
+  "node" : "node-1"
 }
 ----

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -68,12 +68,12 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=timeout-start]
 ==== {api-response-body-title}
 
 `acknowledged`::
-  (boolean) For a success response this is always `true`. On failure an
-  exception will be returned instead.
+  (boolean) For a successful response, this value is always `true`. On failure, an
+  exception is returned instead.
 
 `node`::
-  (string) The ID of the node that the job was started on, or an empty string
-  if the job is allowed to open lazily and has not yet been assigned to a node.
+  (string) The ID of the node that the job was started on.
+  If the job is allowed to open lazily and has not yet been assigned to a node, this value is an empty string.
 
 [[ml-start-dfanalytics-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -64,6 +64,17 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
 (Optional, <<time-units,time units>>) 
 include::{docdir}/ml/ml-shared.asciidoc[tag=timeout-start]
 
+[[ml-start-dfanalytics-response-body]]
+==== {api-response-body-title}
+
+`acknowledged`::
+  (boolean) For a success response this is always `true`. On failure an
+  exception will be returned instead.
+
+`node`::
+  (string) The ID of the node that the job was started on, or an empty string
+  if the job is allowed to open lazily and has not yet been assigned to a node.
+
 [[ml-start-dfanalytics-example]]
 ==== {api-examples-title}
 
@@ -80,6 +91,7 @@ When the {dfanalytics-job} starts, you receive the following results:
 [source,console-result]
 ----
 {
-  "acknowledged" : true
+  "acknowledged" : true,
+  "node" : "node-1"
 }
 ----

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/NodeAcknowledgedResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/NodeAcknowledgedResponse.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class NodeAcknowledgedResponse extends AcknowledgedResponse {
+
+    public static final String NODE_FIELD = "node";
+
+    private final String node;
+
+    public NodeAcknowledgedResponse(boolean acknowledged, String node) {
+        super(acknowledged);
+        this.node = Objects.requireNonNull(node);
+    }
+
+    public NodeAcknowledgedResponse(StreamInput in) throws IOException {
+        super(in);
+        // TODO change in backport
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            node = in.readString();
+        } else {
+            node = "";
+        }
+    }
+
+    public String getNode() {
+        return node;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        // TODO change in backport
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeString(node);
+        }
+    }
+
+    @Override
+    protected void addCustomFields(XContentBuilder builder, Params params) throws IOException {
+        builder.field(NODE_FIELD, node);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeAcknowledgedResponse that = (NodeAcknowledgedResponse) o;
+        return isAcknowledged() == that.isAcknowledged()
+            && Objects.equals(node, that.node);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isAcknowledged(), node);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
@@ -9,7 +9,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -34,13 +33,13 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Objects;
 
-public class OpenJobAction extends ActionType<AcknowledgedResponse> {
+public class OpenJobAction extends ActionType<NodeAcknowledgedResponse> {
 
     public static final OpenJobAction INSTANCE = new OpenJobAction();
     public static final String NAME = "cluster:admin/xpack/ml/job/open";
 
     private OpenJobAction() {
-        super(NAME, AcknowledgedResponse::new);
+        super(NAME, NodeAcknowledgedResponse::new);
     }
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
@@ -257,7 +256,7 @@ public class OpenJobAction extends ActionType<AcknowledgedResponse> {
         }
     }
 
-    static class RequestBuilder extends ActionRequestBuilder<Request, AcknowledgedResponse> {
+    static class RequestBuilder extends ActionRequestBuilder<Request, NodeAcknowledgedResponse> {
 
         RequestBuilder(ElasticsearchClient client, OpenJobAction action) {
             super(client, action, new Request());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
@@ -9,7 +9,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -37,13 +36,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class StartDataFrameAnalyticsAction extends ActionType<AcknowledgedResponse> {
+public class StartDataFrameAnalyticsAction extends ActionType<NodeAcknowledgedResponse> {
 
     public static final StartDataFrameAnalyticsAction INSTANCE = new StartDataFrameAnalyticsAction();
     public static final String NAME = "cluster:admin/xpack/ml/data_frame/analytics/start";
 
     private StartDataFrameAnalyticsAction() {
-        super(NAME, AcknowledgedResponse::new);
+        super(NAME, NodeAcknowledgedResponse::new);
     }
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
@@ -143,7 +142,7 @@ public class StartDataFrameAnalyticsAction extends ActionType<AcknowledgedRespon
         }
     }
 
-    static class RequestBuilder extends ActionRequestBuilder<Request, AcknowledgedResponse> {
+    static class RequestBuilder extends ActionRequestBuilder<Request, NodeAcknowledgedResponse> {
 
         RequestBuilder(ElasticsearchClient client, StartDataFrameAnalyticsAction action) {
             super(client, action, new Request());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
@@ -40,7 +39,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.LongSupplier;
 
-public class StartDatafeedAction extends ActionType<AcknowledgedResponse> {
+public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
 
     public static final ParseField START_TIME = new ParseField("start");
     public static final ParseField END_TIME = new ParseField("end");
@@ -50,7 +49,7 @@ public class StartDatafeedAction extends ActionType<AcknowledgedResponse> {
     public static final String NAME = "cluster:admin/xpack/ml/datafeed/start";
 
     private StartDatafeedAction() {
-        super(NAME, AcknowledgedResponse::new);
+        super(NAME, NodeAcknowledgedResponse::new);
     }
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
@@ -339,7 +338,7 @@ public class StartDatafeedAction extends ActionType<AcknowledgedResponse> {
         }
     }
 
-    static class RequestBuilder extends ActionRequestBuilder<Request, AcknowledgedResponse> {
+    static class RequestBuilder extends ActionRequestBuilder<Request, NodeAcknowledgedResponse> {
 
         RequestBuilder(ElasticsearchClient client, StartDatafeedAction action) {
             super(client, action, new Request());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/NodeAcknowledgedResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/NodeAcknowledgedResponseTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+public class NodeAcknowledgedResponseTests extends AbstractWireSerializingTestCase<NodeAcknowledgedResponse> {
+
+    @Override
+    protected NodeAcknowledgedResponse createTestInstance() {
+        return new NodeAcknowledgedResponse(true, randomFrom(randomAlphaOfLength(10), ""));
+    }
+
+    @Override
+    protected Writeable.Reader<NodeAcknowledgedResponse> instanceReader() {
+        return NodeAcknowledgedResponse::new;
+    }
+
+    @Override
+    protected NodeAcknowledgedResponse mutateInstance(NodeAcknowledgedResponse instance) {
+        if (instance.getNode().isEmpty()) {
+            return new NodeAcknowledgedResponse(true, randomAlphaOfLength(10));
+        } else {
+            return new NodeAcknowledgedResponse(true, "");
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/NodeAcknowledgedResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/NodeAcknowledgedResponseTests.java
@@ -6,10 +6,11 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
-public class NodeAcknowledgedResponseTests extends AbstractWireSerializingTestCase<NodeAcknowledgedResponse> {
+public class NodeAcknowledgedResponseTests extends AbstractBWCWireSerializationTestCase<NodeAcknowledgedResponse> {
 
     @Override
     protected NodeAcknowledgedResponse createTestInstance() {
@@ -25,6 +26,16 @@ public class NodeAcknowledgedResponseTests extends AbstractWireSerializingTestCa
     protected NodeAcknowledgedResponse mutateInstance(NodeAcknowledgedResponse instance) {
         if (instance.getNode().isEmpty()) {
             return new NodeAcknowledgedResponse(true, randomAlphaOfLength(10));
+        } else {
+            return new NodeAcknowledgedResponse(true, "");
+        }
+    }
+
+    @Override
+    protected NodeAcknowledgedResponse mutateInstanceForVersion(NodeAcknowledgedResponse instance, Version version) {
+        // TODO change in backport
+        if (version.onOrAfter(Version.V_8_0_0)) {
+            return instance;
         } else {
             return new NodeAcknowledgedResponse(true, "");
         }

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/test/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/test/java/org/elasticsearch/xpack/ml/integration/MlBasicMultiNodeIT.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
 public class MlBasicMultiNodeIT extends ESRestTestCase {
@@ -55,7 +56,7 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
 
         Response openResponse = client().performRequest(
                 new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_open"));
-        assertEquals(Collections.singletonMap("opened", true), entityAsMap(openResponse));
+        assertThat(entityAsMap(openResponse), hasEntry("opened", true));
 
         Request addData = new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_data");
         addData.setEntity(new NStringEntity(
@@ -136,12 +137,12 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
 
         Response openResponse = client().performRequest(
                 new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_open"));
-        assertEquals(Collections.singletonMap("opened", true), entityAsMap(openResponse));
+        assertThat(entityAsMap(openResponse), hasEntry("opened", true));
 
         Request startRequest = new Request("POST", MachineLearning.BASE_PATH + "datafeeds/" + datafeedId + "/_start");
         startRequest.addParameter("start", "0");
         Response startResponse = client().performRequest(startRequest);
-        assertEquals(Collections.singletonMap("started", true), entityAsMap(startResponse));
+        assertThat(entityAsMap(startResponse), hasEntry("started", true));
 
         assertBusy(() -> {
             try {
@@ -175,7 +176,7 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
 
         Response openResponse = client().performRequest(
                 new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_open"));
-        assertEquals(Collections.singletonMap("opened", true), entityAsMap(openResponse));
+        assertThat(entityAsMap(openResponse), hasEntry("opened", true));
 
         Request addDataRequest = new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_data");
         addDataRequest.setEntity(new NStringEntity(
@@ -214,7 +215,7 @@ public class MlBasicMultiNodeIT extends ESRestTestCase {
         Request openRequest = new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_open");
         openRequest.addParameter("timeout", "20s");
         Response openResponse2 = client().performRequest(openRequest);
-        assertEquals(Collections.singletonMap("opened", true), entityAsMap(openResponse2));
+        assertThat(entityAsMap(openResponse2), hasEntry("opened", true));
 
         // feed some more data points
         Request addDataRequest2 = new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/" + jobId + "/_data");

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.BoostedTreeParams;
@@ -45,6 +46,7 @@ import static org.elasticsearch.xpack.core.ml.MlTasks.AWAITING_UPGRADE;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -308,7 +310,8 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertIsStopped(jobId);
         assertProgress(jobId, 0, 0, 0, 0);
 
-        startAnalytics(jobId);
+        NodeAcknowledgedResponse response = startAnalytics(jobId);
+        assertThat(response.getNode(), not(emptyString()));
 
         // Wait until state is one of REINDEXING or ANALYZING, or until it is STOPPED.
         assertBusy(() -> {
@@ -325,7 +328,8 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         // Now let's start it again
         try {
-            startAnalytics(jobId);
+            response = startAnalytics(jobId);
+            assertThat(response.getNode(), not(emptyString()));
         } catch (Exception e) {
             if (e.getMessage().equals("Cannot start because the job has already finished")) {
                 // That means the job had managed to complete

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
@@ -1003,7 +1003,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
         Request startRequest = new Request("POST", MachineLearning.BASE_PATH + "datafeeds/" + datafeedId + "/_start");
         startRequest.addParameter("start", "2016-06-01T00:00:00Z");
         Response response = client().performRequest(startRequest);
-        assertThat(EntityUtils.toString(response.getEntity()), equalTo("{\"started\":true}"));
+        assertThat(EntityUtils.toString(response.getEntity()), containsString("\"started\":true"));
         assertBusy(() -> {
             try {
                 Response getJobResponse = client().performRequest(new Request("GET",
@@ -1154,7 +1154,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
         options.addHeader("Authorization", authHeader);
         request.setOptions(options);
         Response startDatafeedResponse = client().performRequest(request);
-        assertThat(EntityUtils.toString(startDatafeedResponse.getEntity()), equalTo("{\"started\":true}"));
+        assertThat(EntityUtils.toString(startDatafeedResponse.getEntity()), containsString("\"started\":true"));
         assertBusy(() -> {
             try {
                 Response datafeedStatsResponse = client().performRequest(new Request("GET",

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsRestIT.java
@@ -1062,7 +1062,7 @@ public class DatafeedJobsRestIT extends ESRestTestCase {
         startRequest.addParameter("start", "2016-06-01T00:00:00Z");
         Response response = client().performRequest(startRequest);
         assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
-        assertThat(EntityUtils.toString(response.getEntity()), equalTo("{\"started\":true}"));
+        assertThat(EntityUtils.toString(response.getEntity()), containsString("\"started\":true"));
 
         ResponseException e = expectThrows(ResponseException.class,
                 () -> client().performRequest(new Request("DELETE", MachineLearning.BASE_PATH + "datafeeds/" + datafeedId)));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlJobIT.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 import org.junit.After;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -125,7 +124,7 @@ public class MlJobIT extends ESRestTestCase {
         assertEquals(2, XContentMapValues.extractValue("ml.jobs._all.count", usage));
         assertEquals(2, XContentMapValues.extractValue("ml.jobs.closed.count", usage));
         Response openResponse = client().performRequest(new Request("POST", MachineLearning.BASE_PATH + "anomaly_detectors/job-1/_open"));
-        assertEquals(Collections.singletonMap("opened", true), entityAsMap(openResponse));
+        assertThat(entityAsMap(openResponse), hasEntry("opened", true));
         usage = entityAsMap(client().performRequest(new Request("GET", "_xpack/usage")));
         assertEquals(2, XContentMapValues.extractValue("ml.jobs._all.count", usage));
         assertEquals(1, XContentMapValues.extractValue("ml.jobs.closed.count", usage));

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/MlNativeDataFrameAnalyticsIntegTestCase.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.core.ml.action.EvaluateDataFrameAction;
 import org.elasticsearch.xpack.core.ml.action.ExplainDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StopDataFrameAnalyticsAction;
@@ -125,7 +126,7 @@ abstract class MlNativeDataFrameAnalyticsIntegTestCase extends MlNativeIntegTest
         return client().execute(DeleteDataFrameAnalyticsAction.INSTANCE, request).actionGet();
     }
 
-    protected AcknowledgedResponse startAnalytics(String id) {
+    protected NodeAcknowledgedResponse startAnalytics(String id) {
         StartDataFrameAnalyticsAction.Request request = new StartDataFrameAnalyticsAction.Request(id);
         return client().execute(StartDataFrameAnalyticsAction.INSTANCE, request).actionGet();
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.BoostedTreeParams;
@@ -28,11 +29,13 @@ import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 
 public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
@@ -245,7 +248,8 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertIsStopped(jobId);
         assertProgress(jobId, 0, 0, 0, 0);
 
-        startAnalytics(jobId);
+        NodeAcknowledgedResponse response = startAnalytics(jobId);
+        assertThat(response.getNode(), not(emptyString()));
 
         // Wait until state is one of REINDEXING or ANALYZING, or until it is STOPPED.
         assertBusy(() -> {
@@ -262,7 +266,8 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         // Now let's start it again
         try {
-            startAnalytics(jobId);
+            response = startAnalytics(jobId);
+            assertThat(response.getNode(), not(emptyString()));
         } catch (Exception e) {
             if (e.getMessage().equals("Cannot start because the job has already finished")) {
                 // That means the job had managed to complete

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
@@ -36,12 +37,14 @@ import java.util.Map;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -571,7 +574,8 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertIsStopped(id);
 
         // Due to lazy start being allowed, this should succeed even though no node currently in the cluster is big enough
-        startAnalytics(id);
+        NodeAcknowledgedResponse response = startAnalytics(id);
+        assertThat(response.getNode(), emptyString());
 
         // Wait until state is STARTING, there is no node but there is an assignment explanation.
         assertBusy(() -> {
@@ -620,7 +624,8 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         putAnalytics(config);
 
         assertIsStopped(id);
-        startAnalytics(id);
+        NodeAcknowledgedResponse response = startAnalytics(id);
+        assertThat(response.getNode(), not(emptyString()));
 
         // Wait until state is one of REINDEXING or ANALYZING, or until it is STOPPED.
         assertBusy(() -> {
@@ -633,7 +638,8 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         // Now let's start it again
         try {
-            startAnalytics(id);
+            response = startAnalytics(id);
+            assertThat(response.getNode(), not(emptyString()));
         } catch (Exception e) {
             if (e.getMessage().equals("Cannot start because the job has already finished")) {
                 // That means the job had managed to complete

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -43,6 +42,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedJobValidator;
@@ -79,7 +79,7 @@ import java.util.function.Predicate;
  In case of instability persistent tasks checks may fail and that is ok, in that case all bets are off.
  The start datafeed api is a low through put api, so the fact that we redirect to elected master node shouldn't be an issue.
  */
-public class TransportStartDatafeedAction extends TransportMasterNodeAction<StartDatafeedAction.Request, AcknowledgedResponse> {
+public class TransportStartDatafeedAction extends TransportMasterNodeAction<StartDatafeedAction.Request, NodeAcknowledgedResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportStartDatafeedAction.class);
 
@@ -148,13 +148,13 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     }
 
     @Override
-    protected AcknowledgedResponse read(StreamInput in) throws IOException {
-        return new AcknowledgedResponse(in);
+    protected NodeAcknowledgedResponse read(StreamInput in) throws IOException {
+        return new NodeAcknowledgedResponse(in);
     }
 
     @Override
     protected void masterOperation(Task task, StartDatafeedAction.Request request, ClusterState state,
-                                   ActionListener<AcknowledgedResponse> listener) {
+                                   ActionListener<NodeAcknowledgedResponse> listener) {
         StartDatafeedAction.DatafeedParams params = request.getParams();
         if (licenseState.isMachineLearningAllowed() == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
@@ -283,7 +283,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     }
 
     private void waitForDatafeedStarted(String taskId, StartDatafeedAction.DatafeedParams params,
-                                        ActionListener<AcknowledgedResponse> listener) {
+                                        ActionListener<NodeAcknowledgedResponse> listener) {
         DatafeedPredicate predicate = new DatafeedPredicate();
         persistentTasksService.waitForPersistentTaskCondition(taskId, predicate, params.getTimeout(),
                 new PersistentTasksService.WaitForPersistentTaskListener<StartDatafeedAction.DatafeedParams>() {
@@ -295,7 +295,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                             // what would have happened if the error had been detected in the "fast fail" validation
                             cancelDatafeedStart(persistentTask, predicate.exception, listener);
                         } else {
-                            listener.onResponse(new AcknowledgedResponse(true));
+                            listener.onResponse(new NodeAcknowledgedResponse(true, predicate.node));
                         }
                     }
 
@@ -313,7 +313,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     }
 
     private void cancelDatafeedStart(PersistentTasksCustomMetadata.PersistentTask<StartDatafeedAction.DatafeedParams> persistentTask,
-                                     Exception exception, ActionListener<AcknowledgedResponse> listener) {
+                                     Exception exception, ActionListener<NodeAcknowledgedResponse> listener) {
         persistentTasksService.sendRemoveRequest(persistentTask.getId(),
                 new ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>>() {
                     @Override
@@ -494,6 +494,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     private static class DatafeedPredicate implements Predicate<PersistentTasksCustomMetadata.PersistentTask<?>> {
 
         private volatile Exception exception;
+        private volatile String node = "";
 
         @Override
         public boolean test(PersistentTasksCustomMetadata.PersistentTask<?> persistentTask) {
@@ -514,7 +515,11 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                 }
             }
             DatafeedState datafeedState = (DatafeedState) persistentTask.getState();
-            return datafeedState == DatafeedState.STARTED;
+            if (datafeedState == DatafeedState.STARTED) {
+                node = persistentTask.getExecutorNode();
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStartDatafeedAction.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.rest.datafeeds;
 
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -16,6 +15,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -71,12 +71,14 @@ public class RestStartDatafeedAction extends BaseRestHandler {
         }
         return channel -> {
             client.execute(StartDatafeedAction.INSTANCE, jobDatafeedRequest,
-                    new RestBuilderListener<AcknowledgedResponse>(channel) {
+                    new RestBuilderListener<NodeAcknowledgedResponse>(channel) {
 
                         @Override
-                        public RestResponse buildResponse(AcknowledgedResponse r, XContentBuilder builder) throws Exception {
+                        public RestResponse buildResponse(NodeAcknowledgedResponse r, XContentBuilder builder) throws Exception {
+                            // This doesn't use the toXContent of the response object because we rename "acknowledged" to "opened"
                             builder.startObject();
                             builder.field("started", r.isAcknowledged());
+                            builder.field(NodeAcknowledgedResponse.NODE_FIELD, r.getNode());
                             builder.endObject();
                             return new BytesRestResponse(RestStatus.OK, builder);
                         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestStartDatafeedAction.java
@@ -75,7 +75,7 @@ public class RestStartDatafeedAction extends BaseRestHandler {
 
                         @Override
                         public RestResponse buildResponse(NodeAcknowledgedResponse r, XContentBuilder builder) throws Exception {
-                            // This doesn't use the toXContent of the response object because we rename "acknowledged" to "opened"
+                            // This doesn't use the toXContent of the response object because we rename "acknowledged" to "started"
                             builder.startObject();
                             builder.field("started", r.isAcknowledged());
                             builder.field(NodeAcknowledgedResponse.NODE_FIELD, r.getNode());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/job/RestOpenJobAction.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.rest.job;
 
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -15,6 +14,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestBuilderListener;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -61,11 +61,13 @@ public class RestOpenJobAction extends BaseRestHandler {
             request = new OpenJobAction.Request(jobParams);
         }
         return channel -> {
-            client.execute(OpenJobAction.INSTANCE, request, new RestBuilderListener<AcknowledgedResponse>(channel) {
+            client.execute(OpenJobAction.INSTANCE, request, new RestBuilderListener<NodeAcknowledgedResponse>(channel) {
                 @Override
-                public RestResponse buildResponse(AcknowledgedResponse r, XContentBuilder builder) throws Exception {
+                public RestResponse buildResponse(NodeAcknowledgedResponse r, XContentBuilder builder) throws Exception {
+                    // This doesn't use the toXContent of the response object because we rename "acknowledged" to "opened"
                     builder.startObject();
                     builder.field("opened", r.isAcknowledged());
+                    builder.field(NodeAcknowledgedResponse.NODE_FIELD, r.getNode());
                     builder.endObject();
                     return new BytesRestResponse(RestStatus.OK, builder);
                 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.core.ml.action.DeleteJobAction;
 import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.InternalInferModelAction;
+import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.PutDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
@@ -113,7 +114,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         assertMLAllowed(false);
         // test that license restricted apis do not work
         ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, () -> {
-            PlainActionFuture<AcknowledgedResponse> listener = PlainActionFuture.newFuture();
+            PlainActionFuture<NodeAcknowledgedResponse> listener = PlainActionFuture.newFuture();
             client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), listener);
             listener.actionGet();
         });
@@ -133,9 +134,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         });
 
         // test that license restricted apis do now work
-        PlainActionFuture<AcknowledgedResponse> listener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> listener = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), listener);
-        AcknowledgedResponse response2 = listener.actionGet();
+        NodeAcknowledgedResponse response2 = listener.actionGet();
         assertNotNull(response2);
     }
 
@@ -196,12 +197,12 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         PutDatafeedAction.Response putDatafeedResponse = putDatafeedListener.actionGet();
         assertNotNull(putDatafeedResponse);
         // open job
-        PlainActionFuture<AcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), openJobListener);
-        AcknowledgedResponse openJobResponse = openJobListener.actionGet();
+        NodeAcknowledgedResponse openJobResponse = openJobListener.actionGet();
         assertNotNull(openJobResponse);
         // start datafeed
-        PlainActionFuture<AcknowledgedResponse> listener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> listener = PlainActionFuture.newFuture();
         client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L), listener);
         listener.actionGet();
 
@@ -232,12 +233,12 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         assertMLAllowed(true);
 
         // open job
-        PlainActionFuture<AcknowledgedResponse> openJobListener2 = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> openJobListener2 = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), openJobListener2);
-        AcknowledgedResponse openJobResponse3 = openJobListener2.actionGet();
+        NodeAcknowledgedResponse openJobResponse3 = openJobListener2.actionGet();
         assertNotNull(openJobResponse3);
         // start datafeed
-        PlainActionFuture<AcknowledgedResponse> listener2 = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> listener2 = PlainActionFuture.newFuture();
         client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L), listener2);
         listener2.actionGet();
 
@@ -291,9 +292,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                         Collections.singletonList(datafeedIndex))), putDatafeedListener);
         PutDatafeedAction.Response putDatafeedResponse = putDatafeedListener.actionGet();
         assertNotNull(putDatafeedResponse);
-        PlainActionFuture<AcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), openJobListener);
-        AcknowledgedResponse openJobResponse = openJobListener.actionGet();
+        NodeAcknowledgedResponse openJobResponse = openJobListener.actionGet();
         assertNotNull(openJobResponse);
 
         // Pick a license that does not allow machine learning
@@ -312,7 +313,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
         // test that license restricted apis do not work
         ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, () -> {
-            PlainActionFuture<AcknowledgedResponse> listener = PlainActionFuture.newFuture();
+            PlainActionFuture<NodeAcknowledgedResponse> listener = PlainActionFuture.newFuture();
             client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L), listener);
             listener.actionGet();
         });
@@ -326,14 +327,14 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         assertMLAllowed(true);
         // test that license restricted apis do now work
         // re-open job now that the license is valid again
-        PlainActionFuture<AcknowledgedResponse> openJobListener2 = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> openJobListener2 = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), openJobListener2);
-        AcknowledgedResponse openJobResponse3 = openJobListener2.actionGet();
+        NodeAcknowledgedResponse openJobResponse3 = openJobListener2.actionGet();
         assertNotNull(openJobResponse3);
 
-        PlainActionFuture<AcknowledgedResponse> listener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> listener = PlainActionFuture.newFuture();
         client().execute(StartDatafeedAction.INSTANCE, new StartDatafeedAction.Request(datafeedId, 0L), listener);
-        AcknowledgedResponse response = listener.actionGet();
+        NodeAcknowledgedResponse response = listener.actionGet();
         assertNotNull(response);
     }
 
@@ -354,14 +355,14 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                         Collections.singletonList(datafeedIndex))), putDatafeedListener);
         PutDatafeedAction.Response putDatafeedResponse = putDatafeedListener.actionGet();
         assertNotNull(putDatafeedResponse);
-        PlainActionFuture<AcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), openJobListener);
-        AcknowledgedResponse openJobResponse = openJobListener.actionGet();
+        NodeAcknowledgedResponse openJobResponse = openJobListener.actionGet();
         assertNotNull(openJobResponse);
-        PlainActionFuture<AcknowledgedResponse> startDatafeedListener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> startDatafeedListener = PlainActionFuture.newFuture();
         client().execute(StartDatafeedAction.INSTANCE,
             new StartDatafeedAction.Request(datafeedId, 0L), startDatafeedListener);
-        AcknowledgedResponse startDatafeedResponse = startDatafeedListener.actionGet();
+        NodeAcknowledgedResponse startDatafeedResponse = startDatafeedListener.actionGet();
         assertNotNull(startDatafeedResponse);
 
         boolean invalidLicense = randomBoolean();
@@ -402,9 +403,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         client().execute(PutJobAction.INSTANCE, new PutJobAction.Request(createJob(jobId)), putJobListener);
         PutJobAction.Response putJobResponse = putJobListener.actionGet();
         assertNotNull(putJobResponse);
-        PlainActionFuture<AcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
+        PlainActionFuture<NodeAcknowledgedResponse> openJobListener = PlainActionFuture.newFuture();
         client().execute(OpenJobAction.INSTANCE, new OpenJobAction.Request(jobId), openJobListener);
-        AcknowledgedResponse openJobResponse = openJobListener.actionGet();
+        NodeAcknowledgedResponse openJobResponse = openJobListener.actionGet();
         assertNotNull(openJobResponse);
 
         boolean invalidLicense = randomBoolean();

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -143,6 +143,7 @@
       ml.open_job:
         job_id: job-model-memory-limit-as-string
   - match: { opened: true }
+  - match: { node: /\S+/ }
 
   - do:
       headers:
@@ -563,6 +564,7 @@
       ml.open_job:
         job_id: delete-opened-job
   - match: { opened: true }
+  - match: { node: /\S+/ }
 
   - do:
       catch: /Cannot delete job \[delete-opened-job\] because the job is opened/
@@ -1446,6 +1448,7 @@
       ml.open_job:
         job_id: persistent-task-allocation-allowed-test
   - match: { opened: true }
+  - match: { node: /\S+/ }
 
 ---
 "Test reopen job resets the finished time":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -143,7 +143,7 @@
       ml.open_job:
         job_id: job-model-memory-limit-as-string
   - match: { opened: true }
-  - match: { node: /\S+/ }
+  - match: { node: "" }
 
   - do:
       headers:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/start_stop_datafeed.yml
@@ -365,14 +365,17 @@ setup:
       ml.start_datafeed:
         datafeed_id: "start-stop-datafeed-job-foo-1-feed"
   - match: { started: true }
+  - match: { node: /\S+/ }
   - do:
       ml.start_datafeed:
         datafeed_id: "start-stop-datafeed-job-foo-2-feed"
   - match: { started: true }
+  - match: { node: /\S+/ }
   - do:
       ml.start_datafeed:
         datafeed_id: "start-stop-datafeed-job-bar-1-feed"
   - match: { started: true }
+  - match: { node: /\S+/ }
 
   - do:
       ml.stop_datafeed:


### PR DESCRIPTION
Adds a "node" field to the response from the following endpoints:

1. Open anomaly detection job
2. Start datafeed
3. Start data frame analytics job

If the job or datafeed is assigned to a node immediately then
this field will return the ID of that node.

In the case where a job or datafeed is opened or started lazily
the node field will contain an empty string.  Clients that want
to test whether a job or datafeed was opened or started lazily
can therefore check for this.

Fixes #54067