### PR TITLE
[7.7] json spec - add description for autoscaling (#55748)

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -165,9 +165,6 @@ testClusters.integTest {
 }
 
 validateRestSpec {
-  ignore 'autoscaling.delete_autoscaling_policy.json'
-  ignore 'autoscaling.get_autoscaling_policy.json'
-  ignore 'autoscaling.put_autoscaling_policy.json'
   ignore 'ml.validate.json'
   ignore 'ml.validate_detector.json'
 }


### PR DESCRIPTION
Backports the following commits to 7.7:
 - json spec - add description for autoscaling (#55748)