### PR TITLE
[DOCS] Update upgrade docs for 7.8

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -37,7 +37,7 @@ ifeval::[ "{version}" != "{minor-version}.0" ]
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 endif::[]
 
-|7.0–7.7
+|7.0–7.8
 |<<rolling-upgrades,Rolling upgrade>> to {version}
 
 |6.8


### PR DESCRIPTION
Updates the latest 7.x version to 7.8.

Depends on https://github.com/elastic/docs/pull/1831