### PR TITLE
EQL: Skip execution for filters with empty results

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_supported.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_supported.toml
@@ -147,3 +147,11 @@ sequence
   [process where true] by unique_ppid
 '''
 expected_event_ids  = [1, 2, 2, 3]
+
+[[queries]]
+query = '''
+sequence
+  [process where false] by unique_pid
+  [process where true] by unique_ppid
+'''
+expected_event_ids  = []

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
@@ -16,11 +16,6 @@
 query = 'process where true | head 6'
 expected_event_ids  = [1, 2, 3, 4, 5, 6]
 
-# presently not supported, throwing: org.elasticsearch.xpack.ql.rule.RuleExecutionException: Does not know how to handle a local relation
-[[queries]]
-query = 'process where false'
-expected_event_ids = []
-
 [[queries]]
 expected_event_ids = []
 query = 'process where missing_field != null'

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/optimizer/Optimizer.java
@@ -6,8 +6,10 @@
 
 package org.elasticsearch.xpack.eql.optimizer;
 
+import org.elasticsearch.xpack.eql.plan.logical.Join;
+import org.elasticsearch.xpack.eql.plan.logical.KeyedFilter;
 import org.elasticsearch.xpack.eql.plan.physical.LocalRelation;
-import org.elasticsearch.xpack.eql.session.EmptyExecutable;
+import org.elasticsearch.xpack.eql.session.Results;
 import org.elasticsearch.xpack.eql.util.StringUtils;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.Not;
@@ -27,8 +29,10 @@ import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PruneLiteralsInOrderBy;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.ReplaceSurrogateFunction;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.SetAsOptimized;
+import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.TransformDirection;
 import org.elasticsearch.xpack.ql.plan.logical.Filter;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.ql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.ql.rule.RuleExecutor;
 
 import java.util.Arrays;
@@ -60,10 +64,14 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
                 new PruneLiteralsInOrderBy()
                 );
 
+        Batch local = new Batch("Skip Elasticsearch",
+                new SkipEmptyFilter(),
+                new SkipEmptyJoin());
+
         Batch label = new Batch("Set as Optimized", Limiter.ONCE,
                 new SetAsOptimized());
 
-        return Arrays.asList(substitutions, operators, label);
+        return Arrays.asList(substitutions, operators, local, label);
     }
 
     private static class ReplaceWildcards extends OptimizerRule<Filter> {
@@ -128,7 +136,36 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
 
         @Override
         protected LogicalPlan nonMatchingFilter(Filter filter) {
-            return new LocalRelation(filter.source(), new EmptyExecutable(filter.output()));
+            return new LocalRelation(filter.source(), filter.output());
+        }
+    }
+
+    static class SkipEmptyFilter extends OptimizerRule<UnaryPlan> {
+
+        SkipEmptyFilter() {
+            super(TransformDirection.UP);
+        }
+
+        @Override
+        protected LogicalPlan rule(UnaryPlan plan) {
+            if ((plan instanceof KeyedFilter) == false && plan.child() instanceof LocalRelation) {
+                return new LocalRelation(plan.source(), plan.output(), Results.Type.SEARCH_HIT);
+            }
+            return plan;
+        }
+    }
+    
+    static class SkipEmptyJoin extends OptimizerRule<Join> {
+
+        @Override
+        protected LogicalPlan rule(Join plan) {
+            // check for empty filters
+            for (KeyedFilter filter : plan.queries()) {
+                if (filter.child() instanceof LocalRelation) {
+                    return new LocalRelation(plan.source(), plan.output(), Results.Type.SEQUENCE);
+                }
+            }
+            return plan;
         }
     }
 }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/LocalRelation.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plan/physical/LocalRelation.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.eql.plan.physical;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.xpack.eql.session.EmptyExecutable;
 import org.elasticsearch.xpack.eql.session.EqlSession;
 import org.elasticsearch.xpack.eql.session.Executable;
 import org.elasticsearch.xpack.eql.session.Results;
@@ -23,7 +24,15 @@ public class LocalRelation extends LogicalPlan implements Executable {
 
     private final Executable executable;
 
-    public LocalRelation(Source source, Executable executable) {
+    public LocalRelation(Source source, List<Attribute> output) {
+        this(source, output, Results.Type.SEARCH_HIT);
+    }
+
+    public LocalRelation(Source source, List<Attribute> output, Results.Type resultType) {
+        this(source, new EmptyExecutable(output, resultType));
+    }
+
+    private LocalRelation(Source source, Executable executable) {
         super(source, emptyList());
         this.executable = executable;
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EmptyExecutable.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EmptyExecutable.java
@@ -5,6 +5,8 @@
  */
 package org.elasticsearch.xpack.eql.session;
 
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.TotalHits.Relation;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.xpack.ql.expression.Attribute;
@@ -17,9 +19,11 @@ import static java.util.Collections.emptyList;
 public class EmptyExecutable implements Executable {
 
     private final List<Attribute> output;
+    private final Results.Type resultType;
 
-    public EmptyExecutable(List<Attribute> output) {
+    public EmptyExecutable(List<Attribute> output, Results.Type resultType) {
         this.output = output;
+        this.resultType = resultType;
     }
 
     @Override
@@ -29,12 +33,12 @@ public class EmptyExecutable implements Executable {
 
     @Override
     public void execute(EqlSession session, ActionListener<Results> listener) {
-        listener.onResponse(Results.fromHits(TimeValue.ZERO, emptyList()));
+        listener.onResponse(new Results(new TotalHits(0, Relation.EQUAL_TO), TimeValue.ZERO, false, emptyList(), resultType));
     }
 
     @Override
     public int hashCode() {
-        return output.hashCode();
+        return Objects.hash(output, resultType);
     }
 
     @Override
@@ -48,7 +52,8 @@ public class EmptyExecutable implements Executable {
         }
 
         EmptyExecutable other = (EmptyExecutable) obj;
-        return Objects.equals(output, other.output);
+        return Objects.equals(resultType, other.resultType)
+                && Objects.equals(output, other.output);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/Results.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/Results.java
@@ -41,7 +41,7 @@ public class Results {
         return new Results(new TotalHits(counts.size(), Relation.EQUAL_TO), tookTime, false, counts, Type.COUNT);
     }
 
-    private Results(TotalHits totalHits, TimeValue tookTime, boolean timedOut, List<?> results, Type type) {
+    Results(TotalHits totalHits, TimeValue tookTime, boolean timedOut, List<?> results, Type type) {
         this.totalHits = totalHits;
         this.tookTime = tookTime;
         this.timedOut = timedOut;


### PR DESCRIPTION
Optimize away events queries and joins/sequence that cannot match any
results without having to query Elasticsearch

Fix #53237
