### PR TITLE
Delete expired data by job

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-expired-data.asciidoc
@@ -11,7 +11,9 @@ Deletes expired and unused machine learning data.
 [[ml-delete-expired-data-request]]
 ==== {api-request-title}
 
-`DELETE _ml/_delete_expired_data`
+`DELETE _ml/_delete_expired_data` +
+
+`DELETE _ml/_delete_expired_data/<job_id>`
 
 [[ml-delete-expired-data-prereqs]]
 ==== {api-prereq-title}
@@ -26,6 +28,19 @@ Deletes expired and unused machine learning data.
 Deletes all job results, model snapshots and forecast data that have exceeded
 their `retention days` period. Machine learning state documents that are not
 associated with any job are also deleted.
+
+You can limit the request to a single or set of {anomaly-jobs} by using a job identifier,
+a group name, a comma-separated list of jobs, or a wildcard expression.
+You can delete expired data for all {anomaly-jobs} by using `_all`, by specifying
+`*` as the `<job_id>`, or by omitting the `<job_id>`.
+
+[[ml-delete-expired-data-path-parms]]
+==== {api-path-parms-title}
+
+`<job_id>`::
+(Optional, string)
+Identifier for an {anomaly-job}. It can be a job identifier, a group name, or a
+wildcard expression.
 
 [[ml-delete-expired-data-request-body]]
 ==== {api-request-body-title}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.ml.dataframe.stats.Fields;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -47,6 +48,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
             PARSER.declareFloat(Request::setRequestsPerSecond, REQUESTS_PER_SECOND);
             PARSER.declareString((obj, value) -> obj.setTimeout(TimeValue.parseTimeValue(value, TIMEOUT.getPreferredName())),
                 TIMEOUT);
+            PARSER.declareString(Request::setJobId, Fields.JOB_ID);
         }
 
         private Float requestsPerSecond;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -50,6 +51,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
 
         private Float requestsPerSecond;
         private TimeValue timeout;
+        private String jobId = Metadata.ALL;
 
         public Request() {}
 
@@ -67,6 +69,9 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
                 this.requestsPerSecond = null;
                 this.timeout = null;
             }
+            if (in.getVersion().onOrAfter(Version.CURRENT)) { // TODO BWC for V_7_9_0
+                jobId = in.readString();
+            }
         }
 
         public Float getRequestsPerSecond() {
@@ -77,6 +82,10 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
             return timeout;
         }
 
+        public String getJobId() {
+            return jobId;
+        }
+
         public Request setRequestsPerSecond(Float requestsPerSecond) {
             this.requestsPerSecond = requestsPerSecond;
             return this;
@@ -84,6 +93,11 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
 
         public Request setTimeout(TimeValue timeout) {
             this.timeout = timeout;
+            return this;
+        }
+
+        public Request setJobId(String jobId) {
+            this.jobId = jobId;
             return this;
         }
 
@@ -103,12 +117,13 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
             return Objects.equals(requestsPerSecond, request.requestsPerSecond)
+                && Objects.equals(jobId, request.jobId)
                 && Objects.equals(timeout, request.timeout);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(requestsPerSecond, timeout);
+            return Objects.hash(requestsPerSecond, timeout, jobId);
         }
 
         @Override
@@ -117,6 +132,9 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
             if (out.getVersion().onOrAfter(Version.V_7_8_0)) {
                 out.writeOptionalFloat(requestsPerSecond);
                 out.writeOptionalTimeValue(timeout);
+            }
+            if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO BWC for V_7_9_0
+                out.writeString(jobId);
             }
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.Fields;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -48,7 +48,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
             PARSER.declareFloat(Request::setRequestsPerSecond, REQUESTS_PER_SECOND);
             PARSER.declareString((obj, value) -> obj.setTimeout(TimeValue.parseTimeValue(value, TIMEOUT.getPreferredName())),
                 TIMEOUT);
-            PARSER.declareString(Request::setJobId, Fields.JOB_ID);
+            PARSER.declareString(Request::setJobId, Job.ID);
         }
 
         private Float requestsPerSecond;
@@ -71,7 +71,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
                 this.requestsPerSecond = null;
                 this.timeout = null;
             }
-            if (in.getVersion().onOrAfter(Version.CURRENT)) { // TODO BWC for V_7_9_0
+            if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO BWC for V_7_9_0
                 jobId = in.readString();
             }
         }
@@ -135,7 +135,7 @@ public class DeleteExpiredDataAction extends ActionType<DeleteExpiredDataAction.
                 out.writeOptionalFloat(requestsPerSecond);
                 out.writeOptionalTimeValue(timeout);
             }
