### PR TITLE
[DOCS] Replaces docdir attributes in ML APIs

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,5 +1,5 @@
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 :lucene_version:        8.6.0
 :lucene_version_path:   8_6_0
@@ -72,7 +72,7 @@ endif::[]
 Shared attribute values are pulled from elastic/docs
 ///////
 
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 ///////
 APM does not build n.x documentation. Links from .x branches should point to master instead

--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -22,17 +22,17 @@ ability to "exclude" (`-`), for example: `test*,-test3`.
 
 All multi index APIs support the following url query string parameters:
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 The defaults settings for the above parameters depend on the API being used.
 
 Some multi index APIs also support the following url query string parameter:
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
 NOTE: Single index APIs such as the <<docs>> and the
 <<indices-aliases,single-index `alias` APIs>> do not support multiple indices.

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -2,10 +2,10 @@
 = Elasticsearch Reference
 
 :include-xpack:         true
-:es-test-dir:           {docdir}/../src/test
-:plugins-examples-dir:  {docdir}/../../plugins/examples
-:xes-repo-dir:          {docdir}/../../x-pack/docs/{lang}
-:es-repo-dir:           {docdir}
+:es-test-dir:           {elasticsearch-root}/docs/src/test
+:plugins-examples-dir:  {elasticsearch-root}/plugins/examples
+:xes-repo-dir:          {elasticsearch-root}/x-pack/docs/{lang}
+:es-repo-dir:           {elasticsearch-root}/docs/reference
 
 
 include::../Versions.asciidoc[]

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -61,14 +61,14 @@ results the job might have recently produced or might produce in the future.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildcard]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildcard]
 
 [[ml-close-job-query-parms]]
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
 `force`::
   (Optional, boolean) Use to close a failed job, or to forcefully close a job

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-event.asciidoc
@@ -32,7 +32,7 @@ events and delete the calendar, see the
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `<event_id>`::
   (Required, string) Identifier for the scheduled event. You can obtain this

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar-job.asciidoc
@@ -25,11 +25,11 @@ Deletes {anomaly-jobs} from a calendar.
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-list]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-list]
 
 [[ml-delete-calendar-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-calendar.asciidoc
@@ -31,7 +31,7 @@ calendar.
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 [[ml-delete-calendar-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-datafeed.asciidoc
@@ -29,7 +29,7 @@ can delete it.
 
 `<feed_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [[ml-delete-datafeed-query-parms]]
 ==== {api-query-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-filter.asciidoc
@@ -32,7 +32,7 @@ update or delete the job before you can delete the filter.
 
 `<filter_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter-id]
 
 [[ml-delete-filter-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-forecast.asciidoc
@@ -47,7 +47,7 @@ forecasts from the job.
   
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
   
 
 [[ml-delete-forecast-query-parms]]

--- a/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-job.asciidoc
@@ -40,7 +40,7 @@ separated list.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-delete-job-query-parms]]
 ==== {api-query-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/delete-snapshot.asciidoc
@@ -31,11 +31,11 @@ the `model_snapshot_id` in the results from the get jobs API.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `<snapshot_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=snapshot-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 
 [[ml-delete-snapshot-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/flush-job.asciidoc
@@ -38,7 +38,7 @@ opened again before analyzing further data.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-flush-job-query-parms]]
 ==== {api-query-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/forecast.asciidoc
@@ -45,7 +45,7 @@ forecast. For more information about this property, see <<ml-put-job>>.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-forecast-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-bucket.asciidoc
@@ -37,7 +37,7 @@ bucket.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `<timestamp>`::
 (Optional, string) The timestamp of a single bucket result. If you do not
@@ -58,7 +58,7 @@ this value.
 
 `exclude_interim`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
 `expand`::
 (Optional, boolean) If true, the output includes anomaly records.
@@ -113,11 +113,11 @@ initial value that was calculated at the time the bucket was processed.
 
 `is_interim`:::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=is-interim]
 
 `job_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `probability`:::
 (number) The probability that the bucket has this behavior, in the range 0 to 1.
@@ -137,7 +137,7 @@ this.
 
 `bucket_span`::
 (number)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-span-results]
 
 `event_count`::
 (number) The number of input data records processed in this bucket.
@@ -148,11 +148,11 @@ the initial value that was calculated at the time the bucket was processed.
 
 `is_interim`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=is-interim]
 
 `job_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `processing_time_ms`::
 (number) The amount of time, in milliseconds, that it took to analyze the

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar-event.asciidoc
@@ -36,7 +36,7 @@ For more information, see
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 [[ml-get-calendar-event-request-body]]
 ==== {api-request-body-title}
@@ -62,7 +62,7 @@ following properties:
 
 `calendar_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `description`::
 (string) A description of the scheduled event.

--- a/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-calendar.asciidoc
@@ -36,7 +36,7 @@ For more information, see
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 [[ml-get-calendar-request-body]]
 ==== {api-request-body-title}
@@ -55,7 +55,7 @@ properties:
 
 `calendar_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `job_ids`::
 (array) An array of {anomaly-job} identifiers. For example:

--- a/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-category.asciidoc
@@ -44,7 +44,7 @@ examine the description and examples of that category. For more information, see
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `<category_id>`::
 (Optional, long) Identifier for the category. If you do not specify this
@@ -78,7 +78,7 @@ manual tweaking.
 
 `job_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `max_matching_length`::
 (unsigned integer) The maximum length of the fields that matched the category.

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed-stats.asciidoc
@@ -46,7 +46,7 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 
 `<feed_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 +
 --
 If you do not specify one of these options, the API returns information about
@@ -58,7 +58,7 @@ all {dfeeds}.
 
 `allow_no_datafeeds`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
 [role="child_attributes"]
 [[ml-get-datafeed-stats-results]]
@@ -69,30 +69,30 @@ informational; you cannot update their values.
 
 `assignment_explanation`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=assignment-explanation-datafeeds]
 
 `datafeed_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 `node`::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
 +
 --
 [%collapsible%open]
 ====
 `attributes`:::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-attributes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-attributes]
 
 `ephemeral_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
 
 `id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-id]
 
 `name`:::
 (string)
@@ -100,13 +100,13 @@ The node name. For example, `0-o0tOo`.
 
 `transport_address`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-transport-address]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 ====
 --
 
 `state`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=state-datafeed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=state-datafeed]
 
 `timing_stats`::
 (object) An object that provides statistical information about timing aspect of
