### PR TITLE
[ML] Remove error on parsing progress for unknown phase in DFA

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTracker.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.dataframe.stats;
 
-import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 
 import java.util.ArrayList;
@@ -74,10 +73,7 @@ public class ProgressTracker {
     }
 
     public void updatePhase(PhaseProgress phase) {
-        Integer newValue = progressPercentPerPhase.computeIfPresent(phase.getPhase(), (k, v) -> phase.getProgressPercent());
-        if (newValue == null) {
-            throw ExceptionsHelper.serverError("unknown progress phase [" + phase.getPhase() + "]");
-        }
+        progressPercentPerPhase.computeIfPresent(phase.getPhase(), (k, v) -> phase.getProgressPercent());
     }
 
     public List<PhaseProgress> report() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTrackerTests.java
@@ -68,4 +68,15 @@ public class ProgressTrackerTests extends ESTestCase {
         assertThat(phases.get(2).getProgressPercent(), equalTo(3));
         assertThat(phases.get(3).getProgressPercent(), equalTo(4));
     }
+
+    public void testUpdatePhase_GivenUnknownPhase() {
+        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
+
+        progressTracker.updatePhase(new PhaseProgress("unknown", 42));
+        List<PhaseProgress> phases = progressTracker.report();
+
+        assertThat(phases.size(), equalTo(4));
+        assertThat(phases.stream().map(PhaseProgress::getPhase).collect(Collectors.toList()),
+            contains("reindexing", "loading_data", "foo", "writing_results"));
+    }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/stats/ProgressTrackerTests.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.ml.dataframe.stats;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
 
@@ -68,14 +67,5 @@ public class ProgressTrackerTests extends ESTestCase {
         assertThat(phases.get(1).getProgressPercent(), equalTo(2));
         assertThat(phases.get(2).getProgressPercent(), equalTo(3));
         assertThat(phases.get(3).getProgressPercent(), equalTo(4));
-    }
-
-    public void testUpdatePhase_GivenUnknownPhase() {
-        ProgressTracker progressTracker = ProgressTracker.fromZeroes(Collections.singletonList("foo"));
-
-        ElasticsearchException e = expectThrows(ElasticsearchException.class,
-            () -> progressTracker.updatePhase(new PhaseProgress("bar", 42)));
-
-        assertThat(e.getMessage(), equalTo("unknown progress phase [bar]"));
     }
 }


### PR DESCRIPTION
On second thought, this check does not seem to be adding value.
We can test that the phases are as we expect them for each analysis
by adding yaml tests. Those would fail if we introduce new phases
from c++ accidentally or without coordination. This would achieve
the same thing. At the same time we would not have to comment out
this code each time a new phase is introduced. Instead we can just
temporarily mute those yaml tests. Note I will add those tests
right after the imminent new phases are added to the c++ side.
