### PR TITLE
[7.8] Mute failing test (#57112)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -100,6 +100,7 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         testExpiredDeletion(null, 10010);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/57102")
     public void testDeleteExpiredDataWithStandardThrottle() throws Exception {
         testExpiredDeletion(-1.0f, 100);
     }


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Mute failing test  (#57112)