### PR TITLE
Add a simple 'fetch fields' phase.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -56,6 +56,10 @@
         "type":"string",
         "description":"The field to use as default where no field prefix is given in the query string"
       },
+      "fields": {
+        "type":"list",
+        "description":"A comma-separated list of fields to retrieve as part of each hit"
+      },
       "explain":{
         "type":"boolean",
         "description":"Specify whether to return detailed information about score computation as part of a hit"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -1,0 +1,45 @@
+setup:
+  - skip:
+      version: " - 7.99.99"
+      reason: "fields retrieval is currently only implemented on master"
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              properties:
+                keyword:
+                  type: keyword
+                integer_range:
+                  type: integer_range
+
+  - do:
+      index:
+          index:  test
+          id:     1
+          body:
+            keyword: [ "first", "second" ]
+            integer_range:
+              gte: 0
+              lte: 42
+
+  - do:
+      indices.refresh:
+          index: [ test ]
+
+---
+"Test basic field retrieval":
+  - do:
+      search:
+        index: test
+        body:
+          fields: [keyword, integer_range]
+
+  - is_true: hits.hits.0._id
+  - is_true: hits.hits.0._source
+
+  - match: { hits.hits.0.fields.keyword.0: first }
+  - match: { hits.hits.0.fields.keyword.1: second }
+
+  - match: { hits.hits.0.fields.integer_range.0.gte: 0 }
+  - match: { hits.hits.0.fields.integer_range.0.lte: 42 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -303,6 +303,11 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         return addDocValueField(name, null);
     }
 
+    public SearchRequestBuilder addFetchField(String name) {
+        sourceBuilder().fetchField(name);
+        return this;
+    }
+
     /**
      * Adds a stored field to load and return (note, it must be stored) as part of the search request.
      */

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -113,10 +113,9 @@ public class DocumentField implements Writeable, ToXContentFragment, Iterable<Ob
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(name);
         for (Object value : values) {
-            // this call doesn't really need to support writing any kind of object.
-            // Stored fields values are converted using MappedFieldType#valueForDisplay.
-            // As a result they can either be Strings, Numbers, or Booleans, that's
-            // all.
+            // This call doesn't really need to support writing any kind of object, since the values
+            // here are always serializable to xContent. Each value could be a leaf types like a string,
+            // number, or boolean, a list of such values, or a map of such values with string keys.
             builder.value(value);
         }
         builder.endArray();

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -56,6 +56,7 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight;
@@ -111,6 +112,7 @@ final class DefaultSearchContext extends SearchContext {
     private ScriptFieldsContext scriptFields;
     private FetchSourceContext fetchSourceContext;
     private FetchDocValuesContext docValuesContext;
+    private FetchFieldsContext fetchFieldsContext;
     private int from = -1;
     private int size = -1;
     private SortAndFormats sort;
@@ -451,6 +453,17 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public SearchContext docValuesContext(FetchDocValuesContext docValuesContext) {
         this.docValuesContext = docValuesContext;
+        return this;
+    }
+
+    @Override
+    public FetchFieldsContext fetchFieldsContext() {
+        return fetchFieldsContext;
+    }
+
+    @Override
+    public SearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext) {
+        this.fetchFieldsContext = fetchFieldsContext;
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -218,6 +218,7 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.subphase.ExplainPhase;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesPhase;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsPhase;
 import org.elasticsearch.search.fetch.subphase.FetchScorePhase;
 import org.elasticsearch.search.fetch.subphase.FetchSourcePhase;
 import org.elasticsearch.search.fetch.subphase.FetchVersionPhase;
@@ -714,6 +715,7 @@ public class SearchModule {
         registerFetchSubPhase(new FetchDocValuesPhase());
         registerFetchSubPhase(new ScriptFieldsPhase());
         registerFetchSubPhase(new FetchSourcePhase());
+        registerFetchSubPhase(new FetchFieldsPhase());
         registerFetchSubPhase(new FetchVersionPhase());
         registerFetchSubPhase(new SeqNoPrimaryTermPhase());
         registerFetchSubPhase(new MatchedQueriesPhase());

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -85,6 +85,7 @@ import org.elasticsearch.search.fetch.QueryFetchSearchResult;
 import org.elasticsearch.search.fetch.ScrollQueryFetchSearchResult;
 import org.elasticsearch.search.fetch.ShardFetchRequest;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext.ScriptField;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -928,6 +929,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         + IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.getKey() + "] index level setting.");
             }
             context.docValuesContext(new FetchDocValuesContext(docValueFields));
+        }
+        if (source.fetchFields() != null) {
+            context.fetchFieldsContext(new FetchFieldsContext(source.fetchFields()));
         }
         if (source.highlighter() != null) {
             HighlightBuilder highlightBuilder = source.highlighter();

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -249,9 +249,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         trackTotalHitsUpTo = in.readOptionalInt();
 
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            if (in.readBoolean()) {
-                fetchFields = in.readStringList();
-            }
+            fetchFields = in.readOptionalStringList();
         }
     }
 
