### PR TITLE
Avoid accidental contiguous read

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -349,9 +349,11 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
                 long totalBytesRead = 0L;
                 long minBytesRead = Long.MAX_VALUE;
                 long maxBytesRead = Long.MIN_VALUE;
+                long lastReadPosition = 0L;
+                int iterations = between(1, 10);
 
-                for (long i = 1L; i <= randomLongBetween(1L, 10L); i++) {
-                    final long randomPosition = randomLongBetween(1L, input.length() - 1L);
+                for (int i = 1; i <= iterations; i++) {
+                    final long randomPosition = randomValueOtherThan(lastReadPosition, () -> randomLongBetween(1L, input.length() - 1L));
                     input.seek(randomPosition);
 
                     final byte[] readBuffer = new byte[512];
@@ -360,6 +362,7 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
 
                     // BufferedIndexInput tries to read as much bytes as possible
                     final long bytesRead = Math.min(BufferedIndexInput.bufferSize(ioContext), input.length() - randomPosition);
+                    lastReadPosition = randomPosition + bytesRead;
                     totalBytesRead += bytesRead;
                     minBytesRead = (bytesRead < minBytesRead) ? bytesRead : minBytesRead;
                     maxBytesRead = (bytesRead > maxBytesRead) ? bytesRead : maxBytesRead;


### PR DESCRIPTION
If we choose to read from two random positions that are 1024 bytes apart then
this counts as a contiguous read for stats purposes, failing this test. This
commit ensures that we always perform a non-contiguous read.