@@ -117,24 +117,24 @@ this {dfeed}.
 ====
 `average_search_time_per_bucket_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-bucket-avg]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-bucket-avg]
 
 `bucket_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-count]
 
 `exponential_average_search_time_per_hour_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-exp-avg-hour]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-exp-avg-hour]
 
 `job_id`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `search_count`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-count]
 
 `total_search_time_ms`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-time]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-time]
 ====
 --
 

--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -43,7 +43,7 @@ IMPORTANT: This API returns a maximum of 10,000 {dfeeds}.
 
 `<feed_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 +
 --
 If you do not specify one of these options, the API returns information about
@@ -55,7 +55,7 @@ all {dfeeds}.
 
 `allow_no_datafeeds`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
 [[ml-get-datafeed-results]]
 ==== {api-response-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-filter.asciidoc
@@ -33,7 +33,7 @@ You can get a single filter or all filters. For more information, see
 
 `<filter_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter-id]
 
 [[ml-get-filter-query-parms]]
 ==== {api-query-parms-title}
@@ -55,7 +55,7 @@ properties:
 
 `filter_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter-id]
   
 `items`::
 (array of strings) An array of strings which is the filter item list.

--- a/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-influencer.asciidoc
@@ -35,21 +35,21 @@ the anomalies. Influencer results are available only if an
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-get-influencer-request-body]]
 ==== {api-request-body-title}
 
 `desc`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=desc-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=desc-results]
 
 `end`::
 (Optional, string) Returns influencers with timestamps earlier than this time.
 
 `exclude_interim`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
 `influencer_score`::
 (Optional, double) Returns influencers with anomaly scores greater than or
@@ -75,7 +75,7 @@ properties:
 
 `bucket_span`::
 (number)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-span-results]
 
 `influencer_score`::
 (number) A normalized score between 0-100, which is based on the probability of
@@ -97,11 +97,11 @@ calculated at the time the bucket was processed.
 
 `is_interim`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=is-interim]
 
 `job_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `probability`::
 (number) The probability that the influencer has this behavior, in the range 0
@@ -114,7 +114,7 @@ human-readable and friendly interpretation of this.
 
 `timestamp`::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=timestamp-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timestamp-results]
 
 NOTE: Additional influencer properties are added, depending on the fields being
 analyzed. For example, if it's analyzing `user_name` as an influencer, then a

--- a/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job-stats.asciidoc
@@ -41,14 +41,14 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 `<job_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
 
 [[ml-get-job-stats-query-parms]]
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
 [role="child_attributes"]
 [[ml-get-job-stats-results]]
@@ -59,7 +59,7 @@ job:
 
 `assignment_explanation`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-anomaly-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=assignment-explanation-anomaly-jobs]
 
 //Begin data_counts
 [[datacounts]]`data_counts`::
@@ -73,72 +73,72 @@ counts are not reset.
 ====
 `bucket_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count-anomaly-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-count-anomaly-jobs]
 
 `earliest_record_timestamp`:::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=earliest-record-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=earliest-record-timestamp]
 
 `empty_bucket_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=empty-bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=empty-bucket-count]
 
 `input_bytes`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=input-bytes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=input-bytes]
 
 `input_field_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=input-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=input-field-count]
 
 `input_record_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=input-record-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=input-record-count]
 
 `invalid_date_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
 
 `job_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `last_data_time`:::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=last-data-time]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=last-data-time]
 
 `latest_empty_bucket_timestamp`:::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=latest-empty-bucket-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latest-empty-bucket-timestamp]
 
 `latest_record_timestamp`:::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=latest-record-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latest-record-timestamp]
 
 `latest_sparse_bucket_timestamp`:::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=latest-sparse-record-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latest-sparse-record-timestamp]
 
 `missing_field_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=missing-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=missing-field-count]
 +
 The value of `processed_record_count` includes this count.
 
 `out_of_order_timestamp_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=out-of-order-timestamp-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=out-of-order-timestamp-count]
 
 `processed_field_count`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=processed-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=processed-field-count]
 
 `processed_record_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=processed-record-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=processed-record-count]
 
 `sparse_bucket_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
 ====
 //End data_counts
 
@@ -182,13 +182,13 @@ forecasts related to this job. If there are no forecasts, this property is omitt
 
 `total`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=forecast-total]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=forecast-total]
 ====
 //End forecasts_stats
 
 `job_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 //Begin model_size_stats
 [[modelsizestats]]`model_size_stats`::
@@ -200,77 +200,77 @@ model.
 ====
 `bucket_allocation_failures_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-allocation-failures-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-allocation-failures-count]
 
 `categorized_doc_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorized-doc-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorized-doc-count]
 
 `categorization_status`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-status]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-status]
 
 `dead_category_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dead-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dead-category-count]
 
 `failed_category_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=failed-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=failed-category-count]
 
 `frequent_category_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=frequent-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=frequent-category-count]
 
 `job_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `log_time`:::
 (date) The timestamp of the `model_size_stats` according to server time.
 
 `memory_status`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-status]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-status]
 
 `model_bytes`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-bytes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-bytes]
 
 `model_bytes_exceeded`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-bytes-exceeded]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-bytes-exceeded]
 
 `model_bytes_memory_limit`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit-anomaly-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-anomaly-jobs]
 
 `rare_category_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=rare-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=rare-category-count]
 
 `result_type`:::
 (string) For internal use. The type of result.
 
 `total_by_field_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-by-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-by-field-count]
 
 `total_category_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-category-count]
 
 `total_over_field_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-over-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-over-field-count]
 
 `total_partition_field_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-partition-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-partition-field-count]
 
 `timestamp`:::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-timestamp]
 ====
 //End model_size_stats
 
@@ -284,32 +284,32 @@ available only for open jobs.
 ====
 `attributes`:::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-attributes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-attributes]
   
 `ephemeral_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
 
 `id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-id]
 
 `name`:::
 (string) The node name.
 
 `transport_address`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-transport-address]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 ====
 //End node
 
 `open_time`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=open-time]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=open-time]
 
 `state`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=state-anomaly-job]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=state-anomaly-job]
 
 //Begin timing_stats
 [[timingstats]]`timing_stats`::
@@ -324,31 +324,31 @@ this job.
 
 `bucket_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-count]
 
 `exponential_average_bucket_processing_time_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average]
 
 `exponential_average_bucket_processing_time_per_hour_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average-hour]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average-hour]
 
 `job_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `maximum_bucket_processing_time_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-maximum]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-maximum]
 
 `minimum_bucket_processing_time_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-minimum]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-minimum]
 
 `total_bucket_processing_time_ms`:::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
 ====
 //End timing_stats
 

