### PR TITLE
[7.x] Add support for V2 index templates to /_cat/templates (#55829)

### DIFF
--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -65,7 +65,7 @@ The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
-name      index_patterns order version
+name      index_patterns order version composed_of
 template0 [te*]          0
 template1 [tea*]         1
 template2 [teak*]        2     7

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Help":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         cat.templates:
@@ -32,8 +32,8 @@
 ---
 "Normal templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -83,8 +83,8 @@
 ---
 "Filtered templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -125,8 +125,8 @@
 ---
 "Column headers":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -163,8 +163,8 @@
 ---
 "Select columns":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -197,8 +197,8 @@
 ---
 "Sort templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
         features: default_shards, no_xpack
 
     - do:
@@ -250,8 +250,8 @@
 ---
 "Multiple template":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
         features: default_shards, no_xpack
 
     - do:
@@ -286,8 +286,8 @@
 ---
 "Mixture of V1 and V2 templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
         features: allowed_warnings
 
     - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
@@ -1,5 +1,9 @@
 ---
 "Help":
+    - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
+
     - do:
         cat.templates:
           help: true
@@ -10,6 +14,7 @@
                        index_patterns   .+   \n
                        order            .+   \n
                        version          .+   \n
+                       composed_of      .+   \n
                    $/
 
 ---
@@ -26,6 +31,9 @@
 
 ---
 "Normal templates":
+    - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
 
     - do:
         indices.put_template:
@@ -58,7 +66,7 @@
                  (^|\n)test     \s+
                  \[test-\*\]    \s+
                  0              \s+
-                 1
+                 1              \s+
                  (\n|$)
                /
 
@@ -68,12 +76,15 @@
                 (^|\n)test_2    \s+
                 \[test-2\*\]    \s+
                 1               \s+
-                2
+                2               \s+
                 (\n|$)
                /
 
 ---
 "Filtered templates":
+    - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
 
     - do:
         indices.put_template:
@@ -107,12 +118,16 @@
                     test    \s+
                     \[t\*\] \s+
                     0       \s+
-                    1
+                    1       \s*
                     \n
                 $/
 
 ---
 "Column headers":
+    - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
+
     - do:
         indices.put_template:
           name: test
@@ -135,17 +150,22 @@
                     name            \s+
                     index_patterns  \s+
                     order           \s+
-                    version
+                    version         \s+
+                    composed_of
                     \n
                     test            \s+
                     \[t\*\]         \s+
                     0               \s+
-                    1
+                    1               \s*
                     \n
                  $/
 
 ---
 "Select columns":
+    - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
+
     - do:
         indices.put_template:
           name: test
@@ -177,7 +197,10 @@
 ---
 "Sort templates":
     - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
         features: default_shards, no_xpack
+
     - do:
         indices.put_template:
           name: test
@@ -207,8 +230,8 @@
     - match:
         $body: |
               /^
-                  test   \s+ \[t\*\]  \s+   \n
-                  test_1 \s+ \[te\*\] \s+ 1 \n
+                  test   \s+ \[t\*\]  \s+   \n \n
+                  test_1 \s+ \[te\*\] \s+ 1 \n \n
               $/
 
     - do:
@@ -219,15 +242,18 @@
     - match:
         $body: |
               /^
-                  test_1 \s+ \[te\*\]   \s+ 1\n
-                  test   \s+ \[t\*\]    \s+  \n
+                  test_1 \s+ \[te\*\]   \s+ 1\n \n
+                  test   \s+ \[t\*\]    \s+  \n \n
 
               $/
 
 ---
 "Multiple template":
     - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
         features: default_shards, no_xpack
+
     - do:
         indices.put_template:
           name: test_1
@@ -254,4 +280,57 @@
                  test_1       \s+
                  \[t\*,\ te\*\]
                  \n
+                 \n
               $/
+
+---
+"Mixture of V1 and V2 templates":
+    - skip:
+        version: " - 7.9.99"
+        reason: "not backported yet"
+        features: allowed_warnings
+
+    - do:
+        indices.put_template:
+          name: test
+          body:
+            order: 0
+            version: 1
+            index_patterns: test-*
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+    - do:
+        allowed_warnings:
+          - "index template [testv2] has index patterns [v2-test] matching patterns from existing older templates [global] with patterns (global => [*]); this template [testv2] will take precedence during new index creation"
+        indices.put_index_template:
+          name: testv2
+          body:
+            index_patterns: [v2-test]
+            priority: 4
+            version: 3
+            composed_of: [foo, bar]
+
+    - do:
+        cat.templates: {}
+
+    - match:
+        $body: >
+               /
+                 (^|\n)test     \s+
+                 \[test-\*\]    \s+
+                 0              \s+
+                 1              \s+
+                 (\n|$)
+               /
+
+    - match:
+        $body: >
+               /
+                (^|\n)testv2    \s+
+                \[v2-test\]     \s+
+                4               \s+
+                3               \s+
+                \[foo,\ bar\]
+               /

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTemplatesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTemplatesAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateV2;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.regex.Regex;
@@ -32,6 +33,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestResponseListener;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
@@ -78,8 +80,9 @@ public class RestTemplatesAction extends AbstractCatAction {
         table.startHeaders();
         table.addCell("name", "alias:n;desc:template name");
         table.addCell("index_patterns", "alias:t;desc:template index patterns");
-        table.addCell("order", "alias:o;desc:template application order number");
+        table.addCell("order", "alias:o,p;desc:template application order/priority number");
         table.addCell("version", "alias:v;desc:version");
+        table.addCell("composed_of", "alias:c;desc:component templates comprising index template");
         table.endHeaders();
         return table;
     }
@@ -95,6 +98,21 @@ public class RestTemplatesAction extends AbstractCatAction {
                 table.addCell("[" + String.join(", ", indexData.patterns()) + "]");
                 table.addCell(indexData.getOrder());
                 table.addCell(indexData.getVersion());
+                table.addCell("");
+                table.endRow();
+            }
+        }
+
+        for (Map.Entry<String, IndexTemplateV2> entry : metadata.templatesV2().entrySet()) {
+            String name = entry.getKey();
+            IndexTemplateV2 template = entry.getValue();
+            if (patternString == null || Regex.simpleMatch(patternString, name)) {
+                table.startRow();
+                table.addCell(name);
+                table.addCell("[" + String.join(", ", template.indexPatterns()) + "]");
+                table.addCell(template.priority());
+                table.addCell(template.version());
+                table.addCell("[" + String.join(", ", template.composedOf()) + "]");
                 table.endRow();
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -98,6 +98,7 @@ import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableList;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
@@ -588,12 +589,21 @@ public abstract class ESRestTestCase extends ESTestCase {
                         if ("".equals(template)) {
                             throw new IllegalStateException("empty template in templates list:\n" + templates);
                         }
-                        logger.debug("Clearing template [{}]", template);
-                        adminClient().performRequest(new Request("DELETE", "_template/" + template));
+                        logger.info("Clearing template [{}]", template);
+                        try {
+                            adminClient().performRequest(new Request("DELETE", "_template/" + template));
+                        } catch (ResponseException e) {
+                            // This is fine, it could be a V2 template
+                            assertThat(e.getMessage(), containsString("index_template [" + template + "] missing"));
+                            try {
+                                adminClient().performRequest(new Request("DELETE", "_index_template/" + template));
+                            } catch (ResponseException e2) {
+                                // We hit a version of ES that doesn't support index templates v2 yet, so it's safe to ignore
+                            }
+                        }
                     }
                 }
                 try {
-                    adminClient().performRequest(new Request("DELETE", "_index_template/*"));
                     adminClient().performRequest(new Request("DELETE", "_component_template/*"));
                 } catch (ResponseException e) {
                     // We hit a version of ES that doesn't support index templates v2 yet, so it's safe to ignore


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add support for V2 index templates to /_cat/templates (#55829)