### PR TITLE
Remove Dead Conditional from RoutingTable (#56870)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -477,13 +477,8 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                         builder.addReplica();
                     }
                 } else if (currentNumberOfReplicas > numberOfReplicas) {
-                    int delta = currentNumberOfReplicas - numberOfReplicas;
-                    if (delta <= 0) {
-                        // ignore, can't remove below the current one...
-                    } else {
-                        for (int i = 0; i < delta; i++) {
-                            builder.removeReplica();
-                        }
+                    for (int i = 0; i < (currentNumberOfReplicas - numberOfReplicas); i++) {
+                        builder.removeReplica();
                     }
                 }
                 indicesRouting.put(index, builder.build());


### PR DESCRIPTION
`delta` is always positive here.

backport of #56870 