### PR TITLE
Add CSV delimiter when sourceURL field is empty

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/DependenciesInfoTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/DependenciesInfoTask.groovy
@@ -153,6 +153,8 @@ class DependenciesInfoTask extends ConventionTask {
         if (licenseInfo.sourceRedistributionRequired) {
             File sources = getDependencyInfoFile(group, name, 'SOURCES')
             licenseType += ",${sources.text.trim()}"
+        } else {
+            licenseType += ","
         }
 
         return licenseType


### PR DESCRIPTION
This commit ensure that lines of the CSV dependencies report always have a comma delimiter for `sourceURL` field, even when this field is empty.

Related to #56642.