### PR TITLE
[7.x] deprecrate size from cat.thread_pool in json spec (#55984)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -42,7 +42,11 @@
           "g",
           "t",
           "p"
-        ]
+        ],
+        "deprecated":{
+          "version":"7.8.0",
+          "description":"Setting this value has no effect and will be removed from the specification."
+        }
       },
       "local":{
         "type":"boolean",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - deprecrate size from cat.thread_pool in json spec (#55984)