### PR TITLE
[DOCS] Create API key API requires `name` request body param 

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -44,7 +44,7 @@ service.
 The following parameters can be specified in the body of a POST or PUT request:
 
 `name`::
-(Optional, string) Specifies the name for this API key.
+(Required, string) Specifies the name for this API key.
 
 `role_descriptors`::
 (Optional, array-of-role-descriptor) An array of role descriptors for this API


### PR DESCRIPTION
Fixes #56164. A minor update in the documentation, API key name is required when creating API key. If the API key name is not provided then the request will fail.

Pull request for `master` branch https://github.com/elastic/elasticsearch/pull/56166
