### PR TITLE
Report used memory as zero when total memory cannot be obtained

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -225,6 +225,8 @@ public class OsStats implements Writeable, ToXContentFragment {
 
     public static class Mem implements Writeable, ToXContentFragment {
 
+        private static final Logger logger = LogManager.getLogger(Mem.class);
+
         private final long total;
         private final long free;
 
@@ -253,6 +255,16 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getUsed() {
+            if (total == 0) {
+                // The work in https://github.com/elastic/elasticsearch/pull/42725 established that total memory
+                // can be reported as negative in some cases. In those cases, we force it to zero in which case
+                // we can no longer correctly report the used memory as (total-free) and should report it as zero.
+                //
+                // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
+                // cases where (free > total) which would be a different bug.
+                logger.warn("cannot compute used memory when total memory is 0 and free memory is " + free);
+                return new ByteSizeValue(0);
+            }
             return new ByteSizeValue(total - free);
         }
 

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.monitor.os;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class OsStatsTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
@@ -79,6 +81,11 @@ public class OsStatsTests extends ESTestCase {
                 assertEquals(osStats.getCgroup().getMemoryUsageInBytes(), deserializedOsStats.getCgroup().getMemoryUsageInBytes());
             }
         }
+    }
+
+    public void testGetUsedMemoryWithZeroTotal() {
+        OsStats.Mem mem = new OsStats.Mem(0, 1);
+        assertThat(mem.getUsed().getBytes(), equalTo(0L));
     }
 
 }


### PR DESCRIPTION
We're seeing test failures in 7.x on debian8 (though I have not been able to reproduce them) with negative values for used memory which we compute as `total - free`. We already coerce both total and free memory to zero if negative values are reported for either because @dakrone's work in https://github.com/elastic/elasticsearch/pull/42725  demonstrated that negative values can be returned. That said, it does not appear that those occurrences necessarily coincide such that total may be reported as negative but free is reported as positive thus resulting in a potential `free > total` situation.

Backport of https://github.com/elastic/elasticsearch/pull/56435