### PR TITLE
[7.x] Update template v2 api rest spec (#55948)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -23,13 +23,14 @@
       ]
     },
     "params":{
-      "order":{
-        "type":"number",
-        "description":"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"
-      },
       "create":{
         "type":"boolean",
         "description":"Whether the index template should only be added if new or can also replace an existing one",
+        "default":false
+      },
+      "cause":{
+        "type":"string",
+        "description":"User defined reason for creating/updating the index template",
         "default":false
       },
       "master_timeout":{


### PR DESCRIPTION
This removed the specification of `order` as it is not a parameter of the
v2 put template api (the priority is the equivalent of `order` and is
defined in the body) and add a bit of description for the `cause` parameter
(which is currently used as a cluster update task tracking)

(cherry picked from commit e3e9782b2059e28bc4a08be2232c1e5baecad3d6)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #55948 