### PR TITLE
Fix GCS Repository YAML Test Build (#57073) (#57101)

### DIFF
--- a/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
+++ b/plugins/repository-gcs/qa/google-cloud-storage/build.gradle
@@ -128,7 +128,7 @@ integTest.mustRunAfter(thirdPartyTest)
  * an additional test that forces the large blob threshold to be small to exercise the resumable upload path.
  */
 task largeBlobIntegTest(type: RestIntegTestTask) {
-  mustRunAfter(thirdPartyTest)
+  mustRunAfter(thirdPartyTest, integTest)
 }
 
 check.dependsOn integTest
@@ -159,6 +159,7 @@ final Closure testClustersConfiguration = {
 
   if (useFixture) {
     tasks.integTest.dependsOn createServiceAccountFile
+    tasks.largeBlobIntegTest.dependsOn createServiceAccountFile
     /* Use a closure on the string to delay evaluation until tests are executed */
     setting 'gcs.client.integration_test.endpoint', { "${-> fixtureAddress('gcs-fixture')}" }, IGNORE_VALUE
     setting 'gcs.client.integration_test.token_uri', { "${-> fixtureAddress('gcs-fixture')}/o/oauth2/token" }, IGNORE_VALUE

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.RestUtils;
@@ -40,7 +39,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -259,8 +257,7 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
     }
 
     private String httpServerUrl(final HttpExchange exchange) {
-        final InetSocketAddress address = exchange.getLocalAddress();
-        return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+        return "http://" + exchange.getRequestHeaders().get("HOST").get(0);
     }
 
     private static final Pattern NAME_PATTERN = Pattern.compile("\"name\":\"([^\"]*)\"");


### PR DESCRIPTION
A few relatively obvious issues here:

* We cannot run the different IT runs (large blob setting one and normal integ run) concurrently
* We need to set the dependency tasks up correctly for the large blob run so that it works in isolation
* We can't use the `localAddress` for the location header of the resumable upload
(this breaks in YAML tests because GCS is using a loopback port forward for the initial request and the
local address will be chosen as the actual Docker container host)

Closes #57026


backport of #57073 