### PR TITLE
Clean up numeric type hints on sorts

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -19,6 +19,15 @@
 
 package org.elasticsearch.index.fielddata;
 
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
+import org.elasticsearch.search.sort.BucketedSort;
+import org.elasticsearch.search.sort.SortOrder;
+
 public interface IndexNumericFieldData extends IndexFieldData<LeafNumericFieldData> {
 
     enum NumericType {
@@ -46,4 +55,27 @@ public interface IndexNumericFieldData extends IndexFieldData<LeafNumericFieldDa
     }
 
     NumericType getNumericType();
+
+    /**
+     * Returns the {@link SortField} to used for sorting.
+     * Values are casted to the provided <code>targetNumericType</code> type if it doesn't
+     * match the field's <code>numericType</code>.
+     */
+    SortField sortField(NumericType targetNumericType, Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse);
+
+    /**
+     * Builds a {@linkplain BucketedSort} for the {@code targetNumericType},
+     * casting the values if their native type doesn't match.
+     */
+    BucketedSort newBucketedSort(
+        NumericType targetNumericType,
+        BigArrays bigArrays,
+        @Nullable Object missingValue,
+        MultiValueMode sortMode,
+        Nested nested,
+        SortOrder sortOrder,
+        DocValueFormat format,
+        int bucketSize,
+        BucketedSort.ExtraData extra
+    );
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedNumericIndexFieldData.java
@@ -118,6 +118,7 @@ public class SortedNumericIndexFieldData implements IndexNumericFieldData {
      * Values are casted to the provided <code>targetNumericType</code> type if it doesn't
      * match the field's <code>numericType</code>.
      */
+    @Override
     public SortField sortField(NumericType targetNumericType, Object missingValue, MultiValueMode sortMode,
                                Nested nested, boolean reverse) {
         final XFieldComparatorSource source = comparatorSource(targetNumericType, missingValue, sortMode, nested);
@@ -163,6 +164,7 @@ public class SortedNumericIndexFieldData implements IndexNumericFieldData {
      * Builds a {@linkplain BucketedSort} for the {@code targetNumericType},
      * casting the values if their native type doesn't match.
      */
+    @Override
     public BucketedSort newBucketedSort(NumericType targetNumericType, BigArrays bigArrays, @Nullable Object missingValue,
             MultiValueMode sortMode, Nested nested, SortOrder sortOrder, DocValueFormat format,
             int bucketSize, BucketedSort.ExtraData extra) {

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -345,7 +345,7 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
                 throw new QueryShardException(context,
                     "[numeric_type] option cannot be set on a non-numeric field, got " + fieldType.typeName());
             }
-            SortedNumericIndexFieldData numericFieldData = (SortedNumericIndexFieldData) fieldData;
+            IndexNumericFieldData numericFieldData = (IndexNumericFieldData) fieldData;
             NumericType resolvedType = resolveNumericType(numericType);
             field = numericFieldData.sortField(resolvedType, missing, localSortMode(), nested, reverse);
         } else {
@@ -421,7 +421,11 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
             throw new QueryShardException(context, "we only support AVG, MEDIAN and SUM on number based fields");
         }
         if (numericType != null) {
-            SortedNumericIndexFieldData numericFieldData = (SortedNumericIndexFieldData) fieldData;
+            if (fieldData instanceof IndexNumericFieldData == false) {
+                throw new QueryShardException(context,
+                    "[numeric_type] option cannot be set on a non-numeric field, got " + fieldType.typeName());
+            }
+            IndexNumericFieldData numericFieldData = (IndexNumericFieldData) fieldData;
             NumericType resolvedType = resolveNumericType(numericType);
             return numericFieldData.newBucketedSort(resolvedType, context.bigArrays(), missing, localSortMode(), nested, order,
                     fieldType.docValueFormat(null, null), bucketSize, extra);


### PR DESCRIPTION
This cleans up how we apply numeric type hints in sorts to be ever so
slightly more OO by declaring the type hinted method in the interface
that we use for numeric types. You still need the `instanceof`, but you
are checking for an interface which gives us a bit more flexibility. And
it feels a little less bad.
