### PR TITLE
[DOCS] Changes feature importance links to point to the new page

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -123,7 +123,7 @@ classes to the `probabilities` field. Both fields are contained in the
 
 Update your index mapping of the {feat-imp} result field as you can see below to 
 get the full benefit of aggregating and searching for 
-{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{feat-imp}].
+{ml-docs}/ml-feature-importance.html[{feat-imp}].
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -158,9 +158,8 @@ categories, the API reports all category probabilities. Defaults to 2.
 `num_top_feature_importance_values`::::
 (Optional, integer)
 Advanced configuration option. Specifies the maximum number of
-{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[feature
-importance] values per document to return. By default, it is zero and no feature importance
-calculation occurs.
+{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per 
+document to return. By default, it is zero and no {feat-imp} calculation occurs.
 
 `prediction_field_name`::::
 (Optional, string) 
@@ -268,9 +267,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
 `num_top_feature_importance_values`::::
 (Optional, integer)
 Advanced configuration option. Specifies the maximum number of
-{ml-docs}/dfa-regression.html#dfa-regression-feature-importance[feature importance] 
-values per document to return. By default, it is zero and no feature importance
-calculation occurs.
+{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per 
+document to return. By default, it is zero and no {feat-imp} calculation occurs.
 
 `prediction_field_name`::::
 (Optional, string)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -158,8 +158,8 @@ categories, the API reports all category probabilities. Defaults to 2.
 `num_top_feature_importance_values`::::
 (Optional, integer)
 Advanced configuration option. Specifies the maximum number of
-{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per 
-document to return. By default, it is zero and no {feat-imp} calculation occurs.
+{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document to return. 
+By default, it is zero and no {feat-imp} calculation occurs.
 
 `prediction_field_name`::::
 (Optional, string) 
@@ -267,8 +267,8 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
 `num_top_feature_importance_values`::::
 (Optional, integer)
 Advanced configuration option. Specifies the maximum number of
-{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per 
-document to return. By default, it is zero and no {feat-imp} calculation occurs.
+{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document to return. 
+By default, it is zero and no {feat-imp} calculation occurs.
 
 `prediction_field_name`::::
 (Optional, string)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1117,9 +1117,8 @@ end::inference-config-classification-num-top-classes[]
 
 tag::inference-config-classification-num-top-feature-importance-values[]
 Specifies the maximum number of
-{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[feature
-importance] values per document. By default, it is zero and no feature
-importance calculation occurs.
+{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document. 
+By default, it is zero and no {feat-imp} calculation occurs.
 end::inference-config-classification-num-top-feature-importance-values[]
 
 tag::inference-config-classification-top-classes-results-field[]
@@ -1135,9 +1134,8 @@ end::inference-config-classification-prediction-field-type[]
 
 tag::inference-config-regression-num-top-feature-importance-values[]
 Specifies the maximum number of
-{ml-docs}/dfa-regression.html#dfa-regression-feature-importance[feature
-importance] values per document. By default, it is zero and no feature importance
-calculation occurs.
+{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document. 
+By default, it is zero and no {feat-imp} calculation occurs.
 end::inference-config-regression-num-top-feature-importance-values[]
 
 tag::inference-config-results-field[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1117,8 +1117,8 @@ end::inference-config-classification-num-top-classes[]
 
 tag::inference-config-classification-num-top-feature-importance-values[]
 Specifies the maximum number of
-{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document. 
-By default, it is zero and no {feat-imp} calculation occurs.
+{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document. By 
+default, it is zero and no {feat-imp} calculation occurs.
 end::inference-config-classification-num-top-feature-importance-values[]
 
 tag::inference-config-classification-top-classes-results-field[]
@@ -1134,7 +1134,7 @@ end::inference-config-classification-prediction-field-type[]
 
 tag::inference-config-regression-num-top-feature-importance-values[]
 Specifies the maximum number of
-{ml-docs}/{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document. 
+{ml-docs}/ml-feature-importance.html[{feat-imp}] values per document. 
 By default, it is zero and no {feat-imp} calculation occurs.
 end::inference-config-regression-num-top-feature-importance-values[]
 


### PR DESCRIPTION
## Overview

This PR updates the links pointing to feature importance so that they open the new, dedicated page of the ML book.

## Dependency note

This PR depends on changes of https://github.com/elastic/stack-docs/pull/1004. The docs CI will not pass until that PR is merged.