### PR TITLE
Fix NullPointer when message shortcircuited

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundMessage.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class InboundMessage implements Releasable {
 
@@ -87,7 +88,7 @@ public class InboundMessage implements Releasable {
     public Releasable takeBreakerReleaseControl() {
         final Releasable toReturn = breakerRelease;
         breakerRelease = null;
-        return toReturn;
+        return Objects.requireNonNullElse(toReturn, () -> {});
     }
 
     public StreamInput openOrGetStreamInput() throws IOException {

--- a/server/src/test/java/org/elasticsearch/transport/InboundAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundAggregatorTests.java
@@ -130,6 +130,7 @@ public class InboundAggregatorTests extends ESTestCase {
         assertThat(aggregated, notNullValue());
         assertTrue(aggregated.isShortCircuit());
         assertThat(aggregated.getException(), instanceOf(ActionNotFoundTransportException.class));
+        assertNotNull(aggregated.takeBreakerReleaseControl());
     }
 
     public void testCircuitBreak() throws IOException {


### PR DESCRIPTION
Currently if we shortcircuit a message the breaker release is null since
there is nothing to be broken. However, the TcpTransportChannel
infrastructure still expects it. This commit resolves this issue be
returning a no-op breaker release.