### PR TITLE
Searchable Snapshots should respect max_restore_bytes_per_sec (#55952)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/support/FilterBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/support/FilterBlobContainer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.blobstore.support;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetadata;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.DeleteResult;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public abstract class FilterBlobContainer implements BlobContainer {
+
+    private final BlobContainer delegate;
+
+    public FilterBlobContainer(BlobContainer delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    protected abstract BlobContainer wrapChild(BlobContainer child);
+
+    @Override
+    public BlobPath path() {
+        return delegate.path();
+    }
+
+    @Override
+    public InputStream readBlob(String blobName) throws IOException {
+        return delegate.readBlob(blobName);
+    }
+
+    @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        return delegate.readBlob(blobName, position, length);
+    }
+
+    @Override
+    public long readBlobPreferredLength() {
+        return delegate.readBlobPreferredLength();
+    }
+
+    @Override
+    public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
+        delegate.writeBlob(blobName, inputStream, blobSize, failIfAlreadyExists);
+    }
+
+    @Override
+    public void writeBlobAtomic(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
+        delegate.writeBlobAtomic(blobName, inputStream, blobSize, failIfAlreadyExists);
+    }
+
+    @Override
+    public DeleteResult delete() throws IOException {
+        return delegate.delete();
+    }
+
+    @Override
+    public void deleteBlobsIgnoringIfNotExists(List<String> blobNames) throws IOException {
+        delegate.deleteBlobsIgnoringIfNotExists(blobNames);
+    }
+
+    @Override
+    public Map<String, BlobMetadata> listBlobs() throws IOException {
+        return delegate.listBlobs();
+    }
+
+    @Override
+    public Map<String, BlobContainer> children() throws IOException {
+        return delegate.children().entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> wrapChild(e.getValue())));
+    }
+
+
+    @Override
+    public Map<String, BlobMetadata> listBlobsByPrefix(String blobNamePrefix) throws IOException {
+        return delegate.listBlobsByPrefix(blobNamePrefix);
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -327,7 +327,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             true,
             false,
             IntStream.range(0, nbDocs)
-                .mapToObj(i -> client().prepareIndex(indexName).setSource("foo", randomBoolean() ? "bar" : "baz"))
+                .mapToObj(i -> client().prepareIndex(indexName, "_doc").setSource("foo", randomBoolean() ? "bar" : "baz"))
                 .collect(Collectors.toList())
         );
         refresh(indexName);


### PR DESCRIPTION
This commit changes searchable snapshots so that it now respects the 
repository's max_restore_bytes_per_sec setting when it downloads blobs.

Backport of #55952 for 7.x