### PR TITLE
More Efficient Blobstore Metdata IO

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/compress/Compressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/Compressor.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 public interface Compressor {
 
@@ -37,5 +38,5 @@ public interface Compressor {
      * Creates a new stream output that compresses the contents and writes to the provided stream
      * output. Closing the returned {@link StreamOutput} will close the provided stream output.
      */
-    StreamOutput streamOutput(StreamOutput out) throws IOException;
+    StreamOutput streamOutput(OutputStream out) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -107,8 +107,8 @@ public class DeflateCompressor implements Compressor {
     }
 
     @Override
-    public StreamOutput streamOutput(StreamOutput out) throws IOException {
-        out.writeBytes(HEADER);
+    public StreamOutput streamOutput(OutputStream out) throws IOException {
+        out.write(HEADER);
         final boolean nowrap = true;
         final Deflater deflater = new Deflater(LEVEL, nowrap);
         final boolean syncFlush = true;


### PR DESCRIPTION
No need to copy all these bytes multiple times, especially not when
writing a multiple MB global cluster state snapshot through this method or reading multiple potentially large meta files in parallel.
