### PR TITLE
[7.x] Modified searchAndReduce() to return empty agg when no docs exist

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -47,7 +47,6 @@ import org.elasticsearch.search.aggregations.pipeline.DerivativePipelineAggregat
 import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -205,7 +204,10 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
             }
         );
         testSearchAndReduceCase(DEFAULT_QUERY, dates, aggregation,
-            Assert::assertNull
+            histogram -> {
+                assertEquals(0, histogram.getBuckets().size());
+                assertFalse(AggregationInspectionHelper.hasValue(histogram));
+            }
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -220,20 +220,12 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
         fieldType.setHasDocValues(true);
         fieldType.setName("date_field");
 
-        testCase(
-            aggregation,
-            DEFAULT_QUERY,
+        testCase(aggregation, DEFAULT_QUERY,
             iw -> {},
             (Consumer<InternalAutoDateHistogram>) histogram -> {
-                // TODO: searchAndReduce incorrectly returns null for empty aggs
-                assertNull(histogram);
-                /*
                 assertEquals(0, histogram.getBuckets().size());
                 assertFalse(AggregationInspectionHelper.hasValue(histogram));
-                 */
-            },
-            fieldType
-        );
+            }, fieldType);
     }
 
     public void testUnmappedMissing() throws IOException {
@@ -245,20 +237,12 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
         fieldType.setHasDocValues(true);
         fieldType.setName("date_field");
 
-        testCase(
-            aggregation,
-            DEFAULT_QUERY,
+        testCase(aggregation, DEFAULT_QUERY,
             iw -> {},
             (Consumer<InternalAutoDateHistogram>) histogram -> {
-                // TODO: searchAndReduce incorrectly returns null for empty aggs
-                assertNull(histogram);
-                /*
-                assertEquals(1, histogram.getBuckets().size());
-                assertTrue(AggregationInspectionHelper.hasValue(histogram));
-                 */
-            },
-           fieldType
-        );
+                assertEquals(0, histogram.getBuckets().size());
+                assertFalse(AggregationInspectionHelper.hasValue(histogram));
+        }, fieldType);
     }
 
     public void testIntervalYear() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -212,37 +212,23 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testAggregateWrongField() throws IOException {
-        AutoDateHistogramAggregationBuilder aggregation = new AutoDateHistogramAggregationBuilder("_name").
-            setNumBuckets(10).field("bogus_bogus");
-
-        final DateFieldMapper.Builder builder = new DateFieldMapper.Builder("_name");
-        final DateFieldMapper.DateFieldType fieldType = builder.fieldType();
-        fieldType.setHasDocValues(true);
-        fieldType.setName("date_field");
-
-        testCase(aggregation, DEFAULT_QUERY,
-            iw -> {},
-            (Consumer<InternalAutoDateHistogram>) histogram -> {
+        testBothCases(DEFAULT_QUERY, DATES_WITH_TIME,
+            aggregation -> aggregation.setNumBuckets(10).field("wrong_field"),
+            histogram -> {
                 assertEquals(0, histogram.getBuckets().size());
                 assertFalse(AggregationInspectionHelper.hasValue(histogram));
-            }, fieldType);
+            }
+        );
     }
 
     public void testUnmappedMissing() throws IOException {
-        AutoDateHistogramAggregationBuilder aggregation = new AutoDateHistogramAggregationBuilder("_name").
-            setNumBuckets(10).field("bogus_bogus").missing("2017-12-12");
-
-        final DateFieldMapper.Builder builder = new DateFieldMapper.Builder("_name");
-        final DateFieldMapper.DateFieldType fieldType = builder.fieldType();
-        fieldType.setHasDocValues(true);
-        fieldType.setName("date_field");
-
-        testCase(aggregation, DEFAULT_QUERY,
-            iw -> {},
-            (Consumer<InternalAutoDateHistogram>) histogram -> {
-                assertEquals(0, histogram.getBuckets().size());
-                assertFalse(AggregationInspectionHelper.hasValue(histogram));
-        }, fieldType);
+        testBothCases(DEFAULT_QUERY, DATES_WITH_TIME,
+            aggregation -> aggregation.setNumBuckets(10).field("wrong_field").missing("2017-12-12"),
+            histogram -> {
+                assertEquals(1, histogram.getBuckets().size());
+                assertTrue(AggregationInspectionHelper.hasValue(histogram));
+            }
+        );
     }
 
     public void testIntervalYear() throws IOException {
@@ -817,7 +803,21 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
                                  final Consumer<InternalAutoDateHistogram> verify) throws IOException {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                indexSampleData(dataset, indexWriter);
+                final Document document = new Document();
+                int i = 0;
+                for (final ZonedDateTime date : dataset) {
+                    if (frequently()) {
+                        indexWriter.commit();
+                    }
+
+                    final long instant = date.toInstant().toEpochMilli();
+                    document.add(new SortedNumericDocValuesField(DATE_FIELD, instant));
+                    document.add(new LongPoint(INSTANT_FIELD, instant));
+                    document.add(new SortedNumericDocValuesField(NUMERIC_FIELD, i));
+                    indexWriter.addDocument(document);
+                    document.clear();
+                    i += 1;
+                }
             }
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
@@ -849,24 +849,6 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
                 }
                 verify.accept(histogram);
             }
