### PR TITLE
Re-enable nodes usage tests and update serialization version

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -69,9 +69,6 @@
 
 ---
 "Verify nodes usage works":
-  - skip:
-      version: "all"
-      reason: "for backport"
   - do:
       nodes.usage: {}
   - is_true: nodes

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodeUsage.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodeUsage.java
@@ -43,7 +43,7 @@ public class NodeUsage extends BaseNodeResponse implements ToXContentFragment {
         timestamp = in.readLong();
         sinceTime = in.readLong();
         restUsage = (Map<String, Long>) in.readGenericValue();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             aggregationUsage = (Map<String, Object>) in.readGenericValue();
         } else {
             aggregationUsage = null;
@@ -121,7 +121,7 @@ public class NodeUsage extends BaseNodeResponse implements ToXContentFragment {
         out.writeLong(timestamp);
         out.writeLong(sinceTime);
         out.writeGenericValue(restUsage);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeGenericValue(aggregationUsage);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -34,7 +34,7 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     public NodesUsageRequest(StreamInput in) throws IOException {
         super(in);
         this.restActions = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             this.aggregations = in.readBoolean();
         }
     }
@@ -99,7 +99,7 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeBoolean(restActions);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeBoolean(aggregations);
         }
     }


### PR DESCRIPTION
Updates the serialization version and re-enables bwc tests for nodes
usage api after backport of #55732