--- a/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-job.asciidoc
@@ -41,14 +41,14 @@ IMPORTANT: This API returns a maximum of 10,000 jobs.
 
 `<job_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-default]
 
 [[ml-get-job-query-parms]]
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
 
 [[ml-get-job-results]]
@@ -74,7 +74,7 @@ value.
 
 `model_snapshot_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-snapshot-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-snapshot-id]
 
 [[ml-get-job-response-codes]]
 ==== {api-response-codes-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-overall-buckets.asciidoc
@@ -56,14 +56,14 @@ a span equal to the jobs' largest bucket span.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildcard-list]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-wildcard-list]
 
 [[ml-get-overall-buckets-request-body]]
 ==== {api-request-body-title}
 
 `allow_no_jobs`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
 `bucket_span`::
 (Optional, string) The span of the overall buckets. Must be greater or equal to
@@ -102,7 +102,7 @@ of the job with the longest one.
 
 `is_interim`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=is-interim]
 
 `jobs`::
 (array) An array of objects that contain the `max_anomaly_score` per `job_id`.
@@ -115,7 +115,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
 
 `timestamp`::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=timestamp-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timestamp-results]
 
 [[ml-get-overall-buckets-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -43,21 +43,21 @@ of detectors.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-get-record-request-body]]
 ==== {api-request-body-title}
 
 `desc`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=desc-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=desc-results]
 
 `end`::
 (Optional, string) Returns records with timestamps earlier than this time.
 
 `exclude_interim`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-interim-results]
 
 `page`.`from`::
 (Optional, integer) Skips the specified number of records.
@@ -85,11 +85,11 @@ The API returns an array of record objects, which have the following properties:
 
 `bucket_span`::
 (number)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-span-results]
 
 `by_field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=by-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=by-field-name]
 
 `by_field_value`::
 (string) The value of `by_field_name`.
@@ -142,22 +142,22 @@ at the time the bucket was processed.
 
 `is_interim`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=is-interim]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=is-interim]
 
 `job_id`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `over_field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=over-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=over-field-name]
 
 `over_field_value`::
 (string) The value of `over_field_name`.
 
 `partition_field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=partition-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=partition-field-name]
 
 `partition_field_value`::
 (string) The value of `partition_field_name`.
@@ -184,7 +184,7 @@ be updated by a re-normalization process as new data is analyzed.
 
 `timestamp`::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=timestamp-results]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timestamp-results]
 
 `typical`::
 (array) The typical value for the bucket, according to analytical modeling.

--- a/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-snapshot.asciidoc
@@ -27,11 +27,11 @@ Retrieves information about model snapshots.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `<snapshot_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=snapshot-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 +
 --
 If you do not specify this optional parameter, the API returns information about
@@ -121,7 +121,7 @@ side effect of the way categorization has no prior training.)
 
 `failed_category_count`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=failed-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=failed-category-count]
 
 `frequent_category_count`:::
 (long) The number of categories that match more than 1% of categorized
@@ -129,7 +129,7 @@ documents.
 
 `job_id`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `log_time`:::
 (date) The timestamp that the `model_size_stats` were recorded, according to
@@ -185,7 +185,7 @@ separately for each detector and partition.
 
 `retain`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=retain]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=retain]
 
 `snapshot_id`::
 (string) A numerical character string that uniquely identifies the model

--- a/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/open-job.asciidoc
@@ -38,7 +38,7 @@ data is received.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-open-job-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-calendar-event.asciidoc
@@ -31,7 +31,7 @@ of which must have a start time, end time, and description.
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::../../ml-shared.asciidoc[tag=calendar-id]
 
 [role="child_attributes"]
 [[ml-post-calendar-event-request-body]]

--- a/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/post-data.asciidoc
@@ -54,7 +54,7 @@ or a comma-separated list.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[ml-post-data-query-parms]]
 ==== {api-query-parms-title}

--- a/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/preview-datafeed.asciidoc
@@ -44,7 +44,7 @@ supply the credentials.
 
 `<datafeed_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [[ml-preview-datafeed-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar-job.asciidoc
@@ -25,11 +25,11 @@ Adds an {anomaly-job} to a calendar.
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 `<job_id>`::
 (Required, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-list]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-list]
 
 [[ml-put-calendar-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-calendar.asciidoc
@@ -31,7 +31,7 @@ For more information, see
 
 `<calendar_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=calendar-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=calendar-id]
 
 [[ml-put-calendar-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -51,7 +51,7 @@ credentials are used instead.
 
 `<feed_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [role="child_attributes"]
 [[ml-put-datafeed-request-body]]
@@ -59,51 +59,51 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 `aggregations`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=aggregations]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
 
 `chunking_config`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=chunking-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
 
 `delayed_data_check_config`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
 
 `frequency`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=frequency]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=frequency]
 
 `indices`::
 (Required, array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=indices]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices]
 
 `job_id`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `max_empty_searches`::
 (Optional,integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=max-empty-searches]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-empty-searches]
  
 `query`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=query]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query]
 
 `query_delay`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=query-delay]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query-delay]
 
 `script_fields`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=script-fields]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=script-fields]
 
 `scroll_size`::
 (Optional, unsigned integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 `indices_options`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=indices-options]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices-options]
 
 
 [[ml-put-datafeed-example]]

--- a/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-filter.asciidoc
@@ -32,7 +32,7 @@ the `custom_rules` property of detector configuration objects.
 
 `<filter_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter-id]
 
 [[ml-put-filter-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -33,7 +33,7 @@ a job directly to the `.ml-config` index using the {es} index API. If {es}
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-define]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-define]
 
 [role="child_attributes"]
 [[ml-put-job-request-body]]
@@ -41,31 +41,31 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection-define]
 
 `allow_lazy_open`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-lazy-open]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-lazy-open]
 
 //Begin analysis_config
 [[put-analysisconfig]]`analysis_config`::
 (Required, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-config]
 +
 .Properties of `analysis_config`
 [%collapsible%open]
 ====
 `bucket_span`:::
 (<<time-units,time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-span]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-span]
 
 `categorization_analyzer`:::
 (object or string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-analyzer]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-analyzer]
 
 `categorization_field_name`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-field-name]
 
 `categorization_filters`:::
 (array of strings)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-filters]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-filters]
 
 //Begin analysis_config.detectors
 `detectors`:::
@@ -81,12 +81,12 @@ no analysis can occur and an error is returned.
 =====
 `by_field_name`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=by-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=by-field-name]
 
 //Begin analysis_config.detectors.custom_rules
 [[put-customrules]]`custom_rules`::::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules]
 +
 .Properties of `custom_rules`
 [%collapsible%open]
