### PR TITLE
Backport: enable searchable snapshots feature flag for xpack rest tests.

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -154,6 +154,9 @@ testClusters.integTest {
   extraConfigFile nodeKey.name, nodeKey
   extraConfigFile nodeCert.name, nodeCert
   extraConfigFile 'roles.yml', file('src/test/resources/roles.yml')
+  if (BuildParams.isSnapshotBuild() == false) {
+    systemProperty 'es.searchable_snapshots_feature_enabled', 'true'
+  }
 }
 
 validateRestSpec {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -1,7 +1,7 @@
 ---
 "Verify data stream resolvability for xpack apis":
   - skip:
-      version: " - 7.99.99"
+      version: " - 7.8.99"
       reason: skip untill backported
 
   - do:


### PR DESCRIPTION
Backport of: #56569 

A data stream test, which tests data stream resolvability in xpack apis failed in release builds.
A invocation of a searchable snapshot api failed, because the corresponding feature flag
wasn't enabled for xpack rest tests.