### PR TITLE
Make Annotation a result type

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -55,7 +55,7 @@ public class Annotation implements ToXContentObject, Writeable {
     }
 
     /**
-     * Result type is needed due to the fact that {@link Annotation} can be returned from C++ as a result.
+     * Result type is needed due to the fact that {@link Annotation} can be returned from C++ as an ML result.
      */
     public static final ParseField RESULTS_FIELD = new ParseField("annotation");
 
@@ -87,7 +87,7 @@ public class Annotation implements ToXContentObject, Writeable {
      * Strict parser for cases when {@link Annotation} is returned from C++ as an ML result.
      */
     private static final ObjectParser<Builder, Void> STRICT_PARSER =
-        new ObjectParser<>(RESULTS_FIELD.getPreferredName(), true, Builder::new);
+        new ObjectParser<>(RESULTS_FIELD.getPreferredName(), false, Builder::new);
 
     static {
         STRICT_PARSER.declareString(Builder::setAnnotation, ANNOTATION);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -54,6 +54,11 @@ public class Annotation implements ToXContentObject, Writeable {
         }
     }
 
+    /**
+     * Result type is needed due to the fact that {@link Annotation} can be returned from C++ as a result.
+     */
+    public static final ParseField RESULTS_FIELD = new ParseField("annotation");
+
     public static final ParseField ANNOTATION = new ParseField("annotation");
     public static final ParseField CREATE_TIME = new ParseField("create_time");
     public static final ParseField CREATE_USERNAME = new ParseField("create_username");
@@ -81,7 +86,8 @@ public class Annotation implements ToXContentObject, Writeable {
     /**
      * Strict parser for cases when {@link Annotation} is returned from C++ as an ML result.
      */
-    private static final ObjectParser<Builder, Void> STRICT_PARSER = new ObjectParser<>(ANNOTATION.getPreferredName(), false, Builder::new);
+    private static final ObjectParser<Builder, Void> STRICT_PARSER =
+        new ObjectParser<>(RESULTS_FIELD.getPreferredName(), true, Builder::new);
 
     static {
         STRICT_PARSER.declareString(Builder::setAnnotation, ANNOTATION);

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.core.ml.action.DeleteModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.PutJobAction;
 import org.elasticsearch.xpack.core.ml.annotations.Annotation;
 import org.elasticsearch.xpack.core.ml.annotations.AnnotationIndex;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationTests;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
@@ -88,13 +89,18 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -166,7 +172,9 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         AcknowledgedResponse response = client().execute(DeleteJobAction.INSTANCE, request).actionGet();
         assertTrue(response.isAcknowledged());
         // Verify that deleting job also deletes associated model snapshots annotations
-        assertThat(getAnnotations(), empty());
+        assertThat(
+            getAnnotations().stream().map(Annotation::getAnnotation).collect(toList()),
+            everyItem(not(startsWith("Job model snapshot"))));
     }
 
     public void testProcessResults() throws Exception {
@@ -181,6 +189,8 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         resultsBuilder.addCategoryDefinition(categoryDefinition);
         ModelPlot modelPlot = createModelPlot();
         resultsBuilder.addModelPlot(modelPlot);
+        Annotation annotation = createAnnotation();
+        resultsBuilder.addAnnotation(annotation);
         ModelSizeStats modelSizeStats = createModelSizeStats();
         resultsBuilder.addModelSizeStats(modelSizeStats);
         ModelSnapshot modelSnapshot = createModelSnapshot();
@@ -222,17 +232,20 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         assertEquals(modelSnapshot, persistedModelSnapshot.results().get(0));
         assertEquals(Collections.singletonList(modelSnapshot), capturedUpdateModelSnapshotOnJobRequests);
 
-        // Verify that creating model snapshot also creates associated annotation
-        List<Annotation> annotations = getAnnotations();
-        assertThat(annotations, hasSize(1));
-        assertThat(
-            annotations.get(0).getAnnotation(),
-            is(equalTo(
-                new ParameterizedMessage("Job model snapshot with id [{}] stored", modelSnapshot.getSnapshotId()).getFormattedMessage())));
-
         Optional<Quantiles> persistedQuantiles = getQuantiles();
         assertTrue(persistedQuantiles.isPresent());
         assertEquals(quantiles, persistedQuantiles.get());
+
+        // Verify that there are two annotations:
+        //   1. one related to creating model snapshot
+        //   2. one for {@link Annotation} result
+        List<Annotation> annotations = getAnnotations();
+        assertThat("Annotations were: " + annotations.toString(), annotations, hasSize(2));
+        assertThat(
+            annotations.stream().map(Annotation::getAnnotation).collect(toList()),
+            containsInAnyOrder(
+                new ParameterizedMessage("Job model snapshot with id [{}] stored", modelSnapshot.getSnapshotId()).getFormattedMessage(),
+                annotation.getAnnotation()));
     }
 
     public void testProcessResults_ModelSnapshot() throws Exception {
@@ -464,6 +477,10 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         return new ModelPlotTests().createTestInstance(JOB_ID);
     }
 
+    private static Annotation createAnnotation() {
+        return AnnotationTests.randomAnnotation();
+    }
+
     private static ModelSizeStats createModelSizeStats() {
         ModelSizeStats.Builder builder = new ModelSizeStats.Builder(JOB_ID);
         builder.setTimestamp(randomDate());
@@ -498,47 +515,53 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         private final List<AutodetectResult> results = new ArrayList<>();
 
         ResultsBuilder addBucket(Bucket bucket) {
-            results.add(new AutodetectResult(Objects.requireNonNull(bucket), null, null, null, null, null, null, null, null, null, null));
+            results.add(
+                new AutodetectResult(Objects.requireNonNull(bucket), null, null, null, null, null, null, null, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addRecords(List<AnomalyRecord> records) {
-            results.add(new AutodetectResult(null, records, null, null, null, null, null, null, null, null, null));
+            results.add(new AutodetectResult(null, records, null, null, null, null, null, null, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addInfluencers(List<Influencer> influencers) {
-            results.add(new AutodetectResult(null, null, influencers, null, null, null, null, null, null, null, null));
+            results.add(new AutodetectResult(null, null, influencers, null, null, null, null, null, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addCategoryDefinition(CategoryDefinition categoryDefinition) {
-            results.add(new AutodetectResult(null, null, null, null, null, null, null, null, null, categoryDefinition, null));
+            results.add(new AutodetectResult(null, null, null, null, null, null, null, null, null, null, categoryDefinition, null));
             return this;
         }
 
         ResultsBuilder addModelPlot(ModelPlot modelPlot) {
-            results.add(new AutodetectResult(null, null, null, null, null, null, modelPlot, null, null, null, null));
+            results.add(new AutodetectResult(null, null, null, null, null, null, modelPlot, null, null, null, null, null));
+            return this;
+        }
+
+        ResultsBuilder addAnnotation(Annotation annotation) {
+            results.add(new AutodetectResult(null, null, null, null, null, null, null, annotation, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addModelSizeStats(ModelSizeStats modelSizeStats) {
-            results.add(new AutodetectResult(null, null, null, null, null, modelSizeStats, null, null, null, null, null));
+            results.add(new AutodetectResult(null, null, null, null, null, modelSizeStats, null, null, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addModelSnapshot(ModelSnapshot modelSnapshot) {
-            results.add(new AutodetectResult(null, null, null, null, modelSnapshot, null, null, null, null, null, null));
+            results.add(new AutodetectResult(null, null, null, null, modelSnapshot, null, null, null, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addQuantiles(Quantiles quantiles) {
-            results.add(new AutodetectResult(null, null, null, quantiles, null, null, null, null, null, null, null));
+            results.add(new AutodetectResult(null, null, null, quantiles, null, null, null, null, null, null, null, null));
             return this;
         }
 
         ResultsBuilder addFlushAcknowledgement(FlushAcknowledgement flushAcknowledgement) {
-            results.add(new AutodetectResult(null, null, null, null, null, null, null, null, null, null, flushAcknowledgement));
+            results.add(new AutodetectResult(null, null, null, null, null, null, null, null, null, null, null, flushAcknowledgement));
             return this;
         }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -478,7 +478,7 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
     }
 
     private static Annotation createAnnotation() {
-        return AnnotationTests.randomAnnotation();
+        return AnnotationTests.randomAnnotation(JOB_ID);
     }
 
     private static ModelSizeStats createModelSizeStats() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/BlackHoleAutodetectProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/BlackHoleAutodetectProcess.java
@@ -71,7 +71,7 @@ public class BlackHoleAutodetectProcess implements AutodetectProcess {
         if (Arrays.asList(record).contains(MAGIC_FAILURE_VALUE)) {
             open = false;
             onProcessCrash.accept("simulated failure");
-            AutodetectResult result = new AutodetectResult(null, null, null, null, null, null, null, null, null, null, null);
+            AutodetectResult result = new AutodetectResult(null, null, null, null, null, null, null, null, null, null, null, null);
             results.add(result);
         }
     }
@@ -104,7 +104,8 @@ public class BlackHoleAutodetectProcess implements AutodetectProcess {
     @Override
     public String flushJob(FlushJobParams params) throws IOException {
         FlushAcknowledgement flushAcknowledgement = new FlushAcknowledgement(FLUSH_ID, null);
-        AutodetectResult result = new AutodetectResult(null, null, null, null, null, null, null, null, null, null, flushAcknowledgement);
+        AutodetectResult result =
+            new AutodetectResult(null, null, null, null, null, null, null, null, null, null, null,flushAcknowledgement);
         results.add(result);
         return FLUSH_ID;
     }
@@ -121,7 +122,7 @@ public class BlackHoleAutodetectProcess implements AutodetectProcess {
     public void close() throws IOException {
         if (open) {
             Quantiles quantiles = new Quantiles(jobId, new Date(), "black hole quantiles");
-            AutodetectResult result = new AutodetectResult(null, null, null, quantiles, null, null, null, null, null, null, null);
+            AutodetectResult result = new AutodetectResult(null, null, null, quantiles, null, null, null, null, null, null, null, null);
             results.add(result);
             open = false;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -87,7 +87,6 @@ public class AutodetectResultProcessor {
     private final String jobId;
     private final Renormalizer renormalizer;
     private final JobResultsPersister persister;
-    private final AnnotationPersister annotationPersister;
     private final AutodetectProcess process;
     private final TimingStatsReporter timingStatsReporter;
     private final Clock clock;
@@ -101,6 +100,7 @@ public class AutodetectResultProcessor {
     private final long priorRunsBucketCount;
     private long currentRunBucketCount; // only used from the process() thread, so doesn't need to be volatile
     private final JobResultsPersister.Builder bulkResultsPersister;
+    private final AnnotationPersister.Builder bulkAnnotationsPersister;
     private boolean deleteInterimRequired;
 
     /**
@@ -130,11 +130,11 @@ public class AutodetectResultProcessor {
         this.jobId = Objects.requireNonNull(jobId);
         this.renormalizer = Objects.requireNonNull(renormalizer);
         this.persister = Objects.requireNonNull(persister);
-        this.annotationPersister = Objects.requireNonNull(annotationPersister);
         this.process = Objects.requireNonNull(autodetectProcess);
         this.flushListener = Objects.requireNonNull(flushListener);
         this.latestModelSizeStats = Objects.requireNonNull(latestModelSizeStats);
         this.bulkResultsPersister = persister.bulkPersisterBuilder(jobId).shouldRetry(this::isAlive);
+        this.bulkAnnotationsPersister = annotationPersister.bulkPersisterBuilder(jobId).shouldRetry(this::isAlive);
         this.timingStatsReporter = new TimingStatsReporter(timingStats, bulkResultsPersister);
         this.clock = Objects.requireNonNull(clock);
         this.deleteInterimRequired = true;
@@ -154,6 +154,7 @@ public class AutodetectResultProcessor {
                 if (processKilled == false) {
                     timingStatsReporter.finishReporting();
                     bulkResultsPersister.executeRequest();
+                    bulkAnnotationsPersister.executeRequest();
                 }
             } catch (Exception e) {
                 LOGGER.warn(new ParameterizedMessage("[{}] Error persisting autodetect results", jobId), e);
@@ -252,6 +253,7 @@ public class AutodetectResultProcessor {
             // results are also interim
             timingStatsReporter.reportBucket(bucket);
             bulkResultsPersister.persistBucket(bucket).executeRequest();
+            bulkAnnotationsPersister.executeRequest();
             ++currentRunBucketCount;
         }
         List<AnomalyRecord> records = result.getRecords();
@@ -272,7 +274,7 @@ public class AutodetectResultProcessor {
         }
         Annotation annotation = result.getAnnotation();
         if (annotation != null) {
-            annotationPersister.persistAnnotation(null, annotation, "[" + jobId + "] failed to create annotation.");
+            bulkAnnotationsPersister.persistAnnotation(annotation);
         }
         Forecast forecast = result.getForecast();
         if (forecast != null) {
@@ -316,7 +318,7 @@ public class AutodetectResultProcessor {
             if (indexResponse.getResult() == DocWriteResponse.Result.CREATED) {
                 updateModelSnapshotOnJob(modelSnapshot);
             }
-            annotationPersister.persistAnnotation(
+            bulkAnnotationsPersister.persistAnnotation(
                 ModelSnapshot.annotationDocumentId(modelSnapshot), createModelSnapshotAnnotation(modelSnapshot));
         }
         Quantiles quantiles = result.getQuantiles();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -270,6 +270,10 @@ public class AutodetectResultProcessor {
         if (modelPlot != null) {
             bulkResultsPersister.persistModelPlot(modelPlot);
         }
+        Annotation annotation = result.getAnnotation();
+        if (annotation != null) {
+            annotationPersister.persistAnnotation(null, annotation, "[" + jobId + "] failed to create annotation.");
+        }
         Forecast forecast = result.getForecast();
         if (forecast != null) {
             bulkResultsPersister.persistForecast(forecast);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -343,6 +343,7 @@ public class AutodetectResultProcessor {
             Exception exception = null;
             try {
                 bulkResultsPersister.executeRequest();
+                bulkAnnotationsPersister.executeRequest();
                 persister.commitResultWrites(jobId);
                 LOGGER.debug("[{}] Flush acknowledgement sent to listener for ID {}", jobId, flushAcknowledgement.getId());
             } catch (Exception e) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -156,6 +156,9 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         when(jobResultsPersister.bulkPersisterBuilder(any())).thenReturn(bulkPersisterBuilder);
         jobDataCountsPersister = mock(JobDataCountsPersister.class);
         annotationPersister = mock(AnnotationPersister.class);
+        AnnotationPersister.Builder bulkAnnotationsBuilder = mock(AnnotationPersister.Builder.class);
+        when(bulkAnnotationsBuilder.shouldRetry(any())).thenReturn(bulkAnnotationsBuilder);
+        when(annotationPersister.bulkPersisterBuilder(any())).thenReturn(bulkAnnotationsBuilder);
         autodetectCommunicator = mock(AutodetectCommunicator.class);
         autodetectFactory = mock(AutodetectProcessFactory.class);
         normalizerFactory = mock(NormalizerFactory.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -87,8 +87,9 @@ public class AutodetectResultProcessorTests extends ESTestCase {
     private AnomalyDetectionAuditor auditor;
     private Renormalizer renormalizer;
     private JobResultsPersister persister;
-    private JobResultsPersister.Builder bulkBuilder;
+    private JobResultsPersister.Builder bulkResultsPersister;
     private AnnotationPersister annotationPersister;
+    private AnnotationPersister.Builder bulkAnnotationsPersister;
     private AutodetectProcess process;
     private FlushListener flushListener;
     private AutodetectResultProcessor processorUnderTest;
@@ -104,10 +105,13 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         auditor = mock(AnomalyDetectionAuditor.class);
         renormalizer = mock(Renormalizer.class);
         persister = mock(JobResultsPersister.class);
-        bulkBuilder = mock(JobResultsPersister.Builder.class);
-        when(bulkBuilder.shouldRetry(any())).thenReturn(bulkBuilder);
+        bulkResultsPersister = mock(JobResultsPersister.Builder.class);
+        when(bulkResultsPersister.shouldRetry(any())).thenReturn(bulkResultsPersister);
+        when(persister.bulkPersisterBuilder(eq(JOB_ID))).thenReturn(bulkResultsPersister);
         annotationPersister = mock(AnnotationPersister.class);
-        when(persister.bulkPersisterBuilder(eq(JOB_ID))).thenReturn(bulkBuilder);
+        bulkAnnotationsPersister = mock(AnnotationPersister.Builder.class);
+        when(bulkAnnotationsPersister.shouldRetry(any())).thenReturn(bulkAnnotationsPersister);
+        when(annotationPersister.bulkPersisterBuilder(eq(JOB_ID))).thenReturn(bulkAnnotationsPersister);
         process = mock(AutodetectProcess.class);
         flushListener = mock(FlushListener.class);
         processorUnderTest = new AutodetectResultProcessor(
@@ -126,6 +130,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
 
     @After
     public void cleanup() {
+        verify(annotationPersister).bulkPersisterBuilder(eq(JOB_ID));
         verifyNoMoreInteractions(auditor, renormalizer, persister, annotationPersister);
         executor.shutdown();
     }
@@ -145,8 +150,8 @@ public class AutodetectResultProcessorTests extends ESTestCase {
     }
 
     public void testProcessResult_bucket() {
-        when(bulkBuilder.persistTimingStats(any(TimingStats.class))).thenReturn(bulkBuilder);
-        when(bulkBuilder.persistBucket(any(Bucket.class))).thenReturn(bulkBuilder);
+        when(bulkResultsPersister.persistTimingStats(any(TimingStats.class))).thenReturn(bulkResultsPersister);
+        when(bulkResultsPersister.persistBucket(any(Bucket.class))).thenReturn(bulkResultsPersister);
         AutodetectResult result = mock(AutodetectResult.class);
         Bucket bucket = new Bucket(JOB_ID, new Date(), BUCKET_SPAN_MS);
         when(result.getBucket()).thenReturn(bucket);
@@ -154,16 +159,16 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.setDeleteInterimRequired(false);
         processorUnderTest.processResult(result);
 
-        verify(bulkBuilder).persistTimingStats(any(TimingStats.class));
-        verify(bulkBuilder).persistBucket(bucket);
-        verify(bulkBuilder).executeRequest();
+        verify(bulkResultsPersister).persistTimingStats(any(TimingStats.class));
+        verify(bulkResultsPersister).persistBucket(bucket);
+        verify(bulkResultsPersister).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister, never()).deleteInterimResults(JOB_ID);
     }
 
     public void testProcessResult_bucket_deleteInterimRequired() {
-        when(bulkBuilder.persistTimingStats(any(TimingStats.class))).thenReturn(bulkBuilder);
-        when(bulkBuilder.persistBucket(any(Bucket.class))).thenReturn(bulkBuilder);
+        when(bulkResultsPersister.persistTimingStats(any(TimingStats.class))).thenReturn(bulkResultsPersister);
+        when(bulkResultsPersister.persistBucket(any(Bucket.class))).thenReturn(bulkResultsPersister);
         AutodetectResult result = mock(AutodetectResult.class);
         Bucket bucket = new Bucket(JOB_ID, new Date(), BUCKET_SPAN_MS);
         when(result.getBucket()).thenReturn(bucket);
@@ -171,9 +176,9 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.processResult(result);
         assertFalse(processorUnderTest.isDeleteInterimRequired());
 
-        verify(bulkBuilder).persistTimingStats(any(TimingStats.class));
-        verify(bulkBuilder).persistBucket(bucket);
-        verify(bulkBuilder).executeRequest();
+        verify(bulkResultsPersister).persistTimingStats(any(TimingStats.class));
+        verify(bulkResultsPersister).persistBucket(bucket);
+        verify(bulkResultsPersister).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister).deleteInterimResults(JOB_ID);
     }
@@ -189,8 +194,8 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.setDeleteInterimRequired(false);
         processorUnderTest.processResult(result);
 
-        verify(bulkBuilder).persistRecords(records);
-        verify(bulkBuilder, never()).executeRequest();
+        verify(bulkResultsPersister).persistRecords(records);
+        verify(bulkResultsPersister, never()).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
     }
 
@@ -205,8 +210,8 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.setDeleteInterimRequired(false);
         processorUnderTest.processResult(result);
 
-        verify(bulkBuilder).persistInfluencers(influencers);
-        verify(bulkBuilder, never()).executeRequest();
+        verify(bulkResultsPersister).persistInfluencers(influencers);
+        verify(bulkResultsPersister, never()).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
     }
 
@@ -219,7 +224,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.setDeleteInterimRequired(false);
         processorUnderTest.processResult(result);
 
-        verify(bulkBuilder, never()).executeRequest();
+        verify(bulkResultsPersister, never()).executeRequest();
         verify(persister).persistCategoryDefinition(eq(categoryDefinition), any());
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
     }
@@ -237,7 +242,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(flushListener).acknowledgeFlush(flushAcknowledgement, null);
         verify(persister).commitResultWrites(JOB_ID);
-        verify(bulkBuilder).executeRequest();
+        verify(bulkResultsPersister).executeRequest();
     }
 
     public void testProcessResult_flushAcknowledgementMustBeProcessedLast() {
@@ -253,10 +258,10 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.processResult(result);
         assertTrue(processorUnderTest.isDeleteInterimRequired());
 
-        InOrder inOrder = inOrder(persister, bulkBuilder, flushListener);
+        InOrder inOrder = inOrder(persister, bulkResultsPersister, flushListener);
         inOrder.verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         inOrder.verify(persister).persistCategoryDefinition(eq(categoryDefinition), any());
-        inOrder.verify(bulkBuilder).executeRequest();
+        inOrder.verify(bulkResultsPersister).executeRequest();
         inOrder.verify(persister).commitResultWrites(JOB_ID);
         inOrder.verify(flushListener).acknowledgeFlush(flushAcknowledgement, null);
     }
@@ -270,18 +275,18 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         processorUnderTest.processResult(result);
 
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
-        verify(bulkBuilder).persistModelPlot(modelPlot);
+        verify(bulkResultsPersister).persistModelPlot(modelPlot);
     }
 
     public void testProcessResult_annotation() {
         AutodetectResult result = mock(AutodetectResult.class);
-        Annotation annotation = AnnotationTests.randomAnnotation();
+        Annotation annotation = AnnotationTests.randomAnnotation(JOB_ID);
         when(result.getAnnotation()).thenReturn(annotation);
 
         processorUnderTest.processResult(result);
 
-        verify(persister).bulkPersisterBuilder(eq(JOB_ID), any());
-        verify(annotationPersister).persistAnnotation(null, annotation, "[" + JOB_ID + "] failed to create annotation.");
+        verify(persister).bulkPersisterBuilder(eq(JOB_ID));
+        verify(bulkAnnotationsPersister).persistAnnotation(annotation);
     }
 
     public void testProcessResult_modelSizeStats() {
@@ -407,12 +412,9 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         UpdateJobAction.Request expectedJobUpdateRequest = UpdateJobAction.Request.internal(JOB_ID,
             new JobUpdate.Builder(JOB_ID).setModelSnapshotId("a_snapshot_id").build());
 
-        verify(persister).bulkPersisterBuilder(eq(JOB_ID), any());
+        verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister).persistModelSnapshot(eq(modelSnapshot), eq(WriteRequest.RefreshPolicy.IMMEDIATE), any());
-        verify(annotationPersister).persistAnnotation(
-            ModelSnapshot.annotationDocumentId(modelSnapshot),
-            expectedAnnotation,
-            "[" + JOB_ID + "] failed to create annotation for model snapshot.");
+        verify(bulkAnnotationsPersister).persistAnnotation(ModelSnapshot.annotationDocumentId(modelSnapshot), expectedAnnotation);
         verify(client).execute(same(UpdateJobAction.INSTANCE), eq(expectedJobUpdateRequest), any());
     }
 
@@ -427,7 +429,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
 
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister).persistQuantiles(eq(quantiles), any());
-        verify(bulkBuilder).executeRequest();
+        verify(bulkResultsPersister).executeRequest();
         verify(persister).commitResultWrites(JOB_ID);
         verify(renormalizer).isEnabled();
         verify(renormalizer).renormalize(quantiles);
@@ -444,7 +446,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
 
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister).persistQuantiles(eq(quantiles), any());
-        verify(bulkBuilder).executeRequest();
+        verify(bulkResultsPersister).executeRequest();
         verify(renormalizer).isEnabled();
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xpack.ml.job.results.AutodetectResult;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.time.Clock;
@@ -520,7 +521,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
     }
 
     public void testProcessingOpenedForecasts() {
-        when(bulkBuilder.persistForecastRequestStats(any(ForecastRequestStats.class))).thenReturn(bulkBuilder);
+        when(bulkResultsPersister.persistForecastRequestStats(any(ForecastRequestStats.class))).thenReturn(bulkResultsPersister);
         AutodetectResult result = mock(AutodetectResult.class);
         ForecastRequestStats forecastRequestStats = new ForecastRequestStats("foo", "forecast");
         forecastRequestStats.setStatus(ForecastRequestStats.ForecastRequestStatus.OK);
@@ -533,8 +534,8 @@ public class AutodetectResultProcessorTests extends ESTestCase {
 
         processorUnderTest.handleOpenForecasts();
 
-        verify(bulkBuilder, times(2)).persistForecastRequestStats(argument.capture());
-        verify(bulkBuilder, times(1)).executeRequest();
+        verify(bulkResultsPersister, times(2)).persistForecastRequestStats(argument.capture());
+        verify(bulkResultsPersister, times(1)).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister, never()).deleteInterimResults(JOB_ID);
 
@@ -545,7 +546,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
     }
 
     public void testProcessingForecasts() {
-        when(bulkBuilder.persistForecastRequestStats(any(ForecastRequestStats.class))).thenReturn(bulkBuilder);
+        when(bulkResultsPersister.persistForecastRequestStats(any(ForecastRequestStats.class))).thenReturn(bulkResultsPersister);
         AutodetectResult result = mock(AutodetectResult.class);
         ForecastRequestStats forecastRequestStats = new ForecastRequestStats("foo", "forecast");
         forecastRequestStats.setStatus(ForecastRequestStats.ForecastRequestStatus.OK);
@@ -566,8 +567,8 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         // There shouldn't be any opened forecasts. This call should do nothing
         processorUnderTest.handleOpenForecasts();
 
-        verify(bulkBuilder, times(2)).persistForecastRequestStats(argument.capture());
-        verify(bulkBuilder, times(1)).executeRequest();
+        verify(bulkResultsPersister, times(2)).persistForecastRequestStats(argument.capture());
+        verify(bulkResultsPersister, times(1)).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister, never()).deleteInterimResults(JOB_ID);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/AutodetectResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/AutodetectResultTests.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.ml.job.results;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.annotations.Annotation;
+import org.elasticsearch.xpack.core.ml.annotations.AnnotationTests;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.output.FlushAcknowledgement;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelSnapshot;
@@ -41,6 +43,7 @@ public class AutodetectResultTests extends AbstractSerializingTestCase<Autodetec
         ModelSnapshot modelSnapshot;
         ModelSizeStats.Builder modelSizeStats;
         ModelPlot modelPlot;
+        Annotation annotation;
         Forecast forecast;
         ForecastRequestStats forecastRequestStats;
         CategoryDefinition categoryDefinition;
@@ -93,6 +96,11 @@ public class AutodetectResultTests extends AbstractSerializingTestCase<Autodetec
             modelPlot = null;
         }
         if (randomBoolean()) {
+            annotation = AnnotationTests.randomAnnotation();
+        } else {
+            annotation = null;
+        }
+        if (randomBoolean()) {
             forecast = new Forecast(jobId, randomAlphaOfLength(20), randomDate(),
                 randomNonNegativeLong(), randomInt());
         } else {
@@ -116,8 +124,8 @@ public class AutodetectResultTests extends AbstractSerializingTestCase<Autodetec
             flushAcknowledgement = null;
         }
         return new AutodetectResult(bucket, records, influencers, quantiles, modelSnapshot,
-                modelSizeStats == null ? null : modelSizeStats.build(), modelPlot, forecast, forecastRequestStats, categoryDefinition,
-                flushAcknowledgement);
+                modelSizeStats == null ? null : modelSizeStats.build(), modelPlot, annotation, forecast, forecastRequestStats,
+                categoryDefinition, flushAcknowledgement);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/AutodetectResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/results/AutodetectResultTests.java
@@ -96,7 +96,7 @@ public class AutodetectResultTests extends AbstractSerializingTestCase<Autodetec
             modelPlot = null;
         }
         if (randomBoolean()) {
-            annotation = AnnotationTests.randomAnnotation();
+            annotation = AnnotationTests.randomAnnotation(jobId);
         } else {
             annotation = null;
         }


### PR DESCRIPTION
This PR makes an `Annotation` class a result type . 
Results of this kind will be reported when C++ detects a significant model change.

Relates #55781