### PR TITLE
deprecrate size from cat.thread_pool in json spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -42,7 +42,11 @@
           "g",
           "t",
           "p"
-        ]
+        ],
+        "deprecated":{
+          "version":"7.8.0",
+          "description":"Setting this value has no effect and will be removed from the specification."
+        }
       },
       "local":{
         "type":"boolean",


### PR DESCRIPTION
The rest spec and documentation for _cat/threadpool supports a "size" parameter.
However, the "size" parameter will have no impact since there are no values
of type "SizeValue" of the return value of this _cat api.

This commit deprecates this from JSON spec and will be removed in a followup. 

Note - this only impacts the JSON spec since all cat APIs support the same set 
of parameters, even if the specific call is not impacted by the param. 