### PR TITLE
[7.x] Delete index API properly handles backing indices for data streams

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/20_backing_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/20_backing_indices.yml
@@ -1,0 +1,99 @@
+---
+"Delete backing index on data stream":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "enable in 7.8+ after backporting"
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream
+        body:
+          timestamp_field: "@timestamp"
+  - is_true: acknowledged
+
+  # rollover data stream to create new backing index
+  - do:
+      indices.rollover:
+        alias: "simple-data-stream"
+
+  - match: { old_index: simple-data-stream-000001 }
+  - match: { new_index: simple-data-stream-000002 }
+  - match: { rolled_over: true }
+  - match: { dry_run: false }
+
+  # ensure new index is created
+  - do:
+      indices.exists:
+        index: simple-data-stream-000002
+
+  - is_true: ''
+
+  - do:
+      indices.delete:
+        index: simple-data-stream-000001
+
+  - do:
+      indices.exists:
+        index: simple-data-stream-000001
+
+  - is_false: ''
+
+  - do:
+      indices.get_data_streams:
+        name: "*"
+  - match: { 0.name: simple-data-stream }
+  - match: { 0.timestamp_field: '@timestamp' }
+  - match: { 0.generation: 2 }
+  - length: { 0.indices: 1 }
+  - match: { 0.indices.0.index_name: 'simple-data-stream-000002' }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream
+  - is_true: acknowledged
+
+---
+"Attempt to delete write index on data stream is rejected":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "enable in 7.8+ after backporting"
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream
+        body:
+          timestamp_field: "@timestamp"
+  - is_true: acknowledged
+
+  # rollover data stream to create new backing index
+  - do:
+      indices.rollover:
+        alias: "simple-data-stream"
+
+  - match: { old_index: simple-data-stream-000001 }
+  - match: { new_index: simple-data-stream-000002 }
+  - match: { rolled_over: true }
+  - match: { dry_run: false }
+
+  # ensure new index is created
+  - do:
+      indices.exists:
+        index: simple-data-stream-000002
+
+  - is_true: ''
+
+  - do:
+      catch: bad_request
+      indices.delete:
+        index: simple-data-stream-000002
+
+  - do:
+      indices.exists:
+        index: simple-data-stream-000002
+
+  - is_true: ''
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream
+  - is_true: acknowledged

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -47,6 +47,8 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         this.timeStampField = timeStampField;
         this.indices = indices;
         this.generation = generation;
+        assert indices.size() > 0;
+        assert indices.get(indices.size() - 1).getName().equals(getBackingIndexName(name, generation));
     }
 
     public DataStream(String name, String timeStampField, List<Index> indices) {
@@ -82,6 +84,19 @@ public final class DataStream extends AbstractDiffable<DataStream> implements To
         List<Index> backingIndices = new ArrayList<>(indices);
         backingIndices.add(newWriteIndex);
         return new DataStream(name, timeStampField, backingIndices, generation + 1);
+    }
+
+    /**
+     * Removes the specified backing index and returns a new {@code DataStream} instance with
+     * the remaining backing indices.
+     *
+     * @param index the backing index to remove
+     * @return new {@code DataStream} instance with the remaining backing indices
+     */
+    public DataStream removeBackingIndex(Index index) {
+        List<Index> backingIndices = new ArrayList<>(indices);
+        backingIndices.remove(index);
+        return new DataStream(name, timeStampField, backingIndices, generation);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/DeleteDataStreamRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/DeleteDataStreamRequestTests.java
@@ -74,7 +74,8 @@ public class DeleteDataStreamRequestTests extends AbstractWireSerializingTestCas
     public void testDeleteDataStream() {
         final String dataStreamName = "my-data-stream";
         final List<String> otherIndices = randomSubsetOf(org.elasticsearch.common.collect.List.of("foo", "bar", "baz"));
-        ClusterState cs = getClusterState(org.elasticsearch.common.collect.List.of(new Tuple<>(dataStreamName, 2)), otherIndices);
+        ClusterState cs = getClusterStateWithDataStreams(
+            org.elasticsearch.common.collect.List.of(new Tuple<>(dataStreamName, 2)), otherIndices);
         DeleteDataStreamAction.Request req = new DeleteDataStreamAction.Request(dataStreamName);
         ClusterState newState = DeleteDataStreamAction.TransportAction.removeDataStream(getMetadataDeleteIndexService(), cs, req);
         assertThat(newState.metadata().dataStreams().size(), equalTo(0));
@@ -118,7 +119,7 @@ public class DeleteDataStreamRequestTests extends AbstractWireSerializingTestCas
      * @param dataStreams The names of the data streams to create with their respective number of backing indices
      * @param indexNames  The names of indices to create that do not back any data streams
      */
-    private static ClusterState getClusterState(List<Tuple<String, Integer>> dataStreams, List<String> indexNames) {
+    public static ClusterState getClusterStateWithDataStreams(List<Tuple<String, Integer>> dataStreams, List<String> indexNames) {
         Metadata.Builder builder = Metadata.builder();
 
         List<IndexMetadata> allIndices = new ArrayList<>();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsResponseTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.admin.indices.datastream;
 
 import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction.Response;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamTests;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
@@ -28,8 +29,6 @@ import org.elasticsearch.test.AbstractSerializingTestCase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.elasticsearch.cluster.metadata.DataStreamTests.randomIndexInstances;
 
 public class GetDataStreamsResponseTests extends AbstractSerializingTestCase<Response> {
 
@@ -54,7 +53,7 @@ public class GetDataStreamsResponseTests extends AbstractSerializingTestCase<Res
         int numDataStreams = randomIntBetween(0, 8);
         List<DataStream> dataStreams = new ArrayList<>();
         for (int i = 0; i < numDataStreams; i++) {
-            dataStreams.add(new DataStream(randomAlphaOfLength(4), randomAlphaOfLength(4), randomIndexInstances()));
+            dataStreams.add(DataStreamTests.randomInstance());
         }
         return new Response(dataStreams);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexServiceTests.java
@@ -27,6 +27,8 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.collect.List;
+import org.elasticsearch.common.collect.Set;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -41,9 +43,7 @@ import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.core.IsNull;
 import org.junit.Before;
 
-import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;


### PR DESCRIPTION
The delete index API now handles backing indices for data streams. Specifically:

- If an index is the current write index for a data stream, it will reject the deletion request.
- If an index is a backing index but not the current write index for a data stream, the index will be deleted and the index will be removed from the parent data stream's list of backing indices.

Relates to #53100

Backport of #55690 
