### PR TITLE
Cleanup Dead IOException Handling in OutboundHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -327,16 +327,7 @@ public abstract class TransportTasksAction<
 
         @Override
         public void messageReceived(final NodeTaskRequest request, final TransportChannel channel, Task task) throws Exception {
-            nodeOperation(request, ActionListener.wrap(channel::sendResponse,
-                e -> {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (IOException e1) {
-                        e1.addSuppressed(e);
-                        logger.warn("Failed to send failure", e1);
-                    }
-                }
-            ));
+            nodeOperation(request, ActionListener.wrap(channel::sendResponse, channel::sendResponse));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -53,7 +53,6 @@ import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -154,11 +153,7 @@ public class JoinHelper {
 
             @Override
             public void onSuccess() {
-                try {
-                    channel.sendResponse(Empty.INSTANCE);
-                } catch (IOException e) {
-                    onFailure(e);
-                }
+                channel.sendResponse(Empty.INSTANCE);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -105,21 +105,12 @@ public class PublicationTransportHandler {
 
             @Override
             public void onResponse(Void aVoid) {
-                try {
-                    channel.sendResponse(TransportResponse.Empty.INSTANCE);
-                } catch (IOException e) {
-                    logger.debug("failed to send response on commit", e);
-                }
+                channel.sendResponse(TransportResponse.Empty.INSTANCE);
             }
 
             @Override
             public void onFailure(Exception e) {
-                try {
-                    channel.sendResponse(e);
-                } catch (IOException ie) {
-                    e.addSuppressed(ie);
-                    logger.debug("failed to send response on commit", e);
-                }
+                channel.sendResponse(e);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -184,11 +184,7 @@ public class LocalAllocateDangledIndices {
 
                 @Override
                 public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                    try {
-                        channel.sendResponse(new AllocateDangledResponse());
-                    } catch (IOException e) {
-                        logger.warn("failed send response for allocating dangled", e);
-                    }
+                    channel.sendResponse(new AllocateDangledResponse());
                 }
             });
         }

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -342,7 +342,7 @@ public class IndicesStore implements ClusterStateListener, Closeable {
                         public void sendResult(boolean shardActive) {
                             try {
                                 channel.sendResponse(new ShardActiveResponse(shardActive, clusterService.localNode()));
-                            } catch (IOException | EsRejectedExecutionException e) {
+                            } catch (EsRejectedExecutionException e) {
                                 logger.error(() -> new ParameterizedMessage("failed send response for shard active while trying to " +
                                     "delete shard {} - shard will probably not be removed", request.shardId), e);
                             }

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -70,7 +70,7 @@ public final class OutboundHandler {
      */
     void sendRequest(final DiscoveryNode node, final TcpChannel channel, final long requestId, final String action,
                      final TransportRequest request, final TransportRequestOptions options, final Version channelVersion,
-                     final boolean compressRequest, final boolean isHandshake) throws IOException, TransportException {
+                     final boolean compressRequest, final boolean isHandshake) throws TransportException {
         Version version = Version.min(this.version, channelVersion);
         OutboundMessage.Request message =
             new OutboundMessage.Request(threadPool.getThreadContext(), request, version, action, requestId, isHandshake, compressRequest);
@@ -86,7 +86,7 @@ public final class OutboundHandler {
      * @see #sendErrorResponse(Version, TcpChannel, long, String, Exception) for sending error responses
      */
     void sendResponse(final Version nodeVersion, final TcpChannel channel, final long requestId, final String action,
-                      final TransportResponse response, final boolean compress, final boolean isHandshake) throws IOException {
+                      final TransportResponse response, final boolean compress, final boolean isHandshake) {
         Version version = Version.min(this.version, nodeVersion);
         OutboundMessage.Response message = new OutboundMessage.Response(threadPool.getThreadContext(), response, version,
             requestId, isHandshake, compress);
@@ -98,7 +98,7 @@ public final class OutboundHandler {
      * Sends back an error response to the caller via the given channel
      */
     void sendErrorResponse(final Version nodeVersion, final TcpChannel channel, final long requestId, final String action,
-                           final Exception error) throws IOException {
+                           final Exception error) {
         Version version = Version.min(this.version, nodeVersion);
         TransportAddress address = new TransportAddress(channel.getLocalAddress());
         RemoteTransportException tx = new RemoteTransportException(nodeName, address, action, error);
@@ -108,7 +108,7 @@ public final class OutboundHandler {
         sendMessage(channel, message, listener);
     }
 
-    private void sendMessage(TcpChannel channel, OutboundMessage networkMessage, ActionListener<Void> listener) throws IOException {
+    private void sendMessage(TcpChannel channel, OutboundMessage networkMessage, ActionListener<Void> listener) {
         MessageSerializer serializer = new MessageSerializer(networkMessage, bigArrays);
         SendContext sendContext = new SendContext(channel, serializer, listener, serializer);
         internalSend(channel, sendContext);

--- a/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
@@ -22,8 +22,6 @@ package org.elasticsearch.transport;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lease.Releasable;
 
-import java.io.IOException;
-
 public class TaskTransportChannel implements TransportChannel {
 
     private final TransportChannel channel;
@@ -45,7 +43,7 @@ public class TaskTransportChannel implements TransportChannel {
     }
 
     @Override
-    public void sendResponse(TransportResponse response) throws IOException {
+    public void sendResponse(TransportResponse response) {
         try {
             onTaskFinished.close();
         } finally {
@@ -54,7 +52,7 @@ public class TaskTransportChannel implements TransportChannel {
     }
 
     @Override
-    public void sendResponse(Exception exception) throws IOException {
+    public void sendResponse(Exception exception) {
         try {
             onTaskFinished.close();
         } finally {

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -239,7 +239,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
         @Override
         public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
-            throws IOException, TransportException {
+            throws TransportException {
             if (isClosing.get()) {
                 throw new NodeNotConnectedException(node, "connection already closed");
             }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -22,7 +22,6 @@ package org.elasticsearch.transport;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.lease.Releasable;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class TcpTransportChannel implements TransportChannel {
@@ -55,7 +54,7 @@ public final class TcpTransportChannel implements TransportChannel {
     }
 
     @Override
-    public void sendResponse(TransportResponse response) throws IOException {
+    public void sendResponse(TransportResponse response) {
         try {
             outboundHandler.sendResponse(version, channel, requestId, action, response, compressResponse, isHandshake);
         } finally {
@@ -64,7 +63,7 @@ public final class TcpTransportChannel implements TransportChannel {
     }
 
     @Override
-    public void sendResponse(Exception exception) throws IOException {
+    public void sendResponse(Exception exception) {
         try {
             outboundHandler.sendErrorResponse(version, channel, requestId, action, exception);
         } finally {

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -26,7 +26,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.function.Function;
 
 /**
@@ -77,20 +76,12 @@ public final class TransportActionProxy {
 
         @Override
         public void handleResponse(T response) {
-            try {
-                channel.sendResponse(response);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            channel.sendResponse(response);
         }
 
         @Override
         public void handleException(TransportException exp) {
-            try {
-                channel.sendResponse(exp);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            channel.sendResponse(exp);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportChannel.java
@@ -21,8 +21,6 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.Version;
 
-import java.io.IOException;
-
 /**
  * A transport channel allows to send a response to a request on the channel.
  */
@@ -32,9 +30,9 @@ public interface TransportChannel {
 
     String getChannelType();
 
-    void sendResponse(TransportResponse response) throws IOException;
+    void sendResponse(TransportResponse response);
 
-    void sendResponse(Exception exception) throws IOException;
+    void sendResponse(Exception exception);
 
     /**
      * Returns the version of the other party that this channel will send a response to.

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1151,7 +1151,7 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
         }
 
         @Override
-        public void sendResponse(TransportResponse response) throws IOException {
+        public void sendResponse(TransportResponse response) {
             service.onResponseSent(requestId, action, response);
             final TransportResponseHandler handler = service.responseHandlers.onResponseReceived(requestId, service);
             // ignore if its null, the service logs it
@@ -1185,7 +1185,7 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
         }
 
         @Override
-        public void sendResponse(Exception exception) throws IOException {
+        public void sendResponse(Exception exception) {
             service.onResponseSent(requestId, action, exception);
             final TransportResponseHandler handler = service.responseHandlers.onResponseReceived(requestId, service);
             // ignore if its null, the service logs it


### PR DESCRIPTION
Follow up to #56961:

Since we don't serialize messages before passing them to the IO loop any more
we are also not throwing `IOException` any more on sending to the channel so this is all dead code.

