### PR TITLE
Remove compiler java version flag

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -231,24 +231,10 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                 throw new GradleException("Failed to get canonical path for " + file, e);
             }
         };
-        // common options to both java and groovy
-        Consumer<CompileOptions> configureFork = compileOptions -> {
-            // we only fork if the Gradle JDK is not the same as the compiler JDK
-            String compilerJavaHome = canonicalPath.apply(BuildParams.getCompilerJavaHome());
-            String currentJavaHome = canonicalPath.apply(Jvm.current().getJavaHome());
-            if (compilerJavaHome.equals(currentJavaHome)) {
-                compileOptions.setFork(false);
-            } else {
-                compileOptions.setFork(true);
-                compileOptions.getForkOptions().setJavaHome(BuildParams.getCompilerJavaHome());
-            }
-        };
 
         project.afterEvaluate(p -> {
             project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {
                 CompileOptions compileOptions = compileTask.getOptions();
-
-                configureFork.accept(compileOptions);
                 /*
                  * -path because gradle will send in paths that don't always exist.
                  * -missing because we have tons of missing @returns and @param.
@@ -279,7 +265,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
             });
             // also apply release flag to groovy, which is used in build-tools
             project.getTasks().withType(GroovyCompile.class).configureEach(compileTask -> {
-                configureFork.accept(compileTask.getOptions());
 
                 // TODO: this probably shouldn't apply to groovy at all?
                 // TODO: use native Gradle support for --release when available (cf. https://github.com/gradle/gradle/issues/2510)
@@ -416,7 +401,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
             // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD
             nonInputProperties.systemProperty("java.io.tmpdir", test.getWorkingDir().toPath().resolve("temp"));
 
-            nonInputProperties.systemProperty("compiler.java", BuildParams.getCompilerJavaVersion().getMajorVersion());
             nonInputProperties.systemProperty("runtime.java", BuildParams.getRuntimeJavaVersion().getMajorVersion());
 
             // TODO: remove setting logging level via system property
@@ -493,7 +477,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
                                         "Build-Date",
                                         BuildParams.getBuildDate(),
                                         "Build-Java-Version",
-                                        BuildParams.getCompilerJavaVersion()
+                                        BuildParams.getGradleJavaVersion()
                                     )
                                 );
                         }
@@ -544,18 +528,6 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
     private static void configureJavadoc(Project project) {
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
-            // only explicitly set javadoc executable if compiler JDK is different from Gradle
-            // this ensures better cacheability as setting ths input to an absolute path breaks portability
-            Path compilerJvm = BuildParams.getCompilerJavaHome().toPath();
-            Path gradleJvm = Jvm.current().getJavaHome().toPath();
-            try {
-                if (Files.isSameFile(compilerJvm, gradleJvm) == false) {
-                    javadoc.setExecutable(compilerJvm.resolve("bin/javadoc").toString());
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-
             /*
              * Generate docs using html5 to suppress a warning from `javadoc`
              * that the default will change to html5 in the future.

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -53,16 +53,12 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.external.javadoc.CoreJavadocOptions;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;

--- a/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/info/BuildParams.java
+++ b/buildSrc/src/minimumRuntime/java/org/elasticsearch/gradle/info/BuildParams.java
@@ -13,14 +13,12 @@ import java.util.function.Consumer;
 import static java.util.Objects.requireNonNull;
 
 public class BuildParams {
-    private static File compilerJavaHome;
     private static File runtimeJavaHome;
     private static Boolean isRuntimeJavaHomeSet;
     private static List<JavaHome> javaVersions;
     private static JavaVersion minimumCompilerVersion;
     private static JavaVersion minimumRuntimeVersion;
     private static JavaVersion gradleJavaVersion;
-    private static JavaVersion compilerJavaVersion;
     private static JavaVersion runtimeJavaVersion;
     private static Boolean inFipsJvm;
     private static String gitRevision;
@@ -45,10 +43,6 @@ public class BuildParams {
         initializer.accept(MutableBuildParams.INSTANCE);
     }
 
-    public static File getCompilerJavaHome() {
-        return value(compilerJavaHome);
-    }
-
     public static File getRuntimeJavaHome() {
         return value(runtimeJavaHome);
     }
@@ -71,10 +65,6 @@ public class BuildParams {
 
     public static JavaVersion getGradleJavaVersion() {
         return value(gradleJavaVersion);
-    }
-
-    public static JavaVersion getCompilerJavaVersion() {
-        return value(compilerJavaVersion);
     }
 
     public static JavaVersion getRuntimeJavaVersion() {
@@ -162,10 +152,6 @@ public class BuildParams {
             });
         }
 
-        public void setCompilerJavaHome(File compilerJavaHome) {
-            BuildParams.compilerJavaHome = requireNonNull(compilerJavaHome);
-        }
-
         public void setRuntimeJavaHome(File runtimeJavaHome) {
             BuildParams.runtimeJavaHome = requireNonNull(runtimeJavaHome);
         }
@@ -188,10 +174,6 @@ public class BuildParams {
 
         public void setGradleJavaVersion(JavaVersion gradleJavaVersion) {
             BuildParams.gradleJavaVersion = requireNonNull(gradleJavaVersion);
-        }
-
-        public void setCompilerJavaVersion(JavaVersion compilerJavaVersion) {
-            BuildParams.compilerJavaVersion = requireNonNull(compilerJavaVersion);
         }
 
         public void setRuntimeJavaVersion(JavaVersion runtimeJavaVersion) {

--- a/x-pack/plugin/sql/qa/jdbc/security/with-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/with-ssl/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.info.BuildParams
+import org.gradle.internal.jvm.Jvm
 
 // Tell the tests we're running with ssl enabled
 integTest.runner {
@@ -26,7 +27,7 @@ task createNodeKeyStore(type: LoggedExec) {
             delete nodeKeystore
         }
     }
-    executable = "${BuildParams.compilerJavaHome}/bin/keytool"
+    executable = "${Jvm.current().javaHome}/bin/keytool"
     standardInput = new ByteArrayInputStream('FirstName LastName\nUnit\nOrganization\nCity\nState\nNL\nyes\n\n'.getBytes('UTF-8'))
     args '-genkey',
             '-alias', 'test-node',

--- a/x-pack/plugin/sql/qa/server/security/with-ssl/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/with-ssl/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.info.BuildParams
+import org.gradle.internal.jvm.Jvm
 
 // Tell the tests we're running with ssl enabled
 integTest.runner {
@@ -26,7 +27,7 @@ task createNodeKeyStore(type: LoggedExec) {
       delete nodeKeystore
     }
   }
-  executable = "${BuildParams.compilerJavaHome}/bin/keytool"
+  executable = "${Jvm.current().javaHome}/bin/keytool"
   standardInput = new ByteArrayInputStream('FirstName LastName\nUnit\nOrganization\nCity\nState\nNL\nyes\n\n'.getBytes('UTF-8'))
   args '-genkey',
     '-alias', 'test-node',


### PR DESCRIPTION
This commit removes the compiler.java setting from the build. It was
originally added when Gradle was far behind support for the latest jdk,
but is no longer applicable as we don't have any need to update the
supported compile version before gradle supports the newer version. Note
that the runtime version changing support still exists here, this only
ensures we use the same jdk to compile as we use to run gradle.