### PR TITLE
[DOCS] Clarifying env variable substitution

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -79,7 +79,7 @@ node.name:    ${HOSTNAME}
 network.host: ${ES_NETWORK_HOST}
 --------------------------------------------------
 
-When specifying values for environment variables, you can only use strings. More complex data structures like lists are not supported. However, settings that accept data structures such as lists also accepted comma-separated strings. For example, you can specify multiple values for the `${HOSTNAME}` variable from the previous example:
+Values for environment variables must be simple strings. Use a comma-separated string to provide values that Elasticsearch will parse as a list. For example, Elasticsearch will split the following string into a list of values for the `${HOSTNAME}` environment variable:
 
 [source,yaml]
 ----

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -71,12 +71,19 @@ path.logs: /var/log/elasticsearch
 
 Environment variables referenced with the `${...}` notation within the
 configuration file will be replaced with the value of the environment
-variable, for instance:
+variable. For example:
 
 [source,yaml]
 --------------------------------------------------
 node.name:    ${HOSTNAME}
 network.host: ${ES_NETWORK_HOST}
+--------------------------------------------------
+
+When specifying values for environment variables, you can only use strings. More complex data structures like lists are not supported. However, settings that accept data structures such as lists also accepted comma-separated strings. For example, you can specify multiple values for the `${HOSTNAME}` variable from the previous example:
+
+[source,console]
+--------------------------------------------------
+export HOSTNAME=“host1”, “host2"
 --------------------------------------------------
 
 [discrete]
@@ -88,7 +95,7 @@ Cluster and node settings can be categorized based on how they are configured:
 [[dynamic-cluster-setting]]
 Dynamic::
 You can configure and update dynamic settings on a running cluster using the
-<<cluster-update-settings,cluster update settings API>>. 
+<<cluster-update-settings,cluster update settings API>>.
 +
 You can also configure dynamic settings locally on an unstarted or shut down
 node using `elasticsearch.yml`.

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -83,7 +83,7 @@ When specifying values for environment variables, you can only use strings. More
 
 [source,yaml]
 ----
-export HOSTNAME=“host1”, “host2"
+export HOSTNAME=“host1,host2"
 ----
 
 [discrete]

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -81,10 +81,10 @@ network.host: ${ES_NETWORK_HOST}
 
 When specifying values for environment variables, you can only use strings. More complex data structures like lists are not supported. However, settings that accept data structures such as lists also accepted comma-separated strings. For example, you can specify multiple values for the `${HOSTNAME}` variable from the previous example:
 
-[source,console]
---------------------------------------------------
+[source,yaml]
+----
 export HOSTNAME=“host1”, “host2"
---------------------------------------------------
+----
 
 [discrete]
 [[cluster-setting-types]]


### PR DESCRIPTION
Clarifying environment variable substitution in the ES configuration YAML.

Closes #6352 

Backports:
* 7.8 (#57733)
* 7.7 (#57734)
* 7.6 (#57736)
* 7.x (#57737)
* 6.8 (#57738)