### PR TITLE
Update to highlight the impact of the global state setting

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -58,10 +58,11 @@ The restore operation can be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-open-close,closed>> and
 has the same number of shards as the index in the snapshot. The restore
 operation automatically opens restored indices if they were closed and creates
-new indices if they didn't exist in the cluster. If cluster state is restored
-with `include_global_state` (defaults to `false`), the restored templates that
-don't currently exist in the cluster are added and existing templates with the
-same name are replaced by the restored templates. The restored persistent
+new indices if they didn't exist in the cluster. 
+
+NOTE: If cluster state is restored
+with `"include_global_state": true` (defaults to `false`), the restored templates, ingest pipelines, and policies that
+don't currently exist in the cluster are added and replace the most current configurations. The restored persistent cluster
 settings are added to the existing persistent settings.
 
 [float]

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -47,7 +47,7 @@ POST /_snapshot/my_backup/snapshot_1/_restore
 {
   "indices": "index_1,index_2",
   "ignore_unavailable": true,
-  "include_global_state": true,              <1>
+  "include_global_state": false,              <1>
   "rename_pattern": "index_(.+)",
   "rename_replacement": "restored_index_$1"
 }

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -47,23 +47,26 @@ POST /_snapshot/my_backup/snapshot_1/_restore
 {
   "indices": "index_1,index_2",
   "ignore_unavailable": true,
-  "include_global_state": true,
+  "include_global_state": true,              <1>
   "rename_pattern": "index_(.+)",
   "rename_replacement": "restored_index_$1"
 }
 -----------------------------------
 // TEST[continued]
 
+<1> By default, `include_global_state` is `false`, meaning the snapshot's
+cluster state is not restored.
++
+If `true`, the snapshot's persistent settings, index templates, ingest
+pipelines, and {ilm-init} policies are restored and added to the current
+cluster. This overrides current settings, templates, pipeline, and policies with
+the same name.
+
 The restore operation can be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-open-close,closed>> and
 has the same number of shards as the index in the snapshot. The restore
 operation automatically opens restored indices if they were closed and creates
-new indices if they didn't exist in the cluster. 
-
-NOTE: If cluster state is restored
-with `"include_global_state": true` (defaults to `false`), the restored templates, ingest pipelines, and policies that
-don't currently exist in the cluster are added and replace the most current configurations. The restored persistent cluster
-settings are added to the existing persistent settings.
+new indices if they didn't exist in the cluster.
 
 [float]
 === Partial restore
@@ -160,7 +163,7 @@ The output looks similar to the following:
       "repository": "my_backup",
       "uuid": "XuBo4l4ISYiVg0nYUen9zg",
       "state": "SUCCESS",
-      "include_global_state": true,
+      "include_global_state": false,
       "shards_stats": {
         "initializing": 0,
         "started": 0,

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -59,9 +59,9 @@ POST /_snapshot/my_backup/snapshot_1/_restore
 cluster state is not restored.
 +
 If `true`, the snapshot's persistent settings, index templates, ingest
-pipelines, and {ilm-init} policies are restored into the current
-cluster. This overwrites any existing cluster settings, templates, pipelines and {ilm-init} policies whose names match those in the snapshot.
-the same name.
+pipelines, and {ilm-init} policies are restored into the current cluster. This
+overwrites any existing cluster settings, templates, pipelines and {ilm-init}
+policies whose names match those in the snapshot.
 
 The restore operation can be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-open-close,closed>> and

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -49,7 +49,8 @@ POST /_snapshot/my_backup/snapshot_1/_restore
   "ignore_unavailable": true,
   "include_global_state": false,              <1>
   "rename_pattern": "index_(.+)",
-  "rename_replacement": "restored_index_$1"
+  "rename_replacement": "restored_index_$1",
+  "include_aliases": false
 }
 -----------------------------------
 // TEST[continued]

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -60,7 +60,7 @@ cluster state is not restored.
 +
 If `true`, the snapshot's persistent settings, index templates, ingest
 pipelines, and {ilm-init} policies are restored into the current
-cluster. This overrides current settings, templates, pipeline, and policies with
+cluster. This overwrites any existing cluster settings, templates, pipelines and {ilm-init} policies whose names match those in the snapshot.
 the same name.
 
 The restore operation can be performed on a functioning cluster. However, an

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -58,7 +58,7 @@ POST /_snapshot/my_backup/snapshot_1/_restore
 cluster state is not restored.
 +
 If `true`, the snapshot's persistent settings, index templates, ingest
-pipelines, and {ilm-init} policies are restored and added to the current
+pipelines, and {ilm-init} policies are restored into the current
 cluster. This overrides current settings, templates, pipeline, and policies with
 the same name.
 

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -164,7 +164,7 @@ The output looks similar to the following:
       "repository": "my_backup",
       "uuid": "XuBo4l4ISYiVg0nYUen9zg",
       "state": "SUCCESS",
-      "include_global_state": false,
+      "include_global_state": true,
       "shards_stats": {
         "initializing": 0,
         "started": 0,


### PR DESCRIPTION
Updated the language and added a callout to more prominently detail what happens when including the global state of a snapshot from which indices are being restored. I've had recent cases where customers copy and pasted the second code example verbatim, updated the index and snapshot name values, and executed the command. In effect wiping out their current ILM policies, templates, and ingestion pipelines. In hindsight they realize that they were unclear of the ramifications of including the setting as is.
