### PR TITLE
[7.x] Histogram field type support for ValueCount and Avg aggregations

### DIFF
--- a/docs/reference/aggregations/metrics/avg-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/avg-aggregation.asciidoc
@@ -126,3 +126,57 @@ POST /exams/_search?size=0
 // TEST[setup:exams]
 
 <1> Documents without a value in the `grade` field will fall into the same bucket as documents that have the value `10`.
+
+
+[[search-aggregations-metrics-avg-aggregation-histogram-fields]]
+==== Histogram fields
+When average is computed on <<histogram,histogram fields>>, the result of the aggregation is the weighted average
+of all elements in the `values` array taking into consideration the number in the same position in the `counts` array.
+
+For example, for the following index that stores pre-aggregated histograms with latency metrics for different networks:
+
+[source,console]
+--------------------------------------------------
+PUT metrics_index/_doc/1
+{
+  "network.name" : "net-1",
+  "latency_histo" : {
+      "values" : [0.1, 0.2, 0.3, 0.4, 0.5], <1>
+      "counts" : [3, 7, 23, 12, 6] <2>
+   }
+}
+
+PUT metrics_index/_doc/2
+{
+  "network.name" : "net-2",
+  "latency_histo" : {
+      "values" :  [0.1, 0.2, 0.3, 0.4, 0.5], <1>
+      "counts" : [8, 17, 8, 7, 6] <2>
+   }
+}
+
+POST /metrics_index/_search?size=0
+{
+    "aggs" : {
+        "avg_latency" :
+            { "avg" : { "field" : "latency_histo" }
+        }
+    }
+}
+--------------------------------------------------
+
+For each histogram field the `avg` aggregation adds each number in the `values` array <1> multiplied by its associated count
+in the `counts` array <2>. Eventually, it will compute the average over those values for all histograms and return the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+    ...
+    "aggregations" : {
+        "avg_latency" : {
+           "value" : 0.29690721649
+        }
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE[skip:test not setup]

--- a/docs/reference/aggregations/metrics/sum-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/sum-aggregation.asciidoc
@@ -163,10 +163,10 @@ POST /sales/_search?size=0
 [[search-aggregations-metrics-sum-aggregation-histogram-fields]]
 ==== Histogram fields
 
-When the sums are computed on <<histogram,histogram fields>>, the result of the aggregation is the sum of all elements in the `values`
+When sum is computed on <<histogram,histogram fields>>, the result of the aggregation is the sum of all elements in the `values`
 array multiplied by the number in the same position in the `counts` array.
 
-For example, if we have the following index that stores pre-aggregated histograms with latency metrics for different networks:
+For example, for the following index that stores pre-aggregated histograms with latency metrics for different networks:
 
 [source,console]
 --------------------------------------------------
@@ -196,7 +196,7 @@ POST /metrics_index/_search?size=0
 }
 --------------------------------------------------
 
-For each histogram field the sum aggregation will multiply each number in the `values` array <1> multiplied with its associated count
+For each histogram field the `sum` aggregation will multiply each number in the `values` array <1> multiplied by its associated count
 in the `counts` array <2>. Eventually, it will add all values for all histograms and return the following result:
 
 [source,console-result]

--- a/docs/reference/aggregations/metrics/valuecount-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/valuecount-aggregation.asciidoc
@@ -6,6 +6,9 @@ These values can be extracted either from specific fields in the documents, or b
 this aggregator will be used in conjunction with other single-value aggregations. For example, when computing the `avg`
 one might be interested in the number of values the average is computed over.
 
+`value_count` does not de-duplicate values, so even if a field has duplicates (or a script generates multiple
+identical values for a single document), each value will be counted individually.
+
 [source,console]
 --------------------------------------------------
 POST /sales/_search?size=0
@@ -77,3 +80,60 @@ POST /sales/_search?size=0
 }
 --------------------------------------------------
 // TEST[setup:sales,stored_example_script]
