### PR TITLE
[7.x] add a basic get index rolling upgrade test (#56322)

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -73,3 +73,10 @@
       nodes.usage: {}
   - is_true: nodes
   - match: { _nodes.failed: 0 }
+---
+"Get index works":
+  - do:
+     indices.get:
+       index: queries
+       include_type_name: false
+  - match: { queries.mappings.properties.id.type: "keyword" }


### PR DESCRIPTION
add a very basic rolling upgrade test for get index, post mortem action of #56274

backport #56322