### PR TITLE
Shorter Path in Netty ByteBuf Unwrap (#56740)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -109,6 +109,8 @@ public class Netty4Utils {
         final int readableBytes = buffer.readableBytes();
         if (readableBytes == 0) {
             return BytesArray.EMPTY;
+        } else if (buffer.hasArray()) {
+            return new BytesArray(buffer.array(), buffer.arrayOffset() + buffer.readerIndex(), readableBytes);
         } else {
             final ByteBuffer[] byteBuffers = buffer.nioBuffers();
             return BytesReference.fromByteBuffers(byteBuffers);

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/ByteBufUtils.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/ByteBufUtils.java
@@ -66,6 +66,8 @@ class ByteBufUtils {
         final int readableBytes = buffer.readableBytes();
         if (readableBytes == 0) {
             return BytesArray.EMPTY;
+        } else if (buffer.hasArray()) {
+            return new BytesArray(buffer.array(), buffer.arrayOffset() + buffer.readerIndex(), readableBytes);
         } else {
             final ByteBuffer[] byteBuffers = buffer.nioBuffers();
             return BytesReference.fromByteBuffers(byteBuffers);


### PR DESCRIPTION
In most cases we are seeing a `PooledHeapByteBuf` here now. No need to
redundantly create an new `ByteBuffer` and single element array for it
here when we can just directly unwrap its internal `byte[]`.

backport of #56740 