### PR TITLE
[7.x][ML] Allow stopping DF analytics whose config is missing (#56360)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlStrings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlStrings.java
@@ -6,7 +6,12 @@
 package org.elasticsearch.xpack.core.ml.utils;
 
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.regex.Regex;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -93,5 +98,34 @@ public final class MlStrings {
             return fieldPath;
         }
         return fieldPath.substring(0, lastIndexOfDot);
+    }
+
+    /**
+     * Given a collection of strings and some patterns, it finds the strings that match against at least one pattern.
+     * @param patterns the patterns may contain wildcards
+     * @param items the collections of strings
+     * @return the strings from {@code items} that match against at least one pattern
+     */
+    public static Set<String> findMatching(String[] patterns, Set<String> items) {
+        if (items.isEmpty()) {
+            return Collections.emptySet();
+        }
+        if (Strings.isAllOrWildcard(patterns)) {
+            return items;
+        }
+
+        Set<String> matchingItems = new LinkedHashSet<>();
+        for (String pattern : patterns) {
+            if (items.contains(pattern))  {
+                matchingItems.add(pattern);
+            } else if (Regex.isSimpleMatchPattern(pattern)) {
+                for (String item : items) {
+                    if (Regex.simpleMatch(pattern, item)) {
+                        matchingItems.add(item);
+                    }
+                }
+            }
+        }
+        return matchingItems;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/persistence/DatafeedConfigProvider.java
@@ -53,6 +53,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedUpdate;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
 
@@ -60,7 +61,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -492,27 +492,7 @@ public class DatafeedConfigProvider {
     }
 
     static Collection<String> matchingDatafeedIdsWithTasks(String[] datafeedIdPatterns, PersistentTasksCustomMetadata tasksMetadata) {
-        Set<String> startedDatafeedIds = MlTasks.startedDatafeedIds(tasksMetadata);
-        if (startedDatafeedIds.isEmpty()) {
-            return Collections.emptyList()  ;
-        }
-        if (Strings.isAllOrWildcard(datafeedIdPatterns)) {
-            return startedDatafeedIds;
-        }
-
-        List<String> matchingDatafeedIds = new ArrayList<>();
-        for (String datafeedIdPattern : datafeedIdPatterns) {
-            if (startedDatafeedIds.contains(datafeedIdPattern))  {
-                matchingDatafeedIds.add(datafeedIdPattern);
-            } else if (Regex.isSimpleMatchPattern(datafeedIdPattern)) {
-                for (String startedDatafeedId : startedDatafeedIds) {
-                    if (Regex.simpleMatch(datafeedIdPattern, startedDatafeedId)) {
-                        matchingDatafeedIds.add(startedDatafeedId);
-                    }
-                }
-            }
-        }
-        return matchingDatafeedIds;
+        return MlStrings.findMatching(datafeedIdPatterns, MlTasks.startedDatafeedIds(tasksMetadata));
     }
 
     private QueryBuilder buildDatafeedJobIdsQuery(Collection<String> jobIds) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -66,12 +66,14 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -529,7 +531,7 @@ public class JobConfigProvider {
                 .request();
 
         ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoJobs);
-        Set<String> openMatchingJobs = matchingJobIdsWithTasks(tokens, tasksCustomMetadata);
+        Collection<String> openMatchingJobs = matchingJobIdsWithTasks(tokens, tasksCustomMetadata);
 
         executeAsyncWithOrigin(client.threadPool().getThreadContext(), ML_ORIGIN, searchRequest,
                 ActionListener.<SearchResponse>wrap(
@@ -748,28 +750,8 @@ public class JobConfigProvider {
         ));
     }
 
-    static Set<String> matchingJobIdsWithTasks(String[] jobIdPatterns, PersistentTasksCustomMetadata tasksMetadata) {
-        Set<String> openjobs = MlTasks.openJobIds(tasksMetadata);
-        if (openjobs.isEmpty()) {
-            return Collections.emptySet();
-        }
-        if (Strings.isAllOrWildcard(jobIdPatterns)) {
-            return openjobs;
-        }
-
-        Set<String> matchingJobIds = new HashSet<>();
-        for (String jobIdPattern : jobIdPatterns) {
-            if (openjobs.contains(jobIdPattern))  {
-                matchingJobIds.add(jobIdPattern);
-            } else if (Regex.isSimpleMatchPattern(jobIdPattern)) {
-                for (String openJobId : openjobs) {
-                    if (Regex.simpleMatch(jobIdPattern, openJobId)) {
-                        matchingJobIds.add(openJobId);
-                    }
-                }
-            }
-        }
-        return matchingJobIds;
+    static Collection<String> matchingJobIdsWithTasks(String[] jobIdPatterns, PersistentTasksCustomMetadata tasksMetadata) {
+        return MlStrings.findMatching(jobIdPatterns, MlTasks.openJobIds(tasksMetadata));
     }
 
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/MlStringsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/MlStringsTests.java
@@ -9,11 +9,19 @@ package org.elasticsearch.xpack.ml.utils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.utils.MlStrings;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class MlStringsTests extends ESTestCase {
+
     public void testDoubleQuoteIfNotAlphaNumeric() {
         assertEquals("foo2", MlStrings.doubleQuoteIfNotAlphaNumeric("foo2"));
         assertEquals("\"fo o\"", MlStrings.doubleQuoteIfNotAlphaNumeric("fo o"));
@@ -45,5 +53,27 @@ public class MlStringsTests extends ESTestCase {
     public void testHasValidLengthForId() {
         assertThat(MlStrings.hasValidLengthForId(randomAlphaOfLength(64)), is(true));
         assertThat(MlStrings.hasValidLengthForId(randomAlphaOfLength(65)), is(false));
+    }
+
+    public void testFindMatching_GivenEmptyItems() {
+        assertThat(MlStrings.findMatching(new String[0], Collections.emptySet()), is(empty()));
+    }
+
+    public void testFindMatching_GivenAllPattern() {
+        assertThat(MlStrings.findMatching(new String[] {"_all"}, new HashSet<>(Arrays.asList("a", "b"))), contains("a", "b"));
+    }
+
+    public void testFindMatching_GivenWildcardPattern() {
+        assertThat(MlStrings.findMatching(new String[] {"*"}, new HashSet<>(Arrays.asList("a", "b"))), contains("a", "b"));
+    }
+
+    public void testFindMatching_GivenMixedPatterns() {
+        assertThat(MlStrings.findMatching(new String[] {"concrete", "wild-*"}, new HashSet<>(
+            Arrays.asList("a", "concrete", "con*", "wild-1", "wild-2"))), contains("concrete", "wild-1", "wild-2"));
+    }
+
+    public void testFindMatching_GivenItemMatchedByTwoPatterns() {
+        Set<String> matching = MlStrings.findMatching(new String[]{"a*", "ab*"}, new HashSet<>(Collections.singletonList("abc")));
+        assertThat(matching, contains("abc"));
     }
 }


### PR DESCRIPTION
It is possible that the config document for a data frame
analytics job is deleted from the config index. If that is
the case the user is unable to stop a running job because
we attempt to retrieve the config and that will throw.

This commit changes that. When the request is forced,
we do not expand the requested ids based on the existing
configs but from the list of running tasks instead.

Backport of #56360
