### PR TITLE
Ensure that the monitoring export exceptions are logged.

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
@@ -88,7 +88,7 @@ public abstract class ExportBulk {
                     bulk.add(docs);
                 } catch (ExportException e) {
                     if (exception == null) {
-                        exception = new ExportException("failed to add documents to export bulks");
+                        exception = new ExportException("failed to add documents to export bulks", e);
                     }
                     exception.addExportException(e);
                 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
@@ -243,7 +243,12 @@ public class Exporters extends AbstractLifecycleComponent {
                 } else {
                     listener.onFailure(exceptionRef.get());
                 }
-            }, listener::onFailure));
+            }, (exception) -> {
+                if (exceptionRef.get() != null) {
+                    exception.addSuppressed(exceptionRef.get());
+                }
+                listener.onFailure(exception);
+            }));
         }
     }
 


### PR DESCRIPTION
If an exception occurs while flushing a bulk the cause of the exception
can be lost. This commit ensures that cause of the exception is carried
forward and gets logged.

Note: this was noticed when the date pattern for the monitoring index 
used a `DD` for the date (instead of `dd`) and the server was running 
under Java 8. (Java 11 had no issues)

=====

Before:
```
[2020-05-05T12:57:11,331][WARN ][o.e.x.m.MonitoringService] [zelda] monitoring execution failed
org.elasticsearch.xpack.monitoring.exporter.ExportException: failed to flush export bulks
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.lambda$doFlush$0(ExportBulk.java:111) ~[?:?]
	at org.elasticsearch.action.ActionListener$1.onFailure(ActionListener.java:70) ~[elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk.doFlush(HttpExportBulk.java:99) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.flush(ExportBulk.java:63) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.lambda$doFlush$1(ExportBulk.java:109) ~[?:?]
	at org.elasticsearch.xpack.core.common.IteratingActionListener.run(IteratingActionListener.java:102) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.doFlush(ExportBulk.java:125) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.flush(ExportBulk.java:63) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.doExport(Exporters.java:236) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.lambda$export$3(Exporters.java:211) ~[?:?]
	at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) ~[elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.delegateIfComplete(Exporters.java:310) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.onResponse(Exporters.java:289) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.onResponse(Exporters.java:260) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter.lambda$openBulk$20(HttpExporter.java:680) ~[?:?]
	at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpResource.checkAndPublishIfDirty(HttpResource.java:117) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter.openBulk(HttpExporter.java:676) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.wrapExportBulk(Exporters.java:197) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.export(Exporters.java:209) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.MonitoringService$MonitoringExecution$1.doRun(MonitoringService.java:252) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_241]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_241]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:703) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_241]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_241]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_241]
Caused by: org.elasticsearch.xpack.monitoring.exporter.ExportException: unable to send documents because none were loaded for export bulk [xpack.monitoring.exporters.id1]
	... 26 more
```

After
```
[2020-05-05T14:14:33,701][WARN ][o.e.x.m.MonitoringService] [zelda] monitoring execution failed
org.elasticsearch.xpack.monitoring.exporter.ExportException: failed to flush export bulks
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.lambda$doFlush$0(ExportBulk.java:109) ~[?:?]
	at org.elasticsearch.action.ActionListener$1.onFailure(ActionListener.java:70) ~[elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk.doFlush(HttpExportBulk.java:96) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.flush(ExportBulk.java:63) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.lambda$doFlush$1(ExportBulk.java:107) ~[?:?]
	at org.elasticsearch.xpack.core.common.IteratingActionListener.run(IteratingActionListener.java:102) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.doFlush(ExportBulk.java:123) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.flush(ExportBulk.java:63) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.doExport(Exporters.java:236) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.lambda$export$3(Exporters.java:211) ~[?:?]
	at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) ~[elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.delegateIfComplete(Exporters.java:315) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.onResponse(Exporters.java:294) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.onResponse(Exporters.java:265) ~[?:?]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter.lambda$openBulk$20(HttpExporter.java:680) ~[?:?]
	at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpResource.checkAndPublishIfDirty(HttpResource.java:117) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter.openBulk(HttpExporter.java:676) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.wrapExportBulk(Exporters.java:197) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.exporter.Exporters.export(Exporters.java:209) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.xpack.monitoring.MonitoringService$MonitoringExecution$1.doRun(MonitoringService.java:252) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_241]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_241]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:703) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_241]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_241]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_241]
	Suppressed: org.elasticsearch.xpack.monitoring.exporter.ExportException: failed to add documents to export bulks
		at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.doAdd(ExportBulk.java:91) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.add(ExportBulk.java:52) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters.doExport(Exporters.java:232) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters.lambda$export$3(Exporters.java:211) ~[?:?]
		at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) ~[elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.delegateIfComplete(Exporters.java:315) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.onResponse(Exporters.java:294) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters$AccumulatingExportBulkActionListener.onResponse(Exporters.java:265) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter.lambda$openBulk$20(HttpExporter.java:680) ~[?:?]
		at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.monitoring.exporter.http.HttpResource.checkAndPublishIfDirty(HttpResource.java:117) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.monitoring.exporter.http.HttpExporter.openBulk(HttpExporter.java:676) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters.wrapExportBulk(Exporters.java:197) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.monitoring.exporter.Exporters.export(Exporters.java:209) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.monitoring.MonitoringService$MonitoringExecution$1.doRun(MonitoringService.java:252) [x-pack-monitoring-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_241]
		at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_241]
		at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:703) [elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_241]
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_241]
		at java.lang.Thread.run(Thread.java:748) [?:1.8.0_241]
	Caused by: org.elasticsearch.xpack.monitoring.exporter.ExportException: failed to add documents to export bulk [xpack.monitoring.exporters.id1]
		at org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk.doAdd(HttpExportBulk.java:89) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.add(ExportBulk.java:52) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.doAdd(ExportBulk.java:88) ~[?:?]
		... 21 more
	Caused by: java.time.DateTimeException: Field DayOfYear cannot be printed as the value 126 exceeds the maximum print width of 2
		at java.time.format.DateTimeFormatterBuilder$NumberPrinterParser.format(DateTimeFormatterBuilder.java:2559) ~[?:1.8.0_241]
		at java.time.format.DateTimeFormatterBuilder$CompositePrinterParser.format(DateTimeFormatterBuilder.java:2190) ~[?:1.8.0_241]
		at java.time.format.DateTimeFormatter.formatTo(DateTimeFormatter.java:1746) ~[?:1.8.0_241]
		at java.time.format.DateTimeFormatter.format(DateTimeFormatter.java:1720) ~[?:1.8.0_241]
		at org.elasticsearch.common.time.JavaDateFormatter.format(JavaDateFormatter.java:181) ~[elasticsearch-7.4.2-SNAPSHOT.jar:7.4.2-SNAPSHOT]
		at org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils.indexName(MonitoringTemplateUtils.java:214) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk.toBulkBytes(HttpExportBulk.java:130) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.http.HttpExportBulk.doAdd(HttpExportBulk.java:81) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.ExportBulk.add(ExportBulk.java:52) ~[?:?]
		at org.elasticsearch.xpack.monitoring.exporter.ExportBulk$Compound.doAdd(ExportBulk.java:88) ~[?:?]
		... 21 more
Caused by: org.elasticsearch.xpack.monitoring.exporter.ExportException: unable to send documents because none were loaded for export bulk [xpack.monitoring.exporters.id1]
	... 26 more

```