### PR TITLE
Cleanup AbstractSnapshotIntegTest (#55579)

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
@@ -236,5 +237,12 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
     public static void unblockNode(final String repository, final String node) {
         ((MockRepository)internalCluster().getInstance(RepositoriesService.class, node).repository(repository)).unblock();
+    }
+
+    protected void createRepository(String repoName, String type, Path location) {
+        logger.info("-->  creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository(repoName)
+                .setType(type)
+                .setSettings(Settings.builder().put("location", location)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.translog.BufferedChecksumStreamOutput;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat;
 import org.elasticsearch.snapshots.mockstore.BlobContainerWrapper;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -54,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
+public class BlobStoreFormatTests extends ESTestCase {
 
     public static final String BLOB_CODEC = "blob";
 
@@ -232,7 +233,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
     }
 
     protected BlobStore createTestBlobStore() throws IOException {
-        return new FsBlobStore(Settings.EMPTY, randomRepoPath(), false);
+        return new FsBlobStore(Settings.EMPTY, createTempDir(), false);
     }
 
     protected void randomCorruption(BlobContainer blobContainer, String blobName) throws IOException {
@@ -259,5 +260,4 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
             }
         }
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -78,10 +78,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshot1 = "snap-1";
         final String repo = "test-repo";
-        logger.info("--> creating repository");
-        assertThat(client().admin().cluster().preparePutRepository(repo)
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())).execute().actionGet().isAcknowledged(),
-            is(true));
+        createRepository(repo, "fs", randomRepoPath());
 
         logger.info("--> creating snapshot 1");
         client().admin().cluster().prepareCreateSnapshot(repo, snapshot1).setIndices(indexName).setWaitForCompletion(true).get();
@@ -155,10 +152,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshot1 = "snap-1";
         final String repo = "test-repo";
-        logger.info("--> creating repository");
-        assertThat(client().admin().cluster().preparePutRepository(repo)
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())).execute().actionGet().isAcknowledged(),
-            is(true));
+        createRepository(repo, "fs", randomRepoPath());
 
         logger.info("--> creating snapshot 1");
         client().admin().cluster().prepareCreateSnapshot(repo, snapshot1).setIndices(indexName).setWaitForCompletion(true).get();

--- a/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -216,10 +216,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         setSettingValue.accept("new value");
         assertSettingValue.accept("new value");
 
-        logger.info("--> create repository");
-        AcknowledgedResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())).execute().actionGet();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         logger.info("--> start snapshot");
         CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
@@ -268,10 +265,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             return builder.build();
         });
 
-        logger.info("--> create repository");
-        AcknowledgedResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", tempDir)).execute().actionGet();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo", "fs", tempDir);
 
         logger.info("--> start snapshot");
         CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
@@ -307,10 +301,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> delete repository");
         assertAcked(client.admin().cluster().prepareDeleteRepository("test-repo"));
 
-        logger.info("--> create repository");
-        putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo-2")
-                .setType("fs").setSettings(Settings.builder().put("location", tempDir)).execute().actionGet();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo-2", "fs", tempDir);
 
         logger.info("--> restore snapshot");
         client.admin().cluster().prepareRestoreSnapshot("test-repo-2", "test-snap").setRestoreGlobalState(true).setIndices("-*")
@@ -394,7 +385,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         refresh();
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
 
-        logger.info("--> create repository");
         logger.info("--> creating repository");
         AcknowledgedResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo")
                 .setType("mock").setSettings(
@@ -554,10 +544,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .put("number_of_replicas", 0)).setWaitForActiveShards(ActiveShardCount.NONE).get());
         assertTrue(client().admin().indices().prepareExists("test-idx-none").get().isExists());
 
-        logger.info("--> creating repository");
-        AcknowledgedResponse putRepositoryResponse = client().admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())).execute().actionGet();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         logger.info("--> start snapshot with default settings without a closed index - should fail");
         CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap-1")
@@ -676,10 +663,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         internalCluster().startNodes(2, nodeSettings);
         cluster().wipeIndices("_all");
 
