### PR TITLE
docs: Fix links to APM Server

### DIFF
--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -179,7 +179,7 @@ for these users.
 The `apm_system` user is used internally within APM when monitoring is enabled.
 
 To enable this feature in APM, you need to update the
-{apm-server-ref-70}/configuring-howto-apm-server.html[APM configuration file] to
+{apm-server-ref-v}/configuring-howto-apm-server.html[APM configuration file] to
 reference the correct username and password. For example:
 
 [source,yaml]
@@ -188,7 +188,7 @@ xpack.monitoring.elasticsearch.username: apm_system
 xpack.monitoring.elasticsearch.password: apmserverpassword
 ----------------------------------------------------------
 
-See {apm-server-ref-70}/monitoring.html[Monitoring APM Server].
+See {apm-server-ref-v}/monitoring.html[Monitoring APM Server].
 
 If you have upgraded from an older version of {es}, then you may not have set a
 password for the `apm_system` user. If this is the case,


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/7.6/built-in-users.html#add-built-in-user-apm

This PR fixes links in `7.8` that point to the APM Server reference. These links currently point to the `7.0` version of the documentation. This fix should be backported to `7.7` and `7.6`.

The root of this problem is that APM Server does not build a `7.x` documentation branch. As a workaround, we often tie 7.x links to other versions of the documentation. These links _should_ be updated at a later date, but sometimes they slip through the cracks 🤷.
To fix this in the Kibana reference, we conditionally change links to point to APM Server's `master` docs when `branch == 7.x`:
```
ifeval::[{branch} == 7.x]
:apm-server-ref:       {apm-server-ref-m}
:apm-overview-ref-v:   {apm-overview-ref-m}
endif::[]
```
Is this a solution you'd be willing to consider in the ES reference? If so, I can open a PR on `master`.
