### PR TITLE
Upgrade forbidden apis to 3.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -118,7 +118,7 @@ dependencies {
   compile 'org.apache.rat:apache-rat:0.11'
   compile "org.elasticsearch:jna:4.5.1"
   compile 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
-  compile 'de.thetaphi:forbiddenapis:2.7'
+  compile 'de.thetaphi:forbiddenapis:3.0'
   compile 'com.avast.gradle:gradle-docker-compose-plugin:0.8.12'
   compile 'org.apache.maven:maven-model:3.6.2'
   compile 'com.networknt:json-schema-validator:1.0.36'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -168,10 +168,6 @@ class PrecommitTasks {
             classpath = project.files { sourceSet.runtimeClasspath.plus(sourceSet.compileClasspath) }
 
             targetCompatibility = BuildParams.runtimeJavaVersion.majorVersion
-            if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_13) {
-                // forbidden apis does not yet support java 14 (it will in version 3.0), so we must use java 13 target
-                targetCompatibility = JavaVersion.VERSION_13.majorVersion
-            }
             bundledSignatures = [
                     "jdk-unsafe", "jdk-deprecated", "jdk-non-portable", "jdk-system-out"
             ]

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/PrecommitTasks.groovy
@@ -168,6 +168,10 @@ class PrecommitTasks {
             classpath = project.files { sourceSet.runtimeClasspath.plus(sourceSet.compileClasspath) }
 
             targetCompatibility = BuildParams.runtimeJavaVersion.majorVersion
+            if (BuildParams.runtimeJavaVersion > JavaVersion.VERSION_14) {
+                // TODO: forbidden apis does not yet support java 15, rethink using runtime version
+                targetCompatibility = JavaVersion.VERSION_14.majorVersion
+            }
             bundledSignatures = [
                     "jdk-unsafe", "jdk-deprecated", "jdk-non-portable", "jdk-system-out"
             ]


### PR DESCRIPTION
This commit upgrades forbidden apis to the latest version, which also
means we now get task configuration avoidance.