### PR TITLE
Update spotless plugin to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
   id 'lifecycle-base'
   id 'elasticsearch.docker-support'
   id 'elasticsearch.global-build-info'
-  id "com.diffplug.gradle.spotless" version "3.28.0" apply false
+  id "com.diffplug.gradle.spotless" version "4.0.0" apply false
 }
 
 apply from: 'gradle/build-scan.gradle'


### PR DESCRIPTION
This update includes a minor PR of mine (https://github.com/diffplug/spotless/pull/578) to make the suggested gradle invocation more efficient and copy&paste friendly by using the proper os specific wrapper command + the full task path to run to fix the shown issue.
