### PR TITLE
Conditionally run tests asserting overlapping templates

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -3,11 +3,9 @@
   - skip:
       version: " - 7.99.99"
       reason: "simulate index template API has not been backported"
-      features: allowed_warnings
+      features: ["default_shards"]
 
   - do:
-      allowed_warnings:
-        - "index template [test] has index patterns [te*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
@@ -35,11 +33,9 @@
   - skip:
       version: " - 7.99.99"
       reason: "simulate index template API has not been backported"
-      features: allowed_warnings
+      features: ["default_shards"]
 
   - do:
-      allowed_warnings:
-        - "index template [test] has index patterns [te*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: existing_test
         body:
@@ -122,7 +118,7 @@
   - skip:
       version: " - 7.99.99"
       reason: "simulate index template API has not been backported"
-      features: allowed_warnings
+      features: ["allowed_warnings", "default_shards"]
 
   - do:
       indices.put_template:


### PR DESCRIPTION
Only run the tests verifying the overlapping index templates when there is
no `global` index template (ie. when the default shards are not changed)

Fixes #56017 