### PR TITLE
Fix CancelTests#testDeleteByQueryCancelWithWorkers (#56242)

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/CancelTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.reindex;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
@@ -36,6 +37,7 @@ import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.ingest.IngestTestPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskInfo;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -176,6 +178,9 @@ public class CancelTests extends ReindexTestCase {
         try {
             response = future.get(30, TimeUnit.SECONDS);
         } catch (Exception e) {
+            if (ExceptionsHelper.unwrapCausesAndSuppressed(e, t -> t instanceof TaskCancelledException).isPresent()) {
+                return; // the scroll request was cancelled
+            }
             String tasks = client().admin().cluster().prepareListTasks().setParentTaskId(mainTask.getTaskId())
                         .setDetailed(true).get().toString();
             throw new RuntimeException("Exception while waiting for the response. Running tasks: " + tasks, e);


### PR DESCRIPTION
We need to relax the assertion as a TaskCancelledException
can be suppressed instead.

Closes #55647