### PR TITLE
[7.7] fix the schema validation for scripts_painless_context (#55738)

### DIFF
--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -194,6 +194,3 @@ task regen {
   }
 }
 
-validateRestSpec {
-  ignore 'scripts_painless_context.json'
-}

--- a/modules/lang-painless/src/test/resources/rest-api-spec/api/scripts_painless_context.json
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/api/scripts_painless_context.json
@@ -1,6 +1,10 @@
 {
   "scripts_painless_context": {
     "stability": "experimental",
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-contexts.html",
+      "description": "Returns the painless contexts"
+    },
     "url": {
       "paths": [
         {


### PR DESCRIPTION
Backports the following commits to 7.7:
 - fix the schema validation for scripts_painless_context (#55738)