### PR TITLE
add jvm clarification

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -50,7 +50,7 @@ WARNING: Version {version} of the {es} Docker image has not yet been released.
 
 endif::[]
 
- ifeval::["{release-state}"!="unreleased"]
+ifeval::["{release-state}"!="unreleased"]
 
 To start a single-node {es} cluster for development or testing, specify
 <<single-node-discovery,single-node discovery>> to bypass the <<bootstrap-checks,bootstrap checks>>:

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -50,7 +50,7 @@ WARNING: Version {version} of the {es} Docker image has not yet been released.
 
 endif::[]
 
-ifeval::["{release-state}"!="unreleased"]
+ ifeval::["{release-state}"!="unreleased"]
 
 To start a single-node {es} cluster for development or testing, specify
 <<single-node-discovery,single-node discovery>> to bypass the <<bootstrap-checks,bootstrap checks>>:
@@ -283,7 +283,7 @@ method, you can also configure this by using the `ES_JAVA_OPTS` environment
 variable to set the heap size. For example, to use 16 GB, specify
 `-e ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`. Note that while the
 default root `jvm.options` file sets a default heap of 1 GB, any value you set
-in `ES_JAVA_OPTS` will override it.
+in `ES_JAVA_OPTS` will override it. The yaml file above (docker-compose.yml) sets the size to 512 megabytes.
 
 IMPORTANT: You must <<heap-size,configure the heap size>> even if you are
 https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[limiting

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -283,7 +283,7 @@ method, you can also configure this by using the `ES_JAVA_OPTS` environment
 variable to set the heap size. For example, to use 16 GB, specify
 `-e ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`. Note that while the
 default root `jvm.options` file sets a default heap of 1 GB, any value you set
-in `ES_JAVA_OPTS` will override it. The yaml file above (docker-compose.yml) sets the size to 512 megabytes.
+in `ES_JAVA_OPTS` will override it. The `docker-compose.yml` file above sets the heap size to 512 MB.
 
 IMPORTANT: You must <<heap-size,configure the heap size>> even if you are
 https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory[limiting


### PR DESCRIPTION
found (by running curl localhost:9200/_nodes/es01/jvm) that the jvm heap is set to 512 megabytes, the value in the yml file. It was not apparent by reading the documentation that it wasn't 1 gigabyte, since I used the default of the documentation. This may be clear to developers but wasn't clear to me so further clarification would be great for future readers. 