### PR TITLE
[7.5] [DOCS] Update default value of index.name.time_format (#56453)

### DIFF
--- a/docs/reference/settings/monitoring-settings.asciidoc
+++ b/docs/reference/settings/monitoring-settings.asciidoc
@@ -244,7 +244,7 @@ anything defined here.
 `index.name.time_format`::
 
 A mechanism for changing the default date suffix for the, by default, daily Monitoring indices.
-The default value is `YYYY.MM.DD`, which is why the indices are created daily.
+The default value is `yyyy.MM.dd`, which is why the indices are created daily.
 
 `use_ingest`::
 


### PR DESCRIPTION
Backports the following commits to 7.5:
 - [DOCS] Update default value of index.name.time_format (#56453)