### PR TITLE
Speed up rounding in auto_date_histogram (backport of #56384)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorFactory.java
@@ -37,6 +37,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
 
 public final class AutoDateHistogramAggregatorFactory extends ValuesSourceAggregatorFactory {
 
@@ -77,9 +78,10 @@ public final class AutoDateHistogramAggregatorFactory extends ValuesSourceAggreg
             throw new AggregationExecutionException("Registry miss-match - expected AutoDateHistogramAggregationSupplier, found [" +
                 aggregatorSupplier.getClass().toString() + "]");
         }
+        Function<Rounding, Rounding.Prepared> roundingPreparer =
+                valuesSource.roundingPreparer(searchContext.getQueryShardContext().getIndexReader());
         return ((AutoDateHistogramAggregatorSupplier) aggregatorSupplier).build(name, factories, numBuckets, roundingInfos,
-            // TODO once auto date histo is plugged into the ValuesSource refactoring use the date values source
-            Rounding::prepareForUnknown, valuesSource, config.format(), searchContext, parent, metadata);
+                roundingPreparer, valuesSource, config.format(), searchContext, parent, metadata);
     }
 
     @Override


### PR DESCRIPTION
This wires `auto_date_histogram` into the rounding optimization that I
built in #55559. This is should significantly speed up any
`auto_date_histogram`s with `time_zone`s on them.
