### PR TITLE
Adjust version mute for reload secure settings

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
@@ -4,8 +4,8 @@ setup:
 ---
 "node_reload_secure_settings test wrong password":
   - skip:
-      version: " - 7.9.99"
-      reason:  "support for reloading password protected keystores was introduced in 8.0.0"
+      version: " - 7.6.99"
+      reason:  "support for reloading password protected keystores was introduced in 7.7.0"
 
   - do:
       nodes.reload_secure_settings:


### PR DESCRIPTION
We can safely run the reload_secure_settings tests
after 7.7.0 , the relevant changes have long been
backported there
