### PR TITLE
Adjust reload keystore test to pass in FIPS (#56889)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
@@ -18,7 +18,9 @@ setup:
   - is_true: nodes
   - is_true: cluster_name
   - match: { nodes.$node_id.reload_exception.type: "security_exception" }
-  - match: { nodes.$node_id.reload_exception.reason: "Provided keystore password was incorrect" }
+  - match: { nodes.$node_id.reload_exception.reason:
+               /^(Provided\skeystore\spassword\swas\sincorrect|
+               Keystore\shas\sbeen\scorrupted\sor\stampered\swith)$/ }
 
 ---
 "node_reload_secure_settings test correct(empty) password":


### PR DESCRIPTION
In KeystoreWrapper class we determine if the error to decrypt a
given keystore is caused by a wrong password based on the exception
that the SunJCE implementation of AES is
throwing(AEADBadTagException). Other implementations from other
Security Providers fail with a different exception and as such we
cannot differentiate between a corrupted file and a wrong password
in a foolproof way.
As in other tests such as in
KeyStoreWrapperTests#testDecryptKeyStoreWithWrongPassword
we handle this by matching both possible exception messages.