### PR TITLE
[7.x][ML] Fix race condition updating reindexing progress (#56135)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -338,7 +338,7 @@ public class DataFrameAnalyticsManager {
         ActionListener<RefreshResponse> refreshListener = ActionListener.wrap(
             refreshResponse -> {
                 // Now we can ensure reindexing progress is complete
-                task.getStatsHolder().getProgressTracker().updateReindexingProgress(100);
+                task.setReindexingFinished();
 
                 // TODO This could fail with errors. In that case we get stuck with the copied index.
                 // We could delete the index in case of failure or we could try building the factory before reindexing


### PR DESCRIPTION
In #55763 I thought I could remove the flag that marks
reindexing was finished on a data frame analytics task.
However, that exposed a race condition. It is possible that
between updating reindexing progress to 100 because we
have called `DataFrameAnalyticsManager.startAnalytics()` and
a call to the _stats API which updates reindexing progress via the
method `DataFrameAnalyticsTask.updateReindexTaskProgress()` we
end up overwriting the 100 with a lower progress value.

This commit fixes this issue by bringing back the help of
a `isReindexingFinished` flag as it was prior to #55763.

Closes #56128

Backport of #56135
