### PR TITLE
Convert remaining license methods to isAllowed (#55908)

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsFeatureSet.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsFeatureSet.java
@@ -35,7 +35,7 @@ public class AnalyticsFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isAnalyticsAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.ANALYTICS);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
@@ -167,7 +167,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
 
     private static <T> ContextParser<String, T> checkLicense(ContextParser<String, T> realParser) {
         return (parser, name) -> {
-            if (getLicenseState().isAnalyticsAllowed() == false) {
+            if (getLicenseState().isAllowed(XPackLicenseState.Feature.ANALYTICS) == false) {
                 throw LicenseUtils.newComplianceException(XPackField.ANALYTICS);
             }
             return realParser.parse(parser, name);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -72,7 +72,8 @@ public class CcrLicenseChecker {
      * Constructs a CCR license checker with the default rule based on the license state for checking if CCR is allowed.
      */
     CcrLicenseChecker() {
-        this(XPackPlugin.getSharedLicenseState()::isCcrAllowed, XPackPlugin.getSharedLicenseState()::isSecurityEnabled);
+        this(() -> XPackPlugin.getSharedLicenseState().isAllowed(XPackLicenseState.Feature.CCR),
+             XPackPlugin.getSharedLicenseState()::isSecurityEnabled);
     }
 
     /**

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRFeatureSetTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CCRFeatureSetTests.java
@@ -45,10 +45,10 @@ public class CCRFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         CCRFeatureSet featureSet = new CCRFeatureSet(Settings.EMPTY, licenseState, clusterService);
 
-        when(licenseState.isCcrAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(false);
         assertThat(featureSet.available(), equalTo(false));
 
-        when(licenseState.isCcrAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(true);
         assertThat(featureSet.available(), equalTo(true));
 
         featureSet = new CCRFeatureSet(Settings.EMPTY, null, clusterService);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
@@ -46,14 +46,14 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         whenLocalNodeElectedMaster(isElectedMaster);
 
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
-        when(licenseState.isCcrAllowed()).thenReturn(ccrAllowed);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(ccrAllowed);
 
         final StatsCollector collector = createCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         }
     }
 
@@ -61,8 +61,8 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         // regardless of CCR being enabled
         final Settings settings = randomFrom(ccrEnabledSettings(), ccrDisabledSettings());
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
-        when(licenseState.isCcrAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -75,8 +75,8 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         // this is controls the blockage
         final Settings settings = ccrDisabledSettings();
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
-        when(licenseState.isCcrAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
 
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
@@ -86,16 +86,16 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfCCRIsNotAllowed() {
         final Settings settings = randomFrom(ccrEnabledSettings(), ccrDisabledSettings());
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
         // this is controls the blockage
-        when(licenseState.isCcrAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -104,22 +104,22 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
         final Settings settings = ccrEnabledSettings();
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
-        when(licenseState.isCcrAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final StatsCollector collector = createCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
 
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -36,6 +36,7 @@ public class XPackLicenseState {
      * Each value defines the licensed state necessary for the feature to be allowed.
      */
     public enum Feature {
+        SECURITY(OperationMode.BASIC, false),
         SECURITY_IP_FILTERING(OperationMode.GOLD, false),
         SECURITY_AUDITING(OperationMode.GOLD, false),
         SECURITY_DLS_FLS(OperationMode.PLATINUM, false),
@@ -46,7 +47,49 @@ public class XPackLicenseState {
         SECURITY_API_KEY_SERVICE(OperationMode.MISSING, false),
         SECURITY_AUTHORIZATION_REALM(OperationMode.PLATINUM, true),
         SECURITY_AUTHORIZATION_ENGINE(OperationMode.PLATINUM, true),
-        SPATIAL_GEO_CENTROID(OperationMode.GOLD, true);
+        SECURITY_STATS_AND_HEALTH(OperationMode.MISSING, true),
+
+        WATCHER(OperationMode.STANDARD, true),
+        MONITORING(OperationMode.MISSING, true),
+        // TODO: should just check WATCHER directly?
+        MONITORING_CLUSTER_ALERTS(OperationMode.STANDARD, true),
+        MONITORING_UPDATE_RETENTION(OperationMode.STANDARD, false),
+
+        CCR(OperationMode.PLATINUM, true),
+
+        GRAPH(OperationMode.PLATINUM, true),
+
+        MACHINE_LEARNING(OperationMode.PLATINUM, true),
+
+        TRANSFORM(OperationMode.MISSING, true),
+
+        ROLLUP(OperationMode.MISSING, true),
+
+        VOTING_ONLY(OperationMode.MISSING, true),
+
+        LOGSTASH(OperationMode.STANDARD, true),
+
+        DEPRECATION(OperationMode.MISSING, true),
+
+        ILM(OperationMode.MISSING, true),
+
+        ENRICH(OperationMode.MISSING, true),
+
+        EQL(OperationMode.MISSING, true),
+
+        SQL(OperationMode.MISSING, true),
+
+        JDBC(OperationMode.PLATINUM, true),
+
+        ODBC(OperationMode.PLATINUM, true),
+
+        VECTORS(OperationMode.MISSING, true),
+
+        SPATIAL(OperationMode.MISSING, true),
+
+        SPATIAL_GEO_CENTROID(OperationMode.GOLD, true),
+
+        ANALYTICS(OperationMode.MISSING, true);
 
         final OperationMode minimumOperationMode;
         final boolean needsActive;
@@ -432,55 +475,8 @@ public class XPackLicenseState {
         return isAllowedByLicense(feature.minimumOperationMode, feature.needsActive);
     }
 
-    public boolean isStatsAndHealthAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isWatcherAllowed() {
-        return isAllowedByLicense(OperationMode.STANDARD);
-    }
-
-    public boolean isMonitoringAllowed() {
-        return allowForAllLicenses();
-    }
-
-    /**
-     * Monitoring Cluster Alerts requires the equivalent license to use Watcher.
-     *
-     * @return {@link #isWatcherAllowed()}
-     * @see #isWatcherAllowed()
-     */
-    public boolean isMonitoringClusterAlertsAllowed() {
-        return isWatcherAllowed();
-    }
-
-    /**
-     * Determine if the current license allows the retention of indices to be modified.
-     * <p>
-     * Only users with a non-{@link OperationMode#BASIC} license can update the retention period.
-     * <p>
-     * Note: This does not consider the <em>state</em> of the license so that any change is remembered for when they fix their license.
-     *
-     * @return {@code true} if the user is allowed to modify the retention. Otherwise {@code false}.
-     */
-    public boolean isUpdateRetentionAllowed() {
-        return isAllowedByLicense(OperationMode.STANDARD, false);
-    }
-
-    public boolean isGraphAllowed() {
-        return isAllowedByLicense(OperationMode.PLATINUM);
-    }
-
-    public boolean isMachineLearningAllowed() {
-        return isAllowedByLicense(OperationMode.PLATINUM);
-    }
-
     public static boolean isMachineLearningAllowedForOperationMode(final OperationMode operationMode) {
         return isAllowedByOperationMode(operationMode, OperationMode.PLATINUM);
-    }
-
-    public boolean isTransformAllowed() {
-        return allowForAllLicenses();
     }
 
     public static boolean isTransformAllowedForOperationMode(final OperationMode operationMode) {
@@ -490,91 +486,6 @@ public class XPackLicenseState {
 
     public static boolean isFipsAllowedForOperationMode(final OperationMode operationMode) {
         return isAllowedByOperationMode(operationMode, OperationMode.PLATINUM);
-    }
-
-    public boolean isRollupAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isVotingOnlyAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isLogstashAllowed() {
-        return isAllowedByLicense(OperationMode.STANDARD);
-    }
-
-    public boolean isBeatsAllowed() {
-        return isAllowedByLicense(OperationMode.STANDARD);
-    }
-
-    public boolean isDeprecationAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isUpgradeAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isIndexLifecycleAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isEnrichAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isEqlAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isSqlAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isJdbcAllowed() {
-        return isAllowedByLicense(OperationMode.PLATINUM);
-    }
-
-    public boolean isFlattenedAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isVectorsAllowed() {
-        return allowForAllLicenses();
-    }
-
-
-    /**
-     * Determine if Wildcard support should be enabled.
-     * <p>
-     *  Wildcard is available for all license types except {@link OperationMode#MISSING}
-     */
-    public synchronized boolean isWildcardAllowed() {
-        return status.active;
-    }
-
-    public boolean isOdbcAllowed() {
-        return isAllowedByLicense(OperationMode.PLATINUM);
-    }
-
-    public boolean isSpatialAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isAnalyticsAllowed() {
-        return allowForAllLicenses();
-    }
-
-    public boolean isConstantKeywordAllowed() {
-        return allowForAllLicenses();
-    }
-
-    /**
-     * @return true if security is available to be used with the current license type
-     */
-    public boolean isSecurityAvailable() {
-        return checkAgainstStatus(status -> status.mode != OperationMode.MISSING);
     }
 
     /**
@@ -614,13 +525,6 @@ public class XPackLicenseState {
             default:
                 return isSecurityEnabled;
         }
-    }
-
-    /**
-     * Determine if cross-cluster replication is allowed
-     */
-    public boolean isCcrAllowed() {
-        return isAllowedByLicense(OperationMode.PLATINUM);
     }
 
     public static boolean isCcrAllowedForOperationMode(final OperationMode operationMode) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -83,6 +83,8 @@ public class XPackLicenseState {
 
         ODBC(OperationMode.PLATINUM, true),
 
+        FLATTENED(OperationMode.MISSING, true),
+
         VECTORS(OperationMode.MISSING, true),
 
         SPATIAL(OperationMode.MISSING, true),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CCRFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/CCRFeatureSet.java
@@ -46,7 +46,7 @@ public class CCRFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isCcrAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.CCR);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichFeatureSet.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichFeatureSet.java
@@ -37,7 +37,7 @@ public class EnrichFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState.isEnrichAllowed();
+        return licenseState.isAllowed(XPackLicenseState.Feature.ENRICH);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/ActionThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/ActionThrottler.java
@@ -38,7 +38,7 @@ public class ActionThrottler implements Throttler {
 
     @Override
     public Result throttle(String actionId, WatchExecutionContext ctx) {
-        if (licenseState.isWatcherAllowed() == false) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.WATCHER) == false) {
             return Result.throttle(LICENSE, "watcher license does not allow action execution");
         }
         if (periodThrottler != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -81,7 +81,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
@@ -104,13 +104,13 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
 
-        assertThat(licenseState.isSecurityAvailable(), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY), is(true));
         assertThat(licenseState.isSecurityEnabled(), is(false));
     }
 
@@ -122,13 +122,13 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
 
-        assertThat(licenseState.isSecurityAvailable(), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY), is(true));
         assertThat(licenseState.isSecurityEnabled(), is(true));
     }
 
@@ -139,7 +139,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
@@ -154,7 +154,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
@@ -169,7 +169,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
     }
@@ -182,7 +182,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
     }
@@ -195,7 +195,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -211,7 +211,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -227,7 +227,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(true));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
@@ -243,7 +243,7 @@ public class XPackLicenseStateTests extends ESTestCase {
         assertThat(licenseState.isSecurityEnabled(), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isStatsAndHealthAllowed(), is(false));
+        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
         assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS), is(true));
         assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
@@ -304,172 +304,172 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testMonitoringAllowed() {
-        assertAllowed(randomMode(), true, XPackLicenseState::isMonitoringAllowed, true);
-        assertAllowed(randomMode(), false, XPackLicenseState::isMonitoringAllowed, false);
+        assertAllowed(randomMode(), true, s -> s.isAllowed(Feature.MONITORING), true);
+        assertAllowed(randomMode(), false, s -> s.isAllowed(Feature.MONITORING), false);
     }
 
     public void testMonitoringUpdateRetention() {
-        assertAllowed(STANDARD, true, XPackLicenseState::isUpdateRetentionAllowed, true);
-        assertAllowed(GOLD, true, XPackLicenseState::isUpdateRetentionAllowed, true);
-        assertAllowed(PLATINUM, true, XPackLicenseState::isUpdateRetentionAllowed, true);
-        assertAllowed(TRIAL, true, XPackLicenseState::isUpdateRetentionAllowed, true);
-        assertAllowed(BASIC, true, XPackLicenseState::isUpdateRetentionAllowed, false);
-        assertAllowed(MISSING, false, XPackLicenseState::isUpdateRetentionAllowed, false);
+        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(GOLD, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), false);
+        assertAllowed(MISSING, false, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), false);
     }
 
     public void testWatcherPlatinumGoldTrialStandard() throws Exception {
-        assertAllowed(TRIAL, true, XPackLicenseState::isWatcherAllowed, true);
-        assertAllowed(GOLD, true, XPackLicenseState::isWatcherAllowed, true);
-        assertAllowed(PLATINUM, true, XPackLicenseState::isWatcherAllowed, true);
-        assertAllowed(STANDARD, true, XPackLicenseState::isWatcherAllowed, true);
+        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.WATCHER), true);
+        assertAllowed(GOLD, true, s -> s.isAllowed(Feature.WATCHER), true);
+        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.WATCHER), true);
+        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.WATCHER), true);
     }
 
     public void testWatcherBasicLicense() throws Exception {
-        assertAllowed(BASIC, true, XPackLicenseState::isWatcherAllowed, false);
+        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.WATCHER), false);
     }
 
     public void testWatcherInactive() {
-        assertAllowed(BASIC, false, XPackLicenseState::isWatcherAllowed, false);
+        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.WATCHER), false);
     }
 
     public void testWatcherInactivePlatinumGoldTrial() throws Exception {
-        assertAllowed(TRIAL, false, XPackLicenseState::isWatcherAllowed, false);
-        assertAllowed(GOLD, false, XPackLicenseState::isWatcherAllowed, false);
-        assertAllowed(PLATINUM, false, XPackLicenseState::isWatcherAllowed, false);
-        assertAllowed(STANDARD, false, XPackLicenseState::isWatcherAllowed, false);
+        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.WATCHER), false);
+        assertAllowed(GOLD, false, s -> s.isAllowed(Feature.WATCHER), false);
+        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.WATCHER), false);
+        assertAllowed(STANDARD, false, s -> s.isAllowed(Feature.WATCHER), false);
     }
 
     public void testGraphPlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, true, XPackLicenseState::isGraphAllowed, true);
