### PR TITLE
Enable aggregating indices stats by index patterns.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIndices.java
@@ -48,7 +48,7 @@ public class ClusterStatsIndices implements ToXContentFragment {
     private AnalysisStats analysis;
     private MappingStats mappings;
 
-    public ClusterStatsIndices(List<ClusterStatsNodeResponse> nodeResponses,
+    public ClusterStatsIndices(List<org.elasticsearch.action.admin.indices.stats.ShardStats> shardsStats,
             MappingStats mappingStats,
             AnalysisStats analysisStats) {
         ObjectObjectHashMap<String, ShardStats> countsPerIndex = new ObjectObjectHashMap<>();
@@ -60,28 +60,26 @@ public class ClusterStatsIndices implements ToXContentFragment {
         this.completion = new CompletionStats();
         this.segments = new SegmentsStats();
 
-        for (ClusterStatsNodeResponse r : nodeResponses) {
-            for (org.elasticsearch.action.admin.indices.stats.ShardStats shardStats : r.shardsStats()) {
-                ShardStats indexShardStats = countsPerIndex.get(shardStats.getShardRouting().getIndexName());
-                if (indexShardStats == null) {
-                    indexShardStats = new ShardStats();
-                    countsPerIndex.put(shardStats.getShardRouting().getIndexName(), indexShardStats);
-                }
-
-                indexShardStats.total++;
-
-                CommonStats shardCommonStats = shardStats.getStats();
-
-                if (shardStats.getShardRouting().primary()) {
-                    indexShardStats.primaries++;
-                    docs.add(shardCommonStats.docs);
-                }
-                store.add(shardCommonStats.store);
-                fieldData.add(shardCommonStats.fieldData);
-                queryCache.add(shardCommonStats.queryCache);
-                completion.add(shardCommonStats.completion);
-                segments.add(shardCommonStats.segments);
+        for (org.elasticsearch.action.admin.indices.stats.ShardStats shardStats : shardsStats) {
+            ShardStats indexShardStats = countsPerIndex.get(shardStats.getShardRouting().getIndexName());
+            if (indexShardStats == null) {
+                indexShardStats = new ShardStats();
+                countsPerIndex.put(shardStats.getShardRouting().getIndexName(), indexShardStats);
             }
+
+            indexShardStats.total++;
+
+            CommonStats shardCommonStats = shardStats.getStats();
+
+            if (shardStats.getShardRouting().primary()) {
+                indexShardStats.primaries++;
+                docs.add(shardCommonStats.docs);
+            }
+            store.add(shardCommonStats.store);
+            fieldData.add(shardCommonStats.fieldData);
+            queryCache.add(shardCommonStats.queryCache);
+            completion.add(shardCommonStats.completion);
+            segments.add(shardCommonStats.segments);
         }
 
         shards = new ShardStats();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequest.java
@@ -19,19 +19,73 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ContextParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * A request to get cluster level stats.
  */
 public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
 
+    private static final ObjectParser<ClusterStatsRequest, Void> PARSER = new ObjectParser<>("_cluster/stats");
+    static {
+        // nocommit: there must be existing logic to read lists of strings somewhere right?
+        CheckedFunction<XContentParser, List<String>, IOException> listParser = parser -> {
+            XContentParser.Token token = parser.currentToken();
+            if (token == XContentParser.Token.START_ARRAY) {
+                token = parser.nextToken();
+            } else {
+                throw new XContentParseException(parser.getTokenLocation(), "Failed to parse list:  expecting "
+                        + XContentParser.Token.START_ARRAY + " but got " + token);
+            }
+            ArrayList<String> list = new ArrayList<>();
+            for (; token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {
+                list.add(parser.text());
+            }
+            return list;
+        };
+        ContextParser<Void, Map<String, List<String>>> indexPatternsParser = (parser, context) -> parser.map(HashMap::new, listParser);
+        PARSER.declareObject(ClusterStatsRequest::indexPatterns, indexPatternsParser, new ParseField("index_patterns"));
+    }
+
+    /** Parse a {@link ClusterStatsRequest} from some {@link XContent}. */
+    public static void fromXContent(XContentParser parser, ClusterStatsRequest request) throws IOException {
+        PARSER.parse(parser, request, null);
+    }
+
+    /**
+     * A map from identifiers on an index pattern to a list of index patterns, e.g.
+     * <pre class="prettyprint">
+     * {
+     *   "logs": [ "logs-*", "filebeat-*" ],
+     *   "metrics": [ "metrics-*" ]
+     * }
+     * </pre>
+     */
+    private Map<String, List<String>> indexPatterns = Collections.emptyMap();
+
     public ClusterStatsRequest(StreamInput in) throws IOException {
         super(in);
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            indexPatterns = in.readMap(StreamInput::readString, si -> si.readList(StreamInput::readString));
+        }
     }
 
     /**
@@ -45,6 +99,20 @@ public class ClusterStatsRequest extends BaseNodesRequest<ClusterStatsRequest> {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeMap(indexPatterns, StreamOutput::writeString, (so, list) -> so.writeCollection(list, StreamOutput::writeString));
+        }
+    }
+
+    /** Return index patterns to compute stats on for this request. */
+    public Map<String, List<String>> indexPatterns() {
+        return indexPatterns;
+    }
+
+    /** Set index patterns to compute stats on. */
+    public ClusterStatsRequest indexPatterns(Map<String, List<String>> indexPatterns) {
+        this.indexPatterns = Objects.requireNonNull(indexPatterns);
+        return this;
     }
 
 }


### PR DESCRIPTION
This adds a body to `_cluster/stats` requests so that it's possible to
get index statistics for some specific index patterns such as `logs-*`.

Here is an example request/response:

```
GET _cluster/stats
{
  "index_patterns": {
    "logs": [ "logs-*", "filebeat-*" ],
    "metrics": ["metrics-*", "metricbeat-*" ]
  }
}
```

`index_patterns` takes a map from custom IDs to a list of index
patterns. The IDs are reused in the response in order to provide
stats for these specific index patterns.

```
{
  // usual _cluster/stats response
  "index_patterns" : {
    "metrics" : {
      "count" : 1,
      "shards" : {
        "total" : 1,
        "primaries" : 1,
        "replication" : 0.0,
        "index" : {
          "shards" : {
            "min" : 1,
            "max" : 1,
            "avg" : 1.0
          },
          "primaries" : {
            "min" : 1,
            "max" : 1,
            "avg" : 1.0
          },
          "replication" : {
            "min" : 0.0,
            "max" : 0.0,
            "avg" : 0.0
          }
        }
      },
      "docs" : {
        "count" : 0,
        "deleted" : 0
      },
      "store" : {
        "size_in_bytes" : 208
      },
      "fielddata" : {
        "memory_size_in_bytes" : 0,
        "evictions" : 0
      },
      "query_cache" : {
        "memory_size_in_bytes" : 0,
        "total_count" : 0,
        "hit_count" : 0,
        "miss_count" : 0,
        "cache_size" : 0,
        "cache_count" : 0,
        "evictions" : 0
      },
      "completion" : {
        "size_in_bytes" : 0
      },
      "segments" : {
        "count" : 0,
        "memory_in_bytes" : 0,
        "terms_memory_in_bytes" : 0,
        "stored_fields_memory_in_bytes" : 0,
        "term_vectors_memory_in_bytes" : 0,
        "norms_memory_in_bytes" : 0,
        "points_memory_in_bytes" : 0,
        "doc_values_memory_in_bytes" : 0,
        "index_writer_memory_in_bytes" : 0,
        "version_map_memory_in_bytes" : 0,
        "fixed_bit_set_memory_in_bytes" : 0,
        "max_unsafe_auto_id_timestamp" : -1,
        "file_sizes" : { }
      }
    },
    "logs" : {
      "count" : 2,
      "shards" : {
        "total" : 4,
        "primaries" : 4,
        "replication" : 0.0,
        "index" : {
          "shards" : {
            "min" : 1,
            "max" : 3,
            "avg" : 2.0
          },
          "primaries" : {
            "min" : 1,
            "max" : 3,
            "avg" : 2.0
          },
          "replication" : {
            "min" : 0.0,
            "max" : 0.0,
            "avg" : 0.0
          }
        }
      },
      "docs" : {
        "count" : 0,
        "deleted" : 0
      },
      "store" : {
        "size_in_bytes" : 832
      },
      "fielddata" : {
        "memory_size_in_bytes" : 0,
        "evictions" : 0
      },
      "query_cache" : {
        "memory_size_in_bytes" : 0,
        "total_count" : 0,
        "hit_count" : 0,
        "miss_count" : 0,
        "cache_size" : 0,
        "cache_count" : 0,
        "evictions" : 0
      },
      "completion" : {
        "size_in_bytes" : 0
      },
      "segments" : {
        "count" : 0,
        "memory_in_bytes" : 0,
        "terms_memory_in_bytes" : 0,
        "stored_fields_memory_in_bytes" : 0,
        "term_vectors_memory_in_bytes" : 0,
        "norms_memory_in_bytes" : 0,
        "points_memory_in_bytes" : 0,
        "doc_values_memory_in_bytes" : 0,
        "index_writer_memory_in_bytes" : 0,
        "version_map_memory_in_bytes" : 0,
        "fixed_bit_set_memory_in_bytes" : 0,
        "max_unsafe_auto_id_timestamp" : -1,
        "file_sizes" : { }
      }
    }
  }
}
```