### PR TITLE
[DOCS] Extract the cron docs from Watcher docs and add to the API conventions.

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -8,6 +8,7 @@ API, unless otherwise specified.
 
 * <<multi-index>>
 * <<date-math-index-names>>
+* <<cron-expressions>>
 * <<common-options>>
 * <<url-access-control>>
 
@@ -142,6 +143,8 @@ GET /%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogs
 ----------------------------------------------------------------------
 // TEST[s/^/PUT logstash-2016.09.20\nPUT logstash-2016.09.19\nPUT logstash-2016.09.18\n/]
 // TEST[s/now/2016.09.20%7C%7C/]
+
+include::rest-api/cron-expressions.asciidoc[]
 
 [[common-options]]
 === Common options

--- a/docs/reference/commands/croneval.asciidoc
+++ b/docs/reference/commands/croneval.asciidoc
@@ -3,7 +3,7 @@
 [[elasticsearch-croneval]]
 == elasticsearch-croneval
 
-Validates and evaluates a cron expression. 
+Validates and evaluates a <<cron-expressions,cron expression>>. 
 
 [discrete]
 === Synopsis
@@ -19,12 +19,11 @@ bin/elasticsearch-croneval <expression>
 === Description
 
 This command enables you to verify that your
-https://en.wikipedia.org/wiki/Cron[cron] expressions are valid for use with the
-{es} {alert-features} and produce the expected results.
+cron expressions are valid for use with the
+{es} and produce the expected results.
 
 This command is provided in the `$ES_HOME/bin` directory.
 
-[discrete]
 === Parameters
 
 `-c, --count` <Integer>::
@@ -45,7 +44,7 @@ This command is provided in the `$ES_HOME/bin` directory.
   Shows verbose output.
 
 [discrete]
-=== Examples
+=== Example
 
 If the cron expression is valid, the following command displays the next
 20 times that the schedule will be triggered:

--- a/docs/reference/commands/croneval.asciidoc
+++ b/docs/reference/commands/croneval.asciidoc
@@ -19,7 +19,7 @@ bin/elasticsearch-croneval <expression>
 === Description
 
 This command enables you to verify that your
-cron expressions are valid for use with the
+cron expressions are valid for use with
 {es} and produce the expected results.
 
 This command is provided in the `$ES_HOME/bin` directory.

--- a/docs/reference/rest-api/cron-expressions.asciidoc
+++ b/docs/reference/rest-api/cron-expressions.asciidoc
@@ -1,19 +1,18 @@
 [[cron-expressions]]
 === Cron expressions
 
-{es} uses the cron parser from the http://www.quartz-scheduler.org[Quartz Job Scheduler]. For more
-information about writing Quartz cron expressions, see the
-http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html[Quartz CronTrigger Tutorial].
-
-All schedule times are in coordinated universal time (UTC); other timezones are
-not supported.
-
 A cron expression is a string of the following form:
 
 [source,txt]
 ------------------------------
     <seconds> <minutes> <hours> <day_of_month> <month> <day_of_week> [year]
 ------------------------------
+
+{es} uses the cron parser from the http://www.quartz-scheduler.org[Quartz Job Scheduler]. 
+For more information about writing Quartz cron expressions, see the
+http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html[Quartz CronTrigger Tutorial].
+
+All schedule times are in coordinated universal time (UTC); other timezones are not supported.
 
 TIP: You can use the <<elasticsearch-croneval>> command line tool to validate your cron expressions.
 

