### PR TITLE
[DOCS] Relocate thread pools content

### DIFF
--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -45,15 +45,6 @@ The modules in this section are:
 <<modules-node,Node client>>::
 
     A Java node client joins the cluster, but doesn't hold data or act as a master node.
-
-<<modules-threadpool,Thread pools>>::
-
-    Information about the dedicated thread pools used in Elasticsearch.
-
-<<modules-cross-cluster-search, {ccs-cap}>>::
-
-    {ccs-cap} enables executing search requests across more than one cluster
-    without joining them and acts as a federated client across them.
 --
 
 
@@ -68,5 +59,3 @@ include::modules/http.asciidoc[]
 include::modules/network.asciidoc[]
 
 include::modules/node.asciidoc[]
-
-include::modules/threadpool.asciidoc[]

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -1,10 +1,9 @@
 [[modules-threadpool]]
 === Thread pools
 
-A node holds several thread pools in order to improve how threads memory consumption
-are managed within a node. Many of these pools also have queues associated with them,
-which allow pending requests to be held instead
-of discarded.
+A node uses several thread pools to manage memory consumption. 
+Queues associated with many of the thread pools enable pending requests 
+to be held instead of discarded. 
 
 There are several thread pools, but the important ones include:
 

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -1,11 +1,10 @@
 [[modules-threadpool]]
-== Thread Pool
+=== Thread pools
 
 A node holds several thread pools in order to improve how threads memory consumption
 are managed within a node. Many of these pools also have queues associated with them,
 which allow pending requests to be held instead
 of discarded.
-
 
 There are several thread pools, but the important ones include:
 
@@ -35,7 +34,7 @@ There are several thread pools, but the important ones include:
 `write`::
     For single-document index/delete/update and bulk requests. Thread pool type
     is `fixed` with a size of <<node.processors, `# of allocated processors`>>,
-    queue_size of `200`. The maximum size for this pool is 
+    queue_size of `200`. The maximum size for this pool is
     `pass:[1 + ]`<<node.processors, `# of allocated processors`>>.
 
 `snapshot`::
@@ -94,15 +93,13 @@ thread_pool:
         size: 30
 --------------------------------------------------
 
-[float]
-[[types]]
-=== Thread pool types
+[[thread-pool-types]]
+==== Thread pool types
 
 The following are the types of thread pools and their respective parameters:
 
-[float]
-[[fixed]]
-==== `fixed`
+[[fixed-thread-pool]]
+===== `fixed`
 
 The `fixed` thread pool holds a fixed size of threads to handle the
 requests with a queue (optionally bounded) for pending requests that
@@ -123,9 +120,8 @@ thread_pool:
         queue_size: 1000
 --------------------------------------------------
 
-[float]
-[[scaling]]
-==== `scaling`
+[[scaling-thread-pool]]
+===== `scaling`
 
 The `scaling` thread pool holds a dynamic number of threads. This
 number is proportional to the workload and varies between the value of
@@ -143,9 +139,8 @@ thread_pool:
         keep_alive: 2m
 --------------------------------------------------
 
-[float]
 [[node.processors]]
-=== Allocated processors setting
+==== Allocated processors setting
 
 The number of processors is automatically detected, and the thread pool settings
 are automatically set based on it. In some cases it can be useful to override

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -81,6 +81,8 @@ include::settings/transform-settings.asciidoc[]
 
 include::modules/transport.asciidoc[]
 
+include::modules/threadpool.asciidoc[]
+
 include::settings/notification-settings.asciidoc[]
 
 include::setup/important-settings.asciidoc[]


### PR DESCRIPTION
Moves [thread pools content][0] from [Modules][1] to the
[Configuring Elasticsearch][2].

Supporting changes:
* Changes page title to "Thread pools"
* Increments several headings
* Removes several unneeded `[float]` attributes
* Updates the anchors of several headings

Relates to #53307

[0]: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-threadpool.html
[1]: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules.html
[2]: https://www.elastic.co/guide/en/elasticsearch/reference/master/settings.html