### PR TITLE
[DOCS] Fix remote cluster typo in node docs

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -44,7 +44,7 @@ Valid columns are:
 `node.role`, `r`, `role`, `nodeRole`::
 (Default) Roles of the node. Returned values include `d` (data node), `i`
 (ingest node), `m` (master-eligible node), `l` (machine learning node), `v`
-(voting-only node), `t` ({transform} node), and `-` (coordinating node only).
+(voting-only node), `t` ({transform} node), `r` (remote cluster client node), and `-` (coordinating node only).
 +
 For example, `dim` indicates a master-eligible data and ingest node. See
 <<modules-node>>.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -127,7 +127,7 @@ node.ml: false <5>
 xpack.ml.enabled: true <6>
 node.transform: false <7>
 xpack.transform.enabled: true <8>
-node.remote_client_client: false <9>
+node.remote_cluster_client: false <9>
 -------------------
 <1> The `node.master` role is enabled by default.
 <2> The `node.voting_only` role is disabled by default.


### PR DESCRIPTION
Fixed typo from `node.remote_client_client` to `node.remote_cluster_client`