### PR TITLE
[7.7] docs: fix APM Server links

### DIFF
--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -178,8 +178,8 @@ for these users.
 
 The `apm_system` user is used internally within APM when monitoring is enabled.
 
-To enable this feature in APM, you need to update the 
-{apm-server-ref-70}/configuring-howto-apm-server.html[APM configuration file] to 
+To enable this feature in APM, you need to update the
+{apm-server-ref-v}/configuring-howto-apm-server.html[APM configuration file] to
 reference the correct username and password. For example:
 
 [source,yaml]
@@ -188,7 +188,7 @@ xpack.monitoring.elasticsearch.username: apm_system
 xpack.monitoring.elasticsearch.password: apmserverpassword
 ----------------------------------------------------------
 
-See {apm-server-ref-70}/monitoring.html[Monitoring APM Server]. 
+See {apm-server-ref-v}/monitoring.html[Monitoring APM Server].
 
 If you have upgraded from an older version of {es}, then you may not have set a
 password for the `apm_system` user. If this is the case, 


### PR DESCRIPTION
This PR backports the following commits to `7.7`:

* docs: fix apm server links (#56537)