### PR TITLE
[7.x] Get index includes parent data stream for backing indices

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetIndexResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/indices/GetIndexResponseTests.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -76,6 +77,7 @@ public class GetIndexResponseTests extends ESTestCase {
         Map<String, List<AliasMetadata>> aliases = new HashMap<>();
         Map<String, Settings> settings = new HashMap<>();
         Map<String, Settings> defaultSettings = new HashMap<>();
+        Map<String, String> dataStreams = new HashMap<>();
         IndexScopedSettings indexScopedSettings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS;
         boolean includeDefaults = randomBoolean();
         for (String index: indices) {
@@ -96,8 +98,12 @@ public class GetIndexResponseTests extends ESTestCase {
             if (includeDefaults) {
                 defaultSettings.put(index, indexScopedSettings.diff(settings.get(index), Settings.EMPTY));
             }
+
+            if (randomBoolean()) {
+                dataStreams.put(index, randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+            }
         }
-        return new GetIndexResponse(indices, mappings, aliases, settings, defaultSettings);
+        return new GetIndexResponse(indices, mappings, aliases, settings, defaultSettings, dataStreams);
     }
 
     private static MappingMetadata createMappingsForIndex() {
@@ -186,7 +192,9 @@ public class GetIndexResponseTests extends ESTestCase {
                 allMappings.build(),
                 aliases.build(),
                 settings.build(),
-                defaultSettings.build());
+                defaultSettings.build(),
+                ImmutableOpenMap.<String, String>builder().build()
+            );
 
         // then we can call its toXContent method, forcing no output of types
         Params params = new ToXContent.MapParams(Collections.singletonMap(BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER, "false"));

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/20_backing_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/20_backing_indices.yml
@@ -1,0 +1,35 @@
+---
+"Get backing indices for data stream":
+  - skip:
+      version: " - 7.99.99"
+      reason:  "enable in 7.8+ after backporting"
+
+  - do:
+      indices.create_data_stream:
+        name: data-stream1
+        body:
+          timestamp_field: "@timestamp"
+  - is_true: acknowledged
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 1
+
+  - do:
+      indices.get:
+        index: ['data-stream1-000001', 'test_index']
+
+  - is_true: data-stream1-000001.settings
+  - is_true: data-stream1-000001.data_stream
+  - match: { data-stream1-000001.data_stream: data-stream1 }
+  - is_true: test_index.settings
+  - is_false: test_index.data_stream
+
+  - do:
+      indices.delete_data_stream:
+        name: data-stream1
+  - is_true: acknowledged

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -44,6 +44,8 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Get index action.
@@ -90,6 +92,9 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         ImmutableOpenMap<String, List<AliasMetadata>> aliasesResult = ImmutableOpenMap.of();
         ImmutableOpenMap<String, Settings> settings = ImmutableOpenMap.of();
         ImmutableOpenMap<String, Settings> defaultSettings = ImmutableOpenMap.of();
+        ImmutableOpenMap<String, String> dataStreams = ImmutableOpenMap.<String, String>builder()
+            .putAll(StreamSupport.stream(state.metadata().findDataStreams(concreteIndices).spliterator(), false)
+                .collect(Collectors.toMap(k -> k.key, v -> v.value.getName()))).build();
         Feature[] features = request.features();
         boolean doneAliases = false;
         boolean doneMappings = false;
@@ -141,7 +146,7 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
             }
         }
         listener.onResponse(
-            new GetIndexResponse(concreteIndices, mappingsResult, aliasesResult, settings, defaultSettings)
+            new GetIndexResponse(concreteIndices, mappingsResult, aliasesResult, settings, defaultSettings, dataStreams)
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -451,6 +451,24 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return indexMapBuilder.build();
     }
 
