### PR TITLE
[DOCS] Rename monitoring collection from internal to legacy

### DIFF
--- a/docs/reference/monitoring/collecting-monitoring-data.asciidoc
+++ b/docs/reference/monitoring/collecting-monitoring-data.asciidoc
@@ -1,16 +1,19 @@
 [role="xpack"]
 [testenv="gold"]
 [[collecting-monitoring-data]]
-== Collecting monitoring data
+== Collecting monitoring data using legacy collectors
+++++
+<titleabbrev>Legacy collection methods</titleabbrev>
+++++
 
 [IMPORTANT]
 =========================
 {metricbeat} is the recommended method for collecting and shipping monitoring
 data to a monitoring cluster.
 
-If you have previously configured internal collection, you should migrate to
-using {metricbeat} collection. Use either {metricbeat} collection or
-internal collection; do not use both.
+If you have previously configured legacy collection methods, you should migrate
+to using {metricbeat} collection methods. Use either {metricbeat} collection or
+legacy collection methods; do not use both.
 
 Learn more about <<configuring-metricbeat>>.
 =========================

--- a/docs/reference/monitoring/collectors.asciidoc
+++ b/docs/reference/monitoring/collectors.asciidoc
@@ -8,9 +8,9 @@
 {metricbeat} is the recommended method for collecting and shipping monitoring
 data to a monitoring cluster.
 
-If you have previously configured internal collection, you should migrate to
-using {metricbeat} collection. Use either {metricbeat} collection or
-internal collection; do not use both.
+If you have previously configured legacy collection methods, you should migrate
+to using {metricbeat} collection methods. Use either {metricbeat} collection or
+legacy collection methods; do not use both.
 
 Learn more about <<configuring-metricbeat>>.
 =========================

--- a/docs/reference/monitoring/exporters.asciidoc
+++ b/docs/reference/monitoring/exporters.asciidoc
@@ -8,9 +8,9 @@
 {metricbeat} is the recommended method for collecting and shipping monitoring
 data to a monitoring cluster.
 
-If you have previously configured internal collection, you should migrate to
-using {metricbeat} collection. Use either {metricbeat} collection or
-internal collection; do not use both.
+If you have previously configured legacy collection methods, you should migrate
+to using {metricbeat} collection methods. Use either {metricbeat} collection or
+legacy collection methods; do not use both.
 
 Learn more about <<configuring-metricbeat>>.
 =========================

--- a/docs/reference/monitoring/http-export.asciidoc
+++ b/docs/reference/monitoring/http-export.asciidoc
@@ -8,9 +8,9 @@
 {metricbeat} is the recommended method for collecting and shipping monitoring
 data to a monitoring cluster.
 
-If you have previously configured internal collection, you should migrate to
-using {metricbeat} collection. Use either {metricbeat} collection or
-internal collection; do not use both.
+If you have previously configured legacy collection methods, you should migrate
+to using {metricbeat} collection methods. Use either {metricbeat} collection or
+legacy collection methods; do not use both.
 
 Learn more about <<configuring-metricbeat>>.
 =========================

--- a/docs/reference/monitoring/index.asciidoc
+++ b/docs/reference/monitoring/index.asciidoc
@@ -32,12 +32,12 @@ include::configuring-filebeat.asciidoc[]
 include::indices.asciidoc[]
 
 include::collecting-monitoring-data.asciidoc[]
-include::pause-export.asciidoc[]
 :leveloffset: +1
 include::collectors.asciidoc[]
 include::exporters.asciidoc[]
 :leveloffset: -1
 include::local-export.asciidoc[]
 include::http-export.asciidoc[]
+include::pause-export.asciidoc[]
 
 include::troubleshooting.asciidoc[]

--- a/docs/reference/monitoring/index.asciidoc
+++ b/docs/reference/monitoring/index.asciidoc
@@ -13,10 +13,8 @@ performance of your {es} cluster.
 * <<monitoring-production>>
 * <<configuring-metricbeat>>
 * <<configuring-filebeat>>
-* <<collecting-monitoring-data>>
 * <<config-monitoring-indices>>
-* <<es-monitoring-collectors>>
-* <<es-monitoring-exporters>>
+* <<collecting-monitoring-data>>
 * <<monitoring-troubleshooting>>
 
 --
@@ -27,18 +25,18 @@ include::how-monitoring-works.asciidoc[]
 
 include::production.asciidoc[]
 
