### PR TITLE
[DOCS] EQL: Document nested field support

### DIFF
--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -9,6 +9,14 @@
 experimental::[]
 
 [discrete]
+[[eql-nested-fields]]
+=== EQL search on nested fields is not supported
+
+You cannot use EQL to search the values of a <<nested,`nested`>> field or the
+sub-fields of a `nested` field. However, indices containing `nested` field
+mappings are otherwise supported.
+
+[discrete]
 [[eql-unsupported-syntax]]
 === Unsupported syntax
 

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -10,7 +10,6 @@ experimental::[]
 
 EQL is schema-less and works well with most common log formats.
 
-
 [TIP]
 ====
 While no schema is required to use EQL in {es}, we recommend the
@@ -34,3 +33,10 @@ A field containing the event classification, such as `process`, `file`, or
 Timestamp::
 A field containing the date and/or time the event occurred. This is typically
 mapped as a <<date,`date`>> field.
+
+[NOTE]
+====
+You cannot use EQL to search the values of a <<nested,`nested`>> field or the
+sub-fields of a `nested` field. However, indices containing `nested` field
+mappings are otherwise supported.
+====

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -36,7 +36,7 @@ mapped as a <<date,`date`>> field.
 
 [NOTE]
 ====
-You cannot use EQL to search the values of a <<nested,`nested`>> field or the
-sub-fields of a `nested` field. However, indices containing `nested` field
-mappings are otherwise supported.
+You cannot use a <<nested,`nested`>> field datatype or the sub-fields of a
+`nested` field dataype as the timestamp or event category field. See
+<<eql-nested-fields>>.
 ====


### PR DESCRIPTION
Notes that you cannot use EQL in ES to search the values of `nested`
fields or their sub-fields. However, indices containing `nested` field
mappings are otherwise supported.

Relates to #55721