### PR TITLE
[ML] fix auto-upgrade service so that it runs when indices are available

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -682,7 +682,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
             new MlConfigMigrator(settings, client, clusterService, indexNameExpressionResolver), clusterService);
 
         MlAutoUpdateService mlAutoUpdateService = new MlAutoUpdateService(threadPool,
-            List.of(new DatafeedConfigAutoUpdater(datafeedConfigProvider)));
+            List.of(new DatafeedConfigAutoUpdater(datafeedConfigProvider, indexNameExpressionResolver)));
         clusterService.addListener(mlAutoUpdateService);
         // this object registers as a license state listener, and is never removed, so there's no need to retain another reference to it
         final InvalidLicenseEnforcer enforcer =

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAutoUpdateService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAutoUpdateService.java
@@ -55,8 +55,8 @@ public class MlAutoUpdateService implements ClusterStateListener {
         Version minNodeVersion = event.state().getNodes().getMinNodeVersion();
         final List<UpdateAction> toRun = updateActions.stream()
             .filter(action -> action.isMinNodeVersionSupported(minNodeVersion))
-            .filter(action -> action.isAbleToRun(event.state()))
             .filter(action -> completedUpdates.contains(action.getName()) == false)
+            .filter(action -> action.isAbleToRun(event.state()))
             .filter(action -> currentlyUpdating.add(action.getName()))
             .collect(Collectors.toList());
         threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAutoUpdateService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAutoUpdateService.java
@@ -11,7 +11,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.List;
@@ -24,6 +26,7 @@ public class MlAutoUpdateService implements ClusterStateListener {
 
     public interface UpdateAction {
         boolean isMinNodeVersionSupported(Version minNodeVersion);
+        boolean isAbleToRun(ClusterState latestState);
         String getName();
         void runUpdate();
     }
@@ -42,6 +45,9 @@ public class MlAutoUpdateService implements ClusterStateListener {
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
+        if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
         if (event.localNodeMaster() == false) {
             return;
         }
@@ -49,6 +55,7 @@ public class MlAutoUpdateService implements ClusterStateListener {
         Version minNodeVersion = event.state().getNodes().getMinNodeVersion();
         final List<UpdateAction> toRun = updateActions.stream()
             .filter(action -> action.isMinNodeVersionSupported(minNodeVersion))
+            .filter(action -> action.isAbleToRun(event.state()))
             .filter(action -> completedUpdates.contains(action.getName()) == false)
             .filter(action -> currentlyUpdating.add(action.getName()))
             .collect(Collectors.toList());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdater.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdater.java
@@ -11,9 +11,14 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
+import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.ml.MlAutoUpdateService;
 import org.elasticsearch.xpack.ml.datafeed.persistence.DatafeedConfigProvider;
 
@@ -26,14 +31,33 @@ public class DatafeedConfigAutoUpdater implements MlAutoUpdateService.UpdateActi
 
     private static final Logger logger = LogManager.getLogger(DatafeedConfigAutoUpdater.class);
     private final DatafeedConfigProvider provider;
+    private final IndexNameExpressionResolver expressionResolver;
 
-    public DatafeedConfigAutoUpdater(DatafeedConfigProvider provider) {
+    public DatafeedConfigAutoUpdater(DatafeedConfigProvider provider, IndexNameExpressionResolver expressionResolver) {
         this.provider = provider;
+        this.expressionResolver = expressionResolver;
     }
 
     @Override
     public boolean isMinNodeVersionSupported(Version minNodeVersion) {
         return minNodeVersion.onOrAfter(Version.V_8_0_0);
+    }
+
+    @Override
+    public boolean isAbleToRun(ClusterState latestState) {
+        String[] indices = expressionResolver.concreteIndexNames(latestState,
+            IndicesOptions.lenientExpandOpenHidden(),
+            AnomalyDetectorsIndex.configIndexName());
+        for (String index : indices) {
+            if (latestState.metadata().hasIndex(index) == false) {
+                continue;
+            }
+            IndexRoutingTable routingTable = latestState.getRoutingTable().index(index);
+            if (routingTable == null || routingTable.allPrimaryShardsActive() == false) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/integration/MlAutoUpdateServiceIT.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -69,6 +70,7 @@ public class MlAutoUpdateServiceIT extends MlSingleNodeTestCase {
 
     public void testAutomaticModelUpdate() throws Exception {
         ensureGreen("_all");
+        IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver();
         client().prepareIndex(AnomalyDetectorsIndex.configIndexName())
             .setId(DatafeedConfig.documentId("farequote-datafeed-with-old-agg"))
             .setSource(AGG_WITH_OLD_DATE_HISTOGRAM_INTERVAL, XContentType.JSON)
@@ -82,7 +84,7 @@ public class MlAutoUpdateServiceIT extends MlSingleNodeTestCase {
         assertThat(exceptionHolder.get(), is(nullValue()));
         client().admin().indices().prepareRefresh(AnomalyDetectorsIndex.configIndexName()).get();
 
-        DatafeedConfigAutoUpdater autoUpdater = new DatafeedConfigAutoUpdater(datafeedConfigProvider);
+        DatafeedConfigAutoUpdater autoUpdater = new DatafeedConfigAutoUpdater(datafeedConfigProvider, indexNameExpressionResolver);
         MlAutoUpdateService mlAutoUpdateService = new MlAutoUpdateService(client().threadPool(),
             Collections.singletonList(autoUpdater));
 


### PR DESCRIPTION
MlAutoUpdateService did not take two considerations:

- What if state is currently being recovered from disk
- What if the upgrade processes are able to run given current state?

This commit fixes these two concerns.

closes https://github.com/elastic/elasticsearch/issues/55909