### PR TITLE
scroll_id  never change in code

### DIFF
--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -75,10 +75,6 @@ returned with each batch of results.  Each call to the `scroll` API returns the
 next batch of results until there are no more results left to return, ie the 
 `hits` array is empty.
 
-IMPORTANT: The initial search request and each subsequent scroll request each 
-return a `_scroll_id`. While the `_scroll_id` may change between requests, it doesn’t 
-always change — in any case, only the most recently received `_scroll_id` should be used.
-
 NOTE: If the request specifies aggregations, only the initial search response
 will contain the aggregations results.
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/blob/44b5c2550178ba8a0456008181e96f78e7c0a823/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java#L238

in this link we can find that scroll_id never change, but the reference tell us should use the most recent scroll_id.

I think the docs maybe wrong.