### PR TITLE
[7.7] json spec - add description for searchable snapshots (#55746)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -165,10 +165,6 @@ testClusters.integTest {
 }
 
 validateRestSpec {
-  ignore 'searchable_snapshots.mount.json'
-  ignore 'searchable_snapshots.clear_cache.json'
-  ignore 'searchable_snapshots.stats.json'
-  ignore 'searchable_snapshots.repository_stats.json'
   ignore 'autoscaling.delete_autoscaling_policy.json'
   ignore 'autoscaling.get_autoscaling_policy.json'
   ignore 'autoscaling.put_autoscaling_policy.json'


### PR DESCRIPTION
Backports the following commits to 7.7:
 - json spec - add description for searchable snapshots (#55746)