### PR TITLE
json spec - add description for autoscaling

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -116,9 +116,6 @@ validateRestSpec {
   ignore 'searchable_snapshots.clear_cache.json'
   ignore 'searchable_snapshots.stats.json'
   ignore 'searchable_snapshots.repository_stats.json'
-  ignore 'autoscaling.delete_autoscaling_policy.json'
-  ignore 'autoscaling.get_autoscaling_policy.json'
-  ignore 'autoscaling.put_autoscaling_policy.json'
   ignore 'ml.validate.json'
   ignore 'ml.validate_detector.json'
 }

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -112,10 +112,6 @@ testClusters.integTest {
 }
 
 validateRestSpec {
-  ignore 'searchable_snapshots.mount.json'
-  ignore 'searchable_snapshots.clear_cache.json'
-  ignore 'searchable_snapshots.stats.json'
-  ignore 'searchable_snapshots.repository_stats.json'
   ignore 'ml.validate.json'
   ignore 'ml.validate_detector.json'
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
@@ -1,7 +1,8 @@
 {
   "autoscaling.delete_autoscaling_policy":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-delete-autoscaling-policy.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-delete-autoscaling-policy.html",
+      "description":"Deletes an autoscaling policy."
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
@@ -1,7 +1,8 @@
 {
   "autoscaling.get_autoscaling_policy":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-policy.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-get-autoscaling-policy.html",
+      "description": "Retrieves an autoscaling policy."
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -2,7 +2,7 @@
   "autoscaling.put_autoscaling_policy":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html",
-      "description": "Create a new autoscaling policy."
+      "description": "Creates a new autoscaling policy."
     },
     "stability":"experimental",
     "url":{

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -1,7 +1,8 @@
 {
   "autoscaling.put_autoscaling_policy":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html"
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-put-autoscaling-policy.html",
+      "description": "Create a new autoscaling policy."
     },
     "stability":"experimental",
     "url":{


### PR DESCRIPTION
Allow the autoscaling REST specs to pass the schema validation.