### PR TITLE
Add scope-related fields to Annotation

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/annotations_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/annotations_index_mappings.json
@@ -30,6 +30,27 @@
       },
       "type" : {
         "type" : "keyword"
+      },
+      "detector_index" : {
+        "type" : "integer"
+      },
+      "partition_field_name" : {
+        "type" : "keyword"
+      },
+      "partition_field_value" : {
+        "type" : "keyword"
+      },
+      "over_field_name" : {
+        "type" : "keyword"
+      },
+      "over_field_value" : {
+        "type" : "keyword"
+      },
+      "by_field_name" : {
+        "type" : "keyword"
+      },
+      "by_field_value" : {
+        "type" : "keyword"
       }
     }
   }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationTests.java
@@ -36,6 +36,13 @@ public class AnnotationTests extends AbstractSerializingTestCase<Annotation> {
             .setModifiedTime(randomBoolean() ? new Date(randomNonNegativeLong()) : null)
             .setModifiedUsername(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
             .setType(randomAlphaOfLengthBetween(10, 15))
+            .setDetectorIndex(randomBoolean() ? randomIntBetween(0, 10) : null)
+            .setPartitionFieldName(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
+            .setPartitionFieldValue(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
+            .setOverFieldName(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
+            .setOverFieldValue(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
+            .setByFieldName(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
+            .setByFieldValue(randomBoolean() ? randomAlphaOfLengthBetween(5, 20) : null)
             .build();
     }
 


### PR DESCRIPTION
This PR implements scoped annotations by adding 7 new fields to `Annotation` type: `detector_index`, `partition_field_name`, `partition_field_value`, `over_field_name`, `over_field_value`, `by_field_name`, `by_field_value`.



**Rationale**
Currently the user of Elastic ML has an ability to attach an annotation to a moment in time (or time range) when something interesting happens (e.g.: Black Friday sale causing a sudden bump in request rate). The scope of such an annotation is an ML job. So even if the user configures anomaly detection job with `partition_field_name`, `over_field_name` or `by_field_name` parameters, the annotation is unaware of them. This may cause usability issues for a number of reasons:
- the user could have forgotten the exact time series they were looking at while creating the annotation
- another user seeing the annotation may not have the knowledge (context) their colleague had while creating the annotation
- we (ML team) plan to introduce more system-generated annotations based on model changes. Such annotations only make sense in the context of the model/time series they were created for

Because of these reasons, we should implement scoped (or scope-aware) annotations that carry the relevant context information with them.


Relates https://github.com/elastic/elasticsearch/issues/55781