+    /**
+     * Finds the parent data streams, if any, for the specified concrete indices.
+     */
+    public ImmutableOpenMap<String, IndexAbstraction.DataStream> findDataStreams(String[] concreteIndices) {
+        assert concreteIndices != null;
+        final ImmutableOpenMap.Builder<String, IndexAbstraction.DataStream> builder = ImmutableOpenMap.builder();
+        final SortedMap<String, IndexAbstraction> lookup = getIndicesLookup();
+        for (String indexName : concreteIndices) {
+            IndexAbstraction index = lookup.get(indexName);
+            assert index != null;
+            assert index.getType() == IndexAbstraction.Type.CONCRETE_INDEX;
+            if (index.getParentDataStream() != null) {
+                builder.put(indexName, index.getParentDataStream());
+            }
+        }
+        return builder.build();
+    }
+
     private static ImmutableOpenMap<String, MappingMetadata> filterFields(ImmutableOpenMap<String, MappingMetadata> mappings,
                                                                           Predicate<String> fieldPredicate) throws IOException {
         if (fieldPredicate == MapperPlugin.NOOP_FIELD_PREDICATE) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.Locale;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -80,6 +81,7 @@ public class GetIndexResponseTests extends AbstractSerializingTestCase<GetIndexR
         ImmutableOpenMap.Builder<String, List<AliasMetadata>> aliases = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> settings = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> defaultSettings = ImmutableOpenMap.builder();
+        ImmutableOpenMap.Builder<String, String> dataStreams = ImmutableOpenMap.builder();
         IndexScopedSettings indexScopedSettings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS;
         boolean includeDefaults = randomBoolean();
         for (String index: indices) {
@@ -102,9 +104,13 @@ public class GetIndexResponseTests extends AbstractSerializingTestCase<GetIndexR
             if (includeDefaults) {
                 defaultSettings.put(index, indexScopedSettings.diff(settings.get(index), Settings.EMPTY));
             }
+
+            if (randomBoolean()) {
+                dataStreams.put(index, randomAlphaOfLength(5).toLowerCase(Locale.ROOT));
+            }
         }
         return new GetIndexResponse(
-            indices, mappings.build(), aliases.build(), settings.build(), defaultSettings.build()
+            indices, mappings.build(), aliases.build(), settings.build(), defaultSettings.build(), dataStreams.build()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -165,7 +165,7 @@ public class GetIndexResponseTests extends AbstractSerializingTestCase<GetIndexR
         return
             new GetIndexResponse(
                 indices, getTestMappings(indexName), getTestAliases(indexName), getTestSettings(indexName),
-                ImmutableOpenMap.of()
+                ImmutableOpenMap.of(), ImmutableOpenMap.of()
             );
     }
 
@@ -179,7 +179,7 @@ public class GetIndexResponseTests extends AbstractSerializingTestCase<GetIndexR
         return
             new GetIndexResponse(
                 indices, getTestMappings(indexName), getTestAliases(indexName), getTestSettings(indexName),
-                defaultSettings.build()
+                defaultSettings.build(), ImmutableOpenMap.of()
             );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.DataStreamTestHelper.createBackingIndex;
 import static org.elasticsearch.cluster.DataStreamTestHelper.createFirstBackingIndex;
@@ -135,6 +136,23 @@ public class MetadataTests extends ESTestCase {
             metadata.findAliases(new GetAliasesRequest().aliases("*", "-alias1"), new String[] {"index"}).get("index");
         assertThat(aliases.size(), equalTo(1));
         assertThat(aliases.get(0).alias(), equalTo("alias2"));
+    }
+
+    public void testFindDataStreams() {
+        final int numIndices = randomIntBetween(2, 5);
+        final int numBackingIndices = randomIntBetween(2, 5);
+        final String dataStreamName = "my-data-stream";
+        CreateIndexResult result = createIndices(numIndices, numBackingIndices, dataStreamName);
+
+        List<Index> allIndices = new ArrayList<>(result.indices);
+        allIndices.addAll(result.backingIndices);
+        String[] concreteIndices = allIndices.stream().map(Index::getName).collect(Collectors.toList()).toArray(new String[]{});
+        ImmutableOpenMap<String, IndexAbstraction.DataStream> dataStreams = result.metadata.findDataStreams(concreteIndices);
+        assertThat(dataStreams.size(), equalTo(numBackingIndices));
+        for (Index backingIndex : result.backingIndices) {
+            assertThat(dataStreams.containsKey(backingIndex.getName()), is(true));
+            assertThat(dataStreams.get(backingIndex.getName()).getName(), equalTo(dataStreamName));
+        }
     }
 
     public void testFindAliasWithExclusionAndOverride() {
@@ -1066,47 +1084,18 @@ public class MetadataTests extends ESTestCase {
     }
 
     public void testIndicesLookupRecordsDataStreamForBackingIndices() {
-        // create some indices that do not back a data stream
-        final List<Index> indices = new ArrayList<>();
         final int numIndices = randomIntBetween(2, 5);
-        int lastIndexNum = randomIntBetween(9, 50);
-        Metadata.Builder b = Metadata.builder();
-        for (int k = 1; k <= numIndices; k++) {
-            IndexMetadata im = IndexMetadata.builder(DataStream.getBackingIndexName("index", lastIndexNum))
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(1)
-                .build();
-            b.put(im, false);
-            indices.add(im.getIndex());
-            lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
-        }
-
-        // create some backing indices for a data stream
-        final String dataStreamName = "my-data-stream";
-        final List<Index> backingIndices = new ArrayList<>();
         final int numBackingIndices = randomIntBetween(2, 5);
-        int lastBackingIndexNum = 0;
-        for (int k = 1; k <= numBackingIndices; k++) {
-            lastBackingIndexNum = randomIntBetween(lastBackingIndexNum + 1, lastBackingIndexNum + 50);
-            IndexMetadata im = IndexMetadata.builder(DataStream.getBackingIndexName(dataStreamName, lastBackingIndexNum))
-                .settings(settings(Version.CURRENT))
-                .numberOfShards(1)
-                .numberOfReplicas(1)
-                .build();
-            b.put(im, false);
-            backingIndices.add(im.getIndex());
-        }
-        b.put(new DataStream(dataStreamName, "ts", backingIndices, lastBackingIndexNum));
-        Metadata metadata = b.build();
+        final String dataStreamName = "my-data-stream";
+        CreateIndexResult result = createIndices(numIndices, numBackingIndices, dataStreamName);
 
-        SortedMap<String, IndexAbstraction> indicesLookup = metadata.getIndicesLookup();
-        assertThat(indicesLookup.size(), equalTo(indices.size() + backingIndices.size() + 1));
-        for (Index index : indices) {
+        SortedMap<String, IndexAbstraction> indicesLookup = result.metadata.getIndicesLookup();
+        assertThat(indicesLookup.size(), equalTo(result.indices.size() + result.backingIndices.size() + 1));
+        for (Index index : result.indices) {
             assertTrue(indicesLookup.containsKey(index.getName()));
             assertNull(indicesLookup.get(index.getName()).getParentDataStream());
         }
-        for (Index index : backingIndices) {
+        for (Index index : result.backingIndices) {
             assertTrue(indicesLookup.containsKey(index.getName()));
             assertNotNull(indicesLookup.get(index.getName()).getParentDataStream());
             assertThat(indicesLookup.get(index.getName()).getParentDataStream().getName(), equalTo(dataStreamName));
@@ -1152,5 +1141,50 @@ public class MetadataTests extends ESTestCase {
         md.put(randomDataStream);
 
         return md.build();
+    }
+
+    private static CreateIndexResult createIndices(int numIndices, int numBackingIndices, String dataStreamName) {
+        // create some indices that do not back a data stream
+        final List<Index> indices = new ArrayList<>();
+        int lastIndexNum = randomIntBetween(9, 50);
+        Metadata.Builder b = Metadata.builder();
+        for (int k = 1; k <= numIndices; k++) {
+            IndexMetadata im = IndexMetadata.builder(DataStream.getBackingIndexName("index", lastIndexNum))
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+            b.put(im, false);
+            indices.add(im.getIndex());
+            lastIndexNum = randomIntBetween(lastIndexNum + 1, lastIndexNum + 50);
+        }
+
+        // create some backing indices for a data stream
+        final List<Index> backingIndices = new ArrayList<>();
+        int lastBackingIndexNum = 0;
+        for (int k = 1; k <= numBackingIndices; k++) {
+            lastBackingIndexNum = randomIntBetween(lastBackingIndexNum + 1, lastBackingIndexNum + 50);
+            IndexMetadata im = IndexMetadata.builder(DataStream.getBackingIndexName(dataStreamName, lastBackingIndexNum))
+                .settings(settings(Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build();
+            b.put(im, false);
+            backingIndices.add(im.getIndex());
+        }
+        b.put(new DataStream(dataStreamName, "ts", backingIndices, lastBackingIndexNum));
+        return new CreateIndexResult(indices, backingIndices, b.build());
+    }
+
+    private static class CreateIndexResult {
+        final List<Index> indices;
+        final List<Index> backingIndices;
+        final Metadata metadata;
+
+        CreateIndexResult(List<Index> indices, List<Index> backingIndices, Metadata metadata) {
+            this.indices = indices;
+            this.backingIndices = backingIndices;
+            this.metadata = metadata;
+        }
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -282,8 +282,8 @@ public class DestinationIndexTests extends ESTestCase {
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
         mappings.put(DEST_INDEX, indexMappingsMap.build());
         GetIndexResponse getIndexResponse =
-            new GetIndexResponse(
-                new String[] { DEST_INDEX }, mappings.build(), ImmutableOpenMap.of(), ImmutableOpenMap.of(), ImmutableOpenMap.of());
+            new GetIndexResponse(new String[] { DEST_INDEX }, mappings.build(), ImmutableOpenMap.of(), ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(), ImmutableOpenMap.of());
 
         ArgumentCaptor<PutMappingRequest> putMappingRequestCaptor = ArgumentCaptor.forClass(PutMappingRequest.class);
 
@@ -356,8 +356,8 @@ public class DestinationIndexTests extends ESTestCase {
         ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>> mappings = ImmutableOpenMap.builder();
         mappings.put(DEST_INDEX, indexMappingsMap.build());
         GetIndexResponse getIndexResponse =
-            new GetIndexResponse(
-                new String[] { DEST_INDEX }, mappings.build(), ImmutableOpenMap.of(), ImmutableOpenMap.of(), ImmutableOpenMap.of());
+            new GetIndexResponse(new String[] { DEST_INDEX }, mappings.build(), ImmutableOpenMap.of(), ImmutableOpenMap.of(),
+                ImmutableOpenMap.of(), ImmutableOpenMap.of());
 
         ElasticsearchStatusException e =
             expectThrows(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/EmptyStateIndexRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/EmptyStateIndexRemoverTests.java
@@ -116,7 +116,7 @@ public class EmptyStateIndexRemoverTests extends ESTestCase {
         doReturn(indexStatsMap).when(indicesStatsResponse).getIndices();
         doAnswer(withResponse(indicesStatsResponse)).when(client).execute(eq(IndicesStatsAction.INSTANCE), any(), any());
 
-        GetIndexResponse getIndexResponse = new GetIndexResponse(new String[] { ".ml-state-e" }, null, null, null, null);
+        GetIndexResponse getIndexResponse = new GetIndexResponse(new String[] { ".ml-state-e" }, null, null, null, null, null);
         doAnswer(withResponse(getIndexResponse)).when(client).execute(eq(GetIndexAction.INSTANCE), any(), any());
 
         AcknowledgedResponse deleteIndexResponse = new AcknowledgedResponse(acknowledged);
@@ -147,7 +147,7 @@ public class EmptyStateIndexRemoverTests extends ESTestCase {
         doReturn(Collections.singletonMap(".ml-state-a", indexStats(".ml-state-a", 0))).when(indicesStatsResponse).getIndices();
         doAnswer(withResponse(indicesStatsResponse)).when(client).execute(eq(IndicesStatsAction.INSTANCE), any(), any());
 
-        GetIndexResponse getIndexResponse = new GetIndexResponse(new String[] { ".ml-state-a" }, null, null, null, null);
+        GetIndexResponse getIndexResponse = new GetIndexResponse(new String[] { ".ml-state-a" }, null, null, null, null, null);
         doAnswer(withResponse(getIndexResponse)).when(client).execute(eq(GetIndexAction.INSTANCE), any(), any());
 
         remover.remove(listener, () -> false);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -111,7 +111,7 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
             if (request instanceof GetIndexRequest) {
                 // for this test we only need the indices
                 assert (indices != null);
-                final GetIndexResponse indexResponse = new GetIndexResponse(indices, null, null, null, null);
+                final GetIndexResponse indexResponse = new GetIndexResponse(indices, null, null, null, null, null);
 
                 listener.onResponse((Response) indexResponse);
                 return;


### PR DESCRIPTION
The `GET <index>` endpoint now includes the name of the parent data stream for any backing indices.

Relates to #53100.

Backport of #56022 