### PR TITLE
[DOCS] Add search pagination docs

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -128,6 +128,7 @@ specific index module:
     out of this behavior an explicit value of `1s` should set as the refresh
     interval.
 
+[[index-max-result-window]]
 `index.max_result_window`::
 
     The maximum value of `from + size` for searches to this index. Defaults to

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -562,3 +562,19 @@ For other information, see:
 === Adding and removing nodes
 
 See <<add-elasticsearch-nodes>>.
+
+////
+[role="exclude",id="search-request-body"]
+=== Request body search
+
+This page has been removed.
+
+For search API reference documentation, see <<search-search>>.
+
+For search examples, see <<run-a-search>>.
+
+[role="exclude",id="request-body-search-from-size"]
+==== From / size
+
+See <<paginate-search-results>>.
+////

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -106,8 +106,6 @@ include::request/docvalue-fields.asciidoc[]
 
 include::request/collapse.asciidoc[]
 
-include::request/from-size.asciidoc[]
-
 include::request/highlighting.asciidoc[]
 
 include::request/index-boost.asciidoc[]

--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -5,10 +5,8 @@
 By default, the search API returns the top 10 matching documents, 
 starting with the most-relevant document.
 
-To paginate a larger set of search results, you can use the search API's `size`
-and `from` parameters. The `from` parameter is a zero-indexed offset from
-the first result you want to fetch. The `size` parameter sets the maximum
-number of results to return.
+To paginate through a larger set of results, you can use the search API's `size`
+and `from` parameters. The `size` parameter is the number of matching documents to return. The `from` parameter is a zero-indexed offset from the beginning of the complete result set that indicates the document you want to start with. 
 
 [IMPORTANT]
 ====

--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -2,8 +2,8 @@
 [[paginate-search-results]]
 === Paginate search results
 
-By default, the search API returns documents for only the top 10 search
-results, starting with the first, most relevant document.
+By default, the search API returns the top 10 matching documents, 
+starting with the most-relevant document.
 
 To paginate a larger set of search results, you can use the search API's `size`
 and `from` parameters. The `from` parameter is a zero-indexed offset from

--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -13,11 +13,10 @@ the complete result set that indicates the document you want to start with.
 [%collapsible]
 ====
 The following search API request sets the `from` offset to `5`, meaning the
-request offset the first five results. Documents for those results won't be
-included in the response.
+request offsets, or skips, the first five matching documents.
 
-The `size` parameter is `20`, meaning that the request can return up to 20
-results, starting at the `offset`.
+The `size` parameter is `20`, meaning the request can return up to 20 documents,
+starting at the offset.
 
 [source,console]
 ----
@@ -36,7 +35,7 @@ By default, you cannot page through more than 10,000 documents using the `from`
 and `size` parameters. This limit is set using the
 <<index-max-result-window,`index.max_result_window`>> index setting.
 
-Paging deeply or requesting many results at once can result in slow searches.
+Deep paging or requesting many results at once can result in slow searches.
 Results are sorted before being returned. Because search requests usually span
 multiple shards, each shard must generate its own sorted results. These separate
 results must then be combined and sorted to ensure that the overall sort order

--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -2,19 +2,12 @@
 [[paginate-search-results]]
 === Paginate search results
 
-By default, the search API returns the top 10 matching documents, 
-starting with the most-relevant document.
+By default, the search API returns the top 10 matching documents.
 
 To paginate through a larger set of results, you can use the search API's `size`
-and `from` parameters. The `size` parameter is the number of matching documents to return. The `from` parameter is a zero-indexed offset from the beginning of the complete result set that indicates the document you want to start with. 
-
-[IMPORTANT]
-====
-The combined document count, including offset and and returned documents, for
-the `from` and `size` parameters cannot exceed the
-<<index-max-result-window,`index.max_result_window`>> index setting, which
-defaults to 10,000 documents.
-====
+and `from` parameters. The `size` parameter is the number of matching documents
+to return. The `from` parameter is a zero-indexed offset from the beginning of
+the complete result set that indicates the document you want to start with.
 
 .*Example*
 [%collapsible]
