### PR TITLE
[7.7] Handle exceptions when building _cat/indices response

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -273,3 +273,19 @@
                open \s+ foo\n
                open \s+ baz\n
             $/
+
+---
+"Test cat indices with invalid health parameter":
+
+  - do:
+      indices.create:
+        index: foo
+        body:
+          settings:
+            number_of_shards: "1"
+            number_of_replicas: "0"
+
+  - do:
+      catch: bad_request
+      cat.indices:
+        health: "invalid-health-value"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -276,6 +276,9 @@
 
 ---
 "Test cat indices with invalid health parameter":
+  - skip:
+      version: " - 7.7.1"
+      reason:  "fixed in 7.7.1+"
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -222,8 +222,8 @@ public class RestIndicesAction extends AbstractCatAction {
                         .collect(Collectors.toMap(cursor -> cursor.key, cursor -> cursor.value));
 
                     ClusterStateResponse stateResponse = extractResponse(responses, ClusterStateResponse.class);
-                    Map<String, IndexMetadata> indicesStates =
-                        StreamSupport.stream(stateResponse.getState().getMetadata().spliterator(), false)
+                    Map<String, IndexMetaData> indicesStates =
+                        StreamSupport.stream(stateResponse.getState().getMetaData().spliterator(), false)
                             .collect(Collectors.toMap(indexMetadata -> indexMetadata.getIndex().getName(), Function.identity()));
 
                     ClusterHealthResponse healthResponse = extractResponse(responses, ClusterHealthResponse.class);

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -216,21 +216,27 @@ public class RestIndicesAction extends AbstractCatAction {
         return new GroupedActionListener<>(new ActionListener<Collection<ActionResponse>>() {
             @Override
             public void onResponse(final Collection<ActionResponse> responses) {
-                GetSettingsResponse settingsResponse = extractResponse(responses, GetSettingsResponse.class);
-                Map<String, Settings> indicesSettings = StreamSupport.stream(settingsResponse.getIndexToSettings().spliterator(), false)
-                    .collect(Collectors.toMap(cursor -> cursor.key, cursor -> cursor.value));
+                try {
+                    GetSettingsResponse settingsResponse = extractResponse(responses, GetSettingsResponse.class);
+                    Map<String, Settings> indicesSettings = StreamSupport.stream(settingsResponse.getIndexToSettings().spliterator(), false)
+                        .collect(Collectors.toMap(cursor -> cursor.key, cursor -> cursor.value));
 
-                ClusterStateResponse stateResponse = extractResponse(responses, ClusterStateResponse.class);
-                Map<String, IndexMetaData> indicesStates = StreamSupport.stream(stateResponse.getState().getMetaData().spliterator(), false)
-                    .collect(Collectors.toMap(indexMetaData -> indexMetaData.getIndex().getName(), Function.identity()));
+                    ClusterStateResponse stateResponse = extractResponse(responses, ClusterStateResponse.class);
+                    Map<String, IndexMetadata> indicesStates =
+                        StreamSupport.stream(stateResponse.getState().getMetadata().spliterator(), false)
+                            .collect(Collectors.toMap(indexMetadata -> indexMetadata.getIndex().getName(), Function.identity()));
 
-                ClusterHealthResponse healthResponse = extractResponse(responses, ClusterHealthResponse.class);
-                Map<String, ClusterIndexHealth> indicesHealths = healthResponse.getIndices();
+                    ClusterHealthResponse healthResponse = extractResponse(responses, ClusterHealthResponse.class);
+                    Map<String, ClusterIndexHealth> indicesHealths = healthResponse.getIndices();
 
-                IndicesStatsResponse statsResponse = extractResponse(responses, IndicesStatsResponse.class);
-                Map<String, IndexStats> indicesStats = statsResponse.getIndices();
+                    IndicesStatsResponse statsResponse = extractResponse(responses, IndicesStatsResponse.class);
+                    Map<String, IndexStats> indicesStats = statsResponse.getIndices();
 
-                listener.onResponse(buildTable(request, indicesSettings, indicesHealths, indicesStats, indicesStates));
+                    Table responseTable = buildTable(request, indicesSettings, indicesHealths, indicesStats, indicesStates);
+                    listener.onResponse(responseTable);
+                } catch (Exception e) {
+                    onFailure(e);
+                }
             }
 
             @Override


### PR DESCRIPTION
The root cause of this bug was an unhandled exception in the `onResponse` method for the `_cat/indices` endpoint that resulted in completion of neither the response nor failure methods of the REST handler. Adding a try-catch around the code in the `onResponse` method resolves this specific problem.

Backport of #56993 
