### PR TITLE
[DOCS] Fix remote cluster client node docs

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -44,7 +44,7 @@ Valid columns are:
 `node.role`, `r`, `role`, `nodeRole`::
 (Default) Roles of the node. Returned values include `d` (data node), `i`
 (ingest node), `m` (master-eligible node), `l` (machine learning node), `v`
-(voting-only node), `t` ({transform} node), and `-` (coordinating node only).
+(voting-only node), `t` ({transform} node), `r` (remote cluster client node), and `-` (coordinating node only).
 +
 For example, `dim` indicates a master-eligible data and ingest node. See
 <<modules-node>>.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -123,7 +123,7 @@ node.ingest: false <4>
 node.ml: false <5>
 xpack.ml.enabled: true <6>
 node.transform: false <7>
-node.remote_client_client: false <8>
+node.remote_cluster_client: false <8>
 -------------------
 <1> The `node.master` role is enabled by default.
 <2> The `node.voting_only` role is disabled by default.


### PR DESCRIPTION
This pull request updates the documentation for the new-ish `remote_cluster_client` node role.

- Added this information to the `_cat/nodes` documentation
- Fixed a typo of this attribute in another portion of the documentation

Relates to #54816