### PR TITLE
[DOCS] Add delete snapshot repo API docs

### DIFF
--- a/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
@@ -1,0 +1,52 @@
+[[delete-snapshot-repo-api]]
+=== Delete snapshot repository API
+++++
+<titleabbrev>Delete snapshot repository</titleabbrev>
+++++
+
+Deletes one or more <<snapshots-register-repository,snapshot repositories>>.
+
+////
+[source,console]
+----
+PUT /_snapshot/my_repository
+{
+  "type": "fs",
+  "settings": {
+    "location": "my_backup_location"
+  }
+}
+----
+////
+
+[source,console]
+----
+DELETE /_snapshot/my_repository
+----
+// TEST[continued]
+
+[[delete-snapshot-repo-api-request]]
+==== {api-request-title}
+
+`DELETE /_snapshot/<repository>`
+
+[[delete-snapshot-repo-api-path-params]]
+==== {api-path-parms-title}
+
+`<repository>`::
+(Required, string)
+Name of the snapshot repository to delete. Wildcard (`*`) patterns are
+supported.
+
+[[delete-snapshot-repo-api-query-params]]
+==== {api-query-parms-title}
+
+`master_timeout`::
+(Optional, <<time-units, time units>>) Specifies the period of time to wait for
+a connection to the master node. If no response is received before the timeout
+expires, the request fails and returns an error. Defaults to `30s`.
+
+`timeout`::
+(Optional, <<time-units, time units>>) Specifies the period of time to wait for
+a response. If no response is received before the timeout expires, the request
+fails and returns an error. Defaults to `30s`.

--- a/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-repo-api.asciidoc
@@ -4,7 +4,11 @@
 <titleabbrev>Delete snapshot repository</titleabbrev>
 ++++
 
-Deletes one or more <<snapshots-register-repository,snapshot repositories>>.
+Unregisters one or more <<snapshots-register-repository,snapshot repositories>>.
+
+When a repository is unregistered, {es} only removes the reference to the
+location where the repository is storing the snapshots. The snapshots themselves
+are left untouched and in place.
 
 ////
 [source,console]
@@ -35,7 +39,7 @@ DELETE /_snapshot/my_repository
 
 `<repository>`::
 (Required, string)
-Name of the snapshot repository to delete. Wildcard (`*`) patterns are
+Name of the snapshot repository to unregister. Wildcard (`*`) patterns are
 supported.
 
 [[delete-snapshot-repo-api-query-params]]

--- a/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
+++ b/docs/reference/snapshot-restore/apis/snapshot-restore-apis.asciidoc
@@ -17,8 +17,10 @@ content may not be included yet.
 === Snapshot repository management APIs
 
 * <<clean-up-snapshot-repo-api,Clean up snapshot repository>>
+* <<delete-snapshot-repo-api,Delete snapshot repository>>
 * <<put-snapshot-repo-api,Put snapshot repository>>
 
 
 include::clean-up-repo-api.asciidoc[]
+include::delete-repo-api.asciidoc[]
 include::put-repo-api.asciidoc[]

--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -79,6 +79,18 @@ or
 GET /_snapshot/_all
 -----------------------------------
 
+You can unregister a repository using the <<delete-snapshot-repo-api,delete
+snapshot repository API>>:
+
+[source,console]
+-----------------------------------
+DELETE /_snapshot/my_backup
+-----------------------------------
+
+When a repository is unregistered, {es} only removes the reference to the
+location where the repository is storing the snapshots. The snapshots themselves
+are left untouched and in place.
+
 [float]
 [[snapshots-filesystem-repository]]
 === Shared file system repository

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -201,16 +201,3 @@ DELETE /_snapshot/my_backup/my_backup,my_fs_backup
 DELETE /_snapshot/my_backup/snap*
 -----------------------------------
 // TEST[skip:no my_fs_backup]
-
-A repository can be unregistered using the following command:
-
-[source,console]
------------------------------------
-DELETE /_snapshot/my_backup
------------------------------------
-// TEST[continued]
-
-When a repository is unregistered, Elasticsearch only removes the reference to the location where the repository is storing
-the snapshots. The snapshots themselves are left untouched and in place.
-
-

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -15,7 +15,7 @@
           "parts":{
             "repository":{
               "type":"list",
-              "description":"Name of the snapshot repository to delete. Wildcard (`*`) patterns are supported."
+              "description":"Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported."
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -15,7 +15,7 @@
           "parts":{
             "repository":{
               "type":"list",
-              "description":"A comma-separated list of repository names"
+              "description":"Name of the snapshot repository to delete. Wildcard (`*`) patterns are supported."
             }
           }
         }


### PR DESCRIPTION
Changes:

* Adds API reference docs for the delete snapshot repo API.

* Corrects an error in the delete snapshot repo API spec. Comma-separated repository names are not supported.

* Relocates the existing delete snapshot repo API example docs.