### PR TITLE
Run searchable snapshots integration tests on external services

### DIFF
--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -57,13 +57,21 @@ if (!azureAccount && !azureKey && !azureContainer && !azureBasePath && !azureSas
 if (useFixture) {
   apply plugin: 'elasticsearch.test.fixtures'
   testFixtures.useFixture(fixture.path, 'azure-fixture-other')
+} else {
+  gradle.projectsEvaluated {
+    def repositoryPluginCheckTask = repositoryPlugin.tasks.findByName('check')
+    if (repositoryPluginCheckTask == null) {
+      throw new GradleException('Could not find task \'check\' in repository plugin project')
+    }
+    repositoryPluginCheckTask.dependsOn(project.tasks.check)
+  }
 }
 
 integTest {
   dependsOn repositoryPlugin.bundlePlugin
   runner {
     systemProperty 'test.azure.container', azureContainer
-    systemProperty 'test.azure.base_path', azureBasePath + "/searchable_snapshots_tests"
+    systemProperty 'test.azure.base_path', azureBasePath + "_searchable_snapshots_tests"
   }
 }
 

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -61,10 +61,6 @@ if (!gcsServiceAccount && !gcsBucket && !gcsBasePath) {
   serviceAccountFile = new File(gcsServiceAccount)
 }
 
-def encodedCredentials = {
-  Base64.encoder.encodeToString(Files.readAllBytes(serviceAccountFile.toPath()))
-}
-
 /** A service account file that points to the Google Cloud Storage service emulated by the fixture **/
 task createServiceAccountFile() {
   doLast {
@@ -105,13 +101,21 @@ processTestResources {
 if (useFixture) {
   apply plugin: 'elasticsearch.test.fixtures'
   testFixtures.useFixture(fixture.path, 'gcs-fixture-other')
+} else {
+  gradle.projectsEvaluated {
+    def repositoryPluginCheckTask = repositoryPlugin.tasks.findByName('check')
+    if (repositoryPluginCheckTask == null) {
+      throw new GradleException('Could not find task \'check\' in repository plugin project')
+    }
+    repositoryPluginCheckTask.dependsOn(project.tasks.check)
+  }
 }
 
 integTest {
   dependsOn repositoryPlugin.bundlePlugin
   runner {
     systemProperty 'test.gcs.bucket', gcsBucket
-    systemProperty 'test.gcs.base_path', gcsBasePath + "/searchable_snapshots_tests"
+    systemProperty 'test.gcs.base_path', gcsBasePath + "_searchable_snapshots_tests"
   }
 }
 

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -39,13 +39,21 @@ if (!s3AccessKey && !s3SecretKey && !s3Bucket && !s3BasePath) {
 if (useFixture) {
   apply plugin: 'elasticsearch.test.fixtures'
   testFixtures.useFixture(fixture.path, 's3-fixture-other')
+} else {
+  gradle.projectsEvaluated {
+    def repositoryPluginCheckTask = repositoryPlugin.tasks.findByName('check')
+    if (repositoryPluginCheckTask == null) {
+      throw new GradleException('Could not find task \'check\' in repository plugin project')
+    }
+    repositoryPluginCheckTask.dependsOn(project.tasks.check)
+  }
 }
 
 integTest {
   dependsOn repositoryPlugin.bundlePlugin
   runner {
     systemProperty 'test.s3.bucket', s3Bucket
-    systemProperty 'test.s3.base_path', s3BasePath + "/searchable_snapshots_tests"
+    systemProperty 'test.s3.base_path', s3BasePath + "_searchable_snapshots_tests"
   }
 }
 
@@ -73,7 +81,7 @@ testClusters.integTest {
     setting 's3.client.searchable_snapshots.endpoint', { "${-> fixtureAddress('s3-fixture-other')}" }, IGNORE_VALUE
 
   } else {
-    println "Using an external service to test " + project.name
+    println "Using an external service to test searchable snapshots on " + project.name
   }
 }
 


### PR DESCRIPTION
The searchable snapshots feature can now run on S3, GCP and Azure. This pull request is a proposal to run the searchable snapshots integration tests on real external services when they are available.

To do that, the searchable snapshots QA projects detect the existence of env vars (like we usually do for these kind of tests) and branch their own `check` tasks to the existing repository plugin `check` tasks. On CI, the 3rd party tests that run the repository plugins project will also run the searchable snapshot tasks, similarly to the other `thirdPartyTests` they also run.