### PR TITLE
Enable prewarming by default for searchable snapshots

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -105,7 +105,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     );
     public static final Setting<Boolean> SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING = Setting.boolSetting(
         "index.store.snapshot.cache.prewarm.enabled",
-        false,
+        true,
         Setting.Property.IndexScope
     );
     // The file extensions that are excluded from the cache

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/SearchableSnapshotDirectoryStatsTests.java
@@ -36,6 +36,7 @@ import static org.elasticsearch.index.store.cache.TestUtils.assertCounter;
 import static org.elasticsearch.index.store.cache.TestUtils.createCacheService;
 import static org.elasticsearch.index.store.cache.TestUtils.singleBlobContainer;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING;
+import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -519,7 +520,10 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
     private static void executeTestCase(final TriConsumer<String, byte[], SearchableSnapshotDirectory> test) {
         executeTestCase(
             createCacheService(random()),
-            Settings.builder().put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), randomBoolean()).build(),
+            Settings.builder()
+                .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), randomBoolean())
+                .put(SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false) // disable prewarming as it impacts the stats
+                .build(),
             test
         );
     }
@@ -553,7 +557,10 @@ public class SearchableSnapshotDirectoryStatsTests extends ESIndexInputTestCase 
     ) {
         executeTestCase(
             new CacheService(cacheSize, cacheRangeSize),
-            Settings.builder().put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true).build(),
+            Settings.builder()
+                .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
+                .put(SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false) // disable prewarming as it impacts the stats
+                .build(),
             test
         );
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -157,7 +157,7 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
             );
 
             final BlobContainer blobContainer = singleBlobContainer(blobName, input);
-
+            final ThreadPool threadPool = new TestThreadPool(getTestName(), SearchableSnapshots.executorBuilder());
             final Path cacheDir = createTempDir();
             try (
                 SearchableSnapshotDirectory searchableSnapshotDirectory = new SearchableSnapshotDirectory(
@@ -170,7 +170,7 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                     () -> 0L,
                     cacheService,
                     cacheDir,
-                    null
+                    threadPool
                 )
             ) {
                 final boolean loaded = searchableSnapshotDirectory.loadSnapshot();
@@ -185,6 +185,8 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                         throw new AssertionError("inner EOFException not thrown", exception);
                     }
                 }
+            }finally {
+                terminate(threadPool);
             }
         }
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInputTests.java
@@ -185,7 +185,7 @@ public class CachedBlobContainerIndexInputTests extends ESIndexInputTestCase {
                         throw new AssertionError("inner EOFException not thrown", exception);
                     }
                 }
-            }finally {
+            } finally {
                 terminate(threadPool);
             }
         }


### PR DESCRIPTION
Now searchable snapshots directories respect the repository rate limitations (#55952) we can enable prewarming by default for shards.