### PR TITLE
[7.8] Handle exceptions when building _cat/indices response

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -273,3 +273,19 @@
                open \s+ foo\n
                open \s+ baz\n
             $/
+
+---
+"Test cat indices with invalid health parameter":
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      catch: bad_request
+      cat.indices:
+        health: "invalid-health-value"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -273,19 +273,3 @@
                open \s+ foo\n
                open \s+ baz\n
             $/
-
----
-"Test cat indices with invalid health parameter":
-
-  - do:
-      indices.create:
-        index: foo
-        body:
-          settings:
-            number_of_shards: "1"
-            number_of_replicas: "0"
-
-  - do:
-      catch: bad_request
-      cat.indices:
-        health: "invalid-health-value"


### PR DESCRIPTION
The root cause of this bug was an unhandled exception in the `onResponse` method for the `_cat/indices` endpoint that resulted in completion of neither the response nor failure methods of the REST handler. Adding a try-catch around the code in the `onResponse` method resolves this specific problem.

Fixes https://github.com/elastic/elasticsearch/issues/56816

Backport of #56993.
