### PR TITLE
[Docs] Clarify that _ccr/info omits parameters from the response when the follower index is paused.

### DIFF
--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -76,8 +76,8 @@ replication options and whether the follower indices are active or paused.
 
 //Begin parameters
 `parameters`::
-(object) An object that encapsulates {ccr} parameters. This object will be
-omitted if the follower index's `status` is `paused`.
+(object) An object that encapsulates {ccr} parameters. If the follower index's `status` is `paused`,
+this object is omitted.
 +
 .Properties of `parameters`
 [%collapsible%open]
@@ -147,7 +147,7 @@ This example retrieves follower info:
 GET /follower_index/_ccr/info
 --------------------------------------------------
 
-The API returns the following results if the follower index is `active`:
+If the follower index is `active`, the API returns the following results:
 
 [source,console-result]
 --------------------------------------------------
@@ -175,7 +175,7 @@ The API returns the following results if the follower index is `active`:
 }
 --------------------------------------------------
 
-The API returns the following results if the follower index is `paused`:
+If the follower index is `paused`, the API returns the following results:
 
 [source,console-result]
 --------------------------------------------------

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -182,7 +182,6 @@ POST /follower_index/_ccr/pause_follow
 
 GET /follower_index/_ccr/info
 --------------------------------------------------
-// TEST[continued]
 ////
 
 If the follower index is `paused`, the API returns the following results:

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -23,13 +23,6 @@ PUT /follower_index/_ccr/follow?wait_for_active_shards=1
 --------------------------------------------------
 // TESTSETUP
 // TEST[setup:remote_cluster_and_leader_index]
-
-[source,console]
---------------------------------------------------
-POST /follower_index/_ccr/pause_follow
---------------------------------------------------
-// TEARDOWN
-
 //////////////////////////
 
 [source,console]
@@ -180,6 +173,7 @@ If the follower index is `active`, the API returns the following results:
 --------------------------------------------------
 POST /follower_index/_ccr/pause_follow
 --------------------------------------------------
+// TEST[continued]
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -179,9 +179,13 @@ If the follower index is `active`, the API returns the following results:
 [source,console]
 --------------------------------------------------
 POST /follower_index/_ccr/pause_follow
+--------------------------------------------------
 
+[source,console]
+--------------------------------------------------
 GET /follower_index/_ccr/info
 --------------------------------------------------
+// TEST[continued]
 ////
 
 If the follower index is `paused`, the API returns the following results:

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -175,6 +175,16 @@ If the follower index is `active`, the API returns the following results:
 }
 --------------------------------------------------
 
+////
+[source,console]
+--------------------------------------------------
+POST /follower_index/_ccr/pause_follow
+
+GET /follower_index/_ccr/info
+--------------------------------------------------
+// TEST[continued]
+////
+
 If the follower index is `paused`, the API returns the following results:
 
 [source,console-result]

--- a/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-info.asciidoc
@@ -76,7 +76,8 @@ replication options and whether the follower indices are active or paused.
 
 //Begin parameters
 `parameters`::
-(object) An object that encapsulates {ccr} parameters.
+(object) An object that encapsulates {ccr} parameters. This object will be
+omitted if the follower index's `status` is `paused`.
 +
 .Properties of `parameters`
 [%collapsible%open]
@@ -132,7 +133,7 @@ to read from the leader again.
 leader index.
 
 `status`::
-(string) Whether index following is `active` or `paused`. 
+(string) Whether index following is `active` or `paused`.
 ====
 //End follower_indices
 
@@ -146,7 +147,7 @@ This example retrieves follower info:
 GET /follower_index/_ccr/info
 --------------------------------------------------
 
-The API returns the following results:
+The API returns the following results if the follower index is `active`:
 
 [source,console-result]
 --------------------------------------------------
@@ -169,6 +170,22 @@ The API returns the following results:
                 "max_retry_delay" : "500ms",
                 "read_poll_timeout" : "1m"
             }
+        }
+    ]
+}
+--------------------------------------------------
+
+The API returns the following results if the follower index is `paused`:
+
+[source,console-result]
+--------------------------------------------------
+{
+    "follower_indices" : [
+        {
+            "follower_index" : "follower_index",
+            "remote_cluster" : "remote_cluster",
+            "leader_index" : "leader_index",
+            "status" : "paused"
         }
     ]
 }


### PR DESCRIPTION
This addresses some of the confusion noted in https://github.com/elastic/elasticsearch/issues/54996.

![image](https://user-images.githubusercontent.com/1238659/80632028-7e82dc00-8a0b-11ea-9c6d-581995ede63f.png)

Preview:
http://elasticsearch_55961.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ccr-get-follow-info.html

![image](https://user-images.githubusercontent.com/1238659/80632040-80e53600-8a0b-11ea-9ea8-37769d08050f.png)
