### PR TITLE
[7.x] [DOCS] Adds a doc value field example to Mapper Size docs (#57257)

### DIFF
--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -45,7 +45,7 @@ GET my_index/_search
 {
   "query": {
     "range": {
-      "_size": { <1>
+      "_size": {                      <1>
         "gt": 10
       }
     }
@@ -53,23 +53,29 @@ GET my_index/_search
   "aggs": {
     "sizes": {
       "terms": {
-        "field": "_size", <2>
+        "field": "_size",             <2>
         "size": 10
       }
     }
   },
   "sort": [
     {
-      "_size": { <3>
+      "_size": {                      <3>
         "order": "desc"
       }
     }
   ],
   "script_fields": {
     "size": {
-      "script": "doc['_size']"  <4>
+      "script": "doc['_size']"        <4>
     }
-  }
+  },
+  "docvalue_fields": [
+    {
+      "field": "_size",               <5>
+      "format": "use_field_mapping"
+    }
+  ]
 }
 --------------------------
 // TEST[continued]
@@ -77,4 +83,12 @@ GET my_index/_search
 <1> Querying on the `_size` field
 <2> Aggregating on the `_size` field
 <3> Sorting on the `_size` field
-<4> Accessing the `_size` field in scripts (inline scripts must be modules-security-scripting.html#enable-dynamic-scripting[enabled] for this example to work)
+<4> Uses a
+{ref}/search-request-body.html#request-body-search-script-fields[script field]
+to return the `_size` field in the search response.
+<5> Uses a
+{ref}/search-request-body.html#request-body-search-docvalue-fields[doc value
+field] to return the `_size` field in the search response. Doc value fields are
+useful if
+{ref}/modules-scripting-security.html#allowed-script-types-setting[inline
+scripts are disabled].

--- a/docs/plugins/mapper-size.asciidoc
+++ b/docs/plugins/mapper-size.asciidoc
@@ -72,8 +72,7 @@ GET my_index/_search
   },
   "docvalue_fields": [
     {
-      "field": "_size",               <5>
-      "format": "use_field_mapping"
+      "field": "_size"                <5>
     }
   ]
 }


### PR DESCRIPTION
7.x backport of #57257