### PR TITLE
Remove Outdated Bwc Logic from RepositoryMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -31,8 +30,6 @@ import java.util.Objects;
  * Metadata about registered repository
  */
 public class RepositoryMetadata {
-
-    public static final Version REPO_GEN_IN_CS_VERSION = Version.V_7_6_0;
 
     private final String name;
     private final String type;
@@ -128,13 +125,8 @@ public class RepositoryMetadata {
         name = in.readString();
         type = in.readString();
         settings = Settings.readSettingsFromStream(in);
-        if (in.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
-            generation = in.readLong();
-            pendingGeneration = in.readLong();
-        } else {
-            generation = RepositoryData.UNKNOWN_REPO_GEN;
-            pendingGeneration = RepositoryData.EMPTY_REPO_GEN;
-        }
+        generation = in.readLong();
+        pendingGeneration = in.readLong();
     }
 
     /**
@@ -146,10 +138,8 @@ public class RepositoryMetadata {
         out.writeString(name);
         out.writeString(type);
         Settings.writeSettingsToStream(settings, out);
-        if (out.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
-            out.writeLong(generation);
-            out.writeLong(pendingGeneration);
-        }
+        out.writeLong(generation);
+        out.writeLong(pendingGeneration);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -258,9 +258,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
      * <ul>
      *     <li>All repositories that are read-only, i.e. for which {@link #isReadOnly()} returns {@code true} because there are no
      *     guarantees that another cluster is not writing to the repository at the same time</li>
-     *     <li>The node finds itself in a mixed-version cluster containing nodes older than
-     *     {@link RepositoryMetadata#REPO_GEN_IN_CS_VERSION} where the master node does not update the value of
-     *     {@link RepositoryMetadata#generation()} when writing a new {@code index-N} blob</li>
      *     <li>The value of {@link RepositoryMetadata#generation()} for this repository is {@link RepositoryData#UNKNOWN_REPO_GEN}
      *     indicating that no consistent repository generation is tracked in the cluster state yet.</li>
      *     <li>The {@link #uncleanStart} flag is set to {@code true}</li>
@@ -336,9 +333,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     public void updateState(ClusterState state) {
         metadata = getRepoMetadata(state);
         uncleanStart = uncleanStart && metadata.generation() != metadata.pendingGeneration();
-        bestEffortConsistency = uncleanStart || isReadOnly()
-            || state.nodes().getMinNodeVersion().before(RepositoryMetadata.REPO_GEN_IN_CS_VERSION)
-            || metadata.generation() == RepositoryData.UNKNOWN_REPO_GEN;
+        bestEffortConsistency = uncleanStart || isReadOnly() || metadata.generation() == RepositoryData.UNKNOWN_REPO_GEN;
         if (isReadOnly()) {
             // No need to waste cycles, no operations can run against a read-only repository
             return;


### PR DESCRIPTION
Not going to connect to a node from pre-7.6 any longer so
no need to keep this around.
