### PR TITLE
Make xpack.ilm.enabled setting a no-op (#55592)

### DIFF
--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -292,11 +292,22 @@ greater than `Integer.MAX_VALUE`.  This leniency has been removed.
 [float]
 ==== Option to disable basic license features is deprecated
 
-In Elasticsearch 7.8.0, the following settings have been deprecated:
+In Elasticsearch 7.8.0, the following settings no longer have any effect, and
+have been deprecated:
+
+* `xpack.ilm.enabled`
+
+In other words, even if `xpack.ilm.enabled` is set to `false`, the ILM APIs
+will be available.
+
+If you have disabled ILM so that you can use another tool to manage Watcher
+indices, the newly introduced `xpack.watcher.use_ilm_index_management` setting
+may be set to false.
+
+Additionally, the following settings have been deprecated:
 
 * `xpack.enrich.enabled`
 * `xpack.flattened.enabled`
-* `xpack.ilm.enabled`
 * `xpack.monitoring.enabled`
 * `xpack.rollup.enabled`
 * `xpack.slm.enabled`
@@ -305,4 +316,4 @@ In Elasticsearch 7.8.0, the following settings have been deprecated:
 * `xpack.vectors.enabled`
 
 In future releases, it will not be possible to disable the APIs for Enrichment,
-Flattened mappings, ILM, Monitoring, Rollup, SLM, SQL, Transforms, and Vectors.
+Flattened mappings, Monitoring, Rollup, SLM, SQL, Transforms, and Vectors.

--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -7,9 +7,8 @@ These are the settings available for configuring Index Lifecycle Management
 ==== Cluster level settings
 
 `xpack.ilm.enabled`::
-deprecated:[7.8.0,Basic License features should always be enabled] +
-Whether ILM is enabled or disabled, setting this to `false` disables any ILM
-REST API endpoints and functionality. Defaults to `true`.
+deprecated:[7.8.0,Basic License features are always enabled] +
+This deprecated setting has no effect and will be removed in Elasticsearch 8.0.
 
 `indices.lifecycle.poll_interval`::
 (<<time-units, time units>>) How often {ilm} checks for indices that meet policy

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -93,7 +93,10 @@ public class XPackSettings {
 
     /**
      * Setting for enabling or disabling the index lifecycle extension. Defaults to true.
+     * <p>
+     * This setting is now a no-op: setting it to false is permitted, but does nothing.
      */
+    @Deprecated // since 7.8.0
     public static final Setting<Boolean> INDEX_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.ilm.enabled", true,
         Property.NodeScope, Property.Deprecated);
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -49,12 +49,12 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
         }
     }
 
