### PR TITLE
Use set once for systemd extender

### DIFF
--- a/modules/systemd/src/main/java/org/elasticsearch/systemd/SystemdPlugin.java
+++ b/modules/systemd/src/main/java/org/elasticsearch/systemd/SystemdPlugin.java
@@ -127,6 +127,7 @@ public class SystemdPlugin extends Plugin implements ClusterPlugin {
     @Override
     public void onNodeStarted() {
         if (enabled == false) {
+            assert extender.get() == null;
             return;
         }
         final int rc = sd_notify(0, "READY=1");

--- a/modules/systemd/src/main/java/org/elasticsearch/systemd/SystemdPlugin.java
+++ b/modules/systemd/src/main/java/org/elasticsearch/systemd/SystemdPlugin.java
@@ -95,7 +95,9 @@ public class SystemdPlugin extends Plugin implements ClusterPlugin {
         final NamedWriteableRegistry namedWriteableRegistry,
         final IndexNameExpressionResolver expressionResolver,
         final Supplier<RepositoriesService> repositoriesServiceSupplier) {
-        if (enabled) {
+        if (enabled == false) {
+            extender.set(null);
+        } else {
             /*
              * Since we have set the service type to notify, by default systemd will wait up to sixty seconds for the process to send the
              * READY=1 status via sd_notify. Since our startup can take longer than that (e.g., if we are upgrading on-disk metadata) then
@@ -112,8 +114,6 @@ public class SystemdPlugin extends Plugin implements ClusterPlugin {
                 },
                 TimeValue.timeValueSeconds(15),
                 ThreadPool.Names.SAME));
-        } else {
-            extender.set(null);
         }
         return List.of();
     }

--- a/modules/systemd/src/test/java/org/elasticsearch/systemd/SystemdPluginTests.java
+++ b/modules/systemd/src/test/java/org/elasticsearch/systemd/SystemdPluginTests.java
@@ -63,28 +63,28 @@ public class SystemdPluginTests extends ESTestCase {
         final SystemdPlugin plugin = new SystemdPlugin(false, randomPackageBuildType, Boolean.TRUE.toString());
         plugin.createComponents(null, null, threadPool, null, null, null, null, null, null, null, null);
         assertTrue(plugin.isEnabled());
-        assertNotNull(plugin.extender);
+        assertNotNull(plugin.extender.get());
     }
 
     public void testIsNotPackageDistribution() {
         final SystemdPlugin plugin = new SystemdPlugin(false, randomNonPackageBuildType, Boolean.TRUE.toString());
         plugin.createComponents(null, null, threadPool, null, null, null, null, null, null, null, null);
         assertFalse(plugin.isEnabled());
-        assertNull(plugin.extender);
+        assertNull(plugin.extender.get());
     }
 
     public void testIsImplicitlyNotEnabled() {
         final SystemdPlugin plugin = new SystemdPlugin(false, randomPackageBuildType, null);
         plugin.createComponents(null, null, threadPool, null, null, null, null, null, null, null, null);
         assertFalse(plugin.isEnabled());
-        assertNull(plugin.extender);
+        assertNull(plugin.extender.get());
     }
 
     public void testIsExplicitlyNotEnabled() {
         final SystemdPlugin plugin = new SystemdPlugin(false, randomPackageBuildType, Boolean.FALSE.toString());
         plugin.createComponents(null, null, threadPool, null, null, null, null, null, null, null, null);
         assertFalse(plugin.isEnabled());
-        assertNull(plugin.extender);
+        assertNull(plugin.extender.get());
     }
 
     public void testInvalid() {
@@ -102,7 +102,7 @@ public class SystemdPluginTests extends ESTestCase {
             randomIntBetween(0, Integer.MAX_VALUE),
             (maybe, plugin) -> {
                 assertThat(maybe, OptionalMatchers.isEmpty());
-                verify(plugin.extender).cancel();
+                verify(plugin.extender.get()).cancel();
             });
     }
 
@@ -185,7 +185,7 @@ public class SystemdPluginTests extends ESTestCase {
         if (Boolean.TRUE.toString().equals(esSDNotify)) {
             assertNotNull(plugin.extender);
         } else {
-            assertNull(plugin.extender);
+            assertNull(plugin.extender.get());
         }
 
         boolean success = false;


### PR DESCRIPTION
When Elasticsearch is starting up, we schedule a thread to repeatedly let systemd know that we are still in the process of starting up. Today we use a non-final field for this. This commit changes this to be a set once so we can mark the field as final, and get stronger guarantees when reasoning about the state of execution here.

Relates #49784