### PR TITLE
[DOCS][7.7] Fixes collapsible sections in PUT inference API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -44,7 +44,7 @@ is not created by {dfanalytics}.
 include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
-role="child_attributes"]
+[role="child_attributes"]
 [[ml-put-inference-request-body]]
 ==== {api-request-body-title}
 


### PR DESCRIPTION
## Overview

This PR adds an opening `[` to an attribute line and with this it fixes the layout of the collapsible sections on the page.

### Preview

[PUT inference](https://elasticsearch_57195.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.7/put-inference.html)