### PR TITLE
[DOCS] EQL: Update attribute for multi arg footnotes

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -707,7 +707,7 @@ field datatypes:
 `<wildcard_exp>`::
 +
 --
-(Required{multi-arg}, string)
+(Required{multi-arg-ref}, string)
 Wildcard expression used to match the source string. If `null`, the function
 returns `null`. Fields are not supported as arguments.
 -- 


### PR DESCRIPTION
Changes an occurrence of `{multi-arg}` to `{multi-arg-ref}`.
This prevents duplicate footnotes from displaying:

<img width="468" alt="Screen Shot 2020-04-28 at 10 12 39 AM" src="https://user-images.githubusercontent.com/40268737/80498372-a43fb080-8939-11ea-9072-4888fc62b700.png">

Depends on https://github.com/elastic/docs/pull/1819
