### PR TITLE
[DOCS] Collapse remaining 8.0 breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0.asciidoc
+++ b/docs/reference/migration/migrate_8_0.asciidoc
@@ -40,7 +40,7 @@ coming[8.0.0]
 
 //tag::notable-breaking-changes[]
 
-.Indices created in {es} 7.0 and earlier versions are not supported.
+.Indices created in {es} 6.x and earlier versions are not supported.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_8_0/api.asciidoc
+++ b/docs/reference/migration/migrate_8_0/api.asciidoc
@@ -8,19 +8,23 @@
 
 // end::notable-breaking-changes[]
 
-[float]
-==== Deprecated `?local` parameter removed from `GET _cat/nodes` API
-
+.The cat node API's `local` query parameter has been removed.
+[%collapsible]
+====
+*Details* +
 The `?local` parameter to the `GET _cat/nodes` API was deprecated in 7.x and is
 rejected in 8.0. This parameter caused the API to use the local cluster state
 to determine the nodes returned by the API rather than the cluster state from
 the master, but this API requests information from each selected node
 regardless of the `?local` parameter which means this API does not run in a
 fully node-local fashion.
+====
 
-[float]
-==== Deprecated `local` parameter removed from get field mapping API
-
+.The get field mapping API's `local` query parameter has been removed.
+[%collapsible]
+====
+*Details* +
 The `local` parameter for get field mapping API was deprecated in 7.8 and is
 removed in 8.0. This parameter is a no-op and field mappings are always retrieved
 locally.
+====

--- a/docs/reference/migration/migrate_8_0/ilm.asciidoc
+++ b/docs/reference/migration/migrate_8_0/ilm.asciidoc
@@ -1,6 +1,6 @@
 [float]
 [[breaking_80_ilm_changes]]
-=== Index Lifecycle Management changes
+=== {ilm-cap} changes
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -42,8 +42,7 @@ The same functionality can be achieved without any configuration provided that t
 The `nested_filter` and `nested_path` options, deprecated in 6.x, have been removed in favor of the `nested` context.
 ====
 
-
-.{es} now routes search and get requests to shards using adaptive replica selection.
+.Search and get requests are now routed to shards using adaptive replica selection by default.
 [%collapsible]
 ====
 *Details* +

--- a/docs/reference/migration/migrate_8_0/search.asciidoc
+++ b/docs/reference/migration/migrate_8_0/search.asciidoc
@@ -8,65 +8,87 @@
 //tag::notable-breaking-changes[]
 //end::notable-breaking-changes[]
 
-[float]
-==== Removal of types
-
+.Search-related REST API endpoints containing mapping types have been removed.
+[%collapsible]
+====
+*Details* +
 The `/{index}/{type}/_search`, `/{index}/{type}/_msearch`, `/{index}/{type}/_search/template` and `/{index}/{type}/_msearch/template` REST endpoints have been removed in favour of `/{index}/_search`, `/{index}/_msearch`, `/{index}/_search/template` and `/{index}/_msearch/template`; since indexes no longer contain types, these typed endpoints are obsolete..
 
 The `/{index}/{type}/_termvectors`, `/{index}/{type}/{id}/_termvectors` and `/{index}/{type}/_mtermvectors` REST endpoints have been removed in favour of `/{index}/_termvectors`, `/{index}/{id}/_termvectors` and `/{index}/_mtermvectors`; since indexes no longer contain types, these typed endpoints are obsolete..
 
 The `/{index}/{type}/{doc}` and `/{index}/{type}/_mget` REST endpoints have been removed in favour of `/{index}/_doc/{doc}` and `/{index}/_mget`; since indexes no longer contain types, these typed endpoints are obsolete.
+====
 
-[float]
-==== Removal of queries
-
+.The `common` query has been removed.
+[%collapsible]
+====
+*Details* +
 The `common` query, deprecated in 7.x, has been removed in 8.0.
 The same functionality can be achieved by the `match` query if the total number of hits is not tracked.
