### PR TITLE
[7.x] json spec - add description for searchable snapshots (#55746)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -157,10 +157,6 @@ testClusters.integTest {
 }
 
 validateRestSpec {
-  ignore 'searchable_snapshots.mount.json'
-  ignore 'searchable_snapshots.clear_cache.json'
-  ignore 'searchable_snapshots.stats.json'
-  ignore 'searchable_snapshots.repository_stats.json'
   ignore 'autoscaling.delete_autoscaling_policy.json'
   ignore 'autoscaling.get_autoscaling_policy.json'
   ignore 'autoscaling.put_autoscaling_policy.json'

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -2,6 +2,7 @@
   "searchable_snapshots.clear_cache": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-clear-cache.html"
+      "description" : "Clear the cache of searchable snapshots."
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.clear_cache": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-clear-cache.html"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-clear-cache.html",
       "description" : "Clear the cache of searchable snapshots."
     },
     "stability": "experimental",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -1,7 +1,8 @@
 {
   "searchable_snapshots.mount": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot.html"
+      "description": "Mount a snapshot as a searchable index."
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.mount": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot.html"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot.html",
       "description": "Mount a snapshot as a searchable index."
     },
     "stability": "experimental",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.repository_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.repository_stats.json
@@ -1,7 +1,8 @@
 {
   "searchable_snapshots.repository_stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-repository-stats.html"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-repository-stats.html",
+      "description": "Retrieve usage statistics about a snapshot repository."
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.repository_stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.repository_stats.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.repository_stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-repository-stats.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-repository-stats.html",
       "description": "Retrieve usage statistics about a snapshot repository."
     },
     "stability": "experimental",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
@@ -2,6 +2,7 @@
   "searchable_snapshots.stats": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html"
+      "description": "Retrieve various statistics about searchable snapshots."
     },
     "stability": "experimental",
     "url": {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/searchable_snapshots.stats.json
@@ -1,7 +1,7 @@
 {
   "searchable_snapshots.stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html"
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-stats.html",
       "description": "Retrieve various statistics about searchable snapshots."
     },
     "stability": "experimental",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - json spec - add description for searchable snapshots (#55746)