### PR TITLE
Check data stream feature flag in test teardown

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -394,7 +394,7 @@ public class ActionModule extends AbstractModule {
 
     private static final Logger logger = LogManager.getLogger(ActionModule.class);
 
-    private static final boolean DATASTREAMS_FEATURE_ENABLED;
+    public static final boolean DATASTREAMS_FEATURE_ENABLED;
 
     static {
         final String property = System.getProperty("es.datastreams_feature_enabled");

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.ObjectArrayList;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
@@ -134,7 +135,8 @@ public abstract class TestCluster implements Closeable {
      * Deletes all data streams from the test cluster.
      */
     public void wipeAllDataStreams() {
-        if (size() > 0) {
+        // Feature flag may not be enabled in all gradle modules that use ESIntegTestCase
+        if (size() > 0 && ActionModule.DATASTREAMS_FEATURE_ENABLED) {
             AcknowledgedResponse response =
                 client().admin().indices().deleteDataStream(new DeleteDataStreamAction.Request("*")).actionGet();
             assertAcked(response);


### PR DESCRIPTION
Check whether data stream feature flag is enabled, 
when deleting all data streams in tests, this will fix the release build.

Not all Gradle modules have the data stream feature flag enabled,
but do that have tests that extend from `ESIntegTestCase`.
