### PR TITLE
[7.8] [DOCS] Add JS client helper links to docs (#55216)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -105,6 +105,10 @@ Python::
 
     See http://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
 
+JavaScript::
+
+    See {jsclient}/client-helpers.html[client.helpers.*]
+
 [float]
 [[bulk-curl]]
 ===== Submitting bulk requests with cURL

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -107,7 +107,7 @@ Python::
 
 JavaScript::
 
-    See {jsclient}/client-helpers.html[client.helpers.*]
+    See {jsclient-current}/client-helpers.html[client.helpers.*]
 
 [float]
 [[bulk-curl]]

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -25,6 +25,10 @@ Python::
 
     See http://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
 
+JavaScript::
+
+    See {jsclient}/client-helpers.html[client.helpers.*]
+
 *********************************************
 
 NOTE: The results that are returned from a scroll request reflect the state of

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -27,7 +27,7 @@ Python::
 
 JavaScript::
 
-    See {jsclient}/client-helpers.html[client.helpers.*]
+    See {jsclient-current}/client-helpers.html[client.helpers.*]
 
 *********************************************
 


### PR DESCRIPTION
7.8 backport of #55216