### PR TITLE
[DOCS] Add impact sections to snapshot/restore 8.0 breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -127,6 +127,6 @@ body of a restore snapshot request, but the `settings` value was ignored. The
 restore snapshot API now rejects requests that include a `settings` value.
 
 *Impact* +
-Discontinue use of the `settings` and `index_settings` parameters in restore
+Discontinue use of the `settings` parameter in restore
 snapshot request. Requests that include these parameters will return an error.
 ====

--- a/docs/reference/migration/migrate_8_0/snapshots.asciidoc
+++ b/docs/reference/migration/migrate_8_0/snapshots.asciidoc
@@ -61,6 +61,10 @@ produces the following response
 // TESTRESPONSE[skip:no repo and snapshots are created]
 
 See <<modules-snapshots>> for more information.
+
+*Impact* +
+Update your workflow and applications to use the get snapshot API's new response
+format.
 ====
 
 .The `repositories.fs.compress` node-level setting has been removed.
@@ -71,8 +75,11 @@ For shared file system repositories (`"type": "fs"`), the node level setting `re
 previously be used to enable compression for all shared file system repositories where `compress` was not specified.
 The `repositories.fs.compress` setting has been removed.
 
-Instead use the repository specific `compress` setting to enable compression. See <<modules-snapshots>> for information
-on the `compress` setting.
+*Impact* +
+Use the repository specific `compress` setting to enable compression. See
+<<modules-snapshots>> for information on the `compress` setting.
+
+Discontinue use of the `repositories.fs.compress` node-level setting.
 ====
 
 .Metadata files are now compressed by default.
@@ -85,6 +92,10 @@ This change will affect both newly created repositories and existing repositorie
 explicitly specified.
 
 For more information on the compress option, see <<modules-snapshots>>
+
+*Impact* +
+Update your workflow and applications to assume a default value of `true` for
+the `compress` parameter.
 ====
 
 .The S3 repository plugin now uses a DNS-style access pattern by default.
@@ -95,13 +106,16 @@ Starting in version 7.4 the `repository-s3` plugin does not use the
 now-deprecated path-style access pattern by default. In versions 7.0, 7.1, 7.2
 and 7.3 the `repository-s3` plugin always used the path-style access pattern.
 This is a breaking change for deployments that only support path-style access
-but which are recognized as supporting DNS-style access by the AWS SDK. If your
-deployment only supports path-style access and is affected by this change then
-you must configure the S3 client setting `path_style_access` to `true`. This
+but which are recognized as supporting DNS-style access by the AWS SDK. This
 breaking change was made necessary by
 https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/[AWS's
 announcement] that the path-style access pattern is deprecated and will be
 unsupported on buckets created after September 30th 2020.
+
+*Impact* +
+If your deployment only supports path-style access and is affected by this
+change then you must configure the S3 client setting `path_style_access` to
+`true`.
 ====
 
 .Restore requests no longer accept settings.
@@ -111,4 +125,8 @@ unsupported on buckets created after September 30th 2020.
 In earlier versions, you could pass both `settings` and `index_settings` in the
 body of a restore snapshot request, but the `settings` value was ignored. The
 restore snapshot API now rejects requests that include a `settings` value.
+
+*Impact* +
+Discontinue use of the `settings` and `index_settings` parameters in restore
+snapshot request. Requests that include these parameters will return an error.
 ====


### PR DESCRIPTION
Adds impact sections to the 8.0 breaking changes for snapshot and restore.

Relates to #55629 and #53229