-        }
-    }
-
-    private void indexSampleData(List<ZonedDateTime> dataset, RandomIndexWriter indexWriter) throws IOException {
-        final Document document = new Document();
-        int i = 0;
-        for (final ZonedDateTime date : dataset) {
-            if (frequently()) {
-                indexWriter.commit();
-            }
-
-            final long instant = date.toInstant().toEpochMilli();
-            document.add(new SortedNumericDocValuesField(DATE_FIELD, instant));
-            document.add(new LongPoint(INSTANT_FIELD, instant));
-            document.add(new SortedNumericDocValuesField(NUMERIC_FIELD, i));
-            indexWriter.addDocument(document);
-            document.clear();
-            i += 1;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -212,29 +212,40 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
     }
 
     public void testAggregateWrongField() throws IOException {
-        testBothCases(DEFAULT_QUERY, DATES_WITH_TIME,
-            aggregation -> aggregation.setNumBuckets(10).field("wrong_field"),
-            histogram -> {
+        AutoDateHistogramAggregationBuilder aggregation = new AutoDateHistogramAggregationBuilder("_name").
+            setNumBuckets(10).field("bogus_bogus");
+
+        final DateFieldMapper.Builder builder = new DateFieldMapper.Builder("_name");
+        final DateFieldMapper.DateFieldType fieldType = builder.fieldType();
+        fieldType.setHasDocValues(true);
+        fieldType.setName("date_field");
+
+        testCase(aggregation, DEFAULT_QUERY,
+            iw -> {},
+            (Consumer<InternalAutoDateHistogram>) histogram -> {
                 assertEquals(0, histogram.getBuckets().size());
                 assertFalse(AggregationInspectionHelper.hasValue(histogram));
-            }
-        );
+            }, fieldType);
     }
 
     public void testUnmappedMissing() throws IOException {
-        testBothCases(DEFAULT_QUERY, DATES_WITH_TIME,
-            aggregation -> aggregation.setNumBuckets(10).field("wrong_field").missing("2017-12-12"),
-            histogram -> {
-                assertEquals(1, histogram.getBuckets().size());
-                assertTrue(AggregationInspectionHelper.hasValue(histogram));
-            }
-        );
+        AutoDateHistogramAggregationBuilder aggregation = new AutoDateHistogramAggregationBuilder("_name").
+            setNumBuckets(10).field("bogus_bogus").missing("2017-12-12");
+
+        final DateFieldMapper.Builder builder = new DateFieldMapper.Builder("_name");
+        final DateFieldMapper.DateFieldType fieldType = builder.fieldType();
+        fieldType.setHasDocValues(true);
+        fieldType.setName("date_field");
+
+        testCase(aggregation, DEFAULT_QUERY,
+            iw -> {},
+            (Consumer<InternalAutoDateHistogram>) histogram -> {
+                assertEquals(0, histogram.getBuckets().size());
+                assertFalse(AggregationInspectionHelper.hasValue(histogram));
+        }, fieldType);
     }
 
-
     public void testIntervalYear() throws IOException {
-
-
         final long start = LocalDate.of(2015, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
         final long end = LocalDate.of(2017, 12, 31).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
         final Query rangeQuery = LongPoint.newRangeQuery(INSTANT_FIELD, start, end);
@@ -806,21 +817,7 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
                                  final Consumer<InternalAutoDateHistogram> verify) throws IOException {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                final Document document = new Document();
-                int i = 0;
-                for (final ZonedDateTime date : dataset) {
-                    if (frequently()) {
-                        indexWriter.commit();
-                    }
-
-                    final long instant = date.toInstant().toEpochMilli();
-                    document.add(new SortedNumericDocValuesField(DATE_FIELD, instant));
-                    document.add(new LongPoint(INSTANT_FIELD, instant));
-                    document.add(new SortedNumericDocValuesField(NUMERIC_FIELD, i));
-                    indexWriter.addDocument(document);
-                    document.clear();
-                    i += 1;
-                }
+                indexSampleData(dataset, indexWriter);
             }
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
@@ -852,6 +849,24 @@ public class AutoDateHistogramAggregatorTests extends AggregatorTestCase {
                 }
                 verify.accept(histogram);
             }
+        }
+    }
+
+    private void indexSampleData(List<ZonedDateTime> dataset, RandomIndexWriter indexWriter) throws IOException {
+        final Document document = new Document();
+        int i = 0;
+        for (final ZonedDateTime date : dataset) {
+            if (frequently()) {
+                indexWriter.commit();
+            }
+
+            final long instant = date.toInstant().toEpochMilli();
+            document.add(new SortedNumericDocValuesField(DATE_FIELD, instant));
+            document.add(new LongPoint(INSTANT_FIELD, instant));
+            document.add(new SortedNumericDocValuesField(NUMERIC_FIELD, i));
+            indexWriter.addDocument(document);
+            document.clear();
+            i += 1;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -155,18 +155,17 @@ public class DateHistogramAggregatorTests extends AggregatorTestCase {
     public void testNoDocsDeprecatedInterval() throws IOException {
         Query query = new MatchNoDocsQuery();
         List<String> dates = Collections.emptyList();
-        Consumer<DateHistogramAggregationBuilder> aggregation = agg ->
-                agg.dateHistogramInterval(DateHistogramInterval.YEAR).field(DATE_FIELD);
+        Consumer<DateHistogramAggregationBuilder> aggregation =
+            agg -> agg.dateHistogramInterval(DateHistogramInterval.YEAR).field(DATE_FIELD);
 
-        testSearchCase(query, dates, aggregation,
-                histogram -> {
-                    assertEquals(0, histogram.getBuckets().size());
-                    assertFalse(AggregationInspectionHelper.hasValue(histogram));
-                }, false
-        );
-        testSearchAndReduceCase(query, dates, aggregation,
-                histogram -> assertNull(histogram), false
-        );
+        testSearchCase(query, dates, aggregation, histogram -> {
+            assertEquals(0, histogram.getBuckets().size());
+            assertFalse(AggregationInspectionHelper.hasValue(histogram));
+        }, false);
+        testSearchAndReduceCase(query, dates, aggregation, histogram -> {
+            assertEquals(0, histogram.getBuckets().size());
+            assertFalse(AggregationInspectionHelper.hasValue(histogram));
+        }, false);
         assertWarnings("[interval] on [date_histogram] is deprecated, use [fixed_interval] or [calendar_interval] in the future.");
     }
 
@@ -179,7 +178,7 @@ public class DateHistogramAggregatorTests extends AggregatorTestCase {
             histogram -> assertEquals(0, histogram.getBuckets().size()), false
         );
         testSearchAndReduceCase(query, dates, aggregation,
-            histogram -> assertNull(histogram), false
+            histogram -> assertEquals(0, histogram.getBuckets().size()), false
         );
 
         aggregation = agg ->
@@ -188,7 +187,7 @@ public class DateHistogramAggregatorTests extends AggregatorTestCase {
             histogram -> assertEquals(0, histogram.getBuckets().size()), false
         );
         testSearchAndReduceCase(query, dates, aggregation,
-            histogram -> assertNull(histogram), false
+            histogram -> assertEquals(0, histogram.getBuckets().size()), false
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -69,7 +69,6 @@ import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -239,15 +238,13 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
             agg -> assertEquals(0, agg.getBuckets().size()), ValueType.STRING
         );
 
-        // Note: the search and reduce test will generate no segments (due to no docs)
-        // and so will return a null agg because the aggs aren't run/reduced
         testSearchAndReduceCase(query, Collections.emptyList(),
             aggregation -> aggregation.field(LONG_FIELD).maxDocCount(1),
-            Assert::assertNull, ValueType.NUMERIC
+            agg -> assertEquals(0, agg.getBuckets().size()), ValueType.NUMERIC
         );
         testSearchAndReduceCase(query, Collections.emptyList(),
             aggregation -> aggregation.field(KEYWORD_FIELD).maxDocCount(1),
-            Assert::assertNull, ValueType.STRING
+            agg -> assertEquals(0, agg.getBuckets().size()), ValueType.STRING
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -23,20 +23,17 @@ import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 
@@ -49,8 +46,9 @@ import java.util.function.Consumer;
 import static java.util.Collections.singleton;
 
 public class CardinalityAggregatorTests extends AggregatorTestCase {
+
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             // Intentionally not writing any docs
         }, card -> {
             assertEquals(0.0, card.getValue(), 0);
@@ -69,7 +67,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         Set<RangeFieldMapper.Range> multiRecord = new HashSet<>(2);
         multiRecord.add(range1);
         multiRecord.add(range2);
-        testCase(aggregationBuilder,  new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder,  new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range1)))));
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range1)))));
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range2)))));
@@ -81,7 +79,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 1)));
         }, card -> {
@@ -91,7 +89,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSomeMatchesSortedNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 1)));
         }, card -> {
@@ -101,7 +99,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSomeMatchesNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, card -> {
@@ -111,7 +109,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(IntPoint.newRangeQuery("number", 0, 5), iw -> {
+        testAggregation(IntPoint.newRangeQuery("number", 0, 5), iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("number", 7),
                     new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(Arrays.asList(new IntPoint("number", 1),
@@ -123,7 +121,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltersAll() throws IOException {
-        testCase(IntPoint.newRangeQuery("number", -1, 0), iw -> {
+        testAggregation(IntPoint.newRangeQuery("number", -1, 0), iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("number", 7),
                     new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(Arrays.asList(new IntPoint("number", 1),
@@ -138,7 +136,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name")
             .field("number").missing("🍌🍌🍌");
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
@@ -152,7 +150,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name")
             .field("number").missing(1234);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
@@ -166,7 +164,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name")
             .field("number").missing(new GeoPoint(42.39561, -71.13051));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
@@ -176,34 +174,18 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         }, null);
     }
 
-    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+    private void testAggregation(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
                           Consumer<InternalCardinality> verify) throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(
             NumberFieldMapper.NumberType.LONG);
         fieldType.setName("number");
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("_name").field("number");
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testAggregation(aggregationBuilder, query, buildIndex, verify, fieldType);
     }
 
-    private void testCase(CardinalityAggregationBuilder aggregationBuilder, Query query,
-                          CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalCardinality> verify,
-                          MappedFieldType fieldType) throws IOException {
-        Directory directory = newDirectory();
-        RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-        buildIndex.accept(indexWriter);
-        indexWriter.close();
-
-        IndexReader indexReader = DirectoryReader.open(directory);
-        IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-
-        CardinalityAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher,
-            fieldType);
-        aggregator.preCollection();
-        indexSearcher.search(query, aggregator);
-        aggregator.postCollection();
-        verify.accept((InternalCardinality) aggregator.buildAggregation(0L));
-
-        indexReader.close();
-        directory.close();
+    private void testAggregation(AggregationBuilder aggregationBuilder, Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalCardinality> verify,
+        MappedFieldType fieldType) throws IOException {
+        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
@@ -176,7 +176,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             // Intentionally not writing any docs
         }, max -> {
             assertEquals(Double.NEGATIVE_INFINITY, max.getValue(), 0);
@@ -185,7 +185,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 1)));
         }, max -> {
@@ -195,7 +195,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSomeMatchesSortedNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 1)));
         }, max -> {
@@ -205,7 +205,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSomeMatchesNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, max -> {
@@ -215,7 +215,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(IntPoint.newRangeQuery("number", 0, 5), iw -> {
+        testAggregation(IntPoint.newRangeQuery("number", 0, 5), iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("number", 7), new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(Arrays.asList(new IntPoint("number", 1), new SortedNumericDocValuesField("number", 1)));
         }, max -> {
@@ -225,7 +225,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltersAll() throws IOException {
-        testCase(IntPoint.newRangeQuery("number", -1, 0), iw -> {
+        testAggregation(IntPoint.newRangeQuery("number", -1, 0), iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("number", 7), new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(Arrays.asList(new IntPoint("number", 1), new SortedNumericDocValuesField("number", 1)));
         }, max -> {
@@ -236,34 +236,33 @@ public class MaxAggregatorTests extends AggregatorTestCase {
 
     public void testUnmappedField() throws IOException {
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name").field("number");
-        testCase(aggregationBuilder, new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(aggregationBuilder, new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, max -> {
             assertEquals(max.getValue(), Double.NEGATIVE_INFINITY, 0);
             assertFalse(AggregationInspectionHelper.hasValue(max));
-        }, null);
+        }, (MappedFieldType) null);
     }
 
     public void testUnmappedWithMissingField() throws IOException {
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name").field("number").missing(19L);
 
-        testCase(aggregationBuilder, new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(aggregationBuilder, new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, max -> {
             assertEquals(max.getValue(), 19.0, 0);
             assertTrue(AggregationInspectionHelper.hasValue(max));
-        }, null);
+        }, (MappedFieldType) null);
     }
 
     public void testMissingFieldOptimization() throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.INTEGER);
         fieldType.setName("number");
 
-        MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name").field("number").missing(19L);
-
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        AggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name").field("number").missing(19L);
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("number", 7), new SortedNumericDocValuesField("number", 7)));
             iw.addDocument(Arrays.asList(new IntPoint("number", 1), new SortedNumericDocValuesField("number", 1)));
             iw.addDocument(emptyList());
@@ -277,11 +276,11 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.INTEGER);
         fieldType.setName("number");
 
-        MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name")
+        AggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name")
             .field("number")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, SCRIPT_NAME, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new DocValuesFieldExistsQuery("number"), iw -> {
+        testAggregation(aggregationBuilder, new DocValuesFieldExistsQuery("number"), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, max -> {
@@ -290,33 +289,19 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         }, fieldType);
     }
 
-    private void testCase(Query query,
+    private void testAggregation(Query query,
                           CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
                           Consumer<InternalMax> verify) throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.INTEGER);
         fieldType.setName("number");
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("_name").field("number");
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testAggregation(aggregationBuilder, query, buildIndex, verify, fieldType);
     }
 
-    private void testCase(MaxAggregationBuilder aggregationBuilder, Query query,
-                          CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-                          Consumer<InternalMax> verify, MappedFieldType fieldType) throws IOException {
-        Directory directory = newDirectory();
-        RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-        buildIndex.accept(indexWriter);
-        indexWriter.close();
-        IndexReader indexReader = DirectoryReader.open(directory);
-        IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-
-        MaxAggregator aggregator = createAggregator(query, aggregationBuilder, indexSearcher, createIndexSettings(), fieldType);
-        aggregator.preCollection();
-        indexSearcher.search(query, aggregator);
-        aggregator.postCollection();
-        verify.accept((InternalMax) aggregator.buildAggregation(0L));
-
-        indexReader.close();
-        directory.close();
+    private void testAggregation(AggregationBuilder aggregationBuilder, Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalMax> verify,
+        MappedFieldType fieldType) throws IOException {
+        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
     }
 
     public void testMaxShortcutRandom() throws Exception {
@@ -426,7 +411,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSingleValuedField() throws IOException {
-        testCase( new MatchAllDocsQuery(), iw -> {
+        testAggregation( new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
@@ -445,7 +430,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
             .format("0000.0")
             .field("value");
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+       testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("value", i + 1)));
@@ -547,7 +532,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
             .field("value")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("value", i + 1)));
@@ -568,7 +553,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
             .field("value")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, params));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("value", i + 1)));
@@ -581,7 +566,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
     }
 
     public void testMultiValuedField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -603,7 +588,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
             .field("values")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -626,7 +611,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
             .field("values")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, params));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -647,7 +632,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("max")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_FIELD_SCRIPT, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("value", i + 1)));
