### PR TITLE
[7.8] [DOCS] Fix fingerprint token filter's analyzer example (#56811)

### DIFF
--- a/docs/reference/analysis/tokenfilters/fingerprint-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/fingerprint-tokenfilter.asciidoc
@@ -81,7 +81,7 @@ PUT fingerprint_example
       "analyzer": {
         "whitespace_fingerprint": {
           "tokenizer": "whitespace",
-          "filter": [ "elision" ]
+          "filter": [ "fingerprint" ]
         }
       }
     }


### PR DESCRIPTION
7.8 backport of #56811