### PR TITLE
DOCS Correct audit emit_node_id default value as false

### DIFF
--- a/docs/reference/settings/audit-settings.asciidoc
+++ b/docs/reference/settings/audit-settings.asciidoc
@@ -45,8 +45,7 @@ audited in plain text when including the request body in audit events.
 
 `xpack.security.audit.logfile.emit_node_name`::
 Specifies whether to include the <<node.name,node name>> as a field in
-each audit event.
-The default value is `true`.
+each audit event. The default value is `false`.
 
 `xpack.security.audit.logfile.emit_node_host_address`::
 Specifies whether to include the node's IP address as a field in each audit event.


### PR DESCRIPTION
Since version 7, the `xpack.security.audit.logfile.emit_node_id` setting defaults to `false`, yet the docs say otherwise (we forgot to update the docs in version 7). This commit fixes that.