@@ -309,10 +307,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalInt(trackTotalHitsUpTo);
 
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeBoolean(fetchFields != null);
-            if (fetchFields != null) {
-                out.writeStringCollection(fetchFields);
-            }
+            out.writeOptionalStringCollection(fetchFields);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.builder;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
@@ -94,6 +95,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public static final ParseField _SOURCE_FIELD = new ParseField("_source");
     public static final ParseField STORED_FIELDS_FIELD = new ParseField("stored_fields");
     public static final ParseField DOCVALUE_FIELDS_FIELD = new ParseField("docvalue_fields");
+    public static final ParseField FETCH_FIELDS_FIELD = new ParseField("fields");
     public static final ParseField SCRIPT_FIELDS_FIELD = new ParseField("script_fields");
     public static final ParseField SCRIPT_FIELD = new ParseField("script");
     public static final ParseField IGNORE_FAILURE_FIELD = new ParseField("ignore_failure");
@@ -170,6 +172,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     private List<FieldAndFormat> docValueFields;
     private List<ScriptField> scriptFields;
     private FetchSourceContext fetchSourceContext;
+    private List<String> fetchFields;
 
     private AggregatorFactories.Builder aggregations;
 
@@ -244,6 +247,12 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         sliceBuilder = in.readOptionalWriteable(SliceBuilder::new);
         collapse = in.readOptionalWriteable(CollapseBuilder::new);
         trackTotalHitsUpTo = in.readOptionalInt();
+
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            if (in.readBoolean()) {
+                fetchFields = in.readStringList();
+            }
+        }
     }
 
     @Override
@@ -298,6 +307,13 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         out.writeOptionalWriteable(sliceBuilder);
         out.writeOptionalWriteable(collapse);
         out.writeOptionalInt(trackTotalHitsUpTo);
