### PR TITLE
Correct expected warning in indices.create yml tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_mix_typeless_typeful.yml
@@ -20,7 +20,7 @@
 
  - do:
       allowed_warnings:
-          - "index [test-1] matches multiple v1 templates [global, test_template], v2 index templates will only match a single index template"
+          - "index [test-1] matches multiple legacy templates [global, test_template], composable templates will only match a single template"
       indices.create:
           index: test-1
           body:
@@ -60,8 +60,8 @@
 
  - do:
       allowed_warnings:
-          - "index [test-1] matches multiple v1 templates [global, test_template], v2 index templates will only match a single index template"
-      indices.create: 
+          - "index [test-1] matches multiple legacy templates [global, test_template], composable templates will only match a single template"
+      indices.create:
           include_type_name: true
           index: test-1
           body:
@@ -128,7 +128,7 @@
 
  - do:
       allowed_warnings:
-          - "index [test-1] matches multiple v1 templates [global, test_template], v2 index templates will only match a single index template"
+          - "index [test-1] matches multiple legacy templates [global, test_template], composable templates will only match a single template"
       index:
           index: test-1
           body: { bar: 42 }


### PR DESCRIPTION
The expected header has been changed which is causing multiple failures on the 7.x branch as tracked in #57408 

`v2 index` is now `composable`, `v1` is now `legacy` and the word `index` has been dropped.


Closes #57408