### PR TITLE
[ML] Adjust list of platforms that have ML native code

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSet.java
@@ -72,8 +72,8 @@ public class MachineLearningFeatureSet implements XPackFeatureSet {
     /**
      * List of platforms for which the native processes are available
      */
-    private static final List<String> mlPlatforms =
-            Arrays.asList("darwin-x86_64", "linux-x86_64", "windows-x86_64");
+    private static final List<String> mlPlatforms = Collections.unmodifiableList(
+            Arrays.asList("darwin-x86_64", "linux-aarch64", "linux-x86_64", "windows-x86_64"));
 
     private final boolean enabled;
     private final XPackLicenseState licenseState;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -122,8 +122,10 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
 
     public void testIsRunningOnMlPlatform() {
         assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "amd64", true));
-        assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "amd64", true));
+        assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "aarch64", true));
         assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Mac OS X", "x86_64", true));
+        assertTrue(MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "amd64", true));
+        assertFalse(MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "arm64", false));
         assertFalse(MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "i386", false));
         assertFalse(MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "i386", false));
         assertFalse(MachineLearningFeatureSet.isRunningOnMlPlatform("SunOS", "amd64", false));
@@ -131,6 +133,8 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
                 () -> MachineLearningFeatureSet.isRunningOnMlPlatform("Linux", "i386", true));
         expectThrows(ElasticsearchException.class,
                 () -> MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "i386", true));
+        expectThrows(ElasticsearchException.class,
+                () -> MachineLearningFeatureSet.isRunningOnMlPlatform("Windows 10", "arm64", true));
         expectThrows(ElasticsearchException.class,
                 () -> MachineLearningFeatureSet.isRunningOnMlPlatform("SunOS", "amd64", true));
     }


### PR DESCRIPTION
Native code is now available for linux-aarch64.

Note that it is _not_ currently supported!