### PR TITLE
fix get policy API example

### DIFF
--- a/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/get-enrich-policy.asciidoc
@@ -54,7 +54,7 @@ GET /_enrich/policy/my-policy
 
 `GET /_enrich/policy`
 
-`GET /_enrich/policy1,policy2`
+`GET /_enrich/policy/policy1,policy2`
 
 
 [[get-enrich-policy-api-prereqs]]


### PR DESCRIPTION
Enrich API doc has a wrong example for getting an enrich policy