+====
 
-[float]
-===== Removal of query parameters
-
+.The `cutoff_frequency` parameter has been removed from the `match` and `multi_match` query.
+[%collapsible]
+====
+*Details* +
 The `cutoff_frequency` parameter, deprecated in 7.x, has been removed in 8.0 from `match` and `multi_match` queries.
 The same functionality can be achieved without any configuration provided that the total number of hits is not tracked.
+====
 
-[float]
-===== Removal of sort parameters
-
+.The `nested_filter` and `nested_path` properties have been removed from the search API's `sort` request body parameter.
+[%collapsible]
+====
+*Details* +
 The `nested_filter` and `nested_path` options, deprecated in 6.x, have been removed in favor of the `nested` context.
+====
 
 
-[float]
-===== Shard allocation awareness in Search and Get requests
-
+.{es} now routes search and get requests to shards using adaptive replica selection.
+[%collapsible]
+====
+*Details* +
 {es} will no longer prefer using shards in the same location (with the same awareness attribute values) to process
 `_search` and `_get` requests. Adaptive replica selection (activated by default in this version) will route requests
 more efficiently using the service time of prior inter-node communications.
+====
 
-[float]
-==== Removal of sparse vector fields
+.The `sparse_vector` field datatype has been removed.
+[%collapsible]
+====
+*Details* +
 The `sparse_vector` field type was deprecated in 7.6 and is now removed in
 8.0. We have not seen much interest in this experimental field type, and don't
 see a clear use case as it's currently designed. If you have feedback or
 suggestions around sparse vector functionality, please let us know through
 GitHub or the 'discuss' forums.
+====
 
-[float]
-==== Update to vector function signatures
+.Vector functions using `(query, doc['field'])` are no longer supported.
+[%collapsible]
+====
+*Details* +
 The vector functions of the form `function(query, doc['field'])` were
 deprecated in 7.6, and are now removed in 8.x. The form
 `function(query, 'field')` should be used instead. For example,
 `cosineSimilarity(query, doc['field'])` is replaced by
 `cosineSimilarity(query, 'field')`.
+====
 
-[float]
-==== Object format for `indices_boost`
+.The search API's `indices_boost` request body parameter no longer accepts object values.
+[%collapsible]
+====
+*Details* +
 The `indices_boost` option in the search request used to accept the boosts
 both as an object and as an array. The object format has been deprecated since
 5.2 and is now removed in 8.0.
+====
 
-[float]
-==== Removal of `use_field_mapping` for docvalues fields
+.The search API's `use_field_mapping` request body parameter has been removed.
+[%collapsible]
+====
+*Details* +
 In 7.0, we began formatting `docvalue_fields` by default using each field's
 mapping definition. To ease the transition from 6.x, we added the format
 option `use_field_mapping`. This parameter was deprecated in 7.0, and is now
 removed in 8.0.
+====

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -6,9 +6,10 @@
 //Installation and Upgrade Guide
 
 //tag::notable-breaking-changes[]
-[float]
-==== The realm `order` setting is required
-
+.The realm `order` setting is now required.
+[%collapsible]
+====
+*Details* +
 The `xpack.security.authc.realms.{type}.{name}.order` setting is now required and must be
 specified for each explicitly configured realm. Each value must be unique.
 The cluster will fail to start if the requirements are not met.
@@ -29,49 +30,57 @@ xpack.security.authc.realms.kerberos.kerb1:
   keytab.path: es.keytab
   remove_realm_name: false
 --------------------------------------------------
-
+====
 // end::notable-breaking-changes[]
 
-[float]
 [[accept-default-password-removed]]
-==== The `accept_default_password` setting has been removed
-
+.The `accept_default_password` setting has been removed.
+[%collapsible]
+====
+*Details* +
 The `xpack.security.authc.accept_default_password` setting has not had any affect
 since the 6.0 release of {es}. It has been removed and cannot be used.