--- a/docs/reference/rest-api/cron-expressions.asciidoc
+++ b/docs/reference/rest-api/cron-expressions.asciidoc
@@ -1,0 +1,182 @@
+[[cron-expressions]]
+=== Cron expressions
+
+{es} uses the cron parser from the http://www.quartz-scheduler.org[Quartz Job Scheduler]. For more
+information about writing Quartz cron expressions, see the
+http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html[Quartz CronTrigger Tutorial].
+
+All schedule times are in UTC, other timezones are not supported.
+
+A cron expression is a string of the following form:
+
+[source,txt]
+------------------------------
+    <seconds> <minutes> <hours> <day_of_month> <month> <day_of_week> [year]
+------------------------------
+
+TIP: You can use the <<elasticsearch-croneval>> command line tool to validate your cron expressions.
+
+
+[[cron-elements]]
+==== Cron expression elements
+
+All elements are required except for `year`. 
+See <<cron-special-characters>> for information about the allowed special characters.
+
+seconds::
+(Required)
+Valid values: 0-59 and the special characters `,` `-` `*` `/`
+
+minutes:: 
+(Required)
+Valid values: 0-59 and the special characters `,` `-` `*` `/`
+
+hours:: 
+(Required)
+Valid values: 0-23 and the special characters `,` `-` `*` `/`
+
+day_of_month:: 
+(Required)
+Valid values: 1-31 and the special characters `,` `-` `*` `/` `?` `L` `W`
+
+month::  
+(Required)
+Valid values: 1-12, JAN-DEC, jan-dec, and the special characters `,` `-` `*` `/`
+
+day_of_week:: 
+(Required)
+Valid values: 1-7, SUN-SAT, sun-sat,  and the special characters `,` `-` `*` `/` `?` `L` `#`
+
+year:: 
+(Optional)
+Valid values: 1970-2099 and the special characters `,` `-` `*` `/`
+
+[[cron-special-characters]]
+==== Cron special characters
+
+*::
+All values. Selects every possible value for a field. For
+example, `*` in the `hours` field means "every hour".
+
+?::                
+No specific value. Use when you don't care what the value
+is. For example, if you want the schedule to trigger on a
+particular day of the month, but don't care what day of
+the week that happens to be, you can specify `?` in the
+`day_of_week` field.
+
+-::                 
+A range of values (inclusive). Use to separate a minimum
+and maximum value. For example, if you want the schedule
+to trigger every hour between 9:00 AM and 5:00 PM, you
+could specify  `9-17` in the `hours` field.
+
+,::
+Multiple values. Use to separate multiple values for a
+field. For example, if you want the schedule to trigger
+every Tuesday and Thursday, you could specify `TUE,THU`
+in the `day_of_week` field.
+
+/::
+Increment. Use to separate values when specifying a time
+increment. The first value represents the starting point,
+and the second value represents the interval. For example,
+if you want the schedule to trigger every 20 minutes
+starting at the top of the hour, you could specify `0/20`
+in the `minutes` field. Similarly, specifying `1/5` in
+`day_of_month` field will trigger every 5 days starting on
+the first day of the month.
+
+L::
+Last. Use in the `day_of_month` field to mean the last day
+of the month--day 31 for January, day 28 for February in
+non-leap years, day 30 for April, and so on. Use alone in
+the `day_of_week` field in place of `7` or `SAT`, or after
+a particular day of the week to select the last day of that
+type in the month. For example `6L` means the last Friday
+of the month. You can specify `LW` in the `day_of_month`
+field to specify the last weekday of the month. Avoid using
+the `L` option when specifying lists or ranges of values,
+as the results likely won't be what you expect.
+
+W::
+Weekday. Use to specify the weekday (Monday-Friday) nearest
+the given day. As an example, if you specify `15W` in the
+`day_of_month` field and the 15th is a Saturday, the
+schedule will trigger on the 14th. If the 15th is a Sunday,
+the schedule will trigger on Monday the 16th. If the 15th
+is a Tuesday, the schedule will trigger on Tuesday the 15th.
+However if you specify `1W` as the value for `day_of_month`,
+and the 1st is a Saturday, the schedule will trigger on
+Monday the 3rd--it won't jump over the month boundary. You
+can specify `LW` in the `day_of_month` field to specify the
+last weekday of the month. You can only use the `W` option
+when the `day_of_month` is a single day--it is not valid
+when specifying a range or list of days.
+
+#::
+Nth XXX day in a month. Use in the `day_of_week` field to
+specify the nth XXX day of the month. For example, if you
+specify `6#1`, the schedule will trigger on the first
+Friday of the month. Note that if you specify `3#5` and
+there are not 5 Tuesdays in a particular month, the
+schedule won't trigger that month.
+
+[[cron-expression-examples]]
+==== Examples
+
+[[cron-example-daily]]
+===== Setting daily triggers
+
+`0 5 9 * * ?`::
+Trigger at 9:05 AM UTC every day.
+
+`0 5 9 * * ? 2020`::
+Trigger at 9:05 AM UTC every day during the year 2020.
+
+[[cron-example-range]]
+===== Restricting triggers to a range of days or times
+
+`0 5 9 ? * MON-FRI`::
+Trigger at 9:05 AM UTC Monday through Friday.
+
+`0 0-5 9 * * ?`::
+Trigger every minute starting at 9:00 AM UTC and ending at 9:05 AM UTC every day.=
+
+[[cron-example-interval]]
+===== Setting interval triggers
+
+`0 0/15 9 * * ?`::
+Trigger every 15 minutes starting at 9:00 AM UTC and ending at 9:45 AM UTC every day.
+`0 5 9 1/3 * ?`::
+Trigger at 9:05 AM UTC every 3 days every month, starting on the first day of the month.
+
+[[cron-example-day]]
+===== Setting schedules that trigger on a particular day
+
+`0 1 4 1 4 ?`::
+Trigger every April 1st at 4:01 AM UTC.
+\
+`0 0,30 9 ? 4 WED`::
+Trigger at 9:00 AM UTC and at 9:30 AM UTC every Wednesday in the month of April.
+
+`0 5 9 15 * ?`::
+Trigger at 9:05 AM UTC on the 15th day of every month.
+
+`0 5 9 15W * ?`::
+Trigger at 9:05 AM UTC on the nearest weekday to the 15th of every month.
+
+`0 5 9 ? * 6#1`::
+Trigger at 9:05 AM UTC on the first Friday of every month.
+
+[[cron-example-last]]
+===== Setting triggers using last
+
+`0 5 9 L * ?`::
+Trigger at 9:05 AM UTC on the last day of every month.
+
+`0 5 9 ? * 2L`::
+Trigger at 9:05 AM UTC on the last Monday of every month.
+
+`0 5 9 LW * ?`::
+Trigger at 9:05 AM UTC on the last weekday of every month.

