### PR TITLE
Make SAME Pool on DeterministicTaskQueue more Realistic

### DIFF
--- a/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
@@ -421,6 +421,20 @@ public class DeterministicTaskQueueTests extends ESTestCase {
         assertThat(strings, contains("periodic-0", "periodic-1", "periodic-2"));
     }
 
+    public void testSameExecutor() {
+        final DeterministicTaskQueue taskQueue = newTaskQueue();
+        final ThreadPool threadPool = taskQueue.getThreadPool();
+        final AtomicBoolean executed = new AtomicBoolean(false);
+        final AtomicBoolean executedNested = new AtomicBoolean(false);
+        threadPool.generic().execute(() -> {
+            threadPool.executor(ThreadPool.Names.SAME).execute(() -> executedNested.set(true));
+            assertThat(executedNested.get(), is(true));
+            executed.set(true);
+        });
+        taskQueue.runAllRunnableTasks();
+        assertThat(executed.get(), is(true));
+    }
+
     static DeterministicTaskQueue newTaskQueue() {
         return newTaskQueue(random());
     }

--- a/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
@@ -304,7 +304,7 @@ public class DeterministicTaskQueueTests extends ESTestCase {
             assertFalse(called.get());
             called.set(true);
             runnable.run();
-        });
+        }, taskQueue::scheduleNow);
         executorService.execute(() -> logger.info("runnable executed"));
         assertFalse(called.get());
         taskQueue.runAllRunnableTasks();

--- a/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueueTests.java
@@ -304,7 +304,7 @@ public class DeterministicTaskQueueTests extends ESTestCase {
             assertFalse(called.get());
             called.set(true);
             runnable.run();
-        }, taskQueue::scheduleNow);
+        });
         executorService.execute(() -> logger.info("runnable executed"));
         assertFalse(called.get());
         taskQueue.runAllRunnableTasks();


### PR DESCRIPTION
By forking off the `SAME` pool tasks and executing them in random order,
we are actually creating unrealistic scenarios and missing the actual order
of operations (whatever task that puts the task on the `SAME` queue will always
run before the `SAME` queued task will be executed currently).
Also, added caching for the executors. It doesn't matter much, but saves some objects
and makes debugging a little easier because executor object ids make more sense.
