### PR TITLE
[DOCS] Adds missing space and a relevant link to the slm execute API page

### DIFF
--- a/docs/reference/slm/apis/slm-execute.asciidoc
+++ b/docs/reference/slm/apis/slm-execute.asciidoc
@@ -57,7 +57,9 @@ If successful, this request returns the generated snapshot name:
 --------------------------------------------------
 // TESTRESPONSE[skip:we can't handle snapshots from docs tests]
 
-The snapshot is taken in the background. 
-You can use the<<modules-snapshots,snapshot APIs>> to monitor the status of the snapshot.
+The snapshot is taken in the background. You can use the 
+<<snapshot-lifecycle-management-api,snapshot APIs>> to 
+<<snapshots-monitor-snapshot-restore,monitor the status of the snapshot>>.
 
-To see the status of a policy's most recent snapshot, you can use the <<slm-api-get-policy>>.
+To see the status of a policy's most recent snapshot, you can use the 
+<<slm-api-get-policy>>.

--- a/docs/reference/slm/apis/slm-execute.asciidoc
+++ b/docs/reference/slm/apis/slm-execute.asciidoc
@@ -62,4 +62,4 @@ The snapshot is taken in the background. You can use the
 <<snapshots-monitor-snapshot-restore,monitor the status of the snapshot>>.
 
 To see the status of a policy's most recent snapshot, you can use the 
-<<slm-api-get-policy>>.
+<<slm-api-get-policy,get snapshot lifecycle policy API>>.


### PR DESCRIPTION
## Overview

This PR makes the following changes on the `Execute snapshot lifecycle policy API` page:

* adds a missing space to the text
* adds a link that points to the monitoring snapshots page
* changes a link in the text so that it points to the page of the snapshot APIs.

## Preview

[Execute snapshot lifecycle policy API](http://elasticsearch_55917.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/slm-api-execute-lifecycle.html)