+
+NOTE:: Because `value_count` is designed to work with any field it internally treats all values as simple bytes.
+Due to this implementation, if `_value` script variable is used to fetch a value instead of accessing the field
+directly (e.g. a "value script"), the field value will be returned as a string instead of it's native format.
+
+[[search-aggregations-metrics-valuecount-aggregation-histogram-fields]]
+==== Histogram fields
+When the `value_count` aggregation is computed on <<histogram,histogram fields>>, the result of the aggregation is the sum of all numbers
+in the `counts` array of the histogram.
+
+For example, for the following index that stores pre-aggregated histograms with latency metrics for different networks:
+
+[source,console]
+--------------------------------------------------
+PUT metrics_index/_doc/1
+{
+  "network.name" : "net-1",
+  "latency_histo" : {
+      "values" : [0.1, 0.2, 0.3, 0.4, 0.5],
+      "counts" : [3, 7, 23, 12, 6] <1>
+   }
+}
+
+PUT metrics_index/_doc/2
+{
+  "network.name" : "net-2",
+  "latency_histo" : {
+      "values" :  [0.1, 0.2, 0.3, 0.4, 0.5],
+      "counts" : [8, 17, 8, 7, 6] <1>
+   }
+}
+
+POST /metrics_index/_search?size=0
+{
+    "aggs" : {
+        "total_requests" : {
+            "value_count" : { "field" : "latency_histo" }
+        }
+    }
+}
+--------------------------------------------------
+
+For each histogram field the `value_count` aggregation will sum all numbers in the `counts` array <1>.
+Eventually, it will add all values for all histograms and return the following result:
+
+[source,console-result]
+--------------------------------------------------
+{
+    ...
+    "aggregations" : {
+        "total_requests" : {
+           "value" : 97
+        }
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE[skip:test not setup]

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -36,6 +36,8 @@ Because the data is not indexed, you only can use `histogram` fields for the
 following aggregations and queries:
 
 * <<search-aggregations-metrics-sum-aggregation-histogram-fields,sum>> aggregation
+* <<search-aggregations-metrics-valuecount-aggregation-histogram-fields,value_count>> aggregation
+* <<search-aggregations-metrics-avg-aggregation-histogram-fields,avg>> aggregation
 * <<search-aggregations-metrics-percentile-aggregation,percentiles>> aggregation
 * <<search-aggregations-metrics-percentile-rank-aggregation,percentile ranks>> aggregation
 * <<search-aggregations-metrics-boxplot-aggregation,boxplot>> aggregation

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 public class InternalValueCount extends InternalNumericMetricsAggregation.SingleValue implements ValueCount {
     private final long value;
 
-    InternalValueCount(String name, long value, Map<String, Object> metadata) {
+    public InternalValueCount(String name, long value, Map<String, Object> metadata) {
         super(name, metadata);
         this.value = value;
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
@@ -52,7 +52,6 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.analytics.action.AnalyticsStatsAction;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -86,7 +85,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
 
     @Override
     public List<AggregationSpec> getAggregations() {
-        return Arrays.asList(
+        return org.elasticsearch.common.collect.List.of(
             new AggregationSpec(
                 StringStatsAggregationBuilder.NAME,
                 StringStatsAggregationBuilder::new,
@@ -143,7 +142,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
 
     @Override
     public List<Consumer<ValuesSourceRegistry.Builder>> getAggregationExtentions() {
-        return Arrays.asList(
+        return org.elasticsearch.common.collect.List.of(
             AnalyticsAggregatorFactory::registerPercentilesAggregator,
             AnalyticsAggregatorFactory::registerPercentileRanksAggregator,
             AnalyticsAggregatorFactory::registerHistoBackedSumAggregator,
@@ -162,7 +161,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
 
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return Arrays.asList(
+        return org.elasticsearch.common.collect.List.of(
             new NamedWriteableRegistry.Entry(TTestState.class, PairedTTestState.NAME, PairedTTestState::new),
             new NamedWriteableRegistry.Entry(TTestState.class, UnpairedTTestState.NAME, UnpairedTTestState::new)
         );

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
@@ -146,7 +146,9 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
         return Arrays.asList(
             AnalyticsAggregatorFactory::registerPercentilesAggregator,
             AnalyticsAggregatorFactory::registerPercentileRanksAggregator,
-            AnalyticsAggregatorFactory::registerHistoBackedSumAggregator
+            AnalyticsAggregatorFactory::registerHistoBackedSumAggregator,
+            AnalyticsAggregatorFactory::registerHistoBackedValueCountAggregator,
+            AnalyticsAggregatorFactory::registerHistoBackedAverageAggregator
         );
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AnalyticsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AnalyticsAggregatorFactory.java
@@ -3,9 +3,9 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-
 package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
+import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MetricAggregatorSupplier;
 import org.elasticsearch.search.aggregations.metrics.PercentileRanksAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
@@ -13,8 +13,11 @@ import org.elasticsearch.search.aggregations.metrics.PercentilesAggregatorSuppli
 import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
 import org.elasticsearch.search.aggregations.metrics.PercentilesMethod;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ValueCountAggregatorSupplier;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSourceType;
+import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSource;
 
 public class AnalyticsAggregatorFactory {
 
@@ -65,6 +68,24 @@ public class AnalyticsAggregatorFactory {
     public static void registerHistoBackedSumAggregator(ValuesSourceRegistry.Builder builder) {
         builder.register(SumAggregationBuilder.NAME,
             AnalyticsValuesSourceType.HISTOGRAM,
-            (MetricAggregatorSupplier) HistoBackedSumAggregator::new);
+            (MetricAggregatorSupplier) (name, valuesSource, format, context, parent, metadata) ->
+                new HistoBackedSumAggregator(name, (HistogramValuesSource.Histogram) valuesSource, format, context, parent, metadata)
+        );
+    }
+
+    public static void registerHistoBackedValueCountAggregator(ValuesSourceRegistry.Builder builder) {
+        builder.register(ValueCountAggregationBuilder.NAME,
+            AnalyticsValuesSourceType.HISTOGRAM,
+            (ValueCountAggregatorSupplier) (name, valuesSource, context, parent, metadata) ->
+                new HistoBackedValueCountAggregator(name, (HistogramValuesSource.Histogram) valuesSource, context, parent, metadata)
+        );
+    }
+
+    public static void registerHistoBackedAverageAggregator(ValuesSourceRegistry.Builder builder) {
+        builder.register(AvgAggregationBuilder.NAME,
+            AnalyticsValuesSourceType.HISTOGRAM,
+            (MetricAggregatorSupplier) (name, valuesSource, format, context, parent, metadata) ->
+                new HistoBackedAvgAggregator(name, (HistogramValuesSource.Histogram) valuesSource, format, context, parent, metadata)
+        );
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.index.fielddata.HistogramValue;
+import org.elasticsearch.index.fielddata.HistogramValues;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.metrics.InternalValueCount;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSource;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Value count aggregator operating over histogram datatypes {@link HistogramValuesSource}
+ * The aggregation counts the number of values a histogram field has within the aggregation context
+ * by adding the counts of the histograms.
+ */
+public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.SingleValue {
+
+    final HistogramValuesSource.Histogram valuesSource;
+
+    /** Count per bucket */
+    LongArray counts;
+
+    public HistoBackedValueCountAggregator(
+            String name,
+            HistogramValuesSource.Histogram valuesSource,
+            SearchContext aggregationContext,
+            Aggregator parent,
+            Map<String, Object> metadata) throws IOException {
+        super(name, aggregationContext, parent, metadata);
+        this.valuesSource = valuesSource;
+        if (valuesSource != null) {
+            counts = context.bigArrays().newLongArray(1, true);
+        }
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
+            final LeafBucketCollector sub) throws IOException {
+        if (valuesSource == null) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
+        }
+        final BigArrays bigArrays = context.bigArrays();
+
+        final HistogramValues values = valuesSource.getHistogramValues(ctx);
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                counts = bigArrays.grow(counts, bucket + 1);
+                if (values.advanceExact(doc)) {
+                    final HistogramValue sketch = values.histogram();
+                    while (sketch.next()) {
+                        counts.increment(bucket, sketch.count());
+                    }
+                }
+            }
+        };
+    }
+
+    @Override
+    public double metric(long owningBucketOrd) {
+        return (valuesSource == null || owningBucketOrd >= counts.size()) ? 0 : counts.get(owningBucketOrd);
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long bucket) {
+        if (valuesSource == null || bucket >= counts.size()) {
+            return buildEmptyAggregation();
+        }
+        return new InternalValueCount(name, counts.get(bucket), metadata());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return new InternalValueCount(name, 0L, metadata());
+    }
+
+    @Override
+    public void doClose() {
+        Releasables.close(counts);
+    }
+}

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HDRPreAggregatedPercentileRanksAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HDRPreAggregatedPercentileRanksAggregatorTests.java
@@ -3,10 +3,10 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.analytics.mapper;
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
-import com.tdunning.math.stats.Centroid;
-import com.tdunning.math.stats.TDigest;
+import org.HdrHistogram.DoubleHistogram;
+import org.HdrHistogram.DoubleHistogramIterationValue;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
@@ -20,28 +20,26 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
+import org.elasticsearch.search.aggregations.metrics.InternalHDRPercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.PercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.PercentileRanksAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
 import org.elasticsearch.search.aggregations.metrics.PercentilesMethod;
-import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSourceType;
+import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-
-public class TDigestPreAggregatedPercentileRanksAggregatorTests extends AggregatorTestCase {
+public class HDRPreAggregatedPercentileRanksAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
@@ -50,9 +48,9 @@ public class TDigestPreAggregatedPercentileRanksAggregatorTests extends Aggregat
 
     @Override
     protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
-        return new PercentileRanksAggregationBuilder("tdigest_percentiles", new double[]{1.0})
+        return new PercentileRanksAggregationBuilder("hdr_percentiles", new double[]{1.0})
             .field(fieldName)
-            .percentilesConfig(new PercentilesConfig.TDigest());
+            .percentilesConfig(new PercentilesConfig.Hdr());
     }
 
     @Override
@@ -65,18 +63,19 @@ public class TDigestPreAggregatedPercentileRanksAggregatorTests extends Aggregat
     }
 
     private BinaryDocValuesField getDocValue(String fieldName, double[] values) throws IOException {
-        TDigest histogram = new TDigestState(100.0); //default
+        DoubleHistogram histogram = new DoubleHistogram(3);//default
         for (double value : values) {
-            histogram.add(value);
+            histogram.recordValue(value);
         }
         BytesStreamOutput streamOutput = new BytesStreamOutput();
-        histogram.compress();
-        Collection<Centroid> centroids = histogram.centroids();
-        Iterator<Centroid> iterator = centroids.iterator();
-        while ( iterator.hasNext()) {
-            Centroid centroid = iterator.next();
-            streamOutput.writeVInt(centroid.count());
-            streamOutput.writeDouble(centroid.mean());
+        DoubleHistogram.RecordedValues recordedValues = histogram.recordedValues();
+        Iterator<DoubleHistogramIterationValue> iterator = recordedValues.iterator();
+        while (iterator.hasNext()) {
+            DoubleHistogramIterationValue value = iterator.next();
+            long count = value.getCountAtValueIteratedTo();
+            streamOutput.writeVInt(Math.toIntExact(count));
+            double d = value.getValueIteratedTo();
+            streamOutput.writeDouble(d);
         }
         return new BinaryDocValuesField(fieldName, streamOutput.bytes().toBytesRef());
     }
@@ -88,31 +87,27 @@ public class TDigestPreAggregatedPercentileRanksAggregatorTests extends Aggregat
             doc.add(getDocValue("field", new double[] {3, 0.2, 10}));
             w.addDocument(doc);
 
-            PercentileRanksAggregationBuilder aggBuilder = new PercentileRanksAggregationBuilder("my_agg", new double[] {0.1, 0.5, 12})
+            PercentileRanksAggregationBuilder aggBuilder = new PercentileRanksAggregationBuilder("my_agg", new double[]{0.1, 0.5, 12})
                     .field("field")
-                    .method(PercentilesMethod.TDIGEST);
-            MappedFieldType fieldType = new HistogramFieldMapper.Builder("number").fieldType();
+                    .method(PercentilesMethod.HDR);
+            MappedFieldType fieldType = new HistogramFieldMapper.Builder("field").fieldType();
             fieldType.setName("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                PercentileRanks ranks = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                PercentileRanks ranks = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
                 assertEquals(0.1, rank.getValue(), 0d);
-                // TODO: Fix T-Digest: this assertion should pass but we currently get ~15
-                // https://github.com/elastic/elasticsearch/issues/14851
-                // assertThat(rank.getPercent(), Matchers.equalTo(0d));
+                assertThat(rank.getPercent(), Matchers.equalTo(0d));
                 rank = rankIterator.next();
                 assertEquals(0.5, rank.getValue(), 0d);
                 assertThat(rank.getPercent(), Matchers.greaterThan(0d));
                 assertThat(rank.getPercent(), Matchers.lessThan(100d));
                 rank = rankIterator.next();
                 assertEquals(12, rank.getValue(), 0d);
-                // TODO: Fix T-Digest: this assertion should pass but we currently get ~59
-                // https://github.com/elastic/elasticsearch/issues/14851
-                // assertThat(rank.getPercent(), Matchers.equalTo(100d));
+                assertThat(rank.getPercent(), Matchers.equalTo(100d));
                 assertFalse(rankIterator.hasNext());
-                assertTrue(AggregationInspectionHelper.hasValue(((InternalTDigestPercentileRanks)ranks)));
+                assertTrue(AggregationInspectionHelper.hasValue((InternalHDRPercentileRanks)ranks));
             }
         }
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HDRPreAggregatedPercentilesAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HDRPreAggregatedPercentilesAggregatorTests.java
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.analytics.mapper;
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
 import org.HdrHistogram.DoubleHistogram;
 import org.HdrHistogram.DoubleHistogramIterationValue;
@@ -33,6 +33,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSourceType;
+import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -128,14 +129,16 @@ public class HistoBackedAvgAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
-        return List.of(new AnalyticsPlugin());
+        return org.elasticsearch.common.collect.List.of(new AnalyticsPlugin(Settings.EMPTY));
     }
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
         // Note: this is the same list as Core, plus Analytics
-        return List.of(
+        return org.elasticsearch.common.collect.List.of(
             CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN,
             AnalyticsValuesSourceType.HISTOGRAM
         );
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
@@ -17,13 +17,12 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.metrics.InternalSum;
-import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalAvg;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -40,18 +39,18 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 
-public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
+public class HistoBackedAvgAggregatorTests extends AggregatorTestCase {
 
     private static final String FIELD_NAME = "field";
 
     public void testNoDocs() throws IOException {
         testCase(new MatchAllDocsQuery(), iw -> {
             // Intentionally not writing any docs
-        }, sum -> {
-            assertEquals(0L, sum.getValue(), 0d);
-            assertFalse(AggregationInspectionHelper.hasValue(sum));
+        }, avg -> {
+            assertEquals(Double.NaN, avg.getValue(), 0d);
+            assertFalse(AggregationInspectionHelper.hasValue(avg));
         });
     }
 
@@ -59,9 +58,9 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
         testCase(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(getDocValue("wrong_field", new double[] {3, 1.2, 10})));
             iw.addDocument(singleton(getDocValue("wrong_field", new double[] {5.3, 6, 20})));
-        }, sum -> {
-            assertEquals(0L, sum.getValue(), 0d);
-            assertFalse(AggregationInspectionHelper.hasValue(sum));
+        }, avg -> {
+            assertEquals(Double.NaN, avg.getValue(), 0d);
+            assertFalse(AggregationInspectionHelper.hasValue(avg));
         });
     }
 
@@ -70,9 +69,9 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(getDocValue(FIELD_NAME, new double[] {3, 1.2, 10})));
             iw.addDocument(singleton(getDocValue(FIELD_NAME, new double[] {5.3, 6, 6, 20})));
             iw.addDocument(singleton(getDocValue(FIELD_NAME, new double[] {-10, 0.01, 1, 90})));
-        }, sum -> {
-            assertEquals(132.51d, sum.getValue(), 0.01d);
-            assertTrue(AggregationInspectionHelper.hasValue(sum));
+        }, avg -> {
+            assertEquals(12.0463d, avg.getValue(), 0.01d);
+            assertTrue(AggregationInspectionHelper.hasValue(avg));
         });
     }
 
@@ -98,16 +97,16 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
                 new StringField("match", "yes", Field.Store.NO),
                 getDocValue(FIELD_NAME, new double[] {-10, 0.01, 1, 90}))
             );
-        }, sum -> {
-            assertEquals(126.51d, sum.getValue(), 0.01d);
-            assertTrue(AggregationInspectionHelper.hasValue(sum));
+        }, avg -> {
+            assertEquals(12.651d, avg.getValue(), 0.01d);
+            assertTrue(AggregationInspectionHelper.hasValue(avg));
         });
     }
 
     private void testCase(Query query,
                           CheckedConsumer<RandomIndexWriter, IOException> indexer,
-                          Consumer<InternalSum> verify) throws IOException {
-        testCase(sum("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType(FIELD_NAME));
+                          Consumer<InternalAvg> verify) throws IOException {
+        testCase(avg("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType(FIELD_NAME));
     }
 
     private BinaryDocValuesField getDocValue(String fieldName, double[] values) throws IOException {
@@ -129,13 +128,13 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
-        return Arrays.asList(new AnalyticsPlugin(Settings.EMPTY));
+        return List.of(new AnalyticsPlugin());
     }
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
         // Note: this is the same list as Core, plus Analytics
-        return Arrays.asList(
+        return List.of(
             CoreValuesSourceType.NUMERIC,
             AnalyticsValuesSourceType.HISTOGRAM
         );
@@ -143,7 +142,7 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
-        return new SumAggregationBuilder("_name").field(fieldName);
+        return new AvgAggregationBuilder("_name").field(fieldName);
     }
 
     private MappedFieldType defaultFieldType(String fieldName) {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
@@ -129,14 +129,16 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
-        return Arrays.asList(new AnalyticsPlugin(Settings.EMPTY));
+        return org.elasticsearch.common.collect.List.of(new AnalyticsPlugin(Settings.EMPTY));
     }
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
         // Note: this is the same list as Core, plus Analytics
-        return Arrays.asList(
+        return org.elasticsearch.common.collect.List.of(
             CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN,
             AnalyticsValuesSourceType.HISTOGRAM
         );
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
@@ -17,6 +17,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -129,15 +130,18 @@ public class HistoBackedValueCountAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
-        return List.of(new AnalyticsPlugin());
+        return org.elasticsearch.common.collect.List.of(new AnalyticsPlugin(Settings.EMPTY));
     }
 
     @Override
     protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
         // Note: this is the same list as Core, plus Analytics
-        return List.of(
+        return org.elasticsearch.common.collect.List.of(
             CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN,
             CoreValuesSourceType.BYTES,
+            CoreValuesSourceType.IP,
             CoreValuesSourceType.GEOPOINT,
             CoreValuesSourceType.RANGE,
             AnalyticsValuesSourceType.HISTOGRAM

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistogramPercentileAggregationTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistogramPercentileAggregationTests.java
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.analytics.mapper;
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
 
 import com.tdunning.math.stats.Centroid;

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/TDigestPreAggregatedPercentileRanksAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/TDigestPreAggregatedPercentileRanksAggregatorTests.java
@@ -3,10 +3,10 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.analytics.mapper;
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
-import org.HdrHistogram.DoubleHistogram;
-import org.HdrHistogram.DoubleHistogramIterationValue;
+import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.TDigest;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
@@ -20,25 +20,29 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.metrics.InternalHDRPercentileRanks;
+import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.PercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.PercentileRanksAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
 import org.elasticsearch.search.aggregations.metrics.PercentilesMethod;
+import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSourceType;
+import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-public class HDRPreAggregatedPercentileRanksAggregatorTests extends AggregatorTestCase {
+
+public class TDigestPreAggregatedPercentileRanksAggregatorTests extends AggregatorTestCase {
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {
@@ -47,9 +51,9 @@ public class HDRPreAggregatedPercentileRanksAggregatorTests extends AggregatorTe
 
     @Override
     protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
-        return new PercentileRanksAggregationBuilder("hdr_percentiles", new double[]{1.0})
+        return new PercentileRanksAggregationBuilder("tdigest_percentiles", new double[]{1.0})
             .field(fieldName)
-            .percentilesConfig(new PercentilesConfig.Hdr());
+            .percentilesConfig(new PercentilesConfig.TDigest());
     }
 
     @Override
@@ -62,19 +66,18 @@ public class HDRPreAggregatedPercentileRanksAggregatorTests extends AggregatorTe
     }
 
     private BinaryDocValuesField getDocValue(String fieldName, double[] values) throws IOException {
-        DoubleHistogram histogram = new DoubleHistogram(3);//default
+        TDigest histogram = new TDigestState(100.0); //default
         for (double value : values) {
-            histogram.recordValue(value);
+            histogram.add(value);
         }
         BytesStreamOutput streamOutput = new BytesStreamOutput();
-        DoubleHistogram.RecordedValues recordedValues = histogram.recordedValues();
-        Iterator<DoubleHistogramIterationValue> iterator = recordedValues.iterator();
-        while (iterator.hasNext()) {
-            DoubleHistogramIterationValue value = iterator.next();
-            long count = value.getCountAtValueIteratedTo();
-            streamOutput.writeVInt(Math.toIntExact(count));
-            double d = value.getValueIteratedTo();
-            streamOutput.writeDouble(d);
+        histogram.compress();
+        Collection<Centroid> centroids = histogram.centroids();
+        Iterator<Centroid> iterator = centroids.iterator();
+        while ( iterator.hasNext()) {
+            Centroid centroid = iterator.next();
+            streamOutput.writeVInt(centroid.count());
+            streamOutput.writeDouble(centroid.mean());
         }
         return new BinaryDocValuesField(fieldName, streamOutput.bytes().toBytesRef());
     }
@@ -86,27 +89,31 @@ public class HDRPreAggregatedPercentileRanksAggregatorTests extends AggregatorTe
             doc.add(getDocValue("field", new double[] {3, 0.2, 10}));
             w.addDocument(doc);
 
-            PercentileRanksAggregationBuilder aggBuilder = new PercentileRanksAggregationBuilder("my_agg", new double[]{0.1, 0.5, 12})
+            PercentileRanksAggregationBuilder aggBuilder = new PercentileRanksAggregationBuilder("my_agg", new double[] {0.1, 0.5, 12})
                     .field("field")
-                    .method(PercentilesMethod.HDR);
-            MappedFieldType fieldType = new HistogramFieldMapper.Builder("field").fieldType();
+                    .method(PercentilesMethod.TDIGEST);
+            MappedFieldType fieldType = new HistogramFieldMapper.Builder("number").fieldType();
             fieldType.setName("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                PercentileRanks ranks = searchAndReduce(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
+                PercentileRanks ranks = search(searcher, new MatchAllDocsQuery(), aggBuilder, fieldType);
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
                 assertEquals(0.1, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.equalTo(0d));
+                // TODO: Fix T-Digest: this assertion should pass but we currently get ~15
+                // https://github.com/elastic/elasticsearch/issues/14851
+                // assertThat(rank.getPercent(), Matchers.equalTo(0d));
                 rank = rankIterator.next();
                 assertEquals(0.5, rank.getValue(), 0d);
                 assertThat(rank.getPercent(), Matchers.greaterThan(0d));
                 assertThat(rank.getPercent(), Matchers.lessThan(100d));
                 rank = rankIterator.next();
                 assertEquals(12, rank.getValue(), 0d);
-                assertThat(rank.getPercent(), Matchers.equalTo(100d));
+                // TODO: Fix T-Digest: this assertion should pass but we currently get ~59
+                // https://github.com/elastic/elasticsearch/issues/14851
+                // assertThat(rank.getPercent(), Matchers.equalTo(100d));
                 assertFalse(rankIterator.hasNext());
-                assertTrue(AggregationInspectionHelper.hasValue((InternalHDRPercentileRanks)ranks));
+                assertTrue(AggregationInspectionHelper.hasValue(((InternalTDigestPercentileRanks)ranks)));
             }
         }
     }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/TDigestPreAggregatedPercentilesAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/TDigestPreAggregatedPercentilesAggregatorTests.java
@@ -3,7 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-package org.elasticsearch.xpack.analytics.mapper;
+package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
 import com.tdunning.math.stats.Centroid;
 import com.tdunning.math.stats.TDigest;
@@ -34,6 +34,7 @@ import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSourceType;
+import org.elasticsearch.xpack.analytics.mapper.HistogramFieldMapper;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/analytics/histogram.yml
@@ -19,10 +19,10 @@ setup:
           - '{"index": {}}'
           - '{"latency": {"values" : [0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 7, 23, 12, 6]}}'
           - '{"index": {}}'
-          - '{"latency": {"values" : [0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [2, 5, 10, 1, 8]}}'
+          - '{"latency": {"values" : [0, 0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 2, 5, 10, 1, 8]}}'
 
 ---
-"Histogram Sum Aggregation":
+"Histogram Aggregations":
 
   - do:
       search:
@@ -33,8 +33,17 @@ setup:
             histo_sum:
               sum:
                 field: "latency"
+            histo_value_count:
+              value_count:
+                field: "latency"
+            histo_avg:
+              avg:
+                field: "latency"
 
   - match: { hits.total.value: 2 }
   - match: { aggregations.histo_sum.value: 25 }
+  - match: { aggregations.histo_value_count.value: 80 }
+  - match: { aggregations.histo_avg.value:  0.3125}
+
 
 


### PR DESCRIPTION
Backports #55933 to 7.x

> Implements value_count and avg aggregations over Histogram fields as discussed in #53285
> - value_count returns the sum of all counts array of the histograms
> - avg computes a weighted average of the values array of the histogram by multiplying each value with its associated element in the counts array
