### PR TITLE
Remove codec from ilm action forcemerge

### DIFF
--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -19,17 +19,6 @@ If no rollover action is configured, {ilm-init} will reject the policy.
 (Required, integer) 
 Number of segments to merge to. To fully merge the index, set to `1`.
 
-`codec`::
-(Optional, string)   
-Use the `best_compression` codec. Valid values: `best_compression`.
-+
-[WARNING]
-======
-Setting `"codec": "best_compression"` in the {ilm-init} forcemerge action causes {ilm-int} to
-<<indices-close,close>> and then <<indices-open-close,re-open>> the index prior to the force merge.
-During this time, the index is unavailable for both read and write operations.
-======
-
 [[ilm-forcemerge-action-ex]]
 ==== Example
 


### PR DESCRIPTION
`codec` was removed at some point in the past, yet the documentation still lists it.

The issue: https://github.com/elastic/elasticsearch/issues/41274
and its associated PR: https://github.com/elastic/elasticsearch/pull/49974
... seem to be adding "codec" to ILM action forcemerge in version 7.7. However, older docs need corrected.