### PR TITLE
AwarenessAllocationDecider high availability allocation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -195,12 +195,16 @@ public class AwarenessAllocationDecider extends AllocationDecider {
                         currentNodeCount,
                         maximumNodeCount);
             } else if (shardCount > numberOfAttributes) {
-                int remainingAttributes = numberOfAttributes - shardPerAttribute.size(); // remaining attributes are not assign the shard copies
-                int remainingShards = shardCount - Arrays.stream(shardPerAttribute.values).sum(); // remaining shard copies are not allocated
-                if (remainingAttributes > 0 && remainingShards < remainingAttributes) {
+                // remaining attributes are not assign the shard copies
+                int remainingAttributes = numberOfAttributes - shardPerAttribute.size();
+                // remaining shard copies are not allocated
+                int remainingShards = shardCount - Arrays.stream(shardPerAttribute.values).sum();
+                if (remainingShards > 0 && remainingShards < remainingAttributes) {
                     return allocation.decision(Decision.NO, NAME,
-                        "remaining attributes [%d] are not assign the shard copies, remaining shard copies [%d] are not allocated, " +
-                            "the shard is allocated to the node, it will cause that the later shard copies allocation does not reach absolute high availability",
+                        "remaining attributes [%d] are not assign the shard copies, " +
+                            "remaining shard copies [%d] are not allocated, " +
+                            "the shard is allocated to the node, " +
+                            "it will cause that the later shard copies allocation does not reach absolute high availability",
                         remainingAttributes,
                         remainingShards);
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.util.HashMap;
 import java.util.List;
@@ -500,7 +501,6 @@ public class AwarenessAllocationTests extends ESAllocationTestCase {
             equalTo("node6"));
 
         logger.info("--> complete relocation");
-        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
         clusterState = startInitializingShardsAndReroute(strategy, clusterState);
 
         assertThat(clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.STARTED).size(), equalTo(4));
@@ -1037,7 +1037,8 @@ public class AwarenessAllocationTests extends ESAllocationTestCase {
         for (String awarenessAttribute : awarenessAttributes) {
             ObjectIntHashMap<String> nodesPerAttribute = clusterState.getRoutingNodes().nodesPerAttributesCounts(awarenessAttribute);
             ObjectIntHashMap<String> shardPerAttribute = new ObjectIntHashMap<>();
-            for (ShardRouting assignedShard : clusterState.getRoutingNodes().assignedShards(initialRoutingTable.index("test").shard(0).shardId())) {
+            ShardId shardId = initialRoutingTable.index("test").shard(0).shardId();
+            for (ShardRouting assignedShard : clusterState.getRoutingNodes().assignedShards(shardId)) {
                 if (assignedShard.started() || assignedShard.initializing()) {
                     RoutingNode routingNode = clusterState.getRoutingNodes().node(assignedShard.currentNodeId());
                     shardPerAttribute.addTo(routingNode.node().getAttributes().get(awarenessAttribute), 1);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -496,6 +496,7 @@ public class AwarenessAllocationTests extends ESAllocationTestCase {
 
         logger.info("--> complete relocation");
         clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
 
         assertThat(clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.STARTED).size(), equalTo(4));
 


### PR DESCRIPTION
The awareness attribute of 8 nodes is as follows：
node1：group: yuhua , switch: yuhua_switch1 , rack: yuhua_switch1_rack1
node2：group: yuhua , switch: yuhua_switch1 , rack: yuhua_switch1_rack2
node3：group: yuhua , switch: yuhua_switch2 , rack: yuhua_switch2_rack3
node4：group: yuhua , switch: yuhua_switch2 , rack: yuhua_switch2_rack4
node5：group: jiangbei , switch: jiangbei_switch1 , rack: jiangbei_switch1_rack1
node6：group: jiangbei , switch: jiangbei_switch1 , rack: jiangbei_switch1_rack2
node7：group: jiangbei , switch: jiangbei_switch2 , rack: jiangbei_switch2_rack3
node8：group: jiangbei , switch: jiangbei_switch2 , rack: jiangbei_switch2_rack4

There is an index of 1 shards and 4 copies, and shard 0 is not high availability in the switch.

index shard prirep state node
test_1shards_4replicas 0 p STARTED node1
test_1shards_4replicas 0 r STARTED node2
test_1shards_4replicas 0 r STARTED node3
test_1shards_4replicas 0 r STARTED node7
test_1shards_4replicas 0 r STARTED node8

There should be a shard allocated to node 5 or node 6 so that all switch are used up.

the pr is an improvement to #45653 