### PR TITLE
Remove buildResources from BuildPlugin

### DIFF
--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/ExportElasticsearchBuildResourcesTaskIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/ExportElasticsearchBuildResourcesTaskIT.java
@@ -32,36 +32,20 @@ public class ExportElasticsearchBuildResourcesTaskIT extends GradleIntegrationTe
         BuildResult result = getGradleRunner(PROJECT_NAME).withArguments("buildResources", "-s", "-i").build();
         assertTaskSuccessful(result, ":buildResources");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle.xml");
-
-        // using task avoidance api means the task configuration of the sample task is never triggered
-        assertBuildFileDoesNotExists(result, PROJECT_NAME, "build-tools-exported/checkstyle_suppressions.xml");
+        assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle_suppressions.xml");
 
         result = getGradleRunner(PROJECT_NAME).withArguments("buildResources", "-s", "-i").build();
         assertTaskUpToDate(result, ":buildResources");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle.xml");
-
-        // using task avoidance api means the task configuration of the sample task is never triggered
-        assertBuildFileDoesNotExists(result, PROJECT_NAME, "build-tools-exported/checkstyle_suppressions.xml");
-    }
-
-    public void testImplicitTaskDependencyCopy() {
-        BuildResult result = getGradleRunner(PROJECT_NAME).withArguments("clean", "sampleCopyAll", "-s", "-i").build();
-
-        assertTaskSuccessful(result, ":buildResources");
-        assertTaskSuccessful(result, ":sampleCopyAll");
-        assertBuildFileExists(result, PROJECT_NAME, "sampleCopyAll/checkstyle.xml");
-
-        // using task avoidance api means the task configuration of the sample task is never triggered
-        // which means buildResource is not configured to copy this file
-        assertBuildFileDoesNotExists(result, PROJECT_NAME, "sampleCopyAll/checkstyle_suppressions.xml");
-    }
-
-    public void testImplicitTaskDependencyInputFileOfOther() {
-        BuildResult result = getGradleRunner(PROJECT_NAME).withArguments("clean", "sample", "-s", "-i").build();
-
-        assertTaskSuccessful(result, ":sample");
-        assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle.xml");
         assertBuildFileExists(result, PROJECT_NAME, "build-tools-exported/checkstyle_suppressions.xml");
+    }
+
+    public void testOutputAsInput() {
+        BuildResult result = getGradleRunner(PROJECT_NAME).withArguments("clean", "sampleCopy", "-s", "-i").build();
+
+        assertTaskSuccessful(result, ":sampleCopy");
+        assertBuildFileExists(result, PROJECT_NAME, "sampleCopy/checkstyle.xml");
+        assertBuildFileExists(result, PROJECT_NAME, "sampleCopy/checkstyle_suppressions.xml");
     }
 
     public void testIncorrectUsage() {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -50,8 +50,6 @@ class BuildPlugin implements Plugin<Project> {
         project.pluginManager.apply('elasticsearch.publish')
         project.pluginManager.apply(DependenciesInfoPlugin)
 
-        project.getTasks().register("buildResources", ExportElasticsearchBuildResourcesTask)
-
         project.extensions.getByType(ExtraPropertiesExtension).set('versions', VersionProperties.versions)
         PrecommitTasks.create(project, true)
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ExportElasticsearchBuildResourcesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ExportElasticsearchBuildResourcesTask.java
@@ -56,7 +56,6 @@ public class ExportElasticsearchBuildResourcesTask extends DefaultTask {
 
     public ExportElasticsearchBuildResourcesTask() {
         outputDir = getProject().getObjects().directoryProperty();
-        outputDir.set(new File(getProject().getBuildDir(), "build-tools-exported"));
     }
 
     @OutputDirectory
@@ -80,14 +79,13 @@ public class ExportElasticsearchBuildResourcesTask extends DefaultTask {
         this.outputDir.set(outputDir);
     }
 
-    public File copy(String resource) {
+    public void copy(String resource) {
         if (getState().getExecuted() || getState().getExecuting()) {
             throw new GradleException(
                 "buildResources can't be configured after the task ran. " + "Make sure task is not used after configuration time"
             );
         }
         resources.add(resource);
-        return outputDir.file(resource).get().getAsFile();
     }
 
     @TaskAction

--- a/buildSrc/src/testKit/elasticsearch-build-resources/build.gradle
+++ b/buildSrc/src/testKit/elasticsearch-build-resources/build.gradle
@@ -1,38 +1,26 @@
+import org.elasticsearch.gradle.ExportElasticsearchBuildResourcesTask
+
 plugins {
-  id 'elasticsearch.build'
+  id 'base'
+  id 'elasticsearch.global-build-info'
 }
 
-ext.licenseFile = file("$buildDir/dummy/license")
-ext.noticeFile = file("$buildDir/dummy/notice")
-
-buildResources {
+File buildResourcesDir = new File(project.getBuildDir(), 'build-tools-exported')
+TaskProvider buildResourcesTask = tasks.register('buildResources', ExportElasticsearchBuildResourcesTask) {
+  outputDir = buildResourcesDir
+  copy 'checkstyle_suppressions.xml'
   copy 'checkstyle.xml'
 }
 
-tasks.register("sampleCopyAll", Sync) {
+tasks.register("sampleCopy", Sync) {
   /** Note: no explicit dependency. This works with tasks that use the Provider API a.k.a "Lazy Configuration" **/
-  from buildResources
-  into "$buildDir/sampleCopyAll"
-}
-
-tasks.register("sample") {
-  // This does not work, task dependencies can't be providers
-  // dependsOn buildResources.resource('minimumRuntimeVersion')
-  // Nor does this, despite https://github.com/gradle/gradle/issues/3811
-  // dependsOn buildResources.outputDir
-  // for now it's just
-  dependsOn buildResources
-  // we have to reference it at configuration time in order to be picked up
-  ext.checkstyle_suppressions = buildResources.copy('checkstyle_suppressions.xml')
-  doLast {
-    println "This task is using ${file(checkstyle_suppressions)}"
-  }
+  from buildResourcesTask
+  into "$buildDir/sampleCopy"
 }
 
 tasks.register("noConfigAfterExecution") {
-  dependsOn buildResources
+  dependsOn buildResourcesTask
   doLast {
-    println "This should cause an error because we are refferencing " +
-      "${buildResources.copy('checkstyle_suppressions.xml')} after the `buildResources` task has ran."
+    buildResourcesTask.get().copy('foo')
   }
 }


### PR DESCRIPTION
The shared buildResources task is a catch all for resources needing to
be copied from the build-tools jar at runtime. Utilizing this for all
resources causes any tasks using resources from this to be triggered on
any changes to any of those files. This commit creates separate export
tasks per usage, and removes the buildResources task.