### PR TITLE
[DOCS] Removes the Jobs section from the ML anomaly detection APIs page

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/ml-api.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/ml-api.asciidoc
@@ -48,11 +48,6 @@ See also <<ml-df-analytics-apis>>.
 * <<ml-preview-datafeed,Preview {dfeed}>>
 * <<ml-update-datafeed,Update {dfeed}>>
 
-[discrete]
-[[ml-api-job-endpoint]]
-=== Jobs
-
-See <<ml-api-anomaly-job-endpoint>>.
 
 [discrete]
 [[ml-api-snapshot-endpoint]]


### PR DESCRIPTION
## Overview

This PR removes the Jobs section (`ml-api-job-endpoint`) from the Machine learning anomaly detection APIs page.

The link on `/anomaly_detectors/` on the [API quick reference](https://www.elastic.co/guide/en/machine-learning/current/ml-api-quickref.html) pointed to the Jobs section, but it has been redirected to the Anomaly detection jobs section via https://github.com/elastic/stack-docs/pull/1100.

After searching in the kibana, beats, elasticsearch, ES-js, ES-php, and stack-docs repos, there is no sign of referring to `ml-api-job-endpoint` anywhere. For this reason, it is unnecessary to keep the section.

### Preview

[Machine learning anomaly detection APIs](http://elasticsearch_57031.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-apis.html)