### PR TITLE
Fix CancelTests.testDeleteByQueryCancelWithWorkers

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.reindex;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
@@ -36,6 +37,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.ingest.IngestTestPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskInfo;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -175,18 +177,22 @@ public class CancelTests extends ReindexTestCase {
         try {
             response = future.get(30, TimeUnit.SECONDS);
         } catch (Exception e) {
+            if (ExceptionsHelper.unwrap(e, TaskCancelledException.class) != null) {
+                return; // the scroll request was cancelled
+            }
             String tasks = client().admin().cluster().prepareListTasks().setParentTaskId(mainTask.getTaskId())
                         .setDetailed(true).get().toString();
             throw new RuntimeException("Exception while waiting for the response. Running tasks: " + tasks, e);
+        } finally {
+            if (builder.request().getSlices() >= 1) {
+                // If we have more than one worker we might not have made all the modifications
+                numModifiedDocs -= ALLOWED_OPERATIONS.availablePermits();
+            }
         }
         assertThat(response.getReasonCancelled(), equalTo("by user request"));
         assertThat(response.getBulkFailures(), emptyIterable());
         assertThat(response.getSearchFailures(), emptyIterable());
 
-        if (builder.request().getSlices() >= 1) {
-            // If we have more than one worker we might not have made all the modifications
-            numModifiedDocs -= ALLOWED_OPERATIONS.availablePermits();
-        }
         flushAndRefresh(INDEX);
         assertion.assertThat(response, numDocs, numModifiedDocs);
     }


### PR DESCRIPTION
If a [fetch](https://github.com/elastic/elasticsearch/blob/128bcc59d802b2e1a6062edb09a302d5e79ab9f6/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java#L177) phase gets canceled, then the scroll and reindex requests will fail with TaskCancelledException. We need to relax the tests to take this into account.

Closes #55647