### PR TITLE
Adjust version mute for reload secure settings (#56938)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.reload_secure_settings/10_basic.yml
@@ -4,7 +4,7 @@ setup:
 ---
 "node_reload_secure_settings test wrong password":
   - skip:
-      version: " - 7.99.99"
+      version: " - 7.6.99"
       reason:  "support for reloading password protected keystores was introduced in 7.7.0"
 
   - do:


### PR DESCRIPTION
We can safely run the reload_secure_settings tests
after 7.7.0 , the relevant changes have long been
backported there