### PR TITLE
Fix max-int limit for number of points reduced in geo_centroid

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
@@ -115,7 +115,7 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
     public InternalGeoCentroid reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         double lonSum = Double.NaN;
         double latSum = Double.NaN;
-        int totalCount = 0;
+        long totalCount = 0;
         for (InternalAggregation aggregation : aggregations) {
             InternalGeoCentroid centroidAgg = (InternalGeoCentroid) aggregation;
             if (centroidAgg.count > 0) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -72,7 +72,7 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
     public void testReduceMaxCount() {
         InternalGeoCentroid maxValueGeoCentroid = new InternalGeoCentroid("agg", new GeoPoint(10, 0),
             Long.MAX_VALUE, Collections.emptyMap());
-        InternalGeoCentroid reducedGeoCentroid =maxValueGeoCentroid
+        InternalGeoCentroid reducedGeoCentroid = maxValueGeoCentroid
             .reduce(Collections.singletonList(maxValueGeoCentroid), null);
         assertThat(reducedGeoCentroid.count(), equalTo(Long.MAX_VALUE));
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.geo.GeoEncodingUtils;
-import org.apache.lucene.geo.GeoTestUtil;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -73,9 +73,7 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
     public void testReduceMaxCount() {
         InternalGeoCentroid maxValueGeoCentroid = new InternalGeoCentroid("agg", new GeoPoint(10, 0),
             Long.MAX_VALUE, Collections.emptyMap());
-        InternalGeoCentroid reducingGeoCentroid = new InternalGeoCentroid("agg", new GeoPoint(10, 0),
-            randomNonNegativeLong(), Collections.emptyMap());
-        InternalGeoCentroid reducedGeoCentroid = reducingGeoCentroid
+        InternalGeoCentroid reducedGeoCentroid =maxValueGeoCentroid
             .reduce(Collections.singletonList(maxValueGeoCentroid), null);
         assertThat(reducedGeoCentroid.count(), equalTo(Long.MAX_VALUE));
     }


### PR DESCRIPTION
A bug in InternalGeoCentroid#reduce existed that summed up
the aggregation's long-valued counts into a local integer variable.
Since it is definitely possible to reduce more than Integer.MAX points,
this change simply updates that variable to be a long-valued number.

Closes #55992.