### PR TITLE
In field retrieval API, handle non-standard source paths.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -603,6 +603,14 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
+     * Given a field name, returns its possible paths in the _source. For example,
+     * the 'source path' for a multi-field is the path to its parent field.
+     */
+    public Set<String> sourcePath(String fullName) {
+        return fieldTypes.sourcePaths(fullName);
+    }
+
+    /**
      * Returns all mapped field types.
      */
     public Iterable<MappedFieldType> fieldTypes() {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -44,6 +44,14 @@ public class MockFieldMapper extends FieldMapper {
             MultiFields.empty(), new CopyTo.Builder().build());
     }
 
+    public MockFieldMapper(String fullName,
+                           MappedFieldType fieldType,
+                           MultiFields multifields,
+                           CopyTo copyTo) {
+        super(findSimpleName(fullName), setName(fullName, fieldType), setName(fullName, fieldType), dummySettings,
+            multifields, copyTo);
+    }
+
     static MappedFieldType setName(String fullName, MappedFieldType fieldType) {
         fieldType.setName(fullName);
         return fieldType;
@@ -89,5 +97,18 @@ public class MockFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List list) throws IOException {
+    }
+
+    public static class Builder extends FieldMapper.Builder<MockFieldMapper.Builder, MockFieldMapper> {
+        protected Builder(String name, MappedFieldType fieldType, MappedFieldType defaultFieldType) {
+            super(name, fieldType, defaultFieldType);
+            builder = this;
+        }
+
+        @Override
+        public MockFieldMapper build(BuilderContext context) {
+            MultiFields multiFields = multiFieldsBuilder.build(this, context);
+            return new MockFieldMapper(name(), fieldType, multiFields, copyTo);
+        }
     }
 }


### PR DESCRIPTION
This commit adds the capability to `FieldTypeLookup` to retrieve a field's
paths in the _source. When retrieving a field's values, we consult these
source paths to make sure we load the relevant values. This allows us to handle
requests for field aliases and multi-fields.

We also retrieve values that were copied into the field through copy_to. To me
this is what users would expect out of the API, and it's consistent with what
comes back from `docvalues_fields` and `stored_fields`. However it does add
some complexity, and was not something flagged as important from any of the
clients I spoke to about this API. I'm looking for feedback on this point.

Relates to #55363.