### PR TITLE
Fix Broken ExistingStoreRecoverySource Deserialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RecoverySource.java
@@ -63,7 +63,7 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
         Type type = Type.values()[in.readByte()];
         switch (type) {
             case EMPTY_STORE: return EmptyStoreRecoverySource.INSTANCE;
-            case EXISTING_STORE: return new ExistingStoreRecoverySource(in);
+            case EXISTING_STORE: return ExistingStoreRecoverySource.read(in);
             case PEER: return PeerRecoverySource.INSTANCE;
             case SNAPSHOT: return new SnapshotRecoverySource(in);
             case LOCAL_SHARDS: return LocalShardsRecoverySource.INSTANCE;
@@ -152,8 +152,8 @@ public abstract class RecoverySource implements Writeable, ToXContentObject {
             this.bootstrapNewHistoryUUID = bootstrapNewHistoryUUID;
         }
 
-        private ExistingStoreRecoverySource(StreamInput in) throws IOException {
-            bootstrapNewHistoryUUID = in.readBoolean();
+        private static ExistingStoreRecoverySource read(StreamInput in) throws IOException {
+            return in.readBoolean() ? FORCE_STALE_PRIMARY_INSTANCE : INSTANCE;
         }
 
         @Override


### PR DESCRIPTION
We are using `FORCE_STALE_PRIMARY_INSTANCE` in instance equality checks `==`
but were creating new instances of `ExistingStoreRecoverySource` when reading
from the wire. This could break these checks in corner cases, causing
`org.elasticsearch.cluster.routing.allocation.IndexMetadataUpdater#shardStarted`
to not remove the force allocation fake id when starting a shard (causing the assertion reported in #55513 to trip). This looks like a bug that could come up elsewhere as well, though I couldn't find any occurrences outside of the test from #55513 in the build stats.

Closes #55513

