### PR TITLE
Add xpack setting deprecations to deprecation API

### DIFF
--- a/docs/reference/migration/migrate_7_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/settings.asciidoc
@@ -288,28 +288,3 @@ still be adjusted as desired using the cluster settings API.
 ==== HTTP Max content length setting is no longer parsed leniently
 Previously, `http.max_content_length` would reset to `100mb` if the setting was
 greater than `Integer.MAX_VALUE`.  This leniency has been removed.
-
-[float]
-==== Option to disable basic license features is deprecated
-
-In Elasticsearch 7.8.0, the following settings no longer have any effect, and
-have been deprecated:
-
-* `xpack.enrich.enabled`
-* `xpack.flattened.enabled`
-* `xpack.ilm.enabled`
-* `xpack.monitoring.enabled`
-* `xpack.rollup.enabled`
-* `xpack.slm.enabled`
-* `xpack.sql.enabled`
-* `xpack.transform.enabled`
-* `xpack.vectors.enabled`
-
-Previously, these settings could be set to `false` in order to disable the
-feature's APIs in a cluster. As of 7.8.0, these basic license features are
-always enabled for the {default-dist}.
-
-If you have disabled ILM so that you can use another tool to manage Watcher
-indices, the newly introduced `xpack.watcher.use_ilm_index_management` setting
-may be set to false.
-

--- a/docs/reference/migration/migrate_7_8.asciidoc
+++ b/docs/reference/migration/migrate_7_8.asciidoc
@@ -94,8 +94,13 @@ setting.
 
 [[deprecate-basic-license-feature-enabled]]
 
-.In {es} 7.8.0, the following settings no longer have any effect, and
-have been deprecated:
+.Several {xpack} settings no longer have any effect and are deprecated. 
+
+[%collapsible]
+====
+*Details* +
+Basic {xpack} license features are always enabled for the {default-dist} 
+and the following settings no longer have any effect: 
 
 * `xpack.enrich.enabled`
 * `xpack.flattened.enabled`
@@ -107,12 +112,7 @@ have been deprecated:
 * `xpack.transform.enabled`
 * `xpack.vectors.enabled`
 
-[%collapsible]
-====
-*Details* +
-Previously, these settings could be set to `false` in order to disable the
-feature's APIs in a cluster. As of 7.8.0, these basic license features are
-always enabled for the {default-dist}.
+Previously, they could be set to `false` to disable the feature's APIs in a cluster.
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of these settings.

--- a/docs/reference/migration/migrate_7_8.asciidoc
+++ b/docs/reference/migration/migrate_7_8.asciidoc
@@ -92,6 +92,35 @@ To avoid deprecation warnings, discontinue use of the `node.local_storage`
 setting.
 ====
 
+[[deprecate-basic-license-feature-enabled]]
+
+.In {es} 7.8.0, the following settings no longer have any effect, and
+have been deprecated:
+
+* `xpack.enrich.enabled`
+* `xpack.flattened.enabled`
+* `xpack.ilm.enabled`
+* `xpack.monitoring.enabled`
+* `xpack.rollup.enabled`
+* `xpack.slm.enabled`
+* `xpack.sql.enabled`
+* `xpack.transform.enabled`
+* `xpack.vectors.enabled`
+
+[%collapsible]
+====
+*Details* +
+Previously, these settings could be set to `false` in order to disable the
+feature's APIs in a cluster. As of 7.8.0, these basic license features are
+always enabled for the {default-dist}.
+
+*Impact* +
+To avoid deprecation warnings, discontinue use of these settings.
+If you have disabled ILM so that you can use another tool to manage Watcher
+indices, the newly introduced `xpack.watcher.use_ilm_index_management` setting
+may be set to false.
+====
+
 [float]
 [[builtin-users-changes]]
 ==== Changes to built-in users

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -10,6 +10,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.deprecation.DeprecationInfoAction;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -49,7 +50,25 @@ public class DeprecationChecks {
             (settings, pluginsAndModules) -> NodeDeprecationChecks.checkThreadPoolListenerQueueSize(settings),
             (settings, pluginsAndModules) -> NodeDeprecationChecks.checkThreadPoolListenerSize(settings),
             NodeDeprecationChecks::checkClusterRemoteConnectSetting,
-            NodeDeprecationChecks::checkNodeLocalStorageSetting
+            NodeDeprecationChecks::checkNodeLocalStorageSetting,
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.ENRICH_ENABLED_SETTING),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.FLATTENED_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.INDEX_LIFECYCLE_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.MONITORING_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.ROLLUP_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.SQL_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.TRANSFORM_ENABLED),
+            (settings, pluginsAndModules) -> NodeDeprecationChecks.checkNodeBasicLicenseFeatureEnabledSetting(settings,
+                XPackSettings.VECTORS_ENABLED)
         ));
 
     static List<Function<IndexMetadata, DeprecationIssue>> INDEX_SETTINGS_CHECKS =

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -137,6 +137,14 @@ class NodeDeprecationChecks {
         );
     }
 
