### PR TITLE
[7.x] Enable decompression of response within LowLevelRestClient (#55413)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.client;
 
-import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.client.entity.GzipDecompressingEntity;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
@@ -1874,18 +1872,11 @@ public class RestHighLevelClient implements Closeable {
         return elasticsearchException;
     }
 
-    protected final <Resp> Resp parseEntity(final HttpEntity httpEntity,
+    protected final <Resp> Resp parseEntity(final HttpEntity entity,
                                       final CheckedFunction<XContentParser, Resp, IOException> entityParser) throws IOException {
-        if (httpEntity == null) {
+        if (entity == null) {
             throw new IllegalStateException("Response body expected but not returned");
         }
-
-        final HttpEntity entity = Optional.ofNullable(httpEntity.getContentEncoding())
-            .map(Header::getValue)
-            .filter("gzip"::equalsIgnoreCase)
-            .map(gzipHeaderValue -> (HttpEntity) new GzipDecompressingEntity(httpEntity))
-            .orElse(httpEntity);
-
         if (entity.getContentType() == null) {
             throw new IllegalStateException("Elasticsearch didn't return the [Content-Type] header, unable to parse response body");
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -33,7 +33,6 @@ import org.apache.http.message.BasicRequestLine;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.entity.NByteArrayEntity;
 import org.apache.http.nio.entity.NStringEntity;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -118,12 +117,10 @@ import org.elasticsearch.test.rest.yaml.restspec.ClientYamlSuiteRestSpec;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.SocketTimeoutException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -137,7 +134,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.GZIPOutputStream;
 
 import static org.elasticsearch.client.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider.registeredMetricName;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -324,59 +320,6 @@ public class RestHighLevelClientTests extends ESTestCase {
             HttpEntity cborEntity = createBinaryEntity(CborXContent.contentBuilder(), ContentType.create("application/cbor"));
             assertEquals("value", restHighLevelClient.parseEntity(cborEntity, entityParser));
         }
-    }
-
-    public void testParseCompressedEntity() throws IOException {
-        CheckedFunction<XContentParser, String, IOException> entityParser = parser -> {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertTrue(parser.nextToken().isValue());
-            String value = parser.text();
-            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-            return value;
-        };
-
-        HttpEntity jsonEntity = createGzipEncodedEntity("{\"field\":\"value\"}", ContentType.APPLICATION_JSON);
-        assertEquals("value", restHighLevelClient.parseEntity(jsonEntity, entityParser));
-        HttpEntity yamlEntity = createGzipEncodedEntity("---\nfield: value\n", ContentType.create("application/yaml"));
-        assertEquals("value", restHighLevelClient.parseEntity(yamlEntity, entityParser));
-        HttpEntity smileEntity = createGzipEncodedEntity(SmileXContent.contentBuilder(), ContentType.create("application/smile"));
-        assertEquals("value", restHighLevelClient.parseEntity(smileEntity, entityParser));
-        HttpEntity cborEntity = createGzipEncodedEntity(CborXContent.contentBuilder(), ContentType.create("application/cbor"));
-        assertEquals("value", restHighLevelClient.parseEntity(cborEntity, entityParser));
-    }
-
-    private HttpEntity createGzipEncodedEntity(String content, ContentType contentType) throws IOException {
-        byte[] gzipEncodedContent = compressContentWithGzip(content.getBytes(StandardCharsets.UTF_8));
-        NByteArrayEntity httpEntity = new NByteArrayEntity(gzipEncodedContent, contentType);
-        httpEntity.setContentEncoding("gzip");
-
-        return httpEntity;
-    }
-
-    private HttpEntity createGzipEncodedEntity(XContentBuilder xContentBuilder, ContentType contentType) throws IOException {
-        try (XContentBuilder builder = xContentBuilder) {
-            builder.startObject();
-            builder.field("field", "value");
-            builder.endObject();
-
-            BytesRef bytesRef = BytesReference.bytes(xContentBuilder).toBytesRef();
-            byte[] gzipEncodedContent = compressContentWithGzip(bytesRef.bytes);
-            NByteArrayEntity httpEntity = new NByteArrayEntity(gzipEncodedContent, contentType);
-            httpEntity.setContentEncoding("gzip");
-
-            return httpEntity;
-        }
-    }
-
-    private static byte[] compressContentWithGzip(byte[] content) throws IOException {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream(content.length);
-        GZIPOutputStream gzip = new GZIPOutputStream(bos);
-        gzip.write(content);
-        gzip.close();
-        bos.close();
-
-        return bos.toByteArray();
     }
 
     private static HttpEntity createBinaryEntity(XContentBuilder xContentBuilder, ContentType contentType) throws IOException {

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpCompressionIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpCompressionIT.java
@@ -19,6 +19,8 @@
 package org.elasticsearch.http;
 
 import org.apache.http.HttpHeaders;
+import org.apache.http.client.entity.GzipDecompressingEntity;
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -26,9 +28,14 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 
 import java.io.IOException;
 
-public class HttpCompressionIT extends ESRestTestCase {
-    private static final String GZIP_ENCODING = "gzip";
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 
+public class HttpCompressionIT extends ESRestTestCase {
+
+    private static final String GZIP_ENCODING = "gzip";
     private static final String SAMPLE_DOCUMENT = "{\n" +
         "   \"name\": {\n" +
         "      \"first name\": \"Steve\",\n" +
@@ -36,15 +43,27 @@ public class HttpCompressionIT extends ESRestTestCase {
         "   }\n" +
         "}";
 
-
     public void testCompressesResponseIfRequested() throws IOException {
-        Request request = new Request("GET", "/");
-        RequestOptions.Builder options = request.getOptions().toBuilder();
-        options.addHeader(HttpHeaders.ACCEPT_ENCODING, GZIP_ENCODING);
-        request.setOptions(options);
+        Request request = new Request("POST", "/company/_doc/2");
+        request.setJsonEntity(SAMPLE_DOCUMENT);
         Response response = client().performRequest(request);
+        assertEquals(201, response.getStatusLine().getStatusCode());
+        assertNull(response.getHeader(HttpHeaders.CONTENT_ENCODING));
+        assertThat(response.getEntity(), is(not(instanceOf(GzipDecompressingEntity.class))));
+
+        request = new Request("GET", "/company/_doc/2");
+        RequestOptions requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .addHeader(HttpHeaders.ACCEPT_ENCODING, GZIP_ENCODING)
+            .build();
+
+        request.setOptions(requestOptions);
+        response = client().performRequest(request);
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertEquals(GZIP_ENCODING, response.getHeader(HttpHeaders.CONTENT_ENCODING));
+        assertThat(response.getEntity(), instanceOf(GzipDecompressingEntity.class));
+
+        String body = EntityUtils.toString(response.getEntity());
+        assertThat(body, containsString(SAMPLE_DOCUMENT));
     }
 
     public void testUncompressedResponseByDefault() throws IOException {
@@ -57,6 +76,7 @@ public class HttpCompressionIT extends ESRestTestCase {
         response = client().performRequest(request);
         assertEquals(201, response.getStatusLine().getStatusCode());
         assertNull(response.getHeader(HttpHeaders.CONTENT_ENCODING));
+        assertThat(response.getEntity(), is(not(instanceOf(GzipDecompressingEntity.class))));
     }
 
 }


### PR DESCRIPTION
Added support for decompression at LLRC and added integration test

(cherry picked from commit 2621452473e0c236aa28db749f782a24eca6c974)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #55413 