### PR TITLE
Use ConcurrentSet in testTrackingChannelTask

### DIFF
--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -78,7 +78,7 @@ public class TaskManagerTests extends ESTestCase {
 
     public void testTrackingChannelTask() throws Exception {
         final TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Set.of());
-        Set<CancellableTask> cancelledTasks = new HashSet<>();
+        Set<CancellableTask> cancelledTasks = ConcurrentCollections.newConcurrentSet();
         taskManager.setTaskCancellationService(new TaskCancellationService(mock(TransportService.class)) {
             @Override
             void cancelTaskAndDescendants(CancellableTask task, String reason, boolean waitForCompletion, ActionListener<Void> listener) {


### PR DESCRIPTION
We need to use a ConcurrentSet to track the canceled tasks as cancelTaskAndDescendants can be called [concurrently](https://github.com/elastic/elasticsearch/blob/595ce8b5e3719cad977a501cd39bd2c3fa720771/server/src/main/java/org/elasticsearch/tasks/TaskManager.java#L680).

Closes #56746 