### PR TITLE
fix the schema validation for scripts_painless_context

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -194,6 +194,3 @@ task regen {
   }
 }
 
-validateRestSpec {
-  ignore 'scripts_painless_context.json'
-}

--- a/modules/lang-painless/src/test/resources/rest-api-spec/api/scripts_painless_context.json
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/api/scripts_painless_context.json
@@ -1,6 +1,10 @@
 {
   "scripts_painless_context": {
     "stability": "experimental",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html",
+      "description": "Returns the painless contexts"
+    },
     "url": {
       "paths": [
         {


### PR DESCRIPTION
_note_ - I couldn't find the REST documentation for this, so I added the next closest thing. 

Also, should this be moved into the main rest spec directory, else it may get missed by some consumers (unless that is the point :) )