### PR TITLE
Reindex and friends fail nicely when max_docs < slices (#54901)

### DIFF
--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yml
@@ -88,6 +88,27 @@
             match_all: {}
 
 ---
+"max_docs shoule be greater than slices":
+  - skip:
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      catch: /\[max_docs\] should be >= \[slices\]/
+      delete_by_query:
+        index: test
+        max_docs: 1
+        slices: 2
+        body:
+          query:
+            match_all: {}
+
+---
 "invalid scroll_size fails":
   - do:
       index:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yml
@@ -133,6 +133,28 @@
           max_docs: -4
 
 ---
+"max_docs shoule be greater than slices":
+  - skip:
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      catch: /\[max_docs\] should be >= \[slices\]/
+      reindex:
+        max_docs: 1
+        slices: 2
+        body:
+          source:
+            index: test
+          dest:
+            index: dest
+
+---
 "invalid max_docs in URL fails":
   - skip:
       version: " - 7.2.99"

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yml
@@ -102,6 +102,24 @@
             match_all: {}
 
 ---
+"max_docs shoule be greater than slices":
+  - skip:
+      version: " - 7.2.99"
+      reason: "max_docs introduced in 7.3.0"
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        body:    { "text": "test" }
+  - do:
+      catch: /\[max_docs\] should be >= \[slices\]/
+      update_by_query:
+        index: test
+        max_docs: 1
+        slices: 2
+
+---
 "invalid scroll_size fails":
   - do:
       index:

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -214,6 +214,9 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         if (maxDocs < 0) {
             throw new IllegalArgumentException("[max_docs] parameter cannot be negative, found [" + maxDocs + "]");
         }
+        if (maxDocs < slices) {
+            throw new IllegalArgumentException("[max_docs] should be >= [slices]");
+        }
         this.maxDocs = maxDocs;
         return self();
     }


### PR DESCRIPTION
When the parameter `max_docs` is less than `slices` in update_by_query,
delete_by_query or reindex API, `max_docs ` is set to 0 and we throw an
action_request_validation_exception with confused error message:
"maxDocs should be greater than 0...".
This change checks that whether `max_docs` is less than `slices` and
throw an illegal_argument_exception with clear message.

Relates to #52786.
