### PR TITLE
[7.x] [DOCS] EQL: Document `case_sensitive` param (#56697)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -84,6 +84,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 [[eql-search-api-request-body]]
 ==== {api-request-body-title}
 
+`case_sensitive`::
+(Optional, boolean)
+If `true`, matching for the <<eql-search-api-request-query-param,EQL query>> is
+case sensitive. Defaults to `false`.
+
 `event_category_field`::
 (Required*, string)
 Field containing the event classification, such as `process`, `file`, or
@@ -102,6 +107,7 @@ runs.
 (Optional, string)
 Reserved for future use.
 
+[[eql-search-api-request-query-param]]
 `query`::
 (Required, string)
 <<eql-syntax,EQL>> query you wish to run.

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -215,3 +215,33 @@ GET /sec_logs/_eql/search
 }
 ----
 ====
+
+[discrete]
+[[eql-search-case-sensitive]]
+=== Run a case-sensitive EQL search
+
+By default, matching for EQL queries is case-insensitive. You can use the EQL
+search API's `case_sensitive` parameter to toggle case sensitivity on or off.
+
+.*Example*
+[%collapsible]
+====
+The following search request contains a query that matches `process` events
+with a `process.path` containing `System32`.
+
+Because the `case_sensitive` parameter is `true`, this query only matches
+`process.path` values containing `System32` with the exact same capitalization.
+A `process.path` value containing `system32` or `SYSTEM32` would not match this
+query.
+
+[source,console]
+----
+GET /sec_logs/_eql/search
+{
+  "case_sensitive": true,
+  "query": """
+    process where stringContains(process.path, "System32")
+  """
+}
+----
+====


### PR DESCRIPTION
7.x backport of #56697