### PR TITLE
[7.x] [ML] fixing file structure finder multiline merge max for delimited formats (#56023)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/DelimitedFileStructureFinderFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/filestructurefinder/DelimitedFileStructureFinderFactory.java
@@ -71,7 +71,8 @@ public class DelimitedFileStructureFinderFactory implements FileStructureFinderF
     public FileStructureFinder createFromSample(List<String> explanation, String sample, String charsetName, Boolean hasByteOrderMarker,
                                                 int lineMergeSizeLimit, FileStructureOverrides overrides, TimeoutChecker timeoutChecker)
         throws IOException {
+        CsvPreference adjustedCsvPreference = new CsvPreference.Builder(csvPreference).maxLinesPerRow(lineMergeSizeLimit).build();
         return DelimitedFileStructureFinder.makeDelimitedFileStructureFinder(explanation, sample, charsetName, hasByteOrderMarker,
-            csvPreference, trimFields, overrides, timeoutChecker);
+            adjustedCsvPreference, trimFields, overrides, timeoutChecker);
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] fixing file structure finder multiline merge max for delimited formats (#56023)