### PR TITLE
Increase Timeout in ClusterDisruptionIT.testRestartNodeWhileIndexing (#55877)

### DIFF
--- a/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -489,10 +489,10 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
             threads[i].start();
         }
         ensureGreen(index);
-        assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(100)));
+        assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(100)), 1L, TimeUnit.MINUTES);
         internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback());
         ensureGreen(index);
-        assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(200)));
+        assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(200)), 1L, TimeUnit.MINUTES);
         stopped.set(true);
         for (Thread thread : threads) {
             thread.join();


### PR DESCRIPTION
The test failed in #55869 but the `docId` was never stuck, it just moved slowly upwards.
=> increasing to timeout.

Closes #55869

backport of #55877 