### PR TITLE
[DOCS] Add collapsible sections to 8.0 breaking changes [Part 3]

### DIFF
--- a/docs/reference/migration/migrate_8_0/http.asciidoc
+++ b/docs/reference/migration/migrate_8_0/http.asciidoc
@@ -26,7 +26,7 @@ result in an error on startup.
 ====
 *Details* +
 Starting in version 7.4, a `+` in a URL will be encoded as `%2B` by all REST API functionality. Prior versions handled a `+` as a single space.
-If your application requires handling `+` as a single space you can return to the old behaviour by setting the system property
+In these previous versions, if your application required handling `+` as a single space, you could return to the old behaviour by setting the system property
 `es.rest.url_plus_as_space` to `true`. Note that this behaviour is deprecated and setting this system property to `true` will cease
 to be supported in version 8.
 

--- a/docs/reference/migration/migrate_8_0/http.asciidoc
+++ b/docs/reference/migration/migrate_8_0/http.asciidoc
@@ -8,16 +8,31 @@
 
 // end::notable-breaking-changes[]
 
-[float]
-==== Removal of old HTTP settings
-
+.The `http.tcp_no_delay` setting has been replaced by `http.tcp.no_delay`.
+[%collapsible]
+====
+*Details* +
 The `http.tcp_no_delay` setting was deprecated in 7.x and has been removed in 8.0. It has been replaced by
 `http.tcp.no_delay`.
 
-[float]
-==== Changes to Encoding Plus Signs in URLs
+*Impact* +
+Use the `http.tcp.no_delay` setting. Discontinue use of the `http.tcp_no_delay`
+setting. Specifying the `http.tcp_no_delay` setting in `elasticsearch.yml` will
+result in an error on startup.
+====
 
+.The `es.rest.url_plus_as_space` system property has been removed.
+[%collapsible]
+====
+*Details* +
 Starting in version 7.4, a `+` in a URL will be encoded as `%2B` by all REST API functionality. Prior versions handled a `+` as a single space.
 If your application requires handling `+` as a single space you can return to the old behaviour by setting the system property
 `es.rest.url_plus_as_space` to `true`. Note that this behaviour is deprecated and setting this system property to `true` will cease
 to be supported in version 8.
+
+*Impact* +
+Update your workflow and applications to assume `+` in a URL is encoded as
+`%2B`. Discontinue use of the `es.rest.url_plus_as_space` system property.
+Specifying this property in `elasticsearch.yml` will result in an error on
+startup.
+====

--- a/docs/reference/migration/migrate_8_0/ilm.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ilm.asciidoc
@@ -9,16 +9,35 @@
 
 // end::notable-breaking-changes[]
 
-[float]
 [[ilm-poll-interval-limit]]
-==== `indices.lifecycle.poll_interval` must be greater than 1 second
-
+.The `indices.lifecycle.poll_interval` setting must be greater than `1s`.
+[%collapsible]
+====
+*Details* +
 The setting `indices.lifecycle.poll_interval`, if set too low, can cause
-excessive load on a cluster. This setting must now be set to 1 second or higher.
+excessive load on a cluster. This setting must now be set to `1s` (one second)
+or greater.
 
-[float]
+*Impact* +
+Update the `indices.lifecycle.poll_interval` setting to a value of `1s` or
+greater using `elasticsearch.yml` or the
+{ref}/cluster-update-settings.html[cluster update settings API].
+
+Setting `indices.lifecycle.poll_interval` to less than `1s` in
+`elasticsearch.yml` will result in an error on startup.
+{ref}/cluster-update-settings.html[Cluster update settings API] requests that
+set `indices.lifecycle.poll_interval` to less than `1s` will return an error.
+====
+
 [[ilm-hlrc-rename]]
-==== `indexlifecycle` packages renamed to `ilm`
-
+.The `indexlifecycle` package has been renamed `ilm` in the Java High Level REST Client.
+[%collapsible]
+====
+*Details* +
 In the high level REST client, the `indexlifecycle` package has been
-renamed to `ilm` to match the package rename inside the Elasticsearch code.
+renamed to `ilm` to match the package rename inside the {es} code.
+
+*Impact* +
+Update your workflow and applications to use the `ilm` package in place of
+`indexlifecycle`.
+====

--- a/docs/reference/migration/migrate_8_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_8_0/indices.asciidoc
@@ -8,52 +8,86 @@
 //tag::notable-breaking-changes[]
 //end::notable-breaking-changes[]
 
