### PR TITLE
[7.x] Apply default timeout in StopDataFrameAnalyticsAction.Request (#55512)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
@@ -36,11 +36,14 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public class StartDataFrameAnalyticsAction extends ActionType<AcknowledgedResponse> {
 
     public static final StartDataFrameAnalyticsAction INSTANCE = new StartDataFrameAnalyticsAction();
     public static final String NAME = "cluster:admin/xpack/ml/data_frame/analytics/start";
+
+    public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(20, TimeUnit.SECONDS);
 
     private StartDataFrameAnalyticsAction() {
         super(NAME, AcknowledgedResponse::new);
@@ -69,7 +72,7 @@ public class StartDataFrameAnalyticsAction extends ActionType<AcknowledgedRespon
         }
 
         private String id;
-        private TimeValue timeout = TimeValue.timeValueSeconds(20);
+        private TimeValue timeout = DEFAULT_TIMEOUT;
 
         public Request(String id) {
             setId(id);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
@@ -33,11 +33,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyticsAction.Response> {
 
     public static final StopDataFrameAnalyticsAction INSTANCE = new StopDataFrameAnalyticsAction();
     public static final String NAME = "cluster:admin/xpack/ml/data_frame/analytics/stop";
+
+    public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
 
     private StopDataFrameAnalyticsAction() {
         super(NAME, StopDataFrameAnalyticsAction.Response::new);
@@ -75,6 +78,7 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
         private Set<String> expandedIds = Collections.emptySet();
 
         public Request(String id) {
+            this();
             setId(id);
         }
 
@@ -86,7 +90,9 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
             expandedIds = new HashSet<>(Arrays.asList(in.readStringArray()));
         }
 
-        public Request() {}
+        public Request() {
+            setTimeout(DEFAULT_TIMEOUT);
+        }
 
         public final void setId(String id) {
             this.id = ExceptionsHelper.requireNonNull(id, DataFrameAnalyticsConfig.ID);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteDataFrameAnalyticsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteDataFrameAnalyticsActionRequestTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.action.DeleteDataFrameAnalyticsAction.Request;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class DeleteDataFrameAnalyticsActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+
+    @Override
+    protected Request createTestInstance() {
+        Request request = new Request(randomAlphaOfLength(10));
+        request.setForce(randomBoolean());
+        return request;
+    }
+
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    public void testDefaultTimeout() {
+        assertThat(createTestInstance().timeout(), is(notNullValue()));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
@@ -109,4 +109,8 @@ public class PutDataFrameAnalyticsActionRequestTests extends AbstractSerializing
 
         assertThat(e, is(nullValue()));
     }
+
+    public void testDefaultTimeout() {
+        assertThat(createTestInstance().timeout(), is(notNullValue()));
+    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsRequestTests.java
@@ -7,8 +7,15 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction.Request;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class StartDataFrameAnalyticsRequestTests extends AbstractWireSerializingTestCase<Request> {
 
@@ -24,5 +31,16 @@ public class StartDataFrameAnalyticsRequestTests extends AbstractWireSerializing
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    public void testDefaultTimeout() throws IOException {
+        {
+            Request request = new Request("foo");
+            assertThat(request.getTimeout(), is(notNullValue()));
+        }
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{}")) {
+            Request request = Request.parseRequest("foo", parser);
+            assertThat(request.getTimeout(), is(notNullValue()));
+        }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsRequestTests.java
@@ -7,11 +7,17 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.StopDataFrameAnalyticsAction.Request;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class StopDataFrameAnalyticsRequestTests extends AbstractWireSerializingTestCase<Request> {
 
@@ -39,5 +45,16 @@ public class StopDataFrameAnalyticsRequestTests extends AbstractWireSerializingT
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    public void testDefaultTimeout() throws IOException {
+        {
+            Request request = new Request("foo");
+            assertThat(request.getTimeout(), is(notNullValue()));
+        }
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{}")) {
+            Request request = Request.parseRequest("foo", parser);
+            assertThat(request.getTimeout(), is(notNullValue()));
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Apply default timeout in StopDataFrameAnalyticsAction.Request  (#55512)