### PR TITLE
Fix key usage in SamlAuthenticatorTests

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -403,7 +403,7 @@ public class SamlAuthenticatorTests extends SamlTestCase {
         final String xml = getSimpleResponseAsString(now);
 
         // Encrypting with different cert instead of sp cert will mean that the SP cannot decrypt
-        final Response encrypted = encryptAttributes(xml, readKeyPair("RSA_4096_updated"));
+        final Response encrypted = encryptAttributes(xml, readKeyPair("ENCRYPTION_RSA_4096_updated"));
         final String encryptedString = SamlUtils.getXmlContent(encrypted, false);
         assertThat(encryptedString, not(equalTo(xml)));
 


### PR DESCRIPTION
In #51089 where SamlAuthenticatorTests were refactored, we missed
to update one test case which meant that a single key would be
used both for signing and encryption in the same run. As explained
in #51089, and due to FIPS 140 requirements, BouncyCastle FIPS
provider will block RSA keys that have been used for signing from
being used for encryption and vice versa

This commit changes testNoAttributesReturnedWhenTheyCannotBeDecrypted
to always use the specific keys we have added for encryption.