### PR TITLE
Remove deprecated basic license feature enablement settings from 8.0

### DIFF
--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -67,10 +67,10 @@ In Elasticsearch 8.0.0, the setting `xpack.monitoring.exporters.<exporterName>.a
 removed.
 
 [float]
-==== Option to disable basic license features is deprecated
+==== Option to disable basic license features is removed.
 
-In Elasticsearch 7.8.0, the following settings no longer have any effect, and
-have been deprecated:
+The following settings were deprecated in {es} 7.8.0 and have been removed
+in {es} 8.0.0:
 
 * `xpack.enrich.enabled`
 * `xpack.flattened.enabled`
@@ -82,9 +82,7 @@ have been deprecated:
 * `xpack.transform.enabled`
 * `xpack.vectors.enabled`
 
-Previously, these settings could be set to `false` in order to disable the
-feature's APIs in a cluster. As of 7.8.0, these basic license features are
-always enabled for the {default-dist}.
+These basic license features are now always enabled for the {default-dist}.
 
 If you have disabled ILM so that you can use another tool to manage Watcher
 indices, the newly introduced `xpack.watcher.use_ilm_index_management` setting

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -38,39 +38,12 @@ public class XPackSettings {
     }
 
     /**
-     * Setting for controlling whether or not enrich is enabled.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> ENRICH_ENABLED_SETTING = Setting.boolSetting("xpack.enrich.enabled", true,
-        Property.NodeScope, Property.Deprecated);
-
-    /**
      * Setting for controlling whether or not CCR is enabled.
      */
     public static final Setting<Boolean> CCR_ENABLED_SETTING = Setting.boolSetting("xpack.ccr.enabled", true, Property.NodeScope);
 
-    /**
-     * Setting for enabling or disabling data frame. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> TRANSFORM_ENABLED = Setting.boolSetting("xpack.transform.enabled", true,
-        Property.NodeScope, Property.Deprecated);
-
     /** Setting for enabling or disabling security. Defaults to true. */
     public static final Setting<Boolean> SECURITY_ENABLED = Setting.boolSetting("xpack.security.enabled", true, Setting.Property.NodeScope);
-
-    /**
-     * Setting for enabling or disabling monitoring.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> MONITORING_ENABLED = Setting.boolSetting("xpack.monitoring.enabled", true,
-        Property.NodeScope, Property.Deprecated);
 
     /** Setting for enabling or disabling watcher. Defaults to true. */
     public static final Setting<Boolean> WATCHER_ENABLED = Setting.boolSetting("xpack.watcher.enabled", true, Setting.Property.NodeScope);
@@ -82,15 +55,6 @@ public class XPackSettings {
     public static final Setting<Boolean> MACHINE_LEARNING_ENABLED = Setting.boolSetting("xpack.ml.enabled", true,
             Setting.Property.NodeScope);
 
-    /**
-     * Setting for enabling or disabling rollup. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> ROLLUP_ENABLED = Setting.boolSetting("xpack.rollup.enabled", true,
-        Property.NodeScope, Property.Deprecated);
-
     /** Setting for enabling or disabling auditing. Defaults to false. */
     public static final Setting<Boolean> AUDIT_ENABLED = Setting.boolSetting("xpack.security.audit.enabled", false,
             Setting.Property.NodeScope);
@@ -98,33 +62,6 @@ public class XPackSettings {
     /** Setting for enabling or disabling document/field level security. Defaults to true. */
     public static final Setting<Boolean> DLS_FLS_ENABLED = Setting.boolSetting("xpack.security.dls_fls.enabled", true,
             Setting.Property.NodeScope);
-
-    /**
-     * Setting for enabling or disabling Logstash extensions. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> LOGSTASH_ENABLED = Setting.boolSetting("xpack.logstash.enabled", true,
-            Setting.Property.NodeScope, Property.Deprecated);
-
-    /**
-     * Setting for enabling or disabling the index lifecycle extension. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> INDEX_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.ilm.enabled", true,
-        Property.NodeScope, Property.Deprecated);
-
-    /**
-     * Setting for enabling or disabling the snapshot lifecycle extension. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> SNAPSHOT_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.slm.enabled", true,
-        Property.NodeScope, Property.Deprecated);
 
     /** Setting for enabling or disabling TLS. Defaults to false. */
     public static final Setting<Boolean> TRANSPORT_SSL_ENABLED = Setting.boolSetting("xpack.security.transport.ssl.enabled", false,
@@ -149,33 +86,6 @@ public class XPackSettings {
     /** Setting for enabling or disabling FIPS mode. Defaults to false */
     public static final Setting<Boolean> FIPS_MODE_ENABLED =
         Setting.boolSetting("xpack.security.fips_mode.enabled", false, Property.NodeScope);
-
-    /**
-     * Setting for enabling or disabling sql. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> SQL_ENABLED = Setting.boolSetting("xpack.sql.enabled", true,
-        Property.NodeScope, Property.Deprecated);
-
-    /**
-     * Setting for enabling or disabling flattened fields. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> FLATTENED_ENABLED = Setting.boolSetting("xpack.flattened.enabled", true,
-        Property.NodeScope, Property.Deprecated);
-
-    /**
-     * Setting for enabling or disabling vectors. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
-     */
-    @Deprecated(since = "7.8.0")
-    public static final Setting<Boolean> VECTORS_ENABLED = Setting.boolSetting("xpack.vectors.enabled", true,
-        Property.NodeScope, Property.Deprecated);
 
     /*
      * SSL settings. These are the settings that are specifically registered for SSL. Many are private as we do not explicitly use them
@@ -271,28 +181,18 @@ public class XPackSettings {
         settings.addAll(HTTP_SSL.getAllSettings());
         settings.addAll(TRANSPORT_SSL.getAllSettings());
         settings.add(SECURITY_ENABLED);
-        settings.add(MONITORING_ENABLED);
         settings.add(GRAPH_ENABLED);
         settings.add(MACHINE_LEARNING_ENABLED);
         settings.add(AUDIT_ENABLED);
         settings.add(WATCHER_ENABLED);
         settings.add(DLS_FLS_ENABLED);
-        settings.add(LOGSTASH_ENABLED);
         settings.add(TRANSPORT_SSL_ENABLED);
         settings.add(HTTP_SSL_ENABLED);
         settings.add(RESERVED_REALM_ENABLED_SETTING);
         settings.add(TOKEN_SERVICE_ENABLED_SETTING);
         settings.add(API_KEY_SERVICE_ENABLED_SETTING);
-        settings.add(SQL_ENABLED);
         settings.add(USER_SETTING);
-        settings.add(ROLLUP_ENABLED);
         settings.add(PASSWORD_HASHING_ALGORITHM);
-        settings.add(INDEX_LIFECYCLE_ENABLED);
-        settings.add(SNAPSHOT_LIFECYCLE_ENABLED);
-        settings.add(TRANSFORM_ENABLED);
-        settings.add(FLATTENED_ENABLED);
-        settings.add(VECTORS_ENABLED);
-        settings.add(ENRICH_ENABLED_SETTING);
         return Collections.unmodifiableList(settings);
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -211,7 +211,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     public static final Setting<TimeValue> MAX_STOP_TIMEOUT_SETTING =
             Setting.timeSetting("xpack.watcher.stop.timeout", TimeValue.timeValueSeconds(30), Setting.Property.NodeScope);
     public static final Setting<Boolean> USE_ILM_INDEX_MANAGEMENT =
-        Setting.boolSetting("xpack.watcher.use_ilm_index_management", XPackSettings.INDEX_LIFECYCLE_ENABLED, NodeScope);
+        Setting.boolSetting("xpack.watcher.use_ilm_index_management", true, NodeScope);
     private static final Setting<Integer> SETTING_BULK_ACTIONS =
         Setting.intSetting("xpack.watcher.bulk.actions", 1, 1, 10000, NodeScope);
     private static final Setting<Integer> SETTING_BULK_CONCURRENT_REQUESTS =

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.watcher;
 
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.IndexModule;
@@ -16,7 +15,6 @@ import org.elasticsearch.index.engine.InternalEngineFactory;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.threadpool.ExecutorBuilder;
-import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.watcher.notification.NotificationService;
 
@@ -86,23 +84,6 @@ public class WatcherPluginTests extends ESTestCase {
         assertThat(watcher.createComponents(null, null, null, null, null, null, null, null, null, null, null), hasSize(0));
 
         watcher.close();
-    }
-
-    public void testWatcherUseIlmFallsBackToIlmEnabled() throws Exception {
-        boolean ilmEnabled = randomBoolean();
-        Settings settingsWithoutWatcherUseIlm = Settings.builder()
-            .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), ilmEnabled)
-            .build();
-        assertThat(Watcher.USE_ILM_INDEX_MANAGEMENT.get(settingsWithoutWatcherUseIlm), is(ilmEnabled));
-
-        boolean watcherUseIlmEnabled = randomBoolean();
-        Settings settingsWithWatcherUseIlm = Settings.builder()
-            .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), ilmEnabled)
-            .put(Watcher.USE_ILM_INDEX_MANAGEMENT.getKey(), watcherUseIlmEnabled)
-            .build();
-        assertThat(Watcher.USE_ILM_INDEX_MANAGEMENT.get(settingsWithWatcherUseIlm), is(watcherUseIlmEnabled));
-
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
     }
 
     public void testThreadPoolSize() {


### PR DESCRIPTION
In 7.8.0, we deprecated the settings for disabling basic license feature APIs. This PR removes those settings altogether for 8.0. This is a breaking change: if these options appear in `elasticsearch.yml`, they will no longer be recognized.

Meta issue: #54745