### PR TITLE
Avoid unnecessary Caching Realm invalidations 

### DIFF
--- a/docs/changelog/57480.yaml
+++ b/docs/changelog/57480.yaml
@@ -1,0 +1,6 @@
+pr: 57480
+summary: Avoid unnecessary Caching Realm invalidations
+area: Authentication
+type: enhancement
+issues:
+ - 57364

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
@@ -291,6 +291,7 @@ public abstract class CachingUsernamePasswordRealm extends UsernamePasswordRealm
     private void lookupWithCache(String username, ActionListener<User> listener) {
         assert lookupCache != null;
         assert latestValidCredentialsCache != null;
+        // valid credentials authentication cache is considered for lookups, but not vice-versa
         final CachedResult latestValidCredentials = latestValidCredentialsCache.get(username);
         if (latestValidCredentials != null) {
             listener.onResponse(latestValidCredentials.user);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
@@ -212,9 +212,13 @@ public abstract class CachingUsernamePasswordRealm extends UsernamePasswordRealm
             doAuthenticate(token, ActionListener.wrap(authResult -> {
                 final CachedResult cachedResult = new CachedResult(authResult, cacheHasher, authResult.getUser(), token.credentials());
                 if (authResult.isAuthenticated() && authResult.getUser().enabled()) {
-                    // subsequent requests for the same credentials for this given principal will be honored from the
-                    // {@code latestValidCredentialsCache} until the cache entry expires
-                    latestValidCredentialsCache.put(token.principal(), cachedResult);
+                    if (authResult.getUser().enabled()) {
+                        // subsequent requests for the same credentials for this given principal will be honored from the
+                        // {@code latestValidCredentialsCache} until the cache entry expires
+                        latestValidCredentialsCache.put(token.principal(), cachedResult);
+                    } else {
+                        latestValidCredentialsCache.invalidate(token.principal());
+                    }
                 }
                 // always invalidate the {@code authenticationStallCache} so that subsequent requests reach for the authentication source
                 // (if they are not honored from the {@code latestValidCredentialsCache})

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
@@ -212,7 +212,7 @@ public abstract class CachingUsernamePasswordRealm extends UsernamePasswordRealm
             // attempt authentication against the authentication source
             doAuthenticate(token, ActionListener.wrap(authResult -> {
                 final CachedResult cachedResult = new CachedResult(authResult, cacheHasher, authResult.getUser(), token.credentials());
-                if (authResult.isAuthenticated() && authResult.getUser().enabled()) {
+                if (authResult.isAuthenticated()) {
                     if (authResult.getUser().enabled()) {
                         // subsequent requests for the same credentials for this given principal will be honored from the
                         // {@code latestValidCredentialsCache} until the cache entry expires

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
@@ -94,6 +94,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
             }
         };
         assertThat(realm.cacheHasher, sameInstance(Hasher.resolve(cachingHashAlgo)));
+        assertThat(realm.cacheEnabled, is(true));
     }
 
     public void testCacheSizeWhenCacheDisabled() {
@@ -118,6 +119,7 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
             }
         };
         assertThat(realm.getCacheSize(), equalTo(-1));
+        assertThat(realm.cacheEnabled, is(false));
     }
 
     public void testAuthCache() {


### PR DESCRIPTION
The `CachingUsernamePasswordRealm` class is a decorator for authentication realms that stores the last valid password hash, by username, and uses that for subsequent authentication requests. A subsequent authentication request that tries the same password for the same username is "validated" by the caching realm, without delegating to the decorated realm. If, however, the authentication request contains a different password (again, for the given username) the decorated realm MUST be consulted, i.e. the cache must be bypassed, because the password might have changed in the mean time after the caching.

Previously, the cache entry (per username) was preemptively invalidated, before the authentication request for the different password has confirmed that the cache entry was trully stale. Indeed it is possible that the different password is just wrong, in which case the cache entry is unnecessarily invalidated; a subsequent request containing the same password must be validated anew with the decorated realm.
The proposed enhancement is to not invalidate the cache in the described situation. Instead, the authentication containing the different password is checked by the decorated realm, and if valid, the cache entry for it is updated (not invalidated).

Note that the `CachingUsernamePasswordRealm` has the equally important responsibility to ensure that there's only a single inflight authentication request, per username, delegated to the decorated authentication realm, at any given time. This behavior has been maintained unchanged. In particular, the implementation ensures the single-inflight property is maintained for the requests that bypass the cache to ensure that it's not stale (i.e. not only for the requests that populate the cache).

Resolves https://github.com/elastic/elasticsearch/issues/57364