### PR TITLE
[7.7] remove the term 'system' from indicies doc (#56367)

### DIFF
--- a/docs/reference/setup/install/xpack-indices.asciidoc
+++ b/docs/reference/setup/install/xpack-indices.asciidoc
@@ -1,4 +1,4 @@
-Some commercial features automatically create system indices within {es}.
+Some commercial features automatically create indices within {es}.
 By default, {es} is configured to allow automatic index creation, and no
 additional steps are required. However, if you have disabled automatic index
 creation in {es}, you must configure


### PR DESCRIPTION
Backports the following commits to 7.7:
 - remove the term 'system' from indicies doc (#56367)