### PR TITLE
[DOCS][7.6] Adds a link to inference field_mappings that points to multi-field limitation

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -14,7 +14,7 @@ ingested in the pipeline.
 | Name               | Required  | Default                        | Description
 | `model_id`         | yes       | -                              | (String) The ID of the model to load and infer against.
 | `target_field`     | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
-| `field_mappings`   | yes       | -                              | (Object) Maps the document field names to the known field names of the model.
+| `field_mappings`   | yes       | -                              | (Object) Maps the document field names to the known field names of the model. Refer to {ml-docs}/ml-dfa-limitations.html#dfa-inference-multi-field[this page] for further info about multi-fields and {infer}.
 | `inference_config` | yes       | -                              | (Object) Contains the inference type and its options. There are two types: <<inference-processor-regression-opt,`regression`>> and <<inference-processor-classification-opt,`classification`>>.
 include::common-options.asciidoc[]
 |======


### PR DESCRIPTION
## Overview

This PR expands the inference pipeline documentation with a link that points to the multi-field limitation of inference.

### Preview

[Inference pipeline](https://elasticsearch_57193.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.6/inference-processor.html)