### PR TITLE
Ensure dependency report task depends on upstream reporting tasks

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -20,6 +20,7 @@
 
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.elasticsearch.gradle.ConcatFilesTask
+import org.elasticsearch.gradle.DependenciesInfoTask
 import org.elasticsearch.gradle.MavenFilteringHack
 import org.elasticsearch.gradle.NoticeTask
 import org.elasticsearch.gradle.VersionProperties
@@ -36,6 +37,7 @@ apply plugin: 'elasticsearch.testclusters'
 
 // Concatenates the dependencies CSV files into a single file
 task generateDependenciesReport(type: ConcatFilesTask) {
+  dependsOn rootProject.allprojects.collect { it.tasks.withType(DependenciesInfoTask) }
   files = fileTree(dir: project.rootDir, include: '**/dependencies.csv')
   headerLine = "name,version,url,license,sourceURL"
   target = new File(System.getProperty('csv') ?: "${project.buildDir}/reports/dependencies/es-dependencies.csv")


### PR DESCRIPTION
When the release manager generates the dependencies report, it does so as a single execution of `./gradlew dependenciesInfo :distribution:generateDependenciesReport`. The issue with this is that the later task has no dependency, or ordering rule on the former. Couple that with parallel task execution and you run into an issue where we generate incomplete dependency reports.

This PR fixes this issue by adding the correct task dependencies here. Now running `./gradlew generateDependenciesReport` is sufficient enough to enough all individual project reports are created before concatenating them into the single master report.

cc @mgreau 

Closes https://github.com/elastic/infra/issues/20424