-    public IndexLifecycleFeatureSetUsage(boolean available, boolean enabled) {
-        this(available, enabled, null);
+    public IndexLifecycleFeatureSetUsage(boolean available) {
+        this(available, null);
     }
 
-    public IndexLifecycleFeatureSetUsage(boolean available, boolean enabled, List<PolicyStats> policyStats) {
-        super(XPackField.INDEX_LIFECYCLE, available, enabled);
+    public IndexLifecycleFeatureSetUsage(boolean available, List<PolicyStats> policyStats) {
+        super(XPackField.INDEX_LIFECYCLE, available, true);
         this.policyStats = policyStats;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.XPackClient;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
@@ -203,29 +202,26 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     }
 
     private void addIndexLifecyclePoliciesIfMissing(ClusterState state) {
-        boolean ilmSupported = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
 
-        if (ilmSupported) {
-            Optional<IndexLifecycleMetadata> maybeMeta = Optional.ofNullable(state.metadata().custom(IndexLifecycleMetadata.TYPE));
-            List<LifecyclePolicy> policies = getPolicyConfigs().stream()
-                .map(policyConfig -> policyConfig.load(xContentRegistry))
-                .collect(Collectors.toList());
+        Optional<IndexLifecycleMetadata> maybeMeta = Optional.ofNullable(state.metadata().custom(IndexLifecycleMetadata.TYPE));
+        List<LifecyclePolicy> policies = getPolicyConfigs().stream()
+            .map(policyConfig -> policyConfig.load(xContentRegistry))
+            .collect(Collectors.toList());
 
-            for (LifecyclePolicy policy : policies) {
-                final AtomicBoolean creationCheck = policyCreationsInProgress.computeIfAbsent(policy.getName(),
-                    key -> new AtomicBoolean(false));
-                if (creationCheck.compareAndSet(false, true)) {
-                    final boolean policyNeedsToBeCreated = maybeMeta
-                        .flatMap(ilmMeta -> Optional.ofNullable(ilmMeta.getPolicies().get(policy.getName())))
-                        .isPresent() == false;
-                    if (policyNeedsToBeCreated) {
-                        logger.debug("adding lifecycle policy [{}] for [{}], because it doesn't exist", policy.getName(), getOrigin());
-                        putPolicy(policy, creationCheck);
-                    } else {
-                        logger.trace("not adding lifecycle policy [{}] for [{}], because it already exists",
-                            policy.getName(), getOrigin());
-                        creationCheck.set(false);
-                    }
+        for (LifecyclePolicy policy : policies) {
+            final AtomicBoolean creationCheck = policyCreationsInProgress.computeIfAbsent(policy.getName(),
+                key -> new AtomicBoolean(false));
+            if (creationCheck.compareAndSet(false, true)) {
+                final boolean policyNeedsToBeCreated = maybeMeta
+                    .flatMap(ilmMeta -> Optional.ofNullable(ilmMeta.getPolicies().get(policy.getName())))
+                    .isPresent() == false;
+                if (policyNeedsToBeCreated) {
+                    logger.debug("adding lifecycle policy [{}] for [{}], because it doesn't exist", policy.getName(), getOrigin());
+                    putPolicy(policy, creationCheck);
+                } else {
+                    logger.trace("not adding lifecycle policy [{}] for [{}], because it already exists",
+                        policy.getName(), getOrigin());
+                    creationCheck.set(false);
                 }
             }
         }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_template.json
@@ -8,8 +8,9 @@
     "index" : {
       "auto_expand_replicas" : "0-1",
       "hidden": true
-    }
-    ${xpack.ml.index.lifecycle.settings}
+    },
+    "index.lifecycle.name": "${xpack.ml.index.lifecycle.name}",
+    "index.lifecycle.rollover_alias": "${xpack.ml.index.lifecycle.rollover_alias}"
   },
   "mappings" : {
     "_doc": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/stats_index_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/stats_index_template.json
@@ -9,8 +9,9 @@
       "number_of_shards" : "1",
       "auto_expand_replicas" : "0-1",
       "hidden": true
-    }
-    ${xpack.ml.index.lifecycle.settings}
+    },
+    "index.lifecycle.name": "${xpack.ml.index.lifecycle.name}",
+    "index.lifecycle.rollover_alias": "${xpack.ml.index.lifecycle.rollover_alias}"
   },
   "mappings" : ${xpack.ml.stats.mappings},
   "aliases" : {}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsageTests.java
@@ -28,22 +28,18 @@ public class IndexLifecycleFeatureSetUsageTests extends AbstractWireSerializingT
                 policyStats.add(PolicyStatsTests.createRandomInstance());
             }
         }