--- a/docs/reference/rest-api/cron-expressions.asciidoc
+++ b/docs/reference/rest-api/cron-expressions.asciidoc
@@ -5,7 +5,8 @@
 information about writing Quartz cron expressions, see the
 http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html[Quartz CronTrigger Tutorial].
 
-All schedule times are in UTC, other timezones are not supported.
+All schedule times are in coordinated universal time (UTC); other timezones are
+not supported.
 
 A cron expression is a string of the following form:
 
@@ -23,61 +24,61 @@ TIP: You can use the <<elasticsearch-croneval>> command line tool to validate yo
 All elements are required except for `year`. 
 See <<cron-special-characters>> for information about the allowed special characters.
 
-seconds::
+`<seconds>`::
 (Required)
-Valid values: 0-59 and the special characters `,` `-` `*` `/`
+Valid values: `0`-`59` and the special characters `,` `-` `*` `/`
 
-minutes:: 
+`<minutes>`:: 
 (Required)
-Valid values: 0-59 and the special characters `,` `-` `*` `/`
+Valid values: `0`-`59` and the special characters `,` `-` `*` `/`
 
-hours:: 
+`<hours>`:: 
 (Required)
-Valid values: 0-23 and the special characters `,` `-` `*` `/`
+Valid values: `0`-`23` and the special characters `,` `-` `*` `/`
 
-day_of_month:: 
+`<day_of_month>`:: 
 (Required)
-Valid values: 1-31 and the special characters `,` `-` `*` `/` `?` `L` `W`
+Valid values: `1`-`31` and the special characters `,` `-` `*` `/` `?` `L` `W`
 
-month::  
+`<month>`::  
 (Required)
-Valid values: 1-12, JAN-DEC, jan-dec, and the special characters `,` `-` `*` `/`
+Valid values: `1`-`12`, `JAN`-`DEC`, `jan`-`dec`, and the special characters `,` `-` `*` `/`
 
-day_of_week:: 
+`<day_of_week>`:: 
 (Required)
-Valid values: 1-7, SUN-SAT, sun-sat,  and the special characters `,` `-` `*` `/` `?` `L` `#`
+Valid values: `1`-`7`, `SUN`-`SAT`, `sun`-`sat`,  and the special characters `,` `-` `*` `/` `?` `L` `#`
 
-year:: 
+`<year>`:: 
 (Optional)
-Valid values: 1970-2099 and the special characters `,` `-` `*` `/`
+Valid values: `1970`-`2099` and the special characters `,` `-` `*` `/`
 
 [[cron-special-characters]]
 ==== Cron special characters
 
-*::
-All values. Selects every possible value for a field. For
+`*`::
+Selects every possible value for a field. For
 example, `*` in the `hours` field means "every hour".
 
-?::                
+`?`::                
 No specific value. Use when you don't care what the value
 is. For example, if you want the schedule to trigger on a
 particular day of the month, but don't care what day of
 the week that happens to be, you can specify `?` in the
 `day_of_week` field.
 
--::                 
+`-`::                 
 A range of values (inclusive). Use to separate a minimum
 and maximum value. For example, if you want the schedule
-to trigger every hour between 9:00 AM and 5:00 PM, you
-could specify  `9-17` in the `hours` field.
+to trigger every hour between 9:00 a.m. and 5:00 p.m., you
+could specify `9-17` in the `hours` field.
 
-,::
+`,`::
 Multiple values. Use to separate multiple values for a
 field. For example, if you want the schedule to trigger
 every Tuesday and Thursday, you could specify `TUE,THU`
 in the `day_of_week` field.
 
-/::
+`/`::
 Increment. Use to separate values when specifying a time
 increment. The first value represents the starting point,
 and the second value represents the interval. For example,
@@ -87,7 +88,7 @@ in the `minutes` field. Similarly, specifying `1/5` in
 `day_of_month` field will trigger every 5 days starting on
 the first day of the month.
 
-L::
+`L`::
 Last. Use in the `day_of_month` field to mean the last day
 of the month--day 31 for January, day 28 for February in
 non-leap years, day 30 for April, and so on. Use alone in
@@ -99,7 +100,7 @@ field to specify the last weekday of the month. Avoid using
 the `L` option when specifying lists or ranges of values,
 as the results likely won't be what you expect.
 
-W::
+`W`::
 Weekday. Use to specify the weekday (Monday-Friday) nearest
 the given day. As an example, if you specify `15W` in the
 `day_of_month` field and the 15th is a Saturday, the
@@ -114,7 +115,7 @@ last weekday of the month. You can only use the `W` option
 when the `day_of_month` is a single day--it is not valid
 when specifying a range or list of days.
 
-#::
+`#`::
 Nth XXX day in a month. Use in the `day_of_week` field to
 specify the nth XXX day of the month. For example, if you
 specify `6#1`, the schedule will trigger on the first
@@ -129,54 +130,54 @@ schedule won't trigger that month.
 ===== Setting daily triggers
 
 `0 5 9 * * ?`::
