### PR TITLE
Ensure auto close of HTMLStripCharFilter in HtmlStripProcessor

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/HtmlStripProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/HtmlStripProcessor.java
@@ -41,13 +41,11 @@ public final class HtmlStripProcessor extends AbstractStringProcessor<String> {
             return value;
         }
 
-        HTMLStripCharFilter filter = new HTMLStripCharFilter(new StringReader(value));
-
         StringBuilder builder = new StringBuilder();
-        int ch;
-        try {
+        try (HTMLStripCharFilter filter = new HTMLStripCharFilter(new StringReader(value))) {
+            int ch;
             while ((ch = filter.read()) != -1) {
-                builder.append((char)ch);
+                builder.append((char) ch);
             }
         } catch (IOException e) {
             throw new ElasticsearchException(e);


### PR DESCRIPTION
The HtmlStripProcessor did not use a try-with resources block to ensure
that the used HTMLStripCharFilter is closed.
