### PR TITLE
Fix CancelTests#testDeleteByQueryCancelWithWorkers

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
@@ -177,7 +177,7 @@ public class CancelTests extends ReindexTestCase {
         try {
             response = future.get(30, TimeUnit.SECONDS);
         } catch (Exception e) {
-            if (ExceptionsHelper.unwrap(e, TaskCancelledException.class) != null) {
+            if (ExceptionsHelper.unwrapCausesAndSuppressed(e, t -> t instanceof TaskCancelledException).isPresent()) {
                 return; // the scroll request was cancelled
             }
             String tasks = client().admin().cluster().prepareListTasks().setParentTaskId(mainTask.getTaskId())


### PR DESCRIPTION
We need to relax the assertion as a TaskCancelledException
can be suppressed instead.

Closes #55647
