### PR TITLE
[DOCS] Adds ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-7.8.0>>
+* <<release-notes-7.7.1>>
 * <<release-notes-7.7.0>>
 * <<release-notes-7.6.2>>
 * <<release-notes-7.6.1>>

--- a/docs/reference/release-notes/7.7.asciidoc
+++ b/docs/reference/release-notes/7.7.asciidoc
@@ -1,3 +1,22 @@
+[[release-notes-7.7.1]]
+== {es} version 7.7.1
+
+coming::[7.7.1]
+
+Also see <<breaking-changes-7.7,Breaking changes in 7.7>>.
+
+[discrete]
+[[bug-7.7.1]]
+=== Bug fixes
+
+Machine Learning::
+* Fix background persistence of categorizer state. {ml-pull}1137[#1137] (issue: {ml-issue}1136[#1136])
+* Fix classification job failures when number of classes in configuration differs from the number of classes present in the training data. {ml-pull}1144[#1144]
+* Fix underlying cause for "Failed to calculate splitting significance" log errors. {ml-pull}1157[#1157]
+* Fix possible root cause for "Bad variance scale nan" log errors. {ml-pull}1225[#1225]
+* Change data frame analytics instrumentation timestamp resolution to milliseconds. {ml-pull}1237[#1237]
+* Fix "autodetect process stopped unexpectedly: Fatal error: 'terminate called after throwing an instance of 'std::bad_function_call'". {ml-pull}1246[#1246] (issue: {ml-issue}1245[#1245])
+
 [[release-notes-7.7.0]]
 == {es} version 7.7.0
 


### PR DESCRIPTION
This PR adds the details from https://github.com/elastic/ml-cpp/blob/7.7/docs/CHANGELOG.asciidoc to the Elasticsearch release notes.

## Preview

https://elasticsearch_57444.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.x/release-notes-7.7.1.html