-        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, policyStats);
     }
 
     @Override
     protected IndexLifecycleFeatureSetUsage mutateInstance(IndexLifecycleFeatureSetUsage instance) throws IOException {
         boolean available = instance.available();
-        boolean enabled = instance.enabled();
         List<PolicyStats> policyStats = instance.getPolicyStats();
-        switch (between(0, 2)) {
+        switch (between(0, 1)) {
         case 0:
             available = available == false;
             break;
         case 1:
-            enabled = enabled == false;
-            break;
-        case 2:
             if (policyStats == null) {
                 policyStats = new ArrayList<>();
                 policyStats.add(PolicyStatsTests.createRandomInstance());
@@ -57,7 +53,7 @@ public class IndexLifecycleFeatureSetUsageTests extends AbstractWireSerializingT
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, policyStats);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -141,13 +141,11 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
     private final SetOnce<SnapshotRetentionService> snapshotRetentionService = new SetOnce<>();
     private final SetOnce<SnapshotHistoryStore> snapshotHistoryStore = new SetOnce<>();
     private Settings settings;
-    private boolean ilmEnabled;
     private boolean slmEnabled;
     private boolean transportClientMode;
 
     public IndexLifecycle(Settings settings) {
         this.settings = settings;
-        this.ilmEnabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
         this.slmEnabled = XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED.get(settings);
         this.transportClientMode = XPackPlugin.transportClientMode(settings);
     }
@@ -197,17 +195,15 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             return Collections.emptyList();
         }
         final List<Object> components = new ArrayList<>();
-        if (ilmEnabled) {
-            // This registers a cluster state listener, so appears unused but is not.
-            @SuppressWarnings("unused")
-            ILMHistoryTemplateRegistry ilmTemplateRegistry =
-                new ILMHistoryTemplateRegistry(settings, clusterService, threadPool, client, xContentRegistry);
-            ilmHistoryStore.set(new ILMHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
-                clusterService, threadPool));
-            indexLifecycleInitialisationService.set(new IndexLifecycleService(settings, client, clusterService, threadPool,
-                getClock(), System::currentTimeMillis, xContentRegistry, ilmHistoryStore.get()));
-            components.add(indexLifecycleInitialisationService.get());
-        }
+        // This registers a cluster state listener, so appears unused but is not.
+        @SuppressWarnings("unused")
+        ILMHistoryTemplateRegistry ilmTemplateRegistry =
+            new ILMHistoryTemplateRegistry(settings, clusterService, threadPool, client, xContentRegistry);
+        ilmHistoryStore.set(new ILMHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
+            clusterService, threadPool));
+        indexLifecycleInitialisationService.set(new IndexLifecycleService(settings, client, clusterService, threadPool,
+            getClock(), System::currentTimeMillis, xContentRegistry, ilmHistoryStore.get()));
+        components.add(indexLifecycleInitialisationService.get());
         if (slmEnabled) {
             // the template registry is a cluster state listener
             @SuppressWarnings("unused")
@@ -263,20 +259,19 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter, IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<DiscoveryNodes> nodesInCluster) {
         List<RestHandler> handlers = new ArrayList<>();
-        if (ilmEnabled) {
-            handlers.addAll(Arrays.asList(
-                new RestPutLifecycleAction(),
-                new RestGetLifecycleAction(),
-                new RestDeleteLifecycleAction(),
-                new RestExplainLifecycleAction(),
-                new RestRemoveIndexLifecyclePolicyAction(),
-                new RestMoveToStepAction(),
-                new RestRetryAction(),
-                new RestStopAction(),
-                new RestStartILMAction(),
-                new RestGetStatusAction()
-            ));
-        }
+        // add ILM rest handlers
+        handlers.addAll(Arrays.asList(
+            new RestPutLifecycleAction(),
+            new RestGetLifecycleAction(),
+            new RestDeleteLifecycleAction(),
+            new RestExplainLifecycleAction(),
+            new RestRemoveIndexLifecyclePolicyAction(),
+            new RestMoveToStepAction(),
+            new RestRetryAction(),
+            new RestStopAction(),
+            new RestStartILMAction(),
+            new RestGetStatusAction()
+        ));
         if (slmEnabled) {
             handlers.addAll(Arrays.asList(
                 new RestPutSnapshotLifecycleAction(),
@@ -296,20 +291,19 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>();
-        if (ilmEnabled) {
-            actions.addAll(Arrays.asList(
-                new ActionHandler<>(PutLifecycleAction.INSTANCE, TransportPutLifecycleAction.class),
-                new ActionHandler<>(GetLifecycleAction.INSTANCE, TransportGetLifecycleAction.class),
-                new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifecycleAction.class),
-                new ActionHandler<>(ExplainLifecycleAction.INSTANCE, TransportExplainLifecycleAction.class),
-                new ActionHandler<>(RemoveIndexLifecyclePolicyAction.INSTANCE, TransportRemoveIndexLifecyclePolicyAction.class),
-                new ActionHandler<>(MoveToStepAction.INSTANCE, TransportMoveToStepAction.class),
-                new ActionHandler<>(RetryAction.INSTANCE, TransportRetryAction.class),
-                new ActionHandler<>(StartILMAction.INSTANCE, TransportStartILMAction.class),
-                new ActionHandler<>(StopILMAction.INSTANCE, TransportStopILMAction.class),
-                new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class)
-            ));
-        }
+        // add ILM actions
+        actions.addAll(Arrays.asList(
+            new ActionHandler<>(PutLifecycleAction.INSTANCE, TransportPutLifecycleAction.class),
+            new ActionHandler<>(GetLifecycleAction.INSTANCE, TransportGetLifecycleAction.class),
+            new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifecycleAction.class),
+            new ActionHandler<>(ExplainLifecycleAction.INSTANCE, TransportExplainLifecycleAction.class),
+            new ActionHandler<>(RemoveIndexLifecyclePolicyAction.INSTANCE, TransportRemoveIndexLifecyclePolicyAction.class),
+            new ActionHandler<>(MoveToStepAction.INSTANCE, TransportMoveToStepAction.class),
+            new ActionHandler<>(RetryAction.INSTANCE, TransportRetryAction.class),
+            new ActionHandler<>(StartILMAction.INSTANCE, TransportStartILMAction.class),
+            new ActionHandler<>(StopILMAction.INSTANCE, TransportStopILMAction.class),
+            new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class)
+        ));
         if (slmEnabled) {
             actions.addAll(Arrays.asList(
                 new ActionHandler<>(PutSnapshotLifecycleAction.INSTANCE, TransportPutSnapshotLifecycleAction.class),
@@ -328,10 +322,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
 
     @Override
     public void onIndexModule(IndexModule indexModule) {
-        if (ilmEnabled) {
-            assert indexLifecycleInitialisationService.get() != null;
-            indexModule.addIndexEventListener(indexLifecycleInitialisationService.get());
-        }
+        assert indexLifecycleInitialisationService.get() != null;
+        indexModule.addIndexEventListener(indexLifecycleInitialisationService.get());
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSet.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSet.java
@@ -11,11 +11,9 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PhaseStats;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PolicyStats;
@@ -29,14 +27,12 @@ import java.util.stream.Collectors;
 
 public class IndexLifecycleFeatureSet implements XPackFeatureSet {
 
-    private final boolean enabled;
     private final XPackLicenseState licenseState;
     private ClusterService clusterService;
 
     @Inject
-    public IndexLifecycleFeatureSet(Settings settings, @Nullable XPackLicenseState licenseState, ClusterService clusterService) {
+    public IndexLifecycleFeatureSet(@Nullable XPackLicenseState licenseState, ClusterService clusterService) {
         this.clusterService = clusterService;
-        this.enabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
         this.licenseState = licenseState;
     }
 
@@ -52,7 +48,7 @@ public class IndexLifecycleFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean enabled() {
-        return enabled;
+        return true;
     }
 
     @Override
@@ -83,9 +79,9 @@ public class IndexLifecycleFeatureSet implements XPackFeatureSet {
                 }).collect(Collectors.toMap(Tuple::v1, Tuple::v2));
                 return new PolicyStats(phaseStats, policyUsage.getOrDefault(policy.getName(), 0));
             }).collect(Collectors.toList());
-            listener.onResponse(new IndexLifecycleFeatureSetUsage(available(), enabled(), policyStats));
+            listener.onResponse(new IndexLifecycleFeatureSetUsage(available(), policyStats));
         } else {
-            listener.onResponse(new IndexLifecycleFeatureSetUsage(available(), enabled()));
+            listener.onResponse(new IndexLifecycleFeatureSetUsage(available()));
         }
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetTests.java
@@ -13,11 +13,9 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PolicyStats;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
@@ -53,7 +51,7 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
 
         when(licenseState.isIndexLifecycleAllowed()).thenReturn(false);
         assertThat(featureSet.available(), equalTo(false));
@@ -61,28 +59,17 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
         when(licenseState.isIndexLifecycleAllowed()).thenReturn(true);
         assertThat(featureSet.available(), equalTo(true));
 
-        featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, null, clusterService);
+        featureSet = new IndexLifecycleFeatureSet(null, clusterService);
         assertThat(featureSet.available(), equalTo(false));
     }
 
