### PR TITLE
[ML] Adjust DF Analytics process phases

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MachineLearningIT.java
@@ -1532,7 +1532,7 @@ public class MachineLearningIT extends ESRestHighLevelClientTestCase {
         assertThat(progress.size(), equalTo(4));
         assertThat(progress.get(0), equalTo(new PhaseProgress("reindexing", 0)));
         assertThat(progress.get(1), equalTo(new PhaseProgress("loading_data", 0)));
-        assertThat(progress.get(2), equalTo(new PhaseProgress("analyzing", 0)));
+        assertThat(progress.get(2), equalTo(new PhaseProgress("computing_outliers", 0)));
         assertThat(progress.get(3), equalTo(new PhaseProgress("writing_results", 0)));
         assertThat(stats.getMemoryUsage().getPeakUsageBytes(), equalTo(0L));
         assertThat(stats.getDataCounts(), equalTo(new DataCounts(0, 0, 0)));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PredictionFieldTyp
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -103,6 +104,15 @@ public class Classification implements DataFrameAnalysis {
      * This way the user can see if the prediction was made with confidence they need.
      */
     private static final int DEFAULT_NUM_TOP_CLASSES = 2;
+
+    private static final List<String> PROGRESS_PHASES = Collections.unmodifiableList(
+        Arrays.asList(
+            "feature_selection",
+            "coarse_parameter_search",
+            "fine_tuning_parameters",
+            "final_training"
+        )
+    );
 
     private final String dependentVariable;
     private final BoostedTreeParams boostedTreeParams;
@@ -348,7 +358,7 @@ public class Classification implements DataFrameAnalysis {
 
     @Override
     public List<String> getProgressPhases() {
-        return Collections.singletonList("analyzing");
+        return PROGRESS_PHASES;
     }
 
     public static String extractJobIdFromStateDoc(String stateDocId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -58,6 +58,8 @@ public class OutlierDetection implements DataFrameAnalysis {
         return ignoreUnknownFields ? LENIENT_PARSER.apply(parser, null).build() : STRICT_PARSER.apply(parser, null).build();
     }
 
+    private static final List<String> PROGRESS_PHASES = Collections.singletonList("computing_outliers");
+
     /**
      * The number of neighbors. Leave unspecified for dynamic detection.
      */
@@ -251,7 +253,7 @@ public class OutlierDetection implements DataFrameAnalysis {
 
     @Override
     public List<String> getProgressPhases() {
-        return Collections.singletonList("analyzing");
+        return PROGRESS_PHASES;
     }
 
     public enum Method {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +64,15 @@ public class Regression implements DataFrameAnalysis {
     public static Regression fromXContent(XContentParser parser, boolean ignoreUnknownFields) {
         return ignoreUnknownFields ? LENIENT_PARSER.apply(parser, null) : STRICT_PARSER.apply(parser, null);
     }
+
+    private static final List<String> PROGRESS_PHASES = Collections.unmodifiableList(
+        Arrays.asList(
+            "feature_selection",
+            "coarse_parameter_search",
+            "fine_tuning_parameters",
+            "final_training"
+        )
+    );
 
     private final String dependentVariable;
     private final BoostedTreeParams boostedTreeParams;
@@ -215,7 +225,7 @@ public class Regression implements DataFrameAnalysis {
 
     @Override
     public List<String> getProgressPhases() {
-        return Collections.singletonList("analyzing");
+        return PROGRESS_PHASES;
     }
 
     public static String extractJobIdFromStateDoc(String stateDocId) {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_cat_apis.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/data_frame_analytics_cat_apis.yml
@@ -81,6 +81,6 @@ setup:
   - match:
       $body: |
         /^  id                           \s+ t                 \s+ s       \s+ p                                                         \s+ source_index \s+ dest_index    \n
-           (dfa\-classification\-job     \s+ classification    \s+ stopped \s+ reindexing:0,loading_data:0,analyzing:0,writing_results:0 \s+ index-source \s+ index-dest-c  \n)+
-           (dfa\-outlier\-detection\-job \s+ outlier_detection \s+ stopped \s+ reindexing:0,loading_data:0,analyzing:0,writing_results:0 \s+ index-source \s+ index-dest-od \n)+
-           (dfa\-regression\-job         \s+ regression        \s+ stopped \s+ reindexing:0,loading_data:0,analyzing:0,writing_results:0 \s+ index-source \s+ index-dest-r  \n)+  $/
+           (dfa\-classification\-job     \s+ classification    \s+ stopped \s+ reindexing:0,loading_data:0,feature_selection:0,coarse_parameter_search:0,fine_tuning_parameters:0,final_training:0,writing_results:0 \s+ index-source \s+ index-dest-c  \n)+
+           (dfa\-outlier\-detection\-job \s+ outlier_detection \s+ stopped \s+ reindexing:0,loading_data:0,computing_outliers:0,writing_results:0 \s+ index-source \s+ index-dest-od \n)+
+           (dfa\-regression\-job         \s+ regression        \s+ stopped \s+ reindexing:0,loading_data:0,feature_selection:0,coarse_parameter_search:0,fine_tuning_parameters:0,final_training:0,writing_results:0 \s+ index-source \s+ index-dest-r  \n)+  $/


### PR DESCRIPTION
As of elastic/ml-cpp#1179, the analytics process reports phases
depending on the analysis type. This commit adjusts the phases
of current analyses from `analyzing` to the following:

 - outlier_detection: [`computing_outliers`]
 - regression/classification: [`feature_selection`, `coarse_parameter_search`, `fine_tuning_parameters`, `final_training`]