@@ -39,9 +32,21 @@ GET /_search
 ----
 ====
 
+By default, you cannot page through more than 10,000 documents using the `from`
+and `size` parameters. This limit is set using the
+<<index-max-result-window,`index.max_result_window`>> index setting.
+
+Paging deeply or requesting many results at once can result in slow searches.
+Results are sorted before being returned. Because search requests usually span
+multiple shards, each shard must generate its own sorted results. These separate
+results must then be combined and sorted to ensure that the overall sort order
+is correct.
+
+As an alternative to deep paging, we recommend using the
+<<request-body-search-scroll,Scroll>> or
+<<request-body-search-search-after,Search After>> APIs.
+
 WARNING: {es} uses Lucene's internal doc IDs as tie-breakers. These internal
 doc IDs can be completely different across replicas of the same
 data. When paginating, you might occasionally see that documents with the same
-sort values are not ordered consistently. For deep scrolling, it is more
-efficient to use the <<request-body-search-scroll,Scroll>> or 
-<<request-body-search-search-after,Search After>> APIs.
+sort values are not ordered consistently.

--- a/docs/reference/search/request/from-size.asciidoc
+++ b/docs/reference/search/request/from-size.asciidoc
@@ -1,29 +1,45 @@
-[[request-body-search-from-size]]
-==== From / Size
+[discrete]
+[[paginate-search-results]]
+=== Paginate search results
 
-Pagination of results can be done by using the `from` and `size`
-parameters. The `from` parameter defines the offset from the first
-result you want to fetch. The `size` parameter allows you to configure
-the maximum amount of hits to be returned.
+By default, the search API returns documents for only the top 10 search
+results, starting with the first, most relevant document.
 
-Though `from` and `size` can be set as request parameters, they can also
-be set within the search body. `from` defaults to `0`, and `size`
-defaults to `10`.
+To paginate a larger set of search results, you can use the search API's `size`
+and `from` parameters. The `from` parameter is a zero-indexed offset from
+the first result you want to fetch. The `size` parameter sets the maximum
+number of results to return.
+
+[IMPORTANT]
+====
+The combined document count, including offset and and returned documents, for
+the `from` and `size` parameters cannot exceed the
+<<index-max-result-window,`index.max_result_window`>> index setting, which
+defaults to 10,000 documents.
+====
+
+.*Example*
+[%collapsible]
+====
+The following search API request sets the `from` offset to `5`, meaning the
+request offset the first five results. Documents for those results won't be
+included in the response.
+
+The `size` parameter is `20`, meaning that the request can return up to 20
+results, starting at the `offset`.
 
 [source,console]
---------------------------------------------------
+----
 GET /_search
 {
-    "from" : 0, "size" : 10,
-    "query" : {
-        "term" : { "user" : "kimchy" }
-    }
+  "from": 5,
+  "size": 20,
+  "query": {
+    "term": { "user": "kimchy" }
+  }
 }
---------------------------------------------------
-
-
-Note that `from` + `size` can not be more than the `index.max_result_window`
-index setting, which defaults to 10,000.
+----
+====
 
 WARNING: {es} uses Lucene's internal doc IDs as tie-breakers. These internal
 doc IDs can be completely different across replicas of the same

