### PR TITLE
Remove Overly Strict Safety Mechnism in Shard Snapshot Logic

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
@@ -33,11 +33,15 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.SnapshotException;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -52,6 +56,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFutureThrows;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
@@ -64,7 +69,7 @@ public class SnapshotDisruptionIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockTransportService.TestPlugin.class);
+        return Arrays.asList(MockTransportService.TestPlugin.class, MockRepository.Plugin.class);
     }
 
     @Override
@@ -161,6 +166,68 @@ public class SnapshotDisruptionIT extends ESIntegTestCase {
         }
 
         assertAllSnapshotsCompleted();
+    }
+
+    public void testDisruptionAfterShardFinalization() throws Exception {
+        final String idxName = "test";
+        internalCluster().startMasterOnlyNodes(1);
+        final String dataNode = internalCluster().startDataOnlyNode();
+        ensureStableCluster(2);
+        createIndex(idxName);
+        index(idxName, JsonXContent.contentBuilder().startObject().field("foo", "bar").endObject());
+
+        final String repoName = "test-repo";
+
+        logger.info("--> creating repository");
+        assertAcked(client().admin().cluster().preparePutRepository(repoName).setType("mock")
+                .setSettings(Settings.builder().put("location", randomRepoPath())));
+
+        final String masterNode = internalCluster().getMasterName();
+
+        AbstractSnapshotIntegTestCase.blockAllDataNodes(repoName);
+
+        final String snapshot = "test-snap";
+        logger.info("--> starting snapshot");
+        ActionFuture<CreateSnapshotResponse> future = client(masterNode).admin().cluster()
+                .prepareCreateSnapshot(repoName, snapshot).setWaitForCompletion(true).execute();
+
+        AbstractSnapshotIntegTestCase.waitForBlockOnAnyDataNode(repoName, TimeValue.timeValueSeconds(10L));
+
+        NetworkDisruption networkDisruption = new NetworkDisruption(
+                new NetworkDisruption.TwoPartitions(Collections.singleton(masterNode), Collections.singleton(dataNode)),
+                new NetworkDisruption.NetworkDisconnect());
+        internalCluster().setDisruptionScheme(networkDisruption);
+        networkDisruption.startDisrupting();
+
+        final CreateSnapshotResponse createSnapshotResponse = future.get();
+        final SnapshotInfo snapshotInfo = createSnapshotResponse.getSnapshotInfo();
+        assertThat(snapshotInfo.state(), is(SnapshotState.PARTIAL));
+
+        logger.info("--> stopping disrupting");
+        networkDisruption.stopDisrupting();
+        AbstractSnapshotIntegTestCase.unblockAllDataNodes(repoName);
+
+        ensureStableCluster(2, masterNode);
+        logger.info("--> done");
+
+        logger.info("--> recreate the index with potentially different shard counts");
+        client().admin().indices().prepareDelete(idxName).get();
+        createIndex(idxName);
+        index(idxName, JsonXContent.contentBuilder().startObject().field("foo", "bar").endObject());
+
+        logger.info("--> run a snapshot that fails to finalize but succeeds on the data node");
+        AbstractSnapshotIntegTestCase.blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture =
+                client(masterNode).admin().cluster().prepareCreateSnapshot(repoName, "snapshot-2").setWaitForCompletion(true).execute();
+        AbstractSnapshotIntegTestCase.waitForBlock(masterNode, repoName, TimeValue.timeValueSeconds(10L));
+        AbstractSnapshotIntegTestCase.unblockNode(repoName, masterNode);
+        assertFutureThrows(snapshotFuture, SnapshotException.class);
+
+        logger.info("--> create a snapshot expected to be successful");
+        final CreateSnapshotResponse successfulSnapshot =
+                client(masterNode).admin().cluster().prepareCreateSnapshot(repoName, "snapshot-2").setWaitForCompletion(true).get();
+        final SnapshotInfo successfulSnapshotInfo = successfulSnapshot.getSnapshotInfo();
+        assertThat(successfulSnapshotInfo.state(), is(SnapshotState.SUCCESS));
     }
 
     private void assertAllSnapshotsCompleted() throws Exception {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2128,8 +2128,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             return new Tuple<>(shardSnapshots, latest);
         } else if (blobs.stream().anyMatch(b -> b.startsWith(SNAPSHOT_PREFIX) || b.startsWith(INDEX_FILE_PREFIX)
                                                                               || b.startsWith(UPLOADED_DATA_BLOB_PREFIX))) {
-            throw new IllegalStateException(
-                "Could not find a readable index-N file in a non-empty shard snapshot directory [" + shardContainer.path() + "]");
+            logger.warn("Could not find a readable index-N file in a non-empty shard snapshot directory [" + shardContainer.path() + "]");
         }
         return new Tuple<>(BlobStoreIndexShardSnapshots.EMPTY, latest);
     }

--- a/server/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -134,7 +134,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         internalCluster().stopRandomNode(settings -> settings.get("node.name").equals(node));
     }
 
-    public void waitForBlock(String node, String repository, TimeValue timeout) throws InterruptedException {
+    public static void waitForBlock(String node, String repository, TimeValue timeout) throws InterruptedException {
         long start = System.currentTimeMillis();
         RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class, node);
         MockRepository mockRepository = (MockRepository) repositoriesService.repository(repository);
@@ -215,7 +215,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         }
     }
 
-    public void waitForBlockOnAnyDataNode(String repository, TimeValue timeout) throws InterruptedException {
+    public static void waitForBlockOnAnyDataNode(String repository, TimeValue timeout) throws InterruptedException {
         final boolean blocked = waitUntil(() -> {
             for (RepositoriesService repositoriesService : internalCluster().getDataNodeInstances(RepositoriesService.class)) {
                 MockRepository mockRepository = (MockRepository) repositoriesService.repository(repository);


### PR DESCRIPTION
Unfortunately, we cannot have a safety mechanism like this where we throw whenever we find unreadable
data in a shard.
This breaks in the case of an older ES version (without shard generations enabled) having failed to snapshot
a shard snapshot after writing some data to its path and having finalized it for example.
Another example of where we can't support this check is the test I added, if we snapshot an index with a name
that already exists in the repository and more shards than the existing index, fail doing that and then retry snapshotting it we will also see unexpected data in the path.

We could technically do deeper inspections on the unexpected data but I don't think it's worth it really. In the end if we are
unable to read the data here it's broken anyway. By moving to a new `index-` blob in the shard directory I don't see us ever
corrupting existing data and since we (by virtue of moving to an empty generation) won't do any incremental work on top of
potentially corrupt data we also do not risk creating broken snapshots going forward.
=> Just logging a warning in this very unlikely case is the best we can do I think (this is also what we used to do up until `7.6` anyway)

closes #57198