@@ -94,45 +94,45 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
 
 `actions`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
 //Begin analysis_config.detectors.custom_rules.conditions
 `conditions`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
 +
 .Properties of `conditions`
 [%collapsible%open]
 =======
 `applies_to`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
 
 `operator`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 
 `value`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
 =======
 //End analysis_config.detectors.custom_rules.conditions
 
 //Begin analysis_config.detectors.custom_rules.scope
 `scope`:::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
 +
 .Properties of `scope`
 [%collapsible%open]
 =======
 `filter_id`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
 
 `filter_type`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
 =======
 //End analysis_config.detectors.custom_rules.scope
 ======
@@ -140,134 +140,134 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
 
 `detector_description`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-description]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-description]
 
 `detector_index`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-index]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-index]
 +
 If you specify a value for this property, it is ignored.
 
 `exclude_frequent`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=exclude-frequent]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-frequent]
 
 `field_name`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-field-name]
 
 `function`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=function]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=function]
 
 `over_field_name`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=over-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=over-field-name]
 
 `partition_field_name`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=partition-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=partition-field-name]
 
 `use_null`::::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=use-null]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=use-null]
 =====
 //End analysis_config.detectors
 
 `influencers`:::
 (array of strings)
-include::{docdir}/ml/ml-shared.asciidoc[tag=influencers]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=influencers]
 
 `latency`:::
 (time units)
-include::{docdir}/ml/ml-shared.asciidoc[tag=latency]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latency]
 
 `multivariate_by_fields`:::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=multivariate-by-fields]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=multivariate-by-fields]
 
 `summary_count_field_name`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=summary-count-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=summary-count-field-name]
 ====
 //End analysis_config
 
 //Begin analysis_limits
 [[put-analysislimits]]`analysis_limits`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-limits]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 +
 .Properties of `analysis_limits`
 [%collapsible%open]
 ====
 `categorization_examples_limit`:::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-examples-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-examples-limit]
 
 `model_memory_limit`:::
 (long or string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
 ====
 //End analysis_limits
 
 `background_persist_interval`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
 
 [[put-customsettings]]`custom_settings`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-settings]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-settings]
 
 //Begin data_description
 [[put-datadescription]]`data_description`::
 (Required, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=data-description]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=data-description]
 //End data_description
 
 `daily_model_snapshot_retention_after_days`::
 (Optional, long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after-days]
 
 `description`::
   (Optional, string) A description of the job.
 
 `groups`::
 (Optional, array of strings)
-include::{docdir}/ml/ml-shared.asciidoc[tag=groups]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=groups]
 
 //Begin model_plot_config
 `model_plot_config`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config]
 +
 .Properties of `model_plot_config`
 [%collapsible%open]
 ====
 `enabled`:::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 
 `terms`:::
 experimental[] (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
 ====
 //End model_plot_config
 
 `model_snapshot_retention_days`::
 (Optional, long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-snapshot-retention-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-snapshot-retention-days]
 
 `renormalization_window_days`::
 (Optional, long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=renormalization-window-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=renormalization-window-days]
 
 `results_index_name`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=results-index-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-index-name]
 
 `results_retention_days`::
 (Optional, long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=results-retention-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
 [[ml-put-job-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/revert-snapshot.asciidoc
@@ -37,11 +37,11 @@ Friday or a critical system failure.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `<snapshot_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=snapshot-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 
 [[ml-revert-snapshot-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/start-datafeed.asciidoc
@@ -77,7 +77,7 @@ you created or updated the {dfeed}, those credentials are used instead.
 
 `<feed_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [[ml-start-datafeed-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/stop-datafeed.asciidoc
@@ -41,14 +41,14 @@ comma-separated list of {dfeeds} or a wildcard expression. You can close all
 
 `<feed_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id-wildcard]
 
 [[ml-stop-datafeed-query-parms]]
 ==== {api-query-parms-title}
 
 `allow_no_datafeeds`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
 [[ml-stop-datafeed-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -42,7 +42,7 @@ credentials are used instead.
 
 `<feed_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [role="child_attributes"]
 [[ml-update-datafeed-request-body]]
@@ -52,27 +52,27 @@ The following properties can be updated after the {dfeed} is created:
 
 `aggregations`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=aggregations]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=aggregations]
 
 `chunking_config`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=chunking-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=chunking-config]
 
 `delayed_data_check_config`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=delayed-data-check-config]
 
 `frequency`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=frequency]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=frequency]
 
 `indices`::
 (Optional, array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=indices]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices]
 
 `max_empty_searches`::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=max-empty-searches]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-empty-searches]
 +
 --
 The special value `-1` unsets this setting.
@@ -80,7 +80,7 @@ The special value `-1` unsets this setting.
 
 `query`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=query]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query]
 +
 --
 WARNING: If you change the query, the analyzed data is also changed. Therefore,
