### PR TITLE
 Backport: move data stream test

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/DataStreamIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/DataStreamIT.java
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.elasticsearch.indices;
 
+import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
@@ -28,12 +28,17 @@ import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.rollover.RolloverResponse;
+import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequestBuilder;
+import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.MultiSearchRequestBuilder;
+import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -46,7 +51,22 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT._flush;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.clearCache;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.getAliases;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.getFieldMapping;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.getMapping;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.getSettings;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.health;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.indicesStats;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.msearch;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.refreshBuilder;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.search;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.segments;
+import static org.elasticsearch.indices.IndicesOptionsIntegrationIT.validateQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -176,6 +196,96 @@ public class DataStreamIT extends ESIntegTestCase {
                     .opType(DocWriteRequest.OpType.CREATE));
             BulkResponse bulkItemResponses  = client().bulk(bulkRequest).actionGet();
             assertThat(bulkItemResponses.getItems()[0].getIndex(), equalTo(DataStream.getBackingIndexName(dataStreamName, 1)));
+        }
+    }
+
+    public void testDataStreamsResolvability() {
+        String dataStreamName = "logs-foobar";
+        CreateDataStreamAction.Request request = new CreateDataStreamAction.Request(dataStreamName);
+        request.setTimestampFieldName("ts");
+        client().admin().indices().createDataStream(request).actionGet();
+
+        verifyResolvability(dataStreamName, client().prepareIndex(dataStreamName, "_doc")
+                .setSource("{}", XContentType.JSON)
+                .setOpType(DocWriteRequest.OpType.CREATE),
+            false);
+        verifyResolvability(dataStreamName, refreshBuilder(dataStreamName), false);
+        verifyResolvability(dataStreamName, search(dataStreamName), false, 1);
+        verifyResolvability(dataStreamName, msearch(null, dataStreamName), false);
+        verifyResolvability(dataStreamName, clearCache(dataStreamName), false);
+        verifyResolvability(dataStreamName, _flush(dataStreamName),false);
+        verifyResolvability(dataStreamName, segments(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesStats(dataStreamName), false);
+        verifyResolvability(dataStreamName, IndicesOptionsIntegrationIT.forceMerge(dataStreamName), false);
+        verifyResolvability(dataStreamName, validateQuery(dataStreamName), false);
+        verifyResolvability(dataStreamName, client().admin().indices().prepareUpgrade(dataStreamName), false);
+        verifyResolvability(dataStreamName, client().admin().indices().prepareRecoveries(dataStreamName), false);
+        verifyResolvability(dataStreamName, client().admin().indices().prepareUpgradeStatus(dataStreamName), false);
+        verifyResolvability(dataStreamName, getAliases(dataStreamName), true);
+        verifyResolvability(dataStreamName, getFieldMapping(dataStreamName), true);
+        verifyResolvability(dataStreamName, getMapping(dataStreamName), true);
+        verifyResolvability(dataStreamName, getSettings(dataStreamName), true);
+        verifyResolvability(dataStreamName, health(dataStreamName), false);
+
+        request = new CreateDataStreamAction.Request("logs-barbaz");
+        request.setTimestampFieldName("ts");
+        client().admin().indices().createDataStream(request).actionGet();
+        verifyResolvability("logs-barbaz", client().prepareIndex("logs-barbaz", "_doc")
+                .setSource("{}", XContentType.JSON)
+                .setOpType(DocWriteRequest.OpType.CREATE),
+            false);
+
+        String wildcardExpression = "logs*";
+        verifyResolvability(wildcardExpression, refreshBuilder(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, search(wildcardExpression), false, 2);
+        verifyResolvability(wildcardExpression, msearch(null, wildcardExpression), false);
+        verifyResolvability(wildcardExpression, clearCache(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, _flush(wildcardExpression),false);
+        verifyResolvability(wildcardExpression, segments(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesStats(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, IndicesOptionsIntegrationIT.forceMerge(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, validateQuery(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, client().admin().indices().prepareUpgrade(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, client().admin().indices().prepareRecoveries(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, client().admin().indices().prepareUpgradeStatus(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, getAliases(wildcardExpression), true);
+        verifyResolvability(wildcardExpression, getFieldMapping(wildcardExpression), true);
+        verifyResolvability(wildcardExpression, getMapping(wildcardExpression), true);
+        verifyResolvability(wildcardExpression, getSettings(wildcardExpression), true);
+        verifyResolvability(wildcardExpression, health(wildcardExpression), false);
+    }
+
+    private static void verifyResolvability(String dataStream, ActionRequestBuilder requestBuilder, boolean fail) {
+        verifyResolvability(dataStream, requestBuilder, fail, 0);
+    }
+
+    private static void verifyResolvability(String dataStream, ActionRequestBuilder requestBuilder, boolean fail, long expectedCount) {
+        if (fail) {
+            String expectedErrorMessage = "The provided expression [" + dataStream +
+                "] matches a data stream, specify the corresponding concrete indices instead.";
+            if (requestBuilder instanceof MultiSearchRequestBuilder) {
+                MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
+                assertThat(multiSearchResponse.getResponses().length, equalTo(1));
+                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(true));
+                assertThat(multiSearchResponse.getResponses()[0].getFailure(), instanceOf(IllegalArgumentException.class));
+                assertThat(multiSearchResponse.getResponses()[0].getFailure().getMessage(), equalTo(expectedErrorMessage));
+            } else if (requestBuilder instanceof ValidateQueryRequestBuilder) {
+                ValidateQueryResponse response = (ValidateQueryResponse) requestBuilder.get();
+                assertThat(response.getQueryExplanation().get(0).getError(), equalTo(expectedErrorMessage));
+            } else {
+                Exception e = expectThrows(IllegalArgumentException.class, requestBuilder::get);
+                assertThat(e.getMessage(), equalTo(expectedErrorMessage));
+            }
+        } else {
+            if (requestBuilder instanceof SearchRequestBuilder) {
+                SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) requestBuilder;
+                assertHitCount(searchRequestBuilder.get(), expectedCount);
+            } else if (requestBuilder instanceof MultiSearchRequestBuilder) {
+                MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
+                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(false));
+            } else {
+                requestBuilder.get();
+            }
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -19,14 +19,12 @@
 package org.elasticsearch.indices;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequestBuilder;
 import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistRequestBuilder;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequestBuilder;
 import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheRequestBuilder;
-import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.elasticsearch.action.admin.indices.exists.types.TypesExistsRequestBuilder;
 import org.elasticsearch.action.admin.indices.flush.FlushRequestBuilder;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequestBuilder;
@@ -38,7 +36,6 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequestBui
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequestBuilder;
-import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.action.search.MultiSearchRequestBuilder;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -49,7 +46,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -65,7 +61,6 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -648,101 +643,11 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(client().admin().indices().prepareUpdateSettings("baz*").setSettings(Settings.builder().put("a", "b")), true);
     }
 
-    public void testDataStreamsResolvability() {
-        String dataStreamName = "logs-foobar";
-        CreateDataStreamAction.Request request = new CreateDataStreamAction.Request(dataStreamName);
-        request.setTimestampFieldName("ts");
-        client().admin().indices().createDataStream(request).actionGet();
-
-        verifyResolvability(dataStreamName, client().prepareIndex(dataStreamName, "_doc")
-                .setSource("{}", XContentType.JSON)
-                .setOpType(DocWriteRequest.OpType.CREATE),
-            false);
-        verifyResolvability(dataStreamName, refreshBuilder(dataStreamName), false);
-        verifyResolvability(dataStreamName, search(dataStreamName), false, 1);
-        verifyResolvability(dataStreamName, msearch(null, dataStreamName), false);
-        verifyResolvability(dataStreamName, clearCache(dataStreamName), false);
-        verifyResolvability(dataStreamName, _flush(dataStreamName),false);
-        verifyResolvability(dataStreamName, segments(dataStreamName), false);
-        verifyResolvability(dataStreamName, indicesStats(dataStreamName), false);
-        verifyResolvability(dataStreamName, forceMerge(dataStreamName), false);
-        verifyResolvability(dataStreamName, validateQuery(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareUpgrade(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareRecoveries(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareUpgradeStatus(dataStreamName), false);
-        verifyResolvability(dataStreamName, getAliases(dataStreamName), true);
-        verifyResolvability(dataStreamName, getFieldMapping(dataStreamName), true);
-        verifyResolvability(dataStreamName, getMapping(dataStreamName), true);
-        verifyResolvability(dataStreamName, getSettings(dataStreamName), true);
-        verifyResolvability(dataStreamName, health(dataStreamName), false);
-
-        request = new CreateDataStreamAction.Request("logs-barbaz");
-        request.setTimestampFieldName("ts");
-        client().admin().indices().createDataStream(request).actionGet();
-        verifyResolvability("logs-barbaz", client().prepareIndex("logs-barbaz", "_doc")
-                .setSource("{}", XContentType.JSON)
-                .setOpType(DocWriteRequest.OpType.CREATE),
-            false);
-
-        String wildcardExpression = "logs*";
-        verifyResolvability(wildcardExpression, refreshBuilder(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, search(wildcardExpression), false, 2);
-        verifyResolvability(wildcardExpression, msearch(null, wildcardExpression), false);
-        verifyResolvability(wildcardExpression, clearCache(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, _flush(wildcardExpression),false);
-        verifyResolvability(wildcardExpression, segments(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, indicesStats(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, forceMerge(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, validateQuery(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareUpgrade(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareRecoveries(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareUpgradeStatus(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, getAliases(wildcardExpression), true);
-        verifyResolvability(wildcardExpression, getFieldMapping(wildcardExpression), true);
-        verifyResolvability(wildcardExpression, getMapping(wildcardExpression), true);
-        verifyResolvability(wildcardExpression, getSettings(wildcardExpression), true);
-        verifyResolvability(wildcardExpression, health(wildcardExpression), false);
-    }
-
-    private static void verifyResolvability(String dataStream, ActionRequestBuilder requestBuilder, boolean fail) {
-        verifyResolvability(dataStream, requestBuilder, fail, 0);
-    }
-
-    private static void verifyResolvability(String dataStream, ActionRequestBuilder requestBuilder, boolean fail, long expectedCount) {
-        if (fail) {
-            String expectedErrorMessage = "The provided expression [" + dataStream +
-                "] matches a data stream, specify the corresponding concrete indices instead.";
-            if (requestBuilder instanceof MultiSearchRequestBuilder) {
-                MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
-                assertThat(multiSearchResponse.getResponses().length, equalTo(1));
-                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(true));
-                assertThat(multiSearchResponse.getResponses()[0].getFailure(), instanceOf(IllegalArgumentException.class));
-                assertThat(multiSearchResponse.getResponses()[0].getFailure().getMessage(), equalTo(expectedErrorMessage));
-            } else if (requestBuilder instanceof ValidateQueryRequestBuilder) {
-                ValidateQueryResponse response = (ValidateQueryResponse) requestBuilder.get();
-                assertThat(response.getQueryExplanation().get(0).getError(), equalTo(expectedErrorMessage));
-            } else {
-                Exception e = expectThrows(IllegalArgumentException.class, requestBuilder::get);
-                assertThat(e.getMessage(), equalTo(expectedErrorMessage));
-            }
-        } else {
-            if (requestBuilder instanceof SearchRequestBuilder) {
-                SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) requestBuilder;
-                assertHitCount(searchRequestBuilder.get(), expectedCount);
-            } else if (requestBuilder instanceof MultiSearchRequestBuilder) {
-                MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
-                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(false));
-            } else {
-                requestBuilder.get();
-            }
-        }
-    }
-
-    private static SearchRequestBuilder search(String... indices) {
+    static SearchRequestBuilder search(String... indices) {
         return client().prepareSearch(indices).setQuery(matchAllQuery());
     }
 
-    private static MultiSearchRequestBuilder msearch(IndicesOptions options, String... indices) {
+    static MultiSearchRequestBuilder msearch(IndicesOptions options, String... indices) {
         MultiSearchRequestBuilder multiSearchRequestBuilder = client().prepareMultiSearch();
         if (options != null) {
             multiSearchRequestBuilder.setIndicesOptions(options);
@@ -750,31 +655,31 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         return multiSearchRequestBuilder.add(client().prepareSearch(indices).setQuery(matchAllQuery()));
     }
 
-    private static ClearIndicesCacheRequestBuilder clearCache(String... indices) {
+    static ClearIndicesCacheRequestBuilder clearCache(String... indices) {
         return client().admin().indices().prepareClearCache(indices);
     }
 
-    private static FlushRequestBuilder _flush(String... indices) {
+    static FlushRequestBuilder _flush(String... indices) {
         return client().admin().indices().prepareFlush(indices);
     }
 
-    private static IndicesSegmentsRequestBuilder segments(String... indices) {
+    static IndicesSegmentsRequestBuilder segments(String... indices) {
         return client().admin().indices().prepareSegments(indices);
     }
 
-    private static IndicesStatsRequestBuilder indicesStats(String... indices) {
+    static IndicesStatsRequestBuilder indicesStats(String... indices) {
         return client().admin().indices().prepareStats(indices);
     }
 
-    private static ForceMergeRequestBuilder forceMerge(String... indices) {
+    static ForceMergeRequestBuilder forceMerge(String... indices) {
         return client().admin().indices().prepareForceMerge(indices);
     }
 
-    private static RefreshRequestBuilder refreshBuilder(String... indices) {
+    static RefreshRequestBuilder refreshBuilder(String... indices) {
         return client().admin().indices().prepareRefresh(indices);
     }
 
-    private static ValidateQueryRequestBuilder validateQuery(String... indices) {
+    static ValidateQueryRequestBuilder validateQuery(String... indices) {
         return client().admin().indices().prepareValidateQuery(indices);
     }
 
@@ -786,19 +691,19 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         return client().admin().indices().prepareTypesExists(indices).setTypes("dummy");
     }
 
-    private static GetAliasesRequestBuilder getAliases(String... indices) {
+    static GetAliasesRequestBuilder getAliases(String... indices) {
         return client().admin().indices().prepareGetAliases("dummy").addIndices(indices);
     }
 
-    private static GetFieldMappingsRequestBuilder getFieldMapping(String... indices) {
+    static GetFieldMappingsRequestBuilder getFieldMapping(String... indices) {
         return client().admin().indices().prepareGetFieldMappings(indices);
     }
 
-    private static GetMappingsRequestBuilder getMapping(String... indices) {
+    static GetMappingsRequestBuilder getMapping(String... indices) {
         return client().admin().indices().prepareGetMappings(indices);
     }
 
-    private static GetSettingsRequestBuilder getSettings(String... indices) {
+    static GetSettingsRequestBuilder getSettings(String... indices) {
         return client().admin().indices().prepareGetSettings(indices);
     }
 
@@ -813,7 +718,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
                 .setIndices(indices);
     }
 
-    private static ClusterHealthRequestBuilder health(String... indices) {
+    static ClusterHealthRequestBuilder health(String... indices) {
         return client().admin().cluster().prepareHealth(indices);
     }
 


### PR DESCRIPTION
Backport of #56505

Move data stream resolvability test from IndicesOptionsIntegrationIT to DataStreamIT class.
Whether a transport action supports data streams is no longer controlled via indices options.