### PR TITLE
[DOCS] Fixes formatting of admonition paragraph in PUT inference API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -8,13 +8,13 @@
 ++++
 
 Creates an {infer} trained model.
-+
---
+
 WARNING: Models created in version 7.8.0 are not backwards compatible
          with older node versions. If in a mixed cluster environment,
          all nodes must be at least 7.8.0 to use a model stored by
          a 7.8.0 node.
---
+
+
 experimental[]
 
 


### PR DESCRIPTION
## Overview

Removes unnecessary markup from the docs.

### Preview

[PUT Inference API](https://elasticsearch_57196.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-inference.html)