### PR TITLE
[DOCS] Add document update API link to concurrency control docs

### DIFF
--- a/docs/reference/docs/concurrency-control.asciidoc
+++ b/docs/reference/docs/concurrency-control.asciidoc
@@ -91,7 +91,7 @@ The sequence number and the primary term uniquely identify a change. By noting d
 the sequence number and primary term returned, you can make sure to only change the
 document if no other change was made to it since you retrieved it. This
 is done by setting the `if_seq_no` and `if_primary_term` parameters of either the
-<<docs-index_,Index API>>, <<docs-update_,Update API>>, or the <<docs-delete,Delete API>>. 
+<<docs-index_,Index API>>, <<docs-update,Update API>>, or the <<docs-delete,Delete API>>. 
 
 For example, the following indexing call will make sure to add a tag to the
 document without losing any potential change to the description or an addition

--- a/docs/reference/docs/concurrency-control.asciidoc
+++ b/docs/reference/docs/concurrency-control.asciidoc
@@ -91,7 +91,7 @@ The sequence number and the primary term uniquely identify a change. By noting d
 the sequence number and primary term returned, you can make sure to only change the
 document if no other change was made to it since you retrieved it. This
 is done by setting the `if_seq_no` and `if_primary_term` parameters of either the
-<<docs-index_,Index API>> or the <<docs-delete,Delete API>>. 
+<<docs-index_,Index API>>, <<docs-update_,Update API>> or the <<docs-delete,Delete API>>. 
 
 For example, the following indexing call will make sure to add a tag to the
 document without losing any potential change to the description or an addition

--- a/docs/reference/docs/concurrency-control.asciidoc
+++ b/docs/reference/docs/concurrency-control.asciidoc
@@ -91,7 +91,7 @@ The sequence number and the primary term uniquely identify a change. By noting d
 the sequence number and primary term returned, you can make sure to only change the
 document if no other change was made to it since you retrieved it. This
 is done by setting the `if_seq_no` and `if_primary_term` parameters of either the
-<<docs-index_,Index API>>, <<docs-update_,Update API>> or the <<docs-delete,Delete API>>. 
+<<docs-index_,Index API>>, <<docs-update_,Update API>>, or the <<docs-delete,Delete API>>. 
 
 For example, the following indexing call will make sure to add a tag to the
 document without losing any potential change to the description or an addition
@@ -108,4 +108,3 @@ PUT products/_doc/1567?if_seq_no=362&if_primary_term=2
 --------------------------------------------------
 // TEST[continued]
 // TEST[catch: conflict]
-


### PR DESCRIPTION
Update API also supports `_seq_no`.