### PR TITLE
Support bcrypt $2b$ and $2y$ revisions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
@@ -30,12 +30,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt();
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -43,12 +43,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(4);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -56,12 +56,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(5);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -69,12 +69,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(6);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -82,12 +82,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(7);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -95,12 +95,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(8);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -108,12 +108,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(9);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -121,12 +121,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(10);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -134,12 +134,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(11);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -147,12 +147,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(12);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -160,12 +160,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(13);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -173,12 +173,12 @@ public enum Hasher {
         @Override
         public char[] hash(SecureString text) {
             String salt = BCrypt.gensalt(14);
-            return BCrypt.hashpw(text, salt).toCharArray();
+            return BCrypt.generateHash(text, salt).toCharArray();
         }
 
         @Override
         public boolean verify(SecureString text, char[] hash) {
-            return verifyBcryptHash(text, hash);
+            return BCrypt.verifyHash(text, hash);
         }
     },
 
@@ -383,14 +383,12 @@ public enum Hasher {
         }
     };
 
-    private static final String BCRYPT_PREFIX = "$2a$";
     private static final String SHA1_PREFIX = "{SHA}";
     private static final String MD5_PREFIX = "{MD5}";
     private static final String SSHA256_PREFIX = "{SSHA256}";
     private static final String PBKDF2_PREFIX = "{PBKDF2}";
     private static final int PBKDF2_DEFAULT_COST = 10000;
     private static final int PBKDF2_KEY_LENGTH = 256;
-    private static final int BCRYPT_DEFAULT_COST = 10;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     /**
@@ -465,9 +463,11 @@ public enum Hasher {
      * @return the hasher that can be used for validation
      */
     public static Hasher resolveFromHash(char[] hash) {
-        if (CharArrays.charsBeginsWith(BCRYPT_PREFIX, hash)) {
-            int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, BCRYPT_PREFIX.length(), hash.length - 54)));
-            return cost == BCRYPT_DEFAULT_COST ? Hasher.BCRYPT : resolve("bcrypt" + cost);
+        if (BCrypt.isPrefixValid(hash)) {
+            final int cost = BCrypt.getLogRounds(hash);
+            return cost == BCrypt.DEFAULT_LOG2_ROUNDS
+                ? Hasher.BCRYPT
+                : resolve("bcrypt" + cost);
         } else if (CharArrays.charsBeginsWith(PBKDF2_PREFIX, hash)) {
             int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, PBKDF2_PREFIX.length(), hash.length - 90)));
             return cost == PBKDF2_DEFAULT_COST ? Hasher.PBKDF2 : resolve("pbkdf2_" + cost);
@@ -551,14 +551,6 @@ public enum Hasher {
                 Arrays.fill(computedPwdHash, '\u0000');
             }
         }