@@ -94,19 +94,19 @@ the results of the other job.
 
 `query_delay`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=query-delay]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=query-delay]
 
 `script_fields`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=script-fields]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=script-fields]
 
 `scroll_size`::
 (Optional, unsigned integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=scroll-size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 `indices_options`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=indices-options]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=indices-options]
 
 [[ml-update-datafeed-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-filter.asciidoc
@@ -25,7 +25,7 @@ Updates the description of a filter, adds items, or removes items.
 
 `<filter_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter-id]
 
 [[ml-update-filter-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -26,7 +26,7 @@ Updates certain properties of an {anomaly-job}.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [role="child_attributes"]
 [[ml-update-job-request-body]]
@@ -36,7 +36,7 @@ The following properties can be updated after the job is created:
 
 `allow_lazy_open`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-lazy-open]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-lazy-open]
 +
 --
 NOTE: If the job is open when you make the update, you must stop the {dfeed},
@@ -46,14 +46,14 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 //Begin analysis_limits
 [[update-analysislimits]]`analysis_limits`::
 (Optional, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=analysis-limits]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=analysis-limits]
 +
 .Properties of `analysis_limits`
 [%collapsible%open]
 ====
 `model_memory_limit`:::
 (long or string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit]
 +
 --
 NOTE: You can update the `analysis_limits` only while the job is closed. The 
@@ -70,7 +70,7 @@ to re-run the job with an increased `model_memory_limit`.
 
 `background_persist_interval`::
 (<<time-units,time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=background-persist-interval]
 +
 --
 NOTE: If the job is open when you make the update, you must stop the {dfeed},
@@ -80,11 +80,11 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 
 [[update-customsettings]]`custom_settings`::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-settings]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-settings]
 
 `daily_model_snapshot_retention_after_days`::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after-days]
 
 `description`::
 (string) A description of the job.
@@ -100,7 +100,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=daily-model-snapshot-retention-after
 //Begin detectors.custom_rules
 `custom_rules`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules]
 +
 .Properties of `custom_rules`
 [%collapsible%open]
@@ -108,12 +108,12 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
 
 `actions`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
 // Begin detectors.custom_rules.conditions
 `conditions`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
 +
 .Properties of `conditions`
 [%collapsible%open]
@@ -121,33 +121,33 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
 
 `applies_to`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
 
 `operator`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 
 `value`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
 ======
 //End detectors.custom_rules.conditions
 
 //Begin detectors.custom_rules.scope
 `scope`:::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
 +
 .Properties of `scope`
 [%collapsible%open]
 ======
 `filter_id`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
 
 `filter_type`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
 ======
 //End detectors.custom_rules.scope
 =====
@@ -155,11 +155,11 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
 
 `description`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-description]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-description]
 
 `detector_index`:::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-index]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-index]
 +
 --
 If you want to update a specific detector, you must use this identifier. You
@@ -170,33 +170,33 @@ cannot, however, change the `detector_index` value for a detector.
 
 `groups`::
 (array of strings)
-include::{docdir}/ml/ml-shared.asciidoc[tag=groups]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=groups]
 
 //Begin model_plot_config
 `model_plot_config`::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config]
 +
 .Properties of `model_plot_config`
 [%collapsible%open]
 ====
 `enabled`:::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 
 `terms`:::
 experimental[] (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
 ====
 //End model_plot_config
 
 `model_snapshot_retention_days`::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-snapshot-retention-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-snapshot-retention-days]
 
 `renormalization_window_days`::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=renormalization-window-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=renormalization-window-days]
 +
 --
 NOTE: If the job is open when you make the update, you must stop the {dfeed},
@@ -206,7 +206,7 @@ close the job, then reopen the job and restart the {dfeed} for the changes to ta
 
 `results_retention_days`::
 (long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=results-retention-days]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 
 
 [[ml-update-job-example]]

--- a/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-snapshot.asciidoc
@@ -26,11 +26,11 @@ Updates certain properties of a snapshot.
 
 `<job_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `<snapshot_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=snapshot-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=snapshot-id]
 
 [[ml-update-snapshot-request-body]]
 ==== {api-request-body-title}
@@ -42,7 +42,7 @@ The following properties can be updated after the model snapshot is created:
 
 `retain`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=retain]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=retain]
 
 
 [[ml-update-snapshot-example]]

--- a/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/validate-detector.asciidoc
@@ -31,78 +31,78 @@ before you create an {anomaly-job}.
 
 `by_field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=by-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=by-field-name]
 
 `custom_rules`::
 +
 --
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules]
 
 `analysis_config`.`detectors`.`custom_rules`.`actions`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-actions]
 
 `analysis_config`.`detectors`.`custom_rules`.`scope`:::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope]
 
 `analysis_config`.`detectors`.`custom_rules`.`scope`.`filter_id`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-id]
 
 `analysis_config`.`detectors`.`custom_rules`.`scope`.`filter_type`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-scope-filter-type]
 
 `analysis_config`.`detectors`.`custom_rules`.`conditions`:::
 (array)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions]
 
 `analysis_config`.`detectors`.`custom_rules`.`conditions`.`applies_to`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-applies-to]
 
 `analysis_config`.`detectors`.`custom_rules`.`conditions`.`operator`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-operator]
 
 `analysis_config`.`detectors`.`custom_rules`.`conditions`.`value`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=custom-rules-conditions-value]
 --
 
 `detector_description`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-description]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-description]
 
 `detector_index`::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-index]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-index]
 
 `exclude_frequent`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=exclude-frequent]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=exclude-frequent]
 
 `field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=detector-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=detector-field-name]
 
 `function`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=function]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=function]
 
 `over_field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=over-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=over-field-name]
 
 `partition_field_name`::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=partition-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=partition-field-name]
 
 `use_null`::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=use-null]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=use-null]
 
 [[ml-valid-detector-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-dfanalytics.asciidoc
@@ -35,7 +35,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 `<data_frame_analytics_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 
 [[ml-delete-dfanalytics-query-params]]
 ==== {api-query-parms-title}

--- a/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/delete-inference-trained-model.asciidoc
@@ -36,7 +36,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 `<model_id>`::
 (Optional, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-delete-inference-response-codes]]

--- a/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/explain-dfanalytics.asciidoc
@@ -56,7 +56,7 @@ they are not included in the explanation.
 
 `<data_frame_analytics_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 
 [[ml-explain-dfanalytics-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics-stats.asciidoc
@@ -40,7 +40,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 `<data_frame_analytics_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
 
 
 [[ml-get-dfanalytics-stats-query-params]]
@@ -48,15 +48,15 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
 
 `allow_no_match`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
 
 `from`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=from]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 
 `size`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 [role="child_attributes"]
 [[ml-get-dfanalytics-stats-response-body]]
@@ -96,106 +96,106 @@ An object containing the parameters of the {classanalysis} job.
 =======
 `alpha`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-alpha]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-alpha]
 
 `class_assignment_objective`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=class-assignment-objective]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=class-assignment-objective]
 
 `downsample_factor`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-downsample-factor]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-downsample-factor]
 
 `eta`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=eta]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=eta]
 
 `eta_growth_rate_per_tree`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-eta-growth]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-eta-growth]
 
 `feature_bag_fraction`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
 
 `gamma`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=gamma]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=gamma]
 
 `lambda`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 
 `max_attempts_to_add_tree`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-attempts]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-max-attempts]
 
 `max_optimization_rounds_per_hyperparameter`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
 
 `max_trees`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 
 `num_folds`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-num-folds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-num-folds]
 
 `num_splits_per_feature`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-num-splits]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-num-splits]
 
 `soft_tree_depth_limit`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-soft-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-soft-limit]
 
 `soft_tree_depth_tolerance`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-soft-tolerance]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-soft-tolerance]
 =======
 //End class_hyperparameters
 
 `iteration`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-iteration]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-iteration]
 
 `timestamp`::::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
 
 //Begin class_timing_stats
 `timing_stats`::::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
 +
 .Properties of `timing_stats`
 [%collapsible%open]
 =======
 `elapsed_time`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
 
 `iteration_time`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-iteration]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-iteration]
 =======
 //End class_timing_stats
 
 //Begin class_validation_loss
 `validation_loss`::::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss]
 +
 .Properties of `validation_loss`
 [%collapsible%open]
 =======
 `fold_values`::::
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-fold]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-fold]
 
 `loss_type`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-type]
 =======
 //End class_validation_loss
 ======
@@ -220,45 +220,45 @@ heuristics.
 =======
 `compute_feature_influence`::::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=compute-feature-influence]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=compute-feature-influence]
 
 `feature_influence_threshold`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=feature-influence-threshold]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=feature-influence-threshold]
 
 `method`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=method]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=method]
 
 `n_neighbors`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=n-neighbors]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=n-neighbors]
 
 `outlier_fraction`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=outlier-fraction]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=outlier-fraction]
 
 `standardization_enabled`::::
 (boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=standardization-enabled]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=standardization-enabled]
 =======
 //End parameters
 
 `timestamp`::::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
 
 //Begin od_timing_stats
 `timing_stats`::::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
 +
 .Property of `timing_stats`
 [%collapsible%open]
 =======
 `elapsed_time`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
 =======
 //End od_timing_stats
 ======
@@ -282,103 +282,103 @@ An object containing the parameters of the {reganalysis} job.
 =======
 `alpha`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-alpha]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-alpha]
 
 `downsample_factor`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-downsample-factor]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-downsample-factor]
 
 `eta`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=eta]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=eta]
 
 `eta_growth_rate_per_tree`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-eta-growth]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-eta-growth]
 
 `feature_bag_fraction`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
 
 `gamma`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=gamma]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=gamma]
 
 `lambda`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 
 `max_attempts_to_add_tree`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-attempts]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-max-attempts]
 
 `max_optimization_rounds_per_hyperparameter`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
 
 `max_trees`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 
 `num_folds`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-num-folds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-num-folds]
 
 `num_splits_per_feature`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-num-splits]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-num-splits]
 
 `soft_tree_depth_limit`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-soft-limit]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-soft-limit]
 
 `soft_tree_depth_tolerance`::::
 (double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-soft-tolerance]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-soft-tolerance]
 =======
 //End reg_hyperparameters
 
 `iteration`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-iteration]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-iteration]
 
 `timestamp`::::
 (date)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timestamp]
 
 //Begin reg_timing_stats
 `timing_stats`::::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats]
 +
 .Propertis of `timing_stats`
 [%collapsible%open]
 =======
 `elapsed_time`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-elapsed]
 
 `iteration_time`::::
 (integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-iteration]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-timing-stats-iteration]
 =======
 //End reg_timing_stats
 
 //Begin reg_validation_loss
 `validation_loss`::::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss]
 +
 .Properties of `validation_loss`
 [%collapsible%open]
 =======
 `fold_values`::::
 (array of strings)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-fold]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-fold]
 
 `loss_type`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-validation-loss-type]
 =======
 //End reg_validation_loss
 ======
@@ -450,15 +450,15 @@ available only for running jobs.
 =====
 `attributes`::::
 (object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-attributes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-attributes]
 
 `ephemeral_id`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-ephemeral-id]
 
 `id`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-id]
 
 `name`::::
 (string)
@@ -466,7 +466,7 @@ The node name.
 
 `transport_address`::::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-transport-address]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-transport-address]
 =====
 
 `progress`:::

--- a/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-dfanalytics.asciidoc
@@ -47,7 +47,7 @@ by using a comma-separated list of {dfanalytics-jobs} or a wildcard expression.
 
 `<data_frame_analytics_id>`::
 (Optional, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
 +
 --
 You can get information for all {dfanalytics-jobs} by using _all, by specifying 
@@ -61,15 +61,15 @@ You can get information for all {dfanalytics-jobs} by using _all, by specifying
 
 `allow_no_match`::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
 
 `from`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=from]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 
 `size`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 [role="child_attributes"]
 [[ml-get-dfanalytics-results]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model-stats.asciidoc
@@ -49,7 +49,7 @@ request by using a comma-separated list of model IDs or a wildcard expression.
 
 `<model_id>`::
 (Optional, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-get-inference-stats-query-params]]
@@ -57,15 +57,15 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 
 `allow_no_match`::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
 
 `from`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=from]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 
 `size`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 
 [[ml-get-inference-stats-response-codes]]

--- a/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/get-inference-trained-model.asciidoc
@@ -49,7 +49,7 @@ using a comma-separated list of model IDs or a wildcard expression.
 
 `<model_id>`::
 (Optional, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 
 [[ml-get-inference-query-params]]
@@ -57,7 +57,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
 
 `allow_no_match`::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
 
 `decompress_definition`::
 (Optional, boolean)
@@ -66,7 +66,7 @@ Specifies whether the included model definition should be returned as a JSON map
 
 `from`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=from]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=from]
 
 `include_model_definition`::
 (Optional, boolean)
@@ -76,11 +76,11 @@ provided. Otherwise, a bad request is returned.
 
 `size`::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=size]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=size]
 
 `tags`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=tags]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=tags]
 
 `for_export`::
 (Optional, boolean)

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -58,7 +58,7 @@ determines a value for each of the undefined parameters.
 
 `<data_frame_analytics_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
 
 [role="child_attributes"]
 [[ml-put-dfanalytics-request-body]]
@@ -100,12 +100,12 @@ understand the function of these parameters.
 =====
 `class_assignment_objective`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=class-assignment-objective]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=class-assignment-objective]
 
 `dependent_variable`::::
 (Required, string)
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 The data type of the field must be numeric (`integer`, `short`, `long`, `byte`), 
 categorical (`ip` or `keyword`), or boolean. There must be no more than 30
@@ -113,23 +113,23 @@ different values in this field.
 
 `eta`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=eta]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=eta]
 
 `feature_bag_fraction`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
 
 `gamma`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=gamma]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=gamma]
 
 `lambda`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 
 `max_trees`::::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 
 `num_top_classes`::::
 (Optional, integer)