-[float]
-==== Force Merge API changes
 
-Previously, the Force Merge API allowed the parameters `only_expunge_deletes`
+.The force merge API's `max_num_segments` and `only_expunge_deletes` parameters cannot both be specified in the same request.
+[%collapsible]
+====
+*Details* +
+Previously, the force merge API allowed the parameters `only_expunge_deletes`
 and `max_num_segments` to be set to a non default value at the same time. But
 the `max_num_segments` was silently ignored when `only_expunge_deletes` is set
 to `true`, leaving the false impression that it has been applied.
 
-The Force Merge API now rejects requests that have a `max_num_segments` greater
-than or equal to 0 when the `only_expunge_deletes` is set to true.
+*Impact* +
+When using the {ref}/indices-forcemerge.html[force merge API], do not specify
+values for both the `max_num_segments` and `only_expunge_deletes` parameters.
+Requests that include values for both parameters will return an error.
+====
 
-[float]
-==== On-disk term dictionary cannot be disabled
-
+.The `index.force_memory_term_dictionary` setting has been removed.
+[%collapsible]
+====
+*Details* +
 The `index.force_memory_term_dictionary` setting was introduced in 7.0 as a
 temporary measure to allow users to opt-out of the optimization that leaves the
 term dictionary on disk when appropriate. This optimization is now mandatory
 and the setting is removed.
 
-[float]
-==== Remove support for `template` in put index template requests
+*Impact* +
+Discontinue use of the `index.force_memory_term_dictionary` index setting.
+Requests that include this setting will return an error.
+====
 
-In 6.0, we deprecated the `template` field in put index template requests
-in favor of using `index_patterns`. Support for the `template` field is now
+.The put index template API's `template` parameter has been removed.
+[%collapsible]
+====
+*Details* +
+In 6.0, we deprecated the `template` parameter in put index template requests
+in favor of using `index_patterns`. Support for the `template` parameter is now
 removed in 8.0.
 
+*Impact* +
+Use the {ref}/indices-templates-v1.html[put index template API]'s
+`index_patterns` parameter. Requests that include the `template` parameter will
+return an error.
+====
 
-[float]
-==== Remove synced flush
-
+.Synced flush has been removed.
+[%collapsible]
+====
+*Details* +
 Synced flush was deprecated in 7.6 and is removed in 8.0. Use a regular flush
 instead as it has the same effect as a synced flush in 7.6 and later.
 
+*Impact* +
+Use the {ref}/indices-flush.html[flush API]. Requests to the
+`/<index>/flush/synced` or `/flush/synced` endpoints will return an error.
+====
 
-[float]
-==== Indices with soft deletes disabled
-
+.The `index.soft_deletes.enabled` setting has been removed.
+[%collapsible]
+====
+*Details* +
 Creating indices with soft deletes disabled was deprecated in 7.6 and
-is no longer supported in 8.0. The setting index.soft_deletes.enabled
-can no longer be set to false. As the setting defaults to true, simply
-leave the setting unset.
+is no longer supported in 8.0. The `index.soft_deletes.enabled` setting
+can no longer be set to `false`. 
 
-[float]
-==== Translog retention settings are no longer supported
+*Impact* +
+Discontinue use of the `index.soft_deletes.enabled` index setting. Requests that
+set `index.soft_deletes.enabled` to `false` will return an error.
+====
 
-Translog retention settings `index.translog.retention.size` and
-`index.translog.retention.age` were effectively ignored in 7.4,
-deprecated in 7.7, and removed in 8.0 in favor of
-<<index-modules-history-retention,soft deletes>>.
+.The `index.translog.retention.age` and `index.translog.retention.size` settings have been removed.
+[%collapsible]
+====
+*Details* +
+Translog retention settings `index.translog.retention.age` and
+`index.translog.retention.size` were effectively ignored in 7.4, deprecated in
+7.7, and removed in 8.0 in favor of
+{ref}/index-modules-history-retention.html[soft deletes].
+
+*Impact* +
+Discontinue use of the `index.translog.retention.age` and
+`index.translog.retention.size` index settings. Requests that
+include these settings will return an error.
+====


### PR DESCRIPTION
Adds collapsible sections to the 8.0 breaking changes.

To make reviews easier and avoid introducing errors, I've
tried to limit my changes to formatting, with the exception
of rewording heading as sentences.

I'm also splitting this effort over several PRs to make reviews
manageable.

Relates to #55629 and #53229

### Preview
http://elasticsearch_56297.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html