### PR TITLE
[7.x] [DOCS] Fix default for `http.compression` setting (#56899)

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -48,7 +48,12 @@ to `4kb`
 
 
 |`http.compression` |Support for compression when possible (with
-Accept-Encoding). Defaults to `true`.
+Accept-Encoding). If HTTPS is enabled, defaults to `false`. Otherwise, defaults
+to `true`.
+
+Disabling compression for HTTPS mitigates potential security risks, such as a
+https://en.wikipedia.org/wiki/BREACH[BREACH attack]. To compress HTTPS traffic,
+you must explicitly set `http.compression` to `true`.
 
 |`http.compression_level` |Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression)
 and 9 (maximum compression). Defaults to `3`.


### PR DESCRIPTION
7.x backport of #56899