### PR TITLE
[DRAFT] Implement MlSignificantModelChangeAnnotationCreator

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -5,11 +5,10 @@
  */
 package org.elasticsearch.xpack.core;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
@@ -82,10 +81,8 @@ public final class ClientHelper {
      * Executes an asynchronous action using the provided client. The origin is set in the context and the listener
      * is wrapped to ensure the proper context is restored
      */
-    public static <Request extends ActionRequest, Response extends ActionResponse,
-            RequestBuilder extends ActionRequestBuilder<Request, Response>> void executeAsyncWithOrigin(
-        Client client, String origin, ActionType<Response> action, Request request,
-        ActionListener<Response> listener) {
+    public static <Request extends ActionRequest, Response extends ActionResponse> void executeAsyncWithOrigin(
+            Client client, String origin, ActionType<Response> action, Request request, ActionListener<Response> listener) {
         final ThreadContext threadContext = client.threadPool().getThreadContext();
         final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
         try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(origin)) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationTests.java
@@ -36,6 +36,7 @@ public class AnnotationTests extends AbstractSerializingTestCase<Annotation> {
             .setModifiedTime(randomBoolean() ? new Date(randomNonNegativeLong()) : null)
             .setModifiedUsername(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
             .setType(randomAlphaOfLengthBetween(10, 15))
+            .setLabel(randomBoolean() ? randomAlphaOfLengthBetween(10, 30) : null)
             .build();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -525,7 +525,6 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
         return Clock.systemUTC();
     }
 
-
     @Override
     public Collection<Object> createComponents(Client client, ClusterService clusterService, ThreadPool threadPool,
                                                ResourceWatcherService resourceWatcherService, ScriptService scriptService,
@@ -582,13 +581,16 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
         if (MachineLearningField.AUTODETECT_PROCESS.get(settings)) {
             try {
                 NativeController nativeController = NativeController.makeNativeController(clusterService.getNodeName(), environment);
+                MlSignificantModelChangeAnnotationCreator significantModelChangeHandler =
+                    new MlSignificantModelChangeAnnotationCreator(getClock(), anomalyDetectionAnnotationPersister);
                 autodetectProcessFactory = new NativeAutodetectProcessFactory(
                     environment,
                     settings,
                     nativeController,
                     clusterService,
                     resultsPersisterService,
-                    anomalyDetectionAuditor);
+                    anomalyDetectionAuditor,
+                    significantModelChangeHandler::maybeCreateAnnotation);
                 normalizerProcessFactory = new NativeNormalizerProcessFactory(environment, nativeController, clusterService);
                 analyticsProcessFactory = new NativeAnalyticsProcessFactory(
                     environment,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlSignificantModelChangeAnnotationCreator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlSignificantModelChangeAnnotationCreator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.xpack.core.ml.annotations.Annotation;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationPersister;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
+import org.elasticsearch.xpack.ml.process.logging.CppLogMessage;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * {@link MlSignificantModelChangeAnnotationCreator} class turns cpp log message related to a significant model change into annotation.
+ */
+class MlSignificantModelChangeAnnotationCreator {
+
+    /**
+     * Pattern which all the log messages related to significant model changes must match.
+     */
+    private static final Pattern messagePattern =
+        Pattern.compile("^.*\\[model_change_annotation\\]\\[([0-9]{1,18})\\]\\[([^/]*)/([^/]*)/([^/]*)\\]\\s(.*)$");
+
+    private final Clock clock;
+    private final AnnotationPersister annotationPersister;
+
+    MlSignificantModelChangeAnnotationCreator(Clock clock, AnnotationPersister annotationPersister) {
+        this.clock = Objects.requireNonNull(clock);
+        this.annotationPersister = Objects.requireNonNull(annotationPersister);
+    }
+
+    public void maybeCreateAnnotation(String jobId, CppLogMessage msg) {
+        Matcher messageMatcher = messagePattern.matcher(msg.getMessage());
+        if (messageMatcher.matches() == false) {
+            // This cpp log message is *not* related to a significant model change, do nothing.
+            return;
+        }
+        Annotation annotation = createSignificantModelChangeAnnotation(jobId, messageMatcher);
+        annotationPersister.persistAnnotation(
+            null,
+            annotation,
+            "[" + jobId + "] failed to create annotation for significant model change.");
+    }
+
+    private Annotation createSignificantModelChangeAnnotation(String jobId, Matcher messageMatcher) {
+        assert messageMatcher.matches();
+        // Long.parseLong throws NumberFormatException, but it's impossible here as group(1) was matched as [0-9]{1,18} which parses as long
+        Date modelChangeTime = Date.from(Instant.ofEpochMilli(Long.parseLong(messageMatcher.group(1))));
+        String partition = messageMatcher.group(2);
+        String person = messageMatcher.group(3);
+        String attribute = messageMatcher.group(4);
+        String message = messageMatcher.group(5);
+        Date currentTime = new Date(clock.millis());
+        return new Annotation.Builder()
+            .setAnnotation(
+                new ParameterizedMessage("[partition={};person={};attribute={}] {}", partition, person, attribute, message)
+                    .getFormattedMessage())
+            .setCreateTime(currentTime)
+            .setCreateUsername(XPackUser.NAME)
+            .setTimestamp(modelChangeTime)
+            .setEndTimestamp(modelChangeTime)
+            .setJobId(jobId)
+            .setModifiedTime(currentTime)
+            .setModifiedUsername(XPackUser.NAME)
+            .setType("annotation")
+            .setLabel(new ParameterizedMessage("{}/{}", partition, person).getFormattedMessage())
+            .build();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AbstractNativeAnalyticsProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AbstractNativeAnalyticsProcess.java
@@ -32,7 +32,7 @@ abstract class AbstractNativeAnalyticsProcess<Result> extends AbstractNativeProc
                                              List<Path> filesToDelete, Consumer<String> onProcessCrash, Duration processConnectTimeout,
                                              NamedXContentRegistry namedXContentRegistry) {
         super(jobId, nativeController, logStream, processInStream, processOutStream, processRestoreStream, numberOfFields, filesToDelete,
-            onProcessCrash, processConnectTimeout);
+            msg -> {}, onProcessCrash, processConnectTimeout);
         this.name = Objects.requireNonNull(name);
         this.resultsParser = new ProcessResultsParser<>(Objects.requireNonNull(resultParser), namedXContentRegistry);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcess.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.ml.job.results.AutodetectResult;
 import org.elasticsearch.xpack.ml.process.AbstractNativeProcess;
 import org.elasticsearch.xpack.ml.process.ProcessResultsParser;
 import org.elasticsearch.xpack.ml.process.NativeController;
+import org.elasticsearch.xpack.ml.process.logging.CppLogMessage;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,10 +46,10 @@ class NativeAutodetectProcess extends AbstractNativeProcess implements Autodetec
 
     NativeAutodetectProcess(String jobId, NativeController nativeController, InputStream logStream, OutputStream processInStream,
                             InputStream processOutStream, OutputStream processRestoreStream, int numberOfFields, List<Path> filesToDelete,
-                            ProcessResultsParser<AutodetectResult> resultsParser, Consumer<String> onProcessCrash,
-                            Duration processConnectTimeout) {
+                            ProcessResultsParser<AutodetectResult> resultsParser, Consumer<CppLogMessage> onCppLogMessageReceived,
+                            Consumer<String> onProcessCrash, Duration processConnectTimeout) {
         super(jobId, nativeController, logStream, processInStream, processOutStream, processRestoreStream, numberOfFields, filesToDelete,
-            onProcessCrash, processConnectTimeout);
+            onCppLogMessageReceived, onProcessCrash, processConnectTimeout);
         this.resultsParser = resultsParser;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/NativeNormalizerProcess.java
@@ -23,8 +23,8 @@ class NativeNormalizerProcess extends AbstractNativeProcess implements Normalize
 
     NativeNormalizerProcess(String jobId, NativeController nativeController, InputStream logStream, OutputStream processInStream,
                             InputStream processOutStream, Duration processConnectTimeout) {
-        super(jobId, nativeController, logStream, processInStream, processOutStream, null, 0, Collections.emptyList(), (ignore) -> {},
-            processConnectTimeout);
+        super(jobId, nativeController, logStream, processInStream, processOutStream, null, 0, Collections.emptyList(), ignore -> {},
+            ignore -> {}, processConnectTimeout);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.process.logging.CppLogMessage;
 import org.elasticsearch.xpack.ml.process.logging.CppLogMessageHandler;
 import org.elasticsearch.xpack.ml.process.writer.LengthEncodedWriter;
 
@@ -61,10 +62,11 @@ public abstract class AbstractNativeProcess implements NativeProcess {
 
     protected AbstractNativeProcess(String jobId, NativeController nativeController, InputStream logStream, OutputStream processInStream,
                                     InputStream processOutStream, OutputStream processRestoreStream, int numberOfFields,
-                                    List<Path> filesToDelete, Consumer<String> onProcessCrash, Duration processConnectTimeout) {
+                                    List<Path> filesToDelete, Consumer<CppLogMessage> onCppLogMessageReceived,
+                                    Consumer<String> onProcessCrash, Duration processConnectTimeout) {
         this.jobId = jobId;
         this.nativeController = nativeController;
-        this.cppLogHandler = new CppLogMessageHandler(jobId, logStream);
+        this.cppLogHandler = new CppLogMessageHandler(jobId, logStream, onCppLogMessageReceived);
         this.processInStream = processInStream != null ? new BufferedOutputStream(processInStream) : null;
         this.processOutStream = processOutStream;
         this.processRestoreStream = processRestoreStream;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSignificantModelChangeAnnotationCreatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSignificantModelChangeAnnotationCreatorTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.annotations.Annotation;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationPersister;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
+import org.elasticsearch.xpack.ml.process.logging.CppLogMessage;
+import org.junit.After;
+import org.junit.Before;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class MlSignificantModelChangeAnnotationCreatorTests extends ESTestCase {
+
+    private static final String JOB_ID = "job_id";
+    private static final Instant MSG_TIME = Instant.ofEpochMilli(1000_000_000);
+    private static final Instant NOW = Instant.ofEpochMilli(1000_000_002);
+
+    private Clock clock;
+    private AnnotationPersister annotationPersister;
+
+    @Before
+    public void setUpMocks() {
+        clock = Clock.fixed(NOW, ZoneId.systemDefault());
+        annotationPersister = mock(AnnotationPersister.class);
+    }
+
+    @After
+    public void verifyNoMoreInteractionsWithMocks() {
+        verifyNoMoreInteractions(annotationPersister);
+    }
+
+    public void testMaybeCreateAnnotation_AnnotationCreated() {
+        MlSignificantModelChangeAnnotationCreator annotationCreator = createAnnotationCreator();
+        CppLogMessage msg =
+            createCppLogMessage(
+                "text before bracket doesn't matter [model_change_annotation][1000000001][a/b/c] Model change detected");
+        annotationCreator.maybeCreateAnnotation(JOB_ID, msg);
+
+        verify(annotationPersister).persistAnnotation(
+            null,
+            new Annotation.Builder()
+                .setAnnotation("[partition=a;person=b;attribute=c] Model change detected")
+                .setCreateTime(Date.from(NOW))
+                .setCreateUsername(XPackUser.NAME)
+                .setTimestamp(Date.from(Instant.ofEpochMilli(1000_000_001)))
+                .setEndTimestamp(Date.from(Instant.ofEpochMilli(1000_000_001)))
+                .setJobId(JOB_ID)
+                .setModifiedTime(Date.from(NOW))
+                .setModifiedUsername(XPackUser.NAME)
+                .setType("annotation")
+                .setLabel("a/b")
+                .build(),
+            "[" + JOB_ID + "] failed to create annotation for significant model change.");
+    }
+
+    public void testMaybeCreateAnnotation_AnnotationNotCreated_NoTimestampNoLabel() {
+        MlSignificantModelChangeAnnotationCreator annotationCreator = createAnnotationCreator();
+        CppLogMessage msg = createCppLogMessage("[model_change_annotation] Model change detected");
+        annotationCreator.maybeCreateAnnotation(JOB_ID, msg);
+    }
+
+    public void testMaybeCreateAnnotation_AnnotationNotCreated_BadTimestamp_NotANumber() {
+        MlSignificantModelChangeAnnotationCreator annotationCreator = createAnnotationCreator();
+        CppLogMessage msg = createCppLogMessage("[model_change_annotation][not-a-number][some-label] Model change detected");
+        annotationCreator.maybeCreateAnnotation(JOB_ID, msg);
+    }
+
+    public void testMaybeCreateAnnotation_AnnotationNotCreated_BadTimestamp_TooBig() {
+        MlSignificantModelChangeAnnotationCreator annotationCreator = createAnnotationCreator();
+        CppLogMessage msg = createCppLogMessage("[model_change_annotation][1000000000000000000][some-label] Model change detected");
+        annotationCreator.maybeCreateAnnotation(JOB_ID, msg);
+    }
+
+    public void testMaybeCreateAnnotation_AnnotationNotCreated_MessageNotRelatedToModelChange() {
+        MlSignificantModelChangeAnnotationCreator annotationCreator = createAnnotationCreator();
+        CppLogMessage msg = createCppLogMessage("Pruning all models");
+        annotationCreator.maybeCreateAnnotation(JOB_ID, msg);
+    }
+
+    private MlSignificantModelChangeAnnotationCreator createAnnotationCreator() {
+        return new MlSignificantModelChangeAnnotationCreator(clock, annotationPersister);
+    }
+
+    private static CppLogMessage createCppLogMessage(String message) {
+        CppLogMessage msg = new CppLogMessage(MSG_TIME);
+        msg.setMessage(message);
+        return msg;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcessFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcessFactoryTests.java
@@ -13,56 +13,117 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.ModelPlotConfig;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.process.autodetect.params.AutodetectParams;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.process.NativeController;
 import org.elasticsearch.xpack.ml.process.ProcessPipes;
+import org.elasticsearch.xpack.ml.process.logging.CppLogMessage;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class NativeAutodetectProcessFactoryTests extends ESTestCase {
 
-    public void testSetProcessConnectTimeout() throws IOException {
+    private static final String JOB_ID = "test_job";
+    private static final TimeValue DEFAULT_PROCESS_CONNECT_TIMEOUT = MachineLearning.PROCESS_CONNECT_TIMEOUT.getDefault(null);
 
-        int timeoutSeconds = randomIntBetween(5, 100);
+    private Settings settings;
+    private Environment env;
+    private NativeController nativeController;
+    private ResultsPersisterService resultsPersisterService;
+    private AnomalyDetectionAuditor anomalyDetectionAuditor;
+    private BiConsumer<String, CppLogMessage> onCppLogMessageReceived;
+    private ClusterService clusterService;
+    private Job job;
+    private AutodetectParams autodetectParams;
+    private ProcessPipes processPipes;
 
-        Settings settings = Settings.builder()
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUpMocks() {
+        settings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
             .build();
-        Environment env = TestEnvironment.newEnvironment(settings);
-        NativeController nativeController = mock(NativeController.class);
-        ResultsPersisterService resultsPersisterService = mock(ResultsPersisterService.class);
-        AnomalyDetectionAuditor anomalyDetectionAuditor = mock(AnomalyDetectionAuditor.class);
+        env = TestEnvironment.newEnvironment(settings);
+        nativeController = mock(NativeController.class);
+        resultsPersisterService = mock(ResultsPersisterService.class);
+        anomalyDetectionAuditor = mock(AnomalyDetectionAuditor.class);
+        onCppLogMessageReceived = mock(BiConsumer.class);
         ClusterSettings clusterSettings = new ClusterSettings(settings,
             Set.of(MachineLearning.PROCESS_CONNECT_TIMEOUT, AutodetectBuilder.MAX_ANOMALY_RECORDS_SETTING_DYNAMIC));
-        ClusterService clusterService = mock(ClusterService.class);
+        clusterService = mock(ClusterService.class);
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
-        Job job = mock(Job.class);
-        when(job.getId()).thenReturn("set_process_connect_test_job");
-        AutodetectParams autodetectParams = mock(AutodetectParams.class);
-        ProcessPipes processPipes = mock(ProcessPipes.class);
+        job = mock(Job.class);
+        when(job.getId()).thenReturn(JOB_ID);
+        autodetectParams = mock(AutodetectParams.class);
+        processPipes = mock(ProcessPipes.class);
+    }
 
-        NativeAutodetectProcessFactory nativeAutodetectProcessFactory = new NativeAutodetectProcessFactory(
-            env,
-            settings,
-            nativeController,
-            clusterService,
-            resultsPersisterService,
-            anomalyDetectionAuditor);
+    public void testDefaultProcessConnectTimeout() throws IOException {
+        NativeAutodetectProcessFactory nativeAutodetectProcessFactory = createNativeAutodetectProcessFactory();
+        nativeAutodetectProcessFactory.createNativeProcess(job, autodetectParams, processPipes, Collections.emptyList());
+
+        verify(processPipes, times(1)).connectStreams(eq(Duration.ofSeconds(DEFAULT_PROCESS_CONNECT_TIMEOUT.seconds())));
+    }
+
+    public void testSetProcessConnectTimeout() throws IOException {
+        int timeoutSeconds = randomIntBetween(5, 100);
+        NativeAutodetectProcessFactory nativeAutodetectProcessFactory = createNativeAutodetectProcessFactory();
         nativeAutodetectProcessFactory.setProcessConnectTimeout(TimeValue.timeValueSeconds(timeoutSeconds));
         nativeAutodetectProcessFactory.createNativeProcess(job, autodetectParams, processPipes, Collections.emptyList());
 
         verify(processPipes, times(1)).connectStreams(eq(Duration.ofSeconds(timeoutSeconds)));
+    }
+
+    public void testGetCppLogMessageHandlerForJob_ModelPlotEnabled() {
+        when(job.getModelPlotConfig()).thenReturn(new ModelPlotConfig());
+
+        CppLogMessage cppLogMessage = mock(CppLogMessage.class);
+
+        NativeAutodetectProcessFactory nativeAutodetectProcessFactory = createNativeAutodetectProcessFactory();
+        nativeAutodetectProcessFactory.getCppLogMessageReceivedHandlerForJob(job).accept(cppLogMessage);
+
+        verify(onCppLogMessageReceived).accept(JOB_ID, cppLogMessage);
+        verifyNoMoreInteractions(onCppLogMessageReceived);
+    }
+
+    public void testGetCppLogMessageHandlerForJob_ModelPlotNotEnabled() {
+        when(job.getModelPlotConfig()).thenReturn(new ModelPlotConfig(false, null));
+
+        CppLogMessage cppLogMessage = mock(CppLogMessage.class);
+
+        NativeAutodetectProcessFactory nativeAutodetectProcessFactory = createNativeAutodetectProcessFactory();
+        nativeAutodetectProcessFactory.getCppLogMessageReceivedHandlerForJob(job).accept(cppLogMessage);
+
+        verifyZeroInteractions(onCppLogMessageReceived);
+    }
+
+    public void testGetCppLogMessageHandlerForJob_ModelPlotNull() {
+        CppLogMessage cppLogMessage = mock(CppLogMessage.class);
+
+        NativeAutodetectProcessFactory nativeAutodetectProcessFactory = createNativeAutodetectProcessFactory();
+        nativeAutodetectProcessFactory.getCppLogMessageReceivedHandlerForJob(job).accept(cppLogMessage);
+
+        verifyZeroInteractions(onCppLogMessageReceived);
+    }
+
+    private NativeAutodetectProcessFactory createNativeAutodetectProcessFactory() {
+        return new NativeAutodetectProcessFactory(
+            env, settings, nativeController, clusterService, resultsPersisterService, anomalyDetectionAuditor, onCppLogMessageReceived);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/NativeAutodetectProcessTests.java
@@ -61,10 +61,10 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         when(logStream.read(new byte[1024])).thenReturn(-1);
         InputStream outputStream = mock(InputStream.class);
         when(outputStream.read(new byte[512])).thenReturn(-1);
-        try (NativeAutodetectProcess process = new NativeAutodetectProcess("foo", mock(NativeController.class), logStream,
-                mock(OutputStream.class), outputStream, mock(OutputStream.class),
-                NUMBER_FIELDS, null,
-                new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY), mock(Consumer.class), Duration.ZERO)) {
+        try (NativeAutodetectProcess process = new NativeAutodetectProcess(
+                "foo", mock(NativeController.class), logStream, mock(OutputStream.class), outputStream, mock(OutputStream.class),
+                NUMBER_FIELDS, null, new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY), mock(Consumer.class),
+                mock(Consumer.class), Duration.ZERO)) {
             process.start(executorService, mock(IndexingStateProcessor.class), mock(InputStream.class));
 
             ZonedDateTime startTime = process.getProcessStartTime();
@@ -85,9 +85,10 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         when(outputStream.read(new byte[512])).thenReturn(-1);
         String[] record = {"r1", "r2", "r3", "r4", "r5"};
         ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-        try (NativeAutodetectProcess process = new NativeAutodetectProcess("foo", mock(NativeController.class), logStream,
-                bos, outputStream, mock(OutputStream.class), NUMBER_FIELDS, Collections.emptyList(),
-                new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY), mock(Consumer.class), Duration.ZERO)) {
+        try (NativeAutodetectProcess process = new NativeAutodetectProcess(
+                "foo", mock(NativeController.class), logStream, bos, outputStream, mock(OutputStream.class), NUMBER_FIELDS,
+                Collections.emptyList(), new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY),
+                mock(Consumer.class), mock(Consumer.class), Duration.ZERO)) {
             process.start(executorService, mock(IndexingStateProcessor.class), mock(InputStream.class));
 
             process.writeRecord(record);
@@ -120,9 +121,10 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         InputStream outputStream = mock(InputStream.class);
         when(outputStream.read(new byte[512])).thenReturn(-1);
         ByteArrayOutputStream bos = new ByteArrayOutputStream(AutodetectControlMsgWriter.FLUSH_SPACES_LENGTH + 1024);
-        try (NativeAutodetectProcess process = new NativeAutodetectProcess("foo", mock(NativeController.class), logStream,
-                bos, outputStream, mock(OutputStream.class), NUMBER_FIELDS, Collections.emptyList(),
-                new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY), mock(Consumer.class), Duration.ZERO)) {
+        try (NativeAutodetectProcess process = new NativeAutodetectProcess(
+                "foo", mock(NativeController.class), logStream, bos, outputStream, mock(OutputStream.class), NUMBER_FIELDS,
+                Collections.emptyList(), new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY),
+                mock(Consumer.class), mock(Consumer.class), Duration.ZERO)) {
             process.start(executorService, mock(IndexingStateProcessor.class), mock(InputStream.class));
 
             FlushJobParams params = FlushJobParams.builder().build();
@@ -154,10 +156,10 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         String json = "some string of data";
         ByteArrayInputStream processOutStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
 
-        try (NativeAutodetectProcess process = new NativeAutodetectProcess("foo", mock(NativeController.class), logStream,
-            processInStream, processOutStream, mock(OutputStream.class), NUMBER_FIELDS, Collections.emptyList(),
-            new ProcessResultsParser<AutodetectResult>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY), mock(Consumer.class),
-            Duration.ZERO)) {
+        try (NativeAutodetectProcess process = new NativeAutodetectProcess(
+                "foo", mock(NativeController.class), logStream, processInStream, processOutStream, mock(OutputStream.class), NUMBER_FIELDS,
+                Collections.emptyList(), new ProcessResultsParser<AutodetectResult>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY),
+                mock(Consumer.class), mock(Consumer.class), Duration.ZERO)) {
 
             process.consumeAndCloseOutputStream();
             assertThat(processOutStream.available(), equalTo(0));
@@ -171,9 +173,10 @@ public class NativeAutodetectProcessTests extends ESTestCase {
         InputStream outputStream = mock(InputStream.class);
         when(outputStream.read(new byte[512])).thenReturn(-1);
         ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-        try (NativeAutodetectProcess process = new NativeAutodetectProcess("foo", mock(NativeController.class), logStream,
-                bos, outputStream, mock(OutputStream.class), NUMBER_FIELDS, Collections.emptyList(),
-                new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY), mock(Consumer.class), Duration.ZERO)) {
+        try (NativeAutodetectProcess process = new NativeAutodetectProcess(
+                "foo", mock(NativeController.class), logStream, bos, outputStream, mock(OutputStream.class), NUMBER_FIELDS,
+                Collections.emptyList(), new ProcessResultsParser<>(AutodetectResult.PARSER, NamedXContentRegistry.EMPTY),
+                mock(Consumer.class), mock(Consumer.class), Duration.ZERO)) {
             process.start(executorService, mock(IndexingStateProcessor.class), mock(InputStream.class));
 
             writeFunction.accept(process);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.ml.process.logging.CppLogMessage;
 import org.junit.After;
 import org.junit.Before;
 
@@ -37,6 +38,7 @@ public class AbstractNativeProcessTests extends ESTestCase {
     private OutputStream inputStream;
     private InputStream outputStream;
     private OutputStream restoreStream;
+    private Consumer<CppLogMessage> onCppLogMessageReceived;
     private Consumer<String> onProcessCrash;
     private ExecutorService executorService;
     private CountDownLatch wait = new CountDownLatch(1);
@@ -57,6 +59,7 @@ public class AbstractNativeProcessTests extends ESTestCase {
         outputStream = mock(InputStream.class);
         when(outputStream.read(new byte[512])).thenReturn(-1);
         restoreStream =  mock(OutputStream.class);
+        onCppLogMessageReceived = mock(Consumer.class);
         onProcessCrash = mock(Consumer.class);
         executorService = EsExecutors.newFixed("test", 1, 1, EsExecutors.daemonThreadFactory("test"), new ThreadContext(Settings.EMPTY),
             false);
@@ -144,7 +147,18 @@ public class AbstractNativeProcessTests extends ESTestCase {
     private class TestNativeProcess extends AbstractNativeProcess {
 
         TestNativeProcess(OutputStream inputStream) {
-            super("foo", nativeController, logStream, inputStream, outputStream, restoreStream, 0, null, onProcessCrash, Duration.ZERO);
+            super(
+                "foo",
+                nativeController,
+                logStream,
+                inputStream,
+                outputStream,
+                restoreStream,
+                0,
+                null,
+                onCppLogMessageReceived,
+                onProcessCrash,
+                Duration.ZERO);
         }
 
         @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
@@ -63,7 +63,7 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         // Try different buffer sizes to smoke out edge case problems in the buffer management
         for (int readBufSize : new int[] { 11, 42, 101, 1024, 9999 }) {
             InputStream is = new ByteArrayInputStream(testData.getBytes(StandardCharsets.UTF_8));
-            try (CppLogMessageHandler handler = new CppLogMessageHandler(is, "_id", readBufSize, 3)) {
+            try (CppLogMessageHandler handler = new CppLogMessageHandler(is, "_id", readBufSize, 3, msg -> {})) {
                 handler.tailStream();
 
                 assertTrue(handler.hasLogStreamEnded());


### PR DESCRIPTION
This PR adds `MlSignificantModelChangeAnnotationCreator` class responsible for creating annotations on significant model changes and hooks it into `CppLogMessageHandler` class.

Relates https://github.com/elastic/elasticsearch/issues/55781