### PR TITLE
Always use archive base name as the pom artifact id

### DIFF
--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -27,14 +27,6 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 group = 'org.elasticsearch.client'
 archivesBaseName = 'elasticsearch-rest-client'
 
-publishing {
-  publications {
-    nebula {
-      artifactId = archivesBaseName
-    }
-  }
-}
-
 dependencies {
   compile "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   compile "org.apache.httpcomponents:httpcore:${versions.httpcore}"

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -25,14 +25,6 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 group = 'org.elasticsearch.client'
 archivesBaseName = 'elasticsearch-rest-client-sniffer'
 
-publishing {
-  publications {
-    nebula {
-      artifactId = archivesBaseName
-    }
-  }
-}
-
 dependencies {
   compile project(":client:rest")
   compile "org.apache.httpcomponents:httpclient:${versions.httpclient}"

--- a/modules/lang-painless/spi/build.gradle
+++ b/modules/lang-painless/spi/build.gradle
@@ -23,14 +23,6 @@ apply plugin: 'nebula.maven-base-publish'
 group = 'org.elasticsearch.plugin'
 archivesBaseName = 'elasticsearch-scripting-painless-spi'
 
-publishing {
-  publications {
-    nebula {
-      artifactId = archivesBaseName
-    }
-  }
-}
-
 dependencies {
   compile project(":server")
 }


### PR DESCRIPTION
We override the `archivesBaseName` for several projects. When these are published, we also interpret the GAV coordinates to use the update archive name as well. However, Gradle publishing plugins use the project name by default. We override this manually in several places but it's easy to miss some, like shadow jar projects. This PR moves this logic into our `BuildPlugin` so it's done in a central location and there no risk of forgetting to add the override.

Relates to #56415