### PR TITLE
Upgrade to version 3.3 of gradle enterprise plugin

### DIFF
--- a/gradle/build-scan.gradle
+++ b/gradle/build-scan.gradle
@@ -40,6 +40,9 @@ buildScan {
 
   // Jenkins-specific build scan metadata
   if (jenkinsUrl) {
+    // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
+    uploadInBackground = false
+
     // Parse job name in the case of matrix builds
     // Matrix job names come in the form of "base-job-name/matrix_param1=value1,matrix_param2=value2"
     def splitJobName = jobName.split('/')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.gradle.enterprise" version "3.2"
+  id "com.gradle.enterprise" version "3.3"
 }
 
 String dirName = rootProject.projectDir.name


### PR DESCRIPTION
Since we're upgraded to the Gradle Enterprise 2020.2 we'll want to bump to the latest plugin version. This one includes background scan upload which will be a very welcome feature to the team.