### PR TITLE
[7.8] Don't run IDP tests in FIPS 140 mode (#57048)

### DIFF
--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -368,4 +368,7 @@ gradle.projectsEvaluated {
     .findAll { it.path.startsWith(project.path + ":qa") }
     .each { check.dependsOn it.check }
 }
-
+if (BuildParams.inFipsJvm) {
+  // We don't support the IDP in FIPS-140 mode, so no need to run tests
+  test.enabled = false
+}


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Don't run IDP tests in FIPS 140 mode (#57048)