### PR TITLE
[7.7][ML] Do not fail DFA task that is stopped during reindexing (#55…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -220,7 +220,7 @@ public class DataFrameAnalyticsManager {
                 startAnalytics(task, config);
             },
             error -> {
-                if (error instanceof TaskCancelledException && task.isStopping()) {
+                if (ExceptionsHelper.unwrapCause(error) instanceof TaskCancelledException && task.isStopping()) {
                     LOGGER.debug(new ParameterizedMessage("[{}] Caught task cancelled exception while task is stopping",
                         config.getId()), error);
                     task.markAsCompleted();


### PR DESCRIPTION
…659)

While we were catching `TaskCancelledException` while we wait for
reindexing to complete, we missed the fact that this exception
may be wrapped in a multi-node cluster. This is the reason
we may still fail the task when stop is called while reindexing.

Some times we're lucky and the exception is thrown by the same
node that runs the job. Then the exception is not wrapped and
things work fine. But when that is not the case the exception is
wrapped, we fail to catch it, and set the task to failed.

The fix is to simply unwrap the exception when we check it it
is `TaskCancelledException`.

Closes #55068

Backport of #55659
