### PR TITLE
Random iterations in testDataOnlyNodePersistence

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -395,7 +395,8 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             // generate a series of updates and check if batching works
             final String indexName = randomAlphaOfLength(10);
             long currentTerm = state.term();
-            for (int i = 0; i < 1000; i++) {
+            final int iterations = randomIntBetween(1, 1000);
+            for (int i = 0; i < iterations; i++) {
                 if (rarely()) {
                     // bump term
                     currentTerm = currentTerm + (rarely() ? randomIntBetween(1, 5) : 0L);


### PR DESCRIPTION
PR #56893 was supposed to randomise the iteration count in
`testDataOnlyNodePersistence` but this change was mistakenly omitted. This
commit addresses this.