-    public void testEnabled() {
-        Settings.Builder settings = Settings.builder().put("xpack.ilm.enabled", false);
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(settings.build(), licenseState, clusterService);
-        assertThat(featureSet.enabled(), equalTo(false));
-
-        settings = Settings.builder().put("xpack.ilm.enabled", true);
-        featureSet = new IndexLifecycleFeatureSet(settings.build(), licenseState, clusterService);
-        assertThat(featureSet.enabled(), equalTo(true));
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
-    }
-
     public void testName() {
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
         assertThat(featureSet.name(), equalTo("ilm"));
     }
 
     public void testNativeCodeInfo() {
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
         assertNull(featureSet.nativeCodeInfo());
     }
 
@@ -114,7 +101,7 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
         Mockito.when(clusterService.state()).thenReturn(clusterState);
 
         PlainActionFuture<IndexLifecycleFeatureSet.Usage> future = new PlainActionFuture<>();
-        IndexLifecycleFeatureSet ilmFeatureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
+        IndexLifecycleFeatureSet ilmFeatureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
         ilmFeatureSet.usage(future);
         IndexLifecycleFeatureSetUsage ilmUsage = (IndexLifecycleFeatureSetUsage) future.get();
         assertThat(ilmUsage.enabled(), equalTo(ilmFeatureSet.enabled()));

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetUsageTests.java
@@ -20,35 +20,30 @@ public class IndexLifecycleFeatureSetUsageTests extends AbstractWireSerializingT
     @Override
     protected IndexLifecycleFeatureSetUsage createTestInstance() {
         boolean available = randomBoolean();
-        boolean enabled = randomBoolean();
         List<PolicyStats> policyStats = new ArrayList<>();
         int size = randomIntBetween(0, 10);
         for (int i = 0; i < size; i++) {
             policyStats.add(PolicyStatsTests.randomPolicyStats());
         }
-        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, policyStats);
     }
 
     @Override
     protected IndexLifecycleFeatureSetUsage mutateInstance(IndexLifecycleFeatureSetUsage instance) throws IOException {
         boolean available = instance.available();
-        boolean enabled = instance.enabled();
         List<PolicyStats> policyStats = instance.getPolicyStats();
-        switch (between(0, 2)) {
+        switch (between(0, 1)) {
         case 0:
             available = available == false;
             break;
         case 1:
-            enabled = enabled == false;
-            break;
-        case 2:
             policyStats = new ArrayList<>(policyStats);
             policyStats.add(PolicyStatsTests.randomPolicyStats());
             break;
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, policyStats);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -116,7 +116,6 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
     @Override
     protected Settings transportClientSettings() {
         Settings.Builder settings = Settings.builder().put(super.transportClientSettings());
-        settings.put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), true);
         settings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
         settings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -87,7 +87,6 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings.Builder settings = Settings.builder().put(super.nodeSettings(nodeOrdinal));
-        settings.put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), true);
         settings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
         settings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
