### PR TITLE
[DOCS] Add collapsible sections to 8.0 breaking changes [Part 1]

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -62,8 +62,8 @@ is replaced with a new endpoint that does not contain `_xpack`. As an example,
 `/{index}/_xpack/graph/_explore` is replaced by `/{index}/_graph/explore`.
 
 *Impact* +
-To avoid errors, discontinue use of REST API endpoints that contain `_xpack` in
-their path. Use the replacement REST API endpoints instead.
+Use the replacement REST API endpoints. Requests submitted to the `_xpack`
+API endpoints will return an error.
 ====
 
 

--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -48,8 +48,7 @@ Elasticsearch 8.0 node will not start in the presence of indices created in a
 version of Elasticsearch before 7.0.
 
 *Impact* +
-Indices created in Elasticsearch 6.x or before will need to be reindexed with
-Elasticsearch 7.x in order to be readable by Elasticsearch 8.x.
+Reindex indices created in {es} 6.x or before with {es} 7.x if they need to be carried forward to  {es} 8.x. 
 ====
 
 .REST API endpoints containing `_xpack` have been removed.

--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -38,29 +38,33 @@ coming[8.0.0]
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-[float]
-==== Indices created before 7.0
 
+.Indices created in {es} 7.0 and earlier versions are not supported.
+[%collapsible]
+====
+*Details* +
 Elasticsearch 8.0 can read indices created in version 7.0 or above.  An
 Elasticsearch 8.0 node will not start in the presence of indices created in a
 version of Elasticsearch before 7.0.
 
-[IMPORTANT]
-.Reindex indices from Elasticsearch 6.x or before
-=========================================
-
+*Impact* +
 Indices created in Elasticsearch 6.x or before will need to be reindexed with
 Elasticsearch 7.x in order to be readable by Elasticsearch 8.x.
+====
 
-=========================================
-
-[float]
-==== REST endpoints containing `_xpack`
-
+.REST API endpoints containing `_xpack` have been removed.
+[%collapsible]
+====
+*Details* +
 In 7.0, we deprecated REST endpoints that contain `_xpack` in their path. These
 endpoints are now removed in 8.0. Each endpoint that was deprecated and removed
 is replaced with a new endpoint that does not contain `_xpack`. As an example,
 `/{index}/_xpack/graph/_explore` is replaced by `/{index}/_graph/explore`.
+
+*Impact* +
+To avoid errors, discontinue use of REST API endpoints that contain `_xpack` in
+their path. Use the replacement REST API endpoints instead.
+====
 
 
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -6,12 +6,17 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-[discrete]
 [[percentile-duplication]]
-==== Duplicate values no longer supported in percentiles aggregation
-
+.The `percentiles` aggregation's `percents` parameter no longer supports duplicate values.
+[%collapsible]
+====
+*Details* +
 If you specify the `percents` parameter with the
-{ref}/search-aggregations-metrics-percentile-aggregation.html[percentiles aggregation],
+{ref}/search-aggregations-metrics-percentile-aggregation.html[`percentiles` aggregation],
 its values must be unique. Otherwise, an exception occurs.
 
+*Impact* +
+To avoid errors, use unique values in the `percents` parameter of the
+`percentiles` aggregation.
+====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_8_0/aggregations.asciidoc
@@ -16,7 +16,8 @@ If you specify the `percents` parameter with the
 its values must be unique. Otherwise, an exception occurs.
 
 *Impact* +
-To avoid errors, use unique values in the `percents` parameter of the
-`percentiles` aggregation.
+Use unique values in the `percents` parameter of the `percentiles` aggregation.
+Requests containing duplicate values in the `percents` parameter will return
+an error.
 ====
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/allocation.asciidoc
+++ b/docs/reference/migration/migrate_8_0/allocation.asciidoc
@@ -9,10 +9,11 @@
 
 // end::notable-breaking-changes[]
 
-[float]
 [[breaking_80_allocation_change_flood_stage_block_always_removed]]
-==== Auto-release flood-stage block no longer optional
-
+.The automatic removal of flood-stage blocks is no longer optional.
+[%collapsible]
+====
+*Details* +
 If a node exceeds the flood-stage disk watermark then we add a block to all of
 its indices to prevent further writes as a last-ditch attempt to prevent the
 node completely exhausting its disk space. By default, from 7.4 onwards the
@@ -21,10 +22,16 @@ again, but this behaviour could be disabled by setting the system property
 `es.disk.auto_release_flood_stage_block` to `false`. This behaviour is no
 longer optional, and this system property must now not be set.
 
-[float]
-[[breaking_80_allocation_change_include_relocations_removed]]
-==== Accounting for disk usage of relocating shards no longer optional
+*Impact* +
+To avoid errors, unset the `es.disk.auto_release_flood_stage_block` system
+property and discontinue its use.
+====
 
+[[breaking_80_allocation_change_include_relocations_removed]]
+.Accounting for the disk usage of relocating shards is no longer optional.
+[%collapsible]
+====
+*Details* +
 By default {es} will account for the sizes of relocating shards when making
 allocation decisions based on the disk usage of the nodes in the cluster. In
 earlier versions the `cluster.routing.allocation.disk.include_relocations`
