### PR TITLE
Fix up-to-date checks for precommit related tasks

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -487,6 +487,8 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                     // we put all our distributable files under distributions
                     jarTask.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
                     // fixup the jar manifest
+                    // Explicitly using an Action interface as java lambdas
+                    // are not supported by Gradle up-to-date checks
                     jarTask.doFirst(new Action<Task>() {
                         @Override
                         public void execute(Task task) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -149,7 +149,9 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
     private static final Pattern LUCENE_SNAPSHOT_REGEX = Pattern.compile("\\w+-snapshot-([a-z0-9]+)");
 
-    /** Adds repositories used by ES dependencies */
+    /**
+     * Adds repositories used by ES dependencies
+     */
     public static void configureRepositories(Project project) {
         // ensure all repositories use secure urls
         // TODO: remove this with gradle 7.0, which no longer allows insecure urls
@@ -216,7 +218,9 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         }
     }
 
-    /** Adds compiler settings to the project */
+    /**
+     * Adds compiler settings to the project
+     */
     public static void configureCompile(Project project) {
         project.getExtensions().getExtraProperties().set("compactProfile", "full");
 
@@ -483,8 +487,9 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                     // we put all our distributable files under distributions
                     jarTask.getDestinationDirectory().set(new File(project.getBuildDir(), "distributions"));
                     // fixup the jar manifest
-                    jarTask.doFirst(
-                        t -> {
+                    jarTask.doFirst(new Action<Task>() {
+                        @Override
+                        public void execute(Task task) {
                             // this doFirst is added before the info plugin, therefore it will run
                             // after the doFirst added by the info plugin, and we can override attributes
                             jarTask.getManifest()
@@ -497,7 +502,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                                     )
                                 );
                         }
-                    );
+                    });
                 }
             );
         project.getPluginManager().withPlugin("com.github.johnrengelman.shadow", p -> {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/DependencyLicensesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/DependencyLicensesTask.java
@@ -227,9 +227,9 @@ public class DependencyLicensesTask extends DefaultTask {
 
     }
 
-    // this is just a marker output folder to allow this task being up-to-date
-    // the check logic is exception driven so a failed task will not be defined
-    // by this output but when successful we can safely mark the task as up-to-date
+    // This is just a marker output folder to allow this task being up-to-date.
+    // The check logic is exception driven so a failed tasks will not be defined
+    // by this output but when successful we can safely mark the task as up-to-date.
     @OutputDirectory
     public File getOutputMarker() {
         return new File(getProject().getBuildDir(), "dependencyLicense");

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/DependencyLicensesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/DependencyLicensesTask.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -223,6 +224,15 @@ public class DependencyLicensesTask extends DefaultTask {
         if (shaFiles.isEmpty() == false) {
             throw new GradleException("Unused sha files found: \n" + joinFilenames(shaFiles));
         }
+
+    }
+
+    // this is just a marker output folder to allow this task being up-to-date
+    // the check logic is exception driven so a failed task will not be defined
+    // by this output but when successful we can safely mark the task as up-to-date
+    @OutputDirectory
+    public File getOutputMarker() {
+        return new File(getProject().getBuildDir(), "dependencyLicense");
     }
 
     private void failIfAnyMissing(String item, Boolean exists, String type) {


### PR DESCRIPTION
- Do not use lambdas for doFirst / doLast action declarations as this is not supported by gradle up-to-date check
- Use marker output folder for dependencies license task to make task incremental build compliant