### PR TITLE
Allow field mappers to retrieve fields from source.

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeatureFieldMapper.java
@@ -185,11 +185,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
         float value;
         if (context.externalValueSet()) {
             Object v = context.externalValue();
-            if (v instanceof Number) {
-                value = ((Number) v).floatValue();
-            } else {
-                value = Float.parseFloat(v.toString());
-            }
+            value = objectToFloat(v);
         } else if (context.parser().currentToken() == Token.VALUE_NULL) {
             // skip
             return;
@@ -207,6 +203,19 @@ public class RankFeatureFieldMapper extends FieldMapper {
         }
 
         context.doc().addWithKey(name(), new FeatureField("_feature", name(), value));
+    }
+
+    private Float objectToFloat(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).floatValue();
+        } else {
+            return Float.parseFloat(value.toString());
+        }
+    }
+
+    @Override
+    protected Float parseSourceValue(Object value) {
+        return objectToFloat(value);
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RankFeaturesFieldMapper.java
@@ -176,6 +176,11 @@ public class RankFeaturesFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -499,6 +499,13 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         return doubleValue;
     }
 
+    @Override
+    protected Double parseSourceValue(Object value) {
+        double doubleValue = objectToDouble(value);
+        double scalingFactor = fieldType().getScalingFactor();
+        return Math.round(doubleValue * scalingFactor) / scalingFactor;
+    }
+
     private static class ScaledFloatIndexFieldData implements IndexNumericFieldData {
 
         private final IndexNumericFieldData scaledFieldData;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -676,7 +676,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
+    protected String parseSourceValue(Object value) {
         return value.toString();
     }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/SearchAsYouTypeFieldMapper.java
@@ -474,6 +474,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
         }
@@ -508,6 +513,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         @Override
         protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