-include::collecting-monitoring-data.asciidoc[]
-include::pause-export.asciidoc[]
-
 include::configuring-metricbeat.asciidoc[]
 
 include::configuring-filebeat.asciidoc[]
 
 include::indices.asciidoc[]
 
+include::collecting-monitoring-data.asciidoc[]
+include::pause-export.asciidoc[]
+:leveloffset: +1
 include::collectors.asciidoc[]
-
 include::exporters.asciidoc[]
+:leveloffset: -1
 include::local-export.asciidoc[]
 include::http-export.asciidoc[]
 

--- a/docs/reference/monitoring/local-export.asciidoc
+++ b/docs/reference/monitoring/local-export.asciidoc
@@ -8,9 +8,9 @@
 {metricbeat} is the recommended method for collecting and shipping monitoring
 data to a monitoring cluster.
 
-If you have previously configured internal collection, you should migrate to
-using {metricbeat} collection. Use either {metricbeat} collection or
-internal collection; do not use both.
+If you have previously configured legacy collection methods, you should migrate
+to using {metricbeat} collection methods. Use either {metricbeat} collection or
+legacy collection methods; do not use both.
 
 Learn more about <<configuring-metricbeat>>.
 =========================

--- a/docs/reference/monitoring/production.asciidoc
+++ b/docs/reference/monitoring/production.asciidoc
@@ -6,22 +6,22 @@ In production, you should send monitoring data to a separate _monitoring cluster
 so that historical data is available even when the nodes you are monitoring are
 not. For example, you can use {metricbeat} to ship monitoring data about {kib},
 {es}, {ls}, and Beats to the monitoring cluster.
-//If you are sending your data to the {esms-init}, see <<esms>>.
+If you are sending your data to the {esms-init}, see <<esms>>.
 
 [IMPORTANT]
 =========================
 {metricbeat} is the recommended method for collecting and shipping monitoring
 data to a monitoring cluster.
 
-If you have previously configured internal collection, you should migrate to
-using {metricbeat} collection. Use either {metricbeat} collection or
-internal collection; do not use both.
+If you have previously configured legacy collection methods, you should migrate
+to using {metricbeat} collection. Use either {metricbeat} collection or
+legacy collection methods; do not use both.
 
 Learn more about <<configuring-metricbeat>>.
 =========================
 
-If you have at least a gold license, using a dedicated monitoring cluster also
-enables you to monitor multiple clusters from a central location.
+If you have at least a Gold Subscription, using a dedicated monitoring cluster
+also enables you to monitor multiple clusters from a central location.
 
 To store monitoring data in a separate cluster:
 
@@ -99,11 +99,11 @@ Alternatively, use the `remote_monitoring_user` <<built-in-users,built-in user>>
 --
 
 . Configure your production cluster to collect data and send it to the
-monitoring cluster.
+monitoring cluster:
 
-** <<configuring-metricbeat,Use {metricbeat}>>.
+** <<configuring-metricbeat,{metricbeat} collection methods>>
 
-** <<collecting-monitoring-data,Use HTTP exporters>>.
+** <<collecting-monitoring-data,Legacy collection methods>>
 
 . (Optional)
 {logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster].
@@ -119,9 +119,9 @@ cluster.
 
 . (Optional) Configure {kib} to collect data and send it to the monitoring cluster:
 
-** {kibana-ref}/monitoring-metricbeat.html[Use {metricbeat}].
+** {kibana-ref}/monitoring-metricbeat.html[{metricbeat} collection methods]
 
-** {kibana-ref}/monitoring-kibana.html[Use HTTP exporters].
+** {kibana-ref}/monitoring-kibana.html[Legacy collection methods]
 
 . (Optional) Create a dedicated {kib} instance for monitoring, rather than using
 a single {kib} instance to access both your production cluster and monitoring


### PR DESCRIPTION
Related to https://github.com/elastic/logstash/issues/11843, https://github.com/elastic/kibana/issues/64661, https://github.com/elastic/elastic-stack-testing/pull/549

This PR synchs Elasticsearch monitoring documentation with terminology changes across the stack (i.e. refer to "internal" collection as "legacy" collection). It also groups all of the pages related to the legacy collection methods under a "Legacy collection methods" section in the navigation.

Preview: 
http://elasticsearch_56395.docs-preview.app.elstc.co/diff
For example: http://elasticsearch_56395.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/collecting-monitoring-data.html