-Trigger at 9:05 AM UTC every day.
+Trigger at 9:05 a.m. UTC every day.
 
 `0 5 9 * * ? 2020`::
-Trigger at 9:05 AM UTC every day during the year 2020.
+Trigger at 9:05 a.m. UTC every day during the year 2020.
 
 [[cron-example-range]]
 ===== Restricting triggers to a range of days or times
 
 `0 5 9 ? * MON-FRI`::
-Trigger at 9:05 AM UTC Monday through Friday.
+Trigger at 9:05 a.m. UTC Monday through Friday.
 
 `0 0-5 9 * * ?`::
-Trigger every minute starting at 9:00 AM UTC and ending at 9:05 AM UTC every day.=
+Trigger every minute starting at 9:00 a.m. UTC and ending at 9:05 a.m. UTC every day.
 
 [[cron-example-interval]]
 ===== Setting interval triggers
 
 `0 0/15 9 * * ?`::
-Trigger every 15 minutes starting at 9:00 AM UTC and ending at 9:45 AM UTC every day.
+Trigger every 15 minutes starting at 9:00 a.m. UTC and ending at 9:45 a.m. UTC every day.
+
 `0 5 9 1/3 * ?`::
-Trigger at 9:05 AM UTC every 3 days every month, starting on the first day of the month.
+Trigger at 9:05 a.m. UTC every 3 days every month, starting on the first day of the month.
 
 [[cron-example-day]]
 ===== Setting schedules that trigger on a particular day
 
 `0 1 4 1 4 ?`::
-Trigger every April 1st at 4:01 AM UTC.
-\
+Trigger every April 1st at 4:01 a.m. UTC.
 `0 0,30 9 ? 4 WED`::
-Trigger at 9:00 AM UTC and at 9:30 AM UTC every Wednesday in the month of April.
+Trigger at 9:00 a.m. UTC and at 9:30 a.m. UTC every Wednesday in the month of April.
 
 `0 5 9 15 * ?`::
-Trigger at 9:05 AM UTC on the 15th day of every month.
+Trigger at 9:05 a.m. UTC on the 15th day of every month.
 
 `0 5 9 15W * ?`::
-Trigger at 9:05 AM UTC on the nearest weekday to the 15th of every month.
+Trigger at 9:05 a.m. UTC on the nearest weekday to the 15th of every month.
 
 `0 5 9 ? * 6#1`::
-Trigger at 9:05 AM UTC on the first Friday of every month.
+Trigger at 9:05 a.m. UTC on the first Friday of every month.
 
 [[cron-example-last]]
 ===== Setting triggers using last
 
 `0 5 9 L * ?`::
-Trigger at 9:05 AM UTC on the last day of every month.
+Trigger at 9:05 a.m. UTC on the last day of every month.
 
 `0 5 9 ? * 2L`::
-Trigger at 9:05 AM UTC on the last Monday of every month.
+Trigger at 9:05 a.m. UTC on the last Monday of every month.
 
 `0 5 9 LW * ?`::
-Trigger at 9:05 AM UTC on the last weekday of every month.
+Trigger at 9:05 a.m. UTC on the last weekday of every month.

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -82,6 +82,7 @@ Repository used to store snapshots created by this policy. This repository must
 exist prior to the policy's creation. You can create a repository using the 
 <<modules-snapshots,snapshot repository API>>.
 
+[[slm-api-put-retention]]
 `retention`::
 (Optional, object)
 Retention rules used to retain and delete snapshots created by the policy.

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-[testenv="basic"]
 [[slm-api-put-policy]]
 === Put snapshot lifecycle policy API
 ++++
@@ -84,7 +82,6 @@ Repository used to store snapshots created by this policy. This repository must
 exist prior to the policy's creation. You can create a repository using the 
 <<modules-snapshots,snapshot repository API>>.
 
-[[slm-api-put-retention]]
 `retention`::
 (Optional, object)
 Retention rules used to retain and delete snapshots created by the policy.
@@ -109,7 +106,7 @@ Minimum number of snapshots to retain, even if the snapshots have expired.
 ====
 
 `schedule`::
-(Required, <<schedule-cron,Cron scheduler configuration>>)
+(Required, <<cron-expressions,Cron syntax>>)
 Periodic or absolute schedule at which the policy creates snapshots and deletes 
 expired snapshots. Schedule changes to existing policies are applied immediately.
 

--- a/docs/reference/slm/getting-started-slm.asciidoc
+++ b/docs/reference/slm/getting-started-slm.asciidoc
@@ -112,9 +112,9 @@ This is useful for taking snapshots before making a configuration change,
 upgrading, or to test a new policy. 
 Manually executing a policy does not affect its configured schedule. 
 
-Instead of waiting for our policy to run, let's tell SLM to take a snapshot
+Instead of waiting for our policy to run, let's tell {slm-init} to take a snapshot
 as using the configuration from our policy right now instead of waiting for
-1:30AM.
+1:30 a.m..
 
 [source,console]
 --------------------------------------------------
@@ -183,4 +183,3 @@ repository is lost while copying files.
 <2> the name of the snapshot that was successfully initiated
 <3> information about the last time the policy failed to initiate a snapshot
 <4> the next time the policy will execute
