### PR TITLE
[DOCS] Relocate `local gateway` setting content

### DIFF
--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -25,19 +25,9 @@ The modules in this section are:
 <<modules-cluster,Shard allocation and cluster-level routing>>::
 
     Settings to control where, when, and how shards are allocated to nodes.
-
-<<modules-gateway,Gateway>>::
-
-    How many nodes need to join the cluster before recovery can start.
-
-<<modules-indices,Indices>>::
-
-    Global index-related settings.
 --
 
 
 include::modules/discovery.asciidoc[]
 
 include::modules/cluster.asciidoc[]
-
-include::modules/gateway.asciidoc[]

--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -1,7 +1,7 @@
 [[modules-gateway]]
-== Local Gateway
+=== Local gateway settings
 
-The local gateway module stores the cluster state and shard data across full
+The local gateway stores the cluster state and shard data across full
 cluster restarts.
 
 The following _static_ settings, which must be set on every master node,
@@ -53,8 +53,8 @@ as long as the following conditions are met:
 
 NOTE: These settings only take effect on a full cluster restart.
 
-[[modules-gateway-dangling-indices]]
-=== Dangling indices
+[[dangling-indices]]
+==== Dangling indices
 
 When a node joins the cluster, any shards stored in its local data
 directory which do not already exist in the cluster will be imported into the

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -495,6 +495,11 @@ See <<ilm-actions>>.
 See <<ilm-index-lifecycle>>.
 
 [role="exclude",id="search-uri-request"]
-=== URI Search
+=== URI search
 
 See <<search-search>>.
+
+[role="exclude",id="modules-gateway-dangling-indices"]
+=== Dangling indices
+
+See <<modules-gateway-dangling-indices>>.

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -63,6 +63,8 @@ include::modules/indices/indexing_buffer.asciidoc[]
 
 include::settings/license-settings.asciidoc[]
 
+include::modules/gateway.asciidoc[]
+
 include::setup/logging-config.asciidoc[]
 
 include::settings/ml-settings.asciidoc[]


### PR DESCRIPTION
Moves `local gateway` setting content to `Configuring Elasticsearch`
from `Modules`.

Relates to #53303.