### PR TITLE
SQL: Fix range of version number generation in version test

### DIFF
--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/VersionTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/VersionTests.java
@@ -46,7 +46,7 @@ public class VersionTests extends ESTestCase {
     private static byte[] randomVersion() {
         byte[] parts = new byte[3];
         for (int i = 0; i < parts.length; i ++) {
-            parts[i] = (byte) randomIntBetween(0, SqlVersion.REVISION_MULTIPLIER);
+            parts[i] = (byte) randomIntBetween(0, SqlVersion.REVISION_MULTIPLIER - 1);
         }
         return parts;
     }


### PR DESCRIPTION
The version number component can't equal or exceed the revision
multiplier.
This fixes the VersionTests unit test.

