### PR TITLE
[7.x] Rename endpoint from plural "_data_streams" to singular "_data_stream"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,8 +182,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/56762" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/build.gradle
+++ b/build.gradle
@@ -182,8 +182,8 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/56762" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -859,7 +859,7 @@ public class RestHighLevelClientTests extends ESTestCase {
             "render_search_template",
             "scripts_painless_execute",
             "indices.create_data_stream",
-            "indices.get_data_streams",
+            "indices.get_data_stream",
             "indices.delete_data_stream"
         };
         //These API are not required for high-level client feature completeness

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -27,14 +27,14 @@ DELETE /_data_stream/my-data-stream
 
 [source,console]
 --------------------------------------------------
-GET _data_streams/my-data-stream
+GET _data_stream/my-data-stream
 --------------------------------------------------
 // TEST[skip_shard_failures]
 
 [[get-data-stream-api-request]]
 ==== {api-request-title}
 
-`GET _data_streams/<data-stream>`
+`GET _data_stream/<data-stream>`
 
 
 [[get-data-stream-api-path-params]]
@@ -55,7 +55,7 @@ retrieve.
 
 [source,console]
 --------------------------------------------------
-GET _data_streams/my-data-stream*
+GET _data_stream/my-data-stream*
 --------------------------------------------------
 // TEST[continued]
 // TEST[skip_shard_failures]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -1,5 +1,5 @@
 {
-  "indices.get_data_streams":{
+  "indices.get_data_stream":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "description":"Returns data streams."
@@ -8,13 +8,13 @@
     "url":{
       "paths":[
         {
-          "path":"/_data_streams",
+          "path":"/_data_stream",
           "methods":[
             "GET"
           ]
         },
         {
-          "path":"/_data_streams/{name}",
+          "path":"/_data_stream/{name}",
           "methods":[
             "GET"
           ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/10_basic.yml
@@ -19,7 +19,7 @@
   - is_true: acknowledged
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: "*"
   - match: { 0.name: simple-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
@@ -96,7 +96,7 @@
   - is_true: acknowledged
 
   - do:
-      indices.get_data_streams: {}
+      indices.get_data_stream: {}
   - match: { 0.name: get-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
   - match: { 0.generation: 1 }
@@ -105,14 +105,14 @@
   - match: { 1.generation: 1 }
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: get-data-stream1
   - match: { 0.name: get-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
   - match: { 0.generation: 1 }
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: get-data-*
   - match: { 0.name: get-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
@@ -122,7 +122,7 @@
   - match: { 1.generation: 1 }
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: nonexistent-data-stream
       catch: missing
 
@@ -130,7 +130,7 @@
   - match: { error.root_cause.0.type: "resource_not_found_exception" }
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: nonexistent*
   - match: { $body: [] }
 
@@ -173,7 +173,7 @@
   - is_true: delete-data-stream1-000001.settings
 
   - do:
-      indices.get_data_streams: {}
+      indices.get_data_stream: {}
   - match: { 0.name: delete-data-stream1 }
   - match: { 0.timestamp_field: '@timestamp' }
   - match: { 0.generation: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/30_auto_create_data_stream.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/30_auto_create_data_stream.yml
@@ -38,7 +38,7 @@
   - match: { hits.hits.0._source.foo: 'bar' }
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: logs-foobar
   - match: { 0.name: logs-foobar }
   - match: { 0.timestamp_field: 'timestamp' }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/20_backing_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/20_backing_indices.yml
@@ -39,7 +39,7 @@
   - is_false: ''
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: "*"
   - match: { 0.name: simple-data-stream }
   - match: { 0.timestamp_field: '@timestamp' }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/50_data_streams.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/50_data_streams.yml
@@ -29,7 +29,7 @@
   - is_true: ''
 
   - do:
-      indices.get_data_streams:
+      indices.get_data_stream:
         name: "*"
   - match: { 0.name: data-stream-for-rollover }
   - match: { 0.timestamp_field: '@timestamp' }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -24,7 +24,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
@@ -258,8 +258,8 @@ public class BulkIntegrationIT extends ESIntegTestCase {
         bulkResponse = client().bulk(bulkRequest).actionGet();
         assertThat("bulk failures: " + Strings.toString(bulkResponse), bulkResponse.hasFailures(), is(false));
 
-        GetDataStreamsAction.Request getDataStreamRequest = new GetDataStreamsAction.Request("*");
-        GetDataStreamsAction.Response getDataStreamsResponse = client().admin().indices().getDataStreams(getDataStreamRequest).actionGet();
+        GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request("*");
+        GetDataStreamAction.Response getDataStreamsResponse = client().admin().indices().getDataStreams(getDataStreamRequest).actionGet();
         assertThat(getDataStreamsResponse.getDataStreams(), hasSize(4));
         getDataStreamsResponse.getDataStreams().sort(Comparator.comparing(DataStream::getName));
         assertThat(getDataStreamsResponse.getDataStreams().get(0).getName(), equalTo("logs-foobar"));
@@ -292,8 +292,8 @@ public class BulkIntegrationIT extends ESIntegTestCase {
         BulkResponse bulkResponse = client().bulk(bulkRequest).actionGet();
         assertThat("bulk failures: " + Strings.toString(bulkResponse), bulkResponse.hasFailures(), is(false));
 
-        GetDataStreamsAction.Request getDataStreamRequest = new GetDataStreamsAction.Request("*");
-        GetDataStreamsAction.Response getDataStreamsResponse = client().admin().indices().getDataStreams(getDataStreamRequest).actionGet();
+        GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request("*");
+        GetDataStreamAction.Response getDataStreamsResponse = client().admin().indices().getDataStreams(getDataStreamRequest).actionGet();
         assertThat(getDataStreamsResponse.getDataStreams(), hasSize(0));
 
         GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices("logs-foobar")).actionGet();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/DataStreamIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/DataStreamIT.java
@@ -22,7 +22,7 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -81,8 +81,8 @@ public class DataStreamIT extends ESIntegTestCase {
         createDataStreamRequest.setTimestampFieldName("@timestamp2");
         client().admin().indices().createDataStream(createDataStreamRequest).get();
 
-        GetDataStreamsAction.Request getDataStreamRequest = new GetDataStreamsAction.Request("*");
-        GetDataStreamsAction.Response getDataStreamResponse = client().admin().indices().getDataStreams(getDataStreamRequest).actionGet();
+        GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request("*");
+        GetDataStreamAction.Response getDataStreamResponse = client().admin().indices().getDataStreams(getDataStreamRequest).actionGet();
         getDataStreamResponse.getDataStreams().sort(Comparator.comparing(DataStream::getName));
         assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(2));
         assertThat(getDataStreamResponse.getDataStreams().get(0).getName(), equalTo("metrics-bar"));

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -30,7 +30,7 @@ import org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingCo
 import org.elasticsearch.action.admin.cluster.configuration.TransportClearVotingConfigExclusionsAction;
 import org.elasticsearch.action.admin.indices.create.AutoCreateAction;
 import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction;
 import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
@@ -110,9 +110,6 @@ import org.elasticsearch.action.admin.indices.close.CloseIndexAction;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
-import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
-import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsAction;
@@ -607,7 +604,7 @@ public class ActionModule extends AbstractModule {
         if (DATASTREAMS_FEATURE_ENABLED) {
             actions.register(CreateDataStreamAction.INSTANCE, CreateDataStreamAction.TransportAction.class);
             actions.register(DeleteDataStreamAction.INSTANCE, DeleteDataStreamAction.TransportAction.class);
-            actions.register(GetDataStreamsAction.INSTANCE, GetDataStreamsAction.TransportAction.class);
+            actions.register(GetDataStreamAction.INSTANCE, GetDataStreamAction.TransportAction.class);
         }
 
         // Persistent tasks:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamAction.java
@@ -48,12 +48,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class GetDataStreamsAction extends ActionType<GetDataStreamsAction.Response> {
+public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response> {
 
-    public static final GetDataStreamsAction INSTANCE = new GetDataStreamsAction();
+    public static final GetDataStreamAction INSTANCE = new GetDataStreamAction();
     public static final String NAME = "indices:admin/data_stream/get";
 
-    private GetDataStreamsAction() {
+    private GetDataStreamAction() {
         super(NAME, Response::new);
     }
 

--- a/server/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -22,7 +22,7 @@ package org.elasticsearch.client;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction;
 import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
@@ -845,10 +845,10 @@ public interface IndicesAdminClient extends ElasticsearchClient {
     /**
      * Get data streams
      */
-    void getDataStreams(GetDataStreamsAction.Request request, ActionListener<GetDataStreamsAction.Response> listener);
+    void getDataStreams(GetDataStreamAction.Request request, ActionListener<GetDataStreamAction.Response> listener);
 
     /**
      * Get data streams
      */
-    ActionFuture<GetDataStreamsAction.Response> getDataStreams(GetDataStreamsAction.Request request);
+    ActionFuture<GetDataStreamAction.Response> getDataStreams(GetDataStreamAction.Request request);
 }

--- a/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -31,7 +31,7 @@ import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplai
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequestBuilder;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainResponse;
 import org.elasticsearch.action.admin.indices.datastream.DeleteDataStreamAction;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction;
 import org.elasticsearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -1767,13 +1767,13 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public void getDataStreams(GetDataStreamsAction.Request request, ActionListener<GetDataStreamsAction.Response> listener) {
-            execute(GetDataStreamsAction.INSTANCE, request, listener);
+        public void getDataStreams(GetDataStreamAction.Request request, ActionListener<GetDataStreamAction.Response> listener) {
+            execute(GetDataStreamAction.INSTANCE, request, listener);
         }
 
         @Override
-        public ActionFuture<GetDataStreamsAction.Response> getDataStreams(GetDataStreamsAction.Request request) {
-            return execute(GetDataStreamsAction.INSTANCE, request);
+        public ActionFuture<GetDataStreamAction.Response> getDataStreams(GetDataStreamAction.Request request) {
+            return execute(GetDataStreamAction.INSTANCE, request);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetDataStreamsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetDataStreamsAction.java
@@ -18,14 +18,13 @@
  */
 package org.elasticsearch.rest.action.admin.indices;
 
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 public class RestGetDataStreamsAction extends BaseRestHandler {
@@ -37,14 +36,15 @@ public class RestGetDataStreamsAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return Arrays.asList(
-            new Route(RestRequest.Method.GET, "/_data_streams"),
-            new Route(RestRequest.Method.GET, "/_data_streams/{name}"));
+        return org.elasticsearch.common.collect.List.of(
+            new Route(RestRequest.Method.GET, "/_data_stream"),
+            new Route(RestRequest.Method.GET, "/_data_stream/{name}")
+        );
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        GetDataStreamsAction.Request getDataStreamsRequest = new GetDataStreamsAction.Request(request.param("name"));
+        GetDataStreamAction.Request getDataStreamsRequest = new GetDataStreamAction.Request(request.param("name"));
         return channel -> client.admin().indices().getDataStreams(getDataStreamsRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsRequestTests.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.action.admin.indices.datastream;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction.Request;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction.Request;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.DataStreamTestHelper;
@@ -69,8 +69,8 @@ public class GetDataStreamsRequestTests extends AbstractWireSerializingTestCase<
             new DataStream(dataStreamName, "timestamp", org.elasticsearch.common.collect.List.of(idx.getIndex()));
         ClusterState cs = ClusterState.builder(new ClusterName("_name"))
             .metadata(Metadata.builder().dataStreams(Map.of(dataStreamName, existingDataStream)).build()).build();
-        GetDataStreamsAction.Request req = new GetDataStreamsAction.Request(dataStreamName);
-        List<DataStream> dataStreams = GetDataStreamsAction.TransportAction.getDataStreams(cs, req);
+        GetDataStreamAction.Request req = new GetDataStreamAction.Request(dataStreamName);
+        List<DataStream> dataStreams = GetDataStreamAction.TransportAction.getDataStreams(cs, req);
         assertThat(dataStreams.size(), equalTo(1));
         assertThat(dataStreams.get(0).getName(), equalTo(dataStreamName));
     }
@@ -87,34 +87,34 @@ public class GetDataStreamsRequestTests extends AbstractWireSerializingTestCase<
                 Map.of(dataStreamNames[0], ds1, dataStreamNames[1], ds2)).build())
             .build();
 
-        GetDataStreamsAction.Request req = new GetDataStreamsAction.Request(dataStreamNames[1].substring(0, 5) + "*");
-        List<DataStream> dataStreams = GetDataStreamsAction.TransportAction.getDataStreams(cs, req);
+        GetDataStreamAction.Request req = new GetDataStreamAction.Request(dataStreamNames[1].substring(0, 5) + "*");
+        List<DataStream> dataStreams = GetDataStreamAction.TransportAction.getDataStreams(cs, req);
         assertThat(dataStreams.size(), equalTo(1));
         assertThat(dataStreams.get(0).getName(), equalTo(dataStreamNames[1]));
 
-        req = new GetDataStreamsAction.Request("*");
-        dataStreams = GetDataStreamsAction.TransportAction.getDataStreams(cs, req);
+        req = new GetDataStreamAction.Request("*");
+        dataStreams = GetDataStreamAction.TransportAction.getDataStreams(cs, req);
         assertThat(dataStreams.size(), equalTo(2));
         assertThat(dataStreams.get(0).getName(), equalTo(dataStreamNames[1]));
         assertThat(dataStreams.get(1).getName(), equalTo(dataStreamNames[0]));
 
-        req = new GetDataStreamsAction.Request((String) null);
-        dataStreams = GetDataStreamsAction.TransportAction.getDataStreams(cs, req);
+        req = new GetDataStreamAction.Request((String) null);
+        dataStreams = GetDataStreamAction.TransportAction.getDataStreams(cs, req);
         assertThat(dataStreams.size(), equalTo(2));
         assertThat(dataStreams.get(0).getName(), equalTo(dataStreamNames[1]));
         assertThat(dataStreams.get(1).getName(), equalTo(dataStreamNames[0]));
 
-        req = new GetDataStreamsAction.Request("matches-none*");
-        dataStreams = GetDataStreamsAction.TransportAction.getDataStreams(cs, req);
+        req = new GetDataStreamAction.Request("matches-none*");
+        dataStreams = GetDataStreamAction.TransportAction.getDataStreams(cs, req);
         assertThat(dataStreams.size(), equalTo(0));
     }
 
     public void testGetNonexistentDataStream() {
         final String dataStreamName = "my-data-stream";
         ClusterState cs = ClusterState.builder(new ClusterName("_name")).build();
-        GetDataStreamsAction.Request req = new GetDataStreamsAction.Request(dataStreamName);
+        GetDataStreamAction.Request req = new GetDataStreamAction.Request(dataStreamName);
         ResourceNotFoundException e = expectThrows(ResourceNotFoundException.class,
-            () -> GetDataStreamsAction.TransportAction.getDataStreams(cs, req));
+            () -> GetDataStreamAction.TransportAction.getDataStreams(cs, req));
         assertThat(e.getMessage(), containsString("data_stream matching [" + dataStreamName + "] not found"));
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/datastream/GetDataStreamsResponseTests.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.action.admin.indices.datastream;
 
-import org.elasticsearch.action.admin.indices.datastream.GetDataStreamsAction.Response;
+import org.elasticsearch.action.admin.indices.datastream.GetDataStreamAction.Response;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTests;
 import org.elasticsearch.common.io.stream.Writeable;


### PR DESCRIPTION
Address the comment here: https://github.com/elastic/elasticsearch/pull/55557#discussion_r420377613

Relates to #53100

Backport of #56762 