### PR TITLE
Don't run IDP tests in FIPS 140 mode

### DIFF
--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.info.BuildParams
+
 evaluationDependsOn(xpackModule('core'))
 
 apply plugin: 'elasticsearch.esplugin'

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -365,4 +365,7 @@ gradle.projectsEvaluated {
     .findAll { it.path.startsWith(project.path + ":qa") }
     .each { check.dependsOn it.check }
 }
-
+if (BuildParams.inFipsJvm) {
+  // We don't support the IDP in FIPS-140 mode, so no need to run tests
+  test.enabled = false
+}


### PR DESCRIPTION
We don't support this for now so there is no need to handle all
the test logic/exceptions to run this in FIPS 140 mode