-

--- a/docs/reference/slm/getting-started-slm.asciidoc
+++ b/docs/reference/slm/getting-started-slm.asciidoc
@@ -112,7 +112,9 @@ This is useful for taking snapshots before making a configuration change,
 upgrading, or to test a new policy. 
 Manually executing a policy does not affect its configured schedule. 
 
-For example, the following request manually triggers the `nightly-snapshots` policy:
+Instead of waiting for our policy to run, let's tell SLM to take a snapshot
+as using the configuration from our policy right now instead of waiting for
+1:30AM.
 
 [source,console]
 --------------------------------------------------
@@ -159,19 +161,26 @@ repository is lost while copying files.
         "max_count": 50
       }
     },
-    "last_success": { 
-      "snapshot_name": "nightly-snap-2019.04.24-tmtnyjtrsxkhbrrdcgg18a", <1>
-      "time_string": "2019-04-24T16:43:49.316Z", <2>
+    "last_success": { <1>
+      "snapshot_name": "nightly-snap-2019.04.24-tmtnyjtrsxkhbrrdcgg18a", <2>
+      "time_string": "2019-04-24T16:43:49.316Z",
       "time": 1556124229316
     } ,
-    "next_execution": "2019-04-24T01:30:00.000Z", <3>
-    "next_execution_millis": 1556048160000 
+    "last_failure": { <3>
+      "snapshot_name": "nightly-snap-2019.04.02-lohisb5ith2n8hxacaq3mw",
+      "time_string": "2019-04-02T01:30:00.000Z",
+      "time": 1556042030000,
+      "details": "{\"type\":\"index_not_found_exception\",\"reason\":\"no such index [important]\",\"resource.type\":\"index_or_alias\",\"resource.id\":\"important\",\"index_uuid\":\"_na_\",\"index\":\"important\",\"stack_trace\":\"[important] IndexNotFoundException[no such index [important]]\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.indexNotFoundException(IndexNameExpressionResolver.java:762)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.innerResolve(IndexNameExpressionResolver.java:714)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.resolve(IndexNameExpressionResolver.java:670)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:163)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:142)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:102)\\n\\tat org.elasticsearch.snapshots.SnapshotsService$1.execute(SnapshotsService.java:280)\\n\\tat org.elasticsearch.cluster.ClusterStateUpdateTask.execute(ClusterStateUpdateTask.java:47)\\n\\tat org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:687)\\n\\tat org.elasticsearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:310)\\n\\tat org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:210)\\n\\tat org.elasticsearch.cluster.service.MasterService$Batcher.run(MasterService.java:142)\\n\\tat org.elasticsearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:150)\\n\\tat org.elasticsearch.cluster.service.TaskBatcher$BatchedTask.run(TaskBatcher.java:188)\\n\\tat org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:688)\\n\\tat org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:252)\\n\\tat org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:215)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\\n\\tat java.base/java.lang.Thread.run(Thread.java:834)\\n\"}"
+    } ,
+    "next_execution": "2019-04-24T01:30:00.000Z", <4>
+    "next_execution_millis": 1556048160000
   }
 }
 --------------------------------------------------
 // TESTRESPONSE[skip:the presence of last_failure and last_success is asynchronous and will be present for users, but is untestable]
 
-<1> The name of the last snapshot that was succesfully initiated by the policy
-<2> When the snapshot was initiated
-<3> When the policy will initiate the next snapshot
+<1> information about the last time the policy successfully initated a snapshot
+<2> the name of the snapshot that was successfully initiated
+<3> information about the last time the policy failed to initiate a snapshot
+<4> the next time the policy will execute
 

--- a/docs/reference/slm/getting-started-slm.asciidoc
+++ b/docs/reference/slm/getting-started-slm.asciidoc
@@ -112,9 +112,8 @@ This is useful for taking snapshots before making a configuration change,
 upgrading, or to test a new policy. 
 Manually executing a policy does not affect its configured schedule. 
 
-Instead of waiting for our policy to run, let's tell {slm-init} to take a snapshot
-as using the configuration from our policy right now instead of waiting for
-1:30 a.m..
+Instead of waiting for the policy to run, tell {slm-init} to take a snapshot
+using the configuration right now instead of waiting for 1:30 a.m..
 
 [source,console]
 --------------------------------------------------
@@ -161,25 +160,25 @@ repository is lost while copying files.
         "max_count": 50
       }
     },
