### PR TITLE
[DOCS] Add UUID troubleshooting tip for stack monitoring

### DIFF
--- a/docs/reference/monitoring/how-monitoring-works.asciidoc
+++ b/docs/reference/monitoring/how-monitoring-works.asciidoc
@@ -6,8 +6,8 @@
 <titleabbrev>How it works</titleabbrev>
 ++++
 
-Each {es} node, {ls} node, {kib} instance, and Beat is considered unique in the
-cluster based on its persistent UUID, which is written to the
+Each {es} node, {ls} node, {kib} instance, and Beat instance is considered
+unique in the cluster based on its persistent UUID, which is written to the
 <<path-settings,`path.data`>> directory when the node or instance starts.
 
 Monitoring documents are just ordinary JSON documents built by monitoring each

--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -14,6 +14,9 @@ a ticket in the
 https://support.elastic.co/customers/s/login/[Elastic Support portal].
 Or post in the https://discuss.elastic.co/[Elastic forum].
 
+[[monitoring-troubleshooting-no-data]]
+=== No monitoring data is visible in {kib}
+
 *Symptoms*:
 There is no information about your cluster on the *Stack Monitoring* page in
 {kib}.
@@ -27,3 +30,14 @@ monitoring data by using {metricbeat} the indices have `-mb` in their names. If
 the indices do not exist, review your configuration. For example, see
 <<monitoring-production>>.
 
+[[monitoring-troubleshooting-uuid]]
+=== Some monitoring data is missing from {kib}
+
+*Symptoms*:
+The information about some nodes, instances, or Beats in your cluster are
+missing from the *Stack Monitoring* page in {kib}.
+
+*Resolution*:
+Verify that the missing items have unique UUIDs. Each {es} node, {ls} node,
+{kib} instance, and Beat is considered unique based on its persistent UUID,
+which is found in its `path.data` directory.

--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -45,11 +45,16 @@ Verify that the missing items have unique UUIDs. Each {es} node, {ls} node,
 persistent UUID, which is found in its `path.data` directory. Alternatively, you
 can find the UUIDs in the product logs at startup.
 
-For {ls} nodes, you can also determine the UUID from the `id` property returned
-by the {logstash-ref}/monitoring-logstash.html[monitoring APIs root resource].
-Likewise, if you have enabled the HTTP endpoint for your Beat instances, it
-returns a `uuid` property. For example, refer to
+In some cases, you can also retrieve this information via APIs:
+
+* For Beat instances, use the HTTP endpoint to retrieve the `uuid` property.
+For example, refer to
 {filebeat-ref}/http-endpoint.html[Configure an HTTP endpoint for {filebeat} metrics].
+* For {kib} instances, use the
+{kibana-ref}/access.html#status[status endpoint] to retrieve the `uuid` property.
+* For {ls} nodes, use the
+{logstash-ref}/monitoring-logstash.html[monitoring APIs root resource] to
+retrieve the `id` property.
 
 TIP: When you install {es}, {ls}, {kib}, APM Server, or Beats, their `path.data`
 directory should be non-existent or empty; do not copy this directory from other

--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -47,7 +47,9 @@ can find the UUIDs in the product logs at startup.
 
 For {ls} nodes, you can also determine the UUID from the `id` property returned
 by the {logstash-ref}/monitoring-logstash.html[monitoring APIs root resource].
-
+Likewise, if you have enabled the HTTP endpoint for your Beat instances, it
+returns a `uuid` property. For example, refer to
+{filebeat-ref}/http-endpoint.html[Configure an HTTP endpoint for {filebeat} metrics].
 
 TIP: When you install {es}, {ls}, {kib}, APM Server, or Beats, their `path.data`
 directory should be non-existent or empty; do not copy this directory from other

--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -41,16 +41,16 @@ instances in your cluster.
 
 *Resolution*:
 Verify that the missing items have unique UUIDs. Each {es} node, {ls} node,
-{kib} instance, and Beat instance is considered unique based on its persistent 
-UUID, which is found in its `path.data` directory. Alternatively, you can find
-the UUIDs in the product logs at startup.
+{kib} instance, Beat instance, and APM Server is considered unique based on its
+persistent UUID, which is found in its `path.data` directory. Alternatively, you
+can find the UUIDs in the product logs at startup.
 
 For {ls} nodes, you can also determine the UUID from the `id` property returned
 by the {logstash-ref}/monitoring-logstash.html[monitoring APIs root resource].
 
 
-TIP: When you install {kib} or Beat instances, do not copy existing content into
-the `path.data` directory; it should be non-existent or empty immediately after
-installation.
+TIP: When you install {es}, {ls}, {kib}, APM Server, or Beats, their `path.data`
+directory should be non-existent or empty; do not copy this directory from other
+installations.
 
 

--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -42,4 +42,15 @@ instances in your cluster.
 *Resolution*:
 Verify that the missing items have unique UUIDs. Each {es} node, {ls} node,
 {kib} instance, and Beat instance is considered unique based on its persistent 
-UUID, which is found in its `path.data` directory.
+UUID, which is found in its `path.data` directory. Alternatively, you can find
+the UUIDs in the product logs at startup.
+
+For {ls} nodes, you can also determine the UUID from the `id` property returned
+by the {logstash-ref}/monitoring-logstash.html[monitoring APIs root resource].
+
+
+TIP: When you install {kib} or Beat instances, do not copy existing content into
+the `path.data` directory; it should be non-existent or empty immediately after
+installation.
+
+

--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -14,6 +14,7 @@ a ticket in the
 https://support.elastic.co/customers/s/login/[Elastic Support portal].
 Or post in the https://discuss.elastic.co/[Elastic forum].
 
+[discrete]
 [[monitoring-troubleshooting-no-data]]
 === No monitoring data is visible in {kib}
 
@@ -30,14 +31,15 @@ monitoring data by using {metricbeat} the indices have `-mb` in their names. If
 the indices do not exist, review your configuration. For example, see
 <<monitoring-production>>.
 
+[discrete]
 [[monitoring-troubleshooting-uuid]]
-=== Some monitoring data is missing from {kib}
+=== Monitoring data for some {stack} nodes or instances is missing from {kib}
 
 *Symptoms*:
-The information about some nodes, instances, or Beats in your cluster are
-missing from the *Stack Monitoring* page in {kib}.
+The *Stack Monitoring* page in {kib} does not show information for some nodes or 
+instances in your cluster.
 
 *Resolution*:
 Verify that the missing items have unique UUIDs. Each {es} node, {ls} node,
-{kib} instance, and Beat is considered unique based on its persistent UUID,
-which is found in its `path.data` directory.
+{kib} instance, and Beat instance is considered unique based on its persistent 
+UUID, which is found in its `path.data` directory.


### PR DESCRIPTION
This PR augments https://www.elastic.co/guide/en/elasticsearch/reference/master/monitoring-troubleshooting.html ("Troubleshooting monitoring") with a suggestion to check the UUID when monitoring data is missing for some nodes/instances/Beats in a cluster.

Preview: 
* http://elasticsearch_55744.docs-preview.app.elstc.co/diff