### PR TITLE
Fix list of discovery.zen settings removed in 8.0

### DIFF
--- a/docs/reference/migration/migrate_8_0/discovery.asciidoc
+++ b/docs/reference/migration/migrate_8_0/discovery.asciidoc
@@ -17,6 +17,7 @@
 All settings under the `discovery.zen` namespace, which existed only for BWC reasons in 7.x,
 are no longer supported. In particular, this includes:
 
+- `discovery.zen.minimum_master_nodes`
 - `discovery.zen.no_master_block`
 - `discovery.zen.hosts_provider`
 - `discovery.zen.publish_timeout`
@@ -25,8 +26,8 @@ are no longer supported. In particular, this includes:
 - `discovery.zen.ping.unicast.concurrent_connects`
 - `discovery.zen.ping.unicast.hosts.resolve_timeout`
 - `discovery.zen.ping.unicast.hosts`
+- `discovery.zen.ping_timeout`
 - `discovery.zen.unsafe_rolling_upgrades_enabled`
-- `discovery.zen.commit_timeout`
 - `discovery.zen.fd.connect_on_network_disconnect`
 - `discovery.zen.fd.ping_interval`
 - `discovery.zen.fd.ping_timeout`
@@ -34,6 +35,7 @@ are no longer supported. In particular, this includes:
 - `discovery.zen.fd.register_connection_listener`
 - `discovery.zen.join_retry_attempts`
 - `discovery.zen.join_retry_delay`
+- `discovery.zen.join_timeout`
 - `discovery.zen.max_pings_from_another_master`
 - `discovery.zen.send_leave_request`
 - `discovery.zen.master_election.wait_for_joins_timeout`


### PR DESCRIPTION
In #39466 we removed all the settings in the `discovery.zen` namespace in 8.0
and documented their removal as a breaking change. Conspicuously absent from
the list of removed settings is the `discovery.zen.minimum_master_nodes`
setting, and there are two other omitted settings and a duplicated one too.
This commit fixes up these docs.