-    }
-
-    private static boolean verifyBcryptHash(SecureString text, char[] hash) {
-        String hashStr = new String(hash);
-        if (hashStr.startsWith(BCRYPT_PREFIX) == false) {
-            return false;
-        }
-        return BCrypt.checkpw(text, hashStr);
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/BCryptTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/BCryptTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.security.authc.support;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.xpack.core.security.test.BcryptTestSupport.runWithInvalidRevisions;
+import static org.elasticsearch.xpack.core.security.test.BcryptTestSupport.runWithValidRevisions;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BCryptTests extends ESTestCase {
+
+    private static final SecureString PASSWORD = new SecureString("U21VniQwdEWATfqO".toCharArray());
+    private static final String[] VALID_HASHES = {
+        "$2a$04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa",
+        "$2a$05$XNLcDk8PSYbU70A4bWjY1ugWlNSVM.VPMp6lb9qLotOB9oPV5TyM6",
+        "$2a$06$KMO7CTXk.rzWPve.dRYXgu8x028/6QlBmRTCijvbwFH5Xx4Xhn4tW",
+        "$2a$07$tr.C.OmBfdIBg7gcMruQX.UHZtmoZfi6xNpK6A0/oa.ulR4rXj6Ny",
+        "$2a$08$Er.JIbUaPM7JmIN0iFEhW.H2hgtRT9weKtLdqEgSMAzmEe2xZ0B7a",
+        "$2a$09$OmkfXJKIWhUmnrIlOy9Cd.SOu337FXAKcbB10nMUwpKSez5G4jz8e",
+        "$2a$10$qyfYQcOK13wQmGO3Y.nVj.he5w1.Z0WV81HqBW6NlV.nkmg90utxO",
+        "$2a$11$oNdrIn9.RBEg.XXnZkqwk..2wBrU6SjEJkQTLyxEXVQQcw4BokSaa",
+        "$2a$12$WMLT/yjmMvBTgBnnZw1EhO6r4g7cWoxEOhS9ln4dNVg8gK3es/BZm",
+        "$2a$13$WHkGwOCLz8SnX13tYH0Ez.qwKK0YFD8DA4Anz0a0Laozw75vqmBee",
+        "$2a$14$8Urbk50As1LIgDBWPmXcFOpMWJfy3ddFLgvDlH3G1y4TFo4sLXU9y"
+    };
+
+    public void testVerifyHash() {
+        for (String hash : VALID_HASHES) {
+            testVerifyHashWithValidHash(hash);
+        }
+
+        final String[] INVALID_HASHES = {
+            "$2a$04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGd",
+            "$2a$05$XNLcDk8PSYbU70A4bWjY1ugWlNSVM.VPMp6lb9qLotOB9oPV5Tys6",
+            "$2a$06$KMO7CTXk.rzWPve.dRYXgu8x028/6QlBmRTCijvbwFH5Xx4XhnttW",
+            "$2a$07$tr.C.OmBfdIBg7gcMruQX.UHZtmoZfi6xNpK6A0/oa.ulR4rXh6Ny",
+            "$2a$08$Er.JIbUaPM7JmIN0iFEhW.H2hgtRT9weKtLdqEgSMAzmEe2xi0B7a",
+            "$2a$09$OmkfXJKIWhUmnrIlOy9Cd.SOu337FXAKcbB10nMUwpKSez5R4jz8e",
+            "$2a$10$qyfYQcOK13wQmGO3Y.nVj.he5w1.Z0WV81HqBW6NlV.nkmL90utxO",
+            "$2a$11$oNdrIn9.RBEg.XXnZkqwk..2wBrU6SjEJkQTLyxEXVQQc34BokSaa",
+            "$2a$12$WMLT/yjmMvBTgBnnZw1EhO6r4g7cWoxEOhS9ln4dNVg8lK3es/BZm",
+            "$2a$13$WHkGwOCLz8SnX13tYH0Ez.qwKK0YFD8DA4Anz0a0Lao3w75vqmBee",
+            "$2a$14$8Urbk50As1LIgDBWPmXcFOpMWJfy3ddFLgvDlH3G1yPTFo4sLXU9y"
+        };
+        for (String hash : INVALID_HASHES) {
+            testVerifyHashWithInvalidHash(hash);
+        }
+    }
+
+    private void testVerifyHashWithValidHash(String baseHash) {
+        runWithValidRevisions(baseHash, hash -> assertTrue(BCrypt.verifyHash(PASSWORD, hash)));
+        runWithInvalidRevisions(baseHash, hash -> assertFalse(BCrypt.verifyHash(PASSWORD, hash)));
+    }
+
+    private void testVerifyHashWithInvalidHash(String baseHash) {
+        runWithValidRevisions(baseHash, hash -> assertFalse(BCrypt.verifyHash(PASSWORD, hash)));
+        runWithInvalidRevisions(baseHash, hash -> assertFalse(BCrypt.verifyHash(PASSWORD, hash)));
+    }
+
+    public void testIsPrefixValid() {
+        testInvalidPrefixSeparators();
+        testInvalidPrefixVersion();
+        testInvalidPrefixRevisions();
+
+        assertFalse(BCrypt.isPrefixValid(null));
+    }
+
+    private void testInvalidPrefixSeparators() {
+        final String[] HASHES_WITH_INVALID_SEPARATORS = {
+            "{2a$04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa",
+            "$2a#04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa",
+            "[2a]04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa",
+            ""
+        };
+        for (String hash : HASHES_WITH_INVALID_SEPARATORS) {
+            assertFalse(BCrypt.isPrefixValid(hash.toCharArray()));
+        }
+    }
+
+    private void testInvalidPrefixVersion() {
+        final String[] HASHES_WITH_INVALID_VERSION = {
+            "$3a$04$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa",
+            "$"
+        };
+        for (String hash : HASHES_WITH_INVALID_VERSION) {
+            assertFalse(BCrypt.isPrefixValid(hash.toCharArray()));
+        }
+    }
+
+    private void testInvalidPrefixRevisions() {
+        final String baseHash = VALID_HASHES[0];
+        runWithValidRevisions(baseHash, hash -> assertTrue(BCrypt.isPrefixValid(hash)));
+        runWithInvalidRevisions(baseHash, hash -> assertFalse(BCrypt.isPrefixValid(hash)));
+    }
+
+    public void testGetLogRounds() {
+        final int MIN_ROUNDS = 4;
+        final int MAX_ROUNDS = 14;
+        for (int rounds = MIN_ROUNDS, index = 0; rounds <= MAX_ROUNDS; rounds++, index++) {
+            assertThat(BCrypt.getLogRounds(VALID_HASHES[index].toCharArray()), equalTo(rounds));
+        }
+
+        final String HASH_WITH_TRUNCATED_ROUNDS = "$2a$1";
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> BCrypt.getLogRounds(HASH_WITH_TRUNCATED_ROUNDS.toCharArray()));
+        assertThat(e.getMessage(), containsString("Invalid hash length."));
+
+        final String HASH_WITH_INVALID_ROUNDS = "$2a$w4$OLNTeJiq3vjYqTZwgDi62OU5MvzkV3Jqz.KiR3pwgQv70pD6bUsGa";
+        e = expectThrows(IllegalArgumentException.class,
+            () -> BCrypt.getLogRounds(HASH_WITH_INVALID_ROUNDS.toCharArray()));
+        assertThat(e.getMessage(), containsString("Hash log rounds should be a two digit integer."));
+    }
+
+    public void testGenerateHash() {
+        for (String hash : VALID_HASHES) {
+            assertThat(BCrypt.generateHash(PASSWORD, hash), equalTo(hash));
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/BcryptTestSupport.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/BcryptTestSupport.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.security.test;
+
+import org.elasticsearch.xpack.core.security.authc.support.BCrypt;
+
+import java.util.function.Consumer;
+
+public class BcryptTestSupport {
+
+    public static void runWithValidRevisions(String baseHash, Consumer<char[]> action) {
+        for (char revision : BCrypt.REVISIONS) {
+            char[] hash = toCharArrayWithNewRevision(baseHash, revision);
+            action.accept(hash);
+        }
+    }
+
+    public static void runWithInvalidRevisions(String baseHash, Consumer<char[]> action) {
+        for (char revision = 'a'; revision <= 'z'; revision++) {
+            if (BCrypt.REVISIONS.contains(revision) == false) {
+                char[] hash = toCharArrayWithNewRevision(baseHash, revision);
+                action.accept(hash);
+            }
+        }
+    }
+
+    public static char[] toCharArrayWithNewRevision(String hash, char newRevision) {
+        final int REVISION_INDEX = 2;
+        char[] hashBuilder = hash.toCharArray();
+        if (hash.length() >= (REVISION_INDEX + 1)) {
+            hashBuilder[REVISION_INDEX] = newRevision;
+        }
+        return hashBuilder;
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
@@ -9,6 +9,8 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 
+import static org.elasticsearch.xpack.core.security.test.BcryptTestSupport.runWithInvalidRevisions;
+import static org.elasticsearch.xpack.core.security.test.BcryptTestSupport.runWithValidRevisions;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -90,30 +92,28 @@ public class HasherTests extends ESTestCase {
     }
 
     public void testResolveFromHash() {
-        assertThat(Hasher.resolveFromHash("$2a$10$1oZj.8KmlwiCy4DWKvDH3OU0Ko4WRF4FknyvCh3j/ZtaRCNYA6Xzm".toCharArray()),
-            sameInstance(Hasher.BCRYPT));
-        assertThat(Hasher.resolveFromHash("$2a$04$GwJtIQiGMHASEYphMiCpjeZh1cDyYC5U.DKfNKa4i/y0IbOvc2LiG".toCharArray()),
-            sameInstance(Hasher.BCRYPT4));
-        assertThat(Hasher.resolveFromHash("$2a$05$xLmwSB7Nw7PcqP.6hXdc4eUZbT.4.iAZ3CTPzSaUibrrYjC6Vwq1m".toCharArray()),
-            sameInstance(Hasher.BCRYPT5));
-        assertThat(Hasher.resolveFromHash("$2a$06$WQX1MALAjVOhR2YKmLcHYed2oROzBl3OZPtvq3FkVZYwm9X2LVKYm".toCharArray()),
-            sameInstance(Hasher.BCRYPT6));
-        assertThat(Hasher.resolveFromHash("$2a$07$Satxnu2fCvwYXpHIk8A2sO2uwROrsV7WrNiRJPq1oXEl5lc9FE.7S".toCharArray()),
-            sameInstance(Hasher.BCRYPT7));
-        assertThat(Hasher.resolveFromHash("$2a$08$LLfkTt2C9TUl5sDtgqmE3uRw9nHt748d3eMSGfbFYgQQQhjbXHFo2".toCharArray()),
-            sameInstance(Hasher.BCRYPT8));
-        assertThat(Hasher.resolveFromHash("$2a$09$.VCWA3yFVdd6gfI526TUrufb4TvxMuhW0jIuMfhd4/fy1Ak/zrSFe".toCharArray()),
-            sameInstance(Hasher.BCRYPT9));
-        assertThat(Hasher.resolveFromHash("$2a$10$OEiXFrUUY02Nm7YsEgzFuuJ3yO3HAYzJUU7omseluy28s7FYaictu".toCharArray()),
-            sameInstance(Hasher.BCRYPT));
-        assertThat(Hasher.resolveFromHash("$2a$11$Ya53LCozFlKABu05xsAbj.9xmrczyuAY/fTvxKkDiHOJc5GYcaNRy".toCharArray()),
-            sameInstance(Hasher.BCRYPT11));
-        assertThat(Hasher.resolveFromHash("$2a$12$oUW2hiWBHYwbJamWi6YDPeKS2NBCvD4GR50zh9QZCcgssNFcbpg/a".toCharArray()),
-            sameInstance(Hasher.BCRYPT12));
-        assertThat(Hasher.resolveFromHash("$2a$13$0PDx6mxKK4bLSgpc5H6eaeylWub7UFghjxV03lFYSz4WS4slDT30q".toCharArray()),
-            sameInstance(Hasher.BCRYPT13));
-        assertThat(Hasher.resolveFromHash("$2a$14$lFyXmX7p9/FHr7W4nxTnfuCkjAoBHv6awQlv8jlKZ/YCMI65i38e6".toCharArray()),
-            sameInstance(Hasher.BCRYPT14));
+        testResolveBcryptFromHash("$2a$04$GwJtIQiGMHASEYphMiCpjeZh1cDyYC5U.DKfNKa4i/y0IbOvc2LiG",
+            Hasher.BCRYPT4);
+        testResolveBcryptFromHash("$2a$05$xLmwSB7Nw7PcqP.6hXdc4eUZbT.4.iAZ3CTPzSaUibrrYjC6Vwq1m",
+            Hasher.BCRYPT5);
+        testResolveBcryptFromHash("$2a$06$WQX1MALAjVOhR2YKmLcHYed2oROzBl3OZPtvq3FkVZYwm9X2LVKYm",
+            Hasher.BCRYPT6);
+        testResolveBcryptFromHash("$2a$07$Satxnu2fCvwYXpHIk8A2sO2uwROrsV7WrNiRJPq1oXEl5lc9FE.7S",
+            Hasher.BCRYPT7);
+        testResolveBcryptFromHash("$2a$08$LLfkTt2C9TUl5sDtgqmE3uRw9nHt748d3eMSGfbFYgQQQhjbXHFo2",
+            Hasher.BCRYPT8);
+        testResolveBcryptFromHash("$2a$09$.VCWA3yFVdd6gfI526TUrufb4TvxMuhW0jIuMfhd4/fy1Ak/zrSFe",
+            Hasher.BCRYPT9);
+        testResolveBcryptFromHash("$2a$10$OEiXFrUUY02Nm7YsEgzFuuJ3yO3HAYzJUU7omseluy28s7FYaictu",
+            Hasher.BCRYPT);
+        testResolveBcryptFromHash("$2a$11$Ya53LCozFlKABu05xsAbj.9xmrczyuAY/fTvxKkDiHOJc5GYcaNRy",
+            Hasher.BCRYPT11);
+        testResolveBcryptFromHash("$2a$12$oUW2hiWBHYwbJamWi6YDPeKS2NBCvD4GR50zh9QZCcgssNFcbpg/a",
+            Hasher.BCRYPT12);
+        testResolveBcryptFromHash("$2a$13$0PDx6mxKK4bLSgpc5H6eaeylWub7UFghjxV03lFYSz4WS4slDT30q",
+            Hasher.BCRYPT13);
+        testResolveBcryptFromHash("$2a$14$lFyXmX7p9/FHr7W4nxTnfuCkjAoBHv6awQlv8jlKZ/YCMI65i38e6",
+            Hasher.BCRYPT14);
         assertThat(Hasher.resolveFromHash(
             "{PBKDF2}1000$oNl3JWiDZhXqhrpk9Kl+T0tKpVNNV3UHNxENPePpo2M=$g9lERDX5op20eX534bHdQy7ySRwobxwtaxxsz3AYPIU=".toCharArray()),
             sameInstance(Hasher.PBKDF2_1000));
@@ -133,6 +133,11 @@ public class HasherTests extends ESTestCase {
             "{PBKDF2}1000000$UuyhtjDEzWmE2wyY80akZKPWWpy2r2X50so41YML82U=$WFasYLelqbjQwt3EqFlUcwHiC38EZC45Iu/Iz0xL1GQ=".toCharArray()),
             sameInstance(Hasher.PBKDF2_1000000));
         assertThat(Hasher.resolveFromHash("notavalidhashformat".toCharArray()), sameInstance(Hasher.NOOP));
+    }
+
+    private void testResolveBcryptFromHash(String baseHash, Hasher hasher) {
+        runWithValidRevisions(baseHash, hash -> assertThat(Hasher.resolveFromHash(hash), sameInstance(hasher)));
+        runWithInvalidRevisions(baseHash, hash -> assertThat(Hasher.resolveFromHash(hash), sameInstance(Hasher.NOOP)));
     }
 
     private static void testHasherSelfGenerated(Hasher hasher) {


### PR DESCRIPTION
Although we don't claim support for $2b$ and $2y$ revisions, this
change keeps our bcrypt implementation more in line with OpenBSD's
implementation, that is considered the canonical one and supports
$2b$ besides $2a$, and also other common implementations using $2y$
hashes.

This commit moves specific bcrypt code from Hasher to BCrypt in order
to improve responsibilities separation. We could refactor and move out
other hash specific code in the future (for PBKDF2 and SHA1, for
instance) so Hasher could have only one responsibility.

BCrypt tests were missing, so the commit adds tests for code moved
into it and also some tests for hash generation and verification, but
we should cover the rest of it.

Please note that BCrypt.generateHash still has code to support $2$,
which was already dropped by OpenBSD. We should evaluate if this needs
to be removed in the future.

Closes #51132