### PR TITLE
[TEST] Mute BWC tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,8 +183,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/55573" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
This is to allow https://github.com/elastic/elasticsearch/pull/55570
to be merged to 7.x without breaking all the master branch BWC tests.