### PR TITLE
Remove DEBUG-level logging from actions in docker

### DIFF
--- a/distribution/docker/src/docker/config/log4j2.properties
+++ b/distribution/docker/src/docker/config/log4j2.properties
@@ -1,9 +1,5 @@
 status = error
 
-# log action execution errors for easier debugging
-logger.action.name = org.elasticsearch.action
-logger.action.level = debug
-
 appender.rolling.type = Console
 appender.rolling.name = rolling
 appender.rolling.layout.type = ECSJsonLayout

--- a/distribution/docker/src/docker/config/oss/log4j2.properties
+++ b/distribution/docker/src/docker/config/oss/log4j2.properties
@@ -1,9 +1,5 @@
 status = error
 
-# log action execution errors for easier debugging
-logger.action.name = org.elasticsearch.action
-logger.action.level = debug
-
 appender.rolling.type = Console
 appender.rolling.name = rolling
 appender.rolling.layout.type = ECSJsonLayout


### PR DESCRIPTION
In #51459 DEBUG-level logging was removed from the default log4j
configuration. However, our docker build has its own log4j configuration
which was missed in that change. This commit removes the same from the
docker log4j configuration.

relates #51459
relates #51198