### PR TITLE
Add dummy file for new client example snippets location

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/client/documentation/placeholder.txt
+++ b/server/src/internalClusterTest/java/org/elasticsearch/client/documentation/placeholder.txt
@@ -1,0 +1,1 @@
+This file exists to ensure the containing directory exists, and will be removed after migration of the path containing these documentation examples is complete.


### PR DESCRIPTION
This file is added simply to ensure the new directory exists, so it can
be added to the docs configuration.