### PR TITLE
Fix SnapshotStatusApisIT (#56859)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -106,9 +106,15 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> wait for data nodes to get blocked");
         waitForBlockOnAnyDataNode("test-repo", TimeValue.timeValueMinutes(1));
 
-        assertBusy(() -> assertEquals(SnapshotsInProgress.State.STARTED, client.admin().cluster().snapshotsStatus(
-            new SnapshotsStatusRequest("test-repo", new String[]{"test-snap"})).actionGet().getSnapshots().get(0).getState()), 1L,
-            TimeUnit.MINUTES);
+        assertBusy(() -> {
+            try {
+                assertEquals(SnapshotsInProgress.State.STARTED, client.admin().cluster().snapshotsStatus(
+                        new SnapshotsStatusRequest("test-repo", new String[]{"test-snap"})).actionGet().getSnapshots().get(0)
+                        .getState());
+            } catch (SnapshotMissingException sme) {
+                throw new AssertionError(sme);
+            }
+        }, 1L, TimeUnit.MINUTES);
 
         logger.info("--> unblock all data nodes");
         unblockAllDataNodes("test-repo");


### PR DESCRIPTION
In the unlikely event that the data nodes started snapshotting the
shards already (and hence got blocked on the data blobs) before the
master has applied the cluster state to its own `SnapshotsService` on
the CS applier thread, we can get a `SnapshotMissingException` here which
breaks the busy assert loop so we have to deal with it explicitly.

Closes #56858

backport of #56859 