### PR TITLE
Fix simulating index templates without specified index

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -8,6 +8,12 @@
     "url":{
       "paths":[
         {
+          "path":"/_index_template/_simulate_index",
+          "methods":[
+            "POST"
+          ]
+        },
+        {
           "path":"/_index_template/_simulate_index/{name}",
           "methods":[
             "POST"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Simulate index template without new template in the body":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
       features: ["default_shards"]
 
   - do:
@@ -31,8 +31,8 @@
 ---
 "Simulate index template specifying a new template":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
       features: ["default_shards"]
 
   - do:
@@ -86,8 +86,8 @@
 ---
 "Simulate index template with index not matching any template":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
       features: allowed_warnings
 
   - do:
@@ -116,8 +116,8 @@
 ---
 "Simulate index matches overlapping V1 and V2 templates":
   - skip:
-      version: " - 7.99.99"
-      reason: "simulate index template API has not been backported"
+      version: " - 7.7.99"
+      reason: "index template v2 API unavailable before 7.8"
       features: ["allowed_warnings", "default_shards"]
 
   - do:
@@ -175,3 +175,67 @@
   - match: {overlapping.0.index_patterns: ["t*", "t1*"]}
   - match: {overlapping.1.name: v2_template}
   - match: {overlapping.1.index_patterns: ["te*"]}
+
+---
+"Simulate index template specifying a new template without an index":
+  - skip:
+      version: " - 7.99.99"
+      reason: "simulate index template API has not been backported"
+      features: ["default_shards"]
+
+  - do:
+      indices.put_index_template:
+        name: existing_test
+        body:
+          index_patterns: te*
+          priority: 10
+          template:
+            settings:
+              number_of_shards:   1
+              number_of_replicas: 0
+            mappings:
+              properties:
+                field:
+                  type: keyword
+
+  - do:
+      cluster.put_component_template:
+        name: ct
+        body:
+          template:
+            settings:
+              index.number_of_replicas: 2
+            mappings:
+              properties:
+                ct_field:
+                  type: keyword
+
+  - do:
+      indices.simulate_index_template:
+        body:
+          index_patterns: te*
+          priority: 15
+          template:
+            settings:
+              index.blocks.write: true
+            aliases:
+              test_alias: {}
+          composed_of: ["ct"]
+
+  - match: {template.settings.index.blocks.write: "true"}
+  - match: {template.settings.index.number_of_replicas: "2"}
+  - match: {template.mappings._doc.properties.ct_field.type: "keyword"}
+  - match: {overlapping: []}
+  - length: {template.aliases: 1}
+  - is_true: template.aliases.test_alias
+
+---
+"Simulate without specifying a new template and without an index":
+  - skip:
+      version: " - 7.99.99"
+      reason: "simulate index template API has not been backported"
+      features: ["default_shards"]
+
+  - do:
+      catch: /cannot simulate without either an index name or template body/
+      indices.simulate_index_template: {}


### PR DESCRIPTION
When simulating index template composition, we should not require an index name if a body is
specified, instead if no index is specified we should assume the provided template matches.

Relates to #53101
Resolves #56255
