### PR TITLE
[7.x] ILM stop step execution if writeIndex is false (#54805)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
@@ -111,6 +111,7 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
         if (Boolean.FALSE.equals(isWriteIndex)) {
             listener.onFailure(new IllegalArgumentException(String.format(Locale.ROOT,
                 "index [%s] is not the write index for alias [%s]", indexMetadata.getIndex().getName(), rolloverAlias)));
+            return;
         }
 
         RolloverRequest rolloverRequest = new RolloverRequest(rolloverAlias, null).masterNodeTimeout(masterTimeout);


### PR DESCRIPTION
(cherry picked from commit 47a9fd760f7bf2cc6cd778485dc057b6aaf07709)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #54805 