--- a/docs/reference/search/run-a-search.asciidoc
+++ b/docs/reference/search/run-a-search.asciidoc
@@ -283,3 +283,5 @@ GET /*/_search
 ----
 // TEST[continued]
 ====
+
+include::request/from-size.asciidoc[]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -87,13 +87,19 @@ both parameters are specified, only the query parameter is used.
 include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
 +
 --
-[IMPORTANT]
-====
-The combined document count, including offset and and returned documents, for
-the `from` and `size` parameters cannot exceed the
-<<index-max-result-window,`index.max_result_window`>> index setting, which
-defaults to 10,000 documents.
-====
+By default, you cannot page through more than 10,000 documents using the `from`
+and `size` parameters. This limit is set using the
+<<index-max-result-window,`index.max_result_window`>> index setting.
+
+Paging deeply or requesting many results at once can result in slow searches.
+Results are sorted before being returned. Because search requests usually span
+multiple shards, each shard must generate its own sorted results. These separate
+results must then be combined and sorted to ensure that the overall order is
+correct.
+
+As an alternative to deep paging, we recommend using the
+<<request-body-search-scroll,Scroll>> or
+<<request-body-search-search-after,Search After>> APIs.
 
 [IMPORTANT]
 ====
@@ -178,13 +184,19 @@ parameter. If both parameters are specified, only the query parameter is used.
 (Optional, integer) Defines the number of hits to return. Defaults to `10`.
 +
 --
-[IMPORTANT]
-====
-The combined document count, including offset and and returned documents, for
-the `from` and `size` parameters cannot exceed the
-<<index-max-result-window,`index.max_result_window`>> index setting, which
-defaults to 10,000 documents.
-====
+By default, you cannot page through more than 10,000 documents using the `from`
+and `size` parameters. This limit is set using the
+<<index-max-result-window,`index.max_result_window`>> index setting.
+
+Paging deeply or requesting many results at once can result in slow searches.
+Results are sorted before being returned. Because search requests usually span
+multiple shards, each shard must generate its own sorted results. These separate
+results must then be combined and sorted to ensure that the overall order is
+correct.
+
+As an alternative to deep paging, we recommend using the
+<<request-body-search-scroll,Scroll>> or
+<<request-body-search-search-after,Search After>> APIs.
 
 [IMPORTANT]
 ====
@@ -295,13 +307,19 @@ both parameters are specified, only the query parameter is used.
 include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
 +
 --
-[IMPORTANT]
-====
-The combined document count, including offset and and returned documents, for
-the `from` and `size` parameters cannot exceed the
-<<index-max-result-window,`index.max_result_window`>> index setting, which
-defaults to 10,000 documents.
-====
+By default, you cannot page through more than 10,000 documents using the `from`
+and `size` parameters. This limit is set using the
+<<index-max-result-window,`index.max_result_window`>> index setting.
+
+Paging deeply or requesting many results at once can result in slow searches.
+Results are sorted before being returned. Because search requests usually span
+multiple shards, each shard must generate its own sorted results. These separate
+results must then be combined and sorted to ensure that the overall order is
+correct.
+
+As an alternative to deep paging, we recommend using the
+<<request-body-search-scroll,Scroll>> or
+<<request-body-search-search-after,Search After>> APIs.
 
 [IMPORTANT]
 ====
@@ -333,13 +351,19 @@ If both parameters are specified, only the query parameter is used.
 (Optional, integer) The number of hits to return. Defaults to `10`.
 +
 --
-[IMPORTANT]
-====
-The combined document count, including offset and and returned documents, for
-the `from` and `size` parameters cannot exceed the
-<<index-max-result-window,`index.max_result_window`>> index setting, which
-defaults to 10,000 documents.
-====
+By default, you cannot page through more than 10,000 documents using the `from`
+and `size` parameters. This limit is set using the
+<<index-max-result-window,`index.max_result_window`>> index setting.
+
+Paging deeply or requesting many results at once can result in slow searches.
+Results are sorted before being returned. Because search requests usually span
+multiple shards, each shard must generate its own sorted results. These separate
+results must then be combined and sorted to ensure that the overall order is
+correct.
+
+As an alternative to deep paging, we recommend using the
+<<request-body-search-scroll,Scroll>> or
+<<request-body-search-search-after,Search After>> APIs.
 
 [IMPORTANT]
 ====

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -91,7 +91,7 @@ By default, you cannot page through more than 10,000 documents using the `from`
 and `size` parameters. This limit is set using the
 <<index-max-result-window,`index.max_result_window`>> index setting.
 
-Paging deeply or requesting many results at once can result in slow searches.
+Deep paging or requesting many results at once can result in slow searches.
 Results are sorted before being returned. Because search requests usually span
 multiple shards, each shard must generate its own sorted results. These separate
 results must then be combined and sorted to ensure that the overall order is
@@ -188,7 +188,7 @@ By default, you cannot page through more than 10,000 documents using the `from`
 and `size` parameters. This limit is set using the
 <<index-max-result-window,`index.max_result_window`>> index setting.
 
-Paging deeply or requesting many results at once can result in slow searches.
+Deep paging or requesting many results at once can result in slow searches.
 Results are sorted before being returned. Because search requests usually span
 multiple shards, each shard must generate its own sorted results. These separate
 results must then be combined and sorted to ensure that the overall order is
@@ -311,7 +311,7 @@ By default, you cannot page through more than 10,000 documents using the `from`
 and `size` parameters. This limit is set using the
 <<index-max-result-window,`index.max_result_window`>> index setting.
 
-Paging deeply or requesting many results at once can result in slow searches.
+Deep paging or requesting many results at once can result in slow searches.
 Results are sorted before being returned. Because search requests usually span
 multiple shards, each shard must generate its own sorted results. These separate
 results must then be combined and sorted to ensure that the overall order is
@@ -355,7 +355,7 @@ By default, you cannot page through more than 10,000 documents using the `from`
 and `size` parameters. This limit is set using the
 <<index-max-result-window,`index.max_result_window`>> index setting.
 
-Paging deeply or requesting many results at once can result in slow searches.
+Deep paging or requesting many results at once can result in slow searches.
 Results are sorted before being returned. Because search requests usually span
 multiple shards, each shard must generate its own sorted results. These separate
 results must then be combined and sorted to ensure that the overall order is

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -89,6 +89,14 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
 --
 [IMPORTANT]
 ====
+The combined document count, including offset and and returned documents, for
+the `from` and `size` parameters cannot exceed the
+<<index-max-result-window,`index.max_result_window`>> index setting, which
+defaults to 10,000 documents.
+====
+
+[IMPORTANT]
+====
 You can also specify this value using the `from` request body parameter. If
 both parameters are specified, only the query parameter is used.
 ====
@@ -170,6 +178,14 @@ parameter. If both parameters are specified, only the query parameter is used.
 (Optional, integer) Defines the number of hits to return. Defaults to `10`.
 +
 --
+[IMPORTANT]
+====
+The combined document count, including offset and and returned documents, for
+the `from` and `size` parameters cannot exceed the
+<<index-max-result-window,`index.max_result_window`>> index setting, which
+defaults to 10,000 documents.
+====
+
 [IMPORTANT]
 ====
 You can also specify this value using the `size` request body parameter. If
@@ -281,6 +297,14 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
 --
 [IMPORTANT]
 ====
+The combined document count, including offset and and returned documents, for
+the `from` and `size` parameters cannot exceed the
+<<index-max-result-window,`index.max_result_window`>> index setting, which
+defaults to 10,000 documents.
+====
+
+[IMPORTANT]
+====
 You can also specify this value using the `from` query parameter. If both
 parameters are specified, only the query parameter is used.
 ====
@@ -309,6 +333,14 @@ If both parameters are specified, only the query parameter is used.
 (Optional, integer) The number of hits to return. Defaults to `10`.
 +
 --
+[IMPORTANT]
+====
+The combined document count, including offset and and returned documents, for
+the `from` and `size` parameters cannot exceed the
+<<index-max-result-window,`index.max_result_window`>> index setting, which
+defaults to 10,000 documents.
+====
+
 [IMPORTANT]
 ====
 You can also specify this value using the `size` query parameter. If both


### PR DESCRIPTION
Reworks the `from / size` content to `Paginate search results`.

Moves those docs from the `Request body search` API docs page
(slated for deletion) to the `Run a search` tutorial docs.

Also adds some notes to the `from` and `size` param docs.

~Because this involves redirects, I only plan to merge into `master`.~ I'll be backporting to all maintained branches.

Relates to #48194