### PR TITLE
[7.x] Emit deprecation warning if multiple v1 templates match with a new index (#55558)

### DIFF
--- a/modules/lang-mustache/src/test/resources/rest-api-spec/test/lang_mustache/60_typed_keys.yml
+++ b/modules/lang-mustache/src/test/resources/rest-api-spec/test/lang_mustache/60_typed_keys.yml
@@ -1,4 +1,6 @@
 setup:
+  - skip:
+      features: allowed_warnings
   - do:
       indices.put_template:
         name: index_template
@@ -18,6 +20,8 @@ setup:
                  type: keyword
 
   - do:
+     allowed_warnings:
+      - "index [test-0] matches multiple v1 templates [global, index_template], v2 index templates will only match a single index template"
      bulk:
         refresh: true
         body:

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -342,6 +342,12 @@ public class MetadataCreateIndexService {
                 final List<IndexTemplateMetadata> v1Templates = MetadataIndexTemplateService.findV1Templates(currentState.metadata(),
                     request.index(), isHiddenFromRequest);
 
+                if (v1Templates.size() > 1) {
+                    deprecationLogger.deprecatedAndMaybeLog("index_template_multiple_match", "index [{}] matches multiple v1 templates " +
+                        "[{}], v2 index templates will only match a single index template", request.index(),
+                        v1Templates.stream().map(IndexTemplateMetadata::name).sorted().collect(Collectors.joining(", ")));
+                }
+
                 return applyCreateIndexRequestWithV1Templates(currentState, request, silent, v1Templates, metadataTransformer);
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -343,7 +343,7 @@ public class MetadataCreateIndexService {
                     request.index(), isHiddenFromRequest);
 
                 if (v1Templates.size() > 1) {
-                    deprecationLogger.deprecatedAndMaybeLog("index_template_multiple_match", "index [{}] matches multiple v1 templates " +
+                    DEPRECATION_LOGGER.deprecatedAndMaybeLog("index_template_multiple_match", "index [{}] matches multiple v1 templates " +
                         "[{}], v2 index templates will only match a single index template", request.index(),
                         v1Templates.stream().map(IndexTemplateMetadata::name).sorted().collect(Collectors.joining(", ")));
                 }

--- a/server/src/test/java/org/elasticsearch/indices/template/TemplatePreferenceIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/template/TemplatePreferenceIT.java
@@ -235,6 +235,9 @@ public class TemplatePreferenceIT extends ESSingleNodeTestCase {
                 resp.getSetting(INDEX + "-000002", "index.priority"), equalTo("23"));
             client().admin().indices().prepareDelete(INDEX + "*").get();
         }
+
+        assertWarnings("index [index-000002] matches multiple v1 templates [one_shard_index_template, " +
+            "random-soft-deletes-template, v1], v2 index templates will only match a single index template");
     }
 
     private void assertUsedV1() {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -1,11 +1,15 @@
 ---
 setup:
   - skip:
-      features: headers
+      features:
+        - headers
+        - allowed_warnings
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
         Content-Type: application/json
+      allowed_warnings:
+        - "index [.ml-meta] matches multiple v1 templates [.ml-meta, global], v2 index templates will only match a single index template"
       index:
         index: .ml-meta
         id: filter_imposter-filter
@@ -320,6 +324,8 @@ setup:
       indices.delete:
         index: ".ml-meta"
   - do:
+      allowed_warnings:
+        - "index [.ml-meta] matches multiple v1 templates [.ml-meta, global], v2 index templates will only match a single index template"
       indices.create:
         index: ".ml-meta"
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
@@ -1,7 +1,11 @@
 setup:
   - skip:
-      features: headers
+      features:
+        - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - "index [.ml-inference-000002] matches multiple v1 templates [.ml-inference-000002, global], v2 index templates will only match a single index template"
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       index:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/put_job.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/rollup/put_job.yml
@@ -1,7 +1,11 @@
 setup:
   - skip:
-      features: headers
+      features:
+        - headers
+        - allowed_warnings
   - do:
+      allowed_warnings:
+        - "index [foo_rollup] matches multiple v1 templates [global, test], v2 index templates will only match a single index template"
       indices.create:
         index: foo
         body:
@@ -273,6 +277,8 @@ setup:
                 type: keyword
 
   - do:
+      allowed_warnings:
+        - "index [foo_rollup] matches multiple v1 templates [global, test], v2 index templates will only match a single index template"
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       rollup.put_job:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Emit deprecation warning if multiple v1 templates match with a new index (#55558)