+====
 
-[float]
 [[roles-index-cache-removed]]
-==== The `roles.index.cache.*` settings have been removed
-
+.The `roles.index.cache.*` settings have been removed.
+[%collapsible]
+====
+*Details* +
 The `xpack.security.authz.store.roles.index.cache.max_size` and
 `xpack.security.authz.store.roles.index.cache.ttl` settings have
 been removed. These settings have been redundant and deprecated
 since the 5.2 release of {es}.
+====
 
-[float]
 [[migrate-tool-removed]]
-==== The `elasticsearch-migrate` tool has been removed
-
+.The `elasticsearch-migrate` tool has been removed.
+[%collapsible]
+====
+*Details* +
 The `elasticsearch-migrate` tool provided a way to convert file
 realm users and roles into the native realm. It has been deprecated
 since 7.2.0. Users and roles should now be created in the native
 realm directly.
+====
 
-[float]
 [[separating-node-and-client-traffic]]
-==== The `transport.profiles.*.xpack.security.type` setting has been removed
-
+.The `transport.profiles.*.xpack.security.type` setting has been removed.
+[%collapsible]
+====
+*Details* +
 The `transport.profiles.*.xpack.security.type` setting has been removed since
 the Transport Client has been removed and therefore all client traffic now uses
 the HTTP transport. Transport profiles using this setting should be removed.
+====
 
-[float]
 [[ssl-validation-changes]]
 ==== SSL/TLS configuration validation
 
-[float]
-===== The `xpack.security.transport.ssl.enabled` setting may be required
-
+.The `xpack.security.transport.ssl.enabled` setting is now required to configure `xpack.security.transport.ssl` settings.
+[%collapsible]
+====
+*Details* +
 It is now an error to configure any SSL settings for
 `xpack.security.transport.ssl` without also configuring
 `xpack.security.transport.ssl.enabled`.
@@ -91,10 +100,12 @@ xpack.security.transport.ssl.keystore.path: elastic-certificates.p12
 xpack.security.transport.ssl.truststore.path: elastic-certificates.p12
 --------------------------------------------------
 <1> or `false`.
+====
 
-[float]
-===== The `xpack.security.http.ssl.enabled` setting may be required
-
+.The `xpack.security.http.ssl.enabled` setting is now required to configure `xpack.security.http.ssl` settings.
+[%collapsible]
+====
+*Details* +
 It is now an error to configure any SSL settings for
 `xpack.security.http.ssl` without also configuring
 `xpack.security.http.ssl.enabled`.
@@ -116,31 +127,35 @@ xpack.security.http.ssl.key: elasticsearch.key
 xpack.security.http.ssl.certificate_authorities: [ "corporate-ca.crt" ]
 --------------------------------------------------
 <1> or `false`.
+====
 
-[float]
-===== The `xpack.security.transport.ssl` Certificate and Key may be required
-
+.A `xpack.security.transport.ssl` certificate and key are now required to enable SSL for the transport interface. 
+[%collapsible]
+====
+*Details* +
 It is now an error to enable SSL for the transport interface without also configuring
 a certificate and key through use of the `xpack.security.transport.ssl.keystore.path`
 setting or the `xpack.security.transport.ssl.certificate` and
 `xpack.security.transport.ssl.key` settings.
+====
 
-[float]
-===== The `xpack.security.http.ssl` Certificate and Key may be required
-
+.A `xpack.security.http.ssl` certificate and key are now required to enable SSL for the HTTP server.
+[%collapsible]
+====
+*Details* +
 It is now an error to enable SSL for the HTTP (Rest) server without also configuring
 a certificate and key through use of the `xpack.security.http.ssl.keystore.path`
 setting or the `xpack.security.http.ssl.certificate` and
 `xpack.security.http.ssl.key` settings.
+====
 
