### PR TITLE
Move test error reporting to java plugin

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -80,9 +80,6 @@ class BuildPlugin implements Plugin<Project> {
         project.pluginManager.apply('elasticsearch.publish')
         project.pluginManager.apply(DependenciesInfoPlugin)
 
-        // apply global test task failure listener
-        project.rootProject.pluginManager.apply(TestFailureReportingPlugin)
-
         project.getTasks().register("buildResources", ExportElasticsearchBuildResourcesTask)
 
         project.extensions.getByType(ExtraPropertiesExtension).set('versions', VersionProperties.versions)
@@ -131,35 +128,6 @@ class BuildPlugin implements Plugin<Project> {
                 task.systemProperty('javax.net.ssl.trustStore', bcfksKeystore.toString())
             }
 
-        }
-    }
-
-    private static class TestFailureReportingPlugin implements Plugin<Project> {
-        @Override
-        void apply(Project project) {
-            if (project != project.rootProject) {
-                throw new IllegalStateException("${this.class.getName()} can only be applied to the root project.")
-            }
-
-            project.gradle.addListener(new TaskActionListener() {
-                @Override
-                void beforeActions(Task task) {
-
-                }
-
-                @Override
-                void afterActions(Task task) {
-                    if (task instanceof Test) {
-                        ErrorReportingTestListener listener = task.extensions.findByType(ErrorReportingTestListener)
-                        if (listener != null && listener.getFailedTests().size() > 0) {
-                            task.logger.lifecycle("\nTests with failures:")
-                            listener.getFailedTests().each {
-                                task.logger.lifecycle(" - ${it.getFullName()}")
-                            }
-                        }
-                    }
-                }
-            })
         }
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -582,7 +582,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         @Override
         public void apply(Project project) {
             if (project != project.getRootProject()) {
-                throw new IllegalStateException(this.getClass().getName() +" can only be applied to the root project.");
+                throw new IllegalStateException(this.getClass().getName() + " can only be applied to the root project.");
             }
 
             project.getGradle().addListener(new TaskActionListener() {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -578,7 +578,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(javadoc));
     }
 
-    private static class TestFailureReportingPlugin implements Plugin<Project> {
+    static class TestFailureReportingPlugin implements Plugin<Project> {
         @Override
         public void apply(Project project) {
             if (project != project.getRootProject()) {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ElasticsearchJavaPlugin.java
@@ -39,6 +39,7 @@ import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
@@ -83,8 +84,11 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
     public void apply(Project project) {
         // make sure the global build info plugin is applied to the root project
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
+        // apply global test task failure listener
+        project.getRootProject().getPluginManager().apply(TestFailureReportingPlugin.class);
 
         project.getPluginManager().apply(JavaPlugin.class);
+
         configureConfigurations(project);
         configureRepositories(project);
         configureCompile(project);
@@ -572,5 +576,32 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
         // ensure javadoc task is run with 'check'
         project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(javadoc));
+    }
+
+    private static class TestFailureReportingPlugin implements Plugin<Project> {
+        @Override
+        public void apply(Project project) {
+            if (project != project.getRootProject()) {
+                throw new IllegalStateException(this.getClass().getName() +" can only be applied to the root project.");
+            }
+
+            project.getGradle().addListener(new TaskActionListener() {
+                @Override
+                public void beforeActions(Task task) {}
+
+                @Override
+                public void afterActions(Task task) {
+                    if (task instanceof Test) {
+                        ErrorReportingTestListener listener = task.getExtensions().findByType(ErrorReportingTestListener.class);
+                        if (listener != null && listener.getFailedTests().size() > 0) {
+                            task.getLogger().lifecycle("\nTests with failures:");
+                            for (ErrorReportingTestListener.Descriptor failure : listener.getFailedTests()) {
+                                task.getLogger().lifecycle(" - " + failure.getFullName());
+                            }
+                        }
+                    }
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
This commit moves the global hook for reporting failed test cases to the
ElasticsearchJavaPlugin. It should always be applied for all java
projects since the Test class is what emits the failures logged.