### PR TITLE
SQL: fix test on incompatible client versions

### DIFF
--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/VersionParityTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/VersionParityTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.xpack.sql.client.ClientVersion;
+import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -26,15 +27,22 @@ import java.sql.SQLException;
 public class VersionParityTests extends WebServerTestCase {
 
     public void testExceptionThrownOnIncompatibleVersions() throws IOException, SQLException {
-        Version version = VersionUtils.randomVersionBetween(random(), null, VersionUtils.getPreviousVersion(Version.V_7_7_0));
-        logger.info("Checking exception is thrown for version {}", version);
-        prepareResponse(version);
-        
         String url = JdbcConfiguration.URL_PREFIX + webServerAddress();
-        SQLException ex = expectThrows(SQLException.class, () -> new JdbcHttpClient(JdbcConfiguration.create(url, null, 0)));
-        assertEquals("This version of the JDBC driver is only compatible with Elasticsearch version " +
-            ClientVersion.CURRENT.majorMinorToString() + " or newer; attempting to connect to a server " +
-            "version " + version.toString(), ex.getMessage());
+        Version firstVersion = VersionUtils.getFirstVersion();
+        Version version = Version.V_7_7_0;
+        do {
+            version = VersionUtils.getPreviousVersion(version);
+            logger.info("Checking exception is thrown for version {}", version);
+
+            prepareResponse(version);
+            // Client's version is wired up to patch level, excluding the qualifier => generate the test version as the server does it.
+            String versionString = SqlVersion.fromString(version.toString()).toString();
+
+            SQLException ex = expectThrows(SQLException.class, () -> new JdbcHttpClient(JdbcConfiguration.create(url, null, 0)));
+            assertEquals("This version of the JDBC driver is only compatible with Elasticsearch version " +
+                ClientVersion.CURRENT.majorMinorToString() + " or newer; attempting to connect to a server " +
+                "version " + versionString, ex.getMessage());
+        } while (version.compareTo(firstVersion) > 0);
     }
     
     public void testNoExceptionThrownForCompatibleVersions() throws IOException {


### PR DESCRIPTION
The incompatible client version test is changed to:
- iterate on all versions prior to the allowed one_s;
- format the exception message just as the server does it.

The defect stemmed from the fact that the clients will not send a
version's qualifier, but just major.minor.revision, so the raised
error/exception_message won't contain it, while the test expected it.