-        logger.info("--> create repository");
-        AcknowledgedResponse putRepositoryResponse = client().admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())).execute().actionGet();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo", "fs", randomRepoPath());
+
         int numberOfShards = 6;
         logger.info("--> create an index that will have some unallocated shards");
         assertAcked(prepareCreate("test-idx", 2, Settings.builder().put("number_of_shards", numberOfShards)
@@ -1106,12 +1091,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             client.prepareIndex(indexName, "type").setSource("test", "init").execute().actionGet();
         }
 
-        logger.info("--> register a repository");
-
         final Path repoPath = randomRepoPath();
-        assertAcked(client.admin().cluster().preparePutRepository(repositoryName)
-            .setType("fs")
-            .setSettings(Settings.builder().put("location", repoPath)));
+        createRepository(repositoryName, "fs", repoPath);
 
         logger.info("--> create a snapshot");
         client.admin().cluster().prepareCreateSnapshot(repositoryName, snapshot0)
@@ -1557,5 +1538,4 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             return EnumSet.of(Metadata.XContentContext.GATEWAY, Metadata.XContentContext.SNAPSHOT);
         }
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
@@ -71,9 +70,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
             client().prepareIndex("others", "other").setSource("rank", 4),
             client().prepareIndex("others", "other").setSource("rank", 5));
 
-        assertAcked(client().admin().cluster().preparePutRepository("repository")
-                                              .setType("coutingmock")
-                                              .setSettings(Settings.builder().put("location", randomRepoPath())));
+        createRepository("repository", CountingMockRepositoryPlugin.TYPE, randomRepoPath());
 
         // Creating a snapshot does not load any metadata
         CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("repository", "snap")
@@ -207,10 +204,13 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
 
     /** A plugin that uses CountingMockRepository as implementation of the Repository **/
     public static class CountingMockRepositoryPlugin extends MockRepository.Plugin {
+
+        public static final String TYPE = "countingmock";
+
         @Override
         public Map<String, Repository.Factory> getRepositories(Environment env, NamedXContentRegistry namedXContentRegistry,
                                                                ClusterService clusterService) {
-            return Collections.singletonMap("coutingmock",
+            return Collections.singletonMap(TYPE,
                 metadata -> new CountingMockRepository(metadata, env, namedXContentRegistry, clusterService));
         }
     }

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoriesIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoriesIT.java
@@ -49,12 +49,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
 
         Path location = randomRepoPath();
 
-        logger.info("-->  creating repository");
-        AcknowledgedResponse putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo-1")
-                .setType("fs").setSettings(Settings.builder()
-                                .put("location", location)
-                ).get();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo-1", "fs", location);
 
         logger.info("--> verify the repository");
         int numberOfFiles = FileSystemUtils.files(location).length;
@@ -73,11 +68,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         assertThat(repositoriesMetadata.repository("test-repo-1").type(), equalTo("fs"));
 
         logger.info("-->  creating another repository");
-        putRepositoryResponse = client.admin().cluster().preparePutRepository("test-repo-2")
-                .setType("fs").setSettings(Settings.builder()
-                                .put("location", randomRepoPath())
-                ).get();
-        assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
+        createRepository("test-repo-2", "fs", randomRepoPath());
 
         logger.info("--> check that both repositories are in cluster state");
         clusterStateResponse = client.admin().cluster().prepareState().clear().setMetadata(true).get();

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -326,7 +326,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         String indexName = "testindex";
         String repoName = "test-restore-snapshot-repo";
         String snapshotName = "test-restore-snapshot";
-        String absolutePath = randomRepoPath().toAbsolutePath().toString();
+        Path absolutePath = randomRepoPath().toAbsolutePath();
         logger.info("Path [{}]", absolutePath);
         String restoredIndexName = indexName + "-restored";
         String typeName = "actions";
@@ -337,11 +337,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         String docId = Integer.toString(randomInt());
         index(indexName, typeName, docId, "value", expectedValue);
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository(repoName)
-                .setType("fs").setSettings(Settings.builder()
-                        .put("location", absolutePath)
-                        ));
+        createRepository(repoName, "fs", absolutePath);
 
         logger.info("--> snapshot");
         CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, snapshotName)
@@ -486,9 +482,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testRestoreAliases() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         logger.info("--> create test indices");
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
@@ -546,9 +540,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testRestoreTemplates() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", randomRepoPath())));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         logger.info("-->  creating test template");
         assertThat(client.admin().indices()
@@ -598,10 +590,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testIncludeGlobalState() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        Path location = randomRepoPath();
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", location)));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         boolean testTemplate = randomBoolean();
         boolean testPipeline = randomBoolean();
@@ -915,9 +904,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         Path repositoryLocation = randomRepoPath();
         Client client = client();
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
 
         prepareCreate("test-idx").setSettings(Settings.builder().put("index.allocation.max_retries", Integer.MAX_VALUE)).get();
         ensureGreen();
@@ -980,9 +967,8 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         Path repositoryLocation = randomRepoPath();
         Client client = client();
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-            .setType("fs").setSettings(Settings.builder().put("location", repositoryLocation)));
+
+        createRepository("test-repo", "fs", repositoryLocation);
 
         createIndex("test-idx");
         ensureGreen();
