### PR TITLE
Omit translog bwc test before 6.3.0 with default distro

### DIFF
--- a/qa/translog-policy/build.gradle
+++ b/qa/translog-policy/build.gradle
@@ -27,7 +27,14 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
+boolean isDefaultDistro = System.getProperty('tests.distribution', 'oss') == 'default'
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
+  if (bwcVersion.before('6.3.0') && isDefaultDistro) {
+    // explicitly running restart on the current node does not work in step 2
+    // below when plugins are installed, wihch is the case for x-pack as a plugin
+    // prior to 6.3.0
+    continue
+  }
   String baseName = "v${bwcVersion}"
 
   testClusters {


### PR DESCRIPTION
The new translog bwc test checks a corruption case before 6.3.0.
However, it needs to restart the old node to reproduce, which does not
currently work given how testclusters works when plugins are installed.
As a workaround, this commit omits creating bwc tests before 6.3.0 only
when the default distribution is used.

fixes #57252
