### PR TITLE
Fixed #57270 stack overflow when the alias refers to a field with the same name that does not exist

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -852,7 +852,9 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             return condition.transformDown(u -> {
                 boolean qualified = u.qualifier() != null;
                 for (Alias alias : aliases) {
-                    if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())) {
+                    if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())
+                        && !(alias.child() instanceof UnresolvedAttribute && Objects.equals(((UnresolvedAttribute) alias.child()).name(), alias.name()))) {
+
                         return alias;
                     }
                 }
@@ -1299,7 +1301,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             return true;
         }
     }
-    
+
     abstract static class BaseAnalyzeRule extends AnalyzeRule<LogicalPlan> {
 
         @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -854,7 +854,6 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 for (Alias alias : aliases) {
                     if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())
                         && !(alias.child() instanceof UnresolvedAttribute && Objects.equals(((UnresolvedAttribute) alias.child()).name(), alias.name()))) {
-
                         return alias;
                     }
                 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -853,7 +853,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                 boolean qualified = u.qualifier() != null;
                 for (Alias alias : aliases) {
                     if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())
-                        && !(alias.child() instanceof UnresolvedAttribute && Objects.equals(((UnresolvedAttribute) alias.child()).name(), alias.name()))) {
+                        && !(alias.child() instanceof UnresolvedAttribute
+                        && Objects.equals(((UnresolvedAttribute) alias.child()).name(), alias.name()))) {
                         return alias;
                     }
                 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -845,16 +845,17 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             List<Alias> aliases = new ArrayList<>();
             named.forEach(n -> {
                 if (n instanceof Alias) {
-                    aliases.add((Alias) n);
+                    Alias a = (Alias) n;
+                    if ((a.child() instanceof UnresolvedAttribute && Objects.equals(((UnresolvedAttribute) a.child()).name(),a.name())) == false) {
+                        aliases.add(a);
+                    }
                 }
             });
 
             return condition.transformDown(u -> {
                 boolean qualified = u.qualifier() != null;
                 for (Alias alias : aliases) {
-                    if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())
-                        && !(alias.child() instanceof UnresolvedAttribute
-                        && Objects.equals(((UnresolvedAttribute) alias.child()).name(), alias.name()))) {
+                    if (qualified ? Objects.equals(alias.qualifiedName(), u.qualifiedName()) : Objects.equals(alias.name(), u.name())) {
                         return alias;
                     }
                 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -846,7 +846,8 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
             named.forEach(n -> {
                 if (n instanceof Alias) {
                     Alias a = (Alias) n;
-                    if ((a.child() instanceof UnresolvedAttribute && Objects.equals(((UnresolvedAttribute) a.child()).name(),a.name())) == false) {
+                    if ((a.child() instanceof UnresolvedAttribute &&
+                        Objects.equals(((UnresolvedAttribute) a.child()).name(),a.name())) == false) {
                         aliases.add(a);
                     }
                 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -1020,6 +1020,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
 
     public void testProjectUnresolvedAliasInFilter() {
         assertEquals("1:8: Unknown column [tni]", error("SELECT tni AS i FROM test WHERE i > 10 GROUP BY i"));
+        assertEquals("1:31: Unknown column [i]", error("SELECT i AS i FROM test WHERE i > 10 GROUP BY i"));
     }
 
     public void testGeoShapeInWhereClause() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -1020,6 +1020,9 @@ public class VerifierErrorMessagesTests extends ESTestCase {
 
     public void testProjectUnresolvedAliasInFilter() {
         assertEquals("1:8: Unknown column [tni]", error("SELECT tni AS i FROM test WHERE i > 10 GROUP BY i"));
+    }
+
+    public void testProjectUnresolvedAliasWithSameNameInFilter() {
         assertEquals("1:31: Unknown column [i]", error("SELECT i AS i FROM test WHERE i > 10 GROUP BY i"));
     }
 


### PR DESCRIPTION
Fixed #57270 ,This implementation can solve stack overflow,Only add a filter condition to the relpaceAlias method ,There is no need to modify the depth traversal of the transfromdown method,This is less expensive to implement.But the error message can be confusing. e.g. following sql:
SELECT i AS i FROM test WHERE i > 10 GROUP BY i

The error message is '1:31: Unknown column [i]',
The reasonable error message would be '1:31: Unknown column [i]'
