### PR TITLE
Update snapshot.delete.json to make snapshot a list type

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
@@ -2,7 +2,7 @@
   "snapshot.delete":{
     "documentation":{
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
-      "description":"Deletes a snapshot."
+      "description":"Deletes one or more snapshots."
     },
     "stability":"stable",
     "url":{
@@ -18,8 +18,8 @@
               "description":"A repository name"
             },
             "snapshot":{
-              "type":"string",
-              "description":"A snapshot name"
+              "type":"list",
+              "description":"A comma-separated list of snapshot names"
             }
           }
         }


### PR DESCRIPTION
Relates: elastic/elasticsearch#55474

This commit updates the snapshot.delete.json REST API spec
to make snapshot a list type, now that it can accept a
list of comma-separated snapshot names