### PR TITLE
Fix testTrackingChannelTask

### DIFF
--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -80,7 +80,7 @@ public class TaskManagerTests extends ESTestCase {
 
     public void testTrackingChannelTask() throws Exception {
         final TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Set.of());
-        Set<CancellableTask> cancelledTasks = ConcurrentCollections.newConcurrentSet();
+        Set<Task> cancelledTasks = ConcurrentCollections.newConcurrentSet();
         taskManager.setTaskCancellationService(new TaskCancellationService(mock(TransportService.class)) {
             @Override
             void cancelTaskAndDescendants(CancellableTask task, String reason, boolean waitForCompletion, ActionListener<Void> listener) {

--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -48,6 +48,8 @@ import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.in;
 import static org.mockito.Mockito.mock;
 
 public class TaskManagerTests extends ESTestCase {
@@ -76,7 +78,6 @@ public class TaskManagerTests extends ESTestCase {
         assertEquals(600000L, total);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/56746")
     public void testTrackingChannelTask() throws Exception {
         final TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Set.of());
         Set<CancellableTask> cancelledTasks = ConcurrentCollections.newConcurrentSet();
@@ -111,13 +112,14 @@ public class TaskManagerTests extends ESTestCase {
                 pendingTasks.computeIfAbsent(channel, k -> new HashSet<>()).add(task);
                 stopTrackingTasks.add(() -> {
                     stopTracking.close();
-                    pendingTasks.get(channel).remove(task);
+                    assertTrue(pendingTasks.get(channel).remove(task));
+                    expectedCancelledTasks.remove(task);
                 });
             } else {
                 expectedCancelledTasks.add(task);
             }
         }
-        assertBusy(() -> assertThat(cancelledTasks, equalTo(expectedCancelledTasks)), 30, TimeUnit.SECONDS);
+        assertBusy(() -> assertThat(expectedCancelledTasks, everyItem(in(cancelledTasks))), 30, TimeUnit.SECONDS);
         for (FakeTcpChannel channel : channels) {
             channel.close();
         }


### PR DESCRIPTION
A task might not be canceled on disconnection if it is completed before the cancellation is started. We need to relax the assertion in this test.

Closes #56746 