@@ -145,15 +145,15 @@ By default, it is zero and no {feat-imp} calculation occurs.
 
 `prediction_field_name`::::
 (Optional, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
 
 `randomize_seed`::::
 (Optional, long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=randomize-seed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=randomize-seed]
 
 `training_percent`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=training-percent]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=training-percent]
 //End classification
 =====
 //Begin outlier_detection
@@ -167,27 +167,27 @@ The configuration information necessary to perform
 =====
 `compute_feature_influence`::::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=compute-feature-influence]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=compute-feature-influence]
   
 `feature_influence_threshold`:::: 
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=feature-influence-threshold]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=feature-influence-threshold]
 
 `method`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=method]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=method]
   
 `n_neighbors`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=n-neighbors]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=n-neighbors]
   
 `outlier_fraction`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=outlier-fraction]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=outlier-fraction]
   
 `standardization_enabled`::::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=standardization-enabled]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=standardization-enabled]
 //End outlier_detection
 =====
 //Begin regression
@@ -207,25 +207,25 @@ understand the function of these parameters.
 `dependent_variable`::::
 (Required, string)
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=dependent-variable]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dependent-variable]
 +
 The data type of the field must be numeric.
 
 `eta`::::
 (Optional, double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=eta]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=eta]
 
 `feature_bag_fraction`::::
 (Optional, double)