@@ -32,3 +39,8 @@ setting allowed this accounting to be disabled, which would result in poor
 allocation decisions that might overshoot watermarks and require significant
 extra work to correct. This behaviour is no longer optional, and this setting
 has been removed.
+
+*Impact* +
+To avoid errors, unset the `cluster.routing.allocation.disk.include_relocations`
+setting and discontinue its use.
+====

--- a/docs/reference/migration/migrate_8_0/allocation.asciidoc
+++ b/docs/reference/migration/migrate_8_0/allocation.asciidoc
@@ -23,8 +23,9 @@ again, but this behaviour could be disabled by setting the system property
 longer optional, and this system property must now not be set.
 
 *Impact* +
-To avoid errors, unset the `es.disk.auto_release_flood_stage_block` system
-property and discontinue its use.
+Discontinue use of the `es.disk.auto_release_flood_stage_block` system property.
+Specifying this property in `elasticsearch.yml` will result in an error on
+startup.
 ====
 
 [[breaking_80_allocation_change_include_relocations_removed]]
@@ -41,6 +42,7 @@ extra work to correct. This behaviour is no longer optional, and this setting
 has been removed.
 
 *Impact* +
-To avoid errors, unset the `cluster.routing.allocation.disk.include_relocations`
-setting and discontinue its use.
+Discontinue use of the `cluster.routing.allocation.disk.include_relocations`
+setting. Specifying this setting in `elasticsearch.yml` will result in an error
+on startup.
 ====

--- a/docs/reference/migration/migrate_8_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_8_0/analysis.asciidoc
@@ -9,19 +9,31 @@
 
 // end::notable-breaking-changes[]
 
-[float]
 [[ngram-edgengram-filter-names-removed]]
-==== The `nGram` and `edgeNGram` token filter names have been removed
-
+.The `nGram` and `edgeNGram` token filter names have been removed.
+[%collapsible]
+====
+*Details* +
 The `nGram` and `edgeNGram` token filter names that have been deprecated since
 version 6.4 have been removed. Both token filters can only be used by their 
 alternative names `ngram` and `edge_ngram` since version 7.0.
 
-[float]
-[[nGram-edgeNGram-tokenizer-dreprecation]]
-==== Disallow use of the `nGram` and `edgeNGram` tokenizer names
+*Impact* +
+To avoid the errors, discontinue use of the `nGram` and `edgeNGram` token filter
+names. Use the equivalent `ngram` and `edge_ngram` token filter names instead.
+====
 
+[[nGram-edgeNGram-tokenizer-dreprecation]]
+.The `nGram` and `edgeNGram` tokenizer names have been removed.
+[%collapsible]
+====
+*Details* +
 The `nGram` and `edgeNGram` tokenizer names haven been deprecated with 7.6 and are no longer
 supported on new indices. Mappings for indices created after 7.6 will continue to work but
 emit a deprecation warning. The tokenizer name should be changed to the fully equivalent
 `ngram` or `edge_ngram` names for new indices and in index templates.
+
+*Impact* +
+To avoid errors, discontinue use of the `nGram` and `edgeNGram` tokenizer names.
+Use the equivalent `ngram` and `edge_ngram` tokenizer names instead.
+====

--- a/docs/reference/migration/migrate_8_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_8_0/analysis.asciidoc
@@ -19,8 +19,8 @@ version 6.4 have been removed. Both token filters can only be used by their
 alternative names `ngram` and `edge_ngram` since version 7.0.
 
 *Impact* +
-To avoid the errors, discontinue use of the `nGram` and `edgeNGram` token filter
-names. Use the equivalent `ngram` and `edge_ngram` token filter names instead.
+Use the equivalent `ngram` and `edge_ngram` token filters. Requests containing
+the `nGram` and `edgeNGram` token filter names will return an error.
 ====
 
 [[nGram-edgeNGram-tokenizer-dreprecation]]
@@ -34,6 +34,6 @@ emit a deprecation warning. The tokenizer name should be changed to the fully eq
 `ngram` or `edge_ngram` names for new indices and in index templates.
 
 *Impact* +
-To avoid errors, discontinue use of the `nGram` and `edgeNGram` tokenizer names.
-Use the equivalent `ngram` and `edge_ngram` tokenizer names instead.
+Use the `ngram` and `edge_ngram` tokenizers. Requests to create new indices 
+using the `nGram` and `edgeNGram` tokenizer names will return an error.
 ====

--- a/docs/reference/migration/migrate_8_0/breaker.asciidoc
+++ b/docs/reference/migration/migrate_8_0/breaker.asciidoc
@@ -1,6 +1,6 @@
 [float]
 [[breaking_80_breaker_changes]]
-=== Packaging changes
+=== Circuit breaker changes
 
 //tag::notable-breaking-changes[]
 [float]


### PR DESCRIPTION
Begins adding collapsible sections to the 8.0 breaking changes.

To make reviews easier and avoid introducing errors, I've
tried to limit my changes to formatting, with the exception
of rewording heading as sentences.

I'm also splitting this effort over several PRs to make reviews
manageable. I'll likely make a final pass to relabel or reorganize.

Relates to #55629 and #53229

### Preview
http://elasticsearch_55811.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html