### PR TITLE
[7.x] Disable BWC tests for prefer_v2_template removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,8 +182,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/56541" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
This disables BWC tests for 7.x so the `prefer_v2_template` flag can be removed in 7.8, 7.x, and master.