+    public static DeprecationIssue checkNodeBasicLicenseFeatureEnabledSetting(final Settings settings, Setting<?> setting) {
+        return checkRemovedSetting(
+            settings,
+            setting,
+            "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html#deprecate-basic-license-feature-enabled"
+        );
+    }
+
     private static DeprecationIssue checkDeprecatedSetting(
         final Settings settings,
         final PluginsAndModules pluginsAndModules,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
+import org.elasticsearch.common.collect.Set;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -14,10 +15,12 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -213,6 +216,37 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
         assertThat(issues, contains(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{Node.NODE_LOCAL_STORAGE_SETTING});
+    }
+
+    public void testDeprecatedBasicLicenseSettings() {
+        Collection<Setting<Boolean>> deprecatedXpackSettings = Set.of(
+            XPackSettings.ENRICH_ENABLED_SETTING,
+            XPackSettings.FLATTENED_ENABLED,
+            XPackSettings.INDEX_LIFECYCLE_ENABLED,
+            XPackSettings.MONITORING_ENABLED,
+            XPackSettings.ROLLUP_ENABLED,
+            XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED,
+            XPackSettings.SQL_ENABLED,
+            XPackSettings.TRANSFORM_ENABLED,
+            XPackSettings.VECTORS_ENABLED
+        );
+
+        for (Setting<Boolean> deprecatedSetting : deprecatedXpackSettings) {
+            final boolean value = randomBoolean();
+            final Settings settings = Settings.builder().put(deprecatedSetting.getKey(), value).build();
+            final PluginsAndModules pluginsAndModules = new PluginsAndModules(Collections.emptyList(), Collections.emptyList());
+            final List<DeprecationIssue> issues =
+                DeprecationChecks.filterChecks(DeprecationChecks.NODE_SETTINGS_CHECKS, c -> c.apply(settings, pluginsAndModules));
+            final DeprecationIssue expected = new DeprecationIssue(
+                DeprecationIssue.Level.CRITICAL,
+                "setting [" + deprecatedSetting.getKey() + "] is deprecated and will be removed in the next major version",
+                "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/breaking-changes-7.8.html" +
+                    "#deprecate-basic-license-feature-enabled",
+                "the setting [" + deprecatedSetting.getKey() + "] is currently set to [" + value + "], remove this setting"
+            );
+            assertThat(issues, contains(expected));
+            assertSettingDeprecationsAndWarnings(new Setting<?>[]{deprecatedSetting});
+        }
     }
 
     public void testRemovedSettingNotSet() {


### PR DESCRIPTION
The deprecated settings showed up in the deprecation log file by default, but I did not add them to the deprecation API. This commit fixes that. Now if you use one of the deprecated basic feature enablement settings, calling _monitoring/deprecations will inform you of that fact.

I believe that this takes care of hooking these changes into the upgrade assistant in Kibana. That is, I verified that the upgrade assistant flags these deprecated settings. But if there is more that I need to do, please let me know.

Meta issue: #54745

EDIT: We are considering this small, targeted change to be a bugfix for the purposes of the 7.8.0 release