### PR TITLE
[7.x][ML] Improve error upon DF analytics mappings conflict (#56700)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -108,7 +108,9 @@ public class MappingsMergerTests extends ESTestCase {
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class,
             () -> MappingsMerger.mergeMappings(newSource(), getMappingsResponse));
         assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
-        assertThat(e.getMessage(), equalTo("cannot merge mappings because of differences for field [field_1]"));
+        assertThat(e.getMessage(), containsString("cannot merge mappings because of differences for field [field_1]; "));
+        assertThat(e.getMessage(), containsString("mapped as [different_field_1_mappings] in index [index_2]"));
+        assertThat(e.getMessage(), containsString("mapped as [field_1_mappings] in index [index_1]"));
     }
 
     public void testMergeMappings_GivenIndicesWithDifferentMappingsButNoConflicts() throws IOException {


### PR DESCRIPTION
Adds the conflicting types and an example of an index which specifies
them in order to make it easier for the user to understand the conflict.

Backport of #56700
