### PR TITLE
Recommendation of Amazon Linux 1 is outdated (end-of-life)

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -313,7 +313,7 @@ achieve the same benefits using {es} directly.
 
 ===== Choice of AMI
 
-Prefer the https://aws.amazon.com/amazon-linux-ami/[Amazon Linux AMIs] as these
+Prefer the https://aws.amazon.com/amazon-linux-2/[Amazon Linux 2 AMIs] as these
 allow you to benefit from the lightweight nature, support, and EC2-specific
 performance enhancements that these images offer.
 


### PR DESCRIPTION
Amazon Linux is reaching end of life. This should be adjusted to current Amazon Linux 2.
Side note:  Whole recommendation is debatable as all major distributions have  EC2-specific enhancements.