-
-[float]
 [[builtin-users-changes]]
 ==== Changes to built-in users
 
-[float]
-===== The `kibana` user has been removed in favor of the `kibana_system` user
-
+.The `kibana` user has been renamed `kibana_system`.
+[%collapsible]
+====
+*Details* +
 The `kibana` user was historically used to authenticate {kib} to {es}.
 The name of this user was confusing, and was often mistakenly used to login to {kib}.
 This has been renamed to `kibana_system` in order to reduce confusion, and to better
@@ -157,15 +172,16 @@ then you should update to use the new `kibana_system` user instead:
 --------------------------------------------------
 elasticsearch.username: kibana_system
 --------------------------------------------------
+====
 
-
-[float]
 [[builtin-roles-changes]]
 ==== Changes to built-in roles
 
-[float]
-===== The `kibana_user` role has been removed in favor of the `kibana_admin` role
-
+.The `kibana_user` role has been renamed to `kibana_admin`.
+[%collapsible]
+====
+*Details* +
 Users who were previously assigned the `kibana_user` role should instead be assigned
 the `kibana_admin` role. This role grants the same set of privileges as `kibana_user`, but has been
 renamed to better reflect its intended use.
+====

--- a/docs/reference/migration/migrate_8_0/security.asciidoc
+++ b/docs/reference/migration/migrate_8_0/security.asciidoc
@@ -74,6 +74,7 @@ the Transport Client has been removed and therefore all client traffic now uses
 the HTTP transport. Transport profiles using this setting should be removed.
 ====
 
+[discrete]
 [[ssl-validation-changes]]
 ==== SSL/TLS configuration validation
 
@@ -149,6 +150,7 @@ setting or the `xpack.security.http.ssl.certificate` and
 `xpack.security.http.ssl.key` settings.
 ====
 
+[discrete]
 [[builtin-users-changes]]
 ==== Changes to built-in users
 
@@ -174,6 +176,7 @@ elasticsearch.username: kibana_system
 --------------------------------------------------
 ====
 
+[discrete]
 [[builtin-roles-changes]]
 ==== Changes to built-in roles
 

--- a/docs/reference/migration/migrate_8_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_8_0/settings.asciidoc
@@ -8,67 +8,82 @@
 //tag::notable-breaking-changes[]
 //end::notable-breaking-changes[]
 
-[float]
 [[search-remote-settings-removed]]
-==== The `search.remote` settings have been removed
-
+.The `search.remote.*` settings have been removed.
+[%collapsible]
+====
+*Details* +
 In 6.5 these settings were deprecated in favor of `cluster.remote`. In 7.x we
 provided automatic upgrading of these settings to their `cluster.remote`
 counterparts. In 8.0.0, these settings have been removed. Elasticsearch will
 refuse to start if you have these settings in your configuration or cluster
 state.
+====
 
-[float]
 [[remove-pidfile]]
-==== `pidfile` setting is replaced by `node.pidfile`
-
+.The `pidfile` setting has been replaced by `node.pidfile`.
+[%collapsible]
+====
+*Details* +
 To ensure that all settings are in a proper namespace, the `pidfile` setting was
 previously deprecated in version 7.4.0 of Elasticsearch, and is removed in
 version 8.0.0. Instead, use `node.pidfile`.
+====
 
-[float]
 [[remove-processors]]
-==== `processors` setting is replaced by `node.processors`
-
+.The `processors` setting has been replaced by `node.processors`.
+[%collapsible]
+====
+*Details* +
 To ensure that all settings are in a proper namespace, the `processors` setting
 was previously deprecated in version 7.4.0 of Elasticsearch, and is removed in
 version 8.0.0. Instead, use `node.processors`.
+====
 
