### PR TITLE
Fix locale lowercase test issue in GenerateSnapshotNameStepTests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStepTests.java
@@ -12,11 +12,13 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 
+import java.util.Locale;
+
 import static org.elasticsearch.xpack.core.ilm.AbstractStepMasterTimeoutTestCase.emptyClusterState;
 import static org.elasticsearch.xpack.core.ilm.GenerateSnapshotNameStep.generateSnapshotName;
 import static org.elasticsearch.xpack.core.ilm.GenerateSnapshotNameStep.validateGeneratedSnapshotName;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -74,8 +76,8 @@ public class GenerateSnapshotNameStepTests extends AbstractStepTestCase<Generate
         assertThat("the " + GenerateSnapshotNameStep.NAME + " step must generate a snapshot name", executionState.getSnapshotName(),
             notNullValue());
         assertThat(executionState.getSnapshotRepository(), is(generateSnapshotNameStep.getSnapshotRepository()));
-        assertThat(executionState.getSnapshotName(), containsStringIgnoringCase(indexName));
-        assertThat(executionState.getSnapshotName(), containsStringIgnoringCase(policyName));
+        assertThat(executionState.getSnapshotName(), containsString(indexName.toLowerCase(Locale.ROOT)));
+        assertThat(executionState.getSnapshotName(), containsString(policyName.toLowerCase(Locale.ROOT)));
     }
 
     public void testNameGeneration() {


### PR DESCRIPTION
The testPerformAction test has been failing periodically due to
how Hamcrest's containsStringIgnoringCase does not lowercase using
the same Locale set in the test infrastructure.

This commit falls back to explicitly lowercasing using the root
locale

some reproducible test failures

```
./gradlew ':x-pack:plugin:core:test' --tests "org.elasticsearch.xpack.core.ilm.GenerateSnapshotNameStepTests.testPerformAction" -Dtests.seed=10BB1153AA216174 -Dtests.security.manager=true -Dtests.locale=tr -Dtests.timezone=America/Denver -Dcompiler.java=14

./gradlew ':x-pack:plugin:core:test' --tests "org.elasticsearch.xpack.core.ilm.GenerateSnapshotNameStepTests.testPerformAction" -Dtests.seed=696CF99078402E99 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:-UseConcMarkSweepGC -XX:-UseSerialGC -XX:+UseG1GC" -Dtests.locale=tr-TR -Dtests.timezone=SystemV/MST7 -Dcompiler.java=14
```