### PR TITLE
[DOCS] Puts a link into the loss_function variable description

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -229,12 +229,15 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
 
 `loss_function`::::
 (Optional, string)
-The loss function used during regression. Available options are `mse` (mean squared error),
-`msle` (mean squared logarithmic error),  `huber` (Pseudo-Huber loss). Defaults to `mse`.
+The loss function used during {regression}. Available options are `mse` (mean 
+squared error), `msle` (mean squared logarithmic error),  `huber` (Pseudo-Huber 
+loss). Defaults to `mse`. Refer to 
+{ml-docs}/dfa-regression.html#regression-lossfunction[Loss functions for {regression} analyses] 
+to learn more.
 
 `loss_function_parameter`::::
 (Optional, double)
-A strictly positive number that is used as a parameter to the `loss_function`.
+A positive number that is used as a parameter to the `loss_function`.
 
 `max_trees`::::
 (Optional, integer) 

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -232,7 +232,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
 The loss function used during {regression}. Available options are `mse` (mean 
 squared error), `msle` (mean squared logarithmic error),  `huber` (Pseudo-Huber 
 loss). Defaults to `mse`. Refer to 
-{ml-docs}/dfa-regression.html#regression-lossfunction[Loss functions for {regression} analyses] 
+{ml-docs}/dfa-regression.html#dfa-regression-lossfunction[Loss functions for {regression} analyses] 
 to learn more.
 
 `loss_function_parameter`::::


### PR DESCRIPTION
## Overview

This PR puts a link that points to the loss function conceptual overview into the `loss_function` variable description of the PUT DFA API.

### Dependency note

Do not merge this PR before https://github.com/elastic/stack-docs/pull/1062
The CI will pass after stack-docs#1062 is merged.

### Preview

[PUT DFA API docs](https://elasticsearch_56678.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html)