@@ -1089,9 +1075,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                                      final Runnable fixUpAction) throws Exception {
         // create a test repository
         final Path repositoryLocation = randomRepoPath();
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-                                                .setType("fs")
-                                                .setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
         // create a test index
         assertAcked(prepareCreate(indexName, Settings.builder().put(createIndexSettings)));
 
@@ -1158,9 +1142,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
 
         // update the test repository in order to make it work
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-                                              .setType("fs")
-                                              .setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
 
         // execute action to eventually fix the situation
         fixUpAction.run();
@@ -1182,9 +1164,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testDeletionOfFailingToRecoverIndexShouldStopRestore() throws Exception {
         Path repositoryLocation = randomRepoPath();
         Client client = client();
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
 
         createIndex("test-idx");
         ensureGreen();
@@ -1233,8 +1213,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             equalTo(restoreSnapshotResponse.getRestoreInfo().failedShards()));
 
         logger.info("--> restoring working repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
 
         logger.info("--> trying to restore index again");
         restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
@@ -1248,10 +1227,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testUnallocatedShards() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder()
-                        .put("location", randomRepoPath())));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         logger.info("-->  creating index that cannot be allocated");
         prepareCreate("test-idx", 2, Settings.builder().put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "tag", "nowhere")
@@ -1573,10 +1549,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testSnapshotClosedIndex() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder()
-                        .put("location", randomRepoPath())));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         createIndex("test-idx", "test-idx-closed");
         ensureGreen();
@@ -1596,10 +1569,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testRenameOnRestore() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder()
-                        .put("location", randomRepoPath())));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
         ensureGreen();
@@ -1770,8 +1740,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         cluster().wipeIndices("test-idx");
 
         logger.info("--> replace mock repository with real one at the same location");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
 
         logger.info("--> restore index");
         RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
@@ -1856,8 +1825,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         cluster().wipeIndices("test-idx");
 
         logger.info("--> replace mock repository with real one at the same location");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo")
-                .setType("fs").setSettings(Settings.builder().put("location", repositoryLocation)));
+        createRepository("test-repo", "fs", repositoryLocation);
 
         logger.info("--> restore index");
         RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster().prepareRestoreSnapshot("test-repo", "test-snap")
@@ -2571,11 +2539,8 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testDeleteSnapshotWhileRestoringFails() throws Exception {
         Client client = client();
 
-        logger.info("-->  creating repository");
         final String repoName = "test-repo";
-        assertAcked(client.admin().cluster().preparePutRepository(repoName)
-                        .setType("mock")
-                        .setSettings(Settings.builder().put("location", randomRepoPath())));
+        createRepository(repoName, "mock", randomRepoPath());
 
         logger.info("--> creating index");
         final String indexName = "test-idx";
@@ -2800,10 +2765,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
         flushAndRefresh();
 
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-            .setType("fs")
-            .setSettings(Settings.builder()
-                .put("location", repo)));
+        createRepository("test-repo", "fs", repo);
 
         CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
@@ -2877,11 +2839,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         indexRandom(true, documents);
         flushAndRefresh();
 
-        logger.info("-->  creating repository");
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo")
-            .setType("fs")
-            .setSettings(Settings.builder()
-                .put("location", repo)));
+        createRepository("test-repo", "fs", repo);
 
         final String snapshot1 = "test-snap-1";
         logger.info("-->  creating snapshot [{}]", snapshot1);
@@ -3266,8 +3224,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
 
         logger.info("--> snapshot with no I/O failures");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo-2").setType("mock").setSettings(
-            Settings.builder().put("location", repoPath)));
+        createRepository("test-repo-2", "mock", repoPath);
         CreateSnapshotResponse createSnapshotResponse =
             client.admin().cluster().prepareCreateSnapshot("test-repo-2", "test-snap-2")
                 .setWaitForCompletion(true)
@@ -3508,7 +3465,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         String repoName = "test-restore-snapshot-repo";
         String snapshotName1 = "test-restore-snapshot1";
         String snapshotName2 = "test-restore-snapshot2";
