### PR TITLE
Fix input snapshotting for test tasks

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -24,10 +24,12 @@ import org.elasticsearch.gradle.info.BuildParams;
 import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.test.ErrorReportingTestListener;
 import org.elasticsearch.gradle.util.Util;
+import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
@@ -241,14 +243,19 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
              */
             SystemPropertyCommandLineArgumentProvider nonInputProperties = new SystemPropertyCommandLineArgumentProvider();
 
-            test.doFirst(t -> {
-                project.mkdir(testOutputDir);
-                project.mkdir(heapdumpDir);
-                project.mkdir(test.getWorkingDir());
-                project.mkdir(test.getWorkingDir().toPath().resolve("temp"));
+            // We specifically use an anonymous inner class here because lambda task actions break Gradle cacheability
+            // See: https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:how_does_it_work
+            test.doFirst(new Action<>() {
+                @Override
+                public void execute(Task t) {
+                    project.mkdir(testOutputDir);
+                    project.mkdir(heapdumpDir);
+                    project.mkdir(test.getWorkingDir());
+                    project.mkdir(test.getWorkingDir().toPath().resolve("temp"));
 
-                // TODO remove once jvm.options are added to test system properties
-                test.systemProperty("java.locale.providers", "SPI,COMPAT");
+                    // TODO remove once jvm.options are added to test system properties
+                    test.systemProperty("java.locale.providers", "SPI,COMPAT");
+                }
             });
             if (BuildParams.isInFipsJvm()) {
                 project.getDependencies().add("testRuntimeOnly", "org.bouncycastle:bc-fips:1.0.1");
@@ -269,7 +276,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 "-XX:+HeapDumpOnOutOfMemoryError"
             );
 
-            test.getJvmArgumentProviders().add(() -> List.of("-XX:HeapDumpPath=$heapdumpDir"));
+            test.getJvmArgumentProviders().add(new SimpleCommandLineArgumentProvider("-XX:HeapDumpPath=$heapdumpDir"));
 
             String argline = System.getProperty("tests.jvm.argline");
             if (argline != null) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -276,7 +276,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 "-XX:+HeapDumpOnOutOfMemoryError"
             );
 
-            test.getJvmArgumentProviders().add(new SimpleCommandLineArgumentProvider("-XX:HeapDumpPath=$heapdumpDir"));
+            test.getJvmArgumentProviders().add(new SimpleCommandLineArgumentProvider("-XX:HeapDumpPath=" + heapdumpDir));
 
             String argline = System.getProperty("tests.jvm.argline");
             if (argline != null) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/SimpleCommandLineArgumentProvider.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/SimpleCommandLineArgumentProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle;
+
+import org.gradle.process.CommandLineArgumentProvider;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A {@link CommandLineArgumentProvider} implementation that simply returns the given list. This implementation does not track any
+ * arguments as inputs, so this is useful for passing arguments that should not be used for the purposes of input snapshotting.
+ */
+public class SimpleCommandLineArgumentProvider implements CommandLineArgumentProvider {
+    private final List<String> arguments;
+
+    public SimpleCommandLineArgumentProvider(String... arguments) {
+        this.arguments = Arrays.asList(arguments);
+    }
+
+    @Override
+    public Iterable<String> asArguments() {
+        return arguments;
+    }
+}


### PR DESCRIPTION
When converting some of our build logic from Groovy to Java in #55834, we inadvertently broke incremental build and cacheability because Gradle cannot reliably snapshot lambda task inputs. This PR replaces those lambdas with either a normal class or anonymous inner class implementation.