### PR TITLE
[backport] Add geo_bounds aggregation support for geo_shape (#55328)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorSupplier.java
@@ -30,7 +30,7 @@ import java.util.Map;
 @FunctionalInterface
 public interface GeoBoundsAggregatorSupplier extends AggregatorSupplier {
 
-    GeoBoundsAggregator build(String name, SearchContext aggregationContext, Aggregator parent,
+    MetricsAggregator build(String name, SearchContext aggregationContext, Aggregator parent,
                         ValuesSource valuesSource, boolean wrapLongitude,
                         Map<String, Object> metadata) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
@@ -32,16 +32,16 @@ import java.util.Map;
 import java.util.Objects;
 
 public class InternalGeoBounds extends InternalAggregation implements GeoBounds {
-    final double top;
-    final double bottom;
-    final double posLeft;
-    final double posRight;
-    final double negLeft;
-    final double negRight;
-    final boolean wrapLongitude;
+    public final double top;
+    public final double bottom;
+    public final double posLeft;
+    public final double posRight;
+    public final double negLeft;
+    public final double negRight;
+    public final boolean wrapLongitude;
 
-    InternalGeoBounds(String name, double top, double bottom, double posLeft, double posRight,
-                      double negLeft, double negRight, boolean wrapLongitude, Map<String, Object> metadata) {
+    public InternalGeoBounds(String name, double top, double bottom, double posLeft, double posRight,
+                             double negLeft, double negRight, boolean wrapLongitude, Map<String, Object> metadata) {
         super(name, metadata);
         this.top = top;
         this.bottom = bottom;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -12,7 +12,13 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.aggregations.metrics.GeoBoundsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.GeoBoundsAggregatorSupplier;
+import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.spatial.aggregations.metrics.GeoShapeBoundsAggregator;
+import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeValuesSource;
+import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
 import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
@@ -24,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 
@@ -50,7 +57,19 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, SearchPlug
     }
 
     @Override
+    public List<Consumer<ValuesSourceRegistry>> getBareAggregatorRegistrar() {
+        return org.elasticsearch.common.collect.List.of(SpatialPlugin::registerGeoShapeBoundsAggregator);
+    }
+
+    @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         return Collections.singletonMap(CircleProcessor.TYPE, new CircleProcessor.Factory());
+    }
+
+    public static void registerGeoShapeBoundsAggregator(ValuesSourceRegistry valuesSourceRegistry) {
+        valuesSourceRegistry.register(GeoBoundsAggregationBuilder.NAME, GeoShapeValuesSourceType.INSTANCE,
+            (GeoBoundsAggregatorSupplier) (name, aggregationContext, parent, valuesSource, wrapLongitude, metadata)
+                -> new GeoShapeBoundsAggregator(name, aggregationContext, parent, (GeoShapeValuesSource) valuesSource,
+                wrapLongitude, metadata));
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregator.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.aggregations.metrics;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.metrics.InternalGeoBounds;
+import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeValuesSource;
+import org.elasticsearch.xpack.spatial.index.mapper.MultiGeoShapeValues;
+
+import java.io.IOException;
+import java.util.Map;
+
+public final class GeoShapeBoundsAggregator extends MetricsAggregator {
+    private final GeoShapeValuesSource valuesSource;
+    private final boolean wrapLongitude;
+    private DoubleArray tops;
+    private DoubleArray bottoms;
+    private DoubleArray posLefts;
+    private DoubleArray posRights;
+    private DoubleArray negLefts;
+    private DoubleArray negRights;
+
+    public GeoShapeBoundsAggregator(String name, SearchContext aggregationContext, Aggregator parent,
+                             GeoShapeValuesSource valuesSource, boolean wrapLongitude, Map<String, Object> metadata) throws IOException {
+        super(name, aggregationContext, parent, metadata);
+        this.valuesSource = valuesSource;
+        this.wrapLongitude = wrapLongitude;
+        if (valuesSource != null) {
+            final BigArrays bigArrays = context.bigArrays();
+            tops = bigArrays.newDoubleArray(1, false);
+            tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
+            bottoms = bigArrays.newDoubleArray(1, false);
+            bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
+            posLefts = bigArrays.newDoubleArray(1, false);
+            posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
+            posRights = bigArrays.newDoubleArray(1, false);
+            posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
+            negLefts = bigArrays.newDoubleArray(1, false);
+            negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
+            negRights = bigArrays.newDoubleArray(1, false);
+            negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
+        }
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
+            LeafBucketCollector sub) {
+        if (valuesSource == null) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
+        }
+        final BigArrays bigArrays = context.bigArrays();
+        final MultiGeoShapeValues values = valuesSource.geoShapeValues(ctx);
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (bucket >= tops.size()) {
+                    long from = tops.size();
+                    tops = bigArrays.grow(tops, bucket + 1);
+                    tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
+                    bottoms = bigArrays.resize(bottoms, tops.size());
+                    bottoms.fill(from, bottoms.size(), Double.POSITIVE_INFINITY);
+                    posLefts = bigArrays.resize(posLefts, tops.size());
+                    posLefts.fill(from, posLefts.size(), Double.POSITIVE_INFINITY);
+                    posRights = bigArrays.resize(posRights, tops.size());
+                    posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
+                    negLefts = bigArrays.resize(negLefts, tops.size());
+                    negLefts.fill(from, negLefts.size(), Double.POSITIVE_INFINITY);
+                    negRights = bigArrays.resize(negRights, tops.size());
+                    negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
+                }
+
+                if (values.advanceExact(doc)) {
+                    final int valuesCount = values.docValueCount();
+
+                    for (int i = 0; i < valuesCount; ++i) {
+                        MultiGeoShapeValues.GeoShapeValue value = values.nextValue();
+                        MultiGeoShapeValues.BoundingBox bounds = value.boundingBox();
+                        double top = Math.max(tops.get(bucket), bounds.top);
+                        double bottom = Math.min(bottoms.get(bucket), bounds.bottom);
+                        double posLeft = Math.min(posLefts.get(bucket), bounds.posLeft);
+                        double posRight = Math.max(posRights.get(bucket), bounds.posRight);
+                        double negLeft = Math.min(negLefts.get(bucket), bounds.negLeft);
+                        double negRight = Math.max(negRights.get(bucket), bounds.negRight);
+                        tops.set(bucket, top);
+                        bottoms.set(bucket, bottom);
+                        posLefts.set(bucket, posLeft);
+                        posRights.set(bucket, posRight);
+                        negLefts.set(bucket, negLeft);
+                        negRights.set(bucket, negRight);
+                    }
+                }
+            }
+        };
+    }
+
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrdinal) {
+        if (valuesSource == null) {
+            return buildEmptyAggregation();
+        }
+        double top = tops.get(owningBucketOrdinal);
+        double bottom = bottoms.get(owningBucketOrdinal);
+        double posLeft = posLefts.get(owningBucketOrdinal);
+        double posRight = posRights.get(owningBucketOrdinal);
+        double negLeft = negLefts.get(owningBucketOrdinal);
+        double negRight = negRights.get(owningBucketOrdinal);
+        return new InternalGeoBounds(name, top, bottom, posLeft, posRight, negLeft, negRight, wrapLongitude, metadata());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalGeoBounds(name, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, wrapLongitude, metadata());
+    }
+
+    @Override
+    public void doClose() {
+        Releasables.close(tops, bottoms, posLefts, posRights, negLefts, negRights);
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeValuesSource.java
@@ -29,7 +29,7 @@ public abstract class GeoShapeValuesSource extends ValuesSource {
 
     };
 
-    abstract MultiGeoShapeValues geoShapeValues(LeafReaderContext context);
+    public abstract MultiGeoShapeValues geoShapeValues(LeafReaderContext context);
 
     @Override
     public DocValueBits docsWithValue(LeafReaderContext context) throws IOException {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeValuesSourceType.java
@@ -25,7 +25,7 @@ import java.util.function.LongSupplier;
 
 public class GeoShapeValuesSourceType implements Writeable, ValuesSourceType {
 
-    static GeoShapeValuesSourceType INSTANCE = new GeoShapeValuesSourceType();
+    public static GeoShapeValuesSourceType INSTANCE = new GeoShapeValuesSourceType();
 
     @Override
     public ValuesSource getEmpty() {
@@ -58,7 +58,7 @@ public class GeoShapeValuesSourceType implements Writeable, ValuesSourceType {
         final MultiGeoShapeValues.GeoShapeValue missing = MultiGeoShapeValues.GeoShapeValue.missing(rawMissing.toString());
         return new GeoShapeValuesSource() {
             @Override
-            MultiGeoShapeValues geoShapeValues(LeafReaderContext context) {
+            public MultiGeoShapeValues geoShapeValues(LeafReaderContext context) {
                 MultiGeoShapeValues values = geoShapeValuesSource.geoShapeValues(context);
                 return new MultiGeoShapeValues() {
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -35,6 +35,7 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TypeParsers;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.VectorGeoShapeQueryProcessor;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -168,6 +169,11 @@ public class GeoShapeWithDocValuesFieldMapper extends GeoShapeFieldMapper {
             } else {
                 return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
+        }
+
+        @Override
+        public ValuesSourceType getValuesSourceType() {
+            return GeoShapeValuesSourceType.INSTANCE;
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.spatial.aggregations.metrics;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LatLonDocValuesField;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.geo.GeoEncodingUtils;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.store.Directory;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.MultiPoint;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.metrics.GeoBoundsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalGeoBounds;
+import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.spatial.SpatialPlugin;
+import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
+import org.elasticsearch.xpack.spatial.index.mapper.CentroidCalculator;
+import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeValuesSourceType;
+import org.elasticsearch.xpack.spatial.index.mapper.GeoShapeWithDocValuesFieldMapper;
+import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
+    static final double GEOHASH_TOLERANCE = 1E-5D;
+
+    @BeforeClass()
+    public static void registerAggregator() {
+        SpatialPlugin.registerGeoShapeBoundsAggregator(valuesSourceRegistry);
+    }
+
+    public void testEmpty() throws Exception {
+        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("field")
+                .wrapLongitude(false);
+
+            MappedFieldType fieldType = new GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds bounds = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                assertTrue(Double.isInfinite(bounds.top));
+                assertTrue(Double.isInfinite(bounds.bottom));
+                assertTrue(Double.isInfinite(bounds.posLeft));
+                assertTrue(Double.isInfinite(bounds.posRight));
+                assertTrue(Double.isInfinite(bounds.negLeft));
+                assertTrue(Double.isInfinite(bounds.negRight));
+                assertFalse(AggregationInspectionHelper.hasValue(bounds));
+            }
+        }
+    }
+
+    public void testUnmappedFieldWithDocs() throws Exception {
+        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            if (randomBoolean()) {
+                Document doc = new Document();
+                doc.add(new LatLonDocValuesField("field", 0.0, 0.0));
+                w.addDocument(doc);
+            }
+
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("non_existent")
+                .wrapLongitude(false);
+
+            MappedFieldType fieldType = new GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds bounds = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                assertTrue(Double.isInfinite(bounds.top));
+                assertTrue(Double.isInfinite(bounds.bottom));
+                assertTrue(Double.isInfinite(bounds.posLeft));
+                assertTrue(Double.isInfinite(bounds.posRight));
+                assertTrue(Double.isInfinite(bounds.negLeft));
+                assertTrue(Double.isInfinite(bounds.negRight));
+                assertFalse(AggregationInspectionHelper.hasValue(bounds));
+            }
+        }
+    }
+
+    public void testMissing() throws Exception {
+        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("not_field", 1000L));
+            w.addDocument(doc);
+
+            MappedFieldType fieldType = new GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+
+            Point point = GeometryTestUtils.randomPoint(false);
+            double lon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(point.getX()));
+            double lat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(point.getY()));
+            Object missingVal = "POINT(" + lon + " " + lat + ")";
+
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("field")
+                .missing(missingVal)
+                .wrapLongitude(false);
+
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds bounds = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                assertThat(bounds.top, equalTo(lat));
+                assertThat(bounds.bottom, equalTo(lat));
+                assertThat(bounds.posLeft, equalTo(lon >= 0 ? lon : Double.POSITIVE_INFINITY));
+                assertThat(bounds.posRight, equalTo(lon >= 0 ? lon : Double.NEGATIVE_INFINITY));
+                assertThat(bounds.negLeft, equalTo(lon >= 0 ? Double.POSITIVE_INFINITY : lon));
+                assertThat(bounds.negRight, equalTo(lon >= 0 ? Double.NEGATIVE_INFINITY : lon));
+            }
+        }
+    }
+
+    public void testInvalidMissing() throws Exception {
+        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new NumericDocValuesField("not_field", 1000L));
+            w.addDocument(doc);
+
+            MappedFieldType fieldType = new GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("field")
+                .missing("invalid")
+                .wrapLongitude(false);
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+                    () -> search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType));
+                assertThat(exception.getMessage(), startsWith("Unknown geometry type"));
+            }
+        }
+    }
+
+    public void testRandomShapes() throws Exception {
+        double top = Double.NEGATIVE_INFINITY;
+        double bottom = Double.POSITIVE_INFINITY;
+        double posLeft = Double.POSITIVE_INFINITY;
+        double posRight = Double.NEGATIVE_INFINITY;
+        double negLeft = Double.POSITIVE_INFINITY;
+        double negRight = Double.NEGATIVE_INFINITY;
+        int numDocs = randomIntBetween(50, 100);
+        try (Directory dir = newDirectory();
+             RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                int numValues = randomIntBetween(1, 5);
+                List<Point> points = new ArrayList<>();
+                for (int j = 0; j < numValues; j++) {
+                    Point point = GeometryTestUtils.randomPoint(false);
+                    points.add(point);
+                    if (point.getLat() > top) {
+                        top = point.getLat();
+                    }
+                    if (point.getLat() < bottom) {
+                        bottom = point.getLat();
+                    }
+                    if (point.getLon() >= 0 && point.getLon() < posLeft) {
+                        posLeft = point.getLon();
+                    }
+                    if (point.getLon() >= 0 && point.getLon() > posRight) {
+                        posRight = point.getLon();
+                    }
+                    if (point.getLon() < 0 && point.getLon() < negLeft) {
+                        negLeft = point.getLon();
+                    }
+                    if (point.getLon() < 0 && point.getLon() > negRight) {
+                        negRight = point.getLon();
+                    }
+                }
+                Geometry geometry = new MultiPoint(points);
+                doc.add(new BinaryGeoShapeDocValuesField("field", GeoTestUtils.toDecodedTriangles(geometry),
+                    new CentroidCalculator(geometry)));
+                w.addDocument(doc);
+            }
+            GeoBoundsAggregationBuilder aggBuilder = new GeoBoundsAggregationBuilder("my_agg")
+                .field("field")
+                .wrapLongitude(false);
+
+            MappedFieldType fieldType = new GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType();
+            fieldType.setHasDocValues(true);
+            fieldType.setName("field");
+            try (IndexReader reader = w.getReader()) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                InternalGeoBounds bounds = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                assertThat(bounds.top, closeTo(top, GEOHASH_TOLERANCE));
+                assertThat(bounds.bottom, closeTo(bottom, GEOHASH_TOLERANCE));
+                assertThat(bounds.posLeft, closeTo(posLeft, GEOHASH_TOLERANCE));
+                assertThat(bounds.posRight, closeTo(posRight, GEOHASH_TOLERANCE));
+                assertThat(bounds.negRight, closeTo(negRight, GEOHASH_TOLERANCE));
+                assertThat(bounds.negLeft, closeTo(negLeft, GEOHASH_TOLERANCE));
+                assertTrue(AggregationInspectionHelper.hasValue(bounds));
+            }
+        }
+    }
+
+    @Override
+    protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
+        return new GeoBoundsAggregationBuilder("foo").field(fieldName);
+    }
+
+    @Override
+    protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
+        return List.of(GeoShapeValuesSourceType.INSTANCE);
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
@@ -226,6 +226,6 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
-        return List.of(GeoShapeValuesSourceType.INSTANCE);
+        return org.elasticsearch.common.collect.List.of(GeoShapeValuesSourceType.INSTANCE);
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/aggregations/metrics/GeoShapeBoundsAggregatorTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.metrics.GeoBoundsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.InternalGeoBounds;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
 import org.elasticsearch.xpack.spatial.index.mapper.BinaryGeoShapeDocValuesField;
