### PR TITLE
[DOCS] Fix fingerprint token filter's analyzer example

### DIFF
--- a/docs/reference/analysis/tokenfilters/fingerprint-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/fingerprint-tokenfilter.asciidoc
@@ -81,7 +81,7 @@ PUT fingerprint_example
       "analyzer": {
         "whitespace_fingerprint": {
           "tokenizer": "whitespace",
-          "filter": [ "elision" ]
+          "filter": [ "fingerprint" ]
         }
       }
     }


### PR DESCRIPTION
In the changed example `elision` token filter was being used instead of `fingerprint` token filter