### PR TITLE
EQL: fix QueryFolderOkTests (#56714)

### DIFF
--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryFolderOkTests.java
@@ -110,9 +110,11 @@ public class QueryFolderOkTests extends AbstractQueryFolderTestCase {
     }
 
     public void test() {
+        String testName = name.toLowerCase(Locale.ROOT);
         // skip tests that do not make sense from case sensitivity point of view
-        boolean isCaseSensitiveValidTest = name.toLowerCase(Locale.ROOT).endsWith("-casesensitive") && configuration.isCaseSensitive()
-            || name.toLowerCase(Locale.ROOT).endsWith("-caseinsensitive") && configuration.isCaseSensitive() == false;
+        boolean isCaseSensitiveValidTest = testName.endsWith("sensitive") == false
+            || testName.endsWith("-casesensitive") && configuration.isCaseSensitive()
+            || testName.endsWith("-caseinsensitive") && configuration.isCaseSensitive() == false;
         Assume.assumeTrue(isCaseSensitiveValidTest);
 
         PhysicalPlan p = plan(query);


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/56714.
(cherry picked from commit 8b21ccd0eac3b3d0fbd090152b3dff6ae5217b52)