### PR TITLE
[ML] Make find_file_structure recognize Kibana CSV report timestamps

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/TimestampFormatFinder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/TimestampFormatFinder.java
@@ -177,7 +177,12 @@ public final class TimestampFormatFinder {
         // This one is an ISO8601 date with no time, but the TIMESTAMP_ISO8601 Grok pattern doesn't cover it
         new CandidateTimestampFormat(example -> Collections.singletonList("ISO8601"),
             "\\b\\d{4}-\\d{2}-\\d{2}\\b", "\\b%{YEAR}-%{MONTHNUM2}-%{MONTHDAY}\\b", CUSTOM_TIMESTAMP_GROK_NAME,
-            "1111 11 11", 0, 0)
+            "1111 11 11", 0, 0),
+        // The Kibana export format
+        new CandidateTimestampFormat(example -> Collections.singletonList("MMM dd, yyyy @ HH:mm:ss.SSS"),
+            "\\b[A-Z]\\S{2} \\d{2}, \\d{4} @ \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b",
+            "\\b%{MONTH} %{MONTHDAY}, %{YEAR} @ %{HOUR}:%{MINUTE}:%{SECOND}\\b", CUSTOM_TIMESTAMP_GROK_NAME,
+            "    11  1111   11 11 11 111", 0, 0)
     );
 
     /**

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/filestructurefinder/TimestampFormatFinderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/filestructurefinder/TimestampFormatFinderTests.java
@@ -856,6 +856,10 @@ public class TimestampFormatFinderTests extends FileStructureTestCase {
         validateTimestampMatch("15/05/2018", "DATE", "\\b\\d{1,2}[/.-]\\d{1,2}[/.-](?:\\d{2}){1,2}\\b", "dd/MM/yyyy", 1526338800000L);
         validateTimestampMatch("15-05-2018", "DATE", "\\b\\d{1,2}[/.-]\\d{1,2}[/.-](?:\\d{2}){1,2}\\b", "dd-MM-yyyy", 1526338800000L);
         validateTimestampMatch("15.05.2018", "DATE", "\\b\\d{1,2}[/.-]\\d{1,2}[/.-](?:\\d{2}){1,2}\\b", "dd.MM.yyyy", 1526338800000L);
+
+        // The Kibana export format doesn't correspond to a built-in Grok pattern, so it has to be custom
+        validateTimestampMatch("May 15, 2018 @ 17:14:56.374", "CUSTOM_TIMESTAMP",
+            "\\b[A-Z]\\S{2} \\d{2}, \\d{4} @ \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\b", "MMM dd, yyyy @ HH:mm:ss.SSS", 1526400896374L);
     }
 
     public void testFindFormatGivenOnlySystemDate() {


### PR DESCRIPTION
The Kibana CSV export feature uses a non-standard timestamp format.
This change adds it to the formats the find_file_structure endpoint
recognizes out-of-the-box, to make round-tripping data from Kibana
back to Kibana via CSV files easier.

Fixes #55586