### PR TITLE
[7.x] Don't allow invalid template combinations (#56397)

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -31,6 +31,32 @@ the settings from the create index request take precedence over settings specifi
 
 [source,console]
 --------------------------------------------------
+PUT _component_template/component_template1
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        }
+      }
+    }
+  }
+}
+
+PUT _component_template/other_component_template
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "ip_address": {
+          "type": "ip"
+        }
+      }
+    }
+  }
+}
+
 PUT _index_template/template_1
 {
   "index_patterns": ["te*", "bar*"],
@@ -233,7 +259,7 @@ When multiple component templates are specified in the `composed_of` field for a
 they are merged in the order specified, meaning that later component templates override earlier
 component templates.
 
-For two component templates:
+For two component templates, the order they are specified changes the number of shards for an index:
 
 [source,console]
 --------------------------------------------------
@@ -245,10 +271,7 @@ PUT /_component_template/template_with_2_shards
     }
   }
 }
---------------------------------------------------
 
-[source,console]
---------------------------------------------------
 PUT /_component_template/template_with_3_shards
 {
   "template": {
@@ -257,12 +280,7 @@ PUT /_component_template/template_with_3_shards
     }
   }
 }
---------------------------------------------------
 
-The order they are specified changes the number of shards for an index:
-
-[source,console]
---------------------------------------------------
 PUT /_index_template/template_1
 {
   "index_patterns": ["t*"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.templates/10_basic.yml
@@ -291,6 +291,15 @@
         features: allowed_warnings
 
     - do:
+        cluster.put_component_template:
+          name: foo
+          body:
+            template:
+              settings:
+                number_of_shards: 1
+                number_of_replicas: 0
+
+    - do:
         indices.put_template:
           name: test
           body:
@@ -310,7 +319,7 @@
             index_patterns: [v2-test]
             priority: 4
             version: 3
-            composed_of: [foo, bar]
+            composed_of: [foo]
 
     - do:
         cat.templates: {}
@@ -332,5 +341,5 @@
                 \[v2-test\]     \s+
                 4               \s+
                 3               \s+
-                \[foo,\ bar\]
+                \[foo\]
                /

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -783,6 +784,74 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
         // These should be order of precedence, so the index template (a3), then ct_high (a1), then ct_low (a2)
         assertThat(resolvedAliases, equalTo(Arrays.asList(a3, a1, a2)));
+    }
+
+    public void testAddInvalidTemplate() throws Exception {
+        IndexTemplateV2 template = new IndexTemplateV2(Collections.singletonList("a"), null,
+            Arrays.asList("good", "bad"), null, null, null);
+        ComponentTemplate ct = new ComponentTemplate(new Template(Settings.EMPTY, null, null), null, null);
+
+        final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
+        CountDownLatch ctLatch = new CountDownLatch(1);
+        service.putComponentTemplate("api", randomBoolean(), "good", TimeValue.timeValueSeconds(5), ct,
+            ActionListener.wrap(r -> ctLatch.countDown(), e -> {
+                logger.error("unexpected error", e);
+                fail("unexpected error");
+            }));
+        ctLatch.await(5, TimeUnit.SECONDS);
+        InvalidIndexTemplateException e = expectThrows(InvalidIndexTemplateException.class,
+            () -> {
+                CountDownLatch latch = new CountDownLatch(1);
+                AtomicReference<Exception> err = new AtomicReference<>();
+                service.putIndexTemplateV2("api", randomBoolean(), "template", TimeValue.timeValueSeconds(30), template,
+                    ActionListener.wrap(r -> fail("should have failed!"), exception -> {
+                        err.set(exception);
+                        latch.countDown();
+                    }));
+                latch.await(5, TimeUnit.SECONDS);
+                if (err.get() != null) {
+                    throw err.get();
+                }
+            });
+
+        assertThat(e.name(), equalTo("template"));
+        assertThat(e.getMessage(), containsString("index template [template] specifies " +
+            "component templates [bad] that do not exist"));
+    }
+
+    public void testRemoveComponentTemplateInUse() throws Exception {
+        IndexTemplateV2 template = new IndexTemplateV2(Collections.singletonList("a"), null,
+            Collections.singletonList("ct"), null, null, null);
+        ComponentTemplate ct = new ComponentTemplate(new Template(null, new CompressedXContent("{}"), null), null, null);
+
+        final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
+        CountDownLatch ctLatch = new CountDownLatch(1);
+        service.putComponentTemplate("api", false, "ct", TimeValue.timeValueSeconds(5), ct,
+            ActionListener.wrap(r -> ctLatch.countDown(), e -> fail("unexpected error")));
+        ctLatch.await(5, TimeUnit.SECONDS);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        service.putIndexTemplateV2("api", false, "template", TimeValue.timeValueSeconds(30), template,
+            ActionListener.wrap(r -> latch.countDown(), e -> fail("unexpected error")));
+        latch.await(5, TimeUnit.SECONDS);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> {
+                AtomicReference<Exception> err = new AtomicReference<>();
+                CountDownLatch errLatch = new CountDownLatch(1);
+                service.removeComponentTemplate("c*", TimeValue.timeValueSeconds(30),
+                    ActionListener.wrap(r -> fail("should have failed!"), exception -> {
+                        err.set(exception);
+                        errLatch.countDown();
+                    }));
+                errLatch.await(5, TimeUnit.SECONDS);
+                if (err.get() != null) {
+                    throw err.get();
+                }
+            });
+
+        assertThat(e.getMessage(),
+            containsString("component templates [ct] cannot be removed as they are still in use by index templates [template]"));
     }
 
     private static List<Throwable> putTemplate(NamedXContentRegistry xContentRegistry, PutRequest request) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Don't allow invalid template combinations (#56397)