### PR TITLE
Enable searchable snapshots feature flag for xpack rest tests.

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -109,6 +109,9 @@ testClusters.integTest {
   extraConfigFile nodeKey.name, nodeKey
   extraConfigFile nodeCert.name, nodeCert
   extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
+  }
 }
 
 validateRestSpec {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -1,10 +1,8 @@
 ---
 "Verify data stream resolvability for xpack apis":
   - skip:
-      version: "all"
-      reason: bug url https://github.com/elastic/elasticsearch/issues/56531
-      #version: " - 7.99.99"
-      #reason: skip untill backported
+      version: " - 7.99.99"
+      reason: skip untill backported
 
   - do:
       indices.create_data_stream:


### PR DESCRIPTION
A data stream test, which tests data stream resolvabilty in xpack apis failed in release builds. 
A invocation of a searchable snapshot api failed, because the corresponding feature flag
wasn't enabled for xpack rest tests.

Closes #56531