### PR TITLE
Split dependenciesInfo task to its own plugin

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/DependenciesInfoPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/DependenciesInfoPlugin.groovy
@@ -17,25 +17,25 @@
  * under the License.
  */
 
-package org.elasticsearch.gradle;
+package org.elasticsearch.gradle
 
-import org.elasticsearch.gradle.precommit.DependencyLicensesTask;
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.tasks.TaskProvider;
+import org.elasticsearch.gradle.precommit.DependencyLicensesTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.TaskProvider
 
-public class DependenciesInfoPlugin implements Plugin<Project> {
+class DependenciesInfoPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         TaskProvider<DependenciesInfoTask> depsInfo = project.getTasks().register("dependenciesInfo", DependenciesInfoTask.class);
-        depsInfo.configure(t -> {
+        depsInfo.configure { DependenciesInfoTask t ->
             t.setRuntimeConfiguration(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             t.setCompileOnlyConfiguration(project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
-            t.getConventionMapping().map("mappings", () -> {
+            t.getConventionMapping().map("mappings") { ->
                 TaskProvider<DependencyLicensesTask> depLic = project.getTasks().named("dependencyLicenses", DependencyLicensesTask.class);
                 return depLic.get().getMappings();
-            });
-        });
+            }
+        };
     }
 }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DependenciesInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DependenciesInfoPlugin.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle;
+
+import org.elasticsearch.gradle.precommit.DependencyLicensesTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.TaskProvider;
+
+public class DependenciesInfoPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        TaskProvider<DependenciesInfoTask> depsInfo = project.getTasks().register("dependenciesInfo", DependenciesInfoTask.class);
+        depsInfo.configure(t -> {
+            t.setRuntimeConfiguration(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+            t.setCompileOnlyConfiguration(project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
+            t.getConventionMapping().map("mappings", () -> {
+                TaskProvider<DependencyLicensesTask> depLic = project.getTasks().named("dependencyLicenses", DependencyLicensesTask.class);
+                return depLic.get().getMappings();
+            });
+        });
+    }
+}


### PR DESCRIPTION
The dependenciesInfo task is used to gather information about all
dependencies in elasticsearch. This commit separates it into its own
gradle plugin.