### PR TITLE
[DOCS] Document `dynamic` and `static` setting types

### DIFF
--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -40,9 +40,6 @@ the setting is the same on all nodes. If, on the other hand, you define differen
 settings on different nodes by accident using the configuration file, it is very
 difficult to notice these discrepancies.
 
-You can find the list of settings that you can dynamically update in 
-<<modules,Modules>>.
-
 
 [[cluster-update-settings-api-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -78,3 +78,24 @@ variable, for instance:
 node.name:    ${HOSTNAME}
 network.host: ${ES_NETWORK_HOST}
 --------------------------------------------------
+
+[discrete]
+[[cluster-setting-types]]
+=== Cluster and node setting types
+
+Cluster and node settings can be categorized based on how they are configured:
+
+[[dynamic-cluster-setting]]
+Dynamic::
+You can configure and update dynamic settings on a running cluster using the
+<<cluster-update-settings,cluster update settings API>>. 
++
+You can also configure dynamic settings on an unstarted or shut down node using
+`elasticsearch.yml`, an environment variable, or the command line.
+
+[[static-cluster-setting]]
+Static::
+Static settings can only be configured on an unstarted or shut down node using
+`elasticsearch.yml`, an environment variable, or the command line.
++
+Static settings must be set on every relevant node in the cluster.

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -90,12 +90,18 @@ Dynamic::
 You can configure and update dynamic settings on a running cluster using the
 <<cluster-update-settings,cluster update settings API>>. 
 +
-You can also configure dynamic settings on an unstarted or shut down node using
-`elasticsearch.yml`, an environment variable, or the command line.
+You can also configure dynamic settings locally on an unstarted or shut down
+node using `elasticsearch.yml`.
++
+TIP: It’s best to set dynamic, cluster-wide settings with the cluster update
+settings API and use `elasticsearch.yml` only for local configurations. Using
+the cluster update settings API ensures the setting is the same on all nodes. If
+you accidentally configure different settings in `elasticsearch.yml` on
+different nodes, it can be difficult to notice discrepancies.
 
 [[static-cluster-setting]]
 Static::
 Static settings can only be configured on an unstarted or shut down node using
-`elasticsearch.yml`, an environment variable, or the command line.
+`elasticsearch.yml`.
 +
 Static settings must be set on every relevant node in the cluster.


### PR DESCRIPTION
Documents the `dynamic` and `static`  types for
cluster and node settings.

This documentation was previously housed in the
removed [Modules](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules.html) page.