### PR TITLE
[Doc] 7.7.0 Known issue for slow loggers leaking log4j loggers

### DIFF
--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -168,9 +168,9 @@ that are incompatible with java.time patterns will cause parsing errors, incorre
 https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
-Slow loggers can cause Log4j loggers to leak over time. When a new index is created, a new Log4j logger is associated with it. However, when an index is deleted, Log4j keeps an internal reference to its loggers that results in a memory leak {pull}56171[#56171]
-
-This issue is fixed in Elasticsearch 6.8.10 and 7.7.1.
+* Slow loggers can cause Log4j loggers to leak over time. When a new index is created, a new Log4j logger is associated with it. However, when an index is deleted, Log4j keeps an internal reference to its loggers that results in a memory leak (issue: {issue}56171[#56171])
++
+This issue is fixed in {es} 6.8.10 and 7.7.1.
 [[breaking-7.6.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -168,6 +168,10 @@ that are incompatible with java.time patterns will cause parsing errors, incorre
 https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
+* Slow loggers are causing log4j loggers to leak over time. When new index is created, new log4j logger was associated with it.
+However when deleting an index it, log4j was keeping a reference internally to its loggers causing a memory leak.
+https://github.com/elastic/elasticsearch/issues/56171 Fixed in 7.7.1
+
 [[breaking-7.6.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/7.6.asciidoc
+++ b/docs/reference/release-notes/7.6.asciidoc
@@ -168,10 +168,9 @@ that are incompatible with java.time patterns will cause parsing errors, incorre
 https://github.com/elastic/elasticsearch/pull/52555
 This is fixed in {es} 7.7 and later versions.
 
-* Slow loggers are causing log4j loggers to leak over time. When new index is created, new log4j logger was associated with it.
-However when deleting an index it, log4j was keeping a reference internally to its loggers causing a memory leak.
-https://github.com/elastic/elasticsearch/issues/56171 Fixed in 7.7.1
+Slow loggers can cause Log4j loggers to leak over time. When a new index is created, a new Log4j logger is associated with it. However, when an index is deleted, Log4j keeps an internal reference to its loggers that results in a memory leak {pull}56171[#56171]
 
+This issue is fixed in Elasticsearch 6.8.10 and 7.7.1.
 [[breaking-7.6.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/7.7.asciidoc
+++ b/docs/reference/release-notes/7.7.asciidoc
@@ -3,6 +3,15 @@
 
 Also see <<breaking-changes-7.7,Breaking changes in 7.7>>.
 
+[[known-issues-7.7.0]]
+[float]
+=== Known issues
+
+* Slow loggers are causing log4j loggers to leak over time. When new index is created, new log4j logger was associated with it.
+However when deleting an index it, log4j was keeping a reference internally to its loggers causing a memory leak.
+https://github.com/elastic/elasticsearch/issues/56171 Fixed in 7.7.1
+
+
 [[breaking-7.7.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/7.7.asciidoc
+++ b/docs/reference/release-notes/7.7.asciidoc
@@ -6,8 +6,8 @@ Also see <<breaking-changes-7.7,Breaking changes in 7.7>>.
 [[known-issues-7.7.0]]
 [float]
 === Known issues
-Slow loggers can cause Log4j loggers to leak over time. When a new index is created, a new Log4j logger is associated with it. However, when an index is deleted, Log4j keeps an internal reference to its loggers that results in a memory leak {pull}56171[#56171]
-
+* Slow loggers can cause Log4j loggers to leak over time. When a new index is created, a new Log4j logger is associated with it. However, when an index is deleted, Log4j keeps an internal reference to its loggers that results in a memory leak {pull}57216[#57216] (issue: {issue}56171[#56171])
++
 This issue is fixed in Elasticsearch 6.8.10 and 7.7.1.
 
 

--- a/docs/reference/release-notes/7.7.asciidoc
+++ b/docs/reference/release-notes/7.7.asciidoc
@@ -6,10 +6,9 @@ Also see <<breaking-changes-7.7,Breaking changes in 7.7>>.
 [[known-issues-7.7.0]]
 [float]
 === Known issues
+Slow loggers can cause Log4j loggers to leak over time. When a new index is created, a new Log4j logger is associated with it. However, when an index is deleted, Log4j keeps an internal reference to its loggers that results in a memory leak {pull}56171[#56171]
 
-* Slow loggers are causing log4j loggers to leak over time. When new index is created, new log4j logger was associated with it.
-However when deleting an index it, log4j was keeping a reference internally to its loggers causing a memory leak.
-https://github.com/elastic/elasticsearch/issues/56171 Fixed in 7.7.1
+This issue is fixed in Elasticsearch 6.8.10 and 7.7.1.
 
 
 [[breaking-7.7.0]]


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/56171