-    "last_success": { <1>
+    "last_success": {                                                    <1>
       "snapshot_name": "nightly-snap-2019.04.24-tmtnyjtrsxkhbrrdcgg18a", <2>
       "time_string": "2019-04-24T16:43:49.316Z",
       "time": 1556124229316
     } ,
-    "last_failure": { <3>
+    "last_failure": {                                                    <3>
       "snapshot_name": "nightly-snap-2019.04.02-lohisb5ith2n8hxacaq3mw",
       "time_string": "2019-04-02T01:30:00.000Z",
       "time": 1556042030000,
       "details": "{\"type\":\"index_not_found_exception\",\"reason\":\"no such index [important]\",\"resource.type\":\"index_or_alias\",\"resource.id\":\"important\",\"index_uuid\":\"_na_\",\"index\":\"important\",\"stack_trace\":\"[important] IndexNotFoundException[no such index [important]]\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.indexNotFoundException(IndexNameExpressionResolver.java:762)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.innerResolve(IndexNameExpressionResolver.java:714)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.resolve(IndexNameExpressionResolver.java:670)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:163)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:142)\\n\\tat org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:102)\\n\\tat org.elasticsearch.snapshots.SnapshotsService$1.execute(SnapshotsService.java:280)\\n\\tat org.elasticsearch.cluster.ClusterStateUpdateTask.execute(ClusterStateUpdateTask.java:47)\\n\\tat org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:687)\\n\\tat org.elasticsearch.cluster.service.MasterService.calculateTaskOutputs(MasterService.java:310)\\n\\tat org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:210)\\n\\tat org.elasticsearch.cluster.service.MasterService$Batcher.run(MasterService.java:142)\\n\\tat org.elasticsearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:150)\\n\\tat org.elasticsearch.cluster.service.TaskBatcher$BatchedTask.run(TaskBatcher.java:188)\\n\\tat org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:688)\\n\\tat org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:252)\\n\\tat org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:215)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\\n\\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\\n\\tat java.base/java.lang.Thread.run(Thread.java:834)\\n\"}"
     } ,
-    "next_execution": "2019-04-24T01:30:00.000Z", <4>
+    "next_execution": "2019-04-24T01:30:00.000Z",                        <4>
     "next_execution_millis": 1556048160000
   }
 }
 --------------------------------------------------
 // TESTRESPONSE[skip:the presence of last_failure and last_success is asynchronous and will be present for users, but is untestable]
 
-<1> information about the last time the policy successfully initated a snapshot
-<2> the name of the snapshot that was successfully initiated
-<3> information about the last time the policy failed to initiate a snapshot
-<4> the next time the policy will execute
+<1> Information about the last time the policy successfully initated a snapshot
+<2> The name of the snapshot that was successfully initiated
+<3> Unformation about the last time the policy failed to initiate a snapshot
+<4> The next time the policy will execute

--- a/docs/reference/slm/slm-retention.asciidoc
+++ b/docs/reference/slm/slm-retention.asciidoc
@@ -25,9 +25,6 @@ either according to the policy schedule or through the
 <<slm-api-execute-lifecycle, execute lifecycle>> API. 
 Manual snapshots are ignored and don't count toward the retention limits.
 
-| `slm.retention_duration` | `"1h"` | A limit of how long SLM should spend deleting old snapshots.
-|=====================================
-
 To retrieve information about the snapshot retention task history, 
 use the  <<slm-api-get-stats, get stats>> API:
 

--- a/docs/reference/slm/slm-retention.asciidoc
+++ b/docs/reference/slm/slm-retention.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[slm-retention]]
-=== Snapshot retention
+== Snapshot lifecycle management retention
 
 You can include a retention policy in an {slm-init} policy to automatically delete old snapshots. 
 Retention runs as a cluster-level task and is not associated with a particular policy's schedule.
@@ -25,7 +25,8 @@ either according to the policy schedule or through the
 <<slm-api-execute-lifecycle, execute lifecycle>> API. 
 Manual snapshots are ignored and don't count toward the retention limits.
 
-If multiple policies snapshot to the same repository, they can define differing retention criteria. 
+| `slm.retention_duration` | `"1h"` | A limit of how long SLM should spend deleting old snapshots.
+|=====================================
 
 To retrieve information about the snapshot retention task history, 
 use the  <<slm-api-get-stats, get stats>> API:

--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -1,174 +1,15 @@
-[role="xpack"]
 [[schedule-cron]]
-==== `cron` schedule
+==== Cron schedule
 
-A <<trigger-schedule,`schedule`>> trigger that enables you to use a
-https://en.wikipedia.org/wiki/Cron[cron] style expression to specify when you
-want the scheduler to start the watch execution. {watcher} uses the cron parser
-from the http://www.quartz-scheduler.org[Quartz Job Scheduler]. For more
-information about writing Quartz cron expressions, see the
-http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/tutorial-lesson-06.html[Quartz CronTrigger Tutorial].
+A <<trigger-schedule, `schedule`>> trigger that enables you to use a
+<<cron-expressions, cron expression>> to specify when you
+want the scheduler to start the watch execution.
 
