### PR TITLE
Make internalClusterTest run after unit tests

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -152,6 +152,8 @@ public abstract class GradleUtils {
             task.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             task.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
             task.setClasspath(testSourceSet.getRuntimeClasspath());
+            // make the new test run after unit tests
+            task.mustRunAfter(project.getTasks().named("test"));
         });
 
         Configuration testCompileConfig = project.getConfigurations().getByName(testSourceSet.getCompileClasspathConfigurationName());


### PR DESCRIPTION
This commit adds an ordering rule to ensure unit tests are run first
when running a higher level task like check.