-        assertAllowed(PLATINUM, true, XPackLicenseState::isGraphAllowed, true);
+        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.GRAPH), true);
+        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.GRAPH), true);
     }
 
     public void testGraphBasic() throws Exception {
-        assertAllowed(BASIC, true, XPackLicenseState::isGraphAllowed, false);
+        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.GRAPH), false);
     }
 
     public void testGraphStandard() throws Exception {
-        assertAllowed(STANDARD, true, XPackLicenseState::isGraphAllowed, false);
+        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.GRAPH), false);
     }
 
     public void testGraphInactiveBasic() {
-        assertAllowed(BASIC, false, XPackLicenseState::isGraphAllowed, false);
+        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.GRAPH), false);
     }
 
     public void testGraphInactivePlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, false, XPackLicenseState::isMachineLearningAllowed, false);
-        assertAllowed(PLATINUM, false, XPackLicenseState::isMachineLearningAllowed, false);
+        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningPlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, true, XPackLicenseState::isMachineLearningAllowed, true);
-        assertAllowed(PLATINUM, true, XPackLicenseState::isMachineLearningAllowed, true);
+        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), true);
+        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), true);
     }
 
     public void testMachineLearningBasic() throws Exception {
-        assertAllowed(BASIC, true, XPackLicenseState::isMachineLearningAllowed, false);
+        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningStandard() throws Exception {
-        assertAllowed(STANDARD, true, XPackLicenseState::isMachineLearningAllowed, false);
+        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningInactiveBasic() {
-        assertAllowed(BASIC, false, XPackLicenseState::isMachineLearningAllowed, false);
+        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningInactivePlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, false, XPackLicenseState::isMachineLearningAllowed, false);
-        assertAllowed(PLATINUM, false, XPackLicenseState::isMachineLearningAllowed, false);
+        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
     }
 
     public void testLogstashPlatinumGoldTrialStandard() throws Exception {
-        assertAllowed(TRIAL, true, XPackLicenseState::isLogstashAllowed, true);
-        assertAllowed(GOLD, true, XPackLicenseState::isLogstashAllowed, true);
-        assertAllowed(PLATINUM, true, XPackLicenseState::isLogstashAllowed, true);
-        assertAllowed(STANDARD, true, XPackLicenseState::isLogstashAllowed, true);
+        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.LOGSTASH), true);
+        assertAllowed(GOLD, true, s -> s.isAllowed(Feature.LOGSTASH), true);
+        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.LOGSTASH), true);
+        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.LOGSTASH), true);
     }
 
     public void testLogstashBasicLicense() throws Exception {
-        assertAllowed(BASIC, true, XPackLicenseState::isLogstashAllowed, false);
+        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.LOGSTASH), false);
     }
 
     public void testLogstashInactive() {
-        assertAllowed(BASIC, false, XPackLicenseState::isLogstashAllowed, false);
-        assertAllowed(TRIAL, false, XPackLicenseState::isLogstashAllowed, false);
-        assertAllowed(GOLD, false, XPackLicenseState::isLogstashAllowed, false);
-        assertAllowed(PLATINUM, false, XPackLicenseState::isLogstashAllowed, false);
-        assertAllowed(STANDARD, false, XPackLicenseState::isLogstashAllowed, false);
+        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.LOGSTASH), false);
+        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.LOGSTASH), false);
+        assertAllowed(GOLD, false, s -> s.isAllowed(Feature.LOGSTASH), false);
+        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.LOGSTASH), false);
+        assertAllowed(STANDARD, false, s -> s.isAllowed(Feature.LOGSTASH), false);
     }
 
     public void testSqlDefaults() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
