### PR TITLE
[DOCS] EQL: Drop references to arrays/multi-value fields from fn docs

### DIFF
--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -134,8 +134,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the first array item only.
 --
 
 `<left>`::
@@ -152,8 +150,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-<<array,Array values>> are not supported.
 --
 
 `<right>`::
@@ -170,8 +166,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-<<array,Array values>> are not supported.
 --
 
 `<greedy_matching>`::
@@ -415,10 +409,6 @@ endsWith(file.name, ".dll")               // returns false
 endsWith("regsvr32.exe", file.extension)  // returns true
 endsWith("ntdll.dll", file.name)          // returns false
 
-// file.name = [ "ntdll.dll", "regsvr32.exe" ]
-endsWith(file.name, ".dll")               // returns true
-endsWith(file.name, ".exe")               // returns false
-
 // null handling
 endsWith("regsvr32.exe", null)            // returns null
 endsWith("", null)                        // returns null
@@ -447,8 +437,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the first array item only.
 --
 
 `<substring>`::
@@ -620,8 +608,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-<<array,Array values>> are not supported.
 --
 
 *Returns:* integer or `null`
@@ -828,10 +814,6 @@ startsWith(process.name, "explorer")    // returns false
 startsWith("regsvr32.exe", process.name) // returns true
 startsWith("explorer.exe", process.name) // returns false
 
-// process.name = [ "explorer.exe", "regsvr32.exe" ]
-startsWith(process.name, "explorer")    // returns true
-startsWith(process.name, "regsvr32")    // returns false
-
 // null handling
 startsWith("regsvr32.exe", null)        // returns null
 startsWith("", null)                    // returns null
@@ -860,8 +842,6 @@ field datatypes:
 * <<constant-keyword,`constant_keyword`>>
 * <<text,`text`>> field with a <<keyword,`keyword`>> or
   <<constant-keyword,`constant_keyword`>> sub-field
-
-Fields containing <<array,array values>> use the first array item only.
 --
 
 `<substring>`::


### PR DESCRIPTION
Removing these until #54970 and/or #55341 is resolved.