### PR TITLE
[TEST] Allow more warnings about multiple template matches

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
@@ -4,6 +4,7 @@
  - skip:
       version: " - 6.6.99"
       reason: Merging typeless/typed mappings/templates was added in 6.7
+      features: allowed_warnings
 
  - do:
       indices.put_template:
@@ -18,6 +19,8 @@
                               type: keyword
 
  - do:
+      allowed_warnings:
+          - "index [test-1] matches multiple v1 templates [global, test_template], v2 index templates will only match a single index template"
       indices.create:
           index: test-1
           body:
@@ -42,6 +45,7 @@
  - skip:
       version: " - 6.6.99"
       reason: Merging typeless/typed mappings/templates was added in 6.7
+      features: allowed_warnings
 
  - do:
       indices.put_template:
@@ -55,6 +59,8 @@
                           type: keyword
 
  - do:
+      allowed_warnings:
+          - "index [test-1] matches multiple v1 templates [global, test_template], v2 index templates will only match a single index template"
       indices.create: 
           include_type_name: true
           index: test-1
@@ -106,6 +112,7 @@
  - skip:
       version: " - 6.99.99"
       reason: needs typeless index operations to work on typed indices
+      features: allowed_warnings
 
  - do:
       indices.put_template:
@@ -120,6 +127,8 @@
                               type: keyword
 
  - do:
+      allowed_warnings:
+          - "index [test-1] matches multiple v1 templates [global, test_template], v2 index templates will only match a single index template"
       index:
           index: test-1
           body: { bar: 42 }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/110_geo_shape.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/110_geo_shape.yml
@@ -1,6 +1,10 @@
 ---
 "Test upgraded > 7.7 cluster with pre-7.8 and 7.8+ geo_shape fields":
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+         - "index [new_locations] matches multiple v1 templates [global, template], v2 index templates will only match a single index template"
       indices.create:
         index: new_locations
         body:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_ml_datafeed_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/40_ml_datafeed_crud.yml
@@ -8,7 +8,11 @@ setup:
 
 ---
 "Test old and mixed cluster datafeeds without aggs":
+  - skip:
+      features: allowed_warnings
   - do:
+      allowed_warnings:
+         - "index [airline-data] matches multiple v1 templates [global, template], v2 index templates will only match a single index template"
       indices.create:
         index: airline-data
         body:
@@ -108,6 +112,8 @@ setup:
   - skip:
       features: allowed_warnings
   - do:
+      allowed_warnings:
+         - "index [airline-data] matches multiple v1 templates [global, template], v2 index templates will only match a single index template"
       indices.create:
         index: airline-data
         body:


### PR DESCRIPTION
Adds some extra allowed warnings about multiple index templates
matching on index creation of the same type that were added
in #56038.