### PR TITLE
Adjust skip version for _cat/templates yml tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Help":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         cat.templates:
@@ -32,8 +32,8 @@
 ---
 "Normal templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -83,8 +83,8 @@
 ---
 "Filtered templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -125,8 +125,8 @@
 ---
 "Column headers":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -163,8 +163,8 @@
 ---
 "Select columns":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
 
     - do:
         indices.put_template:
@@ -197,8 +197,8 @@
 ---
 "Sort templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
         features: default_shards, no_xpack
 
     - do:
@@ -250,8 +250,8 @@
 ---
 "Multiple template":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
         features: default_shards, no_xpack
 
     - do:
@@ -286,8 +286,8 @@
 ---
 "Mixture of V1 and V2 templates":
     - skip:
-        version: " - 7.9.99"
-        reason: "not backported yet"
+        version: " - 7.7.99"
+        reason: "format changed in 7.8 to accomodate V2 index templates"
         features: allowed_warnings
 
     - do:


### PR DESCRIPTION
Now that #55829 has been backported (#55866) we can adjust these skip versions to allow testing with
7.8+.

Relates to #53101
