### PR TITLE
Fixed #57270 stack overflow when unresolved alias refers to a field with the same name that does not exist

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -852,7 +852,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             return condition.transformDown(u -> {
                 boolean qualified = u.qualifier() != null;
                 for (Alias alias : aliases) {
-                    if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())) {
+                    if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())
+                     && !(alias.child() instanceof UnresolvedAttribute && Objects.equals(((UnresolvedAttribute) alias.child()).name(), alias.name()))) {
                         return alias;
                     }
                 }
@@ -1299,7 +1300,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             return true;
         }
     }
-    
+
     abstract static class BaseAnalyzeRule extends AnalyzeRule<LogicalPlan> {
 
         @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -1021,7 +1021,6 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     public void testProjectUnresolvedAliasInFilter() {
         assertEquals("1:8: Unknown column [tni]", error("SELECT tni AS i FROM test WHERE i > 10 GROUP BY i"));
         assertEquals("1:31: Unknown column [i]", error("SELECT i AS i FROM test WHERE i > 10 GROUP BY i"));
-
     }
 
     public void testGeoShapeInWhereClause() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -1020,6 +1020,8 @@ public class VerifierErrorMessagesTests extends ESTestCase {
 
     public void testProjectUnresolvedAliasInFilter() {
         assertEquals("1:8: Unknown column [tni]", error("SELECT tni AS i FROM test WHERE i > 10 GROUP BY i"));
+        assertEquals("1:31: Unknown column [i]", error("SELECT i AS i FROM test WHERE i > 10 GROUP BY i"));
+
     }
 
     public void testGeoShapeInWhereClause() {


### PR DESCRIPTION
Fixed #57270 ,This implementation can solve stack overflow,Only add a filter condition to the relpaceAlias method ,There is no need to modify the depth traversal of the transfromdown method,This is less expensive to implement.But the error message can be confusing. e.g. following sql:
> SELECT i AS i FROM test WHERE i > 10 GROUP BY i
The error message is '1:31: Unknown column [i]',
The reasonable error message would be '1:31: Unknown column [i]'

