### PR TITLE
[DOCS] Fix 8.0 breaking changes for reuse in Install/Upgrade Guide

### DIFF
--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -11,7 +11,7 @@
 ==== Duplicate values no longer supported in percentiles aggregation
 
 If you specify the `percents` parameter with the
-<<search-aggregations-metrics-percentile-aggregation,percentiles aggregation>>,
+{ref}/search-aggregations-metrics-percentile-aggregation.html[percentiles aggregation],
 its values must be unique. Otherwise, an exception occurs.
 
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -2,6 +2,12 @@
 [[breaking_80_indices_changes]]
 === Indices changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+//end::notable-breaking-changes[]
+
 [float]
 ==== Force Merge API changes
 

--- a/docs/reference/migration/migrate_8_0/reindex.asciidoc
+++ b/docs/reference/migration/migrate_8_0/reindex.asciidoc
@@ -2,6 +2,12 @@
 [[breaking_80_reindex_changes]]
 === Reindex changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+//end::notable-breaking-changes[]
+
 Reindex from remote would previously allow URL encoded index-names and not
 re-encode them when generating the search request for the remote host. This
 leniency has been removed such that all index-names are correctly encoded when

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -2,6 +2,12 @@
 [[breaking_80_search_changes]]
 === Search Changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+//end::notable-breaking-changes[]
+
 [float]
 ==== Removal of types
 

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -2,6 +2,12 @@
 [[breaking_80_settings_changes]]
 === Settings changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+//end::notable-breaking-changes[]
+
 [float]
 [[search-remote-settings-removed]]
 ==== The `search.remote` settings have been removed

--- a/docs/reference/migration/migrate_8_0/threadpool.asciidoc
+++ b/docs/reference/migration/migrate_8_0/threadpool.asciidoc
@@ -2,6 +2,12 @@
 [[breaking_80_threadpool_changes]]
 === Thread pool changes
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+//end::notable-breaking-changes[]
+
 [float]
 ==== Removal of the `fixed_auto_queue_size` thread pool type
 


### PR DESCRIPTION
Adds `//tag::notable-breaking-changes[]` to several breaking changes
files. This tag is required for reuse in the [Elastic Stack Installation
and Upgrade Guide][0].

Also replaces a relative xref with an external link. External links are
required for reuse in the Installation and Upgrade Guide.