@@ -106,7 +105,6 @@ public class SLMSnapshotBlockingIntegTests extends ESIntegTestCase {
     @Override
     protected Settings transportClientSettings() {
         Settings.Builder settings = Settings.builder().put(super.transportClientSettings());
-        settings.put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), true);
         settings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
         settings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleInitialisationTests.java
@@ -44,7 +44,6 @@ public class SnapshotLifecycleInitialisationTests extends ESSingleNodeTestCase {
     @Override
     protected Settings nodeSettings() {
         Settings.Builder settings = Settings.builder().put(super.nodeSettings());
-        settings.put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false);
         settings.put(XPackSettings.MACHINE_LEARNING_ENABLED.getKey(), false);
         settings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
         settings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
@@ -36,11 +35,12 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
     private static final String ANOMALY_DETECTION_PATH = ROOT_RESOURCE_PATH + "anomalydetection/";
     private static final String VERSION_PATTERN = "xpack.ml.version";
     private static final String VERSION_ID_PATTERN = "xpack.ml.version.id";
+    private static final String INDEX_LIFECYCLE_NAME = "xpack.ml.index.lifecycle.name";
+    private static final String INDEX_LIFECYCLE_ROLLOVER_ALIAS = "xpack.ml.index.lifecycle.rollover_alias";
 
     private static final IndexTemplateConfig ANOMALY_DETECTION_RESULTS_TEMPLATE = anomalyDetectionResultsTemplate();
 
-    private static final IndexTemplateConfig ANOMALY_DETECTION_STATE_TEMPLATE = stateTemplate(true);
-    private static final IndexTemplateConfig ANOMALY_DETECTION_STATE_TEMPLATE_NO_ILM = stateTemplate(false);
+    private static final IndexTemplateConfig ANOMALY_DETECTION_STATE_TEMPLATE = stateTemplate();
 
     private static final IndexTemplateConfig META_TEMPLATE = new IndexTemplateConfig(MlMetaIndex.INDEX_NAME,
         ROOT_RESOURCE_PATH + "meta_index_template.json", Version.CURRENT.id, VERSION_PATTERN,
@@ -56,8 +56,7 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
         ROOT_RESOURCE_PATH + "inference_index_template.json", Version.CURRENT.id, VERSION_PATTERN,
         Collections.singletonMap(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id)));
 
