### PR TITLE
[DOCS] EQL: Correct `cidrMatch` function heading

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -132,7 +132,7 @@ If `true`, matching is case-sensitive. Defaults to `false`.
 
 [discrete]
 [[eql-fn-cidrmatch]]
-==== `cidrMatch`
+=== `cidrMatch`
 
 Returns `true` if an IP address is contained in one or more provided
 https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing[CIDR] blocks.


### PR DESCRIPTION
Heading should be an H3 rather than an H4.