### PR TITLE
[7.x] Fix error massage for unknown value type (#55821)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -109,6 +109,8 @@ public enum ValueType implements Writeable {
             case "string":  return STRING;
             case "double":
             case "float":   return DOUBLE;
+            case "number":
+            case "numeric":
             case "long":
             case "integer":
             case "short":

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -54,7 +54,13 @@ public abstract class ValuesSourceAggregationBuilder<AB extends ValuesSourceAggr
         objectParser.declareField(ValuesSourceAggregationBuilder::missing, XContentParser::objectText,
             ParseField.CommonFields.MISSING, ObjectParser.ValueType.VALUE);
 
-        objectParser.declareField(ValuesSourceAggregationBuilder::userValueTypeHint, p -> ValueType.lenientParse(p.text()),
+        objectParser.declareField(ValuesSourceAggregationBuilder::userValueTypeHint, p -> {
+                ValueType type = ValueType.lenientParse(p.text());
+                if (type == null) {
+                    throw new IllegalArgumentException("Unknown value type [" + p.text() + "]");
+                }
+                return type;
+            },
             ValueType.VALUE_TYPE, ObjectParser.ValueType.STRING);
 
         if (formattable) {


### PR DESCRIPTION
Fixes confusing error message when unknown value type is specified in a terms
aggregation. Adds support for parsing "numeric" and "number" value types.

Fixes #55727