-            if (out.getVersion().onOrAfter(Version.CURRENT)) {  // TODO BWC for V_7_9_0
+            if (out.getVersion().onOrAfter(Version.V_8_0_0)) {  // TODO BWC for V_7_9_0
                 out.writeString(jobId);
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -248,6 +248,15 @@ public class Job extends AbstractDiffable<Job> implements Writeable, ToXContentO
         return ANOMALY_DETECTOR_JOB_TYPE + "-" + jobId;
     }
 
+    /**
+     * Returns the job id from the doc id. Returns {@code null} if the doc id is invalid.
+     */
+    @Nullable
+    public static String extractJobIdFromDocumentId(String docId) {
+        String jobId = docId.replaceAll("^" + ANOMALY_DETECTOR_JOB_TYPE +"-", "");
+        return jobId.equals(docId) ? null : jobId;
+    }
+
 
     /**
      * Return the Job Id.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
@@ -38,7 +38,7 @@ public class DeleteExpiredDataActionRequestTests extends AbstractBWCWireSerializ
         if (version.before(Version.V_7_8_0)) {
             return new Request();
         }
-        if (version.before(Version.CURRENT)) {  // TODO make V_7_9_0
+        if (version.before(Version.V_8_0_0)) {  // TODO make V_7_9_0
             Request request = new Request();
             request.setRequestsPerSecond(instance.getRequestsPerSecond());
             request.setTimeout(instance.getTimeout());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
@@ -15,10 +15,17 @@ public class DeleteExpiredDataActionRequestTests extends AbstractBWCWireSerializ
 
     @Override
     protected Request createTestInstance() {
-        return new Request(
-            randomBoolean() ? null : randomFloat(),
-            randomBoolean() ? null : TimeValue.parseTimeValue(randomTimeValue(), "test")
-        );
+        Request request = new Request();
+        if (randomBoolean()) {
+            request.setRequestsPerSecond(randomFloat());
+        }
+        if (randomBoolean()) {
+            request.setTimeout(TimeValue.parseTimeValue(randomTimeValue(), "test"));
+        }
+        if (randomBoolean()) {
+            request.setJobId(randomAlphaOfLength(5));
+        }
+        return request;
     }
 
     @Override
@@ -30,6 +37,12 @@ public class DeleteExpiredDataActionRequestTests extends AbstractBWCWireSerializ
     protected Request mutateInstanceForVersion(Request instance, Version version) {
         if (version.before(Version.V_7_8_0)) {
             return new Request();
+        }
+        if (version.before(Version.CURRENT)) {
+            Request request = new Request();
+            request.setRequestsPerSecond(instance.getRequestsPerSecond());
+            request.setTimeout(instance.getTimeout());
+            return request;
         }
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/DeleteExpiredDataActionRequestTests.java
@@ -38,7 +38,7 @@ public class DeleteExpiredDataActionRequestTests extends AbstractBWCWireSerializ
         if (version.before(Version.V_7_8_0)) {
             return new Request();
         }
-        if (version.before(Version.CURRENT)) {
+        if (version.before(Version.CURRENT)) {  // TODO make V_7_9_0
             Request request = new Request();
             request.setRequestsPerSecond(instance.getRequestsPerSecond());
             request.setTimeout(instance.getTimeout());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -584,6 +584,15 @@ public class JobTests extends AbstractSerializingTestCase<Job> {
         }
     }
 
+    public void testDocumentId() {
+        String jobFoo = "foo";
+        assertEquals("anomaly_detector-" + jobFoo, Job.documentId(jobFoo));
+        assertEquals(jobFoo, Job.extractJobIdFromDocumentId(
+            Job.documentId(jobFoo)
+        ));
+        assertNull(Job.extractJobIdFromDocumentId("some_other_type-foo"));
+    }
+
     public static Job.Builder buildJobBuilder(String id, Date date) {
         Job.Builder builder = new Job.Builder(id);
         builder.setCreateTime(date);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataAction.java
@@ -21,7 +21,9 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.retention.EmptyStateIndexRemover;
 import org.elasticsearch.xpack.ml.job.retention.ExpiredForecastsRemover;
 import org.elasticsearch.xpack.ml.job.retention.ExpiredModelSnapshotsRemover;
@@ -38,6 +40,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class TransportDeleteExpiredDataAction extends HandledTransportAction<DeleteExpiredDataAction.Request,
         DeleteExpiredDataAction.Response> {
@@ -51,21 +54,25 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<Del
     private final OriginSettingClient client;
     private final ClusterService clusterService;
     private final Clock clock;
+    private final JobConfigProvider jobConfigProvider;
 
     @Inject
     public TransportDeleteExpiredDataAction(ThreadPool threadPool, TransportService transportService,
-                                            ActionFilters actionFilters, Client client, ClusterService clusterService) {
+                                            ActionFilters actionFilters, Client client, ClusterService clusterService,
+                                            JobConfigProvider jobConfigProvider) {
         this(threadPool, MachineLearning.UTILITY_THREAD_POOL_NAME, transportService, actionFilters, client, clusterService,
-            Clock.systemUTC());
+            jobConfigProvider, Clock.systemUTC());
     }
 
     TransportDeleteExpiredDataAction(ThreadPool threadPool, String executor, TransportService transportService,
-                                     ActionFilters actionFilters, Client client, ClusterService clusterService, Clock clock) {
+                                     ActionFilters actionFilters, Client client, ClusterService clusterService,
+                                     JobConfigProvider jobConfigProvider, Clock clock) {
         super(DeleteExpiredDataAction.NAME, transportService, actionFilters, DeleteExpiredDataAction.Request::new, executor);
         this.threadPool = threadPool;
         this.executor = executor;
         this.client = new OriginSettingClient(client, ClientHelper.ML_ORIGIN);
         this.clusterService = clusterService;
+        this.jobConfigProvider = jobConfigProvider;
         this.clock = clock;
     }
 
@@ -77,20 +84,31 @@ public class TransportDeleteExpiredDataAction extends HandledTransportAction<Del
             request.getTimeout() == null ? DEFAULT_MAX_DURATION : Duration.ofMillis(request.getTimeout().millis())
         );
 
-        Supplier<Boolean> isTimedOutSupplier = () -> Instant.now(clock).isAfter(timeoutTime);
-        threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(
-            () -> deleteExpiredData(request, listener, isTimedOutSupplier)
-        );
+        jobConfigProvider.expandJobs(request.getJobId(), true, true, ActionListener.wrap(
+            jobBuilders -> {
+                Supplier<Boolean> isTimedOutSupplier = () -> Instant.now(clock).isAfter(timeoutTime);
+                threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(
+                    () -> {
+                        List<Job> jobs = jobBuilders.stream().map(Job.Builder::build).collect(Collectors.toList());
+                        deleteExpiredData(request, jobs, listener, isTimedOutSupplier);
+                    }
+                );
+            },
+            listener::onFailure
+        ));
+
+
     }
 
     private void deleteExpiredData(DeleteExpiredDataAction.Request request,
+                                   List<Job> jobs,
                                    ActionListener<DeleteExpiredDataAction.Response> listener,
                                    Supplier<Boolean> isTimedOutSupplier) {
         AnomalyDetectionAuditor auditor = new AnomalyDetectionAuditor(client, clusterService.getNodeName());
         List<MlDataRemover> dataRemovers = Arrays.asList(
-                new ExpiredResultsRemover(client, auditor, threadPool),
+                new ExpiredResultsRemover(client, jobs, auditor, threadPool),
                 new ExpiredForecastsRemover(client, threadPool),
-                new ExpiredModelSnapshotsRemover(client, threadPool),
+                new ExpiredModelSnapshotsRemover(client, jobs, threadPool),
                 new UnusedStateRemover(client, clusterService),
                 new EmptyStateIndexRemover(client)
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedJobsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedJobsIterator.java
@@ -7,13 +7,13 @@ package org.elasticsearch.xpack.ml.job.persistence;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.utils.persistence.BatchedDocumentsIterator;
@@ -23,13 +23,17 @@ import java.io.InputStream;
 
 public class BatchedJobsIterator extends BatchedDocumentsIterator<Job.Builder> {
 
-    public BatchedJobsIterator(OriginSettingClient client, String index) {
+    private final String jobIdExpression;
+
+    public BatchedJobsIterator(OriginSettingClient client, String index, String jobIdExpression) {
         super(client, index);
+        this.jobIdExpression = jobIdExpression;
     }
 
     @Override
     protected QueryBuilder getQuery() {
-        return new TermQueryBuilder(Job.JOB_TYPE.getPreferredName(), Job.ANOMALY_DETECTOR_JOB_TYPE);
+        String [] tokens = Strings.tokenizeToStringArray(jobIdExpression, ",");
+        return JobConfigProvider.buildJobWildcardQuery(tokens, true);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobConfigProvider.java
@@ -512,7 +512,7 @@ public class JobConfigProvider {
                               boolean allowMissingConfigs,
                               ActionListener<SortedSet<String>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildJobWildcardQuery(tokens, excludeDeleting));
         sourceBuilder.sort(Job.ID.getPreferredName());
         sourceBuilder.fetchSource(false);
         sourceBuilder.docValueField(Job.ID.getPreferredName(), null);
@@ -573,7 +573,7 @@ public class JobConfigProvider {
      */
     public void expandJobs(String expression, boolean allowNoJobs, boolean excludeDeleting, ActionListener<List<Job.Builder>> listener) {
         String [] tokens = ExpandedIdsMatcher.tokenizeExpression(expression);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildQuery(tokens, excludeDeleting));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(buildJobWildcardQuery(tokens, excludeDeleting));
         sourceBuilder.sort(Job.ID.getPreferredName());
 
         SearchRequest searchRequest = client.prepareSearch(AnomalyDetectorsIndex.configIndexName())
@@ -767,7 +767,7 @@ public class JobConfigProvider {
         }
     }
 
