### PR TITLE
change track_total_hits on async_search.submit to union

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/async_search.submit.json
@@ -196,8 +196,8 @@
         "description":"Whether to calculate and return scores even if they are not used for sorting"
       },
       "track_total_hits":{
-        "type":"boolean",
-        "description":"Indicate if the number of documents that match the query should be tracked"
+        "type":"boolean|long",
+        "description":"Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number."
       },
       "allow_partial_search_results":{
         "type":"boolean",


### PR DESCRIPTION
Relates: elastic/elasticsearch#51846

This commit updates the async_search.submit.json REST API
spec to make track_total_hits a union of boolean and long,
to reflect the possible values that can be passed.

