### PR TITLE
[DOCS] Add `dev` admonition to EQL and autoscaling features

### DIFF
--- a/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
+++ b/docs/reference/autoscaling/apis/autoscaling-apis.asciidoc
@@ -3,6 +3,8 @@
 [[autoscaling-apis]]
 == Autoscaling APIs
 
+dev::[]
+
 You can use the following APIs to perform autoscaling operations.
 
 [float]

--- a/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/delete-autoscaling-policy.asciidoc
@@ -6,6 +6,8 @@
 <titleabbrev>Delete autoscaling policy</titleabbrev>
 ++++
 
+dev::[]
+
 Delete autoscaling policy.
 
 [[autoscaling-delete-autoscaling-policy-request]]

--- a/docs/reference/autoscaling/apis/get-autoscaling-decision.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-decision.asciidoc
@@ -6,6 +6,8 @@
 <titleabbrev>Get autoscaling decision</titleabbrev>
 ++++
 
+dev::[]
+
 Get autoscaling decision.
 
 [[autoscaling-get-autoscaling-decision-request]]

--- a/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-policy.asciidoc
@@ -6,6 +6,8 @@
 <titleabbrev>Get autoscaling policy</titleabbrev>
 ++++
 
+dev::[]
+
 Get autoscaling policy.
 
 [[autoscaling-get-autoscaling-policy-request]]

--- a/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
+++ b/docs/reference/autoscaling/apis/put-autoscaling-policy.asciidoc
@@ -6,6 +6,8 @@
 <titleabbrev>Put autoscaling policy</titleabbrev>
 ++++
 
+dev::[]
+
 Put autoscaling policy.
 
 [[autoscaling-put-autoscaling-policy-request]]

--- a/docs/reference/autoscaling/index.asciidoc
+++ b/docs/reference/autoscaling/index.asciidoc
@@ -4,7 +4,7 @@
 [chapter]
 = Autoscaling
 
-experimental[]
+dev::[]
 
 The autoscaling feature enables an operator to configure tiers of nodes that
 self-monitor whether or not they need to scale based on an operator-defined

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>EQL search</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Function reference</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 {es} supports the following EQL functions:
 

--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>EQL</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 {eql-ref}/index.html[Event Query Language (EQL)] is a query language used for
 logs and other event-based data.

--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Limitations</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 [discrete]
 [[eql-nested-fields]]

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Requirements</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 EQL is schema-less and works well with most common log formats.
 

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -3,7 +3,7 @@
 [[eql-search]]
 == Run an EQL search
 
-experimental::[]
+dev::[]
 
 To start using EQL in {es}, first ensure your event data meets
 <<eql-requirements,EQL requirements>>. You can then use the <<eql-search-api,EQL

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Syntax reference</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Adds the new `dev` admonition to EQL and autoscaling features, which
are in development under a feature flag.

The `dev` admonition expands to the following default text:

> [WARNING] This functionality is in development and may be changed or
> removed completely in a future release. These features are unsupported
> and not subject to the support SLA of official GA features.

The `dev` admonition was added with
https://github.com/elastic/docs/pull/1835. In some cases, it replaces
use of the `experimental` admonition.

Will backport this to 7.x.

### Preview
http://elasticsearch_56599.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/xpack-autoscaling.html