-include::{docdir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=feature-bag-fraction]
 
 `gamma`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=gamma]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=gamma]
 
 `lambda`::::
 (Optional, double) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=lambda]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=lambda]
 
 `loss_function`::::
 (Optional, string)
@@ -241,7 +241,7 @@ A positive number that is used as a parameter to the `loss_function`.
 
 `max_trees`::::
 (Optional, integer) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=max-trees]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 
 `num_top_feature_importance_values`::::
 (Optional, integer)
@@ -251,15 +251,15 @@ By default, it is zero and no {feat-imp} calculation occurs.
 
 `prediction_field_name`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=prediction-field-name]
 
 `randomize_seed`::::
 (Optional, long)
-include::{docdir}/ml/ml-shared.asciidoc[tag=randomize-seed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=randomize-seed]
 
 `training_percent`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=training-percent]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=training-percent]
 =====
 //End regression
 ====
@@ -321,11 +321,11 @@ analysis.
 
 `description`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=description-dfa]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=description-dfa]
 
 `dest`::
 (Required, object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=dest]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dest]
   
 `model_memory_limit`::
 (Optional, string)

--- a/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-inference.asciidoc
@@ -47,7 +47,7 @@ is not created by {dfanalytics}.
 
 `<model_id>`::
 (Required, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 [role="child_attributes"]
 [[ml-put-inference-request-body]]
@@ -359,11 +359,11 @@ Regression configuration for inference.
 =====
 `num_top_feature_importance_values`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
 
 `results_field`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 =====
 
 `classification`:::
@@ -375,23 +375,23 @@ Classification configuration for inference.
 =====
 `num_top_classes`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
 
 `num_top_feature_importance_values`::::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
 
 `prediction_field_type`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
 
 `results_field`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 
 `top_classes_results_field`::::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
 =====
 ====
 //End of inference_config

--- a/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/start-dfanalytics.asciidoc
@@ -60,14 +60,14 @@ when you created the job, those credentials are used.
 
 `<data_frame_analytics_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
 
 [[ml-start-dfanalytics-query-params]]
 ==== {api-query-parms-title}
 
 `timeout`::
 (Optional, <<time-units,time units>>) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=timeout-start]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timeout-start]
 
 [[ml-start-dfanalytics-response-body]]
 ==== {api-response-body-title}

--- a/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/stop-dfanalytics.asciidoc
@@ -49,14 +49,14 @@ stop all {dfanalytics-job} by using _all or by specifying * as the
 
 `<data_frame_analytics_id>`::
 (Required, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-define]
   
 [[ml-stop-dfanalytics-query-params]]
 ==== {api-query-parms-title}  
   
 `allow_no_match`::
 (Optional, boolean) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-match]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match]
 
 
 `force`::
@@ -64,7 +64,7 @@ include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-match]
   
 `timeout`::
 (Optional, <<time-units,time units>>) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=timeout-stop]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=timeout-stop]
 
 
 [[ml-stop-dfanalytics-example]]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -183,15 +183,15 @@ is an object it has the following properties:
 =====
 `char_filter`::::
 (array of strings or objects)
-include::{docdir}/ml/ml-shared.asciidoc[tag=char-filter]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=char-filter]
 
 `tokenizer`::::
 (string or object)
-include::{docdir}/ml/ml-shared.asciidoc[tag=tokenizer]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=tokenizer]
 
 `filter`::::
 (array of strings or objects)
-include::{docdir}/ml/ml-shared.asciidoc[tag=filter]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=filter]
 =====
 end::categorization-analyzer[]
 
@@ -270,11 +270,11 @@ time chunks are calculated and is an advanced configuration option.
 ====
 `mode`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=mode]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=mode]
 
 `time_span`:::
 (<<time-units,time units>>)
-include::{docdir}/ml/ml-shared.asciidoc[tag=time-span]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-span]
 ====
 end::chunking-config[]
 
@@ -391,7 +391,7 @@ for {anomaly-detect} are retained.
 
 `time_format`:::
 (string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=time-format]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=time-format]
 ====
 end::data-description[]
 

--- a/docs/reference/transform/apis/delete-transform.asciidoc
+++ b/docs/reference/transform/apis/delete-transform.asciidoc
@@ -35,7 +35,7 @@ For more information, see <<security-privileges>> and <<built-in-roles>>.
 
 `<transform_id>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 [[delete-transform-query-parms]]
 ==== {api-query-parms-title}

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -53,7 +53,7 @@ specifying `*` as the `<transform_id>`, or by omitting the
 
 `<transform_id>`::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
   
 
 [[get-transform-stats-query-parms]]
@@ -61,15 +61,15 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
 
 `allow_no_match`::
 (Optional, boolean)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
 
 `from`::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from-transforms]
 
 `size`::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=size-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=size-transforms]
 
 [role="child_attributes"]
 [[get-transform-stats-response]]
@@ -88,7 +88,7 @@ informational; you cannot update their values.
 ====
 `changes_last_detected_at`:::
 (date)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=checkpointing-changes-last-detected-at]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=checkpointing-changes-last-detected-at]
 
 //Begin checkpointing.last
 `last`:::
@@ -144,7 +144,7 @@ that the {transform} is failing to keep up.
 
 `id`::
 (string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 //Begin node
 `node`::
@@ -174,11 +174,11 @@ example, `127.0.0.1:9300`.
 
 `reason`::
 (string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform-reason]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=state-transform-reason]
 
 `state`::
 (string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=state-transform]
 
 //Begin stats
 `stats`::
