### PR TITLE
Simplify GroupedActionListener For Void Type

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -137,8 +137,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
         if (blobNames.isEmpty()) {
             result.onResponse(null);
         } else {
-            final GroupedActionListener<Void> listener =
-                new GroupedActionListener<>(ActionListener.map(result, v -> null), blobNames.size());
+            final ActionListener<Void> listener = GroupedActionListener.wrapVoid(result, blobNames.size());
             final ExecutorService executor = threadPool.executor(AzureRepositoryPlugin.REPOSITORY_THREAD_POOL_NAME);
             // Executing deletes in parallel since Azure SDK 8 is using blocking IO while Azure does not provide a bulk delete API endpoint
             // TODO: Upgrade to newer non-blocking Azure SDK 11 and execute delete requests in parallel that way.

--- a/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -106,8 +106,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
             return;
         }
 
-        final GroupedActionListener<Void> listener
-            = new GroupedActionListener<>(ActionListener.wrap(onCompletion), discoveryNodes.getSize());
+        final ActionListener<Void> listener = GroupedActionListener.wrapVoid(ActionListener.wrap(onCompletion), discoveryNodes.getSize());
 
         final List<Runnable> runnables = new ArrayList<>(discoveryNodes.getSize());
         synchronized (mutex) {
@@ -172,7 +171,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
             if (connectionTargets.isEmpty()) {
                 runnables.add(onCompletion);
             } else {
-                final GroupedActionListener<Void> listener = new GroupedActionListener<>(
+                final ActionListener<Void> listener = GroupedActionListener.wrapVoid(
                     ActionListener.wrap(onCompletion), connectionTargets.size());
                 for (final ConnectionTarget connectionTarget : connectionTargets) {
                     runnables.add(connectionTarget.awaitCurrentActivity(listener));
@@ -195,7 +194,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
                 runnables.add(onCompletion);
             } else {
                 logger.trace("connectDisconnectedTargets: {}", targetsByNode);
-                final GroupedActionListener<Void> listener = new GroupedActionListener<>(
+                final ActionListener<Void> listener = GroupedActionListener.wrapVoid(
                     ActionListener.wrap(onCompletion), connectionTargets.size());
                 for (final ConnectionTarget connectionTarget : connectionTargets) {
                     runnables.add(connectionTarget.ensureConnected(listener));

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -224,7 +224,7 @@ public class DiskThresholdMonitor {
             }
         }
 
-        final ActionListener<Void> listener = new GroupedActionListener<>(ActionListener.wrap(this::checkFinished), 3);
+        final ActionListener<Void> listener = GroupedActionListener.wrapVoid(ActionListener.wrap(this::checkFinished), 3);
 
         if (reroute) {
             logger.debug("rerouting shards: [{}]", explanation);

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -297,14 +297,14 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
      */
     void initializeRemoteClusters() {
         final TimeValue timeValue = REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING.get(settings);
-        final PlainActionFuture<Collection<Void>> future = new PlainActionFuture<>();
+        final PlainActionFuture<Void> future = new PlainActionFuture<>();
         Set<String> enabledClusters = RemoteClusterAware.getEnabledRemoteClusters(settings);
 
         if (enabledClusters.isEmpty()) {
             return;
         }
 
-        GroupedActionListener<Void> listener = new GroupedActionListener<>(future, enabledClusters.size());
+        ActionListener<Void> listener = GroupedActionListener.wrapVoid(future, enabledClusters.size());
         for (String clusterAlias : enabledClusters) {
             updateRemoteCluster(clusterAlias, settings, listener);
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -377,8 +377,8 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                     assert input instanceof CachedBlobContainerIndexInput : "expected cached index input but got " + input.getClass();
 
                     final int numberOfParts = Math.toIntExact(file.numberOfParts());
-                    final GroupedActionListener<Void> listener = new GroupedActionListener<>(
-                        ActionListener.wrap(voids -> input.close(), e -> IOUtils.closeWhileHandlingException(input)),
+                    final ActionListener<Void> listener = GroupedActionListener.wrapVoid(
+                        ActionListener.wrap(v -> input.close(), e -> IOUtils.closeWhileHandlingException(input)),
                         numberOfParts
                     );
 


### PR DESCRIPTION
Optimizing this a little so we don't have to create large redundant `AtomicReferenceArray`
when we don't need it and get rid of the confusing `ActionListener.map` calls that just map
collections of `Void` to to `null` in some places.

Mainly motivated by less bothersome construction and the `AzureBlobContainer` where we could conceivably deal with millions of blobs to delete and saving the `Object[]`s of that size might be worthwhile.