### PR TITLE
[7.8] [DOCS] Fix component template API link in JSON specs (#56884)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -1,7 +1,7 @@
 {
   "cluster.delete_component_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Deletes a component template"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -1,7 +1,7 @@
 {
   "cluster.exists_component_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns information about whether a particular component template exist"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -1,7 +1,7 @@
 {
   "cluster.get_component_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns one or more component templates"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -1,7 +1,7 @@
 {
   "cluster.put_component_template":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-templates.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Creates or updates a component template"
     },
     "stability":"experimental",


### PR DESCRIPTION
7.8 backport of #56884