### PR TITLE
Sketch out source value parsing.

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -193,11 +193,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
         float value;
         if (context.externalValueSet()) {
             Object v = context.externalValue();
-            if (v instanceof Number) {
-                value = ((Number) v).floatValue();
-            } else {
-                value = Float.parseFloat(v.toString());
-            }
+            value = objectToFloat(v);
         } else if (context.parser().currentToken() == Token.VALUE_NULL) {
             // skip
             return;
@@ -215,6 +211,19 @@ public class RankFeatureFieldMapper extends FieldMapper {
         }
 
         context.doc().addWithKey(name(), new FeatureField("_feature", name(), value));
+    }
+
+    private Float objectToFloat(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).floatValue();
+        } else {
+            return Float.parseFloat(value.toString());
+        }
+    }
+
+    @Override
+    protected Float parseSourceValue(Object value) {
+        return objectToFloat(value);
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -170,6 +170,11 @@ public class RankFeaturesFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -504,6 +504,13 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         return doubleValue;
     }
 
+    @Override
+    protected Double parseSourceValue(Object value) {
+        double doubleValue = objectToDouble(value);
+        double scalingFactor = fieldType().getScalingFactor();
+        return Math.round(doubleValue * scalingFactor) / scalingFactor;
+    }
+
     private static class ScaledFloatIndexFieldData implements IndexNumericFieldData {
 
         private final IndexNumericFieldData scaledFieldData;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -489,6 +489,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         protected String contentType() {
             return "prefix";
         }
@@ -512,6 +517,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
 
         @Override
         protected void parseCreateField(ParseContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Object parseSourceValue(Object value) {
             throw new UnsupportedOperationException();
         }
 
@@ -690,6 +700,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         if (fieldType().omitNorms()) {
             createFieldNamesField(context);
         }
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -149,6 +149,11 @@ public class TokenCountFieldMapper extends FieldMapper {
         context.doc().addAll(NumberFieldMapper.NumberType.INTEGER.createFields(fieldType().name(), tokenCount, indexed, docValued, stored));
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     /**
      * Count position increments in a token stream.  Package private for testing.
      * @param analyzer analyzer to create token stream

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
@@ -23,9 +23,12 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
 import org.apache.lucene.document.FeatureField;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
@@ -170,5 +173,14 @@ public class RankFeatureFieldMapperTests extends ESSingleNodeTestCase {
                         XContentType.JSON)));
         assertEquals("[rank_feature] fields do not support indexing multiple values for the same field [foo.field] in the same document",
                 e.getCause().getMessage());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        RankFeatureFieldMapper mapper = new RankFeatureFieldMapper.Builder("field").build(context);
+
+        assertEquals(3.14f, mapper.parseSourceValue(3.14), 0.0001);
+        assertEquals(42.9f, mapper.parseSourceValue("42.9"), 0.0001);
     }
 }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -21,9 +21,12 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
@@ -383,5 +386,16 @@ public class ScaledFloatFieldMapperTests extends ESSingleNodeTestCase {
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        ScaledFloatFieldMapper mapper = new ScaledFloatFieldMapper.Builder("field")
+            .scalingFactor(100)
+            .build(context);
+
+        assertEquals(3.14, mapper.parseSourceValue(3.1415926), 0.00001);
+        assertEquals(3.14, mapper.parseSourceValue("3.1415"), 0.00001);
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -143,6 +143,11 @@ public class MetaJoinFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -197,6 +197,10 @@ public final class ParentIdFieldMapper extends FieldMapper {
         context.doc().add(new SortedDocValuesField(fieldType().name(), binaryValue));
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    }
 
     @Override
     protected void doMerge(Mapper mergeWith) {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -381,6 +381,11 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     public void parse(ParseContext context) throws IOException {
         context.path().add(simpleName());
         XContentParser.Token token = context.parser().currentToken();

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -413,6 +413,11 @@ public class PercolatorFieldMapper extends FieldMapper {
         processQuery(query, context);
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     static void createQueryBuilderField(Version indexVersion, BinaryFieldMapper qbField,
                                         QueryBuilder queryBuilder, ParseContext context) throws IOException {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -766,4 +766,9 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
             createFieldNamesField(context);
         }
     }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
+    }
 }

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
@@ -26,9 +26,12 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
@@ -450,4 +453,13 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
         indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        ICUCollationKeywordFieldMapper mapper = new ICUCollationKeywordFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
+    }
 }

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -595,6 +595,11 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -28,10 +28,12 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.termvectors.TermVectorsRequest;
 import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -44,8 +46,10 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -672,4 +676,13 @@ public class AnnotatedTextFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        AnnotatedTextFieldMapper mapper = new AnnotatedTextFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
+    }
 }

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -169,4 +169,8 @@ public class Murmur3FieldMapper extends FieldMapper {
         }
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -21,7 +21,7 @@ setup:
         index:  test
         id:     1
         body:
-          keyword: [ "first", "second" ]
+          keyword: [ "x", "y" ]
           integer_range:
             gte: 0
             lte: 42
@@ -39,8 +39,8 @@ setup:
   - is_true: hits.hits.0._id
   - is_true: hits.hits.0._source
 
-  - match: { hits.hits.0.fields.keyword.0: first }
-  - match: { hits.hits.0.fields.keyword.1: second }
+  - match: { hits.hits.0.fields.keyword.0: x }
+  - match: { hits.hits.0.fields.keyword.1: y }
 
   - match: { hits.hits.0.fields.integer_range.0.gte: 0 }
   - match: { hits.hits.0.fields.integer_range.0.lte: 42 }
@@ -65,7 +65,7 @@ setup:
         index:  test
         id:     1
         body:
-          keyword: [ "value" ]
+          keyword: [ "x" ]
 
   - do:
       catch: bad_request
@@ -76,3 +76,49 @@ setup:
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
   - match: { error.root_cause.0.reason: "Unable to retrieve the requested [fields] since _source is disabled
         in the mappings for index [test]" }
+
+---
+"Test ignore malformed":
+  - do:
+      indices.create:
+        index:  test
+        body:
+          settings:
+            number_of_shards: 1
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+              integer:
+                type: integer
+                ignore_malformed: true
+
+  - do:
+      index:
+        index:  test
+        id:     1
+        body:
+          keyword: "x"
+          integer: 42
+
+  - do:
+      index:
+        index:  test
+        id:     2
+        body:
+          keyword: "y"
+          integer: "not an integer"
+
+  - do:
+      indices.refresh:
+        index: [ test ]
+
+  - do:
+      search:
+        index: test
+        body:
+          sort: [ keyword ]
+          fields: [ integer ]
+
+  - match: { hits.hits.0.fields.integer.0: 42 }
+  - is_false: hits.hits.1.fields.integer

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -158,6 +158,11 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         protected abstract void setGeometryQueryBuilder(FT fieldType);
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract static class TypeParser<T extends Builder> implements Mapper.TypeParser {
         protected abstract T newBuilder(String name, Map<String, Object> params);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -195,7 +195,11 @@ public class BinaryFieldMapper extends FieldMapper {
             // no doc values
             createFieldNamesField(context);
         }
+    }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -254,6 +255,16 @@ public class BooleanFieldMapper extends FieldMapper {
             context.doc().add(new SortedNumericDocValuesField(fieldType().name(), value ? 1 : 0));
         } else {
             createFieldNamesField(context);
+        }
+    }
+
+    @Override
+    public Boolean parseSourceValue(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        } else {
+            String textValue = value.toString();
+            return Booleans.parseBoolean(textValue.toCharArray(), 0, textValue.length(), false);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -620,6 +620,15 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         }
     }
 
+    @Override
+    protected List<?> parseSourceValue(Object value) {
+        if (value instanceof List) {
+            return (List<?>) value;
+        } else {
+            return List.of(value);
+        }
+    }
+
     static class CompletionInputMetadata {
         public final String input;
         public final Map<String, Set<String>> contexts;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -376,6 +376,7 @@ public final class DateFieldMapper extends FieldMapper {
             return dateMathParser;
         }
 
+        // Visible for testing.
         public long parse(String value) {
             return resolution.convert(DateFormatters.from(dateTimeFormatter().parse(value)).toInstant());
         }
@@ -645,6 +646,12 @@ public final class DateFieldMapper extends FieldMapper {
         if (fieldType().stored()) {
             context.doc().add(new StoredField(fieldType().name(), timestamp));
         }
+    }
+
+    @Override
+    public Long parseSourceValue(Object value) {
+        String date = value.toString();
+        return fieldType().parse(date);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.index.similarity.SimilarityService;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -309,6 +310,47 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
      * current failing token
      */
     protected abstract void parseCreateField(ParseContext context) throws IOException;
+
+    /**
+     * Given access to a document's _source, return this field's values.
+     *
+     * In addition to pulling out the values, mappers can parse them into a standard form. This
+     * method delegates parsing to {@link #parseSourceValue} for parsing. Most mappers will choose
+     * to override {@link #parseSourceValue} -- for example numeric field mappers make sure to
+     * parse the  source value into a number of the right type.
+     *
+     * Some mappers may need more flexibility and can override this entire method instead.
+     *
+     * @param lookup a lookup structure over the document's source.
+     * @return a list a standardized field values.
+     */
+    public List<?> lookupValues(SourceLookup lookup) {
+        Object sourceValue = lookup.extractValue(name());
+        if (sourceValue == null) {
+            return List.of();
+        }
+
+        List<Object> values = new ArrayList<>();
+        if (this instanceof ArrayValueMapperParser) {
+            return (List<?>) parseSourceValue(sourceValue);
+        } else {
+            List<?> sourceValues = sourceValue instanceof List ? (List<?>) sourceValue : List.of(sourceValue);
+            for (Object value : sourceValues) {
+                Object parsedValue = parseSourceValue(value);
+                values.add(parsedValue);
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Given a value that has been extracted from a document's source, parse it into a standard
+     * format. This parsing logic should closely mirror the value parsing in
+     * {@link #parseCreateField} or {@link #parse}.
+     *
+     * Note that when overriding this method, {@link #lookupValues} should *not* be overridden.
+     */
+    protected abstract Object parseSourceValue(Object value);
 
     protected void createFieldNamesField(ParseContext context) {
         FieldNamesFieldType fieldNamesFieldType = context.docMapper().metadataMapper(FieldNamesFieldMapper.class).fieldType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -398,6 +398,11 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void doMerge(Mapper mergeWith) {
         super.doMerge(mergeWith);
         IpFieldMapper other = (IpFieldMapper) mergeWith;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -187,6 +187,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
+    }
+
     public static final class KeywordFieldType extends StringFieldType {
 
         private NamedAnalyzer normalizer = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -70,6 +70,11 @@ public abstract class MetadataFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    }
+
+    @Override
     public MetadataFieldMapper merge(Mapper mergeWith) {
         return (MetadataFieldMapper) super.merge(mergeWith);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1094,6 +1094,11 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Number parseSourceValue(Object value) {
+        return fieldType().type.parse(value, coerce.value());
+    }
+
+    @Override
     protected void doMerge(Mapper mergeWith) {
         super.doMerge(mergeWith);
         NumberFieldMapper other = (NumberFieldMapper) mergeWith;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -52,6 +52,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
@@ -399,6 +400,23 @@ public class RangeFieldMapper extends FieldMapper {
         if (docValued == false && (indexed || stored)) {
             createFieldNamesField(context);
         }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Object parseSourceValue(Object value) {
+        RangeType rangeType = fieldType().rangeType();
+        if (rangeType == RangeType.IP) {
+            return value;
+        }
+
+        Map<String, Object> range = (Map<String, Object>) value;
+        Map<String, Object> parsedRange = new HashMap<>();
+        for (Map.Entry<String, Object> entry : range.entrySet()) {
+            Object parsedValue = rangeType.parseValue(entry.getValue(), coerce.value(), fieldType().dateMathParser);
+            parsedRange.put(entry.getKey(), parsedValue);
+        }
+        return parsedRange;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
@@ -70,7 +70,7 @@ public enum RangeType {
             return included ? address : nextDown(address);
         }
         @Override
-        public InetAddress parse(Object value, boolean coerce) {
+        public InetAddress parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
             if (value instanceof InetAddress) {
                 return (InetAddress) value;
             } else {
@@ -170,22 +170,27 @@ public enum RangeType {
         public Field getRangeField(String name, RangeFieldMapper.Range r) {
             return new LongRange(name, new long[] {((Number)r.from).longValue()}, new long[] {((Number)r.to).longValue()});
         }
-        private Number parse(DateMathParser dateMathParser, String dateStr) {
-            return dateMathParser.parse(dateStr, () -> {throw new IllegalArgumentException("now is not used at indexing time");})
-                .toEpochMilli();
-        }
         @Override
         public Number parseFrom(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, boolean included)
                 throws IOException {
-            Number value = parse(fieldType.dateMathParser, parser.text());
+            Number value = parseValue(parser.text(), coerce, fieldType.dateMathParser);
             return included ? value : nextUp(value);
         }
         @Override
         public Number parseTo(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce, boolean included)
                 throws IOException{
-            Number value = parse(fieldType.dateMathParser, parser.text());
+            Number value = parseValue(parser.text(), coerce, fieldType.dateMathParser);
             return included ? value : nextDown(value);
         }
+
+        @Override
+        public Number parseValue(Object dateStr, boolean coerce, @Nullable DateMathParser dateMathParser) {
+            assert dateMathParser != null;
+            return dateMathParser.parse(dateStr.toString(), () -> {
+                throw new IllegalArgumentException("now is not used at indexing time");
+            }).toEpochMilli();
+        }
+
         @Override
         public Long minValue() {
             return Long.MIN_VALUE;
@@ -599,6 +604,11 @@ public enum RangeType {
         }
         return fields;
     }
+
+    public Object parseValue(Object value, boolean coerce, @Nullable DateMathParser dateMathParser) {
+        return numberType.parse(value, coerce);
+    }
+
     /** parses from value. rounds according to included flag */
     public Object parseFrom(RangeFieldMapper.RangeFieldType fieldType, XContentParser parser, boolean coerce,
                             boolean included) throws IOException {
@@ -619,14 +629,12 @@ public enum RangeType {
     public abstract Query withinQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
     public abstract Query containsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
     public abstract Query intersectsQuery(String field, Object from, Object to, boolean includeFrom, boolean includeTo);
-    public Object parse(Object value, boolean coerce) {
-        return numberType.parse(value, coerce);
-    }
+
     public Query rangeQuery(String field, boolean hasDocValues, Object from, Object to, boolean includeFrom, boolean includeTo,
                             ShapeRelation relation, @Nullable ZoneId timeZone, @Nullable DateMathParser dateMathParser,
                             QueryShardContext context) {
-        Object lower = from == null ? minValue() : parse(from, false);
-        Object upper = to == null ? maxValue() : parse(to, false);
+        Object lower = from == null ? minValue() : parseValue(from, false, dateMathParser);
+        Object upper = to == null ? maxValue() : parseValue(to, false, dateMathParser);
         Query indexQuery;
         if (relation == ShapeRelation.WITHIN) {
             indexQuery = withinQuery(field, lower, upper, includeFrom, includeTo);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -480,6 +480,11 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         protected String contentType() {
             return "phrase";
         }
@@ -497,6 +502,11 @@ public class TextFieldMapper extends FieldMapper {
 
         @Override
         protected void parseCreateField(ParseContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Object parseSourceValue(Object value) {
             throw new UnsupportedOperationException();
         }
 
@@ -838,6 +848,11 @@ public class TextFieldMapper extends FieldMapper {
                 context.doc().add(new Field(phraseFieldMapper.fieldType.name(), value, phraseFieldMapper.fieldType));
             }
         }
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -23,12 +23,15 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A fetch sub-phase for high-level field retrieval. Given a list of fields, it
@@ -59,8 +62,22 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             LeafReaderContext readerContext = context.searcher().getIndexReader().leaves().get(readerIndex);
             sourceLookup.setSegmentAndDocument(readerContext, hit.docId());
 
-            Map<String, DocumentField> fieldValues = fieldValueRetriever.retrieve(sourceLookup);
+            Set<String> ignoredFields = getIgnoredFields(hit);
+            Map<String, DocumentField> fieldValues = fieldValueRetriever.retrieve(sourceLookup, ignoredFields);
             hit.fields(fieldValues);
         }
+    }
+
+    private Set<String> getIgnoredFields(SearchHit hit) {
+        DocumentField field = hit.field(IgnoredFieldMapper.NAME);
+        if (field == null) {
+            return Set.of();
+        }
+
+        Set<String> ignoredFields = new HashSet<>();
+        for (Object value : field.getValues()) {
+            ignoredFields.add((String) value);
+        }
+        return ignoredFields;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -128,6 +128,14 @@ public class SourceLookup implements Map<String, Object> {
         return XContentMapValues.extractRawValues(path, loadSourceIfNeeded());
     }
 
+    /**
+     * For the provided path, return its value in the source. Note that in contrast with
+     * {@link SourceLookup#extractRawValues}, array and object values can be returned.
+     */
+    public Object extractValue(String path) {
+        return XContentMapValues.extractValue(path, loadSourceIfNeeded());
+    }
+
     public Object filter(FetchSourceContext context) {
         return context.getFilter().apply(loadSourceIfNeeded());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -30,9 +30,12 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -278,5 +281,15 @@ public class BooleanFieldMapperTests extends ESSingleNodeTestCase {
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        BooleanFieldMapper mapper = new BooleanFieldMapper.Builder("field").build(context);
+
+        assertTrue(mapper.parseSourceValue(true));
+        assertFalse(mapper.parseSourceValue("false"));
+        assertFalse(mapper.parseSourceValue(""));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -31,6 +31,8 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -50,6 +52,7 @@ import org.hamcrest.Matchers;
 import org.hamcrest.core.CombinableMatcher;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -928,6 +931,20 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
         assertTrue(e.getMessage(),
             e.getMessage().contains("Limit of completion field contexts [" +
                 CompletionFieldMapper.COMPLETION_CONTEXTS_LIMIT + "] has been exceeded"));
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        CompletionFieldMapper mapper = new CompletionFieldMapper.Builder("field").build(context);
+
+        assertEquals(List.of("value"), mapper.parseSourceValue("value"));
+
+        List<String> list = List.of("first", "second");
+        assertEquals(list, mapper.parseSourceValue(list));
+
+        Map<String, Object> object = Map.of("input", List.of("first", "second"), "weight", "2.718");
+        assertEquals(List.of(object), mapper.parseSourceValue(object));
     }
 
     private Matcher<IndexableField> suggestField(String value) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -21,10 +21,13 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -443,5 +446,19 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        DateFieldMapper mapper = new DateFieldMapper.Builder("field").build(context);
+        assertEquals(1589578382000L, (long) mapper.parseSourceValue(1589578382000L));
+        assertEquals(1589578382000L, (long) mapper.parseSourceValue("2020-05-15T21:33:02+00:00"));
+
+        DateFieldMapper mapperWithFormat = new DateFieldMapper.Builder("field")
+            .format("yyyy/MM/dd")
+            .build(context);
+        assertEquals(662428800000L, (long) mapperWithFormat.parseSourceValue("1990/12/29"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -115,6 +115,11 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         }
 
         @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         protected String contentType() {
             return null;
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -203,6 +203,11 @@ public class ExternalMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void doMerge(Mapper mergeWith) {
         // ignore this for now
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -141,6 +141,11 @@ public class FakeStringFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -39,8 +39,8 @@ import java.io.IOException;
 import java.util.Collection;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.elasticsearch.index.mapper.AbstractGeometryFieldMapper.Names.IGNORE_MALFORMED;
 import static org.elasticsearch.index.mapper.AbstractGeometryFieldMapper.Names.IGNORE_Z_VALUE;
 import static org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper.Names.NULL_VALUE;

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -26,6 +26,8 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -132,6 +134,9 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
 
         // used by TermVectorsService
         assertArrayEquals(new String[] { "1234" }, TermVectorsService.getValues(doc.rootDoc().getFields("field")));
+
+        FieldMapper fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        assertEquals("1234", fieldMapper.parseSourceValue("1234"));
     }
 
     public void testIgnoreAbove() throws IOException {
@@ -347,11 +352,11 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
     public void testCustomNormalizer() throws IOException {
         checkLowercaseNormalizer("my_lowercase");
     }
-    
+
     public void testInBuiltNormalizer() throws IOException {
-        checkLowercaseNormalizer("lowercase");        
-    }       
-        
+        checkLowercaseNormalizer("lowercase");
+    }
+
     public void checkLowercaseNormalizer(String normalizerName) throws IOException {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field")
@@ -585,5 +590,15 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        KeywordFieldMapper mapper = new KeywordFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -22,9 +22,12 @@ package org.elasticsearch.index.mapper;
 import com.carrotsearch.randomizedtesting.annotations.Timeout;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -390,6 +393,15 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             );
             assertThat(e.getMessage(), containsString("name cannot be empty string"));
         }
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        NumberFieldMapper mapper = new NumberFieldMapper.Builder("field", NumberType.INTEGER).build(context);
+
+        assertEquals(3, mapper.parseSourceValue(3.14));
+        assertEquals(42, mapper.parseSourceValue("42.9"));
     }
 
     @Timeout(millis = 30000)

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -22,10 +22,13 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -39,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.RangeQueryBuilder.GTE_FIELD;
 import static org.elasticsearch.index.query.RangeQueryBuilder.GT_FIELD;
@@ -461,4 +465,21 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertEquals("Invalid format: [[test_format]]: Unknown pattern letter: t", e.getMessage());
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        RangeFieldMapper longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG).build(context);
+        Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
+        assertEquals(Map.of("gte", 3L, "lt", 42L), longMapper.parseSourceValue(longRange));
+
+        RangeFieldMapper ipMapper = new RangeFieldMapper.Builder("field", RangeType.IP).build(context);
+        Map<String, Object> ipRange = Map.of("gte", "127.0.0.1");
+        assertEquals(Map.of("gte", "127.0.0.1"), ipMapper.parseSourceValue(ipRange));
+        assertEquals("2001:db8::/32", ipMapper.parseSourceValue("2001:db8::/32"));
+
+        RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE).build(context);
+        Map<String, Object> dateRange = Map.of("lt", "2020-05-15T21:33:02+00:00");
+        assertEquals(Map.of("lt", 1589578382000L), dateMapper.parseSourceValue(dateRange));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -490,9 +490,9 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testParseIp() {
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parse(InetAddresses.forString("::1"), randomBoolean()));
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parse("::1", randomBoolean()));
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parse(new BytesRef("::1"), randomBoolean()));
+        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue(InetAddresses.forString("::1"), randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue("::1", randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue(new BytesRef("::1"), randomBoolean(), null));
     }
 
     public void testTermQuery() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -45,7 +45,9 @@ import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -1272,5 +1274,15 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        TextFieldMapper mapper = new TextFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
@@ -65,8 +66,8 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         MapperService mapperService = createMapperService();
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .startObject("float_range")
-                .field("gte", 0.0)
-                .field("lte", 2.718)
+                .field("gte", 0.0f)
+                .field("lte", 2.718f)
             .endObject()
         .endObject();
 
@@ -76,14 +77,59 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         DocumentField rangeField = fields.get("float_range");
         assertNotNull(rangeField);
         assertThat(rangeField.getValues().size(), equalTo(1));
-        assertThat(rangeField.getValue(), equalTo(Map.of("gte", 0.0, "lte", 2.718)));
+        assertThat(rangeField.getValue(), equalTo(Map.of("gte", 0.0f, "lte", 2.718f)));
+    }
+
+    public void testNonExistentField() throws IOException {
+        MapperService mapperService = createMapperService();
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .field("field", "value")
+        .endObject();
+
+        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "non-existent");
+        assertThat(fields.size(), equalTo(0));
+    }
+
+    public void testArrayValueMappers() throws IOException {
+        MapperService mapperService = createMapperService();
+
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .array("completion", "first", "second")
+        .endObject();
+
+        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "completion");
+        assertThat(fields.size(), equalTo(1));
+
+        DocumentField field = fields.get("completion");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(2));
+        assertThat(field.getValues(), hasItems("first", "second"));
+
+        // Test a field with multiple geo-points.
+        source = XContentFactory.jsonBuilder().startObject()
+            .startObject("completion")
+                .array("input", "first", "second")
+                .field("weight", "2.718")
+            .endObject()
+        .endObject();
+
+        fields = retrieveFields(mapperService, source, "completion");
+        assertThat(fields.size(), equalTo(1));
+
+        field = fields.get("completion");
+        assertNotNull(field);
+        assertThat(field.getValues().size(), equalTo(1));
+
+        Map<String, Object> expected = Map.of("input", List.of("first", "second"),
+            "weight", "2.718");
+        assertThat(field.getValues().get(0), equalTo(expected));
     }
 
     public void testFieldNamesWithWildcard() throws IOException {
         MapperService mapperService = createMapperService();;
         XContentBuilder source = XContentFactory.jsonBuilder().startObject()
             .array("field", "first", "second")
-            .field("integer_field", "third")
+            .field("integer_field", 333)
             .startObject("object")
                 .field("field", "fourth")
             .endObject()
@@ -100,14 +146,13 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         DocumentField otherField = fields.get("integer_field");
         assertNotNull(otherField);
         assertThat(otherField.getValues().size(), equalTo(1));
-        assertThat(otherField.getValues(), hasItems("third"));
+        assertThat(otherField.getValues(), hasItems(333));
 
         DocumentField objectField = fields.get("object.field");
         assertNotNull(objectField);
         assertThat(objectField.getValues().size(), equalTo(1));
         assertThat(objectField.getValues(), hasItems("fourth"));
     }
-
 
     public void testFieldAliases() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
@@ -226,15 +271,15 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         sourceLookup.setSource(BytesReference.bytes(source));
 
         FieldValueRetriever fetchFieldsLookup = FieldValueRetriever.create(mapperService, fieldPatterns);
-        return fetchFieldsLookup.retrieve(sourceLookup);
+        return fetchFieldsLookup.retrieve(sourceLookup, Set.of());
     }
-
 
     public MapperService createMapperService() throws IOException {
         XContentBuilder mapping = XContentFactory.jsonBuilder().startObject()
             .startObject("properties")
                 .startObject("field").field("type", "keyword").endObject()
                 .startObject("integer_field").field("type", "integer").endObject()
+                .startObject("geo_point").field("type", "geo_point").endObject()
                 .startObject("float_range").field("type", "float_range").endObject()
                 .startObject("object")
                     .startObject("properties")

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -98,7 +98,12 @@ public class MockFieldMapper extends FieldMapper {
     protected void parseCreateField(ParseContext context) throws IOException {
     }
 
-    public static class Builder extends FieldMapper.Builder<MockFieldMapper.Builder, MockFieldMapper> {
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static class Builder extends FieldMapper.Builder<MockFieldMapper.Builder> {
         protected Builder(String name, MappedFieldType fieldType, MappedFieldType defaultFieldType) {
             super(name, fieldType, defaultFieldType);
             builder = this;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -170,6 +170,11 @@ public class HistogramFieldMapper extends FieldMapper {
         throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     public static class HistogramFieldType extends MappedFieldType {
 
         public HistogramFieldType() {

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.mapper.TypeParsers;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -301,6 +302,18 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                     "] only accepts values that are equal to the value defined in the mappings [" + fieldType().value() +
                     "], but got [" + value + "]");
         }
+    }
+
+    @Override
+    public List<String> lookupValues(SourceLookup lookup) {
+        return fieldType().value == null
+            ? List.of()
+            : List.of(fieldType().value);
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("This should never be called, since lookupValues is implemented directly.");
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -13,17 +13,20 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xpack.constantkeyword.ConstantKeywordMapperPlugin;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class ConstantKeywordFieldMapperTests extends ESSingleNodeTestCase {
 
@@ -106,5 +109,28 @@ public class ConstantKeywordFieldMapperTests extends ESSingleNodeTestCase {
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testLookupValues() throws Exception {
+        IndexService indexService = createIndex("test");
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
+            .startObject("properties").startObject("field").field("type", "constant_keyword")
+            .endObject().endObject().endObject().endObject());
+        DocumentMapper mapper = indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        FieldMapper fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        List<?> values = fieldMapper.lookupValues(new SourceLookup());
+        assertTrue(values.isEmpty());
+
+        String mapping2 = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
+            .startObject("properties").startObject("field").field("type", "constant_keyword")
+            .field("value", "foo").endObject().endObject().endObject().endObject());
+        mapper = indexService.mapperService().merge("_doc", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
+
+        fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        values = fieldMapper.lookupValues(new SourceLookup());
+        assertEquals(1, values.size());
+        assertEquals("foo", values.get(0));
     }
 }

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -619,6 +619,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
@@ -184,3 +184,18 @@ setup:
   - match: {hits.hits.0._index: test1 }
   - match: {hits.hits.1._index: test1 }
   - match: {hits.hits.2._index: test2 }
+
+---
+"Field retrieval":
+
+  - do:
+      search:
+        index: test*
+        body:
+          fields: [ foo ]
+          sort: [ { _index: asc } ]
+
+  - match: { "hits.total.value": 3 }
+  - match: {hits.hits.0.fields.foo.0: bar }
+  - match: {hits.hits.1.fields.foo.0: bar }
+  - match: {hits.hits.2.fields.foo.0: baz }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -224,6 +224,11 @@ public class DenseVectorFieldMapper extends FieldMapper implements ArrayValueMap
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
         builder.field("dims", fieldType().dims());

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -139,10 +139,14 @@ public class SparseVectorFieldMapper extends FieldMapper {
         throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
     }
 
-
     @Override
     protected void parseCreateField(ParseContext context) {
         throw new IllegalStateException("parse is implemented directly");
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -551,6 +551,11 @@ public class WildcardFieldMapper extends FieldMapper {
         parseDoc.addAll(fields);
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     // For internal use by Lucene only - used to define ngram index
     final MappedFieldType ngramFieldType;
 


### PR DESCRIPTION
This draft PR shows an approach for parsing out source values. It adds new method to `FieldMapper#lookupValues(SourceLookup)` to let field mappers decide how to extract and parse the source values. This lets us return values like numbers and dates in a consistent format, and also handle special data types like `constant_keyword`. The `lookupValues` method calls into `parseSourceValue`, which mappers can override to specify how values should be parsed.

This PR is just to get feedback on the design and doesn’t handle all field types. I’ll submit a complete PR after, that addresses questions like 'should keywords be normalized?' and 'should geopoints be returned in a standard format?'

One aspect I didn’t like about this approach is that we’re adding **yet another** method to `FieldMapper` that specifies how stored values should be returned. For context, there’s already `valueForDisplay` for stored fields, and `docValueFormat` for doc values. 

**Sharing logic with document parsing?**

I was excited about the idea of sharing logic between `FieldMapper#parseCreateField` and this new method `parseSourceValue`. This makes sense conceptually -- to return the values from source, we’re essentially re-parsing the document as if we’re ingesting it, and returning the values instead of creating Lucene fields. I could imagine `parseCreateField` being replaced by two methods, something like the following:

```
public void parse(ParseContext context) throws IOException {
    Object sourceValue = parseSourceValue(context.parser());
    createFields(context, sourceValue);
}
```

So the `parseSourceValue` method would be used both for indexing, and also when loading values from source. This has the nice benefit of removing duplication between field loading and document parsing. During indexing we make some subtle choices as to how to parse values -- for example boolean types interpret the empty string "" as 'false'. Unifying this logic would make differences in parsing less likely and seems more maintainable.

I tried out this idea, and it didn’t turn out as nicely as I was hoping:
* It doesn’t actually cut down on duplication much, since we’ve already pulled out a lot of shared parsing logic into re-usable components (see `NumberFieldType.NumberType#parse` for example). There is also a lot of extra logic in `parseCreateField` that makes reuse hard, for example handling [external values](https://github.com/elastic/elasticsearch/issues/56063).
* It’s often more comfortable to work with Java objects than `XContentParser`. The method `RangeFieldMapper#parseSourceValue` class gives a good example of this, it would be harder to work with a parser.
* It’s a bit tricky to get a hold of an `XContentParser` from `SourceLookup` (we could change this though, it’s just not access pattern it currently expects).

Perhaps we could keep this refactor in mind as a future improvement. It could be more do-able with simplifications to parsing and more work on the `SourceLookup` interface.