### PR TITLE
Move gradle version check to global build info plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,11 +28,6 @@ plugins {
 
 group = 'org.elasticsearch.gradle'
 
-String minimumGradleVersion = file('src/main/resources/minimumGradleVersion').text.trim()
-if (GradleVersion.current() < GradleVersion.version(minimumGradleVersion)) {
-  throw new GradleException("Gradle ${minimumGradleVersion}+ is required to build elasticsearch")
-}
-
 if (project == rootProject) {
   // change the build dir used during build init, so that doing a clean
   // won't wipe out the buildscript jar

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -63,18 +63,6 @@ class BuildPlugin implements Plugin<Project> {
                     + 'elasticsearch.standalone-rest-test, and elasticsearch.build '
                     + 'are mutually exclusive')
         }
-        String minimumGradleVersion = null
-        InputStream is = getClass().getResourceAsStream("/minimumGradleVersion")
-        try {
-            minimumGradleVersion = IOUtils.toString(is, StandardCharsets.UTF_8.toString())
-        } finally {
-            is.close()
-        }
-        if (GradleVersion.current() < GradleVersion.version(minimumGradleVersion.trim())) {
-            throw new GradleException(
-                    "Gradle ${minimumGradleVersion}+ is required to use elasticsearch.build plugin"
-            )
-        }
         project.pluginManager.apply('elasticsearch.java')
         configureLicenseAndNotice(project)
         project.pluginManager.apply('elasticsearch.publish')

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/info/GlobalBuildInfoPlugin.java
@@ -66,6 +66,10 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         if (project != project.getRootProject()) {
             throw new IllegalStateException(this.getClass().getName() + " can only be applied to the root project.");
         }
+        GradleVersion minimumGradleVersion = GradleVersion.version(Util.getResourceContents("/minimumGradleVersion"));
+        if (GradleVersion.current().compareTo(minimumGradleVersion) < 0) {
+            throw new GradleException("Gradle " + minimumGradleVersion.getVersion() + "+ is required");
+        }
 
         JavaVersion minimumCompilerVersion = JavaVersion.toVersion(Util.getResourceContents("/minimumCompilerVersion"));
         JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(Util.getResourceContents("/minimumRuntimeVersion"));


### PR DESCRIPTION
The gradle version check currently exists in BuildPlugin. However, there
is no reason to check this within every project. Instead, this commit
moves the check to the global build info, which is only applied to the
root project. Additionally, this commit removes the check from buildSrc
because it is not really necessary. The check exists really just for
external plugin authors since we use the gradle wrapper for our own
build.