### PR TITLE
Improve some Byte Array Handling Spots

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -22,13 +22,12 @@ package org.elasticsearch.cluster.metadata;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.DocumentMapper;
 
 import java.io.IOException;
@@ -73,10 +72,9 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
     public MappingMetadata(String type, Map<String, Object> mapping) {
         this.type = type;
         try {
-            XContentBuilder mappingBuilder = XContentFactory.jsonBuilder().map(mapping);
-            this.source = new CompressedXContent(BytesReference.bytes(mappingBuilder));
-        }
-        catch (IOException e) {
+            this.source = new CompressedXContent(
+                    (builder, params) -> builder.mapContents(mapping), XContentType.JSON, ToXContent.EMPTY_PARAMS);
+        } catch (IOException e) {
             throw new UncheckedIOException(e);  // XContent exception, should never happen
         }
         Map<String, Object> withoutType = mapping;

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.bytes;
 
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.BytesStream;
@@ -61,7 +62,7 @@ public interface BytesReference extends Comparable<BytesReference>, ToXContentFr
         if (bytesRef.offset == 0 && bytesRef.length == bytesRef.bytes.length) {
             return bytesRef.bytes;
         }
-        return BytesRef.deepCopyOf(bytesRef).bytes;
+        return ArrayUtil.copyOfSubArray(bytesRef.bytes, bytesRef.offset, bytesRef.offset + bytesRef.length);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.compress;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedOutputStream;
@@ -45,19 +47,9 @@ import java.util.zip.CheckedOutputStream;
 public final class CompressedXContent {
 
     private static int crc32(BytesReference data) {
-        OutputStream dummy = new OutputStream() {
-            @Override
-            public void write(int b) throws IOException {
-                // no-op
-            }
-            @Override
-            public void write(byte[] b, int off, int len) throws IOException {
-                // no-op
-            }
-        };
         CRC32 crc32 = new CRC32();
         try {
-            data.writeTo(new CheckedOutputStream(dummy, crc32));
+            data.writeTo(new CheckedOutputStream(Streams.NULL_OUTPUT_STREAM, crc32));
         } catch (IOException bogus) {
             // cannot happen
             throw new Error(bogus);
@@ -124,7 +116,7 @@ public final class CompressedXContent {
     }
 
     public CompressedXContent(String str) throws IOException {
-        this(new BytesArray(new BytesRef(str)));
+        this(new BytesArray(str.getBytes(StandardCharsets.UTF_8)));
     }
 
     /** Return the compressed bytes. */

--- a/server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -51,6 +51,19 @@ public abstract class Streams {
 
     public static final int BUFFER_SIZE = 1024 * 8;
 
+    /**
+     * OutputStream that just throws all the bytes away
+     */
+    public static final OutputStream NULL_OUTPUT_STREAM = new OutputStream() {
+        @Override
+        public void write(int b) {
+            // no-op
+        }
+        @Override
+        public void write(byte[] b, int off, int len) {
+            // no-op
+        }
+    };
 
     //---------------------------------------------------------------------
     // Copy methods for java.io.InputStream / java.io.OutputStream
@@ -209,7 +222,7 @@ public abstract class Streams {
      * Fully consumes the input stream, throwing the bytes away. Returns the number of bytes consumed.
      */
     public static long consumeFully(InputStream inputStream) throws IOException {
-        return copy(inputStream, new NullOutputStream());
+        return copy(inputStream, NULL_OUTPUT_STREAM);
     }
 
     public static List<String> readAllLines(InputStream input) throws IOException {
@@ -382,22 +395,6 @@ public abstract class Streams {
             if (limitOnLastMark != NO_MARK) {
                 currentLimit = limitOnLastMark;
             }
-        }
-    }
-
-    /**
-     * OutputStream that just throws all the bytes away
-     */
-    static class NullOutputStream extends OutputStream {
-
-        @Override
-        public void write(int b) {
-
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) {
-
         }
     }
 }


### PR DESCRIPTION
Some small memory-saving improvements in `byte[]` handling.
