### PR TITLE
Make bulk processor.add asynchronously execute bulk request if needed #50440

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor.java
@@ -37,8 +37,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;


### PR DESCRIPTION
Hello,
The basic ideas here is to improve the performance of the add method for bulk processor.
In most cases the add and execute can run simultaneously, so as long there is not execution taking place, the add command will return right away and the execution will run on a separate thread if needed.
#50440