### PR TITLE
fix test testDefaultDocValueConfigurationOnPre7_8 after backporting

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -85,7 +85,6 @@ public class GeoShapeWithDocValuesFieldMapperTests extends ESSingleNodeTestCase 
         assertTrue(geoShapeFieldMapper.fieldType().hasDocValues());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/55644")
     public void testDefaultDocValueConfigurationOnPre7_8() throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type1")
             .startObject("properties").startObject("location")
@@ -93,7 +92,7 @@ public class GeoShapeWithDocValuesFieldMapperTests extends ESSingleNodeTestCase 
             .endObject().endObject()
             .endObject().endObject());
 
-        Version oldVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_8_0);
+        Version oldVersion = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_7_0);
         DocumentMapper defaultMapper = createIndex("test", settings(oldVersion).build()).mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
         Mapper fieldMapper = defaultMapper.mappers().getMapper("location");


### PR DESCRIPTION
The test is failing after back porting as version 7.8 does support now doc values. Lowering down to 7.7 the old versions.

closes https://github.com/elastic/elasticsearch/issues/55644