### PR TITLE
[DOCS] Fix ulimit value in system settings docs

### DIFF
--- a/docs/reference/setup/sysconfig/configuring.asciidoc
+++ b/docs/reference/setup/sysconfig/configuring.asciidoc
@@ -41,7 +41,7 @@ You can consult all currently applied limits with `ulimit -a`.
 
 On Linux systems, persistent limits can be set for a particular user by
 editing the `/etc/security/limits.conf` file. To set the maximum number of
-open files for the `elasticsearch` user to 65,536, add the following line to
+open files for the `elasticsearch` user to 65,535, add the following line to
 the `limits.conf` file:
 
 [source,sh]


### PR DESCRIPTION
As part of https://github.com/elastic/elasticsearch/issues/35839 and https://github.com/elastic/elasticsearch/pull/37537 the limit was lowered to 65535, but the configuring.asiidoc still states 65536 instead of 65535. Would it be possible to backport this to at least 7.x?