### PR TITLE
Add Minio tests for searchable snapshots (#56112)

### DIFF
--- a/test/fixtures/minio-fixture/docker-compose.yml
+++ b/test/fixtures/minio-fixture/docker-compose.yml
@@ -11,7 +11,17 @@ services:
     ports:
       - "9000"
     command: ["server", "/minio/data"]
-
+  minio-fixture-other:
+    build:
+      context: .
+      args:
+        bucket: "bucket"
+        accessKey: "access_key"
+        secretKey: "secret_key"
+      dockerfile: Dockerfile
+    ports:
+      - "9000"
+    command: ["server", "/minio/data"]
   minio-fixture-for-snapshot-tool:
       build:
         context: .

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -1,0 +1,52 @@
+import org.elasticsearch.gradle.info.BuildParams
+import static org.elasticsearch.gradle.PropertyNormalization.IGNORE_VALUE
+
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.test.fixtures'
+
+final Project fixture = project(':test:fixtures:minio-fixture')
+final Project repositoryPlugin = project(':plugins:repository-s3')
+
+dependencies {
+  testCompile project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
+  testCompile repositoryPlugin
+}
+
+restResources {
+  restApi {
+    includeCore 'indices', 'search', 'bulk', 'snapshot', 'nodes', '_common'
+    includeXpack 'searchable_snapshots'
+  }
+}
+
+testFixtures.useFixture(fixture.path, 'minio-fixture-other')
+def fixtureAddress = {
+  int ephemeralPort =  fixture.postProcessFixture.ext."test.fixtures.minio-fixture-other.tcp.9000"
+  assert ephemeralPort > 0
+  '127.0.0.1:' + ephemeralPort
+}
+
+integTest {
+  dependsOn repositoryPlugin.bundlePlugin
+  runner {
+    systemProperty 'test.minio.bucket', 'bucket'
+    systemProperty 'test.minio.base_path', 'searchable_snapshots_tests'
+  }
+}
+
+testClusters.integTest {
+  testDistribution = 'DEFAULT'
+  plugin repositoryPlugin.bundlePlugin.archiveFile
+
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
+  }
+
+  keystore 's3.client.searchable_snapshots.access_key', 'access_key'
+  keystore 's3.client.searchable_snapshots.secret_key', 'secret_key'
+  setting 'xpack.license.self_generated.type', 'trial'
+  setting 's3.client.searchable_snapshots.protocol', 'http'
+  setting 's3.client.searchable_snapshots.endpoint', { "${-> fixtureAddress()}" }, IGNORE_VALUE
+}
+

--- a/x-pack/plugin/searchable-snapshots/qa/minio/src/test/java/org/elasticsearch/xpack/searchablesnapshots/minio/MinioSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/src/test/java/org/elasticsearch/xpack/searchablesnapshots/minio/MinioSearchableSnapshotsIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.searchablesnapshots.minio;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.searchablesnapshots.AbstractSearchableSnapshotsRestTestCase;
+
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.not;
+
+public class MinioSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTestCase {
+
+    @Override
+    protected String repositoryType() {
+        return "s3";
+    }
+
+    @Override
+    protected Settings repositorySettings() {
+        final String bucket = System.getProperty("test.minio.bucket");
+        assertThat(bucket, not(blankOrNullString()));
+
+        final String basePath = System.getProperty("test.minio.base_path");
+        assertThat(basePath, not(blankOrNullString()));
+
+        return Settings.builder().put("client", "searchable_snapshots").put("bucket", bucket).put("base_path", basePath).build();
+    }
+}


### PR DESCRIPTION
This commit adds QA tests for searchable snapshot on MinIO,
similarly to what already exist for S3, GCS and Azure.

Backport of #56112 on 7.x