@@ -226,6 +227,6 @@ public class GeoShapeBoundsAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
-        return org.elasticsearch.common.collect.List.of(GeoShapeValuesSourceType.INSTANCE);
+        return org.elasticsearch.common.collect.List.of(CoreValuesSourceType.GEOPOINT, GeoShapeValuesSourceType.INSTANCE);
     }
 }

--- a/x-pack/plugin/spatial/src/test/resources/rest-api-spec/test/10_geo_bounds.yml
+++ b/x-pack/plugin/spatial/src/test/resources/rest-api-spec/test/10_geo_bounds.yml
@@ -1,0 +1,34 @@
+---
+"Test geo_bounds aggregation on geo_shape field":
+  - do:
+      indices.create:
+        index: locations
+        body:
+          mappings:
+            properties:
+              location:
+                type: geo_shape
+
+  - do:
+      index:
+        index:  locations
+        id:     point_with_doc_values
+        body:   { location: "POINT(34.25 -21.76)" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: locations
+        size: 0
+        body:
+          aggs:
+            my_agg:
+              geo_bounds:
+                field: location
+                wrap_longitude: true
+  - match: {hits.total:      1    }
+  - match: { aggregations.my_agg.bounds.top_left.lat: -21.760000032372773 }
+  - match: { aggregations.my_agg.bounds.top_left.lon: 34.24999997019768 }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/110_geo_shape.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/110_geo_shape.yml
@@ -1,0 +1,45 @@
+---
+"Test mixed geo_shape indexing":
+  - skip:
+      version: "7.8.0 -"
+      reason: This is meant to run on 7.7 indices or earlier
+
+  - do:
+      indices.get_field_mapping:
+        index: old_locations
+        fields: location
+        include_defaults: true
+  - is_false: old_locations.mappings.location.mapping.location.doc_values
+
+  - do:
+      index:
+        index:  old_locations
+        id:     mixed_point_without_doc_value
+        body:   { location: "POINT(11.25 43.24)" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: old_locations
+        size: 10
+        body:
+          query:
+            match_all: {}
+  - match: {hits.total:      2    }
+  - length: {hits.hits:      2    }
+
+  - do:
+      catch: bad_request
+      search:
+        rest_total_hits_as_int: true
+        index: old_locations
+        size: 0
+        body:
+          aggs:
+            my_agg:
+              geo_bounds:
+                field: location
+                wrap_longitude: true

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/110_geo_shape.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/110_geo_shape.yml
@@ -1,0 +1,43 @@
+---
+"Test pre-7.8 geo_shape fields":
+  - skip:
+      version: "7.8.0 -"
+      reason: This is meant to run on 7.7 indices or earlier
+
+  - do:
+      indices.create:
+        index: old_locations
+        body:
+          mappings:
+            properties:
+              location:
+                type: geo_shape
+
+
+  - do:
+      indices.get_field_mapping:
+        index: old_locations
+        fields: location
+        include_defaults: true
+  - match: { old_locations.mappings.location.mapping.location.doc_values: null }
+
+  - do:
+      index:
+        index:  old_locations
+        id:     point
+        body:   { location: "POINT(34.25 -21.76)" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: old_locations
+        size: 1
+        body:
+          query:
+            match_all: {}
+  - match: {hits.total:      1    }
+  - length: {hits.hits:      1    }
+  - match: {hits.hits.0._id: "point" }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/110_geo_shape.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/110_geo_shape.yml
@@ -1,0 +1,41 @@
+---
+"Test upgraded > 7.7 cluster with pre-7.8 and 7.8+ geo_shape fields":
+  - do:
+      indices.create:
+        index: new_locations
+        body:
+          mappings:
+            properties:
+              location:
+                type: geo_shape
+
+  - do:
+      indices.get_field_mapping:
+        index: new_locations
+        fields: location
+        include_defaults: true
+  - is_true: new_locations.mappings.location.mapping.location.doc_values
+
+  - do:
+      index:
+        index:  new_locations
+        id:     upgraded_point_with_doc_values
+        body:   { location: "POINT(34.25 -21.76)" }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: new_locations
+        size: 0
+        body:
+          aggs:
+            my_agg:
+              geo_bounds:
+                field: location
+                wrap_longitude: true
+  - match: {hits.total:      1    }
+  - match: { aggregations.my_agg.bounds.top_left.lat: -21.760000032372773 }
+  - match: { aggregations.my_agg.bounds.top_left.lon: 34.24999997019768 }


### PR DESCRIPTION
backport of #55328 

This commit adds a new GeoShapeBoundsAggregator to the spatial plugin and registers it with the GeoShapeValuesSourceType. This enables geo_bounds aggregations on geo_shape fields
