### PR TITLE
Fully stop RetryableAction when cancelled

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/RetryableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RetryableAction.java
@@ -123,6 +123,7 @@ public abstract class RetryableAction<Response> {
 
         @Override
         public void onResponse(Response response) {
+            retryTask = null;
             if (isDone.compareAndSet(false, true)) {
                 finalListener.onResponse(response);
             }

--- a/server/src/test/java/org/elasticsearch/action/support/RetryableActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/RetryableActionTests.java
@@ -201,7 +201,8 @@ public class RetryableActionTests extends ESTestCase {
         retryableAction.cancel(new ElasticsearchException("Cancelled"));
         taskQueue.runAllRunnableTasks();
 
-        assertEquals(2, executedCount.get());
+        // A second run will not occur because it is cancelled
+        assertEquals(1, executedCount.get());
         expectThrows(ElasticsearchException.class, future::actionGet);
     }
 }


### PR DESCRIPTION
Currently cancelling the RetryableAction does not stop one last run from
being executed. This commit makes a best effort attempt to cancel a
scheduled retry and guards future executions from the action already
being completed.