### PR TITLE
Add link to .NET client BulkAllObservable

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -109,6 +109,9 @@ JavaScript::
 
     See {jsclient-current}/client-helpers.html[client.helpers.*]
 
+.NET::
+    See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#_multiple_documents_with_bulkallobservable_helper[`BulkAllObservable`]
+
 [float]
 [[bulk-curl]]
 ===== Submitting bulk requests with cURL


### PR DESCRIPTION
Supersedes: #51388

This PR adds a link in the Bulk API documentation to
the .NET client's BulkAllObservable type and associated methods.