+        }
+
+        @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -663,6 +673,11 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         if (fieldType().omitNorms()) {
             createFieldNamesField(context);
         }
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -151,8 +151,8 @@ public class TokenCountFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
-        return value;
+    protected String parseSourceValue(Object value) {
+        return value.toString();
     }
 
     /**

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -150,6 +150,11 @@ public class TokenCountFieldMapper extends FieldMapper {
         context.doc().addAll(NumberFieldMapper.NumberType.INTEGER.createFields(fieldType().name(), tokenCount, indexed, docValued, stored));
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     /**
      * Count position increments in a token stream.  Package private for testing.
      * @param analyzer analyzer to create token stream

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/RankFeatureFieldMapperTests.java
@@ -23,9 +23,12 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
 import org.apache.lucene.document.FeatureField;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
@@ -180,4 +183,12 @@ public class RankFeatureFieldMapperTests extends FieldMapperTestCase<RankFeature
                 e.getCause().getMessage());
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        RankFeatureFieldMapper mapper = new RankFeatureFieldMapper.Builder("field").build(context);
+
+        assertEquals(3.14f, mapper.parseSourceValue(3.14), 0.0001);
+        assertEquals(42.9f, mapper.parseSourceValue("42.9"), 0.0001);
+    }
 }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -21,9 +21,12 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
@@ -391,5 +394,16 @@ public class ScaledFloatFieldMapperTests extends FieldMapperTestCase<ScaledFloat
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        ScaledFloatFieldMapper mapper = new ScaledFloatFieldMapper.Builder("field")
+            .scalingFactor(100)
+            .build(context);
+
+        assertEquals(3.14, mapper.parseSourceValue(3.1415926), 0.00001);
+        assertEquals(3.14, mapper.parseSourceValue("3.1415"), 0.00001);
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -154,6 +154,11 @@ public class MetaJoinFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -198,6 +198,11 @@ public final class ParentIdFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
         ParentIdFieldMapper parentMergeWith = (ParentIdFieldMapper) other;
         this.children = parentMergeWith.children;

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -368,6 +368,11 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     public void parse(ParseContext context) throws IOException {
         context.path().add(simpleName());
         XContentParser.Token token = context.parser().currentToken();

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -389,6 +389,11 @@ public class PercolatorFieldMapper extends FieldMapper {
         processQuery(query, context);
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     static void createQueryBuilderField(Version indexVersion, BinaryFieldMapper qbField,
                                         QueryBuilder queryBuilder, ParseContext context) throws IOException {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -752,7 +752,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
+    protected String parseSourceValue(Object value) {
         return value.toString();
     }
 }

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -750,4 +750,9 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
             createFieldNamesField(context);
         }
     }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
+    }
 }

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
@@ -26,9 +26,12 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
@@ -477,4 +480,13 @@ public class ICUCollationKeywordFieldMapperTests extends FieldMapperTestCase<ICU
         indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        ICUCollationKeywordFieldMapper mapper = new ICUCollationKeywordFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
+    }
 }

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -600,7 +600,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
+    protected String parseSourceValue(Object value) {
         return value.toString();
     }
 

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -600,6 +600,11 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
+    }
+
+    @Override
     protected String contentType() {
         return CONTENT_TYPE;
     }

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -28,10 +28,12 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.termvectors.TermVectorsRequest;
 import org.elasticsearch.action.termvectors.TermVectorsResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -44,8 +46,10 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -672,4 +676,17 @@ public class AnnotatedTextFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        AnnotatedTextFieldMapper mapper = new AnnotatedTextFieldMapper.Builder("field")
+            .indexAnalyzer(indexService.getIndexAnalyzers().getDefaultIndexAnalyzer())
+            .searchAnalyzer(indexService.getIndexAnalyzers().getDefaultSearchAnalyzer())
+            .searchQuoteAnalyzer(indexService.getIndexAnalyzers().getDefaultSearchQuoteAnalyzer())
+            .build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
+    }
 }

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -171,8 +171,8 @@ public class Murmur3FieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
-        return value;
+    protected String parseSourceValue(Object value) {
+        return value.toString();
     }
 
     @Override

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -171,8 +171,12 @@ public class Murmur3FieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
     }
-
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -21,7 +21,7 @@ setup:
         index:  test
         id:     1
         body:
-          keyword: [ "first", "second" ]
+          keyword: [ "x", "y" ]
           integer_range:
             gte: 0
             lte: 42
@@ -39,8 +39,8 @@ setup:
   - is_true: hits.hits.0._id
   - is_true: hits.hits.0._source
 
-  - match: { hits.hits.0.fields.keyword.0: first }
-  - match: { hits.hits.0.fields.keyword.1: second }
+  - match: { hits.hits.0.fields.keyword.0: x }
+  - match: { hits.hits.0.fields.keyword.1: y }
 
   - match: { hits.hits.0.fields.integer_range.0.gte: 0 }
   - match: { hits.hits.0.fields.integer_range.0.lte: 42 }
@@ -65,7 +65,7 @@ setup:
         index:  test
         id:     1
         body:
-          keyword: [ "value" ]
+          keyword: [ "x" ]
 
   - do:
       catch: bad_request
@@ -76,3 +76,49 @@ setup:
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
   - match: { error.root_cause.0.reason: "Unable to retrieve the requested [fields] since _source is disabled
         in the mappings for index [test]" }
+
+---
+"Test ignore malformed":
+  - do:
+      indices.create:
+        index:  test
+        body:
+          settings:
+            number_of_shards: 1
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+              integer:
+                type: integer
+                ignore_malformed: true
+
+  - do:
+      index:
+        index:  test
+        id:     1
+        body:
+          keyword: "x"
+          integer: 42
+
+  - do:
+      index:
+        index:  test
+        id:     2
+        body:
+          keyword: "y"
+          integer: "not an integer"
+
+  - do:
+      indices.refresh:
+        index: [ test ]
+
+  - do:
+      search:
+        index: test
+        body:
+          sort: [ keyword ]
+          fields: [ integer ]
+
+  - match: { hits.hits.0.fields.integer.0: 42 }
+  - is_false: hits.hits.1.fields.integer

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -384,4 +384,17 @@ public class InetAddresses {
             throw new IllegalArgumentException("Expected [ip/prefix] but was [" + maskedAddress + "]");
         }
     }
+
+    /**
+     * Given an address and prefix length, returns the string representation of the range in CIDR notation.
+     *
+     * See {@link #toAddrString} for details on how the address is represented.
+     */
+    public static String toCidrString(InetAddress address, int prefixLength) {
+        return new StringBuilder()
+            .append(toAddrString(address))
+            .append("/")
+            .append(prefixLength)
+            .toString();
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -158,6 +158,11 @@ public abstract class AbstractGeometryFieldMapper<Parsed, Processed> extends Fie
         protected abstract void setGeometryQueryBuilder(FT fieldType);
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract static class TypeParser<T extends Builder> implements Mapper.TypeParser {
         protected abstract T newBuilder(String name, Map<String, Object> params);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -196,7 +196,11 @@ public class BinaryFieldMapper extends FieldMapper {
             // no doc values
             createFieldNamesField(context);
         }
+    }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -255,6 +256,16 @@ public class BooleanFieldMapper extends FieldMapper {
             context.doc().add(new SortedNumericDocValuesField(fieldType().name(), value ? 1 : 0));
         } else {
             createFieldNamesField(context);
+        }
+    }
+
+    @Override
+    public Boolean parseSourceValue(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        } else {
+            String textValue = value.toString();
+            return Booleans.parseBoolean(textValue.toCharArray(), 0, textValue.length(), false);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -602,6 +602,15 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         }
     }
 
