### PR TITLE
[DOCS] Expands GET DFA stats API docs with new phases

### DIFF
--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -477,7 +477,16 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 =====
 `phase`::::
 (string) Defines the phase of the {dfanalytics-job}. Possible phases: 
-`reindexing`, `loading_data`, `analyzing`, and `writing_results`.
+* `reindexing`, 
+* `loading_data`, 
+* `computing_outliers` (for {oldetection} only),
+* `feature_selection` (for {regression} and {classification} only),
+* `coarse_parameter_search` (for {regression} and {classification} only),
+* `fine_tuning_parameters` (for {regression} and {classification} only),
+* `writing_results`.
+
+To learn more about the different phases, refer to
+{ml-docs}/ml-dfa-phases.html[How a {dfanalytics} job works].
     
 `progress_percent`::::
 (integer) The progress that the {dfanalytics-job} has made expressed in 

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -485,7 +485,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 * `fine_tuning_parameters` (for {regression} and {classification} only),
 * `final_training` (for {regression} and {classification} only),
 * `writing_results`.
-
++
 To learn more about the different phases, refer to
 {ml-docs}/ml-dfa-phases.html[How a {dfanalytics} job works].
     

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -483,6 +483,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 * `feature_selection` (for {regression} and {classification} only),
 * `coarse_parameter_search` (for {regression} and {classification} only),
 * `fine_tuning_parameters` (for {regression} and {classification} only),
+* `final_training` (for {regression} and {classification} only),
 * `writing_results`.
 
 To learn more about the different phases, refer to


### PR DESCRIPTION
## Overview

This PR lists the new phase types in the description of the `phase` property of the GET DFA stats API.

## Preview

[GET DFA stats](http://elasticsearch_56407.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-dfanalytics-stats.html)