### PR TITLE
Enable bwc tests after backporting index templates v2 data stream integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/56596" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Create data stream":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting https://github.com/elastic/elasticsearch/pull/55342 (Add explicit generation attribute)"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -62,8 +62,8 @@
 ---
 "Create data stream with invalid name":
   - skip:
-      version: " - 7.7.99"
-      reason: available only in 7.8+
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       catch: bad_request
@@ -78,8 +78,8 @@
 ---
 "Get data stream":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting https://github.com/elastic/elasticsearch/pull/55342 (Add explicit generation attribute)"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -147,8 +147,8 @@
 ---
 "Delete data stream with backing indices":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting https://github.com/elastic/elasticsearch/pull/55342 (Add explicit generation attribute)"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/20_unsupported_apis.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/20_unsupported_apis.yml
@@ -1,8 +1,8 @@
 ---
 "Test apis that do not supported data streams":
   - skip:
-      version: " - 7.7.99"
-      reason: available only in 7.8+
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/30_auto_create_data_stream.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/30_auto_create_data_stream.yml
@@ -1,8 +1,8 @@
 ---
 "Put index template":
   - skip:
-      version: " - 7.9.99"
-      reason: "not yet backported"
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
       features: allowed_warnings
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/20_backing_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/20_backing_indices.yml
@@ -1,8 +1,8 @@
 ---
 "Delete backing index on data stream":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:
@@ -55,8 +55,8 @@
 ---
 "Attempt to delete write index on data stream is rejected":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/20_backing_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/20_backing_indices.yml
@@ -1,8 +1,8 @@
 ---
 "Get backing indices for data stream":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/50_data_streams.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/50_data_streams.yml
@@ -1,8 +1,8 @@
 ---
 "Roll over a data stream":
   - skip:
-      version: " - 7.99.99"
-      reason:  "enable in 7.8+ after backporting"
+      version: " - 7.8.99"
+      reason:  "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.indices.datastream;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
@@ -39,7 +38,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/CreateDataStreamAction.java
@@ -81,30 +81,14 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
         }
 
         public Request(StreamInput in) throws IOException {
-            // TODO: replace if/else clauses with super(in); after backporting:
-            if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
-                setParentTask(TaskId.readFromStream(in));
-                masterNodeTimeout(in.readTimeValue());
-                timeout(in.readTimeValue());
-            } else {
-                setParentTask(TaskId.readFromStream(in));
-                masterNodeTimeout(in.readTimeValue());
-            }
+            super(in);
             this.name = in.readString();
             this.timestampFieldName = in.readString();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            // TODO: replace if/else clauses with super.writeTo(out); after backporting:
-            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
-                getParentTask().writeTo(out);
-                out.writeTimeValue(masterNodeTimeout());
-                out.writeTimeValue(timeout());
-            } else {
-                getParentTask().writeTo(out);
-                out.writeTimeValue(masterNodeTimeout());
-            }
+            super.writeTo(out);
             out.writeString(name);
             out.writeString(timestampFieldName);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateV2.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateV2.java
@@ -122,7 +122,7 @@ public class IndexTemplateV2 extends AbstractDiffable<IndexTemplateV2> implement
         this.priority = in.readOptionalVLong();
         this.version = in.readOptionalVLong();
         this.metadata = in.readMap();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
             this.dataStreamTemplate = in.readOptionalWriteable(DataStreamTemplate::new);
         } else {
             this.dataStreamTemplate = null;
@@ -181,7 +181,7 @@ public class IndexTemplateV2 extends AbstractDiffable<IndexTemplateV2> implement
         out.writeOptionalVLong(this.priority);
         out.writeOptionalVLong(this.version);
         out.writeMap(this.metadata);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             out.writeOptionalWriteable(dataStreamTemplate);
         }
     }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -1,8 +1,8 @@
 ---
 "Verify data stream resolvability for xpack apis":
   - skip:
-      version: " - 7.99.99"
-      reason: skip untill backported
+      version: " - 7.8.99"
+      reason: "data streams only supported in 7.9+"
 
   - do:
       indices.create_data_stream:


### PR DESCRIPTION
Adjusts serialization logic and version checks.

Relates to #55377