### PR TITLE
[DOCS] Fix `indices.query.bool.max_clause_count` definition

### DIFF
--- a/docs/reference/modules/indices/search-settings.asciidoc
+++ b/docs/reference/modules/indices/search-settings.asciidoc
@@ -6,7 +6,7 @@ limits.
 
 [[indices-query-bool-max-clause-count]]
 `indices.query.bool.max_clause_count`::
-(<<cluster-update-settings,Dynamic>>, integer)
+(integer)
 Maximum number of clauses a Lucene BooleanQuery can contain. Defaults to `1024`.
 +
 This setting limits the number of clauses a Lucene BooleanQuery can have. The


### PR DESCRIPTION
Corrects error introduced in #56449.

Closes #56598