### PR TITLE
[7.8] [DOCS] Add reference docs for `search.max_buckets` setting (#56449)

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -13,9 +13,10 @@ aggregated for the buckets created by their "parent" bucket aggregation.
 There are different bucket aggregators, each with a different "bucketing" strategy. Some define a single bucket, some
 define fixed number of multiple buckets, and others dynamically create the buckets during the aggregation process.
 
-NOTE: The maximum number of buckets allowed in a single response is limited by a dynamic cluster
-setting named `search.max_buckets`. It defaults to 10,000, requests that try to return more than
-the limit will fail with an exception.
+NOTE: The maximum number of buckets allowed in a single response is limited by a
+dynamic cluster setting named
+<<search-settings-max-buckets,`search.max_buckets`>>. It defaults to 10,000,
+requests that try to return more than the limit will fail with an exception.
 
 include::bucket/adjacency-matrix-aggregation.asciidoc[]
 

--- a/docs/reference/modules/indices/search-settings.asciidoc
+++ b/docs/reference/modules/indices/search-settings.asciidoc
@@ -1,12 +1,14 @@
 [[search-settings]]
 === Search Settings
 
-The following _expert_ setting can be set to manage global search limits.
+The following expert settings can be set to manage global search and aggregation
+limits.
 
 [[indices-query-bool-max-clause-count]]
 `indices.query.bool.max_clause_count`::
-    Defaults to `1024`.
-
+(<<cluster-update-settings,Dynamic>>, integer)
+Maximum number of clauses a Lucene BooleanQuery can contain. Defaults to `1024`.
++
 This setting limits the number of clauses a Lucene BooleanQuery can have. The
 default of 1024 is quite high and should normally be sufficient. This limit does
 not only affect Elasticsearchs `bool` query, but many other queries are rewritten to Lucene's
@@ -15,3 +17,11 @@ and taking up too much CPU and memory. In case you're considering increasing thi
 make sure you've exhausted all other options to avoid having to do this. Higher values can lead 
 to performance degradations and memory issues, especially in clusters with a high load or 
 few resources.
+
+[[search-settings-max-buckets]]
+`search.max_buckets`::
+(<<cluster-update-settings,Dynamic>>, integer)
+Maximum number of <<search-aggregations-bucket,aggregation buckets>> allowed in
+a single response. Defaults to `10000`.
++
+Requests that attempt to return more than this limit will return an error.


### PR DESCRIPTION
7.8 backport of #56449