### PR TITLE
docs: [apm] link to master in n.x branches

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -73,3 +73,11 @@ Shared attribute values are pulled from elastic/docs
 ///////
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+///////
+APM does not build n.x documentation. Links from .x branches should point to master instead
+///////
+ifeval::[{source_branch} == 7.x]
+:apm-server-ref:       {apm-server-ref-m}
+:apm-overview-ref-v:   {apm-overview-ref-m}
+endif::[]

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -77,7 +77,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 ///////
 APM does not build n.x documentation. Links from .x branches should point to master instead
 ///////
-ifeval::[{source_branch} == 7.x]
+ifeval::["{source_branch}"=="7.x"]
 :apm-server-ref:       {apm-server-ref-m}
+:apm-server-ref-v:     {apm-server-ref-m}
 :apm-overview-ref-v:   {apm-overview-ref-m}
 endif::[]


### PR DESCRIPTION
Conditionally changes APM Server documentation links to point to `master` from ES  `7.x` docs. See https://github.com/elastic/elasticsearch/pull/56537 for additional context.

I'll open a separate PR that cherry-picks this to `7.x`. This does not need to be backported.