### PR TITLE
Fix Missing IgnoredUnavailable Flag in 7.x SLM Retention Task

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -270,6 +270,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
             for (String repository : repositories) {
                 client.admin().cluster()
                     .prepareGetSnapshots(repository)
+                    .setIgnoreUnavailable(true)
                     .execute(ActionListener.wrap(resp -> {
                             final Set<SnapshotState> retainableStates =
                                 new HashSet<>(Arrays.asList(SnapshotState.SUCCESS, SnapshotState.FAILED, SnapshotState.PARTIAL));


### PR DESCRIPTION
Without the flag we run into the situation where a broken repository (e.g. broken by some old 6.x
version of ES that is missing some snap-${uuid}.dat blobs fails to run the SLM retention task
since it always errors out).

This only affects 7.x, in `master` the flag is set correctly.