### PR TITLE
Fix AsyncSearchActionIT#testTermsAggregation

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -44,7 +44,7 @@ class MutableSearchResponse {
     /**
      * How we get the reduced aggs when {@link #finalResponse} isn't populated.
      * We default to returning no aggs, this {@code -> null}. We'll replace
-     * this as we receive updates on the search progress listener. 
+     * this as we receive updates on the search progress listener.
      */
     private Supplier<InternalAggregations> reducedAggsSource = () -> null;
     private int reducePhase;
@@ -77,6 +77,7 @@ class MutableSearchResponse {
         this.shardFailures = totalShards == -1 ? null : new AtomicArray<>(totalShards-skippedShards);
         this.isPartial = true;
         this.threadContext = threadContext;
+        this.totalHits = new TotalHits(0L, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
     }
 
     /**
@@ -150,7 +151,7 @@ class MutableSearchResponse {
             return finalResponse;
         }
         if (clusters == null) {
-            // An error occurred before we got the shard list 
+            // An error occurred before we got the shard list
             return null;
         }
         /*

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -124,7 +124,6 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/55920")
     public void testTermsAggregation() throws Exception {
         int step = numShards > 2 ? randomIntBetween(2, numShards) : 2;
         int numFailures = randomBoolean() ? randomIntBetween(0, numShards) : 0;


### PR DESCRIPTION
This commit fixes the initialization of total hits in the async search response.

Relates #55683
Closes #55920