### PR TITLE
[7.x] [ML] reduce InferenceProcessor.Factory log spam by not parsing pipelines (#56020)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -355,8 +355,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
 
         InferenceProcessor.Factory inferenceFactory = new InferenceProcessor.Factory(parameters.client,
             parameters.ingestService.getClusterService(),
-            this.settings,
-            parameters.ingestService);
+            this.settings);
         parameters.ingestService.addIngestClusterStateListener(inferenceFactory);
         return Collections.singletonMap(InferenceProcessor.TYPE, inferenceFactory);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -92,8 +92,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
             factoryMap.put(InferenceProcessor.TYPE,
                 new InferenceProcessor.Factory(parameters.client,
                     parameters.ingestService.getClusterService(),
-                    Settings.EMPTY,
-                    parameters.ingestService));
+                    Settings.EMPTY));
 
             factoryMap.put("not_inference", new NotInferenceProcessor.Factory());
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -28,11 +28,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.ingest.IngestMetadata;
-import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.PipelineConfiguration;
-import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
@@ -54,22 +51,9 @@ import static org.mockito.Mockito.when;
 
 public class InferenceProcessorFactoryTests extends ESTestCase {
 
-    private static final IngestPlugin SKINNY_PLUGIN = new IngestPlugin() {
-        @Override
-        public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
-            XPackLicenseState licenseState = mock(XPackLicenseState.class);
-            when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
-            return Collections.singletonMap(InferenceProcessor.TYPE,
-                new InferenceProcessor.Factory(parameters.client,
-                    parameters.ingestService.getClusterService(),
-                    Settings.EMPTY,
-                    parameters.ingestService));
-        }
-    };
     private Client client;
     private XPackLicenseState licenseState;
     private ClusterService clusterService;
-    private IngestService ingestService;
 
     @Before
     public void setUpVariables() {
@@ -86,8 +70,6 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
                 AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
                 ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING)));
         clusterService = new ClusterService(settings, clusterSettings, tp);
-        ingestService = new IngestService(clusterService, tp, null, null,
-            null, Collections.singletonList(SKINNY_PLUGIN), client);
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
     }
@@ -97,8 +79,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
 
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,
-            Settings.EMPTY,
-            ingestService);
+            Settings.EMPTY);
         processorFactory.accept(buildClusterState(metadata));
 
         assertThat(processorFactory.numInferenceProcessors(), equalTo(0));
@@ -111,11 +92,61 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
         assertThat(processorFactory.numInferenceProcessors(), equalTo(3));
     }
 
+    public void testNumInferenceProcessorsRecursivelyDefined() throws Exception {
+        Metadata metadata = null;
+
+        InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
+            clusterService,
+            Settings.EMPTY);
+        processorFactory.accept(buildClusterState(metadata));
+
+        Map<String, PipelineConfiguration> configurations = new HashMap<>();
+        configurations.put("pipeline_with_model_top_level",
+            randomBoolean() ?
+                newConfigurationWithInferenceProcessor("top_level") :
+                newConfigurationWithForeachProcessorProcessor("top_level"));
+        try(XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(Collections.singletonMap("processors",
+            Collections.singletonList(
+                Collections.singletonMap("set",
+                    new HashMap<String, Object>() {{
+                        put("field", "foo");
+                        put("value", "bar");
+                        put("on_failure",
+                            Arrays.asList(
+                                inferenceProcessorForModel("second_level"),
+                                forEachProcessorWithInference("third_level")));
+                    }}))))) {
+            configurations.put("pipeline_with_model_nested",
+                new PipelineConfiguration("pipeline_with_model_nested", BytesReference.bytes(xContentBuilder), XContentType.JSON));
+        }
+
+        IngestMetadata ingestMetadata = new IngestMetadata(configurations);
+
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata))
+            .nodes(DiscoveryNodes.builder()
+                .add(new DiscoveryNode("min_node",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                    Version.CURRENT))
+                .add(new DiscoveryNode("current_node",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9302),
+                    Version.CURRENT))
+                .localNodeId("_node_id")
+                .masterNodeId("_node_id"))
+            .build();
+
+        processorFactory.accept(cs);
+        assertThat(processorFactory.numInferenceProcessors(), equalTo(3));
+    }
+
+    public void testNumInferenceWhenLevelExceedsMaxRecurions() {
+        assertThat(InferenceProcessor.Factory.numInferenceProcessors(InferenceProcessor.TYPE, Collections.emptyMap(), 100), equalTo(0));
+    }
+
     public void testCreateProcessorWithTooManyExisting() throws Exception {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,
-            Settings.builder().put(InferenceProcessor.MAX_INFERENCE_PROCESSORS.getKey(), 1).build(),
-            ingestService);
+            Settings.builder().put(InferenceProcessor.MAX_INFERENCE_PROCESSORS.getKey(), 1).build());
 
         processorFactory.accept(buildClusterStateWithModelReferences("model1"));
 
