### PR TITLE
[7.x] Validate REST specs against schema (#55117)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -119,6 +119,7 @@ dependencies {
   compile 'de.thetaphi:forbiddenapis:2.7'
   compile 'com.avast.gradle:gradle-docker-compose-plugin:0.8.12'
   compile 'org.apache.maven:maven-model:3.6.2'
+  compile 'com.networknt:json-schema-validator:1.0.36'
   compileOnly "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
   testCompile "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
   testCompile "junit:junit:${props.getProperty('junit')}"

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateJsonAgainstSchemaTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateJsonAgainstSchemaTask.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.precommit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaException;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.ChangeType;
+import org.gradle.work.Incremental;
+import org.gradle.work.InputChanges;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+/**
+ * Incremental task to validate a set of JSON files against against a schema.
+ */
+public class ValidateJsonAgainstSchemaTask extends DefaultTask {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private Set<String> ignore = new HashSet<>();
+    private File jsonSchema;
+    private FileCollection inputFiles;
+
+    @Incremental
+    @InputFiles
+    public FileCollection getInputFiles() {
+        return inputFiles;
+    }
+
+    public void setInputFiles(FileCollection inputFiles) {
+        this.inputFiles = inputFiles;
+    }
+
+    @InputFile
+    public File getJsonSchema() {
+        return jsonSchema;
+    }
+
+    public void setJsonSchema(File jsonSchema) {
+        this.jsonSchema = jsonSchema;
+    }
+
+    @Input
+    @Optional
+    public Set<String> getIgnore() {
+        return ignore;
+    }
+
+    public void ignore(String... ignore) {
+        this.ignore.addAll(Arrays.asList(ignore));
+    }
+
+    @OutputFile
+    public File getReport() {
+        return new File(getProject().getBuildDir(), "reports/validateJson.txt");
+    }
+
+    @TaskAction
+    public void validate(InputChanges inputChanges) throws IOException {
+        File jsonSchemaOnDisk = getJsonSchema();
+        getLogger().debug("JSON schema : [{}]", jsonSchemaOnDisk.getAbsolutePath());
+        SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+        JsonSchema jsonSchema = factory.getSchema(mapper.readTree(jsonSchemaOnDisk), config);
+        Map<File, Set<String>> errors = new LinkedHashMap<>();
+        // incrementally evaluate input files
+        StreamSupport.stream(inputChanges.getFileChanges(getInputFiles()).spliterator(), false)
+            .filter(f -> f.getChangeType() != ChangeType.REMOVED)
+            .forEach(fileChange -> {
+                File file = fileChange.getFile();
+                if (ignore.contains(file.getName())) {
+                    getLogger().debug("Ignoring file [{}] due to configuration", file.getName());
+                } else if (file.isDirectory() == false) {
+                    // validate all files and hold on to errors for a complete report if there are failures
+                    getLogger().debug("Validating JSON [{}]", file.getName());
+                    try {
+                        Set<ValidationMessage> validationMessages = jsonSchema.validate(mapper.readTree(file));
+                        maybeLogAndCollectError(validationMessages, errors, file);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+            });
+        if (errors.isEmpty()) {
+            Files.writeString(getReport().toPath(), "Success! No validation errors found.", StandardOpenOption.CREATE);
+        } else {
+            try (PrintWriter printWriter = new PrintWriter(getReport())) {
+                printWriter.printf("Schema: %s%n", jsonSchemaOnDisk);
+                printWriter.println("----------Validation Errors-----------");
+                errors.values().stream().flatMap(Collection::stream).forEach(printWriter::println);
+            }
+            StringBuilder sb = new StringBuilder();
+            sb.append("Error validating JSON. See the report at: ");
+            sb.append(getReport().toURI().toASCIIString());
+            sb.append(System.lineSeparator());
+            sb.append(
+                String.format("JSON validation failed: %d files contained %d violations", errors.keySet().size(), errors.values().size())
+            );
+            throw new JsonSchemaException(sb.toString());
+        }
+    }
+
+    private void maybeLogAndCollectError(Set<ValidationMessage> messages, Map<File, Set<String>> errors, File file) {
+        for (ValidationMessage message : messages) {
+            getLogger().error("[validate JSON][ERROR][{}][{}]", file.getName(), message.toString());
+            errors.computeIfAbsent(file, k -> new LinkedHashSet<>())
+                .add(String.format("%s: %s", file.getAbsolutePath(), message.toString()));
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateJsonAgainstSchemaTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateJsonAgainstSchemaTask.java
@@ -124,7 +124,9 @@ public class ValidateJsonAgainstSchemaTask extends DefaultTask {
                 }
             });
         if (errors.isEmpty()) {
-            Files.writeString(getReport().toPath(), "Success! No validation errors found.", StandardOpenOption.CREATE);
+            try (PrintWriter printWriter = new PrintWriter(getReport())) {
+                printWriter.println("Success! No validation errors found.");
+            }
         } else {
             try (PrintWriter printWriter = new PrintWriter(getReport())) {
                 printWriter.printf("Schema: %s%n", jsonSchemaOnDisk);

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateJsonAgainstSchemaTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateJsonAgainstSchemaTask.java
@@ -42,8 +42,6 @@ import org.gradle.work.InputChanges;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateRestSpecPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ValidateRestSpecPlugin.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.precommit;
+
+import org.elasticsearch.gradle.util.Util;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+
+import java.io.File;
+
+public class ValidateRestSpecPlugin implements Plugin<Project> {
+    private static final String DOUBLE_STAR = "**"; // checkstyle thinks these are javadocs :(
+
+    @Override
+    public void apply(Project project) {
+        Provider<ValidateJsonAgainstSchemaTask> validateRestSpecTask = project.getTasks()
+            .register("validateRestSpec", ValidateJsonAgainstSchemaTask.class, task -> {
+                task.setInputFiles(Util.getJavaTestAndMainSourceResources(project, filter -> {
+                    filter.include(DOUBLE_STAR + "/rest-api-spec/api/" + DOUBLE_STAR + "/*.json");
+                    filter.exclude(DOUBLE_STAR + "/_common.json");
+                }));
+                task.setJsonSchema(new File(project.getRootDir(), "rest-api-spec/src/main/resources/schema.json"));
+            });
+        project.getTasks().named("precommit").configure(t -> t.dependsOn(validateRestSpecTask));
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.validate-rest-spec.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.validate-rest-spec.properties
@@ -1,0 +1,1 @@
+implementation-class=org.elasticsearch.gradle.precommit.ValidateRestSpecPlugin

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask;
+apply plugin: 'elasticsearch.validate-rest-spec'
 
 esplugin {
   description 'An easy, safe and fast scripting language for Elasticsearch'
@@ -190,4 +192,8 @@ task regen {
       patternset(includes: 'Painless*.java')
     }
   }
+}
+
+validateRestSpec {
+  ignore 'scripts_painless_context.json'
 }

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
 apply plugin: 'elasticsearch.rest-resources'
+apply plugin: 'elasticsearch.validate-rest-spec'
 
 test.enabled = false
 jarHell.enabled = false
@@ -8,4 +9,8 @@ jarHell.enabled = false
 artifacts {
   restSpecs(new File(projectDir, "src/main/resources/rest-api-spec/api"))
   restTests(new File(projectDir, "src/main/resources/rest-api-spec/test"))
+}
+
+validateRestSpec {
+   ignore "cat.thread_pool.json"
 }

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -13,4 +13,5 @@ artifacts {
 
 validateRestSpec {
    ignore "cat.thread_pool.json"
+   ignore "indices.put_mapping.json"
 }

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -142,7 +142,7 @@
                 "description"
             ],
             "title": "Documentation",
-            "description": "API documentation including a link to the public reference and a short descritpion"
+            "description": "API documentation including a link to the public reference and a short description"
         },
         "Parts": {
             "type": "object",

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets
 apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.validate-rest-spec'
 
 archivesBaseName = 'x-pack'
 
@@ -155,3 +156,14 @@ testClusters.integTest {
   extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
 }
 
+validateRestSpec {
+  ignore 'searchable_snapshots.mount.json'
+  ignore 'searchable_snapshots.clear_cache.json'
+  ignore 'searchable_snapshots.stats.json'
+  ignore 'searchable_snapshots.repository_stats.json'
+  ignore 'autoscaling.delete_autoscaling_policy.json'
+  ignore 'autoscaling.get_autoscaling_policy.json'
+  ignore 'autoscaling.put_autoscaling_policy.json'
+  ignore 'ml.validate.json'
+  ignore 'ml.validate_detector.json'
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Validate REST specs against schema (#55117)