-        String absolutePath = randomRepoPath().toAbsolutePath().toString();
+        Path absolutePath = randomRepoPath().toAbsolutePath();
         logger.info("Path [{}]", absolutePath);
         String restoredIndexName1 = indexName1 + "-restored";
         String restoredIndexName2 = indexName2 + "-restored";
@@ -3523,11 +3480,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         String docId2 = Integer.toString(randomInt());
         index(indexName2, typeName, docId2, "value", expectedValue);
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository(repoName)
-            .setType("fs").setSettings(Settings.builder()
-                .put("location", absolutePath)
-            ));
+        createRepository(repoName, "fs", absolutePath);
 
         logger.info("--> snapshot");
         CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, snapshotName1)
@@ -3570,7 +3523,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         String indexName2 = "testindex2";
         String repoName = "test-restore-snapshot-repo";
         String snapshotName = "test-restore-snapshot";
-        String absolutePath = randomRepoPath().toAbsolutePath().toString();
+        Path absolutePath = randomRepoPath().toAbsolutePath();
         logger.info("Path [{}]", absolutePath);
         String restoredIndexName1 = indexName1 + "-restored";
         String restoredIndexName2 = indexName2 + "-restored";
@@ -3585,11 +3538,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         String docId2 = Integer.toString(randomInt());
         index(indexName2, typeName, docId2, "value", expectedValue);
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository(repoName)
-            .setType("fs").setSettings(Settings.builder()
-                .put("location", absolutePath)
-            ));
+        createRepository(repoName, "fs", absolutePath);
 
         logger.info("--> snapshot");
         CreateSnapshotResponse createSnapshotResponse = client.admin().cluster().prepareCreateSnapshot(repoName, snapshotName)
@@ -3668,7 +3617,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testSnapshotDifferentIndicesBySameName() {
         String indexName = "testindex";
         String repoName = "test-repo";
-        String absolutePath = randomRepoPath().toAbsolutePath().toString();
+        Path absolutePath = randomRepoPath().toAbsolutePath();
         logger.info("Path [{}]", absolutePath);
 
         final int initialShardCount = randomIntBetween(1, 10);
@@ -3681,10 +3630,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             index(indexName, "_doc", Integer.toString(i), "foo", "bar" + i);
         }
 
-        logger.info("-->  creating repository");
-        assertAcked(client().admin().cluster().preparePutRepository(repoName)
-            .setType("fs")
-            .setSettings(Settings.builder().put("location", absolutePath)));
+        createRepository(repoName, "fs", absolutePath);
 
         logger.info("--> snapshot with [{}] shards", initialShardCount);
         final SnapshotInfo snapshot1 =

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -49,9 +49,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
     public void testStatusApiConsistency() {
         Client client = client();
 
-        logger.info("-->  creating repository");
-        assertAcked(client.admin().cluster().preparePutRepository("test-repo").setType("fs").setSettings(
-            Settings.builder().put("location", randomRepoPath()).build()));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");
         ensureGreen();
@@ -122,10 +120,8 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
     public void testExceptionOnMissingSnapBlob() throws IOException {
         disableRepoConsistencyCheck("This test intentionally corrupts the repository");
 
-        logger.info("--> creating repository");
         final Path repoPath = randomRepoPath();
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo").setType("fs").setSettings(
-            Settings.builder().put("location", repoPath).build()));
+        createRepository("test-repo", "fs", repoPath);
 
         logger.info("--> snapshot");
         final CreateSnapshotResponse response =
@@ -141,10 +137,8 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
     public void testExceptionOnMissingShardLevelSnapBlob() throws IOException {
         disableRepoConsistencyCheck("This test intentionally corrupts the repository");
 
-        logger.info("--> creating repository");
         final Path repoPath = randomRepoPath();
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo").setType("fs").setSettings(
-            Settings.builder().put("location", repoPath).build()));
+        createRepository("test-repo", "fs", repoPath);
 
         createIndex("test-idx-1");
         ensureGreen();
@@ -171,9 +165,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testGetSnapshotsWithoutIndices() {
-        logger.info("--> creating repository");
-        assertAcked(client().admin().cluster().preparePutRepository("test-repo").setType("fs").setSettings(
-            Settings.builder().put("location", randomRepoPath()).build()));
+        createRepository("test-repo", "fs", randomRepoPath());
 
         logger.info("--> snapshot");
         final SnapshotInfo snapshotInfo =


### PR DESCRIPTION
* Dry up repository creation in spots where we aren't using any custom settings
* `BlobStoreFormatIT` doesn't have to be an `IT` it's just a unit test

backport of #55579 