-WARNING:  While `cron` triggers are super powerful, we recommend using one of
-          the other schedule types if you can, as they are much more
-          straightforward to configure. If you use `cron`, construct your `cron`
-          expressions with care to be sure you are actually setting the schedule
-          you want. You can use the <<croneval,`elasticsearch-croneval`>> tool to validate
-          your cron expressions and see what the resulting trigger times will be.
+WARNING:  While cron` triggers are super powerful, we recommend using one of
+the other schedule types if you can, as they are much more
+straightforward to configure.
 
-[[_cron_expressions]]
-===== Cron expressions
-
-A cron expression is a string of the following form:
-
-[source,txt]
-------------------------------
-    <seconds> <minutes> <hours> <day_of_month> <month> <day_of_week> [year]
-------------------------------
-
-All elements are required except for `year`. <<schedule-cron-elements>> shows
-the valid values for each element in a cron expression.
-
-[[schedule-cron-elements]]
-.Cron expression elements
-[cols=",^,,", options="header"]
-|======
-| Name           | Required  | Valid Values            | Valid Special Characters
-| `seconds`      | yes       | `0`-`59`                | `,` `-` `*` `/`
-| `minutes`      | yes       | `0`-`59`                | `,` `-` `*` `/`
-| `hours`        | yes       | `0`-`23`                | `,` `-` `*` `/`
-| `day_of_month` | yes       | `1`-`31`                | `,` `-` `*` `/` `?` `L` `W`
-| `month`        | yes       | `1`-`12` or `JAN`-`DEC` | `,` `-` `*` `/`
-| `day_of_week`  | yes       | `1`-`7` or `SUN`-`SAT`  | `,` `-` `*` `/` `?` `L` `#`
-| `year`         | no        | empty or `1970`-`2099   | `,` `-` `*` `/`
-|======
-
-The special characters you can use in a cron expression are described in
-<<schedule-cron-special-characters>>. The names of months and days of the week
-are not case sensitive. For example, `MON` and `mon` are equivalent.
-
-NOTE: Currently, you must specify `?` for either the `day_of_week` or
-      `day_of_month`. Explicitly specifying both values is not supported.
-
-[[schedule-cron-special-characters]]
-.Cron special characters
-[options="header"]
-|======
-| Special Character | Description
-
-| *                 | All values. Selects every possible value for a field. For
-                      example, `*` in the `hours` field means "every hour".
-
-| ?                 | No specific value. Use when you don't care what the value
-                      is. For example, if you want the schedule to trigger on a
-                      particular day of the month, but don't care what day of
-                      the week that happens to be, you can specify `?` in the
-                      `day_of_week` field.
-
-| -                 | A range of values (inclusive). Use to separate a minimum
-                      and maximum value. For example, if you want the schedule
-                      to trigger every hour between 9:00 AM and 5:00 PM, you
-                      could specify  `9-17` in the `hours` field.
-
-| ,                 | Multiple values. Use to separate multiple values for a
-                      field. For example, if you want the schedule to trigger
-                      every Tuesday and Thursday, you could specify `TUE,THU`
-                      in the `day_of_week` field.
-
-| /                 | Increment. Use to separate values when specifying a time
-                      increment. The first value represents the starting point,
-                      and the second value represents the interval. For example,
-                      if you want the schedule to trigger every 20 minutes
-                      starting at the top of the hour, you could specify `0/20`
-                      in the `minutes` field. Similarly, specifying `1/5` in
-                      `day_of_month` field will trigger every 5 days starting on
-                      the first day of the month.
-
-| L                 | Last. Use in the `day_of_month` field to mean the last day
-                      of the month--day 31 for January, day 28 for February in
-                      non-leap years, day 30 for April, and so on. Use alone in
-                      the `day_of_week` field in place of `7` or `SAT`, or after
-                      a particular day of the week to select the last day of that
-                      type in the month. For example `6L` means the last Friday
-                      of the month. You can specify `LW` in the `day_of_month`
-                      field to specify the last weekday of the month. Avoid using
-                      the `L` option when specifying lists or ranges of values,
-                      as the results likely won't be what you expect.
-
-| W                 | Weekday. Use to specify the weekday (Monday-Friday) nearest
-                      the given day. As an example, if you specify `15W` in the
-                      `day_of_month` field and the 15th is a Saturday, the
-                      schedule will trigger on the 14th. If the 15th is a Sunday,
-                      the schedule will trigger on Monday the 16th. If the 15th
-                      is a Tuesday, the schedule will trigger on Tuesday the 15th.
-                      However if you specify `1W` as the value for `day_of_month`,
-                      and the 1st is a Saturday, the schedule will trigger on
-                      Monday the 3rd--it won't jump over the month boundary. You
-                      can specify `LW` in the `day_of_month` field to specify the
-                      last weekday of the month. You can only use the `W` option
-                      when the `day_of_month` is a single day--it is not valid
-                      when specifying a range or list of days.
-
-| #                 | Nth XXX day in a month. Use in the `day_of_week` field to
-                      specify the nth XXX day of the month. For example, if you
-                      specify `6#1`, the schedule will trigger on the first
-                      Friday of the month. Note that if you specify `3#5` and
-                      there are not 5 Tuesdays in a particular month, the
-                      schedule won't trigger that month.
-
-|======
-
-.Setting daily triggers
-[options="header"]
-|======
-| Cron Expression       | Description
-| `0 5 9 * * ?`         | Trigger at 9:05 AM every day.
-| `0 5 9 * * ? 2015`    | Trigger at 9:05 AM every day during the year 2015.
-|======
-
-.Restricting triggers to a range of days or times
-[options="header"]
-|======
-| Cron Expression       | Description
-| `0 5 9 ? * MON-FRI`   | Trigger at 9:05 AM Monday through Friday.
-| `0 0-5 9 * * ?`       | Trigger every minute starting at 9:00 AM and ending
-                          at 9:05 AM every day.
-|======
-
-.Setting interval triggers
-[options="header"]
-|======
-| Cron Expression       | Description
-| `0 0/15 9 * * ?`      | Trigger every 15 minutes starting at 9:00 AM and ending
-                          at 9:45 AM every day.
-| `0 5 9 1/3 * ?`       | Trigger at 9:05 AM every 3 days every month, starting
-                          on the first day of the month.
-|======
-
-.Setting schedules that trigger on a particular day
-[options="header"]
-|======
-| Cron Expression       | Description
-| `0 1 4 1 4 ?`         | Trigger every April 1st at 4:01 AM.
-| `0 0,30 9 ? 4 WED`    | Trigger at 9:00 AM and at 9:30 AM every Wednesday in
-                          the month of April.
-| `0 5 9 15 * ?`        | Trigger at 9:05 AM on the 15th day of every month.
-| `0 5 9 15W * ?`       | Trigger at 9:05 AM on the nearest weekday to the 15th
-                          of every month.
-| `0 5 9 ? * 6#1`       | Trigger at 9:05 AM on the first Friday of every month.
-|======
-
-.Setting triggers using last
-[options="header"]
-|======
-| Cron Expression       | Description
-| `0 5 9 L * ?`         | Trigger at 9:05 AM on the last day of every month.
-| `0 5 9 ? * 2L`        | Trigger at 9:05 AM on the last Monday of every month
-| `0 5 9 LW * ?`        | Trigger at 9:05 AM on the last weekday of every month.
-|======
-
-[[_configuring_a_cron_schedule]]
-===== Configuring a cron schedule
+===== Configure a cron schedule with one time
 
 To configure a `cron` schedule, you simply specify the cron expression as a
 string value. For example, the following snippet configures a `cron` schedule