-    private QueryBuilder buildQuery(String [] tokens, boolean excludeDeleting) {
+    public static QueryBuilder buildJobWildcardQuery(String [] tokens, boolean excludeDeleting) {
         QueryBuilder jobQuery = new TermQueryBuilder(Job.JOB_TYPE.getPreferredName(), Job.ANOMALY_DETECTOR_JOB_TYPE);
         if (Strings.isAllOrWildcard(tokens) && excludeDeleting == false) {
             // match all

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -6,21 +6,15 @@
 package org.elasticsearch.xpack.ml.job.retention;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
-import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
-import org.elasticsearch.xpack.ml.job.persistence.BatchedJobsIterator;
-import org.elasticsearch.xpack.ml.utils.VolatileCursorIterator;
 
-import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Removes job data that expired with respect to their retention period.
@@ -31,11 +25,9 @@ import java.util.stream.Collectors;
  */
 abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
 
-    private final OriginSettingClient client;
     private final List<Job> jobs;
 
-    AbstractExpiredJobDataRemover(OriginSettingClient client, List<Job> jobs) {
-        this.client = client;
+    AbstractExpiredJobDataRemover(List<Job> jobs) {
         this.jobs = jobs;
     }
 
@@ -106,51 +98,6 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
         return QueryBuilders.boolQuery()
                 .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
                 .filter(QueryBuilders.rangeQuery(Result.TIMESTAMP.getPreferredName()).lt(cutoffEpochMs).format("epoch_millis"));
-    }
-
-    /**
-     * BatchedJobsIterator efficiently returns batches of jobs using a scroll
-     * search but AbstractExpiredJobDataRemover works with one job at a time.
-     * This class abstracts away the logic of pulling one job at a time from
-     * multiple batches.
-     */
-    private static class WrappedBatchedJobsIterator implements Iterator<Job> {
-        private final BatchedJobsIterator batchedIterator;
-        private VolatileCursorIterator<Job> currentBatch;
-
-        WrappedBatchedJobsIterator(BatchedJobsIterator batchedIterator) {
-            this.batchedIterator = batchedIterator;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return (currentBatch != null && currentBatch.hasNext()) || batchedIterator.hasNext();
-        }
-
-        /**
-         * Before BatchedJobsIterator has run a search it reports hasNext == true
-         * but the first search may return no results. In that case null is return
-         * and clients have to handle null.
-         */
-        @Override
-        public Job next() {
-            if (currentBatch != null && currentBatch.hasNext()) {
-                return currentBatch.next();
-            }
-
-            // currentBatch is either null or all its elements have been iterated.
-            // get the next currentBatch
-            currentBatch = createBatchIteratorFromBatch(batchedIterator.next());
-
-            // BatchedJobsIterator.hasNext maybe true if searching the first time
-            // but no results are returned.
-            return currentBatch.hasNext() ? currentBatch.next() : null;
-        }
-
-        private VolatileCursorIterator<Job> createBatchIteratorFromBatch(Deque<Job.Builder> builders) {
-            List<Job> jobs = builders.stream().map(Job.Builder::build).collect(Collectors.toList());
-            return new VolatileCursorIterator<>(jobs);
-        }
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -39,11 +39,6 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
         this.client = client;
     }
 
-    private WrappedBatchedJobsIterator newJobIterator() {
-        BatchedJobsIterator jobsIterator = new BatchedJobsIterator(client, jobIdExpression, AnomalyDetectorsIndex.configIndexName());
-        return new WrappedBatchedJobsIterator(jobsIterator);
-    }
-
     @Override
     public void remove(float requestsPerSecond,
                        ActionListener<Boolean> listener,
@@ -51,7 +46,7 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
         removeData(newJobIterator(), requestsPerSecond, listener, isTimedOutSupplier);
     }
 
-    private void removeData(Iterator<Job> jobIterator,
+    private void removeData(WrappedBatchedJobsIterator jobIterator,
                             float requestsPerSecond,
                             ActionListener<Boolean> listener,
                             Supplier<Boolean> isTimedOutSupplier) {
@@ -89,6 +84,11 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
                 },
                 listener::onFailure
         ));
+    }
+
+    private WrappedBatchedJobsIterator newJobIterator() {
+        BatchedJobsIterator jobsIterator = new BatchedJobsIterator(client, AnomalyDetectorsIndex.configIndexName(), jobIdExpression);
+        return new WrappedBatchedJobsIterator(jobsIterator);
     }
 
     abstract void calcCutoffEpochMs(String jobId, long retentionDays, ActionListener<CutoffDetails> listener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -10,6 +10,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
+import org.elasticsearch.xpack.ml.utils.VolatileCursorIterator;
 
 import java.util.Iterator;
 import java.util.List;
@@ -35,7 +36,7 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
     public void remove(float requestsPerSecond,
                        ActionListener<Boolean> listener,
                        Supplier<Boolean> isTimedOutSupplier) {
-        removeData(jobs.iterator(), requestsPerSecond, listener, isTimedOutSupplier);
+        removeData(new VolatileCursorIterator<>(jobs), requestsPerSecond, listener, isTimedOutSupplier);
     }
 
     private void removeData(Iterator<Job> jobIterator,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -32,19 +32,21 @@ import java.util.stream.Collectors;
 abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
 
     private final OriginSettingClient client;
+    private final List<Job> jobs;
 
-    AbstractExpiredJobDataRemover(OriginSettingClient client) {
+    AbstractExpiredJobDataRemover(OriginSettingClient client, List<Job> jobs) {
         this.client = client;
+        this.jobs = jobs;
     }
 
     @Override
     public void remove(float requestsPerSecond,
                        ActionListener<Boolean> listener,
                        Supplier<Boolean> isTimedOutSupplier) {
-        removeData(newJobIterator(), requestsPerSecond, listener, isTimedOutSupplier);
+        removeData(jobs.iterator(), requestsPerSecond, listener, isTimedOutSupplier);
     }
 
-    private void removeData(WrappedBatchedJobsIterator jobIterator,
+    private void removeData(Iterator<Job> jobIterator,
                             float requestsPerSecond,
                             ActionListener<Boolean> listener,
                             Supplier<Boolean> isTimedOutSupplier) {
@@ -82,11 +84,6 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
                 },
                 listener::onFailure
         ));
-    }
-
-    private WrappedBatchedJobsIterator newJobIterator() {
-        BatchedJobsIterator jobsIterator = new BatchedJobsIterator(client, AnomalyDetectorsIndex.configIndexName());
-        return new WrappedBatchedJobsIterator(jobsIterator);
     }
 
     abstract void calcCutoffEpochMs(String jobId, long retentionDays, ActionListener<CutoffDetails> listener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
@@ -66,8 +66,8 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
     private final OriginSettingClient client;
     private final ThreadPool threadPool;
 
-    public ExpiredModelSnapshotsRemover(OriginSettingClient client, ThreadPool threadPool) {
-        super(client);
+    public ExpiredModelSnapshotsRemover(OriginSettingClient client, List<Job> jobs, ThreadPool threadPool) {
+        super(jobs);
         this.client = Objects.requireNonNull(client);
         this.threadPool = Objects.requireNonNull(threadPool);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
@@ -63,12 +63,10 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
      */
     private static final int MODEL_SNAPSHOT_SEARCH_SIZE = 10000;
 
-    private final OriginSettingClient client;
     private final ThreadPool threadPool;
 
-    public ExpiredModelSnapshotsRemover(OriginSettingClient client, List<Job> jobs, ThreadPool threadPool) {
-        super(jobs);
-        this.client = Objects.requireNonNull(client);
+    public ExpiredModelSnapshotsRemover(OriginSettingClient client, String jobIdExpression, ThreadPool threadPool) {
+        super(jobIdExpression, client);
         this.threadPool = Objects.requireNonNull(threadPool);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
@@ -50,7 +50,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -68,14 +67,12 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
 
     private static final Logger LOGGER = LogManager.getLogger(ExpiredResultsRemover.class);
 
-    private final OriginSettingClient client;
     private final AnomalyDetectionAuditor auditor;
     private final ThreadPool threadPool;
 
-    public ExpiredResultsRemover(OriginSettingClient client, List<Job> jobs,
+    public ExpiredResultsRemover(OriginSettingClient client, String jobIdExpression,
                                  AnomalyDetectionAuditor auditor, ThreadPool threadPool) {
-        super(jobs);
-        this.client = Objects.requireNonNull(client);
+        super(jobIdExpression, client);
         this.auditor = Objects.requireNonNull(auditor);
         this.threadPool = Objects.requireNonNull(threadPool);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
@@ -50,6 +50,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -71,8 +72,9 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
     private final AnomalyDetectionAuditor auditor;
     private final ThreadPool threadPool;
 
-    public ExpiredResultsRemover(OriginSettingClient client, AnomalyDetectionAuditor auditor, ThreadPool threadPool) {
-        super(client);
+    public ExpiredResultsRemover(OriginSettingClient client, List<Job> jobs,
+                                 AnomalyDetectionAuditor auditor, ThreadPool threadPool) {
+        super(jobs);
         this.client = Objects.requireNonNull(client);
         this.auditor = Objects.requireNonNull(auditor);
         this.threadPool = Objects.requireNonNull(threadPool);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/UnusedStateRemover.java
@@ -13,7 +13,6 @@ import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
@@ -27,7 +26,6 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.CategorizerS
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.ModelState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.Quantiles;
 import org.elasticsearch.xpack.ml.dataframe.StoredProgress;
-import org.elasticsearch.xpack.ml.job.persistence.BatchedJobsIterator;
 import org.elasticsearch.xpack.ml.job.persistence.BatchedStateDocIdsIterator;
 import org.elasticsearch.xpack.ml.utils.persistence.DocIdBatchedDocumentIterator;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestDeleteExpiredDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestDeleteExpiredDataAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
-import org.elasticsearch.xpack.core.ml.dataframe.stats.Fields;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
@@ -25,7 +25,7 @@ public class RestDeleteExpiredDataAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return Collections.singletonList(
-            new Route(DELETE, MachineLearning.BASE_PATH + "_delete_expired_data/{" + Fields.JOB_ID.getPreferredName() + "}"));
+            new Route(DELETE, MachineLearning.BASE_PATH + "_delete_expired_data/{" + Job.ID.getPreferredName() + "}"));
     }
 
     @Override
@@ -67,7 +67,7 @@ public class RestDeleteExpiredDataAction extends BaseRestHandler {
             }
         }
 
-        String jobId = restRequest.param(Fields.JOB_ID.getPreferredName());
+        String jobId = restRequest.param(Job.ID.getPreferredName());
         if (Strings.isNullOrEmpty(jobId) == false) {
             request.setJobId(jobId);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestDeleteExpiredDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestDeleteExpiredDataAction.java
@@ -6,10 +6,14 @@
 package org.elasticsearch.xpack.ml.rest;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
+import org.elasticsearch.xpack.core.ml.dataframe.stats.Fields;
+import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.ml.MachineLearning;
 
 import java.io.IOException;
@@ -22,7 +26,8 @@ public class RestDeleteExpiredDataAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return Collections.emptyList();
+        return Collections.singletonList(
+            new Route(DELETE, MachineLearning.BASE_PATH + "_delete_expired_data/{" + Fields.JOB_ID.getPreferredName() + "}"));
     }
 
     @Override
@@ -41,6 +46,11 @@ public class RestDeleteExpiredDataAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String jobId = restRequest.param(Job.ID.getPreferredName());
+        if (Strings.isNullOrEmpty(jobId)) {
+            jobId = Metadata.ALL;
+        }
+
         DeleteExpiredDataAction.Request request = restRequest.hasContent() ?
             DeleteExpiredDataAction.Request.PARSER.apply(restRequest.contentParser(), null) :
             new DeleteExpiredDataAction.Request();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
+import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.retention.MlDataRemover;
 import org.junit.After;
 import org.junit.Before;
@@ -54,8 +55,9 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
         TransportService transportService = mock(TransportService.class);
         Client client = mock(Client.class);
         ClusterService clusterService = mock(ClusterService.class);
+        JobConfigProvider configProvider = mock(JobConfigProvider.class);
         transportDeleteExpiredDataAction = new TransportDeleteExpiredDataAction(threadPool, ThreadPool.Names.SAME, transportService,
-            new ActionFilters(Collections.emptySet()), client, clusterService, Clock.systemUTC());
+            new ActionFilters(Collections.emptySet()), client, clusterService, configProvider, Clock.systemUTC());
     }
 
     @After

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.DeleteExpiredDataAction;
-import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.retention.MlDataRemover;
 import org.junit.After;
 import org.junit.Before;
@@ -55,9 +54,8 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
         TransportService transportService = mock(TransportService.class);
         Client client = mock(Client.class);
         ClusterService clusterService = mock(ClusterService.class);
-        JobConfigProvider configProvider = mock(JobConfigProvider.class);
         transportDeleteExpiredDataAction = new TransportDeleteExpiredDataAction(threadPool, ThreadPool.Names.SAME, transportService,
-            new ActionFilters(Collections.emptySet()), client, clusterService, configProvider, Clock.systemUTC());
+            new ActionFilters(Collections.emptySet()), client, clusterService, Clock.systemUTC());
     }
 
     @After

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
@@ -7,7 +7,10 @@ package org.elasticsearch.xpack.ml.job.retention;
 
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -16,12 +19,16 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobTests;
+import org.elasticsearch.xpack.ml.test.MockOriginSettingClient;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +37,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,8 +51,8 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
 
         private int getRetentionDaysCallCount = 0;
 
-        ConcreteExpiredJobDataRemover(List<Job> jobs) {
-            super(jobs);
+        ConcreteExpiredJobDataRemover(String jobId, OriginSettingClient client) {
+            super(jobId, client);
         }
 
         @Override
@@ -68,6 +78,15 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
         ) {
             listener.onResponse(Boolean.TRUE);
         }
+    }
+
+    private OriginSettingClient originSettingClient;
+    private Client client;
+
+    @Before
+    public void setUpTests() {
+        client = mock(Client.class);
+        originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
     }
 
     static SearchResponse createSearchResponse(List<? extends ToXContent> toXContents) throws IOException {
@@ -96,9 +115,12 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
         return searchResponse;
     }
 
-    public void testRemoveGivenNoJobs() {
+    public void testRemoveGivenNoJobs() throws IOException {
+        SearchResponse response = createSearchResponse(Collections.emptyList());
+        mockSearchResponse(response);
+
         TestListener listener = new TestListener();
-        ConcreteExpiredJobDataRemover remover = new ConcreteExpiredJobDataRemover(Collections.emptyList());
+        ConcreteExpiredJobDataRemover remover = new ConcreteExpiredJobDataRemover("*", originSettingClient);
         remover.remove(1.0f,listener, () -> false);
 
         listener.waitToCompletion();
@@ -106,24 +128,76 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
         assertEquals(0, remover.getRetentionDaysCallCount);
     }
 
-    public void testRemoveGivenTimeOut() {
-
-        List<Job> jobs = Arrays.asList(
+    @SuppressWarnings("unchecked")
+    public void testRemoveGivenMultipleBatches() throws IOException {
+        // This is testing AbstractExpiredJobDataRemover.WrappedBatchedJobsIterator
+        int totalHits = 7;
+        List<SearchResponse> responses = new ArrayList<>();
+        responses.add(createSearchResponse(Arrays.asList(
                 JobTests.buildJobBuilder("job1").build(),
                 JobTests.buildJobBuilder("job2").build(),
                 JobTests.buildJobBuilder("job3").build()
-            );
+        ), totalHits));
 
-        final int timeoutAfter = randomIntBetween(0, jobs.size() - 1);
-        AtomicInteger attemptsLeft = new AtomicInteger(timeoutAfter);
+        responses.add(createSearchResponse(Arrays.asList(
+                JobTests.buildJobBuilder("job4").build(),
+                JobTests.buildJobBuilder("job5").build(),
+                JobTests.buildJobBuilder("job6").build()
+        ), totalHits));
+
+        responses.add(createSearchResponse(Collections.singletonList(
+                JobTests.buildJobBuilder("job7").build()
+        ), totalHits));
+
+
+        AtomicInteger searchCount = new AtomicInteger(0);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(responses.get(searchCount.getAndIncrement()));
+            return null;
+        }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
 
         TestListener listener = new TestListener();
-        ConcreteExpiredJobDataRemover remover = new ConcreteExpiredJobDataRemover(jobs);
+        ConcreteExpiredJobDataRemover remover = new ConcreteExpiredJobDataRemover("*", originSettingClient);
+        remover.remove(1.0f,listener, () -> false);
+
+        listener.waitToCompletion();
+        assertThat(listener.success, is(true));
+        assertEquals(3, searchCount.get());
+        assertEquals(7, remover.getRetentionDaysCallCount);
+    }
+
+    public void testRemoveGivenTimeOut() throws IOException {
+
+        int totalHits = 3;
+        SearchResponse response = createSearchResponse(Arrays.asList(
+                JobTests.buildJobBuilder("job1").build(),
+                JobTests.buildJobBuilder("job2").build(),
+                JobTests.buildJobBuilder("job3").build()
+            ), totalHits);
+
+        final int timeoutAfter = randomIntBetween(0, totalHits - 1);
+        AtomicInteger attemptsLeft = new AtomicInteger(timeoutAfter);
+
+        mockSearchResponse(response);
+
+        TestListener listener = new TestListener();
+        ConcreteExpiredJobDataRemover remover = new ConcreteExpiredJobDataRemover("*", originSettingClient);
         remover.remove(1.0f,listener, () -> attemptsLeft.getAndDecrement() <= 0);
 
         listener.waitToCompletion();
         assertThat(listener.success, is(false));
         assertEquals(timeoutAfter, remover.getRetentionDaysCallCount);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockSearchResponse(SearchResponse searchResponse) {
+        doAnswer(invocationOnMock -> {
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
     static class TestListener implements ActionListener<Boolean> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
@@ -82,17 +82,6 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
         return searchResponse;
     }
 
-//    @SuppressWarnings("unchecked")
-//    static void givenJobs(Client client, List<Job> jobs) throws IOException {
-//        SearchResponse response = AbstractExpiredJobDataRemoverTests.createSearchResponse(jobs);
-//
-//        doAnswer(invocationOnMock -> {
-//            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
-//            listener.onResponse(response);
-//            return null;
-//        }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
-//    }
-
     private static SearchResponse createSearchResponse(List<? extends ToXContent> toXContents, int totalHits) throws IOException {
         SearchHit[] hitsArray = new SearchHit[toXContents.size()];
         for (int i = 0; i < toXContents.size(); i++) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemoverTests.java
@@ -47,7 +47,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,27 +70,24 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
     }
 
     public void testRemove_GivenJobWithoutActiveSnapshot() throws IOException {
-        List<SearchResponse> responses = Arrays.asList(
-                AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.singletonList(JobTests.buildJobBuilder("foo")
-                        .setModelSnapshotRetentionDays(7L).build())),
+        List<SearchResponse> responses = Collections.singletonList(
                 AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.emptyList()));
 
         givenClientRequestsSucceed(responses);
 
-        createExpiredModelSnapshotsRemover().remove(1.0f, listener, () -> false);
+        List<Job> jobs = Collections.singletonList(JobTests.buildJobBuilder("foo").setModelSnapshotRetentionDays(7L).build());
+        createExpiredModelSnapshotsRemover(jobs).remove(1.0f, listener, () -> false);
 
         listener.waitToCompletion();
         assertThat(listener.success, is(true));
-        verify(client, times(2)).execute(eq(SearchAction.INSTANCE), any(), any());
+        verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
-    public void testRemove_GivenJobsWithMixedRetentionPolicies() throws IOException {
+    public void testRemove_GivenJobsWithMixedRetentionPolicies() {
         List<SearchResponse> searchResponses = new ArrayList<>();
-        searchResponses.add(
-                AbstractExpiredJobDataRemoverTests.createSearchResponse(Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                         JobTests.buildJobBuilder("job-1").setModelSnapshotRetentionDays(7L).setModelSnapshotId("active").build(),
-                        JobTests.buildJobBuilder("job-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build()
-        )));
+                        JobTests.buildJobBuilder("job-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build());
 
         Date now = new Date();
         Date oneDayAgo = new Date(now.getTime() - TimeValue.timeValueDays(1).getMillis());
@@ -111,12 +107,12 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         searchResponses.add(AbstractExpiredJobDataRemoverTests.createSearchResponseFromHits(Collections.emptyList()));
 
         givenClientRequestsSucceed(searchResponses);
-        createExpiredModelSnapshotsRemover().remove(1.0f, listener, () -> false);
+        createExpiredModelSnapshotsRemover(jobs).remove(1.0f, listener, () -> false);
 
         listener.waitToCompletion();
         assertThat(listener.success, is(true));
 
-        assertThat(capturedSearchRequests.size(), equalTo(5));
+        assertThat(capturedSearchRequests.size(), equalTo(4));
         SearchRequest searchRequest = capturedSearchRequests.get(1);
         assertThat(searchRequest.indices(), equalTo(new String[] {AnomalyDetectorsIndex.jobResultsAliasedName("job-1")}));
         searchRequest = capturedSearchRequests.get(3);
@@ -130,11 +126,9 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
 
     public void testRemove_GivenTimeout() throws IOException {
         List<SearchResponse> searchResponses = new ArrayList<>();
-        searchResponses.add(
-                AbstractExpiredJobDataRemoverTests.createSearchResponse(Arrays.asList(
+        List<Job> jobs = Arrays.asList(
             JobTests.buildJobBuilder("snapshots-1").setModelSnapshotRetentionDays(7L).setModelSnapshotId("active").build(),
-            JobTests.buildJobBuilder("snapshots-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build()
-        )));
+            JobTests.buildJobBuilder("snapshots-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build());
 
         Date now = new Date();
         List<ModelSnapshot> snapshots1JobSnapshots = Arrays.asList(createModelSnapshot("snapshots-1", "snapshots-1_1", now),
@@ -148,40 +142,36 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         final int timeoutAfter = randomIntBetween(0, 1);
         AtomicInteger attemptsLeft = new AtomicInteger(timeoutAfter);
 
-        createExpiredModelSnapshotsRemover().remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
+        createExpiredModelSnapshotsRemover(jobs).remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
 
         listener.waitToCompletion();
         assertThat(listener.success, is(false));
     }
 
-    public void testRemove_GivenClientSearchRequestsFail() throws IOException {
+    public void testRemove_GivenClientSearchRequestsFail() {
         List<SearchResponse> searchResponses = new ArrayList<>();
-        searchResponses.add(
-                AbstractExpiredJobDataRemoverTests.createSearchResponse(Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                 JobTests.buildJobBuilder("snapshots-1").setModelSnapshotRetentionDays(7L).setModelSnapshotId("active").build(),
-                JobTests.buildJobBuilder("snapshots-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build()
-        )));
+                JobTests.buildJobBuilder("snapshots-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build());
 
         givenClientSearchRequestsFail(searchResponses);
-        createExpiredModelSnapshotsRemover().remove(1.0f, listener, () -> false);
+        createExpiredModelSnapshotsRemover(jobs).remove(1.0f, listener, () -> false);
 
         listener.waitToCompletion();
         assertThat(listener.success, is(false));
 
-        assertThat(capturedSearchRequests.size(), equalTo(2));
-        SearchRequest searchRequest = capturedSearchRequests.get(1);
+        assertThat(capturedSearchRequests.size(), equalTo(1));
+        SearchRequest searchRequest = capturedSearchRequests.get(0);
         assertThat(searchRequest.indices(), equalTo(new String[] {AnomalyDetectorsIndex.jobResultsAliasedName("snapshots-1")}));
 
         assertThat(capturedDeleteModelSnapshotRequests.size(), equalTo(0));
     }
 
-    public void testRemove_GivenClientDeleteSnapshotRequestsFail() throws IOException {
+    public void testRemove_GivenClientDeleteSnapshotRequestsFail() {
         List<SearchResponse> searchResponses = new ArrayList<>();
-        searchResponses.add(
-                AbstractExpiredJobDataRemoverTests.createSearchResponse(Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                 JobTests.buildJobBuilder("snapshots-1").setModelSnapshotRetentionDays(7L).setModelSnapshotId("active").build(),
-                JobTests.buildJobBuilder("snapshots-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build()
-        )));
+                JobTests.buildJobBuilder("snapshots-2").setModelSnapshotRetentionDays(17L).setModelSnapshotId("active").build());
 
         Date now = new Date();
         Date oneDayAgo = new Date(new Date().getTime() - TimeValue.timeValueDays(1).getMillis());
@@ -199,12 +189,12 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         searchResponses.add(AbstractExpiredJobDataRemoverTests.createSearchResponseFromHits(Collections.singletonList(snapshot2_2)));
 
         givenClientDeleteModelSnapshotRequestsFail(searchResponses);
-        createExpiredModelSnapshotsRemover().remove(1.0f, listener, () -> false);
+        createExpiredModelSnapshotsRemover(jobs).remove(1.0f, listener, () -> false);
 
         listener.waitToCompletion();
         assertThat(listener.success, is(false));
 
-        assertThat(capturedSearchRequests.size(), equalTo(3));
+        assertThat(capturedSearchRequests.size(), equalTo(2));
         SearchRequest searchRequest = capturedSearchRequests.get(1);
         assertThat(searchRequest.indices(), equalTo(new String[] {AnomalyDetectorsIndex.jobResultsAliasedName("snapshots-1")}));
 
@@ -226,7 +216,7 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
 
         long retentionDays = 3L;
         ActionListener<AbstractExpiredJobDataRemover.CutoffDetails> cutoffListener = mock(ActionListener.class);
-        createExpiredModelSnapshotsRemover().calcCutoffEpochMs("job-1", retentionDays, cutoffListener);
+        createExpiredModelSnapshotsRemover(Collections.emptyList()).calcCutoffEpochMs("job-1", retentionDays, cutoffListener);
 
         long dayInMills = 60 * 60 * 24 * 1000;
         long expectedCutoffTime = oneDayAgo.getTime() - (dayInMills * retentionDays);
@@ -244,7 +234,7 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
         assertTrue(id.hasNullValue());
     }
 
-    private ExpiredModelSnapshotsRemover createExpiredModelSnapshotsRemover() {
+    private ExpiredModelSnapshotsRemover createExpiredModelSnapshotsRemover(List<Job> jobs) {
         ThreadPool threadPool = mock(ThreadPool.class);
         ExecutorService executor = mock(ExecutorService.class);
 
@@ -256,7 +246,7 @@ public class ExpiredModelSnapshotsRemoverTests extends ESTestCase {
                     return null;
                 }
         ).when(executor).execute(any());
-        return new ExpiredModelSnapshotsRemover(originSettingClient, threadPool);
+        return new ExpiredModelSnapshotsRemover(originSettingClient, jobs, threadPool);
     }
 
     private static ModelSnapshot createModelSnapshot(String jobId, String snapshotId, Date date) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
@@ -7,7 +7,6 @@ package org.elasticsearch.xpack.ml.job.retention;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
@@ -26,7 +25,6 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.test.MockOriginSettingClient;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,40 +59,33 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         listener = mock(ActionListener.class);
     }
 
-    public void testRemove_GivenNoJobs() throws IOException {
-        givenDBQRequestsSucceed();
-        AbstractExpiredJobDataRemoverTests.givenJobs(client, Collections.emptyList());
-
-        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
-
-        verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
+    public void testRemove_GivenNoJobs() {
+        createExpiredResultsRemover(Collections.emptyList()).remove(1.0f, listener, () -> false);
         verify(listener).onResponse(true);
     }
 
-    public void testRemove_GivenJobsWithoutRetentionPolicy() throws IOException {
+    public void testRemove_GivenJobsWithoutRetentionPolicy() {
         givenDBQRequestsSucceed();
-        AbstractExpiredJobDataRemoverTests.givenJobs(client,
-                Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                 JobTests.buildJobBuilder("foo").build(),
-                JobTests.buildJobBuilder("bar").build()
-        ));
+                JobTests.buildJobBuilder("bar").build());
 
-        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
+        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> false);
 
         verify(listener).onResponse(true);
-        verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
     public void testRemove_GivenJobsWithAndWithoutRetentionPolicy() {
         givenDBQRequestsSucceed();
 
-        givenSearchResponses(Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                 JobTests.buildJobBuilder("none").build(),
                 JobTests.buildJobBuilder("results-1").setResultsRetentionDays(10L).build(),
-                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build()),
-                new Bucket("id_not_important", new Date(), 60));
+                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build());
 
-        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
+        givenSearchResponses(new Bucket("id_not_important", new Date(), 60));
+
+        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> false);
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(2));
         DeleteByQueryRequest dbqRequest = capturedDeleteByQueryRequests.get(0);
@@ -106,15 +97,16 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
 
     public void testRemove_GivenTimeout() {
         givenDBQRequestsSucceed();
-        givenSearchResponses(Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                 JobTests.buildJobBuilder("results-1").setResultsRetentionDays(10L).build(),
-                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build()
-        ), new Bucket("id_not_important", new Date(), 60));
+                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build());
+
+        givenSearchResponses(new Bucket("id_not_important", new Date(), 60));
 
         final int timeoutAfter = randomIntBetween(0, 1);
         AtomicInteger attemptsLeft = new AtomicInteger(timeoutAfter);
 
-        createExpiredResultsRemover().remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
+        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(timeoutAfter));
         verify(listener).onResponse(false);
@@ -122,14 +114,14 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
 
     public void testRemove_GivenClientRequestsFailed() {
         givenDBQRequestsFailed();
-        givenSearchResponses(
-                Arrays.asList(
+        List<Job> jobs = Arrays.asList(
                         JobTests.buildJobBuilder("none").build(),
                         JobTests.buildJobBuilder("results-1").setResultsRetentionDays(10L).build(),
-                        JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build()),
-                new Bucket("id_not_important", new Date(), 60));
+                        JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build());
 
-        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
+        givenSearchResponses(new Bucket("id_not_important", new Date(), 60));
+
+        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> false);
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(1));
         DeleteByQueryRequest dbqRequest = capturedDeleteByQueryRequests.get(0);
@@ -142,11 +134,11 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         String jobId = "calc-cutoff";
         Date latest = new Date();
 
-        givenSearchResponses(Collections.singletonList(JobTests.buildJobBuilder(jobId).setResultsRetentionDays(1L).build()),
-                new Bucket(jobId, latest, 60));
+        List<Job> jobs = Collections.singletonList(JobTests.buildJobBuilder(jobId).setResultsRetentionDays(1L).build());
+        givenSearchResponses(new Bucket(jobId, latest, 60));
 
         ActionListener<AbstractExpiredJobDataRemover.CutoffDetails> cutoffListener = mock(ActionListener.class);
-        createExpiredResultsRemover().calcCutoffEpochMs(jobId, 1L, cutoffListener);
+        createExpiredResultsRemover(jobs).calcCutoffEpochMs(jobId, 1L, cutoffListener);
 
         long dayInMills = 60 * 60 * 24 * 1000;
         long expectedCutoffTime = latest.getTime() - dayInMills;
@@ -180,22 +172,15 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private void givenSearchResponses(List<Job> jobs, Bucket bucket) {
+    private void givenSearchResponses(Bucket bucket) {
         doAnswer(invocationOnMock -> {
-            SearchRequest request = (SearchRequest) invocationOnMock.getArguments()[1];
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
-
-            if (request.indices()[0].startsWith(AnomalyDetectorsIndex.jobResultsIndexPrefix())) {
-                // asking for the bucket result
-                listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.singletonList(bucket)));
-            } else {
-                listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(jobs));
-            }
+            listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.singletonList(bucket)));
             return null;
         }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
-    private ExpiredResultsRemover createExpiredResultsRemover() {
+    private ExpiredResultsRemover createExpiredResultsRemover(List<Job> jobs) {
         ThreadPool threadPool = mock(ThreadPool.class);
         ExecutorService executor = mock(ExecutorService.class);
 
@@ -208,6 +193,6 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
             }
         ).when(executor).execute(any());
 
-        return new ExpiredResultsRemover(originSettingClient, mock(AnomalyDetectionAuditor.class), threadPool);
+        return new ExpiredResultsRemover(originSettingClient, jobs, mock(AnomalyDetectionAuditor.class), threadPool);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.ml.job.retention;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.test.MockOriginSettingClient;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,33 +61,40 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         listener = mock(ActionListener.class);
     }
 
-    public void testRemove_GivenNoJobs() {
-        createExpiredResultsRemover(Collections.emptyList()).remove(1.0f, listener, () -> false);
+    public void testRemove_GivenNoJobs() throws IOException {
+        givenDBQRequestsSucceed();
+        givenJobs(client, Collections.emptyList());
+
+        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
+
+        verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
         verify(listener).onResponse(true);
     }
 
-    public void testRemove_GivenJobsWithoutRetentionPolicy() {
+    public void testRemove_GivenJobsWithoutRetentionPolicy() throws IOException {
         givenDBQRequestsSucceed();
-        List<Job> jobs = Arrays.asList(
+        givenJobs(client,
+                Arrays.asList(
                 JobTests.buildJobBuilder("foo").build(),
-                JobTests.buildJobBuilder("bar").build());
+                JobTests.buildJobBuilder("bar").build()
+        ));
 
-        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> false);
+        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
 
         verify(listener).onResponse(true);
+        verify(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
     public void testRemove_GivenJobsWithAndWithoutRetentionPolicy() {
         givenDBQRequestsSucceed();
 
-        List<Job> jobs = Arrays.asList(
+        givenSearchResponses(Arrays.asList(
                 JobTests.buildJobBuilder("none").build(),
                 JobTests.buildJobBuilder("results-1").setResultsRetentionDays(10L).build(),
-                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build());
+                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build()),
+                new Bucket("id_not_important", new Date(), 60));
 
-        givenSearchResponses(new Bucket("id_not_important", new Date(), 60));
-
-        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> false);
+        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(2));
         DeleteByQueryRequest dbqRequest = capturedDeleteByQueryRequests.get(0);
@@ -97,16 +106,15 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
 
     public void testRemove_GivenTimeout() {
         givenDBQRequestsSucceed();
-        List<Job> jobs = Arrays.asList(
+        givenSearchResponses(Arrays.asList(
                 JobTests.buildJobBuilder("results-1").setResultsRetentionDays(10L).build(),
-                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build());
-
-        givenSearchResponses(new Bucket("id_not_important", new Date(), 60));
+                JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build()
+        ), new Bucket("id_not_important", new Date(), 60));
 
         final int timeoutAfter = randomIntBetween(0, 1);
         AtomicInteger attemptsLeft = new AtomicInteger(timeoutAfter);
 
-        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
+        createExpiredResultsRemover().remove(1.0f, listener, () -> (attemptsLeft.getAndDecrement() <= 0));
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(timeoutAfter));
         verify(listener).onResponse(false);
@@ -114,14 +122,14 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
 
     public void testRemove_GivenClientRequestsFailed() {
         givenDBQRequestsFailed();
-        List<Job> jobs = Arrays.asList(
+        givenSearchResponses(
+                Arrays.asList(
                         JobTests.buildJobBuilder("none").build(),
                         JobTests.buildJobBuilder("results-1").setResultsRetentionDays(10L).build(),
-                        JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build());
+                        JobTests.buildJobBuilder("results-2").setResultsRetentionDays(20L).build()),
+                new Bucket("id_not_important", new Date(), 60));
 
-        givenSearchResponses(new Bucket("id_not_important", new Date(), 60));
-
-        createExpiredResultsRemover(jobs).remove(1.0f, listener, () -> false);
+        createExpiredResultsRemover().remove(1.0f, listener, () -> false);
 
         assertThat(capturedDeleteByQueryRequests.size(), equalTo(1));
         DeleteByQueryRequest dbqRequest = capturedDeleteByQueryRequests.get(0);
@@ -134,15 +142,26 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         String jobId = "calc-cutoff";
         Date latest = new Date();
 
-        List<Job> jobs = Collections.singletonList(JobTests.buildJobBuilder(jobId).setResultsRetentionDays(1L).build());
-        givenSearchResponses(new Bucket(jobId, latest, 60));
+        givenSearchResponses(Collections.singletonList(JobTests.buildJobBuilder(jobId).setResultsRetentionDays(1L).build()),
+                new Bucket(jobId, latest, 60));
 
         ActionListener<AbstractExpiredJobDataRemover.CutoffDetails> cutoffListener = mock(ActionListener.class);
-        createExpiredResultsRemover(jobs).calcCutoffEpochMs(jobId, 1L, cutoffListener);
+        createExpiredResultsRemover().calcCutoffEpochMs(jobId, 1L, cutoffListener);
 
         long dayInMills = 60 * 60 * 24 * 1000;
         long expectedCutoffTime = latest.getTime() - dayInMills;
         verify(cutoffListener).onResponse(eq(new AbstractExpiredJobDataRemover.CutoffDetails(latest.getTime(), expectedCutoffTime)));
+    }
+
+    @SuppressWarnings("unchecked")
+    static void givenJobs(Client client, List<Job> jobs) throws IOException {
+        SearchResponse response = AbstractExpiredJobDataRemoverTests.createSearchResponse(jobs);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
     private void givenDBQRequestsSucceed() {
@@ -172,15 +191,22 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private void givenSearchResponses(Bucket bucket) {
+    private void givenSearchResponses(List<Job> jobs, Bucket bucket) {
         doAnswer(invocationOnMock -> {
+            SearchRequest request = (SearchRequest) invocationOnMock.getArguments()[1];
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[2];
-            listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.singletonList(bucket)));
+
+            if (request.indices()[0].startsWith(AnomalyDetectorsIndex.jobResultsIndexPrefix())) {
+                // asking for the bucket result
+                listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(Collections.singletonList(bucket)));
+            } else {
+                listener.onResponse(AbstractExpiredJobDataRemoverTests.createSearchResponse(jobs));
+            }
             return null;
         }).when(client).execute(eq(SearchAction.INSTANCE), any(), any());
     }
 
-    private ExpiredResultsRemover createExpiredResultsRemover(List<Job> jobs) {
+    private ExpiredResultsRemover createExpiredResultsRemover() {
         ThreadPool threadPool = mock(ThreadPool.class);
         ExecutorService executor = mock(ExecutorService.class);
 
@@ -193,6 +219,6 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
             }
         ).when(executor).execute(any());
 
-        return new ExpiredResultsRemover(originSettingClient, jobs, mock(AnomalyDetectionAuditor.class), threadPool);
+        return new ExpiredResultsRemover(originSettingClient, "*", mock(AnomalyDetectionAuditor.class), threadPool);
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -8,12 +8,36 @@
     "url":{
       "paths":[
         {
+          "path":"/_ml/_delete_expired_data/{job_id}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "job_id":{
+              "type":"string",
+              "description":"The ID of the job(s) to perform expired data hygiene for"
+            }
+          }
+        },
+        {
           "path":"/_ml/_delete_expired_data",
           "methods":[
             "DELETE"
           ]
         }
       ]
+    },
+    "params":{
+      "requests_per_second":{
+        "type":"number",
+        "required":false,
+        "description":"The desired requests per second for the deletion processes."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"How long can the underlying delete processes run until they are canceled"
+      }
     },
     "body":{
       "description":"deleting expired data parameters"

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -59,16 +59,6 @@ setup:
 
 ---
 "Test delete expired data with job id":
-
-# open the job to create the state index and alias
-  - do:
-      ml.open_job:
-        job_id: delete-expired-data-a
-
-  - do:
-      ml.close_job:
-        job_id: delete-expired-data-a
-
   - do:
       headers:
         Content-Type: application/json

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -3,12 +3,11 @@ setup:
       features: headers
   - do:
       headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
       ml.put_job:
-        job_id: delete-expired-data
+        job_id: delete-expired-data-a
         body:  >
           {
-            "job_id": "delete-expired-data",
             "description":"Analysis of response time by airline",
             "analysis_config" : {
                 "bucket_span" : "1h",
@@ -18,7 +17,30 @@ setup:
                 "field_delimiter":",",
                 "time_field":"time",
                 "time_format":"yyyy-MM-dd HH:mm:ssX"
-            }
+            },
+            "results_retention_days" : 1,
+            "model_snapshot_retention_days" : 1
+          }
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
+      ml.put_job:
+        job_id: delete-expired-data-b
+        body:  >
+          {
+            "description":"Analysis of response time by airline",
+            "analysis_config" : {
+                "bucket_span" : "1h",
+                "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
+            },
+            "data_description" : {
+                "field_delimiter":",",
+                "time_field":"time",
+                "time_format":"yyyy-MM-dd HH:mm:ssX"
+            },
+            "results_retention_days" : 1,
+            "model_snapshot_retention_days" : 1
           }
 
 ---
@@ -34,3 +56,100 @@ setup:
         body:  >
            { "timeout": "10h", "requests_per_second": 100000.0 }
   - match: { deleted: true}
+
+---
+"Test delete expired data with job id":
+
+# open the job to create the state index and alias
+  - do:
+      ml.open_job:
+        job_id: delete-expired-data-a
+
+  - do:
+      ml.close_job:
+        job_id: delete-expired-data-a
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+        index:  .ml-anomalies-shared
+        id:     "delete-expired-data-a_model_snapshot_inactive-snapshot"
+        body: >
+          {
+            "job_id": "delete-expired-data-a",
+            "timestamp": "2020-05-01T00:00:00Z",
+            "snapshot_id": "inactive-snapshot",
+            "description": "first",
+            "latest_record_time_stamp": "2020-05-01T00:00:00Z",
+            "latest_result_time_stamp": "2020-05-01T00:00:00Z",
+            "snapshot_doc_count": 1
+          }
+
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+        index:  .ml-anomalies-shared
+        id:     "delete-expired-data-a_model_snapshot_active-snapshot"
+        body: >
+          {
+            "job_id": "delete-expired-data-a",
+            "timestamp": "2020-05-10T00:00:00Z",
+            "snapshot_id": "active-snapshot",
+            "description": "second",
+            "latest_record_time_stamp": "2020-05-10T00:00:00Z",
+            "latest_result_time_stamp": "2020-05-10T00:00:00Z",
+            "snapshot_doc_count": 1,
+            "model_size_stats": {
+                "job_id" : "delete-expired-data-a",
+                "result_type" : "model_size_stats",
+                "model_bytes" : 0
+            },
+            "quantiles": {
+              "job_id": "delete-expired-data-a",
+              "timestamp": 1,
+              "quantile_state": "quantiles-1"
+            }
+          }
+
+  - do:
+      indices.refresh:
+        index: [.ml-anomalies-shared]
+
+  - do:
+      ml.get_model_snapshots:
+        job_id: delete-expired-data-a
+  - match: { count: 2 }
+
+# make the above document the current snapshot
+  - do:
+      ml.revert_model_snapshot:
+        job_id: delete-expired-data-a
+        snapshot_id: active-snapshot
+
+  - do:
+      ml.get_model_snapshots:
+        job_id: delete-expired-data-a
+  - match: { count: 2 }
+
+  - do:
+      ml.delete_expired_data:
+        job_id: delete-expired-data-b
+
+  - do:
+      ml.get_model_snapshots:
+        job_id: delete-expired-data-a
+  - match: { count: 2 }
+
+  - do:
+      ml.delete_expired_data:
+        job_id: delete-expired-data-a
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      ml.get_model_snapshots:
+        job_id: delete-expired-data-a
+  - match: { count: 1 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -156,9 +156,3 @@ setup:
       ml.get_model_snapshots:
         job_id: delete-expired-data-a
   - match: { count: 1 }
-
----
-"Test delete expired data with unknown job id":
-  - do:
-      ml.delete_expired_data:
-        job_id: not-a-job

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -156,3 +156,9 @@ setup:
       ml.get_model_snapshots:
         job_id: delete-expired-data-a
   - match: { count: 1 }
+
+---
+"Test delete expired data with unknown job id":
+  - do:
+      ml.delete_expired_data:
+        job_id: not-a-job

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -56,6 +56,13 @@ setup:
         body:  >
            { "timeout": "10h", "requests_per_second": 100000.0 }
   - match: { deleted: true}
+---
+"Test delete expired data with path parameters":
+  - do:
+      ml.delete_expired_data:
+        timeout: "10h"
+        requests_per_second: 100000.0
+  - match: { deleted: true}
 
 ---
 "Test delete expired data with job id":

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_expired_data.yml
@@ -62,6 +62,7 @@ setup:
   - do:
       headers:
         Content-Type: application/json
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
       index:
         index:  .ml-anomalies-shared
         id:     "delete-expired-data-a_model_snapshot_inactive-snapshot"
@@ -79,6 +80,7 @@ setup:
   - do:
       headers:
         Content-Type: application/json
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
       index:
         index:  .ml-anomalies-shared
         id:     "delete-expired-data-a_model_snapshot_active-snapshot"
@@ -104,6 +106,8 @@ setup:
           }
 
   - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
       indices.refresh:
         index: [.ml-anomalies-shared]
 
@@ -137,6 +141,8 @@ setup:
         job_id: delete-expired-data-a
 
   - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA=="
       indices.refresh: {}
 
   - do:


### PR DESCRIPTION
Deleting expired data can take a long time leading to timeouts if there are many jobs. Often the problem is due to a few large jobs which prevent the regular maintenance of the remaining jobs. This change adds a `job_id` parameter to the delete expired data endpoint to help clean up those problematic jobs. 

This change only affects model snapshots and results. Forecasts cannot be removed by job_id _yet_ if desired that could be implemented. 

TODO HLRC