+    @Override
+    protected List<?> parseSourceValue(Object value) {
+        if (value instanceof List) {
+            return (List<?>) value;
+        } else {
+            return List.of(value);
+        }
+    }
+
     static class CompletionInputMetadata {
         public final String input;
         public final Map<String, Set<String>> contexts;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -61,6 +61,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -634,9 +635,12 @@ public final class DateFieldMapper extends FieldMapper {
     }
 
     @Override
-    public Long parseSourceValue(Object value) {
+    public String parseSourceValue(Object value) {
         String date = value.toString();
-        return fieldType().parse(date);
+        long timestamp = fieldType().parse(date);
+
+        ZonedDateTime dateTime = fieldType().resolution().toInstant(timestamp).atZone(ZoneOffset.UTC);
+        return fieldType().dateTimeFormatter().format(dateTime);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -361,6 +361,7 @@ public final class DateFieldMapper extends FieldMapper {
             return dateMathParser;
         }
 
+        // Visible for testing.
         public long parse(String value) {
             return resolution.convert(DateFormatters.from(dateTimeFormatter().parse(value)).toInstant());
         }
@@ -630,6 +631,12 @@ public final class DateFieldMapper extends FieldMapper {
         if (fieldType().stored()) {
             context.doc().add(new StoredField(fieldType().name(), timestamp));
         }
+    }
+
+    @Override
+    public Long parseSourceValue(Object value) {
+        String date = value.toString();
+        return fieldType().parse(date);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.index.similarity.SimilarityService;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -309,6 +310,47 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
      * current failing token
      */
     protected abstract void parseCreateField(ParseContext context) throws IOException;
+
+    /**
+     * Given access to a document's _source, return this field's values.
+     *
+     * In addition to pulling out the values, mappers can parse them into a standard form. This
+     * method delegates parsing to {@link #parseSourceValue} for parsing. Most mappers will choose
+     * to override {@link #parseSourceValue} -- for example numeric field mappers make sure to
+     * parse the  source value into a number of the right type.
+     *
+     * Some mappers may need more flexibility and can override this entire method instead.
+     *
+     * @param lookup a lookup structure over the document's source.
+     * @return a list a standardized field values.
+     */
+    public List<?> lookupValues(SourceLookup lookup) {
+        Object sourceValue = lookup.extractValue(name());
+        if (sourceValue == null) {
+            return List.of();
+        }
+
+        List<Object> values = new ArrayList<>();
+        if (this instanceof ArrayValueMapperParser) {
+            return (List<?>) parseSourceValue(sourceValue);
+        } else {
+            List<?> sourceValues = sourceValue instanceof List ? (List<?>) sourceValue : List.of(sourceValue);
+            for (Object value : sourceValues) {
+                Object parsedValue = parseSourceValue(value);
+                values.add(parsedValue);
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Given a value that has been extracted from a document's source, parse it into a standard
+     * format. This parsing logic should closely mirror the value parsing in
+     * {@link #parseCreateField} or {@link #parse}.
+     *
+     * Note that when overriding this method, {@link #lookupValues} should *not* be overridden.
+     */
+    protected abstract Object parseSourceValue(Object value);
 
     protected void createFieldNamesField(ParseContext context) {
         FieldNamesFieldType fieldNamesFieldType = context.docMapper().metadataMapper(FieldNamesFieldMapper.class).fieldType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -398,8 +398,9 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
-        return value;
+    protected String parseSourceValue(Object value) {
+        InetAddress address = InetAddresses.forString(value.toString());
+        return InetAddresses.toAddrString(address);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -398,6 +398,11 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
         IpFieldMapper mergeWith = (IpFieldMapper) other;
         if (mergeWith.ignoreMalformed.explicit()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -187,6 +187,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
+    }
+
     public static final class KeywordFieldType extends StringFieldType {
 
         private NamedAnalyzer normalizer = null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -188,7 +188,7 @@ public final class KeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
+    protected String parseSourceValue(Object value) {
         return value.toString();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -71,5 +71,10 @@ public abstract class MetadataFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("The " + typeName() + " field is not stored in _source.");
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) { }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1094,6 +1094,11 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Number parseSourceValue(Object value) {
+        return fieldType().type.parse(value, coerce.value());
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
         NumberFieldMapper m = (NumberFieldMapper) other;
         if (fieldType().type != m.fieldType().type) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -52,6 +52,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -400,6 +401,23 @@ public class RangeFieldMapper extends FieldMapper {
         if (docValued == false && (indexed || stored)) {
             createFieldNamesField(context);
         }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Object parseSourceValue(Object value) {
+        RangeType rangeType = fieldType().rangeType();
+        if (rangeType == RangeType.IP) {
+            return value;
+        }
+
+        Map<String, Object> range = (Map<String, Object>) value;
+        Map<String, Object> parsedRange = new HashMap<>();
+        for (Map.Entry<String, Object> entry : range.entrySet()) {
+            Object parsedValue = rangeType.parseValue(entry.getValue(), coerce.value(), fieldType().dateMathParser);
+            parsedRange.put(entry.getKey(), parsedValue);
+        }
+        return parsedRange;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -50,8 +50,10 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -415,6 +417,13 @@ public class RangeFieldMapper extends FieldMapper {
         Map<String, Object> parsedRange = new HashMap<>();
         for (Map.Entry<String, Object> entry : range.entrySet()) {
             Object parsedValue = rangeType.parseValue(entry.getValue(), coerce.value(), fieldType().dateMathParser);
+
+            if (rangeType == RangeType.DATE) {
+                long timestamp = (long) parsedValue;
+                ZonedDateTime dateTime = Instant.ofEpochMilli(timestamp).atZone(ZoneOffset.UTC);
+                parsedValue = fieldType().dateTimeFormatter().format(dateTime);
+            }
+
             parsedRange.put(entry.getKey(), parsedValue);
         }
         return parsedRange;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
@@ -184,7 +184,7 @@ public enum RangeType {
         }
 
         @Override
-        public Number parseValue(Object dateStr, boolean coerce, @Nullable DateMathParser dateMathParser) {
+        public Long parseValue(Object dateStr, boolean coerce, @Nullable DateMathParser dateMathParser) {
             assert dateMathParser != null;
             return dateMathParser.parse(dateStr.toString(), () -> {
                 throw new IllegalArgumentException("now is not used at indexing time");

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -839,7 +839,7 @@ public class TextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
+    protected String parseSourceValue(Object value) {
         return value.toString();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -480,6 +480,11 @@ public class TextFieldMapper extends FieldMapper {
         }
 
         @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
         }
@@ -502,6 +507,11 @@ public class TextFieldMapper extends FieldMapper {
 
         @Override
         protected void parseCreateField(ParseContext context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Object parseSourceValue(Object value) {
             throw new UnsupportedOperationException();
         }
 
@@ -826,6 +836,11 @@ public class TextFieldMapper extends FieldMapper {
                 context.doc().add(new Field(phraseFieldMapper.fieldType.name(), value, phraseFieldMapper.fieldType));
             }
         }
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value.toString();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -23,12 +23,15 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A fetch sub-phase for high-level field retrieval. Given a list of fields, it
@@ -59,8 +62,22 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             LeafReaderContext readerContext = context.searcher().getIndexReader().leaves().get(readerIndex);
             sourceLookup.setSegmentAndDocument(readerContext, hit.docId());
 
-            Map<String, DocumentField> fieldValues = fieldValueRetriever.retrieve(sourceLookup);
+            Set<String> ignoredFields = getIgnoredFields(hit);
+            Map<String, DocumentField> fieldValues = fieldValueRetriever.retrieve(sourceLookup, ignoredFields);
             hit.fields(fieldValues);
         }
+    }
+
+    private Set<String> getIgnoredFields(SearchHit hit) {
+        DocumentField field = hit.field(IgnoredFieldMapper.NAME);
+        if (field == null) {
+            return Set.of();
+        }
+
+        Set<String> ignoredFields = new HashSet<>();
+        for (Object value : field.getValues()) {
+            ignoredFields.add((String) value);
+        }
+        return ignoredFields;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -132,6 +132,14 @@ public class SourceLookup implements Map<String, Object> {
         return XContentMapValues.extractRawValues(path, loadSourceIfNeeded());
     }
 
+    /**
+     * For the provided path, return its value in the source. Note that in contrast with
+     * {@link SourceLookup#extractRawValues}, array and object values can be returned.
+     */
+    public Object extractValue(String path) {
+        return XContentMapValues.extractValue(path, loadSourceIfNeeded());
+    }
+
     public Object filter(FetchSourceContext context) {
         return context.getFilter().apply(loadSourceIfNeeded());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -30,9 +30,12 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -280,9 +283,18 @@ public class BooleanFieldMapperTests extends FieldMapperTestCase<BooleanFieldMap
         assertEquals(mapping3, mapper.mappingSource().toString());
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        BooleanFieldMapper mapper = new BooleanFieldMapper.Builder("field").build(context);
+
+        assertTrue(mapper.parseSourceValue(true));
+        assertFalse(mapper.parseSourceValue("false"));
+        assertFalse(mapper.parseSourceValue(""));
+    }
+
     @Override
     protected BooleanFieldMapper.Builder newBuilder() {
         return new BooleanFieldMapper.Builder("boolean");
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -31,6 +31,8 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -53,6 +55,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -948,6 +951,20 @@ public class CompletionFieldMapperTests extends FieldMapperTestCase<CompletionFi
         assertTrue(e.getMessage(),
             e.getMessage().contains("Limit of completion field contexts [" +
                 CompletionFieldMapper.COMPLETION_CONTEXTS_LIMIT + "] has been exceeded"));
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        CompletionFieldMapper mapper = new CompletionFieldMapper.Builder("field").build(context);
+
+        assertEquals(List.of("value"), mapper.parseSourceValue("value"));
+
+        List<String> list = List.of("first", "second");
+        assertEquals(list, mapper.parseSourceValue(list));
+
+        Map<String, Object> object = Map.of("input", List.of("first", "second"), "weight", "2.718");
+        assertEquals(List.of(object), mapper.parseSourceValue(object));
     }
 
     private Matcher<IndexableField> suggestField(String value) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -21,10 +21,13 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.JavaVersion;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -457,4 +460,34 @@ public class DateFieldMapperTests extends FieldMapperTestCase<DateFieldMapper.Bu
         assertEquals(mapping3, mapper.mappingSource().toString());
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        DateFieldMapper mapper = new DateFieldMapper.Builder("field").build(context);
+        assertEquals(1589578382000L, (long) mapper.parseSourceValue(1589578382000L));
+        assertEquals(1589578382000L, (long) mapper.parseSourceValue("2020-05-15T21:33:02+00:00"));
+
+        DateFieldMapper mapperWithFormat = new DateFieldMapper.Builder("field")
+            .format("yyyy/MM/dd")
+            .build(context);
+        assertEquals(662428800000L, (long) mapperWithFormat.parseSourceValue("1990/12/29"));
+    }
+
+    public void testParseSourceValueNanos() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        DateFieldMapper mapper = new DateFieldMapper.Builder("field")
+            .withResolution(DateFieldMapper.Resolution.NANOSECONDS)
+            .build(context);
+        assertEquals(1589578382000000000L, (long) mapper.parseSourceValue(1589578382000L));
+        assertEquals(1589578382123456789L, (long) mapper.parseSourceValue("2020-05-15T21:33:02.123456789"));
+
+        DateFieldMapper mapperWithFormat = new DateFieldMapper.Builder("field")
+            .withResolution(DateFieldMapper.Resolution.NANOSECONDS)
+            .format("yyyy/MM/dd")
+            .build(context);
+        assertEquals(662428800000000000L, (long) mapperWithFormat.parseSourceValue("1990/12/29"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -465,13 +465,23 @@ public class DateFieldMapperTests extends FieldMapperTestCase<DateFieldMapper.Bu
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         DateFieldMapper mapper = new DateFieldMapper.Builder("field").build(context);
-        assertEquals(1589578382000L, (long) mapper.parseSourceValue(1589578382000L));
-        assertEquals(1589578382000L, (long) mapper.parseSourceValue("2020-05-15T21:33:02+00:00"));
+        String date = "2020-05-15T21:33:02.000Z";
+        assertEquals(date, mapper.parseSourceValue(date));
+        assertEquals(date, mapper.parseSourceValue(1589578382000L));
 
         DateFieldMapper mapperWithFormat = new DateFieldMapper.Builder("field")
-            .format("yyyy/MM/dd")
+            .format("yyyy/MM/dd||epoch_millis")
             .build(context);
-        assertEquals(662428800000L, (long) mapperWithFormat.parseSourceValue("1990/12/29"));
+        String dateInFormat = "1990/12/29";
+        assertEquals(dateInFormat, mapperWithFormat.parseSourceValue(dateInFormat));
+        assertEquals(dateInFormat, mapperWithFormat.parseSourceValue(662428800000L));
+
+        DateFieldMapper mapperWithMillis = new DateFieldMapper.Builder("field")
+            .format("epoch_millis")
+            .build(context);
+        String dateInMillis = "662428800000";
+        assertEquals(dateInMillis, mapperWithMillis.parseSourceValue(dateInMillis));
+        assertEquals(dateInMillis, mapperWithMillis.parseSourceValue(662428800000L));
     }
 
     public void testParseSourceValueNanos() {
@@ -479,15 +489,11 @@ public class DateFieldMapperTests extends FieldMapperTestCase<DateFieldMapper.Bu
         Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
 
         DateFieldMapper mapper = new DateFieldMapper.Builder("field")
+            .format("strict_date_time||epoch_millis")
             .withResolution(DateFieldMapper.Resolution.NANOSECONDS)
             .build(context);
-        assertEquals(1589578382000000000L, (long) mapper.parseSourceValue(1589578382000L));
-        assertEquals(1589578382123456789L, (long) mapper.parseSourceValue("2020-05-15T21:33:02.123456789"));
-
-        DateFieldMapper mapperWithFormat = new DateFieldMapper.Builder("field")
-            .withResolution(DateFieldMapper.Resolution.NANOSECONDS)
-            .format("yyyy/MM/dd")
-            .build(context);
-        assertEquals(662428800000000000L, (long) mapperWithFormat.parseSourceValue("1990/12/29"));
+        String date = "2020-05-15T21:33:02.123456789Z";
+        assertEquals("2020-05-15T21:33:02.123456789Z", mapper.parseSourceValue(date));
+        assertEquals("2020-05-15T21:33:02.123Z", mapper.parseSourceValue(1589578382123L));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -116,6 +116,11 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         }
 
         @Override
+        protected Object parseSourceValue(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -204,6 +204,11 @@ public class ExternalMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     public Iterator<Mapper> iterator() {
         return Iterators.concat(super.iterator(), Arrays.asList(binMapper, boolMapper, pointMapper, shapeMapper, stringMapper).iterator());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -142,6 +142,11 @@ public class FakeStringFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -142,8 +142,8 @@ public class FakeStringFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
-        return value;
+    protected String parseSourceValue(Object value) {
+        return value.toString();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -23,10 +23,13 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -277,5 +280,15 @@ public class IpFieldMapperTests extends ESSingleNodeTestCase {
             () -> parser.parse("type", new CompressedXContent(mapping))
         );
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        IpFieldMapper mapper = new IpFieldMapper.Builder("field").build(context);
+
+        assertEquals("2001:db8::2:1", mapper.parseSourceValue("2001:db8::2:1"));
+        assertEquals("2001:db8::2:1", mapper.parseSourceValue("2001:db8:0:0:0:0:2:1"));
+        assertEquals("::1", mapper.parseSourceValue("0:0:0:0:0:0:0:1"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -26,6 +26,8 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -141,6 +143,9 @@ public class KeywordFieldMapperTests extends FieldMapperTestCase<KeywordFieldMap
 
         // used by TermVectorsService
         assertArrayEquals(new String[] { "1234" }, TermVectorsService.getValues(doc.rootDoc().getFields("field")));
+
+        FieldMapper fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        assertEquals("1234", fieldMapper.parseSourceValue("1234"));
     }
 
     public void testIgnoreAbove() throws IOException {
@@ -594,5 +599,15 @@ public class KeywordFieldMapperTests extends FieldMapperTestCase<KeywordFieldMap
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        KeywordFieldMapper mapper = new KeywordFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -22,9 +22,12 @@ package org.elasticsearch.index.mapper;
 import com.carrotsearch.randomizedtesting.annotations.Timeout;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -390,6 +393,15 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase<N
             );
             assertThat(e.getMessage(), containsString("name cannot be empty string"));
         }
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        NumberFieldMapper mapper = new NumberFieldMapper.Builder("field", NumberType.INTEGER).build(context);
+
+        assertEquals(3, mapper.parseSourceValue(3.14));
+        assertEquals(42, mapper.parseSourceValue("42.9"));
     }
 
     @Timeout(millis = 30000)

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -22,10 +22,13 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -40,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.index.query.RangeQueryBuilder.GTE_FIELD;
 import static org.elasticsearch.index.query.RangeQueryBuilder.GT_FIELD;
@@ -480,4 +484,21 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase<Ra
         assertEquals("Invalid format: [[test_format]]: Unknown pattern letter: t", e.getMessage());
     }
 
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+
+        RangeFieldMapper longMapper = new RangeFieldMapper.Builder("field", RangeType.LONG).build(context);
+        Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
+        assertEquals(Map.of("gte", 3L, "lt", 42L), longMapper.parseSourceValue(longRange));
+
+        RangeFieldMapper ipMapper = new RangeFieldMapper.Builder("field", RangeType.IP).build(context);
+        Map<String, Object> ipRange = Map.of("gte", "127.0.0.1");
+        assertEquals(Map.of("gte", "127.0.0.1"), ipMapper.parseSourceValue(ipRange));
+        assertEquals("2001:db8::/32", ipMapper.parseSourceValue("2001:db8::/32"));
+
+        RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE).build(context);
+        Map<String, Object> dateRange = Map.of("lt", "2020-05-15T21:33:02+00:00");
+        assertEquals(Map.of("lt", 1589578382000L), dateMapper.parseSourceValue(dateRange));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -497,8 +497,11 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase<Ra
         assertEquals(Map.of("gte", "127.0.0.1"), ipMapper.parseSourceValue(ipRange));
         assertEquals("2001:db8::/32", ipMapper.parseSourceValue("2001:db8::/32"));
 
-        RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE).build(context);
-        Map<String, Object> dateRange = Map.of("lt", "2020-05-15T21:33:02+00:00");
-        assertEquals(Map.of("lt", 1589578382000L), dateMapper.parseSourceValue(dateRange));
+        RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE)
+            .format("yyyy/MM/dd||epoch_millis")
+            .build(context);
+        Map<String, Object> dateRange = Map.of("lt", "1990/12/29", "gte", 597429487111L);
+        assertEquals(Map.of("lt", "1990/12/29", "gte", "1988/12/06"),
+            dateMapper.parseSourceValue(dateRange));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -492,11 +492,6 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase<Ra
         Map<String, Object> longRange = Map.of("gte", 3.14, "lt", "42.9");
         assertEquals(Map.of("gte", 3L, "lt", 42L), longMapper.parseSourceValue(longRange));
 
-        RangeFieldMapper ipMapper = new RangeFieldMapper.Builder("field", RangeType.IP).build(context);
-        Map<String, Object> ipRange = Map.of("gte", "127.0.0.1");
-        assertEquals(Map.of("gte", "127.0.0.1"), ipMapper.parseSourceValue(ipRange));
-        assertEquals("2001:db8::/32", ipMapper.parseSourceValue("2001:db8::/32"));
-
         RangeFieldMapper dateMapper = new RangeFieldMapper.Builder("field", RangeType.DATE)
             .format("yyyy/MM/dd||epoch_millis")
             .build(context);

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -254,14 +254,14 @@ public class RangeFieldTypeTests extends FieldTypeTestCase<RangeFieldType> {
         assertEquals(1466062190000L, formatter.parseMillis(to));
 
         fieldType.setDateTimeFormatter(formatter);
-        final Query query = fieldType.rangeQuery(from, to, true, true, relation, null, null, context);
+        final Query query = fieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
         assertEquals("field:<ranges:[1465975790000 : 1466062190999]>", query.toString());
 
         // compare lower and upper bounds with what we would get on a `date` field
         DateFieldType dateFieldType = new DateFieldType();
         dateFieldType.setName(FIELDNAME);
         dateFieldType.setDateTimeFormatter(formatter);
-        final Query queryOnDateField = dateFieldType.rangeQuery(from, to, true, true, relation, null, null, context);
+        final Query queryOnDateField = dateFieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
         assertEquals("field:[1465975790000 TO 1466062190999]", queryOnDateField.toString());
     }
 
@@ -486,9 +486,9 @@ public class RangeFieldTypeTests extends FieldTypeTestCase<RangeFieldType> {
     }
 
     public void testParseIp() {
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parse(InetAddresses.forString("::1"), randomBoolean()));
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parse("::1", randomBoolean()));
-        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parse(new BytesRef("::1"), randomBoolean()));
+        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue(InetAddresses.forString("::1"), randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue("::1", randomBoolean(), null));
+        assertEquals(InetAddresses.forString("::1"), RangeType.IP.parseValue(new BytesRef("::1"), randomBoolean(), null));
     }
 
     public void testTermQuery() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -46,7 +46,9 @@ import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -1306,5 +1308,15 @@ public class TextFieldMapperTests extends FieldMapperTestCase<TextFieldMapper.Bu
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testParseSourceValue() {
+        Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT.id).build();
+        Mapper.BuilderContext context = new Mapper.BuilderContext(settings, new ContentPath());
+        TextFieldMapper mapper = new TextFieldMapper.Builder("field").build(context);
+
+        assertEquals("value", mapper.parseSourceValue("value"));
+        assertEquals("42", mapper.parseSourceValue(42L));
+        assertEquals("true", mapper.parseSourceValue(true));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -100,6 +100,11 @@ public class MockFieldMapper extends FieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void mergeOptions(FieldMapper other, List<String> conflicts) {
 
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -170,6 +170,11 @@ public class HistogramFieldMapper extends FieldMapper {
         throw new UnsupportedOperationException("Parsing is implemented in parse(), this method should NEVER be called");
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     public static class HistogramFieldType extends MappedFieldType {
 
         public HistogramFieldType() {

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.mapper.TypeParsers;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -287,6 +288,18 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
                     "] only accepts values that are equal to the value defined in the mappings [" + fieldType().value() +
                     "], but got [" + value + "]");
         }
+    }
+
+    @Override
+    public List<String> lookupValues(SourceLookup lookup) {
+        return fieldType().value == null
+            ? List.of()
+            : List.of(fieldType().value);
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException("This should never be called, since lookupValues is implemented directly.");
     }
 
     @Override

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -13,18 +13,21 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.FieldMapperTestCase;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.xpack.constantkeyword.ConstantKeywordMapperPlugin;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.junit.Before;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase<ConstantKeywordFieldMapper.Builder> {
 
@@ -126,5 +129,28 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase<Constan
         mapper = indexService.mapperService().merge("_doc",
                 new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
+    }
+
+    public void testLookupValues() throws Exception {
+        IndexService indexService = createIndex("test");
+        String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
+            .startObject("properties").startObject("field").field("type", "constant_keyword")
+            .endObject().endObject().endObject().endObject());
+        DocumentMapper mapper = indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        FieldMapper fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        List<?> values = fieldMapper.lookupValues(new SourceLookup());
+        assertTrue(values.isEmpty());
+
+        String mapping2 = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
+            .startObject("properties").startObject("field").field("type", "constant_keyword")
+            .field("value", "foo").endObject().endObject().endObject().endObject());
+        mapper = indexService.mapperService().merge("_doc", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
+
+        fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");
+        values = fieldMapper.lookupValues(new SourceLookup());
+        assertEquals(1, values.size());
+        assertEquals("foo", values.get(0));
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -134,8 +134,8 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase<Constan
     public void testLookupValues() throws Exception {
         IndexService indexService = createIndex("test");
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
-            .startObject("properties").startObject("field").field("type", "constant_keyword")
-            .endObject().endObject().endObject().endObject());
+                .startObject("properties").startObject("field").field("type", "constant_keyword")
+                .endObject().endObject().endObject().endObject());
         DocumentMapper mapper = indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
@@ -144,8 +144,8 @@ public class ConstantKeywordFieldMapperTests extends FieldMapperTestCase<Constan
         assertTrue(values.isEmpty());
 
         String mapping2 = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc")
-            .startObject("properties").startObject("field").field("type", "constant_keyword")
-            .field("value", "foo").endObject().endObject().endObject().endObject());
+                .startObject("properties").startObject("field").field("type", "constant_keyword")
+                .field("value", "foo").endObject().endObject().endObject().endObject());
         mapper = indexService.mapperService().merge("_doc", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
 
         fieldMapper = (FieldMapper) mapper.mappers().getMapper("field");

--- a/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
+++ b/x-pack/plugin/mapper-flattened/src/main/java/org/elasticsearch/xpack/flattened/mapper/FlatObjectFieldMapper.java
@@ -618,6 +618,11 @@ public final class FlatObjectFieldMapper extends DynamicKeyFieldMapper {
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
 

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/constant_keyword/10_basic.yml
@@ -184,3 +184,18 @@ setup:
   - match: {hits.hits.0._index: test1 }
   - match: {hits.hits.1._index: test1 }
   - match: {hits.hits.2._index: test2 }
+
+---
+"Field retrieval":
+
+  - do:
+      search:
+        index: test*
+        body:
+          fields: [ foo ]
+          sort: [ { _index: asc } ]
+
+  - match: { "hits.total.value": 3 }
+  - match: {hits.hits.0.fields.foo.0: bar }
+  - match: {hits.hits.1.fields.foo.0: bar }
+  - match: {hits.hits.2.fields.foo.0: baz }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -225,6 +225,11 @@ public class DenseVectorFieldMapper extends FieldMapper implements ArrayValueMap
     }
 
     @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
+    @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
         builder.field("dims", fieldType().dims());

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/SparseVectorFieldMapper.java
@@ -145,10 +145,14 @@ public class SparseVectorFieldMapper extends FieldMapper {
         throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
     }
 
-
     @Override
     protected void parseCreateField(ParseContext context) {
         throw new IllegalStateException("parse is implemented directly");
+    }
+
+    @Override
+    protected Object parseSourceValue(Object value) {
+        throw new UnsupportedOperationException(ERROR_MESSAGE_7X);
     }
 
     @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -894,8 +894,8 @@ public class WildcardFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected Object parseSourceValue(Object value) {
-        return value;
+    protected String parseSourceValue(Object value) {
+        return value.toString();
     }
 
     // For internal use by Lucene only - used to define ngram index

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -893,6 +893,11 @@ public class WildcardFieldMapper extends FieldMapper {
         parseDoc.addAll(fields);
     }
 
+    @Override
+    protected Object parseSourceValue(Object value) {
+        return value;
+    }
+
     // For internal use by Lucene only - used to define ngram index
     final MappedFieldType ngramFieldType;
 


### PR DESCRIPTION
This PR adds new method `FieldMapper#lookupValues(SourceLookup)` that extracts and parses the source values. This lets us return values like numbers and dates in a consistent format, and also handle special data types like `constant_keyword`. The `lookupValues` method calls into `parseSourceValue`, which mappers can override to specify how values should be parsed.

Older draft PR: #56473 

Relates to #55363.