### PR TITLE
update version boundary for geo_shape with doc values field

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -96,7 +96,7 @@ public class GeoShapeWithDocValuesFieldMapper extends GeoShapeFieldMapper {
 
         @Override
         public boolean defaultDocValues(Version indexCreated) {
-            return Version.V_8_0_0.onOrBefore(indexCreated);
+            return Version.V_7_8_0.onOrBefore(indexCreated);
         }
 
         protected Explicit<Boolean> docValues() {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -85,14 +85,14 @@ public class GeoShapeWithDocValuesFieldMapperTests extends ESSingleNodeTestCase 
         assertTrue(geoShapeFieldMapper.fieldType().hasDocValues());
     }
 
-    public void testDefaultDocValueConfigurationOnPre8() throws IOException {
+    public void testDefaultDocValueConfigurationOnPre7_8() throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
             .startObject("properties").startObject("location")
             .field("type", "geo_shape")
             .endObject().endObject()
             .endObject().endObject());
 
-        Version oldVersion = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
+        Version oldVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_8_0);
         DocumentMapper defaultMapper = createIndex("test", settings(oldVersion).build()).mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
         Mapper fieldMapper = defaultMapper.mappers().getMapper("location");


### PR DESCRIPTION
After backporting the geo_shape with doc-values field to 7.x(7.8),
this the version boundary for this feature can now be pulled from
8.0 to 7.8.

relates #55037.