-        assertThat(licenseState.isSqlAllowed(), is(true));
-        assertThat(licenseState.isJdbcAllowed(), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(true));
     }
 
     public void testSqlBasic() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(BASIC, true, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(true));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlBasicExpired() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(BASIC, false, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(false));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlStandard() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(STANDARD, true, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(true));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlStandardExpired() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(STANDARD, false, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(false));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlGold() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(GOLD, true, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(true));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlGoldExpired() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(GOLD, false, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(false));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlPlatinum() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(PLATINUM, true, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(true));
-        assertThat(licenseState.isJdbcAllowed(), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(true));
     }
 
     public void testSqlPlatinumExpired() {
         XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
         licenseState.update(PLATINUM, false, null);
 
-        assertThat(licenseState.isSqlAllowed(), is(false));
-        assertThat(licenseState.isJdbcAllowed(), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlAckAnyToTrialOrPlatinum() {
@@ -482,63 +482,63 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     public void testCcrDefaults() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
-        assertTrue(state.isCcrAllowed());
+        assertTrue(state.isAllowed(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrBasic() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(BASIC, true, null);
 
-        assertThat(state.isCcrAllowed(), is(false));
+        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrBasicExpired() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(BASIC, false, null);
 
-        assertThat(state.isCcrAllowed(), is(false));
+        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrStandard() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(STANDARD, true, null);
 
-        assertThat(state.isCcrAllowed(), is(false));
+        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrStandardExpired() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(STANDARD, false, null);
 
-        assertThat(state.isCcrAllowed(), is(false));
+        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrGold() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(GOLD, true, null);
 
-        assertThat(state.isCcrAllowed(), is(false));
+        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrGoldExpired() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(GOLD, false, null);
 
-        assertThat(state.isCcrAllowed(), is(false));
+        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrPlatinum() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(PLATINUM, true, null);
 
-        assertTrue(state.isCcrAllowed());
+        assertTrue(state.isAllowed(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrPlatinumExpired() {
         final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
         state.update(PLATINUM, false, null);
 
-        assertFalse(state.isCcrAllowed());
+        assertFalse(state.isAllowed(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrAckAnyToTrialOrPlatinum() {
@@ -550,14 +550,14 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testTransformBasic() throws Exception {
-        assertAllowed(BASIC, true, XPackLicenseState::isTransformAllowed, true);
+        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.TRANSFORM), true);
     }
 
     public void testTransformStandard() throws Exception {
-        assertAllowed(STANDARD, true, XPackLicenseState::isTransformAllowed, true);
+        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.TRANSFORM), true);
     }
 
     public void testTransformInactiveBasic() {
-        assertAllowed(BASIC, false, XPackLicenseState::isTransformAllowed, false);
+        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.TRANSFORM), false);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.watcher.actions.throttler;
 
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 
@@ -24,7 +25,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result expectedResult = Throttler.Result.throttle(Throttler.Type.ACK, "_reason");
         when(ackThrottler.throttle("_action", ctx)).thenReturn(expectedResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isWatcherAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -39,7 +40,7 @@ public class WatchThrottlerTests extends ESTestCase {
         when(periodThrottler.throttle("_action", ctx)).thenReturn(expectedResult);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isWatcherAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -55,7 +56,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result ackResult = Throttler.Result.throttle(Throttler.Type.ACK, "_reason_ack");
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isWatcherAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -70,7 +71,7 @@ public class WatchThrottlerTests extends ESTestCase {
         when(periodThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isWatcherAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -83,7 +84,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result ackResult = mock(Throttler.Result.class);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isWatcherAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(null, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -96,7 +97,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result ackResult = mock(Throttler.Result.class);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isWatcherAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(false);
         ActionThrottler throttler = new ActionThrottler(null, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -86,7 +86,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
     @Override
     protected final void masterOperation(final DeprecationInfoAction.Request request, ClusterState state,
                                          final ActionListener<DeprecationInfoAction.Response> listener) {
-        if (licenseState.isDeprecationAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.DEPRECATION)) {
 
             NodesDeprecationCheckRequest nodeDepReq = new NodesDeprecationCheckRequest("_all");
             ClientHelper.executeAsyncWithOrigin(client, ClientHelper.DEPRECATION_ORIGIN,

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
@@ -46,14 +46,14 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         whenLocalNodeElectedMaster(isElectedMaster);
 
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
-        when(licenseState.isEnrichAllowed()).thenReturn(enrichAllowed);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(enrichAllowed);
 
         final EnrichStatsCollector collector = createCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         }
     }
 
@@ -61,8 +61,8 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         // regardless of enrich being enabled
         final Settings settings = randomFrom(enrichEnabledSettings(), enrichDisabledSettings());
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
-        when(licenseState.isEnrichAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -76,8 +76,8 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         final Settings settings = enrichDisabledSettings();
 
         boolean isMonitoringAllowed = randomBoolean();
-        when(licenseState.isMonitoringAllowed()).thenReturn(isMonitoringAllowed);
-        when(licenseState.isEnrichAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(isMonitoringAllowed);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(randomBoolean());
 
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
@@ -87,7 +87,7 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         }
         if (isElectedMaster && isMonitoringAllowed) {
             // The enrich setting is only checked if the node is master and monitoring is allowed,
@@ -100,9 +100,9 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         final Settings settings = randomFrom(enrichEnabledSettings(), enrichDisabledSettings());
 
         boolean isMonitoringAllowed = randomBoolean();
-        when(licenseState.isMonitoringAllowed()).thenReturn(isMonitoringAllowed);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(isMonitoringAllowed);
         // this is controls the blockage
-        when(licenseState.isEnrichAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -111,7 +111,7 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         }
         if (isElectedMaster && isMonitoringAllowed && settings.get(XPackSettings.ENRICH_ENABLED_SETTING.getKey()) != null) {
             assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.ENRICH_ENABLED_SETTING });
@@ -121,15 +121,15 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
     public void testShouldCollectReturnsTrue() {
         final Settings settings = enrichEnabledSettings();
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
-        when(licenseState.isEnrichAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final EnrichStatsCollector collector = createCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
 
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
         if (settings.get(XPackSettings.ENRICH_ENABLED_SETTING.getKey()) != null) {
             assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.ENRICH_ENABLED_SETTING });
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlFeatureSet.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/EqlFeatureSet.java
@@ -32,14 +32,14 @@ public class EqlFeatureSet implements XPackFeatureSet {
     private final boolean enabled;
     private final XPackLicenseState licenseState;
     private final Client client;
-    
+
     @Inject
     public EqlFeatureSet(Settings settings, @Nullable XPackLicenseState licenseState, Client client) {
         this.enabled = EqlPlugin.isEnabled(settings);
         this.licenseState = licenseState;
         this.client = client;
     }
-    
+
     @Override
     public String name() {
         return XPackField.EQL;
@@ -47,7 +47,7 @@ public class EqlFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState.isEqlAllowed();
+        return licenseState.isAllowed(XPackLicenseState.Feature.EQL);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlFeatureSetTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlFeatureSetTests.java
@@ -5,8 +5,10 @@
  */
 package org.elasticsearch.xpack.eql;
 
+import com.sun.tools.javac.util.Convert;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
@@ -53,7 +55,7 @@ public class EqlFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         EqlFeatureSet featureSet = new EqlFeatureSet(Settings.EMPTY, licenseState, client);
         boolean available = randomBoolean();
-        when(licenseState.isEqlAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.EQL)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 
@@ -96,11 +98,11 @@ public class EqlFeatureSetTests extends ESTestCase {
         PlainActionFuture<EqlFeatureSet.Usage> future = new PlainActionFuture<>();
         new EqlFeatureSet(Settings.builder().put("xpack.eql.enabled", true).build(), licenseState, client).usage(future);
         EqlFeatureSetUsage eqlUsage = (EqlFeatureSetUsage) future.get();
-        
+
         long fooBarBaz = ObjectPath.eval("foo.bar.baz", eqlUsage.stats());
         long fooFoo = ObjectPath.eval("foo.foo", eqlUsage.stats());
         long spam = ObjectPath.eval("spam", eqlUsage.stats());
-        
+
         assertThat(eqlUsage.stats().keySet(), containsInAnyOrder("foo", "spam"));
         assertThat(fooBarBaz, is(5L));
         assertThat(fooFoo, is(1L));

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlFeatureSetTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlFeatureSetTests.java
@@ -31,7 +31,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class EqlFeatureSetTests extends ESTestCase {
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlFeatureSetTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlFeatureSetTests.java
@@ -5,10 +5,8 @@
  */
 package org.elasticsearch.xpack.eql;
 
-import com.sun.tools.javac.util.Convert;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
@@ -33,9 +31,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class EqlFeatureSetTests extends ESTestCase {
 

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/GraphFeatureSet.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/GraphFeatureSet.java
@@ -35,7 +35,7 @@ public class GraphFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isGraphAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.GRAPH);
     }
 
     @Override

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
@@ -92,7 +92,7 @@ public class TransportGraphExploreAction extends HandledTransportAction<GraphExp
 
     @Override
     protected void doExecute(Task task, GraphExploreRequest request, ActionListener<GraphExploreResponse> listener) {
-        if (licenseState.isGraphAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.GRAPH)) {
             new AsyncGraphAction(request, listener).start();
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.GRAPH));

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphFeatureSetTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/GraphFeatureSetTests.java
@@ -30,7 +30,7 @@ public class GraphFeatureSetTests extends ESTestCase {
     public void testAvailable() throws Exception {
         GraphFeatureSet featureSet = new GraphFeatureSet(Settings.EMPTY, licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isGraphAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.GRAPH)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
         PlainActionFuture<XPackFeatureSet.Usage> future = new PlainActionFuture<>();
         featureSet.usage(future);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSet.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSet.java
@@ -47,7 +47,7 @@ public class IndexLifecycleFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isIndexLifecycleAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.ILM);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SLMFeatureSet.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SLMFeatureSet.java
@@ -41,7 +41,7 @@ public class SLMFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isIndexLifecycleAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.ILM);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class SLMFeatureSet implements XPackFeatureSet {
     @Override
     public void usage(ActionListener<Usage> listener) {
         final ClusterState state = clusterService.state();
-        boolean available = licenseState.isIndexLifecycleAllowed();
+        boolean available = licenseState.isAllowed(XPackLicenseState.Feature.ILM);
         final SnapshotLifecycleMetadata slmMeta = state.metadata().custom(SnapshotLifecycleMetadata.TYPE);
         final SLMFeatureSetUsage usage = new SLMFeatureSetUsage(available, enabled,
             slmMeta == null ? null : slmMeta.getStats());

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetTests.java
@@ -55,10 +55,10 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
 
-        when(licenseState.isIndexLifecycleAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ILM)).thenReturn(false);
         assertThat(featureSet.available(), equalTo(false));
 
-        when(licenseState.isIndexLifecycleAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ILM)).thenReturn(true);
         assertThat(featureSet.available(), equalTo(true));
 
         featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, null, clusterService);

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/LogstashFeatureSet.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/LogstashFeatureSet.java
@@ -35,7 +35,7 @@ public class LogstashFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isLogstashAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.LOGSTASH);
     }
 
     @Override

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/LogstashFeatureSetTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/LogstashFeatureSetTests.java
@@ -49,7 +49,7 @@ public class LogstashFeatureSetTests extends ESTestCase {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         LogstashFeatureSet featureSet = new LogstashFeatureSet(Settings.EMPTY, licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isLogstashAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.LOGSTASH)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
 
         PlainActionFuture<XPackFeatureSet.Usage> future = new PlainActionFuture<>();

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/FlattenedFeatureSet.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/FlattenedFeatureSet.java
@@ -40,7 +40,7 @@ public class FlattenedFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isFlattenedAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.FLATTENED);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/InvalidLicenseEnforcer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/InvalidLicenseEnforcer.java
@@ -48,7 +48,7 @@ public class InvalidLicenseEnforcer implements LicenseStateListener {
     @Override
     public void licenseStateChanged() {
         assert licenseStateListenerRegistered;
-        if (licenseState.isMachineLearningAllowed() == false) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             // if the license has expired, close jobs and datafeeds
             threadPool.generic().execute(new AbstractRunnable() {
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
@@ -134,7 +134,7 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isMachineLearningAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -69,7 +69,7 @@ public class TransportExplainDataFrameAnalyticsAction
     protected void doExecute(Task task,
                              PutDataFrameAnalyticsAction.Request request,
                              ActionListener<ExplainDataFrameAnalyticsAction.Response> listener) {
-        if (licenseState.isMachineLearningAllowed() == false) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -73,7 +73,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             listener::onFailure
         );
 
-        if (licenseState.isMachineLearningAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             responseBuilder.setLicensed(true);
             this.modelLoadingService.getModel(request.getModelId(), getModelListener);
         } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -213,7 +213,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
         }
 
         OpenJobAction.JobParams jobParams = request.getJobParams();
-        if (licenseState.isMachineLearningAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
 
             // Clear job finished time once the job is started and respond
             ActionListener<NodeAcknowledgedResponse> clearJobFinishTime = ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -231,7 +231,7 @@ public class TransportPutDataFrameAnalyticsAction
     @Override
     protected void doExecute(Task task, PutDataFrameAnalyticsAction.Request request,
                              ActionListener<PutDataFrameAnalyticsAction.Response> listener) {
-        if (licenseState.isMachineLearningAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
@@ -266,7 +266,7 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
 
     @Override
     protected void doExecute(Task task, PutDatafeedAction.Request request, ActionListener<PutDatafeedAction.Response> listener) {
-        if (licenseState.isMachineLearningAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
@@ -68,7 +68,7 @@ public class TransportPutJobAction extends TransportMasterNodeAction<PutJobActio
 
     @Override
     protected void doExecute(Task task, PutJobAction.Request request, ActionListener<PutJobAction.Response> listener) {
-        if (licenseState.isMachineLearningAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -220,7 +220,7 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
-        if (licenseState.isMachineLearningAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -156,7 +156,7 @@ public class TransportStartDataFrameAnalyticsAction
     @Override
     protected void masterOperation(StartDataFrameAnalyticsAction.Request request, ClusterState state,
                                    ActionListener<NodeAcknowledgedResponse> listener) {
-        if (licenseState.isMachineLearningAllowed() == false) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -155,7 +155,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     protected void masterOperation(StartDatafeedAction.Request request, ClusterState state,
                                    ActionListener<NodeAcknowledgedResponse> listener) {
         StartDatafeedAction.DatafeedParams params = request.getParams();
-        if (licenseState.isMachineLearningAllowed() == false) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/license/MachineLearningLicensingTests.java
@@ -781,7 +781,7 @@ public class MachineLearningLicensingTests extends BaseMlIntegTestCase {
 
     private static void assertMLAllowed(boolean expected) {
         for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-            assertEquals(licenseState.isMachineLearningAllowed(), expected);
+            assertEquals(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING), expected);
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -139,7 +139,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
         MachineLearningFeatureSet featureSet = new MachineLearningFeatureSet(TestEnvironment.newEnvironment(commonSettings), clusterService,
                 client, licenseState, jobManagerHolder);
         boolean available = randomBoolean();
-        when(licenseState.isMachineLearningAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
         PlainActionFuture<Usage> future = new PlainActionFuture<>();
         featureSet.usage(future);
@@ -176,7 +176,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
     }
 
     public void testUsage() throws Exception {
-        when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", true);
 
@@ -334,7 +334,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
     }
 
     public void testUsageDisabledML() throws Exception {
-        when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", false);
 
@@ -356,7 +356,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
     }
 
     public void testNodeCount() throws Exception {
-        when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         int nodeCount = randomIntBetween(1, 3);
         givenNodeCount(nodeCount);
         Settings.Builder settings = Settings.builder().put(commonSettings);
@@ -399,7 +399,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
     }
 
     public void testUsageGivenMlMetadataNotInstalled() throws Exception {
-        when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", true);
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -88,7 +88,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
         public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
             Map<String, Processor.Factory> factoryMap = new HashMap<>();
             XPackLicenseState licenseState = mock(XPackLicenseState.class);
-            when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+            when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
             factoryMap.put(InferenceProcessor.TYPE,
                 new InferenceProcessor.Factory(parameters.client,
                     parameters.ingestService.getClusterService(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -58,7 +58,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         @Override
         public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
             XPackLicenseState licenseState = mock(XPackLicenseState.class);
-            when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+            when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
             return Collections.singletonMap(InferenceProcessor.TYPE,
                 new InferenceProcessor.Factory(parameters.client,
                     parameters.ingestService.getClusterService(),
@@ -89,7 +89,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         ingestService = new IngestService(clusterService, tp, null, null,
             null, Collections.singletonList(SKINNY_PLUGIN), client);
         licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
     }
 
     public void testNumInferenceProcessors() throws Exception {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringFeatureSet.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringFeatureSet.java
@@ -45,7 +45,7 @@ public class MonitoringFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isMonitoringAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.MONITORING);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.AbstractLifecycleRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.monitoring.MonitoringField;
@@ -86,11 +87,11 @@ public class CleanerService extends AbstractLifecycleComponent {
      * This will ignore the global retention if the license does not allow retention updates.
      *
      * @return Never {@code null}
-     * @see XPackLicenseState#isUpdateRetentionAllowed()
+     * @see XPackLicenseState.Feature#MONITORING_UPDATE_RETENTION
      */
     public TimeValue getRetention() {
         // we only care about their value if they are allowed to set it
-        if (licenseState.isUpdateRetentionAllowed() && globalRetention != null) {
+        if (licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION) && globalRetention != null) {
             return globalRetention;
         }
         else {
@@ -108,7 +109,7 @@ public class CleanerService extends AbstractLifecycleComponent {
      */
     public void setGlobalRetention(TimeValue globalRetention) {
         // notify the user that their setting will be ignored until they get the right license
-        if (licenseState.isUpdateRetentionAllowed() == false) {
+        if (licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION) == false) {
             logger.warn("[{}] setting will be ignored until an appropriate license is applied", MonitoringField.HISTORY_DURATION.getKey());
         }
 
@@ -165,7 +166,7 @@ public class CleanerService extends AbstractLifecycleComponent {
 
         @Override
         protected void doRunInLifecycle() throws Exception {
-            if (licenseState.isMonitoringAllowed() == false) {
+            if (licenseState.isAllowed(Feature.MONITORING) == false) {
                 logger.debug("cleaning service is disabled due to invalid license");
                 return;
             }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/Collector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/Collector.java
@@ -73,7 +73,7 @@ public abstract class Collector {
      * @param isElectedMaster true if the current local node is the elected master node
      */
     protected boolean shouldCollect(final boolean isElectedMaster) {
-        if (licenseState.isMonitoringAllowed() == false) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.MONITORING) == false) {
             logger.trace("collector [{}] can not collect data due to invalid license", name());
             return false;
         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollector.java
@@ -65,7 +65,7 @@ public final class StatsCollector extends Collector {
         return isElectedMaster
                 && super.shouldCollect(isElectedMaster)
                 && XPackSettings.CCR_ENABLED_SETTING.get(settings)
-                && licenseState.isCcrAllowed();
+                && licenseState.isAllowed(XPackLicenseState.Feature.CCR);
     }
 
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollector.java
@@ -55,7 +55,7 @@ public final class EnrichStatsCollector extends Collector {
         return isElectedMaster
             && super.shouldCollect(isElectedMaster)
             && XPackSettings.ENRICH_ENABLED_SETTING.get(settings)
-            && licenseState.isEnrichAllowed();
+            && licenseState.isAllowed(XPackLicenseState.Feature.ENRICH);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollector.java
@@ -64,7 +64,7 @@ public class JobStatsCollector extends Collector {
         return isElectedMaster
                 && super.shouldCollect(isElectedMaster)
                 && XPackSettings.MACHINE_LEARNING_ENABLED.get(settings)
-                && licenseState.isMachineLearningAllowed();
+                && licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResource.java
@@ -82,7 +82,7 @@ public class ClusterAlertHttpResource extends PublishableHttpResource {
     @Override
     protected void doCheck(final RestClient client, final ActionListener<Boolean> listener) {
         // if we should be adding, then we need to check for existence
-        if (isWatchDefined() && licenseState.isMonitoringClusterAlertsAllowed()) {
+        if (isWatchDefined() && licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)) {
             final CheckedFunction<Response, Boolean, IOException> watchChecker =
                     (response) -> shouldReplaceClusterAlert(response, XContentType.JSON.xContent(), LAST_UPDATED_VERSION);
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 import org.elasticsearch.xpack.core.ssl.SSLConfiguration;
 import org.elasticsearch.xpack.core.ssl.SSLConfigurationSettings;
@@ -906,7 +907,7 @@ public class HttpExporter extends Exporter {
 
     @Override
     public void openBulk(final ActionListener<ExportBulk> listener) {
-        final boolean canUseClusterAlerts = config.licenseState().isMonitoringClusterAlertsAllowed();
+        final boolean canUseClusterAlerts = config.licenseState().isAllowed(Feature.MONITORING_CLUSTER_ALERTS);
 
         // if this changes between updates, then we need to add OR remove the watches
         if (clusterAlertsAllowed.compareAndSet(!canUseClusterAlerts, canUseClusterAlerts)) {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -433,7 +433,7 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
                                                           final AtomicInteger pendingResponses) {
         final XPackClient xpackClient = new XPackClient(client);
         final WatcherClient watcher = xpackClient.watcher();
-        final boolean canAddWatches = licenseState.isMonitoringClusterAlertsAllowed();
+        final boolean canAddWatches = licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS);
 
         for (final String watchId : ClusterAlertsUtil.WATCH_IDS) {
             final String uniqueWatchId = ClusterAlertsUtil.createUniqueWatchId(clusterService, watchId);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringFeatureSetTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringFeatureSetTests.java
@@ -46,7 +46,7 @@ public class MonitoringFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         MonitoringFeatureSet featureSet = new MonitoringFeatureSet(Settings.EMPTY, monitoring, licenseState, exporters);
         boolean available = randomBoolean();
-        when(licenseState.isMonitoringAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -65,32 +66,32 @@ public class CleanerServiceTests extends ESTestCase {
         TimeValue expected = TimeValue.timeValueHours(25);
         Settings settings = Settings.builder().put(MonitoringField.HISTORY_DURATION.getKey(), expected.getStringRep()).build();
 
-        when(licenseState.isUpdateRetentionAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
 
         assertEquals(expected, new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
 
-        verify(licenseState).isUpdateRetentionAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testGetRetentionDefaultValueWithNoSettings() {
-        when(licenseState.isUpdateRetentionAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
 
         assertEquals(MonitoringField.HISTORY_DURATION.get(Settings.EMPTY),
                      new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState).getRetention());
 
-        verify(licenseState).isUpdateRetentionAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testGetRetentionDefaultValueWithSettingsButUpdatesNotAllowed() {
         TimeValue notExpected = TimeValue.timeValueHours(25);
         Settings settings = Settings.builder().put(MonitoringField.HISTORY_DURATION.getKey(), notExpected.getStringRep()).build();
 
-        when(licenseState.isUpdateRetentionAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false);
 
         assertEquals(MonitoringField.HISTORY_DURATION.get(Settings.EMPTY),
                      new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
 
-        verify(licenseState).isUpdateRetentionAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testSetGlobalRetention() {
@@ -98,7 +99,7 @@ public class CleanerServiceTests extends ESTestCase {
         // only thing calling this method and it will use the settings object to validate the time value
         TimeValue expected = TimeValue.timeValueHours(2);
 
-        when(licenseState.isUpdateRetentionAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
 
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState);
 
@@ -106,7 +107,7 @@ public class CleanerServiceTests extends ESTestCase {
 
         assertEquals(expected, service.getRetention());
 
-        verify(licenseState, times(2)).isUpdateRetentionAllowed(); // once by set, once by get
+        verify(licenseState, times(2)).isAllowed(Feature.MONITORING_UPDATE_RETENTION); // once by set, once by get
     }
 
     public void testSetGlobalRetentionAppliesEvenIfLicenseDisallows() {
@@ -115,7 +116,7 @@ public class CleanerServiceTests extends ESTestCase {
         TimeValue expected = TimeValue.timeValueHours(2);
 
         // required to be true on the second call for it to see it take effect
-        when(licenseState.isUpdateRetentionAllowed()).thenReturn(false).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false).thenReturn(true);
 
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState);
 
@@ -125,7 +126,7 @@ public class CleanerServiceTests extends ESTestCase {
         // uses allow=true
         assertEquals(expected, service.getRetention());
 
-        verify(licenseState, times(2)).isUpdateRetentionAllowed();
+        verify(licenseState, times(2)).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testNextExecutionDelay() {
@@ -157,7 +158,7 @@ public class CleanerServiceTests extends ESTestCase {
 
         logger.debug("--> creates a cleaner service that cleans every second");
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, licenseState, threadPool,
                 new TestExecutionScheduler(1_000));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.BaseCollectorTestCase;
@@ -50,7 +51,7 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -58,23 +59,23 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         final IndexRecoveryCollector collector = new IndexRecoveryCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(false), is(false));
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         final IndexRecoveryCollector collector = new IndexRecoveryCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(true), is(true));
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.BaseCollectorTestCase;
@@ -45,7 +46,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -53,23 +54,23 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         final IndexStatsCollector collector = new IndexStatsCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(false), is(false));
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         final IndexStatsCollector collector = new IndexStatsCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(true), is(true));
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
@@ -10,6 +10,8 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction.Request;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction.Response;
@@ -47,14 +49,14 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         whenLocalNodeElectedMaster(isElectedMaster);
 
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
-        when(licenseState.isMachineLearningAllowed()).thenReturn(mlAllowed);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(mlAllowed);
 
         final JobStatsCollector collector = new JobStatsCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
@@ -62,8 +64,8 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         // regardless of ML being enabled
         final Settings settings = randomFrom(mlEnabledSettings(), mlDisabledSettings());
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
-        when(licenseState.isMachineLearningAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -76,8 +78,8 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         // this is controls the blockage
         final Settings settings = mlDisabledSettings();
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
-        when(licenseState.isMachineLearningAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(randomBoolean());
 
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
@@ -87,16 +89,16 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfMLIsNotAllowed() {
         final Settings settings = randomFrom(mlEnabledSettings(), mlDisabledSettings());
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(randomBoolean());
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(randomBoolean());
         // this is controls the blockage
-        when(licenseState.isMachineLearningAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -105,22 +107,22 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
         final Settings settings = mlEnabledSettings();
 
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
-        when(licenseState.isMachineLearningAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final JobStatsCollector collector = new JobStatsCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
 
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.BaseCollectorTestCase;
@@ -38,7 +39,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -46,22 +47,22 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final NodeStatsCollector collector = new NodeStatsCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING);
     }
 
     public void testDoCollectWithFailures() throws Exception {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
 
         final TimeValue timeout = TimeValue.parseTimeValue(randomPositiveTimeValue(), NodeStatsCollectorTests.class.getName());
         withCollectionTimeout(NodeStatsCollector.NODE_STATS_TIMEOUT, timeout);
@@ -84,7 +85,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
     }
 
     public void testDoCollect() throws Exception {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
 
         final TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(1, 120));
         withCollectionTimeout(NodeStatsCollector.NODE_STATS_TIMEOUT, timeout);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.BaseCollectorTestCase;
@@ -43,7 +44,7 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isMonitoringAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -51,12 +52,12 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isMonitoringAllowed();
+            verify(licenseState).isAllowed(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         // this controls the blockage
         whenLocalNodeElectedMaster(false);
 
@@ -66,13 +67,13 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isMonitoringAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
         whenLocalNodeElectedMaster(true);
 
         final ShardsCollector collector = new ShardsCollector(clusterService, licenseState);
 
         assertThat(collector.shouldCollect(true), is(true));
-        verify(licenseState).isMonitoringAllowed();
+        verify(licenseState).isAllowed(Feature.MONITORING);
     }
 
     public void testDoCollectWhenNoClusterState() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
@@ -60,7 +60,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoCheckGetWatchExists() throws IOException {
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
 
         final HttpEntity entity = entityForClusterAlert(true, minimumVersion);
 
@@ -68,7 +68,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoCheckGetWatchDoesNotExist() throws IOException {
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
 
         if (randomBoolean()) {
             // it does not exist because it's literally not there
@@ -82,7 +82,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoCheckWithExceptionGetWatchError() throws IOException {
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
 
         if (randomBoolean()) {
             // error because of a server error
@@ -100,7 +100,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
         final boolean clusterAlertsAllowed = randomBoolean();
 
         // should not matter
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(clusterAlertsAllowed);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(clusterAlertsAllowed);
 
         assertCheckAsDeleteExists(noWatchResource, "/_watcher/watch", watchId);
     }
@@ -110,19 +110,19 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
         final boolean clusterAlertsAllowed = randomBoolean();
 
         // should not matter
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(clusterAlertsAllowed);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(clusterAlertsAllowed);
 
         assertCheckAsDeleteWithException(noWatchResource, "/_watcher/watch", watchId);
     }
 
     public void testDoCheckAsDeleteWatchExists() throws IOException {
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(false);
 
         assertCheckAsDeleteExists(resource, "/_watcher/watch", watchId);
     }
 
     public void testDoCheckWithExceptionAsDeleteWatchError() throws IOException {
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(false);
 
         assertCheckAsDeleteWithException(resource, "/_watcher/watch", watchId);
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
@@ -735,7 +735,7 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
         when(state.metadata()).thenReturn(metadata);
         when(metadata.clusterUUID()).thenReturn("the_clusters_uuid");
 
-        when(licenseState.isMonitoringClusterAlertsAllowed()).thenReturn(validLicense);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(validLicense);
 
         final HttpEntity entity =
                 new StringEntity("{\"features\":{\"watcher\":{\"enabled\":true,\"available\":true}}}", ContentType.APPLICATION_JSON);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupFeatureSet.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupFeatureSet.java
@@ -35,7 +35,7 @@ public class RollupFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isRollupAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.ROLLUP);
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -96,7 +96,7 @@ public class TransportPutRollupJobAction extends TransportMasterNodeAction<PutRo
     protected void masterOperation(PutRollupJobAction.Request request, ClusterState clusterState,
                                    ActionListener<AcknowledgedResponse> listener) {
 
-        if (!licenseState.isRollupAllowed()) {
+        if (!licenseState.isAllowed(XPackLicenseState.Feature.ROLLUP)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.ROLLUP));
             return;
         }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
@@ -47,7 +47,7 @@ public class TransportStartRollupAction extends TransportTasksAction<RollupJobTa
     @Override
     protected void doExecute(Task task, StartRollupJobAction.Request request, ActionListener<StartRollupJobAction.Response> listener) {
 
-        if (!licenseState.isRollupAllowed()) {
+        if (!licenseState.isAllowed(XPackLicenseState.Feature.ROLLUP)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.ROLLUP));
             return;
         }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupFeatureSetTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupFeatureSetTests.java
@@ -35,7 +35,7 @@ public class RollupFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         RollupFeatureSet featureSet = new RollupFeatureSet(Settings.EMPTY, licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isRollupAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.ROLLUP)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatureSet.java
@@ -71,7 +71,7 @@ public class SecurityFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isSecurityAvailable();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.SECURITY);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.XPackField;
@@ -72,7 +73,7 @@ public class SecurityActionFilter implements ActionFilter {
          A functional requirement - when the license of security is disabled (invalid/expires), security will continue
          to operate normally, except all read operations will be blocked.
          */
-        if (licenseState.isStatsAndHealthAllowed() == false && LICENSE_EXPIRATION_ACTION_MATCHER.test(action)) {
+        if (licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH) == false && LICENSE_EXPIRATION_ACTION_MATCHER.test(action)) {
             logger.error("blocking [{}] operation due to expired license. Cluster health, cluster stats and indices stats \n" +
                     "operations are blocked on license expiration. All data operations (read and write) continue to work. \n" +
                     "If you have a new license, please update it. Otherwise, please reach out to your support contact.", action);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandler.java
@@ -68,7 +68,7 @@ public abstract class SecurityBaseRestHandler extends BaseRestHandler {
     protected Exception checkFeatureAvailable(RestRequest request) {
         if (XPackSettings.SECURITY_ENABLED.get(settings) == false) {
             return new IllegalStateException("Security is not enabled but a security rest handler is registered");
-        } else if (licenseState.isSecurityAvailable() == false) {
+        } else if (licenseState.isAllowed(XPackLicenseState.Feature.SECURITY) == false) {
             return LicenseUtils.newComplianceException(XPackField.SECURITY);
         } else if (licenseState.isSecurityEnabled() == false) {
             return new ElasticsearchException("Security must be explicitly enabled when using a [" +

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListener.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListener.java
@@ -35,7 +35,7 @@ public class SecurityStatusChangeListener implements LicenseStateListener {
      */
     @Override
     public synchronized void licenseStateChanged() {
-        final boolean newState = licenseState.isSecurityAvailable() && licenseState.isSecurityEnabled();
+        final boolean newState = licenseState.isAllowed(XPackLicenseState.Feature.SECURITY) && licenseState.isSecurityEnabled();
         // old state might be null (undefined) so do Object comparison
         if (Objects.equals(newState, securityEnabled) == false) {
             logger.info("Active license is now [{}]; Security is {}", licenseState.getOperationMode(), newState ? "enabled" : "disabled");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityFeatureSetTests.java
@@ -69,10 +69,10 @@ public class SecurityFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         SecurityFeatureSet featureSet = new SecurityFeatureSet(settings, licenseState, realms,
                 rolesStore, roleMappingStore, ipFilter);
-        when(licenseState.isSecurityAvailable()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         assertThat(featureSet.available(), is(true));
 
-        when(licenseState.isSecurityAvailable()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
         assertThat(featureSet.available(), is(false));
     }
 
@@ -92,7 +92,7 @@ public class SecurityFeatureSetTests extends ESTestCase {
         final boolean authcAuthzAvailable = randomBoolean();
         final boolean explicitlyDisabled = randomBoolean();
         final boolean enabled = explicitlyDisabled == false && randomBoolean();
-        when(licenseState.isSecurityAvailable()).thenReturn(authcAuthzAvailable);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(authcAuthzAvailable);
         when(licenseState.isSecurityEnabled()).thenReturn(enabled);
 
         Settings.Builder settings = Settings.builder().put(this.settings);
@@ -260,7 +260,7 @@ public class SecurityFeatureSetTests extends ESTestCase {
     }
 
     public void testUsageOnTrialLicenseWithSecurityDisabledByDefault() throws Exception {
-        when(licenseState.isSecurityAvailable()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(licenseState.isSecurityEnabled()).thenReturn(false);
 
         Settings.Builder settings = Settings.builder().put(this.settings);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -66,7 +67,7 @@ public class SecurityActionFilterTests extends ESTestCase {
         authzService = mock(AuthorizationService.class);
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isStatsAndHealthAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH)).thenReturn(true);
         ThreadPool threadPool = mock(ThreadPool.class);
         threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
@@ -30,7 +30,7 @@ public class SecurityBaseRestHandlerTests extends ESTestCase {
         final boolean securityDefaultEnabled = randomBoolean();
         final AtomicBoolean consumerCalled = new AtomicBoolean(false);
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isSecurityAvailable()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(licenseState.isSecurityEnabled()).thenReturn(securityDefaultEnabled);
         when(licenseState.getOperationMode()).thenReturn(
             randomFrom(License.OperationMode.BASIC, License.OperationMode.STANDARD, License.OperationMode.GOLD));
@@ -63,7 +63,7 @@ public class SecurityBaseRestHandlerTests extends ESTestCase {
         verifyZeroInteractions(licenseState);
         handler.handleRequest(fakeRestRequest, fakeRestChannel, client);
 
-        verify(licenseState).isSecurityAvailable();
+        verify(licenseState).isAllowed(XPackLicenseState.Feature.SECURITY);
         if (securityDefaultEnabled) {
             assertTrue(consumerCalled.get());
             assertEquals(0, fakeRestChannel.responses().get());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateApiKeyActionTests.java
@@ -54,7 +54,7 @@ public class RestCreateApiKeyActionTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
         threadPool = new ThreadPool(settings);
-        when(mockLicenseState.isSecurityAvailable()).thenReturn(true);
+        when(mockLicenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(mockLicenseState.isSecurityEnabled()).thenReturn(true);
         when(mockLicenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
@@ -54,7 +54,7 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         settings = Settings.builder().put("path.home", createTempDir().toString()).put("node.name", "test-" + getTestName())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
         threadPool = new ThreadPool(settings);
-        when(mockLicenseState.isSecurityAvailable()).thenReturn(true);
+        when(mockLicenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(mockLicenseState.isSecurityEnabled()).thenReturn(true);
         when(mockLicenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
@@ -54,7 +54,7 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
         threadPool = new ThreadPool(settings);
-        when(mockLicenseState.isSecurityAvailable()).thenReturn(true);
+        when(mockLicenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(mockLicenseState.isSecurityEnabled()).thenReturn(true);
         when(mockLicenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesActionTests.java
@@ -42,7 +42,7 @@ public class RestGetUserPrivilegesActionTests extends ESTestCase {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         final RestGetUserPrivilegesAction action =
             new RestGetUserPrivilegesAction(Settings.EMPTY, mock(SecurityContext.class), licenseState);
-        when(licenseState.isSecurityAvailable()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
         final FakeRestRequest request = new FakeRestRequest();
         final FakeRestChannel channel = new FakeRestChannel(request, true, 1);
         action.handleRequest(request, channel, mock(NodeClient.class));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesActionTests.java
@@ -53,7 +53,7 @@ public class RestHasPrivilegesActionTests extends ESTestCase {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         final RestHasPrivilegesAction action =
             new RestHasPrivilegesAction(Settings.EMPTY, mock(SecurityContext.class), licenseState);
-        when(licenseState.isSecurityAvailable()).thenReturn(false);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
         try (XContentBuilder bodyBuilder = JsonXContent.contentBuilder().startObject().endObject()) {
             final RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
                 .withPath("/_security/user/_has_privileges/")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
@@ -30,7 +30,7 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
     @Before
     public void setup() throws IllegalAccessException {
         licenseState = Mockito.mock(XPackLicenseState.class);
-        when(licenseState.isSecurityAvailable()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
 
         listener = new SecurityStatusChangeListener(licenseState);
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialFeatureSet.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialFeatureSet.java
@@ -31,7 +31,7 @@ public class SpatialFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isSpatialAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.SPATIAL);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialFeatureSetTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/SpatialFeatureSetTests.java
@@ -29,7 +29,7 @@ public class SpatialFeatureSetTests extends ESTestCase {
     public void testAvailable() throws Exception {
         SpatialFeatureSet featureSet = new SpatialFeatureSet(Settings.EMPTY, licenseState);
         boolean available = randomBoolean();
-        when(licenseState.isSpatialAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SPATIAL)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
         PlainActionFuture<XPackFeatureSet.Usage> future = new PlainActionFuture<>();
         featureSet.usage(future);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/SqlFeatureSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/SqlFeatureSet.java
@@ -32,14 +32,14 @@ public class SqlFeatureSet implements XPackFeatureSet {
     private final boolean enabled;
     private final XPackLicenseState licenseState;
     private final Client client;
-    
+
     @Inject
     public SqlFeatureSet(Settings settings, @Nullable XPackLicenseState licenseState, Client client) {
         this.enabled = XPackSettings.SQL_ENABLED.get(settings);
         this.licenseState = licenseState;
         this.client = client;
     }
-    
+
     @Override
     public String name() {
         return XPackField.SQL;
@@ -47,7 +47,7 @@ public class SqlFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isSqlAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.SQL);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
@@ -57,18 +57,18 @@ public class SqlPlugin extends Plugin implements ActionPlugin {
             XPackLicenseState licenseState = getLicenseState();
             switch (mode) {
                 case JDBC:
-                    if (licenseState.isJdbcAllowed() == false) {
+                    if (licenseState.isAllowed(XPackLicenseState.Feature.JDBC) == false) {
                         throw LicenseUtils.newComplianceException("jdbc");
                     }
                     break;
                 case ODBC:
-                    if (licenseState.isOdbcAllowed() == false) {
+                    if (licenseState.isAllowed(XPackLicenseState.Feature.ODBC) == false) {
                         throw LicenseUtils.newComplianceException("odbc");
                     }
                     break;
                 case PLAIN:
                 case CLI:
-                    if (licenseState.isSqlAllowed() == false) {
+                    if (licenseState.isAllowed(XPackLicenseState.Feature.SQL) == false) {
                         throw LicenseUtils.newComplianceException(XPackField.SQL);
                     }
                     break;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlFeatureSetTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlFeatureSetTests.java
@@ -55,7 +55,7 @@ public class SqlFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         SqlFeatureSet featureSet = new SqlFeatureSet(Settings.EMPTY, licenseState, client);
         boolean available = randomBoolean();
-        when(licenseState.isSqlAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.SQL)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformFeatureSet.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/TransformFeatureSet.java
@@ -89,7 +89,7 @@ public class TransformFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isTransformAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM);
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -132,7 +132,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, PreviewTransformAction.Request request, ActionListener<PreviewTransformAction.Response> listener) {
-        if (!licenseState.isTransformAllowed()) {
+        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -203,7 +203,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
     protected void masterOperation(Request request, ClusterState clusterState, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
 
-        if (!licenseState.isTransformAllowed()) {
+        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -161,7 +161,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
         ClusterState state,
         ActionListener<StartTransformAction.Response> listener
     ) throws Exception {
-        if (!licenseState.isTransformAllowed()) {
+        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -146,7 +146,7 @@ public class TransportUpdateTransformAction extends TransportMasterNodeAction<Re
     @Override
     protected void masterOperation(Request request, ClusterState clusterState, ActionListener<Response> listener) {
 
-        if (!licenseState.isTransformAllowed()) {
+        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformFeatureSetTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformFeatureSetTests.java
@@ -57,7 +57,7 @@ public class TransformFeatureSetTests extends ESTestCase {
             licenseState
         );
         boolean available = randomBoolean();
-        when(licenseState.isTransformAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 
@@ -169,7 +169,7 @@ public class TransformFeatureSetTests extends ESTestCase {
     }
 
     public void testUsageDisabled() throws IOException, InterruptedException, ExecutionException {
-        when(licenseState.isTransformAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)).thenReturn(true);
         Settings.Builder settings = Settings.builder();
         settings.put("xpack.transform.enabled", false);
         TransformFeatureSet featureSet = new TransformFeatureSet(

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/VectorsFeatureSet.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/VectorsFeatureSet.java
@@ -41,7 +41,7 @@ public class VectorsFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isVectorsAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.VECTORS);
     }
 
     @Override

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/VectorsFeatureSetTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/VectorsFeatureSetTests.java
@@ -40,7 +40,7 @@ public class VectorsFeatureSetTests extends ESTestCase {
     public void testAvailable() throws Exception {
         VectorsFeatureSet featureSet = new VectorsFeatureSet(Settings.EMPTY, licenseState, clusterService);
         boolean available = randomBoolean();
-        when(licenseState.isVectorsAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.VECTORS)).thenReturn(available);
         assertEquals(available, featureSet.available());
 
         PlainActionFuture<XPackFeatureSet.Usage> future = new PlainActionFuture<>();
@@ -100,7 +100,7 @@ public class VectorsFeatureSetTests extends ESTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName("_testcluster")).metadata(metadata).build();
 
         Mockito.when(clusterService.state()).thenReturn(clusterState);
-        when(licenseState.isVectorsAllowed()).thenReturn(true);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.VECTORS)).thenReturn(true);
 
         PlainActionFuture<XPackFeatureSet.Usage> future = new PlainActionFuture<>();
         VectorsFeatureSet vectorsFeatureSet = new VectorsFeatureSet(Settings.EMPTY, licenseState, clusterService);

--- a/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeFeatureSet.java
+++ b/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeFeatureSet.java
@@ -9,6 +9,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.XPackLicenseState.Feature;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.votingonly.VotingOnlyNodeFeatureSetUsage;
@@ -31,7 +32,7 @@ public class VotingOnlyNodeFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isVotingOnlyAllowed();
+        return licenseState != null && licenseState.isAllowed(Feature.VOTING_ONLY);
     }
 
     @Override
@@ -46,6 +47,6 @@ public class VotingOnlyNodeFeatureSet implements XPackFeatureSet {
 
     @Override
     public void usage(ActionListener<XPackFeatureSet.Usage> listener) {
-        listener.onResponse(new VotingOnlyNodeFeatureSetUsage(licenseState.isVotingOnlyAllowed()));
+        listener.onResponse(new VotingOnlyNodeFeatureSetUsage(licenseState.isAllowed(Feature.VOTING_ONLY)));
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherFeatureSet.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherFeatureSet.java
@@ -49,7 +49,7 @@ public class WatcherFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean available() {
-        return licenseState != null && licenseState.isWatcherAllowed();
+        return licenseState != null && licenseState.isAllowed(XPackLicenseState.Feature.WATCHER);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/WatcherTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/WatcherTransportAction.java
@@ -35,7 +35,7 @@ public abstract class WatcherTransportAction<Request extends ActionRequest, Resp
 
     @Override
     protected final void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        if (licenseState.isWatcherAllowed()) {
+        if (licenseState.isAllowed(XPackLicenseState.Feature.WATCHER)) {
             doExecute(request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.WATCHER));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherFeatureSetTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherFeatureSetTests.java
@@ -62,7 +62,7 @@ public class WatcherFeatureSetTests extends ESTestCase {
     public void testAvailable() {
         WatcherFeatureSet featureSet = new WatcherFeatureSet(Settings.EMPTY, licenseState, client);
         boolean available = randomBoolean();
-        when(licenseState.isWatcherAllowed()).thenReturn(available);
+        when(licenseState.isAllowed(XPackLicenseState.Feature.WATCHER)).thenReturn(available);
         assertThat(featureSet.available(), is(available));
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -534,7 +534,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
     protected void ensureLicenseEnabled() throws Exception {
         assertBusy(() -> {
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                assertThat(licenseState.isWatcherAllowed(), is(true));
+                assertThat(licenseState.isAllowed(XPackLicenseState.Feature.WATCHER), is(true));
             }
         });
     }


### PR DESCRIPTION
This commit converts the remaining isXXXAllowed methods to instead of
use isAllowed with a Feature value. There are a couple other methods
that are static, as well as some licensed features that check the
license directly, but those will be dealt with in other followups.