### PR TITLE
Include JUnit test output files in build log artifact uploaded to GCP

### DIFF
--- a/gradle/build-complete.gradle
+++ b/gradle/build-complete.gradle
@@ -16,6 +16,7 @@ if (buildNumber) {
           Set<File> fileSet = fileTree(projectDir) {
             include("**/*.hprof")
             include("**/reaper.log")
+            include("**/build/test-results/**/*.xml")
             include("**/build/testclusters/**")
             exclude("**/build/testclusters/**/data/**")
             exclude("**/build/testclusters/**/distro/**")


### PR DESCRIPTION
In an attempt to try and track down what is causing #52610 it occurred to me that perhaps it's `ESIntegTest` tests that are spinning up on ports clashing with the Gradle daemon and test workers. Since I've yet to find any references to the ports in any test clusters node logs, it must be something else.

This PR adds the JUnit XML output to the list of files we upload to GCP on build completion. These files include _all_ test output, which would include the node logs for internal cluster tests as well, even those that didn't fail. This should allow us to confirm if we are indeed overlapping ports here.