### PR TITLE
Fix up BWC for serialization of GetIndexResponse

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -431,7 +431,6 @@ public class RecoveryIT extends AbstractRollingTestCase {
      * is effectively closed and potentially replicated if the cluster supports replication of closed indices at the
      * time the index was closed.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/56265")
     public void testCloseIndexDuringRollingUpgrade() throws Exception {
         final Version minimumNodeVersion = minimumNodeVersion();
         final String indexName =

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -132,7 +132,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
         }
         defaultSettings = defaultSettingsMapBuilder.build();
 
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_8_0)) {
             ImmutableOpenMap.Builder<String, String> dataStreamsMapBuilder = ImmutableOpenMap.builder();
             int dataStreamsSize = in.readVInt();
             for (int i = 0; i < dataStreamsSize; i++) {
@@ -255,7 +255,7 @@ public class GetIndexResponse extends ActionResponse implements ToXContentObject
             out.writeString(indexEntry.key);
             Settings.writeSettingsToStream(indexEntry.value, out);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
             out.writeVInt(dataStreams.size());
             for (ObjectObjectCursor<String, String> indexEntry : dataStreams) {
                 out.writeString(indexEntry.key);


### PR DESCRIPTION
Completes the backport of #56022

Closes #56265