@@ -189,7 +30,7 @@ that triggers every day at noon:
 // NOTCONSOLE
 
 [[_configuring_a_multiple_times_cron_schedule]]
-===== Configuring a multiple times cron schedule
+===== Configure a cron schedule with multiple times
 
 To configure a `cron` schedule that triggers multiple times, you can
 specify an array of cron expressions. For example, the following `cron`
@@ -214,21 +55,15 @@ minute during the weekend:
 // NOTCONSOLE
 
 [[croneval]]
-===== Verifying cron expressions
+===== Use croneval to validate cron expressions
 
-The {es} {alert-features} provide a
-<<elasticsearch-croneval,`elasticsearch-croneval`>> command line tool
-that you can use to verify that your cron expressions are valid and produce the
-expected results. This tool is provided in the `$ES_HOME/bin` directory.
+{es} provides a <<elasticsearch-croneval, `elasticsearch-croneval`>> command line tool 
+in the `$ES_HOME/bin` directory that you can use to check that your cron expressions 
+are valid and produce the expected results.
 
-To verify a cron expression, simply pass it in as a parameter to
-`elasticsearch-croneval`:
+To validate a cron expression, pass it in as a parameter to	`elasticsearch-croneval`:	
 
-[source,bash]
---------------------------------------------------
+[source,bash]	
+--------------------------------------------------	
 bin/elasticsearch-croneval "0 0/1 * * * ?"
---------------------------------------------------
-
-If the cron expression is valid, `elasticsearch-croneval` displays the next 10
-times that the schedule will be triggered. You can specify the `-c` option to
-control how many future trigger times are displayed.
+--------------------------------------------------	

--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -61,9 +61,9 @@ minute during the weekend:
 in the `$ES_HOME/bin` directory that you can use to check that your cron expressions 
 are valid and produce the expected results.
 
-To validate a cron expression, pass it in as a parameter to	`elasticsearch-croneval`:	
+To validate a cron expression, pass it in as a parameter to `elasticsearch-croneval`:	
 
-[source,bash]	
---------------------------------------------------	
+[source,bash]
+--------------------------------------------------
 bin/elasticsearch-croneval "0 0/1 * * * ?"
 --------------------------------------------------	

--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -1,13 +1,14 @@
 [[schedule-cron]]
 ==== Cron schedule
 
-A <<trigger-schedule, `schedule`>> trigger that enables you to use a
-<<cron-expressions, cron expression>> to specify when you
-want the scheduler to start the watch execution.
+Defines a <<trigger-schedule, `schedule`>> using a <<cron-expressions, cron expression>> 
+that specifiues when to execute a watch.
 
-WARNING:  While cron` triggers are super powerful, we recommend using one of
-the other schedule types if you can, as they are much more
-straightforward to configure.
+TIP:  While cron expressions are powerful, a regularly occurring schedule 
+is easier to configure with the other schedule types. 
+If you must use a cron schedule, make sure you verify it with 
+<<elasticsearch-croneval, `elasticsearch-croneval`>> . 
+
 
 ===== Configure a cron schedule with one time
 


### PR DESCRIPTION
Picks up the changes from #49156, splits the cron expressions to a separate page, and adds the topic to the API conventions.

Based on the commits from #55953, will remove the WIP label once they've been merged.