### PR TITLE
[DOCS] Improves navigation between forecast APIs and adds short description

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -23,7 +23,14 @@ Predicts the future behavior of a time series by using its historical behavior.
 [[ml-forecast-desc]]
 ==== {api-description-title}
 
-See {ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future].
+You can create a forecast job based on an {anomaly-job} to extrapolate future 
+behavior. Refer to 
+{ml-docs}/ml-overview.html#ml-forecasting[Forecasting the future] and 
+{ml-docs}/ml-limitations.html#ml-forecast-limitations[forecast limitations] to 
+learn more.
+
+You can delete a forecast by using the 
+<<ml-delete-forecast,Delete forecast API>>.
 
 [NOTE]
 ===============================
@@ -50,9 +57,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
   processed.
 
 `expires_in`::
-  (Optional, <<time-units, time units>>) The period of time that forecast results are retained.
-  After a forecast expires, the results are deleted. The default value is 14 days.
-  If set to a value of `0`, the forecast is never automatically deleted.
+  (Optional, <<time-units, time units>>) The period of time that forecast 
+  results are retained. After a forecast expires, the results are deleted. The 
+  default value is 14 days. If set to a value of `0`, the forecast is never 
+  automatically deleted.
+
 
 [[ml-forecast-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
## Overview

This PR:
* adds a link to the Forecast API that points to delete forecast,
* provides a short description of the Forecast API,
* adds a link to the description that points to the Forecast limitation section in the ML book.

### Preview

[Forecast API](http://elasticsearch_57035.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-forecast.html)