### PR TITLE
Fix testCollectNodes test assertion

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -651,8 +651,9 @@ public class RemoteClusterServiceTests extends ESTestCase {
                             });
                         failLatch.await();
                         assertNotNull(ex.get());
-                        if (ex.get() instanceof  IllegalStateException) {
-                            assertThat(ex.get().getMessage(), equalTo("no seed node left"));
+                        if (ex.get() instanceof IllegalStateException) {
+                            assertThat(ex.get().getMessage(), either(equalTo("no seed node left"))
+                                .or(equalTo("Unable to open any connections to remote cluster [cluster_2]")));
                         } else {
                             assertThat(ex.get(),
                                 either(instanceOf(TransportException.class)).or(instanceOf(NoSuchRemoteClusterException.class)));


### PR DESCRIPTION
Currently when a connection closes a new sniff round begins. The
testCollectNodes test closes four transports before triggering the
method to collect the remote nodes. This leads to a race where there are
a number of reasons the collect nodes call might fail. This commit fixes
that issue by changing the test assertion to include a potential failure
condition.

Fixes #55292.