### PR TITLE
Fix Test Failure from Incorrect Mapping Conflict Assertion

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -65,7 +65,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
             // yet and sends a mapping update to the master node to map "bar" as "text". This
             // fails as it had been already mapped as a long by the previous index request.
             assertThat(e.getMessage(),
-                    Matchers.containsString("mapper [foo] of different type, current_type [long], merged_type [text]"));
+                    Matchers.containsString("mapper [foo] cannot be changed from type [long] to [text]"));
         }
     }
 


### PR DESCRIPTION
I think this is a left-over from #56915 where a change in assertion
message didn't make it to this very rare-case assertion.

Failed here https://gradle-enterprise.elastic.co/s/ppxvrwszi2t6g