### PR TITLE
Report used memory as zero when total memory cannot be obtained

### DIFF
--- a/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class OsStatsTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
@@ -79,6 +81,11 @@ public class OsStatsTests extends ESTestCase {
                 assertEquals(osStats.getCgroup().getMemoryUsageInBytes(), deserializedOsStats.getCgroup().getMemoryUsageInBytes());
             }
         }
+    }
+
+    public void testGetUsedMemoryWithZeroTotal() {
+        OsStats.Mem mem = new OsStats.Mem(0, 1);
+        assertThat(mem.getUsed().getBytes(), equalTo(0L));
     }
 
 }


### PR DESCRIPTION
We're seeing test failures in 7.x on debian8 (though I have not been able to reproduce them) with negative values for used memory which we compute as `total - free`. We already coerce both total and free memory to zero if negative values are reported for either because @dakrone's work in #42725 demonstrated that negative values can be returned. That said, it does not appear that those occurrences necessarily coincide such that total may be reported as negative but free is reported as positive thus resulting in a potential `free > total` situation.

Fixes https://github.com/elastic/elasticsearch/issues/54415