+
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeBoolean(fetchFields != null);
+            if (fetchFields != null) {
+                out.writeStringCollection(fetchFields);
+            }
+        }
     }
 
     /**
@@ -826,6 +842,24 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     }
 
     /**
+     * Gets the fields to load and return as part of the search request.
+     */
+    public List<String> fetchFields() {
+        return fetchFields;
+    }
+
+    /**
+     * Adds a field to load and return as part of the search request.
+     */
+    public SearchSourceBuilder fetchField(String fieldName) {
+        if (fetchFields == null) {
+            fetchFields = new ArrayList<>();
+        }
+        fetchFields.add(fieldName);
+        return this;
+    }
+
+    /**
      * Adds a script field under the given name with the provided script.
      *
      * @param name
@@ -1120,6 +1154,11 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         docValueFields.add(FieldAndFormat.fromXContent(parser));
                     }
+                } else if (FETCH_FIELDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    fetchFields = new ArrayList<>();
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        fetchFields.add(parser.text());
+                    }
                 } else if (INDICES_BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         indexBoosts.add(new IndexBoost(parser));
@@ -1225,6 +1264,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 builder.endObject();
             }
             builder.endArray();
+        }
+
+        if (fetchFields != null) {
+            builder.array(FETCH_FIELDS_FIELD.getPreferredName(), fetchFields);
         }
 
         if (scriptFields != null) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsContext.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.fetch.subphase;
+
+import java.util.List;
+
+/**
+ * The context needed to retrieve fields.
+ */
+public class FetchFieldsContext {
+
+    private final List<String> fields;
+
+    public FetchFieldsContext(List<String> fields) {
+        this.fields = fields;
+    }
+
+    public List<String> fields() {
+        return this.fields;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -53,6 +53,9 @@ public final class FetchFieldsPhase implements FetchSubPhase {
 
         Set<String> fields = new HashSet<>();
         for (String fieldPattern : context.fetchFieldsContext().fields()) {
+            if (documentMapper.objectMappers().containsKey(fieldPattern)) {
+                continue;
+            }
             Collection<String> concreteFields = context.mapperService().simpleMatchToFullName(fieldPattern);
             fields.addAll(concreteFields);
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.subphase;
+
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.lookup.SourceLookup;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A fetch sub-phase for high-level field retrieval. Given a list of fields, it
+ * retrieves the field values from _source and returns them as document fields.
+ */
+public final class FetchFieldsPhase implements FetchSubPhase {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void hitExecute(SearchContext context, HitContext hitContext) {
+        FetchFieldsContext fetchFieldsContext = context.fetchFieldsContext();
+        if (fetchFieldsContext == null || fetchFieldsContext.fields().isEmpty()) {
+            return;
+        }
+
+        DocumentMapper documentMapper = context.mapperService().documentMapper();
+        if (documentMapper.sourceMapper().enabled() == false) {
+            throw new IllegalArgumentException("Unable to retrieve the requested [fields] since _source is " +
+                "disabled in the mappings for index [" + context.indexShard().shardId().getIndexName() + "]");
+        }
+
+        Set<String> fields = new HashSet<>();
+        for (String fieldPattern : context.fetchFieldsContext().fields()) {
+            Collection<String> concreteFields = context.mapperService().simpleMatchToFullName(fieldPattern);
+            fields.addAll(concreteFields);
+        }
+
+        SourceLookup sourceLookup = context.lookup().source();
+        Map<String, Object> valuesByField = sourceLookup.extractValues(fields);
+
+        for (Map.Entry<String, Object> entry : valuesByField.entrySet()) {
+            String field = entry.getKey();
+            Object value = entry.getValue();
+            List<Object> values = value instanceof List
+                ? (List<Object>) value
+                : List.of(value);
+
+            DocumentField documentField = new DocumentField(field, values);
+            hitContext.hit().setField(field, documentField);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -50,6 +50,7 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.fetch.subphase.InnerHitsContext;
 import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext;
@@ -200,6 +201,10 @@ public abstract class SearchContext extends AbstractRefCounted implements Releas
     public abstract FetchDocValuesContext docValuesContext();
 
     public abstract SearchContext docValuesContext(FetchDocValuesContext docValuesContext);
+
+    public abstract FetchFieldsContext fetchFieldsContext();
+
+    public abstract SearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext);
 
     public abstract ContextIndexSearcher searcher();
 

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -202,8 +202,14 @@ public abstract class SearchContext extends AbstractRefCounted implements Releas
 
     public abstract SearchContext docValuesContext(FetchDocValuesContext docValuesContext);
 
+    /**
+     * Contains the context related to retrieving fields.
+     */
     public abstract FetchFieldsContext fetchFieldsContext();
 
+    /**
+     * Sets the context related to retrieving fields.
+     */
     public abstract SearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext);
 
     public abstract ContextIndexSearcher searcher();

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -203,7 +203,7 @@ public abstract class SearchContext extends AbstractRefCounted implements Releas
     public abstract SearchContext docValuesContext(FetchDocValuesContext docValuesContext);
 
     /**
-     * Contains the context related to retrieving fields.
+     * The context related to retrieving fields.
      */
     public abstract FetchFieldsContext fetchFieldsContext();
 

--- a/server/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -26,6 +26,7 @@ import org.elasticsearch.search.collapse.CollapseContext;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight;
@@ -59,6 +60,7 @@ public class SubSearchContext extends FilteredSearchContext {
     private ScriptFieldsContext scriptFields;
     private FetchSourceContext fetchSourceContext;
     private FetchDocValuesContext docValuesContext;
+    private FetchFieldsContext fetchFieldsContext;
     private SearchContextHighlight highlight;
 
     private boolean explain;
@@ -157,6 +159,17 @@ public class SubSearchContext extends FilteredSearchContext {
     @Override
     public SearchContext docValuesContext(FetchDocValuesContext docValuesContext) {
         this.docValuesContext = docValuesContext;
+        return this;
+    }
+
+    @Override
+    public FetchFieldsContext fetchFieldsContext() {
+        return fetchFieldsContext;
+    }
+
+    @Override
+    public SearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext) {
+        this.fetchFieldsContext = fetchFieldsContext;
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -127,22 +126,6 @@ public class SourceLookup implements Map<String, Object> {
      */
     public List<Object> extractRawValues(String path) {
         return XContentMapValues.extractRawValues(path, loadSourceIfNeeded());
-    }
-
-    /**
-     * For each of the provided paths, return its value in the source. Note that
-     */
-    public Map<String, Object> extractValues(Collection<String> paths) {
-        Map<String, Object> source = loadSourceIfNeeded();
-        Map<String, Object> result = new HashMap<>(paths.size());
-
-        for (String path : paths) {
-            Object value = XContentMapValues.extractValue(path, source);
-            if (value != null) {
-                result.put(path, value);
-            }
-        }
-        return result;
     }
 
     public Object filter(FetchSourceContext context) {

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -129,6 +129,9 @@ public class SourceLookup implements Map<String, Object> {
         return XContentMapValues.extractRawValues(path, loadSourceIfNeeded());
     }
 
+    /**
+     * For each of the provided paths, return its value in the source. Note that
+     */
     public Map<String, Object> extractValues(Collection<String> paths) {
         Map<String, Object> source = loadSourceIfNeeded();
         Map<String, Object> result = new HashMap<>(paths.size());

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,6 +127,19 @@ public class SourceLookup implements Map<String, Object> {
      */
     public List<Object> extractRawValues(String path) {
         return XContentMapValues.extractRawValues(path, loadSourceIfNeeded());
+    }
+
+    public Map<String, Object> extractValues(Collection<String> paths) {
+        Map<String, Object> source = loadSourceIfNeeded();
+        Map<String, Object> result = new HashMap<>(paths.size());
+
+        for (String path : paths) {
+            Object value = XContentMapValues.extractValue(path, source);
+            if (value != null) {
+                result.put(path, value);
+            }
+        }
+        return result;
     }
 
     public Object filter(FetchSourceContext context) {

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -188,7 +188,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         XContentType xContentType = randomFrom(XContentType.values());
         SearchHit searchHit = createTestItem(xContentType, true, true);
         BytesReference originalBytes = toXContent(searchHit, xContentType, true);
-        Predicate<String> pathsToExclude = path -> (path.endsWith("highlight") || path.endsWith("fields") || path.contains("_source")
+        Predicate<String> pathsToExclude = path -> (path.endsWith("highlight") || path.contains("fields") || path.contains("_source")
                 || path.contains("inner_hits"));
         BytesReference withRandomFields = insertRandomFields(xContentType, originalBytes, pathsToExclude, random());
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhaseTests.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.fetch.subphase;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.TestSearchContext;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+
+public class FetchFieldsPhaseTests extends ESSingleNodeTestCase {
+
+    private IndexService indexService;
+
+    @Before
+    public void setupIndex() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
+            .startObject("properties")
+                .startObject("field").field("type", "keyword").endObject()
+                .startObject("integer_field").field("type", "integer").endObject()
+                .startObject("float_range").field("type", "float_range").endObject()
+                .startObject("object")
+                    .startObject("properties")
+                        .startObject("field").field("type", "keyword").endObject()
+                    .endObject()
+                .endObject()
+                .startObject("field_that_does_not_match").field("type", "keyword").endObject()
+            .endObject()
+        .endObject();
+        indexService = createIndex("index", Settings.EMPTY, mapping);
+    }
+
+    public void testLeafValues() throws IOException {
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .array("field", "first", "second")
+            .startObject("object")
+                .field("field", "third")
+            .endObject()
+        .endObject();
+
+        FetchSubPhase.HitContext hitContext = hitExecute(indexService, source, List.of("field", "object.field"));
+        assertThat(hitContext.hit().getFields().size(), equalTo(2));
+
+        DocumentField field = hitContext.hit().getFields().get("field");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(2));
+        assertThat(field.getValues(), hasItems("first", "second"));
+
+        DocumentField objectField = hitContext.hit().getFields().get("object.field");
+        assertNotNull(objectField);
+        assertThat(objectField.getValues().size(), equalTo(1));
+        assertThat(objectField.getValues(), hasItems("third"));
+    }
+
+    public void testObjectValues() throws IOException {
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .startObject("float_range")
+                .field("gte", 0.0)
+                .field("lte", 2.718)
+            .endObject()
+        .endObject();
+
+        FetchSubPhase.HitContext hitContext = hitExecute(indexService, source, "float_range");
+        assertThat(hitContext.hit().getFields().size(), equalTo(1));
+
+        DocumentField rangeField = hitContext.hit().getFields().get("float_range");
+        assertNotNull(rangeField);
+        assertThat(rangeField.getValues().size(), equalTo(1));
+        assertThat(rangeField.getValue(), equalTo(Map.of("gte", 0.0, "lte", 2.718)));
+    }
+
+    public void testFieldNamesWithWildcard() throws IOException {
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .array("field", "first", "second")
+            .field("integer_field", "third")
+            .startObject("object")
+                .field("field", "fourth")
+            .endObject()
+        .endObject();
+
+        FetchSubPhase.HitContext hitContext = hitExecute(indexService, source, "*field");
+        assertThat(hitContext.hit().getFields().size(), equalTo(3));
+
+        DocumentField field = hitContext.hit().getFields().get("field");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(2));
+        assertThat(field.getValues(), hasItems("first", "second"));
+
+        DocumentField otherField = hitContext.hit().getFields().get("integer_field");
+        assertNotNull(otherField);
+        assertThat(otherField.getValues().size(), equalTo(1));
+        assertThat(otherField.getValues(), hasItems("third"));
+
+        DocumentField objectField = hitContext.hit().getFields().get("object.field");
+        assertNotNull(objectField);
+        assertThat(objectField.getValues().size(), equalTo(1));
+        assertThat(objectField.getValues(), hasItems("fourth"));
+    }
+
+    public void testSourceDisabled() throws IOException {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
+            .startObject("_source").field("enabled", false).endObject()
+            .startObject("properties")
+                .startObject("field").field("type", "keyword").endObject()
+            .endObject()
+        .endObject();
+
+        IndexService sourceDisabledIndexService = createIndex("disabled-index", Settings.EMPTY, mapping);
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .field("field", "value")
+        .endObject();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> hitExecute(sourceDisabledIndexService, source, "field"));
+        assertThat(e.getMessage(), containsString("Unable to retrieve the requested [fields] since _source is disabled in the mapping"));
+    }
+
+    public void testNonExistentFields() throws IOException {
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .field("field", "value")
+            .endObject();
+
+        FetchSubPhase.HitContext hitContext = hitExecute(indexService, source, "non_existent");
+        assertFalse(hitContext.hit().getFields().containsKey("non_existent"));
+    }
+
+    private FetchSubPhase.HitContext hitExecute(IndexService indexService, XContentBuilder source, String field) {
+        return hitExecute(indexService, source, List.of(field));
+    }
+
+    private FetchSubPhase.HitContext hitExecute(IndexService indexService, XContentBuilder source, List<String> fields) {
+        FetchFieldsContext fetchFieldsContext = new FetchFieldsContext(fields);
+        BytesReference sourceAsBytes = source != null ? BytesReference.bytes(source) : null;
+        SearchContext searchContext = new FetchFieldsPhaseTestSearchContext(indexService, fetchFieldsContext, sourceAsBytes);
+
+        FetchSubPhase.HitContext hitContext = new FetchSubPhase.HitContext();
+        SearchHit searchHit = new SearchHit(1, null, null, null, null);
+        hitContext.reset(searchHit, null, 1, null);
+
+        FetchFieldsPhase phase = new FetchFieldsPhase();
+        phase.hitExecute(searchContext, hitContext);
+        return hitContext;
+    }
+
+    private static class FetchFieldsPhaseTestSearchContext extends TestSearchContext {
+        private final FetchFieldsContext context;
+        private final BytesReference source;
+
+        FetchFieldsPhaseTestSearchContext(IndexService indexService,
+                                          FetchFieldsContext context,
+                                          BytesReference source) {
+            super(indexService.getBigArrays(), indexService);
+            this.context = context;
+            this.source = source;
+        }
+
+        @Override
+        public FetchFieldsContext fetchFieldsContext() {
+            return context;
+        }
+
+        @Override
+        public SearchLookup lookup() {
+            SearchLookup lookup = new SearchLookup(this.mapperService(), this::getForField);
+            lookup.source().setSource(source);
+            return lookup;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhaseTests.java
@@ -157,6 +157,18 @@ public class FetchFieldsPhaseTests extends ESSingleNodeTestCase {
         assertFalse(hitContext.hit().getFields().containsKey("non_existent"));
     }
 
+    public void testObjectFields() throws IOException {
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .array("field", "first", "second")
+            .startObject("object")
+                .field("field", "third")
+            .endObject()
+        .endObject();
+
+        FetchSubPhase.HitContext hitContext = hitExecute(indexService, source, "object");
+        assertFalse(hitContext.hit().getFields().containsKey("object"));
+    }
+
     private FetchSubPhase.HitContext hitExecute(IndexService indexService, XContentBuilder source, String field) {
         return hitExecute(indexService, source, List.of(field));
     }

--- a/server/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
@@ -87,7 +87,7 @@ public class CompletionSuggestionOptionTests extends ESTestCase {
             // also there can be inner search hits fields inside this option, we need to exclude another couple of paths
             // where we cannot add random stuff
             Predicate<String> excludeFilter = (path) -> (path.endsWith(CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName())
-                    || path.endsWith("highlight") || path.endsWith("fields") || path.contains("_source") || path.contains("inner_hits"));
+                    || path.endsWith("highlight") || path.contains("fields") || path.contains("_source") || path.contains("inner_hits"));
             mutated = insertRandomFields(xContentType, originalBytes, excludeFilter, random());
         } else {
             mutated = originalBytes;

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
@@ -104,7 +104,7 @@ public class SuggestionEntryTests extends ESTestCase {
                 // where we cannot add random stuff
                 Predicate<String> excludeFilter = (
                         path) -> (path.endsWith(CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName()) || path.endsWith("highlight")
-                                || path.endsWith("fields") || path.contains("_source") || path.contains("inner_hits"));
+                                || path.contains("fields") || path.contains("_source") || path.contains("inner_hits"));
                 mutated = insertRandomFields(xContentType, originalBytes, excludeFilter, random());
             } else {
                 mutated = originalBytes;

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -124,7 +124,7 @@ public class SuggestionTests extends ESTestCase {
                 // - the root object should be excluded since it contains the named suggestion arrays
                 Predicate<String> excludeFilter = path -> (path.isEmpty()
                         || path.endsWith(CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName()) || path.endsWith("highlight")
-                        || path.endsWith("fields") || path.contains("_source") || path.contains("inner_hits"));
+                        || path.contains("fields") || path.contains("_source") || path.contains("inner_hits"));
                 mutated = insertRandomFields(xContentType, originalBytes, excludeFilter, random());
             } else {
                 mutated = originalBytes;

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -46,6 +46,7 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.StoredFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
+import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight;
@@ -268,6 +269,16 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public SearchContext docValuesContext(FetchDocValuesContext docValuesContext) {
+        return null;
+    }
+
+    @Override
+    public FetchFieldsContext fetchFieldsContext() {
+        return null;
+    }
+
+    @Override
+    public SearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext) {
         return null;
     }
 


### PR DESCRIPTION
Note: the PR is opened against the `field-retrieval` feature branch.

Currently the phase just looks up each field name in the _source and returns its values in the 'fields' section of the response. This PR just lays out the initial class structure and tests -- much of the interesting functionality will come in subsequent PRs.

Known issues that will be addressed in future commits:
* Fields like geopoints whose value can be an array are not handled correctly. Without consulting the mapping, it's not possible to know if it's a multi-valued field, or a single field with an array value.
* We take a very simple approach to loading the values from _source. I've had discussions with the scripting team about a new `SourceLookup` method they have planned to efficiently load particular values: https://github.com/elastic/elasticsearch/issues/52591. I plan to make use of this when it's available, but for now added a placeholder method `extractValues`.

Relates to #55363.