### PR TITLE
[DOCS] Fix formatting of create API key API docs

### DIFF
--- a/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-api-keys.asciidoc
@@ -11,6 +11,7 @@ Creates an API key for access without requiring basic authentication.
 ==== {api-request-title}
 
 `POST /_security/api_key`
+
 `PUT /_security/api_key`
 
 [[security-api-create-api-key-prereqs]]


### PR DESCRIPTION
Inserts a new line so the request formats are on different lines.