### PR TITLE
[7.x] json spec: allow null for documentation url (#55749)

### DIFF
--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -43,6 +43,37 @@
                     "$ref": "#/definitions/Body"
                 }
             },
+            "if": {
+              "properties": {
+                "stability": {
+                  "const": "stable"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "documentation": {
+                  "$ref": "#/definitions/Documentation",
+                  "properties": {
+                    "url" : {
+                      "type": ["string"]
+                    }
+                  }
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "documentation": {
+                  "$ref": "#/definitions/Documentation",
+                  "properties": {
+                    "url" : {
+                      "type": ["string", "null"]
+                    }
+                  }
+                }
+              }
+            },
             "required": [
                 "documentation",
                 "stability",
@@ -130,7 +161,6 @@
             "additionalProperties": false,
             "properties": {
                 "url": {
-                    "type": "string",
                     "format": "uri"
                 },
                 "description": {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -159,7 +159,4 @@ testClusters.integTest {
   }
 }
 
-validateRestSpec {
-  ignore 'ml.validate.json'
-  ignore 'ml.validate_detector.json'
-}
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate.json
@@ -1,7 +1,7 @@
 {
   "ml.validate":{
     "documentation":{
-      "url":null,
+      "url":"https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html",
       "description":"Validates an anomaly detection job."
     },
     "stability":"stable",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.validate_detector.json
@@ -1,7 +1,7 @@
 {
   "ml.validate_detector":{
     "documentation":{
-      "url":null,
+      "url":"https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html",
       "description":"Validates an anomaly detection detector."
     },
     "stability":"stable",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - json spec: allow null for documentation url (#55749)