### PR TITLE
[DOCS] Remove outdated links for `similarity` mapping param args

### DIFF
--- a/docs/reference/mapping/params/similarity.asciidoc
+++ b/docs/reference/mapping/params/similarity.asciidoc
@@ -16,14 +16,13 @@ The only similarities which can be used out of the box, without any further
 configuration are:
 
 `BM25`::
-        The Okapi BM25 algorithm. The algorithm used by default in Elasticsearch and Lucene.
-        See {defguide}/pluggable-similarites.html[Pluggable Similarity Algorithms]
-        for more information.
+The https://en.wikipedia.org/wiki/Okapi_BM25[Okapi BM25 algorithm]. The
+algorithm used by default in {es} and Lucene.
 
 `classic`::
-        The TF/IDF algorithm which used to be the default in Elasticsearch and
-        Lucene. See {defguide}/practical-scoring-function.html[Lucene’s Practical Scoring Function]
-        for more information.
+deprecated:[7.0.0]
+The https://en.wikipedia.org/wiki/Tf%E2%80%93idf[TF/IDF algorithm], the former
+default in {es} and Lucene.
 
 `boolean`::
         A simple boolean similarity, which is used when full-text ranking is not needed


### PR DESCRIPTION
Changes:

* Removes outdated links to the Elasticsearch Definitive Guide. The
  guide hasn't been updated since 2.x.
* Add Wikipedia links for the Okapi BM25 and TF/IDF algorithms.
* Adds a deprecated tag to the `classic` arg.
  The `classic` arg was deprecated with #29187.

Opening the initial PR on `7.x`, as that's the latest branch with docs
for the `classic` arg. However, I plan to backport to `master` and
other maintained branches.

Fixes #56912