### PR TITLE
[DOCS] Add collapsible sections to 8.0 breaking changes [Part 2]

### DIFF
--- a/docs/reference/migration/migrate_8_0/breaker.asciidoc
+++ b/docs/reference/migration/migrate_8_0/breaker.asciidoc
@@ -3,9 +3,14 @@
 === Packaging changes
 
 //tag::notable-breaking-changes[]
-[float]
-==== In Flight Request Circuit Breaker
-
+.The `in_flight_requests` stat has been renamed `inflight_requests` in logs and diagnostic APIs.
+[%collapsible]
+====
+*Details* +
 The name of the in flight requests circuit breaker in log output and diagnostic APIs (such as the node stats API) changes from `in_flight_requests` to `inflight_requests` to align it with the name of the corresponding settings.
 
+*Impact* +
+Update your workflow and applications to use the `inflight_requests` stat in
+place of `in_flight_requests`.
+====
 //end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster.asciidoc
@@ -9,10 +9,17 @@
 
 // end::notable-breaking-changes[]
 
-[float]
-==== Change to API to add voting configuration exclusions
-
+.The voting configuration exclusions API endpoint has changed.
+[%collapsible]
+====
+*Details* +
 The `POST /_cluster/voting_config_exclusions/{node_filter}` API has been
 removed in favour of `POST /_cluster/voting_config_exclusions?node_names=...`
 and `POST /_cluster/voting_config_exclusions?node_ids=...` which allow you to
 specify the names or IDs of the nodes to exclude.
+
+*Impact* +
+To avoid errors, discontinue use of the `POST
+/_cluster/voting_config_exclusions/{node_filter}` API endpoint.
+Use `POST /_cluster/voting_config_exclusions?node_ids=...` instead.
+====

--- a/docs/reference/migration/migrate_8_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_8_0/cluster.asciidoc
@@ -19,7 +19,8 @@ and `POST /_cluster/voting_config_exclusions?node_ids=...` which allow you to
 specify the names or IDs of the nodes to exclude.
 
 *Impact* +
-To avoid errors, discontinue use of the `POST
-/_cluster/voting_config_exclusions/{node_filter}` API endpoint.
-Use `POST /_cluster/voting_config_exclusions?node_ids=...` instead.
+Use `POST /_cluster/voting_config_exclusions?node_ids=...` and specify the nodes
+to exclude instead of using a node filter. Requests submitted to the
+`/_cluster/voting_config_exclusions/{node_filter}` endpoint will return an
+error.
 ====

--- a/docs/reference/migration/migrate_8_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_8_0/discovery.asciidoc
@@ -9,9 +9,11 @@
 
 // end::notable-breaking-changes[]
 
-[float]
-==== Removal of old discovery settings
 
+.`discovery.zen` settings have been removed.
+[%collapsible]
+====
+*Details* +
 All settings under the `discovery.zen` namespace, which existed only for BWC reasons in 7.x,
 are no longer supported. In particular, this includes:
 
@@ -37,3 +39,7 @@ are no longer supported. In particular, this includes:
 - `discovery.zen.master_election.wait_for_joins_timeout`
 - `discovery.zen.master_election.ignore_non_master_pings`
 - `discovery.zen.publish.max_pending_cluster_states`
+
+*Impact* +
+To avoid errors, unset and discontinue use of any `discovery.zen.` settings.
+====

--- a/docs/reference/migration/migrate_8_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_8_0/discovery.asciidoc
@@ -41,5 +41,6 @@ are no longer supported. In particular, this includes:
 - `discovery.zen.publish.max_pending_cluster_states`
 
 *Impact* +
-To avoid errors, unset and discontinue use of any `discovery.zen.` settings.
+Discontinue use of the `discovery.zen` settings. Specifying these settings in
+`elasticsearch.yml` will result in an error on startup.
 ====

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -18,8 +18,8 @@ The number of completion contexts within a single completion field
 has been limited to 10.
 
 *Impact* +
-To avoid errors, use no more than 10 completion contexts within a single
-completion field.
+Use a maximum of 10 completion contexts in a completion field. Specifying more
+than 10 completions context will return an error.
 ====
 
 
@@ -32,8 +32,8 @@ APIs have been removed in favour of their typeless REST endpoints, since indexes
 no longer contain types, these typed endpoints are obsolete.
 
 *Impact* +
-To avoid errors, discontinue use of mapping API endpoints that contain document
-types in their path. Use the replacement mapping API endpoints instead.
+Use the typeless REST endpoints to update and retrieve mappings. Requests
+submitted to the typed mapping API endpoints will return an error.
 ====
 
 .Multi-fields within multi-fields is no longer supported.

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -19,7 +19,7 @@ has been limited to 10.
 
 *Impact* +
 Use a maximum of 10 completion contexts in a completion field. Specifying more
-than 10 completions context will return an error.
+than 10 completion contexts will return an error.
 ====
 
 

--- a/docs/reference/migration/migrate_8_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/mappings.asciidoc
@@ -9,33 +9,56 @@
 
 // end::notable-breaking-changes[]
 
-[float]
-==== Limiting the number of completion contexts
 
+.The maximum number of completion contexts per field is now 10.
+[%collapsible]
+====
+*Details* +
 The number of completion contexts within a single completion field
 has been limited to 10.
 
-[float]
-==== Removal of types
+*Impact* +
+To avoid errors, use no more than 10 completion contexts within a single
+completion field.
+====
 
+
+.Mapping API endpoints containing document types have been removed.
+[%collapsible]
+====
+*Details* +
 The typed REST endpoints of the Put Mapping, Get Mapping and Get Field mapping
 APIs have been removed in favour of their typeless REST endpoints, since indexes
 no longer contain types, these typed endpoints are obsolete.
 
-[float]
-==== Defining multi-fields within multi-fields
+*Impact* +
+To avoid errors, discontinue use of mapping API endpoints that contain document
+types in their path. Use the replacement mapping API endpoints instead.
+====
 
+.Multi-fields within multi-fields is no longer supported.
+[%collapsible]
+====
+*Details* +
 Previously, it was possible to define a multi-field within a multi-field.
 Defining chained multi-fields was deprecated in 7.3 and is now no longer
-supported. To migrate the mappings, all instances of `fields` that occur within
+supported.
+
+*Impact* +
+To migrate mappings, all instances of `fields` that occur within
 a `fields` block should be removed, either by flattening the chained `fields`
 blocks into a single level, or by switching to `copy_to` if appropriate.
+====
 
-[float]
 [[fieldnames-enabling]]
-==== Disallow use of the `enabled` setting on the  `_field_names` field
-
+.The `_field_names` meta-field's `enabled` parameter has been removed.
+[%collapsible]
+====
+*Details* +
 The setting has been deprecated with 7.5 and is no longer supported on new indices.
 Mappings for older indices will continue to work but emit a deprecation warning.
+
+*Impact* +
 The `enabled` setting for `_field_names` should be removed from templates and mappings. 
 Disabling _field_names is not necessary because it no longer carries a large index overhead.
+====


### PR DESCRIPTION
Adds collapsible sections to the 8.0 breaking changes.

To make reviews easier and avoid introducing errors, I've
tried to limit my changes to formatting, with the exception
of rewording heading as sentences.

I'm also splitting this effort over several PRs to make reviews
manageable.

Relates to #55629 and #53229

### Preview
http://elasticsearch_55862.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html