### PR TITLE
Rename docker context artifacts to satisfy release-manager

### DIFF
--- a/distribution/docker/docker-aarch64-build-context/build.gradle
+++ b/distribution/docker/docker-aarch64-build-context/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'base'
 task buildDockerBuildContext(type: Tar) {
   extension = 'tar.gz'
   compression = Compression.GZIP
-  archiveClassifier = "docker-build-context"
-  archiveBaseName = "elasticsearch-aarch64"
+  archiveClassifier = "docker-build-context-aarch64"
+  archiveBaseName = "elasticsearch"
   with dockerBuildContext("aarch64", false, false)
 }
 

--- a/distribution/docker/oss-docker-aarch64-build-context/build.gradle
+++ b/distribution/docker/oss-docker-aarch64-build-context/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'base'
 task buildOssDockerBuildContext(type: Tar) {
   extension = 'tar.gz'
   compression = Compression.GZIP
-  archiveClassifier = "docker-build-context"
-  archiveBaseName = "elasticsearch-aarch64-oss"
+  archiveClassifier = "docker-build-context-aarch64"
+  archiveBaseName = "elasticsearch-oss"
   with dockerBuildContext("aarch64", true, false)
 }
 


### PR DESCRIPTION
Our release tool expects artifacts to have a certain naming convention. Rename the Docker context artifacts to match this convention.