@@ -669,7 +654,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("max")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, SUM_FIELD_PARAMS_SCRIPT, params));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("value", i + 1)));
@@ -687,7 +672,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("max")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, SUM_VALUES_FIELD_SCRIPT, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -712,7 +697,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         MaxAggregationBuilder aggregationBuilder = new MaxAggregationBuilder("max")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, SUM_FIELD_PARAMS_SCRIPT, params));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
@@ -22,15 +22,11 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -42,7 +38,6 @@ import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -92,14 +87,14 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
 
     // intentionally not writing any docs
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), writer -> {}, agg -> {
+        testAggregation(new MatchAllDocsQuery(), writer -> {}, agg -> {
             assertThat(agg.getMedianAbsoluteDeviation(), equalTo(Double.NaN));
             assertFalse(AggregationInspectionHelper.hasValue(agg));
         });
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(
+        testAggregation(
             new MatchAllDocsQuery(),
             writer -> {
                 writer.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 1)));
@@ -115,7 +110,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
     public void testSomeMatchesSortedNumericDocValues() throws IOException {
         final int size = randomIntBetween(100, 1000);
         final List<Long> sample = new ArrayList<>(size);
-        testCase(
+        testAggregation(
             new DocValuesFieldExistsQuery(FIELD_NAME),
             randomSample(size, point -> {
                 sample.add(point);
@@ -131,7 +126,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
     public void testSomeMatchesNumericDocValues() throws IOException {
         final int size = randomIntBetween(100, 1000);
         final List<Long> sample = new ArrayList<>(size);
-        testCase(
+        testAggregation(
             new DocValuesFieldExistsQuery(FIELD_NAME),
             randomSample(size, point -> {
                 sample.add(point);
@@ -149,7 +144,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
         final int upperRange = 500;
         final int[] sample = IntStream.rangeClosed(1, 1000).toArray();
         final int[] filteredSample = Arrays.stream(sample).filter(point -> point  >= lowerRange && point <= upperRange).toArray();
-        testCase(
+        testAggregation(
             IntPoint.newRangeQuery(FIELD_NAME, lowerRange, upperRange),
             writer -> {
                 for (int point : sample) {
@@ -164,7 +159,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltersAll() throws IOException {
-        testCase(
+        testAggregation(
             IntPoint.newRangeQuery(FIELD_NAME, -1, 0),
             writer -> {
                 writer.addDocument(Arrays.asList(new IntPoint(FIELD_NAME, 1), new SortedNumericDocValuesField(FIELD_NAME, 1)));
@@ -181,13 +176,13 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
         MedianAbsoluteDeviationAggregationBuilder aggregationBuilder = new MedianAbsoluteDeviationAggregationBuilder("foo")
             .field(FIELD_NAME);
 
-        testCase(aggregationBuilder, new DocValuesFieldExistsQuery(FIELD_NAME), iw -> {
+        testAggregation(aggregationBuilder, new DocValuesFieldExistsQuery(FIELD_NAME), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 1)));
         }, agg -> {
             assertEquals(Double.NaN,  agg.getMedianAbsoluteDeviation(),0);
             assertFalse(AggregationInspectionHelper.hasValue(agg));
-        }, null);
+        },  null);
     }
 
     public void testUnmappedMissing() throws IOException {
@@ -195,7 +190,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
             .field(FIELD_NAME)
             .missing(1234);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
@@ -216,7 +211,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
 
         final int size = randomIntBetween(100, 1000);
         final List<Long> sample = new ArrayList<>(size);
-        testCase(aggregationBuilder,
+        testAggregation(aggregationBuilder,
             new MatchAllDocsQuery(),
             randomSample(size, point -> {
                 sample.add(point);
@@ -237,7 +232,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
 
         final int size = randomIntBetween(100, 1000);
         final List<Long> sample = new ArrayList<>(size);
-        testCase(aggregationBuilder,
+        testAggregation(aggregationBuilder,
             new MatchAllDocsQuery(),
             iw -> {
                 for (int i = 0; i < 10; i++) {
@@ -250,7 +245,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
             }, fieldType);
     }
 
-    private void testCase(Query query,
+    private void testAggregation(Query query,
                           CheckedConsumer<RandomIndexWriter,
                           IOException> buildIndex,
                           Consumer<InternalMedianAbsoluteDeviation> verify) throws IOException {
@@ -261,26 +256,13 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.LONG);
         fieldType.setName(FIELD_NAME);
 
-        testCase(builder, query, buildIndex, verify, fieldType);
+        testAggregation(builder, query, buildIndex, verify, fieldType);
     }
 
-    private void testCase(MedianAbsoluteDeviationAggregationBuilder aggregationBuilder, Query query,
+    private void testAggregation(AggregationBuilder aggregationBuilder, Query query,
                           CheckedConsumer<RandomIndexWriter, IOException> indexer,
                           Consumer<InternalMedianAbsoluteDeviation> verify, MappedFieldType fieldType) throws IOException {
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                indexer.accept(indexWriter);
-            }
-
-            try (IndexReader indexReader = DirectoryReader.open(directory)) {
-                IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-                Aggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
-                aggregator.preCollection();
-                indexSearcher.search(query, aggregator);
-                aggregator.postCollection();
-                verify.accept((InternalMedianAbsoluteDeviation) aggregator.buildAggregation(0L));
-            }
-        }
+        testCase(aggregationBuilder, query, indexer, verify, fieldType);
     }
 
     public static class IsCloseToRelative extends TypeSafeMatcher<Double> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -59,7 +59,6 @@ import org.elasticsearch.search.lookup.LeafDocLookup;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +68,7 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
@@ -80,7 +80,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
     private static final String FIELD_SCRIPT_NAME = "field_script";
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             // Intentionally not writing any docs
         }, count -> {
             assertEquals(0L, count.getValue(), 0d);
@@ -89,7 +89,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("wrong_number", 1)));
         }, count -> {
@@ -99,7 +99,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNumericDocValues() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 1)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 2)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 1)));
@@ -123,7 +123,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSortedNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery(FIELD_NAME), iw -> {
+        testAggregation(new DocValuesFieldExistsQuery(FIELD_NAME), iw -> {
             iw.addDocument(Arrays.asList(new SortedNumericDocValuesField(FIELD_NAME, 3),
                 new SortedNumericDocValuesField(FIELD_NAME, 4)));
             iw.addDocument(Arrays.asList(new SortedNumericDocValuesField(FIELD_NAME, 3),
@@ -136,7 +136,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(new TermQuery(new Term("match", "yes")), iw -> {
+        testAggregation(new TermQuery(new Term("match", "yes")), iw -> {
             iw.addDocument(Arrays.asList(new StringField("match", "yes", Field.Store.NO), new NumericDocValuesField(FIELD_NAME, 1)));
             iw.addDocument(Arrays.asList(new StringField("match", "no", Field.Store.NO), new NumericDocValuesField(FIELD_NAME, 2)));
             iw.addDocument(Arrays.asList(new StringField("match", "yes", Field.Store.NO), new NumericDocValuesField(FIELD_NAME, 3)));
@@ -150,7 +150,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
 
     public void testStringField() throws IOException {
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> {
-            testCase(new MatchAllDocsQuery(), iw -> {
+            testAggregation(new MatchAllDocsQuery(), iw -> {
                 iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("1"))));
             }, count -> {
                 assertEquals(0L, count.getValue(), 0d);
@@ -193,15 +193,16 @@ public class SumAggregatorTests extends AggregatorTestCase {
     }
 
     private void verifySummationOfDoubles(double[] values, double expected, double delta) throws IOException {
-        testCase(new MatchAllDocsQuery(),
+        testAggregation(
             sum("_name").field(FIELD_NAME),
+            new MatchAllDocsQuery(),
             iw -> {
                 for (double value : values) {
                     iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, NumericUtils.doubleToSortableLong(value))));
                 }
             },
             result -> assertEquals(expected, result.getValue(), delta),
-            singleton(defaultFieldType(NumberType.DOUBLE))
+            defaultFieldType(NumberType.DOUBLE)
         );
     }
 
@@ -321,16 +322,14 @@ public class SumAggregatorTests extends AggregatorTestCase {
         }
         final long finalSum = sum;
 
-        testCase(new MatchAllDocsQuery(),
-            sum("_name")
-                .field(aggField.name())
-                .missing(missingValue),
+        testAggregation(
+            sum("_name").field(aggField.name()).missing(missingValue),
+            new MatchAllDocsQuery(),
             writer -> writer.addDocuments(docs),
             internalSum -> {
                 assertEquals(finalSum, internalSum.getValue(), 0d);
                 assertTrue(AggregationInspectionHelper.hasValue(internalSum));
-            },
-            org.elasticsearch.common.collect.List.of(aggField, irrelevantField)
+            }, aggField, irrelevantField
         );
     }
 
@@ -367,46 +366,31 @@ public class SumAggregatorTests extends AggregatorTestCase {
         }
         final long finalSum = sum;
 
-        testCase(new MatchAllDocsQuery(),
+        testAggregation(
             builder,
+            new MatchAllDocsQuery(),
             writer -> writer.addDocuments(docs),
             internalSum -> verify.apply(finalSum, docs, internalSum),
-            singleton(fieldType)
+            fieldType
         );
     }
 
-    private void testCase(Query query,
+    private void testAggregation(Query query,
                           CheckedConsumer<RandomIndexWriter, IOException> indexer,
                           Consumer<InternalSum> verify) throws IOException {
-        testCase(query, sum("_name").field(FIELD_NAME), indexer, verify, singleton(defaultFieldType()));
+        AggregationBuilder aggregationBuilder = sum("_name").field(FIELD_NAME);
+        testAggregation( aggregationBuilder, query, indexer, verify, defaultFieldType());
     }
 
-    private void testCase(Query query,
-                          SumAggregationBuilder aggregationBuilder,
-                          CheckedConsumer<RandomIndexWriter, IOException> indexer,
-                          Consumer<InternalSum> verify,
-                          Collection<MappedFieldType> fieldTypes) throws IOException {
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                indexer.accept(indexWriter);
-            }
-
-            try (IndexReader indexReader = DirectoryReader.open(directory)) {
-                IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-
-                final MappedFieldType[] fieldTypesArray = fieldTypes.toArray(new MappedFieldType[0]);
-                final InternalSum internalSum = search(indexSearcher, query, aggregationBuilder, fieldTypesArray);
-                verify.accept(internalSum);
-            }
-        }
+    private void testAggregation(AggregationBuilder aggregationBuilder, Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> indexer,
+        Consumer<InternalSum> verify, MappedFieldType... fieldTypes) throws IOException {
+        testCase(aggregationBuilder, query, indexer, verify, fieldTypes);
     }
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
-        return Arrays.asList(
-            CoreValuesSourceType.NUMERIC,
-            CoreValuesSourceType.DATE,
-            CoreValuesSourceType.BOOLEAN);
+        return singletonList(CoreValuesSourceType.NUMERIC);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -68,7 +68,6 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
@@ -390,7 +389,10 @@ public class SumAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
-        return singletonList(CoreValuesSourceType.NUMERIC);
+        return Arrays.asList(
+            CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -28,14 +28,10 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -119,7 +115,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
 
     public void testGeoField() throws IOException {
-        testCase(new MatchAllDocsQuery(), ValueType.GEOPOINT, iw -> {
+        testAggregation(new MatchAllDocsQuery(), ValueType.GEOPOINT, iw -> {
             for (int i = 0; i < 10; i++) {
                 Document document = new Document();
                 document.add(new LatLonDocValuesField("field", 10, 10));
@@ -129,7 +125,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testDoubleField() throws IOException {
-        testCase(new MatchAllDocsQuery(), ValueType.DOUBLE, iw -> {
+        testAggregation(new MatchAllDocsQuery(), ValueType.DOUBLE, iw -> {
             for (int i = 0; i < 15; i++) {
                 Document document = new Document();
                 document.add(new DoubleDocValuesField(FIELD_NAME, 23D));
@@ -139,7 +135,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testKeyWordField() throws IOException {
-        testCase(new MatchAllDocsQuery(), ValueType.STRING, iw -> {
+        testAggregation(new MatchAllDocsQuery(), ValueType.STRING, iw -> {
             for (int i = 0; i < 20; i++) {
                 Document document = new Document();
                 document.add(new SortedSetDocValuesField(FIELD_NAME, new BytesRef("stringValue")));
@@ -151,7 +147,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
     public void testNoDocs() throws IOException {
         for (ValueType valueType : ValueType.values()) {
-            testCase(new MatchAllDocsQuery(), valueType, iw -> {
+            testAggregation(new MatchAllDocsQuery(), valueType, iw -> {
                 // Intentionally not writing any docs
             }, count -> {
                 assertEquals(0L, count.getValue());
@@ -161,7 +157,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), ValueType.LONG, iw -> {
+        testAggregation(new MatchAllDocsQuery(), ValueType.LONG, iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 1)));
         }, count -> {
@@ -171,7 +167,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSomeMatchesSortedNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery(FIELD_NAME), ValueType.NUMERIC, iw -> {
+        testAggregation(new DocValuesFieldExistsQuery(FIELD_NAME), ValueType.NUMERIC, iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField("wrong_number", 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField(FIELD_NAME, 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField(FIELD_NAME, 1)));
@@ -182,7 +178,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSomeMatchesNumericDocValues() throws IOException {
-        testCase(new DocValuesFieldExistsQuery(FIELD_NAME), ValueType.NUMBER, iw -> {
+        testAggregation(new DocValuesFieldExistsQuery(FIELD_NAME), ValueType.NUMBER, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 1)));
         }, count -> {
@@ -192,7 +188,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(IntPoint.newRangeQuery("level", 0, 5), ValueType.STRING, iw -> {
+        testAggregation(IntPoint.newRangeQuery("level", 0, 5), ValueType.STRING, iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("level", 0), new SortedDocValuesField(FIELD_NAME, new BytesRef("foo"))));
             iw.addDocument(Arrays.asList(new IntPoint("level", 1), new SortedDocValuesField(FIELD_NAME, new BytesRef("bar"))));
             iw.addDocument(Arrays.asList(new IntPoint("level", 3), new SortedDocValuesField(FIELD_NAME, new BytesRef("foo"))));
@@ -205,7 +201,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     }
 
     public void testQueryFiltersAll() throws IOException {
-        testCase(IntPoint.newRangeQuery("level", -1, 0), ValueType.STRING, iw -> {
+        testAggregation(IntPoint.newRangeQuery("level", -1, 0), ValueType.STRING, iw -> {
             iw.addDocument(Arrays.asList(new IntPoint("level", 3), new SortedDocValuesField(FIELD_NAME, new BytesRef("foo"))));
             iw.addDocument(Arrays.asList(new IntPoint("level", 5), new SortedDocValuesField(FIELD_NAME, new BytesRef("baz"))));
         }, count -> {
@@ -218,7 +214,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name")
             .field("number").missing("🍌🍌🍌");
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
@@ -232,7 +228,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name")
             .field("number").missing(1234);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
@@ -246,14 +242,14 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name")
             .field("number").missing(new GeoPoint(42.39561, -71.13051));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
         }, valueCount -> {
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        }, null);
+        },  null);
     }
 
     public void testRangeFieldValues() throws IOException {
@@ -267,7 +263,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         Set<RangeFieldMapper.Range> multiRecord = new HashSet<>(2);
         multiRecord.add(range1);
         multiRecord.add(range2);
-        testCase(aggregationBuilder,  new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder,  new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range1)))));
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range1)))));
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range2)))));
@@ -287,7 +283,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         fieldType.setName(FIELD_NAME);
         fieldType.setHasDocValues(true);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 8)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 9)));
@@ -305,7 +301,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         fieldType.setName(FIELD_NAME);
         fieldType.setHasDocValues(true);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             Document doc = new Document();
             doc.add(new SortedNumericDocValuesField(FIELD_NAME, 7));
             doc.add(new SortedNumericDocValuesField(FIELD_NAME, 7));
@@ -337,7 +333,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         fieldType.setName(FIELD_NAME);
         fieldType.setHasDocValues(true);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("1"))));
             iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("2"))));
             iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("3"))));
@@ -355,7 +351,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         fieldType.setName(FIELD_NAME);
         fieldType.setHasDocValues(true);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             Document doc = new Document();
             // Note: unlike numerics, lucene de-dupes strings so we increment here
             doc.add(new SortedSetDocValuesField(FIELD_NAME, new BytesRef("1")));
@@ -379,16 +375,16 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         }, fieldType);
     }
 
-    private void testCase(Query query,
+    private void testAggregation(Query query,
                           ValueType valueType,
                           CheckedConsumer<RandomIndexWriter, IOException> indexer,
                           Consumer<InternalValueCount> verify) throws IOException {
         // Test both with and without the userValueTypeHint
-        testCase(query, valueType, indexer, verify, true);
-        testCase(query, valueType, indexer, verify, false);
+        testAggregation(query, valueType, indexer, verify, true);
+        testAggregation(query, valueType, indexer, verify, false);
     }
 
-    private void testCase(Query query,
+    private void testAggregation(Query query,
                           ValueType valueType,
                           CheckedConsumer<RandomIndexWriter, IOException> indexer,
                           Consumer<InternalValueCount> verify, boolean testWithHint) throws IOException {
@@ -402,28 +398,16 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         }
         aggregationBuilder.field(FIELD_NAME);
 
-        testCase(aggregationBuilder, query, indexer, verify, fieldType);
-
+        testAggregation(aggregationBuilder, query, indexer, verify, fieldType);
     }
 
-    private void testCase(ValueCountAggregationBuilder aggregationBuilder, Query query,
-                          CheckedConsumer<RandomIndexWriter, IOException> indexer,
-                          Consumer<InternalValueCount> verify, MappedFieldType fieldType) throws IOException {
-        try (Directory directory = newDirectory()) {
-            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                indexer.accept(indexWriter);
-            }
-
-            try (IndexReader indexReader = DirectoryReader.open(directory)) {
-                IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-
-                ValueCountAggregator aggregator = createAggregator(aggregationBuilder, indexSearcher, fieldType);
-                aggregator.preCollection();
-                indexSearcher.search(query, aggregator);
-                aggregator.postCollection();
-                verify.accept((InternalValueCount) aggregator.buildAggregation(0L));
-            }
-        }
+    private void testAggregation(
+        AggregationBuilder aggregationBuilder,
+        Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        Consumer<InternalValueCount> verify,
+        MappedFieldType fieldType)  throws IOException {
+        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
     }
 
     private static MappedFieldType createMappedFieldType(ValueType valueType) {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -503,7 +503,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             InternalAggregationTestCase.assertMultiBucketConsumer(agg, shardBucketConsumer);
         }
         if (aggs.isEmpty()) {
-            return null;
+            return (A) root.buildEmptyAggregation();
         } else {
             if (randomBoolean() && aggs.size() > 1) {
                 // sometimes do an incremental reduce
@@ -543,10 +543,12 @@ public abstract class AggregatorTestCase extends ESTestCase {
         InternalAggregationTestCase.assertMultiBucketConsumer(agg, bucketConsumer);
     }
 
-    protected <T extends AggregationBuilder,
-               V extends InternalAggregation> void testCase(T aggregationBuilder, Query query,
-                                                            CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-                                                            Consumer<V> verify, MappedFieldType fieldType) throws IOException {
+    protected <T extends AggregationBuilder, V extends InternalAggregation> void testCase(
+        T aggregationBuilder,
+        Query query,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        Consumer<V> verify,
+        MappedFieldType... fieldTypes) throws IOException {
         try (Directory directory = newDirectory()) {
             RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
             buildIndex.accept(indexWriter);
@@ -555,9 +557,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
 
-                V agg = searchAndReduce(indexSearcher, query, aggregationBuilder, fieldType);
+                V agg = searchAndReduce(indexSearcher, query, aggregationBuilder, fieldTypes);
                 verify.accept(agg);
-
             }
         }
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
@@ -9,13 +9,9 @@ package org.elasticsearch.xpack.analytics.ttest;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
@@ -32,7 +28,6 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.global.InternalGlobal;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
@@ -655,24 +650,5 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             aggregationBuilder.testType(type);
         }
         testCase(aggregationBuilder, query, buildIndex, verify, fieldType1, fieldType2);
-    }
-
-    private <T extends AggregationBuilder, V extends InternalAggregation> void testCase(
-        T aggregationBuilder, Query query,
-        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-        Consumer<V> verify, MappedFieldType... fieldType) throws IOException {
-        try (Directory directory = newDirectory()) {
-            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-            buildIndex.accept(indexWriter);
-            indexWriter.close();
-
-            try (IndexReader indexReader = DirectoryReader.open(directory)) {
-                IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-
-                V agg = searchAndReduce(indexSearcher, query, aggregationBuilder, fieldType);
-                verify.accept(agg);
-
-            }
-        }
     }
 }


### PR DESCRIPTION
Backports #55826 to 7.x 

> Modified AggregatorTestCase.searchAndReduce() method so that it returns an empty aggregation result when no documents have been inserted.
> 
> Also refactored several aggregation tests so they do not re-implement method AggregatorTestCase.testCase()
> 
> Fixes #55824