### PR TITLE
[ML] Add daily_model_snapshot_retention_after_days to job config

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
@@ -63,8 +63,8 @@ public class Job implements ToXContentObject {
     public static final ParseField RENORMALIZATION_WINDOW_DAYS = new ParseField("renormalization_window_days");
     public static final ParseField BACKGROUND_PERSIST_INTERVAL = new ParseField("background_persist_interval");
     public static final ParseField MODEL_SNAPSHOT_RETENTION_DAYS = new ParseField("model_snapshot_retention_days");
-    public static final ParseField MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS =
-        new ParseField("model_snapshot_retention_sparse_after_days");
+    public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
+        new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
@@ -95,7 +95,7 @@ public class Job implements ToXContentObject {
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         PARSER.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
-        PARSER.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
+        PARSER.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         PARSER.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
         PARSER.declareStringOrNull(Builder::setModelSnapshotId, MODEL_SNAPSHOT_ID);
         PARSER.declareString(Builder::setResultsIndexName, RESULTS_INDEX_NAME);
@@ -117,7 +117,7 @@ public class Job implements ToXContentObject {
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
-    private final Long modelSnapshotRetentionSparseAfterDays;
+    private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
@@ -129,7 +129,7 @@ public class Job implements ToXContentObject {
                 Date createTime, Date finishedTime,
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
-                Long modelSnapshotRetentionDays, Long modelSnapshotRetentionSparseAfterDays, Long resultsRetentionDays,
+                Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
                 Map<String, Object> customSettings, String modelSnapshotId, String resultsIndexName, Boolean deleting,
                 Boolean allowLazyOpen) {
 
@@ -146,7 +146,7 @@ public class Job implements ToXContentObject {
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
-        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
@@ -265,8 +265,8 @@ public class Job implements ToXContentObject {
         return modelSnapshotRetentionDays;
     }
 
-    public Long getModelSnapshotRetentionSparseAfterDays() {
-        return modelSnapshotRetentionSparseAfterDays;
+    public Long getDailyModelSnapshotRetentionAfterDays() {
+        return dailyModelSnapshotRetentionAfterDays;
     }
 
     public Long getResultsRetentionDays() {
@@ -329,8 +329,8 @@ public class Job implements ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
-        if (modelSnapshotRetentionSparseAfterDays != null) {
-            builder.field(MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        if (dailyModelSnapshotRetentionAfterDays != null) {
+            builder.field(DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(), dailyModelSnapshotRetentionAfterDays);
         }
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
@@ -378,7 +378,7 @@ public class Job implements ToXContentObject {
             && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
             && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
             && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
-            && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
+            && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
             && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
             && Objects.equals(this.customSettings, that.customSettings)
             && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
@@ -391,7 +391,7 @@ public class Job implements ToXContentObject {
     public int hashCode() {
         return Objects.hash(jobId, jobType, groups, description, createTime, finishedTime,
             analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-            backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+            backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
             customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
     }
 
@@ -419,7 +419,7 @@ public class Job implements ToXContentObject {
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays;
-        private Long modelSnapshotRetentionSparseAfterDays;
+        private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
@@ -448,7 +448,7 @@ public class Job implements ToXContentObject {
             this.renormalizationWindowDays = job.getRenormalizationWindowDays();
             this.backgroundPersistInterval = job.getBackgroundPersistInterval();
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
-            this.modelSnapshotRetentionSparseAfterDays = job.getModelSnapshotRetentionSparseAfterDays();
+            this.dailyModelSnapshotRetentionAfterDays = job.getDailyModelSnapshotRetentionAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
@@ -531,8 +531,8 @@ public class Job implements ToXContentObject {
             return this;
         }
 
-        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
-            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        public Builder setDailyModelSnapshotRetentionAfterDays(Long dailyModelSnapshotRetentionAfterDays) {
+            this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
             return this;
         }
 
@@ -572,7 +572,7 @@ public class Job implements ToXContentObject {
             return new Job(
                 id, jobType, groups, description, createTime, finishedTime,
                 analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
                 customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
         }
     }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/Job.java
@@ -63,6 +63,8 @@ public class Job implements ToXContentObject {
     public static final ParseField RENORMALIZATION_WINDOW_DAYS = new ParseField("renormalization_window_days");
     public static final ParseField BACKGROUND_PERSIST_INTERVAL = new ParseField("background_persist_interval");
     public static final ParseField MODEL_SNAPSHOT_RETENTION_DAYS = new ParseField("model_snapshot_retention_days");
+    public static final ParseField MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS =
+        new ParseField("model_snapshot_retention_sparse_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField RESULTS_INDEX_NAME = new ParseField("results_index_name");
@@ -93,6 +95,7 @@ public class Job implements ToXContentObject {
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         PARSER.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
+        PARSER.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
         PARSER.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
         PARSER.declareStringOrNull(Builder::setModelSnapshotId, MODEL_SNAPSHOT_ID);
         PARSER.declareString(Builder::setResultsIndexName, RESULTS_INDEX_NAME);
@@ -114,6 +117,7 @@ public class Job implements ToXContentObject {
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
+    private final Long modelSnapshotRetentionSparseAfterDays;
     private final Long resultsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
@@ -125,8 +129,9 @@ public class Job implements ToXContentObject {
                 Date createTime, Date finishedTime,
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
-                Long modelSnapshotRetentionDays, Long resultsRetentionDays, Map<String, Object> customSettings,
-                String modelSnapshotId, String resultsIndexName, Boolean deleting, Boolean allowLazyOpen) {
+                Long modelSnapshotRetentionDays, Long modelSnapshotRetentionSparseAfterDays, Long resultsRetentionDays,
+                Map<String, Object> customSettings, String modelSnapshotId, String resultsIndexName, Boolean deleting,
+                Boolean allowLazyOpen) {
 
         this.jobId = jobId;
         this.jobType = jobType;
@@ -141,6 +146,7 @@ public class Job implements ToXContentObject {
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
+        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
@@ -259,6 +265,10 @@ public class Job implements ToXContentObject {
         return modelSnapshotRetentionDays;
     }
 
+    public Long getModelSnapshotRetentionSparseAfterDays() {
+        return modelSnapshotRetentionSparseAfterDays;
+    }
+
     public Long getResultsRetentionDays() {
         return resultsRetentionDays;
     }
@@ -319,6 +329,9 @@ public class Job implements ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
+        if (modelSnapshotRetentionSparseAfterDays != null) {
+            builder.field(MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        }
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
@@ -365,6 +378,7 @@ public class Job implements ToXContentObject {
             && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
             && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
             && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
+            && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
             && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
             && Objects.equals(this.customSettings, that.customSettings)
             && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
@@ -377,8 +391,8 @@ public class Job implements ToXContentObject {
     public int hashCode() {
         return Objects.hash(jobId, jobType, groups, description, createTime, finishedTime,
             analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-            backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, customSettings,
-            modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
+            backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+            customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
     }
 
     @Override
@@ -405,6 +419,7 @@ public class Job implements ToXContentObject {
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays;
+        private Long modelSnapshotRetentionSparseAfterDays;
         private Long resultsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
@@ -433,6 +448,7 @@ public class Job implements ToXContentObject {
             this.renormalizationWindowDays = job.getRenormalizationWindowDays();
             this.backgroundPersistInterval = job.getBackgroundPersistInterval();
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
+            this.modelSnapshotRetentionSparseAfterDays = job.getModelSnapshotRetentionSparseAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
@@ -515,6 +531,11 @@ public class Job implements ToXContentObject {
             return this;
         }
 
+        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
+            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+            return this;
+        }
+
         public Builder setResultsRetentionDays(Long resultsRetentionDays) {
             this.resultsRetentionDays = resultsRetentionDays;
             return this;
@@ -551,8 +572,8 @@ public class Job implements ToXContentObject {
             return new Job(
                 id, jobType, groups, description, createTime, finishedTime,
                 analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, customSettings,
-                modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
+                backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                customSettings, modelSnapshotId, resultsIndexName, deleting, allowLazyOpen);
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
@@ -52,6 +52,7 @@ public class JobUpdate implements ToXContentObject {
         PARSER.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
         PARSER.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
+        PARSER.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
         PARSER.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
         PARSER.declareField(Builder::setCustomSettings, (p, c) -> p.map(), Job.CUSTOM_SETTINGS, ObjectParser.ValueType.OBJECT);
         PARSER.declareBoolean(Builder::setAllowLazyOpen, Job.ALLOW_LAZY_OPEN);
@@ -66,6 +67,7 @@ public class JobUpdate implements ToXContentObject {
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
+    private final Long modelSnapshotRetentionSparseAfterDays;
     private final Long resultsRetentionDays;
     private final List<String> categorizationFilters;
     private final Map<String, Object> customSettings;
@@ -75,7 +77,8 @@ public class JobUpdate implements ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long modelSnapshotRetentionDays, @Nullable List<String> categorisationFilters,
+                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long modelSnapshotRetentionSparseAfterDays,
+                      @Nullable List<String> categorizationFilters,
                       @Nullable Map<String, Object> customSettings, @Nullable Boolean allowLazyOpen) {
         this.jobId = jobId;
         this.groups = groups;
@@ -86,8 +89,9 @@ public class JobUpdate implements ToXContentObject {
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
+        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
-        this.categorizationFilters = categorisationFilters;
+        this.categorizationFilters = categorizationFilters;
         this.customSettings = customSettings;
         this.allowLazyOpen = allowLazyOpen;
     }
@@ -172,6 +176,9 @@ public class JobUpdate implements ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.field(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
+        if (modelSnapshotRetentionSparseAfterDays != null) {
+            builder.field(Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        }
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
@@ -209,6 +216,7 @@ public class JobUpdate implements ToXContentObject {
             && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
             && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
             && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
+            && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
             && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
             && Objects.equals(this.categorizationFilters, that.categorizationFilters)
             && Objects.equals(this.customSettings, that.customSettings)
@@ -218,8 +226,8 @@ public class JobUpdate implements ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
-            backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, categorizationFilters, customSettings,
-            allowLazyOpen);
+            backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+            categorizationFilters, customSettings, allowLazyOpen);
     }
 
     public static class DetectorUpdate implements ToXContentObject {
@@ -312,6 +320,7 @@ public class JobUpdate implements ToXContentObject {
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays;
+        private Long modelSnapshotRetentionSparseAfterDays;
         private Long resultsRetentionDays;
         private List<String> categorizationFilters;
         private Map<String, Object> customSettings;
@@ -423,6 +432,18 @@ public class JobUpdate implements ToXContentObject {
         }
 
         /**
+         * The time in days after which only one model snapshot per day is retained for the job.
+         *
+         * Updates the {@link Job#modelSnapshotRetentionSparseAfterDays} setting
+         *
+         * @param modelSnapshotRetentionSparseAfterDays number of days to keep a model snapshot
+         */
+        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
+            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+            return this;
+        }
+
+        /**
          * Advanced configuration option. The number of days for which job results are retained
          *
          * Updates the {@link Job#resultsRetentionDays} setting
@@ -466,8 +487,8 @@ public class JobUpdate implements ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, categorizationFilters, customSettings,
-                allowLazyOpen);
+                renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays,
+                categorizationFilters, customSettings, allowLazyOpen);
         }
     }
 }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/JobUpdate.java
@@ -52,7 +52,7 @@ public class JobUpdate implements ToXContentObject {
         PARSER.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
         PARSER.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
         PARSER.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
-        PARSER.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
+        PARSER.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         PARSER.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
         PARSER.declareField(Builder::setCustomSettings, (p, c) -> p.map(), Job.CUSTOM_SETTINGS, ObjectParser.ValueType.OBJECT);
         PARSER.declareBoolean(Builder::setAllowLazyOpen, Job.ALLOW_LAZY_OPEN);
@@ -67,7 +67,7 @@ public class JobUpdate implements ToXContentObject {
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
-    private final Long modelSnapshotRetentionSparseAfterDays;
+    private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
     private final List<String> categorizationFilters;
     private final Map<String, Object> customSettings;
@@ -77,7 +77,7 @@ public class JobUpdate implements ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long modelSnapshotRetentionSparseAfterDays,
+                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long dailyModelSnapshotRetentionAfterDays,
                       @Nullable List<String> categorizationFilters,
                       @Nullable Map<String, Object> customSettings, @Nullable Boolean allowLazyOpen) {
         this.jobId = jobId;
@@ -89,7 +89,7 @@ public class JobUpdate implements ToXContentObject {
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
-        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
         this.categorizationFilters = categorizationFilters;
         this.customSettings = customSettings;
@@ -176,8 +176,8 @@ public class JobUpdate implements ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.field(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
-        if (modelSnapshotRetentionSparseAfterDays != null) {
-            builder.field(Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        if (dailyModelSnapshotRetentionAfterDays != null) {
+            builder.field(Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(), dailyModelSnapshotRetentionAfterDays);
         }
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
@@ -216,7 +216,7 @@ public class JobUpdate implements ToXContentObject {
             && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
             && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
             && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
-            && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
+            && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
             && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
             && Objects.equals(this.categorizationFilters, that.categorizationFilters)
             && Objects.equals(this.customSettings, that.customSettings)
@@ -226,7 +226,7 @@ public class JobUpdate implements ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
-            backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+            backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
             categorizationFilters, customSettings, allowLazyOpen);
     }
 
@@ -320,7 +320,7 @@ public class JobUpdate implements ToXContentObject {
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays;
-        private Long modelSnapshotRetentionSparseAfterDays;
+        private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
         private List<String> categorizationFilters;
         private Map<String, Object> customSettings;
@@ -434,12 +434,12 @@ public class JobUpdate implements ToXContentObject {
         /**
          * The time in days after which only one model snapshot per day is retained for the job.
          *
-         * Updates the {@link Job#modelSnapshotRetentionSparseAfterDays} setting
+         * Updates the {@link Job#dailyModelSnapshotRetentionAfterDays} setting
          *
-         * @param modelSnapshotRetentionSparseAfterDays number of days to keep a model snapshot
+         * @param dailyModelSnapshotRetentionAfterDays number of days to keep a model snapshot
          */
-        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
-            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        public Builder setDailyModelSnapshotRetentionAfterDays(Long dailyModelSnapshotRetentionAfterDays) {
+            this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
             return this;
         }
 
@@ -487,7 +487,7 @@ public class JobUpdate implements ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays,
+                renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays,
                 categorizationFilters, customSettings, allowLazyOpen);
         }
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
@@ -145,6 +145,9 @@ public class JobTests extends AbstractXContentTestCase<Job> {
             builder.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            builder.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobTests.java
@@ -145,7 +145,7 @@ public class JobTests extends AbstractXContentTestCase<Job> {
             builder.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            builder.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+            builder.setDailyModelSnapshotRetentionAfterDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setResultsRetentionDays(randomNonNegativeLong());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
@@ -71,6 +71,9 @@ public class JobUpdateTests extends AbstractXContentTestCase<JobUpdate> {
             update.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            update.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             update.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ml/job/config/JobUpdateTests.java
@@ -71,7 +71,7 @@ public class JobUpdateTests extends AbstractXContentTestCase<JobUpdate> {
             update.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            update.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+            update.setDailyModelSnapshotRetentionAfterDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             update.setResultsRetentionDays(randomNonNegativeLong());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -72,8 +72,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public static final ParseField RENORMALIZATION_WINDOW_DAYS = new ParseField("renormalization_window_days");
     public static final ParseField BACKGROUND_PERSIST_INTERVAL = new ParseField("background_persist_interval");
     public static final ParseField MODEL_SNAPSHOT_RETENTION_DAYS = new ParseField("model_snapshot_retention_days");
-    public static final ParseField MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS =
-        new ParseField("model_snapshot_retention_sparse_after_days");
+    public static final ParseField DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS =
+        new ParseField("daily_model_snapshot_retention_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField MODEL_SNAPSHOT_MIN_VERSION = new ParseField("model_snapshot_min_version");
@@ -125,7 +125,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         parser.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
         parser.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
-        parser.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
+        parser.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
         parser.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
         parser.declareStringOrNull(Builder::setModelSnapshotId, MODEL_SNAPSHOT_ID);
         parser.declareStringOrNull(Builder::setModelSnapshotMinVersion, MODEL_SNAPSHOT_MIN_VERSION);
@@ -158,7 +158,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
-    private final Long modelSnapshotRetentionSparseAfterDays;
+    private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
@@ -171,7 +171,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 Date createTime, Date finishedTime,
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
-                Long modelSnapshotRetentionDays, Long modelSnapshotRetentionSparseAfterDays, Long resultsRetentionDays,
+                Long modelSnapshotRetentionDays, Long dailyModelSnapshotRetentionAfterDays, Long resultsRetentionDays,
                 Map<String, Object> customSettings, String modelSnapshotId, Version modelSnapshotMinVersion, String resultsIndexName,
                 boolean deleting, boolean allowLazyOpen) {
 
@@ -189,7 +189,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
-        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
@@ -222,9 +222,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         modelSnapshotRetentionDays = in.readOptionalLong();
         // TODO: change version in backport
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            modelSnapshotRetentionSparseAfterDays = in.readOptionalLong();
+            dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         } else {
-            modelSnapshotRetentionSparseAfterDays = null;
+            dailyModelSnapshotRetentionAfterDays = null;
         }
         resultsRetentionDays = in.readOptionalLong();
         Map<String, Object> readCustomSettings = in.readMap();
@@ -391,8 +391,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return modelSnapshotRetentionDays;
     }
 
-    public Long getModelSnapshotRetentionSparseAfterDays() {
-        return modelSnapshotRetentionSparseAfterDays;
+    public Long getDailyModelSnapshotRetentionAfterDays() {
+        return dailyModelSnapshotRetentionAfterDays;
     }
 
     public Long getResultsRetentionDays() {
@@ -499,7 +499,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         out.writeOptionalLong(modelSnapshotRetentionDays);
         // TODO: change version in backport
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeOptionalLong(modelSnapshotRetentionSparseAfterDays);
+            out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         }
         out.writeOptionalLong(resultsRetentionDays);
         out.writeMap(customSettings);
@@ -565,8 +565,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (modelSnapshotRetentionDays != null) {
             builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
-        if (modelSnapshotRetentionSparseAfterDays != null) {
-            builder.field(MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        if (dailyModelSnapshotRetentionAfterDays != null) {
+            builder.field(DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(), dailyModelSnapshotRetentionAfterDays);
         }
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
@@ -613,7 +613,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
                 && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
-                && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
+                && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
                 && Objects.equals(this.customSettings, that.customSettings)
                 && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
@@ -627,7 +627,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public int hashCode() {
         return Objects.hash(jobId, jobType, jobVersion, groups, description, createTime, finishedTime,
                 analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
                 customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
     }
 
@@ -670,7 +670,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays = DEFAULT_MODEL_SNAPSHOT_RETENTION_DAYS;
-        private Long modelSnapshotRetentionSparseAfterDays;
+        private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
@@ -701,7 +701,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             this.renormalizationWindowDays = job.getRenormalizationWindowDays();
             this.backgroundPersistInterval = job.getBackgroundPersistInterval();
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
-            this.modelSnapshotRetentionSparseAfterDays = job.getModelSnapshotRetentionSparseAfterDays();
+            this.dailyModelSnapshotRetentionAfterDays = job.getDailyModelSnapshotRetentionAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
@@ -734,7 +734,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             modelSnapshotRetentionDays = in.readOptionalLong();
             // TODO: change version in backport
             if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-                modelSnapshotRetentionSparseAfterDays = in.readOptionalLong();
+                dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
             }
             resultsRetentionDays = in.readOptionalLong();
             customSettings = in.readMap();
@@ -839,8 +839,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
-        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
-            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        public Builder setDailyModelSnapshotRetentionAfterDays(Long dailyModelSnapshotRetentionAfterDays) {
+            this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
             return this;
         }
 
@@ -936,7 +936,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             out.writeOptionalLong(modelSnapshotRetentionDays);
             // TODO: change version in backport
             if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-                out.writeOptionalLong(modelSnapshotRetentionSparseAfterDays);
+                out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
             }
             out.writeOptionalLong(resultsRetentionDays);
             out.writeMap(customSettings);
@@ -996,8 +996,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             if (modelSnapshotRetentionDays != null) {
                 builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
             }
-            if (modelSnapshotRetentionSparseAfterDays != null) {
-                builder.field(MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+            if (dailyModelSnapshotRetentionAfterDays != null) {
+                builder.field(DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(), dailyModelSnapshotRetentionAfterDays);
             }
             if (resultsRetentionDays != null) {
                 builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
@@ -1045,7 +1045,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
                     && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
                     && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
-                    && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
+                    && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                     && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
                     && Objects.equals(this.customSettings, that.customSettings)
                     && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
@@ -1059,7 +1059,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         public int hashCode() {
             return Objects.hash(id, jobType, jobVersion, groups, description, analysisConfig, analysisLimits, dataDescription,
                     createTime, finishedTime, modelPlotConfig, renormalizationWindowDays,
-                    backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                    backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
                     customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
         }
 
@@ -1082,8 +1082,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             checkValidBackgroundPersistInterval();
             checkValueNotLessThan(0, RENORMALIZATION_WINDOW_DAYS.getPreferredName(), renormalizationWindowDays);
             checkValueNotLessThan(0, MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
-            checkValueNotLessThan(0, MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(),
-                modelSnapshotRetentionSparseAfterDays);
+            checkValueNotLessThan(0, DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(),
+                dailyModelSnapshotRetentionAfterDays);
             checkValueNotLessThan(0, RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
 
             if (!MlStrings.isValidId(id)) {
@@ -1188,7 +1188,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return new Job(
                     id, jobType, jobVersion, groups, description, createTime, finishedTime,
                     analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                    backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                    backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
                     customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -72,6 +72,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public static final ParseField RENORMALIZATION_WINDOW_DAYS = new ParseField("renormalization_window_days");
     public static final ParseField BACKGROUND_PERSIST_INTERVAL = new ParseField("background_persist_interval");
     public static final ParseField MODEL_SNAPSHOT_RETENTION_DAYS = new ParseField("model_snapshot_retention_days");
+    public static final ParseField MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS =
+        new ParseField("model_snapshot_retention_sparse_after_days");
     public static final ParseField RESULTS_RETENTION_DAYS = new ParseField("results_retention_days");
     public static final ParseField MODEL_SNAPSHOT_ID = new ParseField("model_snapshot_id");
     public static final ParseField MODEL_SNAPSHOT_MIN_VERSION = new ParseField("model_snapshot_min_version");
@@ -123,6 +125,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             TimeValue.parseTimeValue(val, BACKGROUND_PERSIST_INTERVAL.getPreferredName())), BACKGROUND_PERSIST_INTERVAL);
         parser.declareLong(Builder::setResultsRetentionDays, RESULTS_RETENTION_DAYS);
         parser.declareLong(Builder::setModelSnapshotRetentionDays, MODEL_SNAPSHOT_RETENTION_DAYS);
+        parser.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
         parser.declareField(Builder::setCustomSettings, (p, c) -> p.mapOrdered(), CUSTOM_SETTINGS, ValueType.OBJECT);
         parser.declareStringOrNull(Builder::setModelSnapshotId, MODEL_SNAPSHOT_ID);
         parser.declareStringOrNull(Builder::setModelSnapshotMinVersion, MODEL_SNAPSHOT_MIN_VERSION);
@@ -155,6 +158,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
+    private final Long modelSnapshotRetentionSparseAfterDays;
     private final Long resultsRetentionDays;
     private final Map<String, Object> customSettings;
     private final String modelSnapshotId;
@@ -167,8 +171,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 Date createTime, Date finishedTime,
                 AnalysisConfig analysisConfig, AnalysisLimits analysisLimits, DataDescription dataDescription,
                 ModelPlotConfig modelPlotConfig, Long renormalizationWindowDays, TimeValue backgroundPersistInterval,
-                Long modelSnapshotRetentionDays, Long resultsRetentionDays, Map<String, Object> customSettings,
-                String modelSnapshotId, Version modelSnapshotMinVersion, String resultsIndexName, boolean deleting, boolean allowLazyOpen) {
+                Long modelSnapshotRetentionDays, Long modelSnapshotRetentionSparseAfterDays, Long resultsRetentionDays,
+                Map<String, Object> customSettings, String modelSnapshotId, Version modelSnapshotMinVersion, String resultsIndexName,
+                boolean deleting, boolean allowLazyOpen) {
 
         this.jobId = jobId;
         this.jobType = jobType;
@@ -184,6 +189,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
+        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
         this.customSettings = customSettings == null ? null : Collections.unmodifiableMap(customSettings);
         this.modelSnapshotId = modelSnapshotId;
@@ -214,6 +220,12 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         renormalizationWindowDays = in.readOptionalLong();
         backgroundPersistInterval = in.readOptionalTimeValue();
         modelSnapshotRetentionDays = in.readOptionalLong();
+        // TODO: change version in backport
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            modelSnapshotRetentionSparseAfterDays = in.readOptionalLong();
+        } else {
+            modelSnapshotRetentionSparseAfterDays = null;
+        }
         resultsRetentionDays = in.readOptionalLong();
         Map<String, Object> readCustomSettings = in.readMap();
         customSettings = readCustomSettings == null ? null : Collections.unmodifiableMap(readCustomSettings);
@@ -379,6 +391,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return modelSnapshotRetentionDays;
     }
 
+    public Long getModelSnapshotRetentionSparseAfterDays() {
+        return modelSnapshotRetentionSparseAfterDays;
+    }
+
     public Long getResultsRetentionDays() {
         return resultsRetentionDays;
     }
@@ -481,6 +497,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         out.writeOptionalLong(renormalizationWindowDays);
         out.writeOptionalTimeValue(backgroundPersistInterval);
         out.writeOptionalLong(modelSnapshotRetentionDays);
+        // TODO: change version in backport
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeOptionalLong(modelSnapshotRetentionSparseAfterDays);
+        }
         out.writeOptionalLong(resultsRetentionDays);
         out.writeMap(customSettings);
         out.writeOptionalString(modelSnapshotId);
@@ -545,6 +565,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         if (modelSnapshotRetentionDays != null) {
             builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
+        if (modelSnapshotRetentionSparseAfterDays != null) {
+            builder.field(MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        }
         if (resultsRetentionDays != null) {
             builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
@@ -590,6 +613,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                 && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
                 && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
+                && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
                 && Objects.equals(this.customSettings, that.customSettings)
                 && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
@@ -603,8 +627,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
     public int hashCode() {
         return Objects.hash(jobId, jobType, jobVersion, groups, description, createTime, finishedTime,
                 analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, customSettings,
-                modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
+                backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
     }
 
     // Class already extends from AbstractDiffable, so copied from ToXContentToBytes#toString()
@@ -646,6 +670,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays = DEFAULT_MODEL_SNAPSHOT_RETENTION_DAYS;
+        private Long modelSnapshotRetentionSparseAfterDays;
         private Long resultsRetentionDays;
         private Map<String, Object> customSettings;
         private String modelSnapshotId;
@@ -676,6 +701,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             this.renormalizationWindowDays = job.getRenormalizationWindowDays();
             this.backgroundPersistInterval = job.getBackgroundPersistInterval();
             this.modelSnapshotRetentionDays = job.getModelSnapshotRetentionDays();
+            this.modelSnapshotRetentionSparseAfterDays = job.getModelSnapshotRetentionSparseAfterDays();
             this.resultsRetentionDays = job.getResultsRetentionDays();
             this.customSettings = job.getCustomSettings() == null ? null : new LinkedHashMap<>(job.getCustomSettings());
             this.modelSnapshotId = job.getModelSnapshotId();
@@ -706,6 +732,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             renormalizationWindowDays = in.readOptionalLong();
             backgroundPersistInterval = in.readOptionalTimeValue();
             modelSnapshotRetentionDays = in.readOptionalLong();
+            // TODO: change version in backport
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+                modelSnapshotRetentionSparseAfterDays = in.readOptionalLong();
+            }
             resultsRetentionDays = in.readOptionalLong();
             customSettings = in.readMap();
             modelSnapshotId = in.readOptionalString();
@@ -809,6 +839,11 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return this;
         }
 
+        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
+            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+            return this;
+        }
+
         public Builder setResultsRetentionDays(Long resultsRetentionDays) {
             this.resultsRetentionDays = resultsRetentionDays;
             return this;
@@ -899,6 +934,10 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             out.writeOptionalLong(renormalizationWindowDays);
             out.writeOptionalTimeValue(backgroundPersistInterval);
             out.writeOptionalLong(modelSnapshotRetentionDays);
+            // TODO: change version in backport
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+                out.writeOptionalLong(modelSnapshotRetentionSparseAfterDays);
+            }
             out.writeOptionalLong(resultsRetentionDays);
             out.writeMap(customSettings);
             out.writeOptionalString(modelSnapshotId);
@@ -957,6 +996,9 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             if (modelSnapshotRetentionDays != null) {
                 builder.field(MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
             }
+            if (modelSnapshotRetentionSparseAfterDays != null) {
+                builder.field(MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+            }
             if (resultsRetentionDays != null) {
                 builder.field(RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
             }
@@ -1003,6 +1045,7 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
                     && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
                     && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
                     && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
+                    && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
                     && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
                     && Objects.equals(this.customSettings, that.customSettings)
                     && Objects.equals(this.modelSnapshotId, that.modelSnapshotId)
@@ -1016,8 +1059,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         public int hashCode() {
             return Objects.hash(id, jobType, jobVersion, groups, description, analysisConfig, analysisLimits, dataDescription,
                     createTime, finishedTime, modelPlotConfig, renormalizationWindowDays,
-                    backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, customSettings, modelSnapshotId,
-                    modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
+                    backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
         }
 
         /**
@@ -1039,6 +1082,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             checkValidBackgroundPersistInterval();
             checkValueNotLessThan(0, RENORMALIZATION_WINDOW_DAYS.getPreferredName(), renormalizationWindowDays);
             checkValueNotLessThan(0, MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
+            checkValueNotLessThan(0, MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(),
+                modelSnapshotRetentionSparseAfterDays);
             checkValueNotLessThan(0, RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
 
             if (!MlStrings.isValidId(id)) {
@@ -1143,8 +1188,8 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
             return new Job(
                     id, jobType, jobVersion, groups, description, createTime, finishedTime,
                     analysisConfig, analysisLimits, dataDescription, modelPlotConfig, renormalizationWindowDays,
-                    backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, customSettings,
-                    modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
+                    backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                    customSettings, modelSnapshotId, modelSnapshotMinVersion, resultsIndexName, deleting, allowLazyOpen);
         }
 
         private void checkValidBackgroundPersistInterval() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -52,7 +52,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
             parser.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
             parser.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
             parser.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
-            parser.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
+            parser.declareLong(Builder::setDailyModelSnapshotRetentionAfterDays, Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS);
             parser.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
             parser.declareField(Builder::setCustomSettings, (p, c) -> p.map(), Job.CUSTOM_SETTINGS, ObjectParser.ValueType.OBJECT);
             parser.declareBoolean(Builder::setAllowLazyOpen, Job.ALLOW_LAZY_OPEN);
@@ -73,7 +73,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
-    private final Long modelSnapshotRetentionSparseAfterDays;
+    private final Long dailyModelSnapshotRetentionAfterDays;
     private final Long resultsRetentionDays;
     private final List<String> categorizationFilters;
     private final Map<String, Object> customSettings;
@@ -87,7 +87,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long modelSnapshotRetentionSparseAfterDays,
+                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long dailyModelSnapshotRetentionAfterDays,
                       @Nullable List<String> categorizationFilters,
                       @Nullable Map<String, Object> customSettings, @Nullable String modelSnapshotId,
                       @Nullable Version modelSnapshotMinVersion, @Nullable Version jobVersion, @Nullable Boolean clearJobFinishTime,
@@ -101,7 +101,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
-        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
         this.categorizationFilters = categorizationFilters;
         this.customSettings = customSettings;
@@ -129,9 +129,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         modelSnapshotRetentionDays = in.readOptionalLong();
         // TODO: change version on backport
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-            modelSnapshotRetentionSparseAfterDays = in.readOptionalLong();
+            dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         } else {
-            modelSnapshotRetentionSparseAfterDays = null;
+            dailyModelSnapshotRetentionAfterDays = null;
         }
         resultsRetentionDays = in.readOptionalLong();
         if (in.readBoolean()) {
@@ -176,7 +176,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalLong(modelSnapshotRetentionDays);
         // TODO: change on backport
         if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-            out.writeOptionalLong(modelSnapshotRetentionSparseAfterDays);
+            out.writeOptionalLong(dailyModelSnapshotRetentionAfterDays);
         }
         out.writeOptionalLong(resultsRetentionDays);
         out.writeBoolean(categorizationFilters != null);
@@ -241,8 +241,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         return modelSnapshotRetentionDays;
     }
 
-    public Long getModelSnapshotRetentionSparseAfterDays() {
-        return modelSnapshotRetentionSparseAfterDays;
+    public Long getDailyModelSnapshotRetentionAfterDays() {
+        return dailyModelSnapshotRetentionAfterDays;
     }
 
     public Long getResultsRetentionDays() {
@@ -309,8 +309,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.field(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
-        if (modelSnapshotRetentionSparseAfterDays != null) {
-            builder.field(Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        if (dailyModelSnapshotRetentionAfterDays != null) {
+            builder.field(Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName(), dailyModelSnapshotRetentionAfterDays);
         }
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
@@ -366,8 +366,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             updateFields.add(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName());
         }
-        if (modelSnapshotRetentionSparseAfterDays != null) {
-            updateFields.add(Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName());
+        if (dailyModelSnapshotRetentionAfterDays != null) {
+            updateFields.add(Job.DAILY_MODEL_SNAPSHOT_RETENTION_AFTER_DAYS.getPreferredName());
         }
         if (resultsRetentionDays != null) {
             updateFields.add(Job.RESULTS_RETENTION_DAYS.getPreferredName());
@@ -447,8 +447,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.setModelSnapshotRetentionDays(modelSnapshotRetentionDays);
         }
-        if (modelSnapshotRetentionSparseAfterDays != null) {
-            builder.setModelSnapshotRetentionSparseAfterDays(modelSnapshotRetentionSparseAfterDays);
+        if (dailyModelSnapshotRetentionAfterDays != null) {
+            builder.setDailyModelSnapshotRetentionAfterDays(dailyModelSnapshotRetentionAfterDays);
         }
         if (resultsRetentionDays != null) {
             builder.setResultsRetentionDays(resultsRetentionDays);
@@ -488,8 +488,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && (renormalizationWindowDays == null || Objects.equals(renormalizationWindowDays, job.getRenormalizationWindowDays()))
                 && (backgroundPersistInterval == null || Objects.equals(backgroundPersistInterval, job.getBackgroundPersistInterval()))
                 && (modelSnapshotRetentionDays == null || Objects.equals(modelSnapshotRetentionDays, job.getModelSnapshotRetentionDays()))
-                && (modelSnapshotRetentionSparseAfterDays == null
-                        || Objects.equals(modelSnapshotRetentionSparseAfterDays, job.getModelSnapshotRetentionSparseAfterDays()))
+                && (dailyModelSnapshotRetentionAfterDays == null
+                        || Objects.equals(dailyModelSnapshotRetentionAfterDays, job.getDailyModelSnapshotRetentionAfterDays()))
                 && (resultsRetentionDays == null || Objects.equals(resultsRetentionDays, job.getResultsRetentionDays()))
                 && (categorizationFilters == null
                         || Objects.equals(categorizationFilters, job.getAnalysisConfig().getCategorizationFilters()))
@@ -540,7 +540,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
                 && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
-                && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
+                && Objects.equals(this.dailyModelSnapshotRetentionAfterDays, that.dailyModelSnapshotRetentionAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
                 && Objects.equals(this.categorizationFilters, that.categorizationFilters)
                 && Objects.equals(this.customSettings, that.customSettings)
@@ -554,7 +554,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                backgroundPersistInterval, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays, resultsRetentionDays,
                 categorizationFilters, customSettings, modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime,
                 allowLazyOpen);
     }
@@ -661,7 +661,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays;
-        private Long modelSnapshotRetentionSparseAfterDays;
+        private Long dailyModelSnapshotRetentionAfterDays;
         private Long resultsRetentionDays;
         private List<String> categorizationFilters;
         private Map<String, Object> customSettings;
@@ -720,8 +720,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
             return this;
         }
 
-        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
-            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+        public Builder setDailyModelSnapshotRetentionAfterDays(Long dailyModelSnapshotRetentionAfterDays) {
+            this.dailyModelSnapshotRetentionAfterDays = dailyModelSnapshotRetentionAfterDays;
             return this;
         }
 
@@ -777,7 +777,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                    renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays,
+                    renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, dailyModelSnapshotRetentionAfterDays,
                     categorizationFilters, customSettings, modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime,
                     allowLazyOpen);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -52,6 +52,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
             parser.declareLong(Builder::setRenormalizationWindowDays, Job.RENORMALIZATION_WINDOW_DAYS);
             parser.declareLong(Builder::setResultsRetentionDays, Job.RESULTS_RETENTION_DAYS);
             parser.declareLong(Builder::setModelSnapshotRetentionDays, Job.MODEL_SNAPSHOT_RETENTION_DAYS);
+            parser.declareLong(Builder::setModelSnapshotRetentionSparseAfterDays, Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS);
             parser.declareStringArray(Builder::setCategorizationFilters, AnalysisConfig.CATEGORIZATION_FILTERS);
             parser.declareField(Builder::setCustomSettings, (p, c) -> p.map(), Job.CUSTOM_SETTINGS, ObjectParser.ValueType.OBJECT);
             parser.declareBoolean(Builder::setAllowLazyOpen, Job.ALLOW_LAZY_OPEN);
@@ -72,6 +73,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
     private final Long renormalizationWindowDays;
     private final TimeValue backgroundPersistInterval;
     private final Long modelSnapshotRetentionDays;
+    private final Long modelSnapshotRetentionSparseAfterDays;
     private final Long resultsRetentionDays;
     private final List<String> categorizationFilters;
     private final Map<String, Object> customSettings;
@@ -85,7 +87,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
                       @Nullable List<DetectorUpdate> detectorUpdates, @Nullable ModelPlotConfig modelPlotConfig,
                       @Nullable AnalysisLimits analysisLimits, @Nullable TimeValue backgroundPersistInterval,
                       @Nullable Long renormalizationWindowDays, @Nullable Long resultsRetentionDays,
-                      @Nullable Long modelSnapshotRetentionDays, @Nullable List<String> categorisationFilters,
+                      @Nullable Long modelSnapshotRetentionDays, @Nullable Long modelSnapshotRetentionSparseAfterDays,
+                      @Nullable List<String> categorizationFilters,
                       @Nullable Map<String, Object> customSettings, @Nullable String modelSnapshotId,
                       @Nullable Version modelSnapshotMinVersion, @Nullable Version jobVersion, @Nullable Boolean clearJobFinishTime,
                       @Nullable Boolean allowLazyOpen) {
@@ -98,8 +101,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         this.renormalizationWindowDays = renormalizationWindowDays;
         this.backgroundPersistInterval = backgroundPersistInterval;
         this.modelSnapshotRetentionDays = modelSnapshotRetentionDays;
+        this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
         this.resultsRetentionDays = resultsRetentionDays;
-        this.categorizationFilters = categorisationFilters;
+        this.categorizationFilters = categorizationFilters;
         this.customSettings = customSettings;
         this.modelSnapshotId = modelSnapshotId;
         this.modelSnapshotMinVersion = modelSnapshotMinVersion;
@@ -123,6 +127,12 @@ public class JobUpdate implements Writeable, ToXContentObject {
         renormalizationWindowDays = in.readOptionalLong();
         backgroundPersistInterval = in.readOptionalTimeValue();
         modelSnapshotRetentionDays = in.readOptionalLong();
+        // TODO: change version on backport
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            modelSnapshotRetentionSparseAfterDays = in.readOptionalLong();
+        } else {
+            modelSnapshotRetentionSparseAfterDays = null;
+        }
         resultsRetentionDays = in.readOptionalLong();
         if (in.readBoolean()) {
             categorizationFilters = in.readStringList();
@@ -164,6 +174,10 @@ public class JobUpdate implements Writeable, ToXContentObject {
         out.writeOptionalLong(renormalizationWindowDays);
         out.writeOptionalTimeValue(backgroundPersistInterval);
         out.writeOptionalLong(modelSnapshotRetentionDays);
+        // TODO: change on backport
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeOptionalLong(modelSnapshotRetentionSparseAfterDays);
+        }
         out.writeOptionalLong(resultsRetentionDays);
         out.writeBoolean(categorizationFilters != null);
         if (categorizationFilters != null) {
@@ -225,6 +239,10 @@ public class JobUpdate implements Writeable, ToXContentObject {
 
     public Long getModelSnapshotRetentionDays() {
         return modelSnapshotRetentionDays;
+    }
+
+    public Long getModelSnapshotRetentionSparseAfterDays() {
+        return modelSnapshotRetentionSparseAfterDays;
     }
 
     public Long getResultsRetentionDays() {
@@ -291,6 +309,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.field(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName(), modelSnapshotRetentionDays);
         }
+        if (modelSnapshotRetentionSparseAfterDays != null) {
+            builder.field(Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName(), modelSnapshotRetentionSparseAfterDays);
+        }
         if (resultsRetentionDays != null) {
             builder.field(Job.RESULTS_RETENTION_DAYS.getPreferredName(), resultsRetentionDays);
         }
@@ -344,6 +365,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         }
         if (modelSnapshotRetentionDays != null) {
             updateFields.add(Job.MODEL_SNAPSHOT_RETENTION_DAYS.getPreferredName());
+        }
+        if (modelSnapshotRetentionSparseAfterDays != null) {
+            updateFields.add(Job.MODEL_SNAPSHOT_RETENTION_SPARSE_AFTER_DAYS.getPreferredName());
         }
         if (resultsRetentionDays != null) {
             updateFields.add(Job.RESULTS_RETENTION_DAYS.getPreferredName());
@@ -423,6 +447,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
         if (modelSnapshotRetentionDays != null) {
             builder.setModelSnapshotRetentionDays(modelSnapshotRetentionDays);
         }
+        if (modelSnapshotRetentionSparseAfterDays != null) {
+            builder.setModelSnapshotRetentionSparseAfterDays(modelSnapshotRetentionSparseAfterDays);
+        }
         if (resultsRetentionDays != null) {
             builder.setResultsRetentionDays(resultsRetentionDays);
         }
@@ -461,6 +488,8 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && (renormalizationWindowDays == null || Objects.equals(renormalizationWindowDays, job.getRenormalizationWindowDays()))
                 && (backgroundPersistInterval == null || Objects.equals(backgroundPersistInterval, job.getBackgroundPersistInterval()))
                 && (modelSnapshotRetentionDays == null || Objects.equals(modelSnapshotRetentionDays, job.getModelSnapshotRetentionDays()))
+                && (modelSnapshotRetentionSparseAfterDays == null
+                        || Objects.equals(modelSnapshotRetentionSparseAfterDays, job.getModelSnapshotRetentionSparseAfterDays()))
                 && (resultsRetentionDays == null || Objects.equals(resultsRetentionDays, job.getResultsRetentionDays()))
                 && (categorizationFilters == null
                         || Objects.equals(categorizationFilters, job.getAnalysisConfig().getCategorizationFilters()))
@@ -511,6 +540,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
                 && Objects.equals(this.renormalizationWindowDays, that.renormalizationWindowDays)
                 && Objects.equals(this.backgroundPersistInterval, that.backgroundPersistInterval)
                 && Objects.equals(this.modelSnapshotRetentionDays, that.modelSnapshotRetentionDays)
+                && Objects.equals(this.modelSnapshotRetentionSparseAfterDays, that.modelSnapshotRetentionSparseAfterDays)
                 && Objects.equals(this.resultsRetentionDays, that.resultsRetentionDays)
                 && Objects.equals(this.categorizationFilters, that.categorizationFilters)
                 && Objects.equals(this.customSettings, that.customSettings)
@@ -524,8 +554,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, renormalizationWindowDays,
-                backgroundPersistInterval, modelSnapshotRetentionDays, resultsRetentionDays, categorizationFilters, customSettings,
-                modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime, allowLazyOpen);
+                backgroundPersistInterval, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays, resultsRetentionDays,
+                categorizationFilters, customSettings, modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime,
+                allowLazyOpen);
     }
 
     public static class DetectorUpdate implements Writeable, ToXContentObject {
@@ -630,6 +661,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
         private Long renormalizationWindowDays;
         private TimeValue backgroundPersistInterval;
         private Long modelSnapshotRetentionDays;
+        private Long modelSnapshotRetentionSparseAfterDays;
         private Long resultsRetentionDays;
         private List<String> categorizationFilters;
         private Map<String, Object> customSettings;
@@ -688,6 +720,11 @@ public class JobUpdate implements Writeable, ToXContentObject {
             return this;
         }
 
+        public Builder setModelSnapshotRetentionSparseAfterDays(Long modelSnapshotRetentionSparseAfterDays) {
+            this.modelSnapshotRetentionSparseAfterDays = modelSnapshotRetentionSparseAfterDays;
+            return this;
+        }
+
         public Builder setResultsRetentionDays(Long resultsRetentionDays) {
             this.resultsRetentionDays = resultsRetentionDays;
             return this;
@@ -740,8 +777,9 @@ public class JobUpdate implements Writeable, ToXContentObject {
 
         public JobUpdate build() {
             return new JobUpdate(jobId, groups, description, detectorUpdates, modelPlotConfig, analysisLimits, backgroundPersistInterval,
-                    renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, categorizationFilters, customSettings,
-                    modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime, allowLazyOpen);
+                    renormalizationWindowDays, resultsRetentionDays, modelSnapshotRetentionDays, modelSnapshotRetentionSparseAfterDays,
+                    categorizationFilters, customSettings, modelSnapshotId, modelSnapshotMinVersion, jobVersion, clearJobFinishTime,
+                    allowLazyOpen);
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -106,7 +106,7 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         assertNull(job.getRenormalizationWindowDays());
         assertNull(job.getBackgroundPersistInterval());
         assertThat(job.getModelSnapshotRetentionDays(), equalTo(1L));
-        assertNull(job.getModelSnapshotRetentionSparseAfterDays());
+        assertNull(job.getDailyModelSnapshotRetentionAfterDays());
         assertNull(job.getResultsRetentionDays());
         assertNotNull(job.allInputFields());
         assertFalse(job.allInputFields().isEmpty());
@@ -628,7 +628,7 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
             builder.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            builder.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+            builder.setDailyModelSnapshotRetentionAfterDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setResultsRetentionDays(randomNonNegativeLong());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -106,6 +106,7 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         assertNull(job.getRenormalizationWindowDays());
         assertNull(job.getBackgroundPersistInterval());
         assertThat(job.getModelSnapshotRetentionDays(), equalTo(1L));
+        assertNull(job.getModelSnapshotRetentionSparseAfterDays());
         assertNull(job.getResultsRetentionDays());
         assertNotNull(job.allInputFields());
         assertFalse(job.allInputFields().isEmpty());
@@ -625,6 +626,9 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         }
         if (randomBoolean()) {
             builder.setModelSnapshotRetentionDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
+            builder.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setResultsRetentionDays(randomNonNegativeLong());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -77,7 +77,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
             update.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            update.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+            update.setDailyModelSnapshotRetentionAfterDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             update.setResultsRetentionDays(randomNonNegativeLong());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -77,6 +77,9 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
             update.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            update.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             update.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean() && jobSupportsCategorizationFilters(job)) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
@@ -61,7 +61,7 @@ public class JobBuilderTests extends AbstractSerializingTestCase<Job.Builder> {
             builder.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
-            builder.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+            builder.setDailyModelSnapshotRetentionAfterDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
             builder.setResultsRetentionDays(randomNonNegativeLong());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobBuilderTests.java
@@ -61,6 +61,9 @@ public class JobBuilderTests extends AbstractSerializingTestCase<Job.Builder> {
             builder.setModelSnapshotRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {
+            builder.setModelSnapshotRetentionSparseAfterDays(randomNonNegativeLong());
+        }
+        if (randomBoolean()) {
             builder.setResultsRetentionDays(randomNonNegativeLong());
         }
         if (randomBoolean()) {


### PR DESCRIPTION
This change adds a new setting, daily_model_snapshot_retention_after_days,
to the anomaly detection job config.

Initially this has no effect, the effect will be added in a followup PR.
This PR gets the complexities of making changes that interact with BWC
over well before feature freeze.

Relates #52150