### PR TITLE
Fix bug in faster interval rounding

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
+++ b/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
@@ -494,6 +494,9 @@ public abstract class LocalTimeOffset {
             long utcStart = transition.toEpochSecond() * 1000;
             long offsetBeforeMillis = transition.getOffsetBefore().getTotalSeconds() * 1000;
             long offsetAfterMillis = transition.getOffsetAfter().getTotalSeconds() * 1000;
+            assert (false == previous instanceof Transition) || ((Transition) previous).startUtcMillis < utcStart :
+                    "transition list out of order at [" + previous + "] and [" + transition + "]";
+            assert previous.millis != offsetAfterMillis : "transition list is has a duplicate at [" + previous + "] and [" + transition + "]";
             if (transition.isGap()) {
                 long firstMissingLocalTime = utcStart + offsetBeforeMillis;
                 long firstLocalTimeAfterGap = utcStart + offsetAfterMillis;
@@ -560,6 +563,11 @@ public abstract class LocalTimeOffset {
         if (false == itr.hasNext()) {
             if (minSecond < t.toEpochSecond() && t.toEpochSecond() < maxSecond) {
                 transitions.add(t);
+                /*
+                 * Sometimes the rules duplicate the transitions. And
+                 * duplicates confuse us. So we have to skip past them.
+                 */
+                minSecond = t.toEpochSecond() + 1;
             }
             transitions = buildTransitionsFromRules(transitions, zone, rules, minSecond, maxSecond);
             if (transitions != null && transitions.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
+++ b/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
@@ -496,7 +496,8 @@ public abstract class LocalTimeOffset {
             long offsetAfterMillis = transition.getOffsetAfter().getTotalSeconds() * 1000;
             assert (false == previous instanceof Transition) || ((Transition) previous).startUtcMillis < utcStart :
                     "transition list out of order at [" + previous + "] and [" + transition + "]";
-            assert previous.millis != offsetAfterMillis : "transition list is has a duplicate at [" + previous + "] and [" + transition + "]";
+            assert previous.millis != offsetAfterMillis :
+                    "transition list is has a duplicate at [" + previous + "] and [" + transition + "]";
             if (transition.isGap()) {
                 long firstMissingLocalTime = utcStart + offsetBeforeMillis;
                 long firstLocalTimeAfterGap = utcStart + offsetAfterMillis;

--- a/server/src/test/java/org/elasticsearch/common/LocalTimeOffsetTests.java
+++ b/server/src/test/java/org/elasticsearch/common/LocalTimeOffsetTests.java
@@ -156,10 +156,12 @@ public class LocalTimeOffsetTests extends ESTestCase {
 
     public void testLastTransitionOverlapsRules() {
         /*
-         * America/Tijuana's transitions overlap its rules and we have to make
-         * sure not to collect duplicate transitions or we'll trip assertions.
-         * If we don't trip the assertions then trying to use the transitions
-         * will produce incorrect results.
+         * America/Tijuana's fully defined transitions overlap with its future
+         * rules and if we're not careful we can end up with duplicate
+         * transitions because we have to collect them independently. That
+         * will trip assertions, failing this test real fast. If they don't
+         * trip the assertions then trying to use the transitions will produce
+         * incorrect results, failing the size assertion.
          */
         ZoneId zone = ZoneId.of("America/Tijuana");
         long min = utcTime("2011-11-06T08:31:57.091Z");

--- a/server/src/test/java/org/elasticsearch/common/LocalTimeOffsetTests.java
+++ b/server/src/test/java/org/elasticsearch/common/LocalTimeOffsetTests.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneRules;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -154,15 +155,17 @@ public class LocalTimeOffsetTests extends ESTestCase {
         assertRoundingAtOffset(lookup.lookup(time), time, TimeUnit.MINUTES.toMillis(345));
     }
 
+    /**
+     * America/Tijuana's
+     * {@link ZoneRules#getTransitions() fully defined transitions} overlap
+     * with its {@link ZoneRules#getTransitionRules() future rules} and if
+     * we're not careful we can end up with duplicate transitions because we
+     * have to collect them independently. That will trip assertions, failing
+     * this test real fast. If they don't trip the assertions then trying to
+     * use the transitions will produce incorrect results, failing the
+     * size assertion.
+     */
     public void testLastTransitionOverlapsRules() {
-        /*
-         * America/Tijuana's fully defined transitions overlap with its future
-         * rules and if we're not careful we can end up with duplicate
-         * transitions because we have to collect them independently. That
-         * will trip assertions, failing this test real fast. If they don't
-         * trip the assertions then trying to use the transitions will produce
-         * incorrect results, failing the size assertion.
-         */
         ZoneId zone = ZoneId.of("America/Tijuana");
         long min = utcTime("2011-11-06T08:31:57.091Z");
         long max = utcTime("2011-11-06T09:02:57.091Z");


### PR DESCRIPTION
This fixes a bug in the interval rounding and two test bugs that showed
up when I ran 1000s of iterations of the tests. The bug was that we
could end up with duplicate transitions if we only needed the last
transition from the list of fully defined transitions and the
transitions overlapped with the rules. This happens. Its ok. We had
defence against that if we needed more than one transition but forgot it
in this case. Now we have it and assertions to make sure we catch any
similar mistakes.

One test bug had to do with the randomized test calling
`round(round(min))` because sometimes the first `round` call will return
a time less than min. Specifically if `min` is near daylight savings
time. Anyway, this change fixes it by building an extra-wide prepared
rounding just in case.

The other test bug came up when adding a test for the real bug, namely
that `assertRoundingAtOffset` made an assertion that wasn't true if the
time to round ended up being in an overlap. This just drops that
assertion. We have similar assertions in cases where we *know* what kind
of offsets we're working with in other tests.

Closes #56400
