### PR TITLE
Improve same-shard allocation explanations

### DIFF
--- a/docs/reference/cluster/allocation-explain.asciidoc
+++ b/docs/reference/cluster/allocation-explain.asciidoc
@@ -239,7 +239,7 @@ allocation:
         {
           "decider" : "same_shard",
           "decision" : "NO",
-          "explanation" : "the shard cannot be allocated to the same node on which a copy of the shard already exists [[my_index][0], node[3sULLVJrRneSg0EfBB-2Ew], [P], s[STARTED], a[id=eV9P8BN1QPqRc3B4PLx6cg]]"
+          "explanation" : "a copy of this shard is already allocated to this node [[my_index][0], node[3sULLVJrRneSg0EfBB-2Ew], [P], s[STARTED], a[id=eV9P8BN1QPqRc3B4PLx6cg]]"
         }
       ]
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -97,16 +97,15 @@ public class SameShardAllocationDecider extends AllocationDecider {
                             String hostType = checkNodeOnSameHostAddress ? "address" : "name";
                             String host = checkNodeOnSameHostAddress ? node.node().getHostAddress() : node.node().getHostName();
                             return allocation.decision(Decision.NO, NAME,
-                                "the shard cannot be allocated on host %s [%s], where it already exists on node [%s]; " +
-                                    "set cluster setting [%s] to false to allow multiple nodes on the same host to hold the same " +
-                                    "shard copies",
+                                "a copy of this shard is already allocated to host %s [%s], on node [%s], and [%s] is [true] which " +
+                                    "forbids more than one node on this host from holding a copy of this shard",
                                 hostType, host, node.nodeId(), CLUSTER_ROUTING_ALLOCATION_SAME_HOST_SETTING.getKey());
                         }
                     }
                 }
             }
         }
-        return allocation.decision(Decision.YES, NAME, "the shard does not exist on the same host");
+        return allocation.decision(Decision.YES, NAME, "none of the nodes on this host hold a copy of this shard");
     }
 
     @Override
@@ -122,15 +121,15 @@ public class SameShardAllocationDecider extends AllocationDecider {
             if (node.nodeId().equals(assignedShard.currentNodeId())) {
                 if (assignedShard.isSameAllocation(shardRouting)) {
                     return allocation.decision(Decision.NO, NAME,
-                        "the shard cannot be allocated to the node on which it already exists [%s]",
+                        "this shard is already allocated to this node [%s]",
                         shardRouting.toString());
                 } else {
                     return allocation.decision(Decision.NO, NAME,
-                        "the shard cannot be allocated to the same node on which a copy of the shard already exists [%s]",
+                        "a copy of this shard is already allocated to this node [%s]",
                         assignedShard.toString());
                 }
             }
         }
-        return allocation.decision(Decision.YES, NAME, "the shard does not exist on the same node");
+        return allocation.decision(Decision.YES, NAME, "this node does not hold a copy of this shard");
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -232,8 +232,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             for (Decision d : result.getCanAllocateDecision().getDecisions()) {
                 if (d.label().equals("same_shard") && nodeHoldingPrimary) {
                     assertEquals(Decision.Type.NO, d.type());
-                    assertThat(d.getExplanation(), startsWith(
-                        "the shard cannot be allocated to the same node on which a copy of the shard already exists"));
+                    assertThat(d.getExplanation(), startsWith("a copy of this shard is already allocated to this node ["));
                 } else {
                     assertEquals(Decision.Type.YES, d.type());
                     assertNotNull(d.getExplanation());
@@ -351,8 +350,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             for (Decision d : result.getCanAllocateDecision().getDecisions()) {
                 if (d.label().equals("same_shard") && nodeHoldingPrimary) {
                     assertEquals(Decision.Type.NO, d.type());
-                    assertThat(d.getExplanation(), startsWith(
-                        "the shard cannot be allocated to the same node on which a copy of the shard already exists"));
+                    assertThat(d.getExplanation(), startsWith("a copy of this shard is already allocated to this node ["));
                 } else if (d.label().equals("filter") && nodeHoldingPrimary == false) {
                     assertEquals(Decision.Type.NO, d.type());
                     assertEquals("node does not match index setting [index.routing.allocation.include] " +


### PR DESCRIPTION
I see occasional confusion about the explanations emitted by the same-shard
allocation decider, particularly amongst new users setting up a single-node
cluster and trying to determine why their cluster has `yellow` health. For
example:

    the shard cannot be allocated to the same node on which a copy of the shard
    already exists

This is technically correct but it's quite a complicated sentence. Also, by
starting with "the shard cannot be allocated" it makes it sound like this is
the problem, whereas in fact this message is a good thing and users should
typically focus their attention elsewhere.

This commit simplifies the wording of these messages and makes them sound more
positive, for example:

    a copy of this shard is already allocated to this node