@@ -190,63 +190,63 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform]
 
 `documents_indexed`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-indexed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-indexed]
 
 `documents_processed`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-processed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-processed]
 
 `exponential_avg_checkpoint_duration_ms`:::
 (double)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-checkpoint-duration-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=exponential-avg-checkpoint-duration-ms]
 
 `exponential_avg_documents_indexed`:::
 (double)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-indexed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-indexed]
 
 `exponential_avg_documents_processed`:::
 (double)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-processed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-processed]
 
 `index_failures`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-failures]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-failures]
 
 `index_time_in_ms`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-time-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-time-ms]
 
 `index_total`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-total]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-total]
 
 `pages_processed`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pages-processed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pages-processed]
 
 `processing_time_in_ms`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=processing-time-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=processing-time-ms]
 
 `processing_total`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=processing-total]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=processing-total]
 
 `search_failures`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-failures]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-failures]
 
 `search_time_in_ms`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-time-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-time-ms]
 
 `search_total`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-total]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-total]
 
 `trigger_count`:::
 (long)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=trigger-count]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=trigger-count]
 ====
 //End stats
   

--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -48,22 +48,22 @@ specifying `*` as the `<transform_id>`, or by omitting the `<transform_id>`.
 
 `<transform_id>`::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
   
 [[get-transform-query-parms]]
 ==== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
 
 `from`::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from-transforms]
 
 `size`::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=size-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=size-transforms]
 
 [[get-transform-response]]
 ==== {api-response-body-title}

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -58,29 +58,29 @@ or an index template with your preferred mappings before you start the
 //Begin dest
 `dest`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest]
 +
 .Properties of `dest`
 [%collapsible%open]
 ====
 `index`:::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
 `pipeline`:::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
 ====
 //End dest
 
 `frequency`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 
 //Begin pivot
 `pivot`::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot]
 +
 .Properties of `pivot`
 [%collapsible%open]
@@ -88,18 +88,18 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
 
 `aggregations` or `aggs`:::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 
 `group_by`:::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 ====
 //End pivot
 
 //Begin source
 `source`::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 +
 .Properties of `source`
 [%collapsible%open]
@@ -107,18 +107,18 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 
 `index`:::
 (Required, string or array)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
 
 `query`:::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
 ====
 //End source
 
 //Begin sync
 `sync`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync]
 +
 .Properties of `sync`
 [%collapsible%open]
@@ -127,7 +127,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
 
 `time`:::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 +
 .Properties of `analysis_config`
 [%collapsible%open]
@@ -135,11 +135,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
 
 `delay`::::
 (Optional, <<time-units, time units>>)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
     
 `field`::::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 =====
 //End sync.time
 ====
@@ -148,17 +148,17 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 //Begin settings
 `settings`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings]
 +
 .Properties of `settings`
 [%collapsible%open]
 ====
 `docs_per_second`:::
 (Optional, float)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `max_page_search_size`:::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
 ====
 //End settings
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -68,7 +68,7 @@ IMPORTANT:  You must use {kib} or this API to create a {transform}.
 
 `<transform_id>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 [[put-transform-query-parms]]
 ==== {api-query-parms-title}
@@ -88,7 +88,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
 //Begin dest
 `dest`::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest]
 +
 .Properties of `dest`
 [%collapsible%open]
@@ -96,22 +96,22 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
 
 `index`:::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
 `pipeline`:::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
 ====
 //End dest
 
 `frequency`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 
 //Begin pivot
 `pivot`::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot]
 +
 .Properties of `pivot`
 [%collapsible%open]
@@ -119,11 +119,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot]
 
 `aggregations` or `aggs`:::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 
 `group_by`:::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 
 ====
 //End pivot
@@ -131,24 +131,24 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
 //Begin settings
 `settings`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings]
 +
 .Properties of `settings`
 [%collapsible%open]
 ====
 `docs_per_second`:::
 (Optional, float)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `max_page_search_size`:::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
 ====
 //End settings
 
 //Begin source
 `source`::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 +
 .Properties of `source`
 [%collapsible%open]
@@ -156,18 +156,18 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 
 `index`:::
 (Required, string or array)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
 
 `query`:::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
 ====
 //End source
 
 //Begin sync
 `sync`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync]
 +
 .Properties of `sync`
 [%collapsible%open]
@@ -176,7 +176,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
 //Begin time
 `time`:::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 +
 .Properties of `time`
 [%collapsible%open]
@@ -184,11 +184,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
 
 `delay`::::
 (Optional, <<time-units, time units>>)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
     
 `field`::::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 +
 --
 TIP: In general, it’s a good idea to use a field that contains the

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -55,7 +55,7 @@ required privileges on the source and destination indices, the
 
 `<transform_id>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 [[start-transform-example]]
 ==== {api-examples-title}

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -48,14 +48,14 @@ All {transforms} can be stopped by using `_all` or `*` as the
 
 `<transform_id>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 [[stop-transform-query-parms]]
 ==== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
 
 `force`::
   (Optional, boolean) Set to `true` to stop a failed {transform} or to 

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -62,7 +62,7 @@ give users any privileges on `.data-frame-internal*` indices.
 
 `<transform_id>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 [[update-transform-query-parms]]
 ==== {api-query-parms-title}
@@ -82,7 +82,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
 //Begin dest
 `dest`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest]
 +
 .Properties of `dest`
 [%collapsible%open]
@@ -90,39 +90,39 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=dest]
 
 `index`:::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
 `pipeline`:::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
 ====
 //End dest
 
 `frequency`::
 (Optional, <<time-units, time units>>)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 
 //Begin settings
 `settings`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings]
 +
 .Properties of `settings`
 [%collapsible%open]
 ====
 `docs_per_second`:::
 (Optional, float)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `max_page_search_size`:::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
 ====
 //End settings
 
 //Begin source
 `source`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 +
 .Properties of `source`
 [%collapsible%open]
@@ -130,18 +130,18 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 
 `index`:::
 (Required, string or array)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
     
 `query`:::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-query-transforms]
 ====
 //End source
 
 //Begin sync
 `sync`::
 (Optional, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync]
 +
 .Properties of `sync`
 [%collapsible%open]
@@ -150,7 +150,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync]
 //Begin sync.time
 `time`:::
 (Required, object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 +
 .Properties of `time`
 [%collapsible%open]
@@ -158,11 +158,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time]
 
 `delay`::::
 (Optional, <<time-units, time units>>)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
 
 `field`::::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 +
 --
 TIP: In general, it’s a good idea to use a field that contains the


### PR DESCRIPTION
This PR changes the use of the {docdir} attribute in machine learning APIs and the API conventions file, since that attribute varies depending on where you build the documentation from.

It also updates the *-repo-dir attributes so that instead of relative paths, they use *-root attributes, which are created automatically by the build.