-    private static final IndexTemplateConfig STATS_TEMPLATE = statsTemplate(true);
-    private static final IndexTemplateConfig STATS_TEMPLATE_NO_ILM = statsTemplate(false);
+    private static final IndexTemplateConfig STATS_TEMPLATE = statsTemplate();
 
     private static final String ML_SIZE_BASED_ILM_POLICY_NAME = "ml-size-based-ilm-policy";
     private static final LifecyclePolicyConfig ML_SIZE_BASED_ILM_POLICY =
@@ -76,15 +75,11 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
             variables);
     }
 
-    private static IndexTemplateConfig stateTemplate(boolean ilmEnabled) {
+    private static IndexTemplateConfig stateTemplate() {
         Map<String, String> variables = new HashMap<>();
         variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
-        variables.put(
-            "xpack.ml.index.lifecycle.settings",
-            ilmEnabled
-                ? ",\"index.lifecycle.name\": \"" + ML_SIZE_BASED_ILM_POLICY_NAME + "\"\n" +
-                  ",\"index.lifecycle.rollover_alias\": \"" + AnomalyDetectorsIndex.jobStateIndexWriteAlias() + "\"\n"
-                : "");
+        variables.put(INDEX_LIFECYCLE_NAME, ML_SIZE_BASED_ILM_POLICY_NAME);
+        variables.put(INDEX_LIFECYCLE_ROLLOVER_ALIAS, AnomalyDetectorsIndex.jobStateIndexWriteAlias());
 
         return new IndexTemplateConfig(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
             ANOMALY_DETECTION_PATH + "state_index_template.json",
@@ -103,16 +98,12 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
             variables);
     }
 
-    private static IndexTemplateConfig statsTemplate(boolean ilmEnabled) {
+    private static IndexTemplateConfig statsTemplate() {
         Map<String, String> variables = new HashMap<>();
         variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
         variables.put("xpack.ml.stats.mappings", MlStatsIndex.mapping());
-        variables.put(
-            "xpack.ml.index.lifecycle.settings",
-            ilmEnabled
-                ? ",\"index.lifecycle.name\": \"" + ML_SIZE_BASED_ILM_POLICY_NAME + "\"\n" +
-                ",\"index.lifecycle.rollover_alias\": \"" + MlStatsIndex.writeAlias() + "\"\n"
-                : "");
+        variables.put(INDEX_LIFECYCLE_NAME, ML_SIZE_BASED_ILM_POLICY_NAME);
+        variables.put(INDEX_LIFECYCLE_ROLLOVER_ALIAS, MlStatsIndex.writeAlias());
 
         return new IndexTemplateConfig(MlStatsIndex.TEMPLATE_NAME,
             ROOT_RESOURCE_PATH + "stats_index_template.json",
@@ -125,15 +116,14 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
     public MlIndexTemplateRegistry(Settings nodeSettings, ClusterService clusterService, ThreadPool threadPool, Client client,
                                    NamedXContentRegistry xContentRegistry) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
-        boolean ilmEnabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
         templatesToUse = Arrays.asList(
             ANOMALY_DETECTION_RESULTS_TEMPLATE,
-            ilmEnabled ? ANOMALY_DETECTION_STATE_TEMPLATE : ANOMALY_DETECTION_STATE_TEMPLATE_NO_ILM,
+            ANOMALY_DETECTION_STATE_TEMPLATE,
             CONFIG_TEMPLATE,
             INFERENCE_TEMPLATE,
             META_TEMPLATE,
             NOTIFICATIONS_TEMPLATE,
-            ilmEnabled ? STATS_TEMPLATE : STATS_TEMPLATE_NO_ILM);
+            STATS_TEMPLATE);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -20,14 +20,12 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
@@ -42,8 +40,6 @@ import java.util.List;
 import static org.elasticsearch.mock.orig.Mockito.verify;
 import static org.elasticsearch.mock.orig.Mockito.when;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
@@ -84,7 +80,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
         putIndexTemplateRequestCaptor = ArgumentCaptor.forClass(PutIndexTemplateRequest.class);
     }
 
-    public void testStateTemplateWithIlm() {
+    public void testStateTemplate() {
         MlIndexTemplateRegistry registry =
             new MlIndexTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
 
@@ -100,29 +96,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
         assertThat(req.settings().get("index.lifecycle.rollover_alias"), equalTo(".ml-state-write"));
     }
 
-    public void testStateTemplateWithNoIlm() {
-        MlIndexTemplateRegistry registry =
-            new MlIndexTemplateRegistry(
-                Settings.builder()
-                    .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false)
-                    .build(),
-                clusterService, threadPool, client, xContentRegistry);
-
-        registry.clusterChanged(createClusterChangedEvent(nodes));
-
-        verify(client.admin().indices(), times(7)).putTemplate(putIndexTemplateRequestCaptor.capture(), anyObject());
-
-        PutIndexTemplateRequest req = putIndexTemplateRequestCaptor.getAllValues().stream()
-            .filter(r -> r.name().equals(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("expected the ml state index template to be put"));
-        assertThat(req.settings().get("index.lifecycle.name"), is(nullValue()));
-        assertThat(req.settings().get("index.lifecycle.rollover_alias"), is(nullValue()));
-
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
-    }
-
-    public void testStatsTemplateWithIlm() {
+    public void testStatsTemplate() {
         MlIndexTemplateRegistry registry =
             new MlIndexTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
 
@@ -136,28 +110,6 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
             .orElseThrow(() -> new AssertionError("expected the ml stats index template to be put"));
         assertThat(req.settings().get("index.lifecycle.name"), equalTo("ml-size-based-ilm-policy"));
         assertThat(req.settings().get("index.lifecycle.rollover_alias"), equalTo(".ml-stats-write"));
-    }
-
-    public void testStatsTemplateWithNoIlm() {
-        MlIndexTemplateRegistry registry =
-            new MlIndexTemplateRegistry(
-                Settings.builder()
-                    .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false)
-                    .build(),
-                clusterService, threadPool, client, xContentRegistry);
-
-        registry.clusterChanged(createClusterChangedEvent(nodes));
-
-        verify(client.admin().indices(), times(7)).putTemplate(putIndexTemplateRequestCaptor.capture(), anyObject());
-
-        PutIndexTemplateRequest req = putIndexTemplateRequestCaptor.getAllValues().stream()
-            .filter(r -> r.name().equals(MlStatsIndex.TEMPLATE_NAME))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("expected the ml stats index template to be put"));
-        assertThat(req.settings().get("index.lifecycle.name"), is(nullValue()));
-        assertThat(req.settings().get("index.lifecycle.rollover_alias"), is(nullValue()));
-
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -212,6 +212,8 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
             Setting.boolSetting("xpack.watcher.encrypt_sensitive_data", false, Setting.Property.NodeScope);
     public static final Setting<TimeValue> MAX_STOP_TIMEOUT_SETTING =
             Setting.timeSetting("xpack.watcher.stop.timeout", TimeValue.timeValueSeconds(30), Setting.Property.NodeScope);
+    public static final Setting<Boolean> USE_ILM_INDEX_MANAGEMENT =
+        Setting.boolSetting("xpack.watcher.use_ilm_index_management", XPackSettings.INDEX_LIFECYCLE_ENABLED, NodeScope);
     private static final Setting<Integer> SETTING_BULK_ACTIONS =
         Setting.intSetting("xpack.watcher.bulk.actions", 1, 1, 10000, NodeScope);
     private static final Setting<Integer> SETTING_BULK_CONCURRENT_REQUESTS =
@@ -470,6 +472,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         settings.add(Setting.intSetting("xpack.watcher.watch.scroll.size", 0, Setting.Property.NodeScope));
         settings.add(ENCRYPT_SENSITIVE_DATA_SETTING);
         settings.add(WatcherField.ENCRYPTION_KEY_SETTING);
+        settings.add(USE_ILM_INDEX_MANAGEMENT);
 
         settings.add(Setting.simpleString("xpack.watcher.internal.ops.search.default_timeout", Setting.Property.NodeScope));
         settings.add(Setting.simpleString("xpack.watcher.internal.ops.bulk.default_timeout", Setting.Property.NodeScope));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.watcher;
 
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.IndexModule;
@@ -15,6 +16,7 @@ import org.elasticsearch.index.engine.InternalEngineFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.threadpool.ExecutorBuilder;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.watcher.notification.NotificationService;
 
@@ -85,6 +87,23 @@ public class WatcherPluginTests extends ESTestCase {
         assertThat(watcher.createComponents(null, null, null, null, null, null, null, null, null, null, null), hasSize(0));
 
         watcher.close();
+    }
+
+    public void testWatcherUseIlmFallsBackToIlmEnabled() throws Exception {
+        boolean ilmEnabled = randomBoolean();
+        Settings settingsWithoutWatcherUseIlm = Settings.builder()
+            .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), ilmEnabled)
+            .build();
+        assertThat(Watcher.USE_ILM_INDEX_MANAGEMENT.get(settingsWithoutWatcherUseIlm), is(ilmEnabled));
+
+        boolean watcherUseIlmEnabled = randomBoolean();
+        Settings settingsWithWatcherUseIlm = Settings.builder()
+            .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), ilmEnabled)
+            .put(Watcher.USE_ILM_INDEX_MANAGEMENT.getKey(), watcherUseIlmEnabled)
+            .build();
+        assertThat(Watcher.USE_ILM_INDEX_MANAGEMENT.get(settingsWithWatcherUseIlm), is(watcherUseIlmEnabled));
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
     }
 
     public void testThreadPoolSize() {


### PR DESCRIPTION
* Make xpack.ilm.enabled setting a no-op

* Add watcher setting to not use ILM

* Update documentation for no-op setting

* Remove NO_ILM ml index templates

* Remove unneeded setting from test setup

* Inline variable definitions for ML templates

* Use identical parameter names in templates

* New ILM/watcher setting falls back to old setting

* Add fallback unit test for watcher/ilm setting
