### PR TITLE
Remove Dead Code in SLM Delete Handling

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/history/SnapshotHistoryItem.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/history/SnapshotHistoryItem.java
@@ -116,11 +116,6 @@ public class SnapshotHistoryItem implements Writeable, ToXContentObject {
         return new SnapshotHistoryItem(timestamp, policyId, repository, snapshotName, DELETE_OPERATION, true, null, null);
     }
 
-    public static SnapshotHistoryItem deletionPossibleSuccessRecord(long timestamp, String snapshotName, String policyId, String repository,
-                                                                    String details) {
-        return new SnapshotHistoryItem(timestamp, policyId, repository, snapshotName, DELETE_OPERATION, true, null, details);
-    }
-
     public static SnapshotHistoryItem deletionFailureRecord(long timestamp, String snapshotName, String policyId, String repository,
                                                             Exception exception) throws IOException {
         String exceptionString = exceptionToString(exception);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -366,14 +366,9 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                 //       i.e are newer or equal to SnapshotsService#MULTI_DELETE_VERSION
                 deleteSnapshot(policyId, repo, info.snapshotId(), slmStats, ActionListener.wrap(acknowledgedResponse -> {
                     deleted.incrementAndGet();
-                    if (acknowledgedResponse.isAcknowledged()) {
-                        historyStore.putAsync(SnapshotHistoryItem.deletionSuccessRecord(Instant.now().toEpochMilli(),
+                    assert acknowledgedResponse.isAcknowledged();
+                    historyStore.putAsync(SnapshotHistoryItem.deletionSuccessRecord(Instant.now().toEpochMilli(),
                             info.snapshotId().getName(), policyId, repo));
-                    } else {
-                        SnapshotHistoryItem.deletionPossibleSuccessRecord(Instant.now().toEpochMilli(),
-                            info.snapshotId().getName(), policyId, repo,
-                            "deletion request issued successfully, no acknowledgement received");
-                    }
                 }, e -> {
                     failed.incrementAndGet();
                     try {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
@@ -471,7 +471,6 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
                 threadPool);
 
             AtomicBoolean onFailureCalled = new AtomicBoolean(false);
-            AtomicReference<Exception> errHandlerCalled = new AtomicReference<>(null);
             task.deleteSnapshot("policy", "foo", new SnapshotId("name", "uuid"),
                 new SnapshotLifecycleStats(0, 0, 0, 0, new HashMap<>()), new ActionListener<>() {
                     @Override


### PR DESCRIPTION
The delete response is always acknowledged. No need to handle anything else.
