### PR TITLE
Update the audit logfile list of system users

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
@@ -209,6 +209,10 @@ public class User implements ToXContentObject {
         output.writeBoolean(false); // last user written, regardless of bwc, does not have an inner user
     }
 
+    public static boolean isInternal(User user) {
+        return SystemUser.is(user) || XPackUser.is(user) || XPackSecurityUser.is(user) || AsyncSearchUser.is(user);
+    }
+
     /** Write just the given {@link User}, but not the inner {@link #authenticatedUser}. */
     private static void writeUser(User user, StreamOutput output) throws IOException {
         output.writeBoolean(false); // not a system user


### PR DESCRIPTION
Out of the box "access granted" audit events are not logged for system users. The list of  system users was stale and included only the `_system` and `_xpack` users. This commit expands this list with `_xpack_security` and `_async_search`, effectively reducing the auditing noise by not logging the audit events of these system users out of the box.

Closes https://github.com/elastic/elasticsearch/issues/37924