### PR TITLE
[7.x] Limit _cat/indices test to versions with fix (#57244)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -276,6 +276,9 @@
 
 ---
 "Test cat indices with invalid health parameter":
+  - skip:
+      version: " - 7.7.1"
+      reason:  "fixed in 7.7.1+"
 
   - do:
       indices.create:


### PR DESCRIPTION
Fixes #57119

Backport of #57244 