-[float]
-==== `node.processors` can no longer exceed the available number of processors
-
+.The `node.processors` setting can no longer exceed the available number of processors.
+[%collapsible]
+====
+*Details* +
 Previously it was possible to set the number of processors used to set the
 default sizes for the thread pools to be more than the number of available
 processors. As this leads to more context switches and more threads but without
 an increase in the number of physical CPUs on which to schedule these additional
 threads, the `node.processors` setting is now bounded by the number of available
 processors.
+====
 
-[float]
-==== `cluster.remote.connect` is removed
-
+.The `cluster.remote.connect` setting has been removed.
+[%collapsible]
+====
+*Details* +
 In Elasticsearch 7.7.0, the setting `cluster.remote.connect` was deprecated in
 favor of setting `node.remote_cluster_client`. In Elasticsearch 8.0.0, the
 setting `cluster.remote.connect` is removed.
+====
 
-[float]
-==== `node.local_storage` is removed
-
+.The `node.local_storage` setting has been removed.
+[%collapsible]
+====
+*Details* +
 In Elasticsearch 7.8.0, the setting `node.local_storage` was deprecated and
 beginning in Elasticsearch 8.0.0 all nodes will require local storage. Therefore,
 the `node.local_storage` setting has been removed.
+====
 
-[float]
-==== `auth.password` for HTTP monitoring is removed
-
+.The `auth.password` setting for HTTP monitoring has been removed.
+[%collapsible]
+====
+*Details* +
 In Elasticsearch 7.7.0, the setting `xpack.monitoring.exporters.<exporterName>.auth.password`
 was deprecated in favor of setting `xpack.monitoring.exporters.<exporterName>.auth.secure_password`.
 In Elasticsearch 8.0.0, the setting `xpack.monitoring.exporters.<exporterName>.auth.password` is
 removed.
+====
 
-[float]
-==== Option to disable basic license features is removed.
-
+.Settings used to disable basic license features have been removed.
+[%collapsible]
+====
+*Details* +
 The following settings were deprecated in {es} 7.8.0 and have been removed
 in {es} 8.0.0:
 
@@ -87,10 +102,12 @@ These basic license features are now always enabled for the {default-dist}.
 If you have disabled ILM so that you can use another tool to manage Watcher
 indices, the newly introduced `xpack.watcher.use_ilm_index_management` setting
 may be set to false.
+====
 
-[float]
-==== The `prefer_v2_templates` parameter now defaults to `true`
-
+.The `prefer_v2_templates` parameter now defaults to `true` for several document and index APIs.
+[%collapsible]
+====
+*Details* +
 In Elasticsearch 7.8.0 the `?prefer_v2_templates=true|false` parameter was introduced to allow
 specifying whether to favor V1 or V2 templates when a new index is created. In 8.0 this now defaults
 to `true`, meaning that V2 index templates will always take precedence if they match. V1 templates
@@ -99,3 +116,4 @@ will continue to be applied if no V2 index template matches the newly created in
 The `?prefer_v2_templates` parameter is supported on the <<indices-create-index,Create Index>>,
 <<docs-index_,Index>>, <<docs-bulk,Bulk>>, <<docs-update,Update>>, and
 <<indices-rollover-index,Rollover>> APIs.
+====

--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -1,6 +1,6 @@
 [float]
 [[breaking_80_snapshots_changes]]
-=== Snapshot and Restore changes
+=== Snapshot and restore changes
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide

--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -9,8 +9,10 @@
 
 // end::notable-breaking-changes[]
 
-[float]
-=== Get snapshots response format is changed
+.The get snapshot API's response format has changed.
+[%collapsible]
+====
+*Details* +
 It's possible to get snapshots from multiple repositories in one go. The response format has changed
 and now contains separate response for each repository.
 
@@ -59,30 +61,36 @@ produces the following response
 // TESTRESPONSE[skip:no repo and snapshots are created]
 
 See <<modules-snapshots>> for more information.
+====
 
