### PR TITLE
Fix geotile_grid group_by field mapping

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GeoTileGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GeoTileGroupSource.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.transform.transforms.pivot;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.builders.PolygonBuilder;
 import org.elasticsearch.common.geo.parsers.ShapeParser;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -26,6 +27,7 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -172,12 +174,17 @@ public class GeoTileGroupSource extends SingleGroupSource {
         assert key instanceof String;
         Rectangle rectangle = GeoTileUtils.toBoundingBox(key.toString());
         final Map<String, Object> geoShape = new HashMap<>();
-        geoShape.put(ShapeParser.FIELD_TYPE.getPreferredName(), "BBOX");
+        geoShape.put(ShapeParser.FIELD_TYPE.getPreferredName(), PolygonBuilder.TYPE.shapeName());
         geoShape.put(
             ShapeParser.FIELD_COORDINATES.getPreferredName(),
-            Arrays.asList(
-                new Double[] { rectangle.getMinLon(), rectangle.getMaxLat() },
-                new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() }
+            Collections.singletonList(
+                Arrays.asList(
+                    new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() },
+                    new Double[] { rectangle.getMinLon(), rectangle.getMinLat() },
+                    new Double[] { rectangle.getMinLon(), rectangle.getMaxLat() },
+                    new Double[] { rectangle.getMaxLon(), rectangle.getMaxLat() },
+                    new Double[] { rectangle.getMaxLon(), rectangle.getMinLat() }
+                )
             )
         );
         return geoShape;

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -1083,12 +1083,15 @@ public class TransformPivotRestIT extends TransformRestTestCase {
             "hits.hits._source.tile",
             searchResult
         )).get(0);
-        assertThat(actualObj.get("type"), equalTo("BBOX"));
-        List<List<Double>> coordinates = (List<List<Double>>) actualObj.get("coordinates");
+        assertThat(actualObj.get("type"), equalTo("polygon"));
+        List<List<Double>> coordinates = ((List<List<List<Double>>>) actualObj.get("coordinates")).get(0);
         assertThat(coordinates, is(not(nullValue())));
-        assertThat(coordinates, hasSize(2));
+        assertThat(coordinates, hasSize(5));
         assertThat(coordinates.get(0), hasSize(2));
         assertThat(coordinates.get(1), hasSize(2));
+        assertThat(coordinates.get(2), hasSize(2));
+        assertThat(coordinates.get(3), hasSize(2));
+        assertThat(coordinates.get(4), hasSize(2));
     }
 
     public void testPivotWithWeightedAvgAgg() throws Exception {


### PR DESCRIPTION
The original implementation utilized `bbox` as the index mapping type. This would not work as it would have to be `envelope`. But, given that `envelope` and `polygon` are tessellated in the same way, we choose to use `polygon` as the geo_shape type. This is for easier support other places in the stack (a la kibana maps)