### PR TITLE
[8.0] [DOCS] Document impact of restore API's `include_global_state` param (#57067)

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -48,22 +48,27 @@ POST /_snapshot/my_backup/snapshot_1/_restore
   "indices": "index_1,index_2",
   "include_aliases": false,
   "ignore_unavailable": true,
-  "include_global_state": true,
+  "include_global_state": false,              <1>
   "rename_pattern": "index_(.+)",
-  "rename_replacement": "restored_index_$1"
+  "rename_replacement": "restored_index_$1",
+  "include_aliases": false
 }
 -----------------------------------
 // TEST[continued]
+
+<1> By default, `include_global_state` is `false`, meaning the snapshot's
+cluster state is not restored.
++
+If `true`, the snapshot's persistent settings, index templates, ingest
+pipelines, and {ilm-init} policies are restored into the current cluster. This
+overwrites any existing cluster settings, templates, pipelines and {ilm-init}
+policies whose names match those in the snapshot.
 
 The restore operation can be performed on a functioning cluster. However, an
 existing index can be only restored if it's <<indices-open-close,closed>> and
 has the same number of shards as the index in the snapshot. The restore
 operation automatically opens restored indices if they were closed and creates
-new indices if they didn't exist in the cluster. If cluster state is restored
-with `include_global_state` (defaults to `false`), the restored templates that
-don't currently exist in the cluster are added and existing templates with the
-same name are replaced by the restored templates. The restored persistent
-settings are added to the existing persistent settings.
+new indices if they didn't exist in the cluster.
 
 [float]
 === Partial restore

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -46,7 +46,6 @@ with associated indices.
 POST /_snapshot/my_backup/snapshot_1/_restore
 {
   "indices": "index_1,index_2",
-  "include_aliases": false,
   "ignore_unavailable": true,
   "include_global_state": false,              <1>
   "rename_pattern": "index_(.+)",


### PR DESCRIPTION
master backport of #57067