### PR TITLE
Add build scan tag when running in FIPS mode

### DIFF
--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -15,6 +15,11 @@ buildScan {
 
   tag OS.current().name()
 
+  // Tag if this build is run in FIPS mode
+  if (BuildParams.inFipsJvm) {
+    tag 'FIPS'
+  }
+
   // Automatically publish scans from Elasticsearch CI
   if (jenkinsUrl?.host?.endsWith('elastic.co')) {
     publishAlways()


### PR DESCRIPTION
It can be useful to filter FIPS builds when doing test failure analysis. While we can do this by job name, we have to do it for each branch and it's a bit awkward. This is the equivalent of the new "team" labels in GH but for a category of build.