### PR TITLE
[7.7] Print runtime.java in test failures (#55515)

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -726,7 +726,8 @@ class BuildPlugin implements Plugin<Project> {
                 // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD
                 nonInputProperties.systemProperty('java.io.tmpdir', test.workingDir.toPath().resolve('temp'))
 
-                nonInputProperties.systemProperty('compiler.java', "${-> BuildParams.compilerJavaVersion.majorVersion}")
+                nonInputProperties.systemProperty('compiler.java', BuildParams.compilerJavaVersion.majorVersion)
+                nonInputProperties.systemProperty('runtime.java', BuildParams.runtimeJavaVersion.majorVersion)
 
                 // TODO: remove setting logging level via system property
                 test.systemProperty 'tests.logger.level', 'WARN'


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Print runtime.java in test failures (#55515)