### PR TITLE
[DOCS] Fix default for `http.compression` setting

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -48,7 +48,7 @@ to `4kb`
 
 
 |`http.compression` |Support for compression when possible (with
-Accept-Encoding). Defaults to `true`.
+Accept-Encoding). Defaults to `true`. Please be aware if HTTPS is enabled, compression will be disabled (set to `false`) to mitigate potential security risks like the BREACH attack. If you want to enforce compress HTTPS traffic, please explicitly set this to `true`.
 
 |`http.compression_level` |Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression)
 and 9 (maximum compression). Defaults to `3`.

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -48,7 +48,12 @@ to `4kb`
 
 
 |`http.compression` |Support for compression when possible (with
-Accept-Encoding). Defaults to `true`. Please be aware if HTTPS is enabled, compression will be disabled (set to `false`) to mitigate potential security risks like the BREACH attack. If you want to enforce compress HTTPS traffic, please explicitly set this to `true`.
+Accept-Encoding). If HTTPS is enabled, defaults to `false`. Otherwise, defaults
+to `true`.
+
+Disabling compression for HTTPS mitigates potential security risks, such as a
+https://en.wikipedia.org/wiki/BREACH[BREACH attack]. To compress HTTPS traffic,
+you must explicitly set `http.compression` to `true`.
 
 |`http.compression_level` |Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression)
 and 9 (maximum compression). Defaults to `3`.


### PR DESCRIPTION
Elasticsearch enables HTTP compression by default now. However, to mitigate potential security risks like the BREACH attack, X-Pack security disables compression if HTTPS is enabled. <-- This is not clear from the doc, hence adding some more details here.
See https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityHttpSettings.java#L19 and https://www.elastic.co/guide/en/x-pack/5.4/xpack-change-list.html#breaking-5.0.0 for more details.

