### PR TITLE
Change prefer_v2_templates parameter to default to true

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -385,7 +385,7 @@ Returns:
     "settings": {
       "index.number_of_replicas": "1",
       "index.number_of_shards": "1",
-      "index.prefer_v2_templates": "false",
+      "index.prefer_v2_templates": "true",
       "index.creation_date": "1474389951325",
       "index.uuid": "n6gzFZTgS664GUfx0Xrpjw",
       "index.version.created": ...,
@@ -423,7 +423,7 @@ Returns:
           "created": ...
         },
         "provided_name" : "twitter",
-        "prefer_v2_templates": "false"
+        "prefer_v2_templates": "true"
       }
     }
   }

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -77,3 +77,15 @@ In Elasticsearch 7.8.0, the following settings have been deprecated:
 
 In future releases, it will not be possible to disable the APIs for Enrichment,
 Flattened mappings, ILM, Monitoring, Rollup, SLM, SQL, Transforms, and Vectors.
+
+[float]
+==== The `prefer_v2_templates` parameter now defaults to `true`
+
+In Elasticsearch 7.8.0 the `?prefer_v2_templates=true|false` parameter was introduced to allow
+specifying whether to favor V1 or V2 templates when a new index is created. In 8.0 this now defaults
+to `true`, meaning that V2 index templates will always take precedence if they match. V1 templates
+will continue to be applied if no V2 index template matches the newly created index pattern.
+
+The `?prefer_v2_templates` parameter is supported on the <<indices-create-index,Create Index>>,
+<<docs-index_,Index>>, <<docs-bulk,Bulk>>, <<docs-update,Update>>, and
+<<indices-rollover-index,Rollover>> APIs.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -249,7 +249,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         // this is only setable internally not a registered setting!!
     public static final String PREFER_V2_TEMPLATES_FLAG = "prefer_v2_templates";
     public static final String SETTING_PREFER_V2_TEMPLATES = "index." + PREFER_V2_TEMPLATES_FLAG;
-    public static final Setting<Boolean> PREFER_V2_TEMPLATES_SETTING = Setting.boolSetting(SETTING_PREFER_V2_TEMPLATES, false,
+    public static final Setting<Boolean> PREFER_V2_TEMPLATES_SETTING = Setting.boolSetting(SETTING_PREFER_V2_TEMPLATES, true,
         Property.Dynamic, Property.IndexScope);
 
     /**

--- a/server/src/test/java/org/elasticsearch/indices/template/TemplatePreferenceIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/template/TemplatePreferenceIT.java
@@ -69,7 +69,7 @@ public class TemplatePreferenceIT extends ESSingleNodeTestCase {
 
     public void testCreateIndexPreference() throws Exception {
         client().admin().indices().prepareCreate(INDEX).get();
-        assertUsedV1();
+        assertUsedV2();
 
         client().admin().indices().create(new CreateIndexRequest(INDEX).preferV2Templates(false)).get();
         assertUsedV1();
@@ -80,7 +80,7 @@ public class TemplatePreferenceIT extends ESSingleNodeTestCase {
 
     public void testIndexingRequestPreference() throws Exception {
         client().index(new IndexRequest(INDEX).source("foo", "bar")).get();
-        assertUsedV1();
+        assertUsedV2();
 
         client().index(new IndexRequest(INDEX).source("foo", "bar").preferV2Templates(false)).get();
         assertUsedV1();
@@ -89,7 +89,7 @@ public class TemplatePreferenceIT extends ESSingleNodeTestCase {
         assertUsedV2();
 
         client().update(new UpdateRequest(INDEX, "1").doc("foo", "bar").docAsUpsert(true)).get();
-        assertUsedV1();
+        assertUsedV2();
 
         client().update(new UpdateRequest(INDEX, "1").doc("foo", "bar").docAsUpsert(true).preferV2Templates(false)).get();
         assertUsedV1();
@@ -98,7 +98,7 @@ public class TemplatePreferenceIT extends ESSingleNodeTestCase {
         assertUsedV2();
 
         client().bulk(new BulkRequest(INDEX).add(new IndexRequest(INDEX).source("foo", "bar"))).get();
-        assertUsedV1();
+        assertUsedV2();
 
         client().bulk(new BulkRequest(INDEX).add(new IndexRequest(INDEX).source("foo", "bar")).preferV2Templates(false)).get();
         assertUsedV1();
@@ -115,8 +115,8 @@ public class TemplatePreferenceIT extends ESSingleNodeTestCase {
 
             client().admin().indices().prepareRolloverIndex("alias").get();
             GetSettingsResponse resp = client().admin().indices().prepareGetSettings().setIndices(INDEX + "-000002").get();
-            assertThat("expected index to use V1 template and have priority of 15",
-                resp.getSetting(INDEX + "-000002", "index.priority"), equalTo("15"));
+            assertThat("expected index to use V2 template and have priority of 23",
+                resp.getSetting(INDEX + "-000002", "index.priority"), equalTo("23"));
             client().admin().indices().prepareDelete(INDEX + "*").get();
         }
 


### PR DESCRIPTION
As a followup to #55411, this commit changes the default for the `?prefer_v2_templates` querystring
parameter to be `true`. This means that V2 templates will take precedence by default in 8.0+

Relates to #53101