@@ -129,8 +160,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     public void testCreateProcessorWithInvalidInferenceConfig() {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,
-            Settings.EMPTY,
-            ingestService);
+            Settings.EMPTY);
 
         Map<String, Object> config = new HashMap<String, Object>() {{
             put(InferenceProcessor.FIELD_MAP, Collections.emptyMap());
@@ -170,8 +200,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     public void testCreateProcessorWithTooOldMinNodeVersion() throws IOException {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,
-            Settings.EMPTY,
-            ingestService);
+            Settings.EMPTY);
         processorFactory.accept(builderClusterStateWithModelReferences(Version.V_7_5_0, "model1"));
 
         Map<String, Object> regression = new HashMap<String, Object>() {{
@@ -214,8 +243,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     public void testCreateProcessor() {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,
-            Settings.EMPTY,
-            ingestService);
+            Settings.EMPTY);
 
         Map<String, Object> regression = new HashMap<String, Object>() {{
             put(InferenceProcessor.FIELD_MAP, Collections.emptyMap());
@@ -249,8 +277,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     public void testCreateProcessorWithDuplicateFields() {
         InferenceProcessor.Factory processorFactory = new InferenceProcessor.Factory(client,
             clusterService,
-            Settings.EMPTY,
-            ingestService);
+            Settings.EMPTY);
 
         Map<String, Object> regression = new HashMap<String, Object>() {{
             put(InferenceProcessor.FIELD_MAP, Collections.emptyMap());
@@ -280,7 +307,8 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     private static ClusterState builderClusterStateWithModelReferences(Version minNodeVersion, String... modelId) throws IOException {
         Map<String, PipelineConfiguration> configurations = new HashMap<>(modelId.length);
         for (String id : modelId) {
-            configurations.put("pipeline_with_model_" + id, newConfigurationWithInferenceProcessor(id));
+            configurations.put("pipeline_with_model_" + id,
+                randomBoolean() ? newConfigurationWithInferenceProcessor(id) : newConfigurationWithForeachProcessorProcessor(id));
         }
         IngestMetadata ingestMetadata = new IngestMetadata(configurations);
 
@@ -300,17 +328,35 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
 
     private static PipelineConfiguration newConfigurationWithInferenceProcessor(String modelId) throws IOException {
         try(XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(Collections.singletonMap("processors",
-            Collections.singletonList(
-                Collections.singletonMap(InferenceProcessor.TYPE,
-                    new HashMap<String, Object>() {{
-                        put(InferenceProcessor.MODEL_ID, modelId);
-                        put(InferenceProcessor.INFERENCE_CONFIG,
-                                Collections.singletonMap(RegressionConfig.NAME.getPreferredName(), Collections.emptyMap()));
-                        put(InferenceProcessor.TARGET_FIELD, "new_field");
-                        put(InferenceProcessor.FIELD_MAP, Collections.singletonMap("source", "dest"));
-                    }}))))) {
+            Collections.singletonList(inferenceProcessorForModel(modelId))))) {
             return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
         }
+    }
+
+    private static PipelineConfiguration newConfigurationWithForeachProcessorProcessor(String modelId) throws IOException {
+        try(XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(Collections.singletonMap("processors",
+            Collections.singletonList(forEachProcessorWithInference(modelId))))) {
+            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+        }
+    }
+
+    private static Map<String, Object> forEachProcessorWithInference(String modelId) {
+        return Collections.singletonMap("foreach",
+            new HashMap<String, Object>() {{
+                put("field", "foo");
+                put("processor", inferenceProcessorForModel(modelId));
+            }});
+    }
+
+    private static Map<String, Object> inferenceProcessorForModel(String modelId) {
+        return Collections.singletonMap(InferenceProcessor.TYPE,
+            new HashMap<String, Object>() {{
+                put(InferenceProcessor.MODEL_ID, modelId);
+                put(InferenceProcessor.INFERENCE_CONFIG,
+                    Collections.singletonMap(RegressionConfig.NAME.getPreferredName(), Collections.emptyMap()));
+                put(InferenceProcessor.TARGET_FIELD, "new_field");
+                put(InferenceProcessor.FIELD_MAP, Collections.singletonMap("source", "dest"));
+            }});
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] reduce InferenceProcessor.Factory log spam by not parsing pipelines (#56020)