### PR TITLE
Suppress cluster UUID logs in 6.8/7.x upgrade

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -505,7 +505,12 @@ public class CoordinationState {
                     metadataBuilder = Metadata.builder(lastAcceptedState.metadata());
                 }
                 metadataBuilder.clusterUUIDCommitted(true);
-                logger.info("cluster UUID set to [{}]", lastAcceptedState.metadata().clusterUUID());
+
+                if (lastAcceptedState.term() != ZEN1_BWC_TERM) {
+                    // Zen1 masters never publish a committed cluster UUID so if we logged this it'd happen on on every update. Let's just
+                    // not log it at all in a 6.8/7.x rolling upgrade.
+                    logger.info("cluster UUID set to [{}]", lastAcceptedState.metadata().clusterUUID());
+                }
             }
             if (metadataBuilder != null) {
                 setLastAcceptedState(ClusterState.builder(lastAcceptedState).metadata(metadataBuilder).build());


### PR DESCRIPTION
Today a 7.x node logs `cluster UUID set to [...]` on every cluster state update
received from a 6.8 master, because 6.8 nodes are not able to commit the
cluster UUID properly. We could try and deduplicate these logs somehow, but
that would introduce a good deal of complexity. Instead, this commit suppresses
these logs entirely when receiving cluster state updates from a 6.8 master.