### PR TITLE
Catch InputCoercionException thrown by Jackson parser (#57287)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
+import com.fasterxml.jackson.core.exc.InputCoercionException;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FloatPoint;
@@ -1060,7 +1061,7 @@ public class NumberFieldMapper extends FieldMapper {
         } else {
             try {
                 numericValue = fieldType().type.parse(parser, coerce.value());
-            } catch (IllegalArgumentException | JsonParseException e) {
+            } catch (InputCoercionException | IllegalArgumentException | JsonParseException e) {
                 if (ignoreMalformed.value() && parser.currentToken().isValue()) {
                     context.addIgnoredField(fieldType.name());
                     return;

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -466,7 +466,8 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase<N
             .endObject().endObject()
             .endObject().endObject());
         createIndex("test57287");
-        client().admin().indices().preparePutMapping("test57287").setSource(mapping, XContentType.JSON).get();
+        client().admin().indices().preparePutMapping("test57287")
+            .setType("_doc").setSource(mapping, XContentType.JSON).get();
         String doc = "{\"number\" : 9223372036854775808}";
         IndexResponse response = client().index(new IndexRequest("test57287").source(doc, XContentType.JSON)).get();
         assertTrue(response.status() == RestStatus.CREATED);


### PR DESCRIPTION
Jackson 2.10 library has added a new type of error that is thrown when a numeric value is out 
of range. This error should be catch and handle properly in case the flag ignore_malformed 
has been set to true.

backport #57287