### PR TITLE
Fix java detection for JDKs without jrunscript

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -157,7 +157,7 @@ class BuildPlugin implements Plugin<Project> {
                 runtimeJavaVersionEnum = JavaVersion.toVersion(findJavaSpecificationVersion(project, runtimeJavaHome))
             }
 
-            String inFipsJvmScript = 'print(java.security.Security.getProviders()[0].name.toLowerCase().contains("fips"));'
+            String inFipsJvmScript = 'java.security.Security.getProviders()[0].name.toLowerCase().contains("fips")'
             boolean inFipsJvm = Boolean.parseBoolean(runScript(project, runtimeJavaHome, inFipsJvmScript))
 
             // Build debugging info

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -23,6 +23,7 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import org.apache.commons.io.IOUtils
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.precommit.PrecommitTasks
+import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.JavaVersion
@@ -53,6 +54,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
+import org.gradle.process.internal.ExecException
 import org.gradle.util.GradleVersion
 
 import java.nio.charset.StandardCharsets
@@ -156,7 +158,7 @@ class BuildPlugin implements Plugin<Project> {
             }
 
             String inFipsJvmScript = 'print(java.security.Security.getProviders()[0].name.toLowerCase().contains("fips"));'
-            boolean inFipsJvm = Boolean.parseBoolean(runJavaAsScript(project, runtimeJavaHome, inFipsJvmScript))
+            boolean inFipsJvm = Boolean.parseBoolean(runScript(project, runtimeJavaHome, inFipsJvmScript))
 
             // Build debugging info
             println '======================================='
@@ -446,46 +448,52 @@ class BuildPlugin implements Plugin<Project> {
 
     /** Finds printable java version of the given JAVA_HOME */
     private static String findJavaVersionDetails(Project project, String javaHome) {
-        String versionInfoScript = 'print(' +
-            'java.lang.System.getProperty("java.vendor.version", java.lang.System.getProperty("java.vendor")) + " " + ' +
+        String versionInfoScript = 'java.lang.System.getProperty("java.vendor.version", java.lang.System.getProperty("java.vendor")) + " " + ' +
             'java.lang.System.getProperty("java.version") + " [" +' +
             'java.lang.System.getProperty("java.vm.name") + " " + ' +
-            'java.lang.System.getProperty("java.vm.version") + "]");'
-        return runJavaAsScript(project, javaHome, versionInfoScript).trim()
+            'java.lang.System.getProperty("java.vm.version") + "]"'
+        return runScript(project, javaHome, versionInfoScript).trim()
     }
 
     /** Finds the parsable java specification version */
     private static String findJavaSpecificationVersion(Project project, String javaHome) {
-        String versionScript = 'print(java.lang.System.getProperty("java.specification.version"));'
-        return runJavaAsScript(project, javaHome, versionScript)
-    }
-
-    private static String findJavaVendor(Project project, String javaHome) {
-        String vendorScript = 'print(java.lang.System.getProperty("java.vendor.version", System.getProperty("java.vendor"));'
-        return runJavaAsScript(project, javaHome, vendorScript)
-    }
-
-    /** Finds the parsable java specification version */
-    private static String findJavaVersion(Project project, String javaHome) {
-        String versionScript = 'print(java.lang.System.getProperty("java.version"));'
-        return runJavaAsScript(project, javaHome, versionScript)
+        String versionScript = 'java.lang.System.getProperty("java.specification.version")'
+        return runScript(project, javaHome, versionScript)
     }
 
     /** Runs the given javascript using jjs from the jdk, and returns the output */
-    private static String runJavaAsScript(Project project, String javaHome, String script) {
-        ByteArrayOutputStream stdout = new ByteArrayOutputStream()
-        ByteArrayOutputStream stderr = new ByteArrayOutputStream()
+    private static String runScript(Project project, String javaHome, String script) {
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             // gradle/groovy does not properly escape the double quote for windows
             script = script.replace('"', '\\"')
         }
-        File jrunscriptPath = new File(javaHome, 'bin/jrunscript')
-        ExecResult result = project.exec {
-            executable = jrunscriptPath
-            args '-e', script
-            standardOutput = stdout
-            errorOutput = stderr
-            ignoreExitValue = true
+
+        try {
+            File jrunscriptPath = new File(javaHome, 'bin/jrunscript')
+            return exec(project, false) { spec ->
+                spec.executable = jrunscriptPath
+                spec.args '-e', "print($script);"
+            }
+        } catch (ExecException ex) {
+            // if jrunscript fails, let's try jshell
+            ByteArrayInputStream input = new ByteArrayInputStream("System.err.print(${script});\n".getBytes('UTF-8'))
+            File jshellPath = new File(javaHome, 'bin/jshell')
+            return exec(project, true) { spec ->
+                spec.executable = jshellPath
+                spec.args '-s'
+                spec.standardInput = input
+            }
+        }
+    }
+
+    private static String exec(Project project, boolean captureStdErr, Action<? super ExecSpec> spec) {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream()
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream()
+        ExecResult result = project.exec { ExecSpec s ->
+            spec.execute(s)
+            s.standardOutput = stdout
+            s.errorOutput = stderr
+            s.ignoreExitValue = true
         }
         if (result.exitValue != 0) {
             project.logger.error("STDOUT:")
@@ -493,8 +501,9 @@ class BuildPlugin implements Plugin<Project> {
             project.logger.error("STDERR:")
             stderr.toString('UTF-8').eachLine { line -> project.logger.error(line) }
             result.rethrowFailure()
+            result.assertNormalExitValue() // assert exit value in case the failure cause is null
         }
-        return stdout.toString('UTF-8').trim()
+        return (captureStdErr ? stderr : stdout).toString('UTF-8').trim()
     }
 
     /** Return the configuration name used for finding transitive deps of the given dependency. */

--- a/x-pack/plugin/sql/qa/security/with-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/security/with-ssl/build.gradle
@@ -205,10 +205,7 @@ integTestCluster {
     return tmpFile.exists()
   }
 }
-Closure notRunningFips = {
-  Boolean.parseBoolean(BuildPlugin.runJavaAsScript(project, project.runtimeJavaHome,
-          'print(java.security.Security.getProviders()[0].name.toLowerCase().contains("fips"));')) == false
-}
+Closure notRunningFips = { rootProject.ext.inFipsJvm == false }
 
 // Do not attempt to form a cluster in a FIPS JVM, as doing so with a JKS keystore will fail.
 // TODO Revisit this when SQL CLI client can handle key/certificate instead of only Keystores.


### PR DESCRIPTION
The latest openjdk 15 build has removed nashorn, so there are no longer any Javascript execution engines packaged in the JDK. We rely on this to probe Java versions so this PR now falls back to using `jshell` if the `runjscript` method fails.

Closes #55804