### PR TITLE
Add gradle task to build platform specific distro

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,17 +22,14 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.BuildPlugin
-import org.elasticsearch.gradle.BwcVersions
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
-import org.elasticsearch.gradle.OS
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion
-
 import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
 
 plugins {
@@ -48,6 +45,7 @@ apply from: 'gradle/runtime-jdk-provision.gradle'
 apply from: 'gradle/ide.gradle'
 apply from: 'gradle/forbidden-dependencies.gradle'
 apply from: 'gradle/formatting.gradle'
+apply from: 'gradle/local-distribution.gradle'
 
 // common maven publishing configuration
 allprojects {
@@ -506,14 +504,6 @@ allprojects {
       checkPart1.configure { dependsOn 'check' }
     }
   }
-}
-
-tasks.register('assemblePlatformArchive') {
-  def osDependetProjectName = OS.conditionalString().onWindows({"windows-zip"})
-                                                    .onLinux({"linux-tar"})
-                                                    .onMac({"darwin-tar"})
-                                                    .supply()
-  dependsOn ":distribution:archives:${osDependetProjectName}:assemble"
 }
 
 // TODO: remove this once 7.7 is released and the 7.x branch is 7.8

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
+import org.elasticsearch.gradle.OS
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.gradle.util.DistributionLocator
@@ -505,6 +506,14 @@ allprojects {
       checkPart1.configure { dependsOn 'check' }
     }
   }
+}
+
+tasks.register('assemblePlatformArchive') {
+  def osDependetProjectName = OS.conditionalString().onWindows({"windows-zip"})
+                                                    .onLinux({"linux-tar"})
+                                                    .onMac({"darwin-tar"})
+                                                    .supply()
+  dependsOn ":distribution:archives:${osDependetProjectName}:assemble"
 }
 
 // TODO: remove this once 7.7 is released and the 7.x branch is 7.8

--- a/gradle/local-distribution.gradle
+++ b/gradle/local-distribution.gradle
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This script sets up a local distribution including.
+ * To install a local distribution run `installLocalDistribution`.
+ * The local distribution will be installed to
+ * build/distributions/local
+ * */
+import org.elasticsearch.gradle.Architecture
+
+apply plugin:'elasticsearch.distribution-download'
+
+elasticsearch_distributions {
+  local {
+    flavor = 'default'
+    type = 'archive'
+    architecture = Architecture.current()
+  }
+}
+
+tasks.register('installLocalDistribution', Copy) {
+  from(elasticsearch_distributions.local.extracted)
+  into("build/distribution/local")
+}

--- a/gradle/local-distribution.gradle
+++ b/gradle/local-distribution.gradle
@@ -18,8 +18,8 @@
  */
 
 /**
- * This script sets up a local distribution including.
- * To install a local distribution run `installLocalDistribution`.
+ * This script sets up a local distribution.
+ * To install a local distribution run `localDistro`.
  * The local distribution will be installed to
  * build/distributions/local
  * */

--- a/gradle/local-distribution.gradle
+++ b/gradle/local-distribution.gradle
@@ -35,7 +35,10 @@ elasticsearch_distributions {
   }
 }
 
-tasks.register('installLocalDistribution', Copy) {
+tasks.register('localDistro', Sync) {
   from(elasticsearch_distributions.local.extracted)
   into("build/distribution/local")
+  doLast {
+    logger.quiet("Elasticsearch distribution installed to ${destinationDir}.")
+  }
 }

--- a/gradle/local-distribution.gradle
+++ b/gradle/local-distribution.gradle
@@ -39,6 +39,6 @@ tasks.register('localDistro', Sync) {
   from(elasticsearch_distributions.local.extracted)
   into("build/distribution/local")
   doLast {
-    logger.quiet("Elasticsearch distribution installed to ${destinationDir}.")
+    logger.lifecycle("Elasticsearch distribution installed to ${destinationDir}.")
   }
 }


### PR DESCRIPTION
This adds the gradle task ':installLocalDistribution' that installs a distribution locally matching the local architecture.
 
Closes #53682

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
