### PR TITLE
Wildcard field - add support for custom null values

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -14,12 +14,16 @@ setup:
             properties:
               my_wildcard:
                  type: wildcard
+              null_wildcard:
+                 type: wildcard
+                 null_value: BLANK
   - do:
       index:
         index: test-index
         id: 1
         body:
           my_wildcard: hello world
+          null_wildcard: null
   - do:
       index:
         index: test-index
@@ -32,6 +36,7 @@ setup:
         id: 3
         body:
           my_wildcard: cAsE iNsEnSiTiVe World
+          null_wildcard: HAS_VALUE
 
   - do:
       indices.refresh: {}
@@ -97,6 +102,19 @@ setup:
           query:
             wildcard:
               my_wildcard: {value: "*Worl*" }
+
+
+  - match: {hits.total.value: 1}
+
+---
+"null query":
+  - do:
+      search:
+        body:
+          track_total_hits: true
+          query:
+            wildcard:
+              null_wildcard: {value: "*BLANK*" }
 
 
   - match: {hits.total.value: 1}

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -98,11 +98,12 @@ public class WildcardFieldMapper extends FieldMapper {
             FIELD_TYPE.freeze();
         }
         public static final int IGNORE_ABOVE = Integer.MAX_VALUE;
+        public static final String NULL_VALUE = null;
     }
 
     public static class Builder extends FieldMapper.Builder<Builder> {
         protected int ignoreAbove = Defaults.IGNORE_ABOVE;
-
+        protected String nullValue = Defaults.NULL_VALUE;
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
@@ -188,7 +189,13 @@ public class WildcardFieldMapper extends FieldMapper {
                 Map.Entry<String, Object> entry = iterator.next();
                 String propName = entry.getKey();
                 Object propNode = entry.getValue();
-                if (propName.equals("ignore_above")) {
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                    iterator.remove();
+                } else if (propName.equals("ignore_above")) {
                     builder.ignoreAbove(XContentMapValues.nodeIntegerValue(propNode, -1));
                     iterator.remove();
                 }
@@ -526,6 +533,9 @@ public class WildcardFieldMapper extends FieldMapper {
     @Override
     protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
         super.doXContentBody(builder, includeDefaults, params);
+        if (includeDefaults || fieldType().nullValue() != null) {
+            builder.field("null_value", fieldType().nullValue());
+        }
         if (includeDefaults || ignoreAbove != Defaults.IGNORE_ABOVE) {
             builder.field("ignore_above", ignoreAbove);
         }


### PR DESCRIPTION
As part of achieving parity with `keyword` fields the wildcard field should support `null_value` definitions in the mappings.

