### PR TITLE
Fix validate query listener invocation bug

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -88,6 +88,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
             if (ex instanceof IndexNotFoundException ||
                 ex instanceof IndexClosedException) {
                 listener.onFailure(ex);
+                return;
             }
             List<QueryExplanation> explanations = new ArrayList<>();
             explanations.add(new QueryExplanation(null,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryActionTests.java
@@ -20,11 +20,9 @@
 package org.elasticsearch.action.admin.indices.validate.query;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryActionTests.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.validate.query;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.NotifyOnceListener;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransportValidateQueryActionTests extends ESSingleNodeTestCase {
+
+    /*
+     * This test covers a fallthrough bug that we had, where if the index we were validating against did not exist, we would invoke the
+     * failure listener, and then fallthrough and invoke the success listener too. This would cause problems when the listener was
+     * ultimately wrapping sending a response on the channel, as it could lead to us sending both a failure or success responses, and having
+     * them garbled together, or trying to write one after the channel had closed, etc.
+     */
+    public void testListenerOnlyInvokedOnceWhenIndexDoesNotExist() {
+        final ValidateQueryRequest request = new ValidateQueryRequest("non-existent-index");
+
+        final AtomicBoolean invoked = new AtomicBoolean();
+
+        final ActionListener<ValidateQueryResponse> listener = new ActionListener<>() {
+
+            @Override
+            public void onResponse(final ValidateQueryResponse validateQueryResponse) {
+                fail("onResponse should not be invoked in this failure case");
+            }
+
+            @Override
+            public void onFailure(final Exception e) {
+                if (invoked.compareAndSet(false, true) == false) {
+                    fail("onFailure invoked more than once");
+                }
+            }
+
+        };
+        client().admin().indices().validateQuery(request, listener);
+        assertThat(invoked.get(), equalTo(true)); // ensure that onFailure was invoked
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryActionTests.java
@@ -35,10 +35,7 @@ public class TransportValidateQueryActionTests extends ESSingleNodeTestCase {
      * them garbled together, or trying to write one after the channel had closed, etc.
      */
     public void testListenerOnlyInvokedOnceWhenIndexDoesNotExist() {
-        final ValidateQueryRequest request = new ValidateQueryRequest("non-existent-index");
-
         final AtomicBoolean invoked = new AtomicBoolean();
-
         final ActionListener<ValidateQueryResponse> listener = new ActionListener<>() {
 
             @Override
@@ -54,7 +51,7 @@ public class TransportValidateQueryActionTests extends ESSingleNodeTestCase {
             }
 
         };
-        client().admin().indices().validateQuery(request, listener);
+        client().admin().indices().validateQuery(new ValidateQueryRequest("non-existent-index"), listener);
         assertThat(invoked.get(), equalTo(true)); // ensure that onFailure was invoked
     }
 


### PR DESCRIPTION
When the index we are validating a query does not exist, we try to send back a response letting the client know that the index does not exist. Yet, we accidentally fallthrough into the case that the validation failed for some other reason. This means that we end up notifying the channel twice. Sometimes the notification occurs after the failure has been written out and the channel closed (so the second invocation leads to a silent failed to write to a closed channel issue), and sometimes the response does end up in the channel, creating garbled responses to the client. This commit fixes that issue by avoiding the fallthrough.