-[float]
-==== Deprecated node level compress setting removed
-
+.The `repositories.fs.compress` node-level setting has been removed.
+[%collapsible]
+====
+*Details* +
 For shared file system repositories (`"type": "fs"`), the node level setting `repositories.fs.compress` could
 previously be used to enable compression for all shared file system repositories where `compress` was not specified.
 The `repositories.fs.compress` setting has been removed.
 
 Instead use the repository specific `compress` setting to enable compression. See <<modules-snapshots>> for information
 on the `compress` setting.
+====
 
-[float]
-==== Compression of meta data files is now on by default
-
+.Metadata files are now compressed by default.
+[%collapsible]
+====
+*Details* +
 Previously, the default value for `compress` was `false`. The default has been changed to `true`.
 
 This change will affect both newly created repositories and existing repositories where `compress=false` has not been
 explicitly specified.
 
 For more information on the compress option, see <<modules-snapshots>>
+====
 
-[float]
-==== The S3 repository plugin uses the DNS style access pattern by default
-
+.The S3 repository plugin now uses a DNS-style access pattern by default.
+[%collapsible]
+====
+*Details* +
 Starting in version 7.4 the `repository-s3` plugin does not use the
 now-deprecated path-style access pattern by default. In versions 7.0, 7.1, 7.2
 and 7.3 the `repository-s3` plugin always used the path-style access pattern.
@@ -94,10 +102,13 @@ breaking change was made necessary by
 https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/[AWS's
 announcement] that the path-style access pattern is deprecated and will be
 unsupported on buckets created after September 30th 2020.
+====
 
-[float]
-==== Restore requests no longer accept settings
-
+.Restore requests no longer accept settings.
+[%collapsible]
+====
+*Details* +
 In earlier versions, you could pass both `settings` and `index_settings` in the
 body of a restore snapshot request, but the `settings` value was ignored. The
 restore snapshot API now rejects requests that include a `settings` value.
+====

--- a/docs/reference/migration/migrate_8_0/threadpool.asciidoc
+++ b/docs/reference/migration/migrate_8_0/threadpool.asciidoc
@@ -8,9 +8,11 @@
 //tag::notable-breaking-changes[]
 //end::notable-breaking-changes[]
 
-[float]
-==== Removal of the `fixed_auto_queue_size` thread pool type
-
+.The `fixed_auto_queue_size` thread pool type has been removed.
+[%collapsible]
+====
+*Details* +
 The `fixed_auto_queue_size` thread pool type, previously marked as an
 experimental feature, was deprecated in 7.x and has been removed in 8.0.
 The `search` and `search_throttled` thread pools have the `fixed` type now.
+====

--- a/docs/reference/migration/migrate_8_0/transport.asciidoc
+++ b/docs/reference/migration/migrate_8_0/transport.asciidoc
@@ -3,9 +3,10 @@
 === Transport changes
 
 //tag::notable-breaking-changes[]
-[float]
-==== Removal of old transport settings
-
+.Several `tranport` settings have been replaced.
+[%collapsible]
+====
+*Details* +
 The following settings have been deprecated in 7.x and removed in 8.0. Each setting has a replacement
 setting that was introduced in 6.7.
 
@@ -18,5 +19,6 @@ setting that was introduced in 6.7.
 - `transport.profiles.profile_name.reuse_address` replaced by `transport.profiles.profile_name.tcp.reuse_address`
 - `transport.profiles.profile_name.send_buffer_size` replaced by `transport.profiles.profile_name.tcp.send_buffer_size`
 - `transport.profiles.profile_name.receive_buffer_size` replaced by `transport.profiles.profile_name.tcp.receive_buffer_size`
+====
 
 // end::notable-breaking-changes[]


### PR DESCRIPTION
Adds collapsible sections to the 8.0 breaking changes.

To make reviews easier and avoid introducing errors, I've
tried to limit my changes to formatting, with the exception
of rewording heading as sentences.

I plan to add *Impact* sections to each change as part of a later update.

Relates to #55629 and #53229

### Preview
http://elasticsearch_56418.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html