### PR TITLE
Fix OsStatsTests by providing always a positive long

### DIFF
--- a/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -84,12 +84,12 @@ public class OsStatsTests extends ESTestCase {
     }
 
     public void testGetUsedMemoryWithZeroTotal() {
-        OsStats.Mem mem = new OsStats.Mem(0, randomLong());
+        OsStats.Mem mem = new OsStats.Mem(0, randomNonNegativeLong());
         assertThat(mem.getUsed().getBytes(), equalTo(0L));
     }
 
     public void testGetUsedSwapWithZeroTotal() {
-        OsStats.Swap swap = new OsStats.Swap(0, randomLong());
+        OsStats.Swap swap = new OsStats.Swap(0, randomNonNegativeLong());
         assertThat(swap.getUsed().getBytes(), equalTo(0L));
     }
 }


### PR DESCRIPTION
Make sure we always provide a positive long

fixes  #57333