### PR TITLE
[7.7] Ensure that the monitoring export exceptions are logged. (#56237)

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportBulk.java
@@ -88,7 +88,7 @@ public abstract class ExportBulk {
                     bulk.add(docs);
                 } catch (ExportException e) {
                     if (exception == null) {
-                        exception = new ExportException("failed to add documents to export bulks");
+                        exception = new ExportException("failed to add documents to export bulks", e);
                     }
                     exception.addExportException(e);
                 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/Exporters.java
@@ -243,7 +243,12 @@ public class Exporters extends AbstractLifecycleComponent {
                 } else {
                     listener.onFailure(exceptionRef.get());
                 }
-            }, listener::onFailure));
+            }, (exception) -> {
+                if (exceptionRef.get() != null) {
+                    exception.addSuppressed(exceptionRef.get());
+                }
+                listener.onFailure(exception);
+            }));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Ensure that the monitoring export exceptions are logged. (#56237)