### PR TITLE
docs: [7.x][apm] link to master in n.x branches

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -77,7 +77,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 ///////
 APM does not build n.x documentation. Links from .x branches should point to master instead
 ///////
-ifeval::[{source_branch} == 7.x]
+ifeval::["{source_branch}"=="7.x"]
 :apm-server-ref:       {apm-server-ref-m}
 :apm-overview-ref-v:   {apm-overview-ref-m}
 endif::[]

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -73,3 +73,11 @@ Shared attribute values are pulled from elastic/docs
 ///////
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+///////
+APM does not build n.x documentation. Links from .x branches should point to master instead
+///////
+ifeval::[{source_branch} == 7.x]
+:apm-server-ref:       {apm-server-ref-m}
+:apm-overview-ref-v:   {apm-overview-ref-m}
+endif::[]

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -79,5 +79,6 @@ APM does not build n.x documentation. Links from .x branches should point to mas
 ///////
 ifeval::["{source_branch}"=="7.x"]
 :apm-server-ref:       {apm-server-ref-m}
+:apm-server-ref-v:     {apm-server-ref-m}
 :apm-overview-ref-v:   {apm-overview-ref-m}
 endif::[]

--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -179,7 +179,7 @@ for these users.
 The `apm_system` user is used internally within APM when monitoring is enabled.
 
 To enable this feature in APM, you need to update the
-{apm-server-ref-70}/configuring-howto-apm-server.html[APM configuration file] to
+{apm-server-ref-v}/configuring-howto-apm-server.html[APM configuration file] to
 reference the correct username and password. For example:
 
 [source,yaml]
@@ -188,7 +188,7 @@ xpack.monitoring.elasticsearch.username: apm_system
 xpack.monitoring.elasticsearch.password: apmserverpassword
 ----------------------------------------------------------
 
-See {apm-server-ref-70}/monitoring.html[Monitoring APM Server].
+See {apm-server-ref-v}/monitoring.html[Monitoring APM Server].
 
 If you have upgraded from an older version of {es}, then you may not have set a
 password for the `apm_system` user. If this is the case,


### PR DESCRIPTION
Cherry-picks the following commits to `7.x`:

* docs: [apm] link to master in n.x branches (https://github.com/elastic/elasticsearch/pull/56538)
* docs: fix apm server (https://github.com/elastic/elasticsearch/pull/56537)