### PR TITLE
Fix incorrect log warning when exporting monitoring via HTTP without authentication

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -703,8 +703,14 @@ public class HttpExporter extends Exporter {
      * @throws SettingsException if the username is missing, but a password is supplied
      */
     @Nullable
-    private static CredentialsProvider createCredentialsProvider(final Config config) {
+    // visible for testing
+    static CredentialsProvider createCredentialsProvider(final Config config) {
         final String username = AUTH_USERNAME_SETTING.getConcreteSettingForNamespace(config.name()).get(config.settings());
+
+        if (Strings.isNullOrEmpty(username)) {
+            // nothing to configure; default situation for most users
+            return null;
+        }
 
         final SecureString securePassword = SECURE_AUTH_PASSWORDS.get(config.name());
         final String password = securePassword != null ? securePassword.toString() : null;

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.monitoring.exporter.http;
 
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
@@ -330,6 +331,17 @@ public class HttpExporterTests extends ESTestCase {
 
         // doesn't explode
         HttpExporter.createRestClient(config, sslService, listener).close();
+    }
+
+    public void testCreateCredentialsProviderWithoutSecurity() {
+        final Settings.Builder builder = Settings.builder()
+            .put("xpack.monitoring.exporters._http.type", "http")
+            .put("xpack.monitoring.exporters._http.host", "http://localhost:9200");
+
+        final Config config = createConfig(builder.build());
+        CredentialsProvider provider = HttpExporter.createCredentialsProvider(config);
+
+        assertNull(provider);
     }
 
     public void testCreateSnifferDisabledByDefault() {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/56810
