### PR TITLE
[7.7] [DOCS] Relocate thread pools content (#55814)

### DIFF
--- a/docs/reference/modules.asciidoc
+++ b/docs/reference/modules.asciidoc
@@ -41,15 +41,6 @@ The modules in this section are:
 <<modules-node,Node client>>::
 
     A Java node client joins the cluster, but doesn't hold data or act as a master node.
-
-<<modules-threadpool,Thread pools>>::
-
-    Information about the dedicated thread pools used in Elasticsearch.
-
-<<modules-cross-cluster-search, {ccs-cap}>>::
-
-    {ccs-cap} enables executing search requests across more than one cluster
-    without joining them and acts as a federated client across them.
 --
 
 
@@ -62,5 +53,3 @@ include::modules/gateway.asciidoc[]
 include::modules/http.asciidoc[]
 
 include::modules/node.asciidoc[]
-
-include::modules/threadpool.asciidoc[]

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -1,11 +1,9 @@
 [[modules-threadpool]]
-== Thread Pool
+=== Thread pools
 
-A node holds several thread pools in order to improve how threads memory consumption
-are managed within a node. Many of these pools also have queues associated with them,
-which allow pending requests to be held instead
-of discarded.
-
+A node uses several thread pools to manage memory consumption. 
+Queues associated with many of the thread pools enable pending requests 
+to be held instead of discarded. 
 
 There are several thread pools, but the important ones include:
 
@@ -91,15 +89,13 @@ thread_pool:
         size: 30
 --------------------------------------------------
 
-[float]
-[[types]]
-=== Thread pool types
+[[thread-pool-types]]
+==== Thread pool types
 
 The following are the types of thread pools and their respective parameters:
 
-[float]
-[[fixed]]
-==== `fixed`
+[[fixed-thread-pool]]
+===== `fixed`
 
 The `fixed` thread pool holds a fixed size of threads to handle the
 requests with a queue (optionally bounded) for pending requests that
@@ -120,9 +116,8 @@ thread_pool:
         queue_size: 1000
 --------------------------------------------------
 
-[float]
 [[fixed-auto-queue-size]]
-==== `fixed_auto_queue_size`
+===== `fixed_auto_queue_size`
 
 experimental[]
 
@@ -169,9 +164,8 @@ thread_pool:
         target_response_time: 1s
 --------------------------------------------------
 
-[float]
-[[scaling]]
-==== `scaling`
+[[scaling-thread-pool]]
+===== `scaling`
 
 The `scaling` thread pool holds a dynamic number of threads. This
 number is proportional to the workload and varies between the value of
@@ -189,9 +183,8 @@ thread_pool:
         keep_alive: 2m
 --------------------------------------------------
 
-[float]
-[[processors]]
-=== Allocated processors setting
+[[node.processors]]
+==== Allocated processors setting
 
 The number of processors is automatically detected, and the thread pool settings
 are automatically set based on it. In some cases it can be useful to override

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -85,6 +85,8 @@ include::settings/transform-settings.asciidoc[]
 
 include::modules/transport.asciidoc[]
 
+include::modules/threadpool.asciidoc[]
+
 include::settings/notification-settings.asciidoc[]
 
 include::setup/important-settings.asciidoc[]


### PR DESCRIPTION
7.7 backport of #55814