### PR TITLE
Adjust serialization versions for prefer_v2_templates flag

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -1,7 +1,7 @@
 ---
 "Component and index template composition":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
       features: allowed_warnings
 
@@ -89,7 +89,7 @@
 ---
 "Index template priority":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
       features: allowed_warnings
 
@@ -133,7 +133,7 @@
 ---
 "Component template only composition":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
       features: allowed_warnings
 
@@ -179,7 +179,7 @@
 ---
 "Index template without component templates":
   - skip:
-      version: " - 7.9.99"
+      version: " - 7.7.99"
       reason: "index template v2 API unavailable before 7.8"
       features: allowed_warnings
 
@@ -208,8 +208,8 @@
 ---
 "Version 1 templates are preferred if the flag is set":
   - skip:
-      version: " - 7.9.99"
-      reason: "not backported yet"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
       features: allowed_warnings
 
   - do:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -110,7 +110,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
             aliases.add(new Alias(in));
         }
         waitForActiveShards = ActiveShardCount.readFrom(in);
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             preferV2Templates = in.readOptionalBoolean();
         }
     }
@@ -484,7 +484,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
             alias.writeTo(out);
         }
         waitForActiveShards.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeOptionalBoolean(preferV2Templates);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -89,7 +89,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         }
         refreshPolicy = RefreshPolicy.readFrom(in);
         timeout = in.readTimeValue();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             this.preferV2Templates = in.readOptionalBoolean();
         }
     }
@@ -371,7 +371,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         }
         refreshPolicy.writeTo(out);
         out.writeTimeValue(timeout);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeOptionalBoolean(preferV2Templates);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -144,7 +144,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         }
         ifSeqNo = in.readZLong();
         ifPrimaryTerm = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             this.preferV2Templates = in.readOptionalBoolean();
         }
     }
@@ -656,7 +656,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         }
         out.writeZLong(ifSeqNo);
         out.writeVLong(ifPrimaryTerm);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeOptionalBoolean(preferV2Templates);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -153,7 +153,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         ifPrimaryTerm = in.readVLong();
         detectNoop = in.readBoolean();
         scriptedUpsert = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             preferV2Templates = in.readOptionalBoolean();
         }
     }
@@ -855,7 +855,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         out.writeVLong(ifPrimaryTerm);
         out.writeBoolean(detectNoop);
         out.writeBoolean(scriptedUpsert);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeOptionalBoolean(preferV2Templates);
         }
     }


### PR DESCRIPTION
This adjusts the minimum version for serialization for #55411.

It should only be merged after #55476 has been merged
