### PR TITLE
[DOCS] Replace docdir attribute with es-repo-dir

### DIFF
--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -24,8 +24,8 @@ the same response objects.
 
 --
 
-:doc-tests: {docdir}/../../client/rest-high-level/src/test/java/org/elasticsearch/client/documentation
-:hlrc-tests: {docdir}/../../client/rest-high-level/src/test/java/org/elasticsearch/client
+:doc-tests: {elasticsearch-root}/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation
+:hlrc-tests: {elasticsearch-root}/client/rest-high-level/src/test/java/org/elasticsearch/client
 
 include::getting-started.asciidoc[]
 include::supported-apis.asciidoc[]

--- a/docs/java-rest/low-level/index.asciidoc
+++ b/docs/java-rest/low-level/index.asciidoc
@@ -24,11 +24,11 @@ The low-level client's features include:
 
 --
 
-:doc-tests: {docdir}/../../client/rest/src/test/java/org/elasticsearch/client/documentation
+:doc-tests: {elasticsearch-root}/client/rest/src/test/java/org/elasticsearch/client/documentation
 include::usage.asciidoc[]
 include::configuration.asciidoc[]
 
-:doc-tests: {docdir}/../../client/sniffer/src/test/java/org/elasticsearch/client/sniff/documentation
+:doc-tests: {elasticsearch-root}/client/sniffer/src/test/java/org/elasticsearch/client/sniff/documentation
 include::sniffer.asciidoc[]
 
 include::../license.asciidoc[]

--- a/docs/plugins/authors.asciidoc
+++ b/docs/plugins/authors.asciidoc
@@ -1,7 +1,7 @@
 [[plugin-authors]]
 == Help for plugin authors
 
-:plugin-properties-files: {docdir}/../../buildSrc/src/main/resources
+:plugin-properties-files: {elasticsearch-root}/buildSrc/src/main/resources
 
 The Elasticsearch repository contains examples of:
 

--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -20,25 +20,25 @@ filter and routing information.
 
 `<alias>`::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-alias]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
 
 
 [[cat-alias-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 
 [[cat-alias-api-example]]

--- a/docs/reference/cat/allocation.asciidoc
+++ b/docs/reference/cat/allocation.asciidoc
@@ -19,26 +19,26 @@ and their disk space.
 [[cat-allocation-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 [[cat-allocation-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [[cat-allocation-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/cat/anomaly-detectors.asciidoc
+++ b/docs/reference/cat/anomaly-detectors.asciidoc
@@ -35,20 +35,20 @@ NOTE: This API returns a maximum of 10,000 jobs.
 
 `<job_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 [[cat-anomaly-detectors-query-params]]
 ==== {api-query-parms-title}
 
 `allow_no_jobs`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-jobs]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 If you do not specify which columns to include, the API returns the default
 columns. If you explicitly specify one or more columns, it returns only the
@@ -57,75 +57,75 @@ specified columns.
 Valid columns are:
 
 `assignment_explanation`, `ae`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-anomaly-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=assignment-explanation-anomaly-jobs]
 
 `buckets.count`, `bc`, `bucketsCount`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count-anomaly-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-count-anomaly-jobs]
 
 `buckets.time.exp_avg`, `btea`, `bucketsTimeExpAvg`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average]
 
 `buckets.time.exp_avg_hour`, `bteah`, `bucketsTimeExpAvgHour`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average-hour]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-exponential-average-hour]
 
 `buckets.time.max`, `btmax`, `bucketsTimeMax`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-maximum]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-maximum]
 
 `buckets.time.min`, `btmin`, `bucketsTimeMin`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-minimum]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-minimum]
 
 `buckets.time.total`, `btt`, `bucketsTimeTotal`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-time-total]
 
 `data.buckets`, `db`, `dataBuckets`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-count]
 
 `data.earliest_record`, `der`, `dataEarliestRecord`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=earliest-record-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=earliest-record-timestamp]
 
 `data.empty_buckets`, `deb`, `dataEmptyBuckets`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=empty-bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=empty-bucket-count]
 
 `data.input_bytes`, `dib`, `dataInputBytes`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=input-bytes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=input-bytes]
 
 `data.input_fields`, `dif`, `dataInputFields`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=input-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=input-field-count]
 
 `data.input_records`, `dir`, `dataInputRecords`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=input-record-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=input-record-count]
 
 `data.invalid_dates`, `did`, `dataInvalidDates`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=invalid-date-count]
 
 `data.last`, `dl`, `dataLast`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=last-data-time]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=last-data-time]
 
 `data.last_empty_bucket`, `dleb`, `dataLastEmptyBucket`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=latest-empty-bucket-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latest-empty-bucket-timestamp]
 
 `data.last_sparse_bucket`, `dlsb`, `dataLastSparseBucket`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=latest-sparse-record-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latest-sparse-record-timestamp]
 
 `data.latest_record`, `dlr`, `dataLatestRecord`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=latest-record-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=latest-record-timestamp]
 
 `data.missing_fields`, `dmf`, `dataMissingFields`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=missing-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=missing-field-count]
 
 `data.out_of_order_timestamps`, `doot`, `dataOutOfOrderTimestamps`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=out-of-order-timestamp-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=out-of-order-timestamp-count]
 
 `data.processed_fields`, `dpf`, `dataProcessedFields`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=processed-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=processed-field-count]
 
 `data.processed_records`, `dpr`, `dataProcessedRecords`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=processed-record-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=processed-record-count]
 
 `data.sparse_buckets`, `dsb`, `dataSparseBuckets`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=sparse-bucket-count]
 
 `forecasts.memory.avg`, `fmavg`, `forecastsMemoryAvg`:::
 The average memory usage in bytes for forecasts related to the {anomaly-job}.
@@ -169,99 +169,99 @@ The total runtime in milliseconds for forecasts related to the {anomaly-job}.
 
 `forecasts.total`, `ft`, `forecastsTotal`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=forecast-total]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=forecast-total]
 
 `id`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
 `model.bucket_allocation_failures`, `mbaf`, `modelBucketAllocationFailures`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-allocation-failures-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-allocation-failures-count]
 
 `model.by_fields`, `mbf`, `modelByFields`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-by-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-by-field-count]
 
 `model.bytes`, `mb`, `modelBytes`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-bytes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-bytes]
 
 `model.bytes_exceeded`, `mbe`, `modelBytesExceeded`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-bytes-exceeded]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-bytes-exceeded]
 
 `model.categorization_status`, `mcs`, `modelCategorizationStatus`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorization-status]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorization-status]
                          
 `model.categorized_doc_count`, `mcdc`, `modelCategorizedDocCount`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=categorized-doc-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=categorized-doc-count]
 
 `model.dead_category_count`, `mdcc`, `modelDeadCategoryCount`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=dead-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dead-category-count]
 
 `model.failed_category_count`, `mdcc`, `modelFailedCategoryCount`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=failed-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=failed-category-count]
 
 `model.frequent_category_count`, `mfcc`, `modelFrequentCategoryCount`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=frequent-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=frequent-category-count]
 
 `model.log_time`, `mlt`, `modelLogTime`:::
 The timestamp when the model stats were gathered, according to server time.
 
 `model.memory_limit`, `mml`, `modelMemoryLimit`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-limit-anomaly-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-anomaly-jobs]
 
 `model.memory_status`, `mms`, `modelMemoryStatus`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-memory-status]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-status]
 
 `model.over_fields`, `mof`, `modelOverFields`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-over-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-over-field-count]
 
 `model.partition_fields`, `mpf`, `modelPartitionFields`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-partition-field-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-partition-field-count]
 
 `model.rare_category_count`, `mrcc`, `modelRareCategoryCount`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=rare-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=rare-category-count]
 
 `model.timestamp`, `mt`, `modelTimestamp`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=model-timestamp]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-timestamp]
                                                            
 `model.total_category_count`, `mtcc`, `modelTotalCategoryCount`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=total-category-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=total-category-count]
                             
 `node.address`, `na`, `nodeAddress`:::
 The network address of the node.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-jobs]
 
 `node.ephemeral_id`, `ne`, `nodeEphemeralId`:::
 The ephemeral ID of the node.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-jobs]
 
 `node.id`, `ni`, `nodeId`:::
 The unique identifier of the node.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-jobs]
 
 `node.name`, `nn`, `nodeName`:::
 The node name.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-jobs]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-jobs]
 
 `opened_time`, `ot`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=open-time]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=open-time]
 
 `state`, `s`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=state-anomaly-job] 
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=state-anomaly-job] 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [[cat-anomaly-detectors-example]]
 ==== {api-examples-title}

--- a/docs/reference/cat/count.asciidoc
+++ b/docs/reference/cat/count.asciidoc
@@ -22,21 +22,21 @@ which have not yet been removed by the merge process.
 [[cat-count-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[cat-count-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-count-api-example]]

--- a/docs/reference/cat/datafeeds.asciidoc
+++ b/docs/reference/cat/datafeeds.asciidoc
@@ -36,18 +36,18 @@ NOTE: This API returns a maximum of 10,000 jobs.
 
 `<feed_id>`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 [[cat-datafeeds-query-params]]
 ==== {api-query-parms-title}
 
 `allow_no_datafeeds`::
 (Optional, boolean)
-include::{docdir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-datafeeds]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 If you do not specify which columns to include, the API returns the default
 columns. If you explicitly specify one or more columns, it returns only the
@@ -56,60 +56,60 @@ specified columns.
 Valid columns are:
 
 `assignment_explanation`, `ae`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=assignment-explanation-datafeeds]
 
 `buckets.count`, `bc`, `bucketsCount`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=bucket-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=bucket-count]
 
 `id`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=datafeed-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=datafeed-id]
 
 `node.address`, `na`, `nodeAddress`:::
 The network address of the node.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
   
 `node.ephemeral_id`, `ne`, `nodeEphemeralId`:::
 The ephemeral ID of the node.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
   
 `node.id`, `ni`, `nodeId`:::
 The unique identifier of the node.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
 
 `node.name`, `nn`, `nodeName`:::
 The node name.
 +
-include::{docdir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=node-datafeeds]
 
 `search.bucket_avg`, `sba`, `searchBucketAvg`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-bucket-avg]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-bucket-avg]
   
 `search.count`, `sc`, `searchCount`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-count]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-count]
 
 `search.exp_avg_hour`, `seah`, `searchExpAvgHour`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-exp-avg-hour]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-exp-avg-hour]
 
 `search.time`, `st`, `searchTime`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=search-time]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=search-time]
 
 `state`, `s`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=state-datafeed]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=state-datafeed]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [[cat-datafeeds-example]]
 ==== {api-examples-title}

--- a/docs/reference/cat/dataframeanalytics.asciidoc
+++ b/docs/reference/cat/dataframeanalytics.asciidoc
@@ -39,15 +39,15 @@ For more information, see <<security-privileges>> and {ml-docs}/setup.html[Set u
 
 `<data_frame_analytics_id>`::
 (Optional, string) 
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics-default]
 
 
 [[cat-dfanalytics-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 If you do not specify which columns to include, the API returns the default
 columns. If you explicitly specify one or more columns, it returns only the
@@ -56,14 +56,14 @@ specified columns.
 Valid columns are:
 
 `assignment_explanation`, `ae`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=assignment-explanation-dfanalytics]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=assignment-explanation-dfanalytics]
 
 `create_time`, `ct`, `createTime`:::
 (Default)
 The time when the {dfanalytics-job} was created.
 
 `description`, `d`:::
-include::{docdir}/ml/ml-shared.asciidoc[tag=description-dfa]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=description-dfa]
 
 `dest_index`, `di`, `destIndex`:::
 Name of the destination index.
@@ -73,7 +73,7 @@ Contains messages about the reason why a {dfanalytics-job} failed.
 
 `id`:::
 (Default)
-include::{docdir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-data-frame-analytics]
 
 `model_memory_limit`, `mml`, `modelMemoryLimit`:::
 The approximate maximum amount of memory resources that are permitted for the 
@@ -108,13 +108,13 @@ The type of analysis that the {dfanalytics-job} performs.
 `version`, `v`:::
 The {es} version number in which the {dfanalytics-job} was created.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-dfanalytics-example]]

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -27,17 +27,17 @@ information.
 [[cat-fielddata-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-fielddata-api-example]]

--- a/docs/reference/cat/health.asciidoc
+++ b/docs/reference/cat/health.asciidoc
@@ -39,22 +39,22 @@ over a longer period of time. See <<cat-health-api-example-large-cluster>>.
 [[cat-health-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
 `ts` (timestamps)::
 (Optional, boolean) If `true`, returns `HH:MM:SS` and
 https://en.wikipedia.org/wiki/Unix_time[Unix `epoch`] timestamps. Defaults to
 `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-health-api-example]]

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -39,17 +39,17 @@ To get an accurate count of {es} documents, use the <<cat-count,cat count>> or
 [[cat-indices-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[cat-indices-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
 `health`::
 +
@@ -64,26 +64,26 @@ are:
 By default, the response includes indices of any health status.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-unloaded-segments]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-unloaded-segments]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 [[pri-flag]]
 `pri` (primary shards)::
 (Optional, boolean) If `true`, the response only includes information from
 primary shards. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 
 [[cat-indices-api-example]]

--- a/docs/reference/cat/master.asciidoc
+++ b/docs/reference/cat/master.asciidoc
@@ -17,19 +17,19 @@ and name.
 [[cat-master-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-master-api-example]]

--- a/docs/reference/cat/nodeattrs.asciidoc
+++ b/docs/reference/cat/nodeattrs.asciidoc
@@ -14,9 +14,9 @@ Returns information about custom node attributes.
 [[cat-nodeattrs-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 --
 If you do not specify which columns to include, the API returns the default columns in the order listed below. If you explicitly specify one or more columns, it only returns the specified columns.
@@ -48,15 +48,15 @@ Process ID, such as `13061`.
 Bound transport port, such as `9300`.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-nodeattrs-api-example]]

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -14,15 +14,15 @@ Returns information about a cluster's nodes.
 [[cat-nodes-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
 `full_id`::
 (Optional, boolean) If `true`, return the full node ID.  If `false`, return the
 shortened node ID. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 --
 If you do not specify which columns to include, the API returns the default columns in the order listed below. If you explicitly specify one or more columns, it only returns the specified columns.
@@ -283,15 +283,15 @@ Time spent in suggest, such as `0`.
 Number of suggest operations, such as `0`.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-nodes-api-example]]

--- a/docs/reference/cat/pending_tasks.asciidoc
+++ b/docs/reference/cat/pending_tasks.asciidoc
@@ -15,21 +15,21 @@ Returns cluster-level changes that have not yet been executed, similar to the
 [[cat-pending-tasks-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-pending-tasks-api-example]]

--- a/docs/reference/cat/plugins.asciidoc
+++ b/docs/reference/cat/plugins.asciidoc
@@ -16,19 +16,19 @@ Returns a list of plugins running on each node of a cluster.
 [[cat-plugins-tasks-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-plugins-api-example]]

--- a/docs/reference/cat/recovery.asciidoc
+++ b/docs/reference/cat/recovery.asciidoc
@@ -24,37 +24,37 @@ The cat recovery API returns information about shard recoveries, both
 ongoing and completed. It is a more compact view of the JSON
 <<indices-recovery,index recovery>> API.
 
-include::{docdir}/indices/recovery.asciidoc[tag=shard-recovery-desc]
+include::{es-repo-dir}/indices/recovery.asciidoc[tag=shard-recovery-desc]
 
 
 [[cat-recovery-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[cat-recovery-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=active-only]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=active-only]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=detailed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-query-parm]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-query-parm]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-recovery-api-example]]

--- a/docs/reference/cat/repositories.asciidoc
+++ b/docs/reference/cat/repositories.asciidoc
@@ -16,19 +16,19 @@ Returns the <<snapshots-repositories,snapshot repositories>> for a cluster.
 [[cat-repositories-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-repositories-api-example]]

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -19,17 +19,17 @@ API.
 [[cat-segments-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[cat-segments-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 --
 If you do not specify which columns to include, the API returns the default
@@ -52,39 +52,39 @@ Valid columns are:
 
 `segment`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment]
 
 `generation`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=generation]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=generation]
 
 `docs.count`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-count]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-count]
                 
 `docs.deleted`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
 
 `size`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment-size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-size]
 
 `size.memory`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=memory]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=memory]
 
 `committed`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=committed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=committed]
 
 `searchable`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment-search]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-search]
 
 `version`::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment-version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-version]
 
 `compound`::
 (Default) If `true`, the segment is stored in a compound file. This means Lucene
@@ -94,11 +94,11 @@ merged all files from the segment in a single file to save file descriptors.
 ID of the node, such as `k0zy`.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-segments-api-example]]

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -20,17 +20,17 @@ docs, the bytes it takes on disk, and the node where it's located.
 [[cat-shards-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[cat-shards-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 --
 If you do not specify which columns to include, the API returns the default
@@ -263,17 +263,17 @@ Reason the shard is unassigned. Returned values are:
 
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-shards-api-example]]

--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -32,9 +32,9 @@ If any repository fails during the request, {es} returns an error.
 [[cat-snapshots-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 --
 If you do not specify which columns to include, the API returns the default
@@ -93,19 +93,19 @@ units>>.
 Reason for any snapshot failures.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
 `ignore_unavailable`::
 (Optional, boolean) If `true`, the response does not include information from
 unavailable snapshots. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-snapshots-api-example]]

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -29,25 +29,25 @@ of the JSON <<tasks,task management>> API.
 [[cat-tasks-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=detailed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-tasks-api-response-codes]]
 ==== {api-response-codes-title}
 
-include::{docdir}/cluster/tasks.asciidoc[tag=tasks-api-404]
+include::{es-repo-dir}/cluster/tasks.asciidoc[tag=tasks-api-404]
 
 
 [[cat-tasks-api-examples]]

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -28,19 +28,19 @@ the request. Accepts wildcard expressions.
 [[cat-templates-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-templates-api-example]]

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -28,9 +28,9 @@ request. Accepts wildcard expressions.
 [[cat-thread-pool-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 --
 If you do not specify which columns to include, the API returns the default
@@ -101,17 +101,17 @@ Type of thread pool. Returned values are `fixed` or `scaling`.
 
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-thread-pool-api-example]]

--- a/docs/reference/cat/trainedmodel.asciidoc
+++ b/docs/reference/cat/trainedmodel.asciidoc
@@ -36,11 +36,11 @@ For more information, see <<security-privileges>> and
 [[cat-trained-model-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bytes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bytes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 If you do not specify which columns to include, the API returns the default
 columns. If you explicitly specify one or more columns, it returns only the
@@ -97,13 +97,13 @@ measuring the computational complexity of the model.
 `version`, `v`:::
 The {es} version number in which the trained model was created.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 
 [[cat-trained-model-example]]

--- a/docs/reference/cat/transforms.asciidoc
+++ b/docs/reference/cat/transforms.asciidoc
@@ -33,22 +33,22 @@ privileges. For more information, see <<security-privileges>> and
 
 `<transform_id>`::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
 
 [[cat-transforms-api-query-params]]
 ==== {api-query-parms-title}
 
 `allow_no_match`::
 (Optional, boolean)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=http-format]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=http-format]
 
 `from`::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from-transforms]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-h]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-h]
 +
 If you do not specify which columns to include, the API returns the default
 columns. If you explicitly specify one or more columns, it returns only the
@@ -57,10 +57,10 @@ specified columns.
 Valid columns are:
 
 `changes_last_detection_time`, `cldt`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=checkpointing-changes-last-detected-at]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=checkpointing-changes-last-detected-at]
 
 `checkpoint_duration_time_exp_avg`, `cdtea`, `checkpointTimeExpAvg`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-checkpoint-duration-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=exponential-avg-checkpoint-duration-ms]
 
 `create_time`, `ct`, `createTime`:::
 (Default)
@@ -72,94 +72,94 @@ The description of the {transform}.
 
 `dest_index`, `di`, `destIndex`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-index]
 
 `documents_indexed`, `doci`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-indexed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-indexed]
 
 `documents_processed`, `docp`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-processed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-processed]
 
 `frequency`, `f`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=frequency]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=frequency]
 
 `id`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id]
 
 `index_failure`, `if`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-failures]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-failures]
 
 `index_time`, `itime`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-time-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-time-ms]
 
 `index_total`, `it`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-total]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-total]
 
 `indexed_documents_exp_avg`, `idea`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-indexed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-indexed]
 
 `max_page_search_size`, `mpsz`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
 
 `pages_processed`, `pp`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pages-processed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pages-processed]
 
 `pipeline`, `p`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=dest-pipeline]
 
 `processed_documents_exp_avg`, `pdea`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-processed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=exponential-avg-documents-processed]
 
 `processing_time`, `pt`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=processing-time-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=processing-time-ms]
 
 `reason`, `r`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform-reason]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=state-transform-reason]
 
 `search_failure`, `sf`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-failures]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-failures]
 
 `search_time`, `stime`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-time-ms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-time-ms]
 
 `search_total`, `st`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-total]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-total]
 
 `source_index`, `si`, `sourceIndex`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
 
 `state`, `s`:::
 (Default)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=state-transform]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=state-transform]
 
 `transform_type`, `tt`:::
 (Default)
 Indicates the type of {transform}: `batch` or `continuous`. 
 
 `trigger_count`, `tc`:::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=trigger-count]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=trigger-count]
 
 `version`, `v`:::
 (Default)
 The version of {es} that existed on the node when the {transform} was
 created.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=help]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=help]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-s]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-s]
 
 `size`::
 (Optional, integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=size-transforms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=size-transforms]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=time]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=time]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cat-v]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cat-v]
 
 [[cat-transforms-api-examples]]
 ==== {api-examples-title}

--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -20,10 +20,10 @@ defined, but can also include the default settings by calling the
 ==== {api-query-parms-title}
 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
 `include_defaults`::
     (Optional, boolean) If `true`, returns all default cluster settings. 
     Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -39,7 +39,7 @@ GET /_cluster/health?wait_for_status=yellow&timeout=50s
 [[cluster-health-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 [[cluster-health-api-query-params]]
 ==== {api-query-parms-title}
@@ -48,9 +48,9 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
     (Optional, string) Can be one of `cluster`, `indices` or `shards`. Controls 
     the details level of the health information returned. Defaults to `cluster`.
     
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
     
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `wait_for_active_shards`::
     (Optional, string) A number controlling to how many active shards to wait 
@@ -91,7 +91,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
     (string) The name of the cluster.
 
 `status`::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
 
 `timed_out`::
     (boolean) If `false` the response returned within the period of 

--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -26,7 +26,7 @@ threads.
 [[cluster-nodes-hot-threads-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 
 [[cluster-nodes-hot-threads-api-query-params]]
@@ -50,7 +50,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
 		(Optional, integer) Specifies the number of hot threads to provide 
 		information for. Defaults to `3`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `type`::
 		(Optional, string) The type to sample. Available options are `block`, `cpu`, and 

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -80,7 +80,7 @@ By default, it returns all attributes and core settings for a node.
 --
 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 
 [[cluster-nodes-info-api-response-body]]
@@ -153,9 +153,9 @@ running process:
 [[cluster-nodes-info-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[cluster-nodes-info-api-example]]

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -109,29 +109,29 @@ using metrics.
     * `warmer`
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 
 [[cluster-nodes-stats-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=completion-fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=completion-fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fielddata-fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fielddata-fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=groups]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=groups]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=level]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=level]
 
 `types`::
     (Optional, string) A comma-separated list of document types for the
     `indexing` index metric.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-segment-file-sizes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-segment-file-sizes]
 
 [role="child_attributes"]
 [[cluster-nodes-stats-api-response-body]]
@@ -224,11 +224,11 @@ node.
 =======
 `count`::
 (integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-count]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-count]
 
 `deleted`::
 (integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
 =======
 
 `store`::

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -43,13 +43,13 @@ of features for each node. All the nodes selective options are explained
         that action has been called on the node.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 
 [[cluster-nodes-usage-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[cluster-nodes-usage-api-example]]

--- a/docs/reference/cluster/pending.asciidoc
+++ b/docs/reference/cluster/pending.asciidoc
@@ -29,9 +29,9 @@ might be reported by both task api and pending cluster tasks API.
 [[cluster-pending-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[cluster-pending-api-response-body]]

--- a/docs/reference/cluster/reroute.asciidoc
+++ b/docs/reference/cluster/reroute.asciidoc
@@ -102,7 +102,7 @@ query parameter, which will attempt a single retry round for these shards.
     (Optional, boolean) If `true`, then retries allocation of shards that are
     blocked due to too many subsequent allocation failures.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [role="child_attributes"]
 [[cluster-reroute-api-request-body]]

--- a/docs/reference/cluster/state.asciidoc
+++ b/docs/reference/cluster/state.asciidoc
@@ -86,7 +86,7 @@ you can request only the part of the cluster state that you need:
       Shows the cluster state version.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[cluster-state-api-query-params]]
@@ -104,15 +104,15 @@ Defaults to `true`.
     that are open, closed or both. Available options: `open`, `closed`, `none`, 
     `all`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
     
 `ignore_unavailable`::
     (Optional, boolean) If `true`, unavailable indices (missing or closed) will 
     be ignored.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 `wait_for_metadata_version`::
     (Optional, integer) Waits for the metadata version to be equal or greater 

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -28,15 +28,15 @@ memory usage) and information about the current nodes that form the cluster
 ==== {api-path-parms-title}
 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-filter]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-filter]
 
 
 [[cluster-stats-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
 [role="child_attributes"]
 [[cluster-stats-api-response-body]]
@@ -78,7 +78,7 @@ https://en.wikipedia.org/wiki/Unix_time[Unix timestamp], in milliseconds, of
 the last time the cluster statistics were refreshed.
 
 `status`::
-include::{docdir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
 +
 See <<cluster-health>>.
 

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -27,25 +27,25 @@ on one or more nodes in the cluster.
 [[tasks-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=task-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=task-id]
 
 
 [[tasks-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=actions]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=actions]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=detailed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=group-by]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=group-by]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=node-id-query-parm]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id-query-parm]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
 
     
 [[tasks-api-response-codes]]

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -44,13 +44,13 @@ difficult to notice these discrepancies.
 [[cluster-update-settings-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
 `include_defaults`::
     (Optional, boolean) If `true`, returns all default cluster settings. 
     Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[cluster-update-settings-api-example]]

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -198,21 +198,21 @@ See <<url-access-control>>.
 [[docs-bulk-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 [[bulk-api-request-body]]
 ==== {api-request-body-title}
@@ -225,9 +225,9 @@ Indexes the specified document if it does not already exist.
 The following line must contain the source data to be indexed. 
 +
 --
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
 --
 
 `delete`::
@@ -235,7 +235,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-id]
 Removes the specified document from the index.
 +
 --
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
 `_id`::
 (Required, string) 
@@ -249,9 +249,9 @@ If the document exists, replaces the document and increments the version.
 The following line must contain the source data to be indexed. 
 +
 --
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
 --
 
 `update`::
@@ -260,9 +260,9 @@ Performs a partial document update.
 The following line must contain the partial document and update options.
 +
 --
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=bulk-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
 --
 
 `doc`::

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -160,73 +160,73 @@ or omit to search all indices.
 [[docs-delete-by-query-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
   
 `conflicts`::
   (Optional, string) What to do if delete by query hits version conflicts: 
   `abort` or `proceed`. Defaults to `abort`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=lenient]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=max_docs]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=max_docs]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=request_cache]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll_size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll_size]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_type]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_timeout]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=slices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sort]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sort]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=stats]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 [[docs-delete-by-query-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -141,23 +141,23 @@ DELETE /twitter/_doc/1?timeout=5m
 [[docs-delete-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=doc-version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version_type]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 [[docs-delete-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -156,28 +156,28 @@ deleted documents in the background as you continue to index more data.
 [[docs-get-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=realtime]
 
 `refresh`::
 (Optional, boolean)
 If `true`, {es} refreshes the affected shards to make this operation visible to
 search. If `false`, do nothing with refreshes. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=stored_fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stored_fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=doc-version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version_type]
 
 [[docs-get-api-response-body]]
 ==== {api-response-body-title}

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -37,9 +37,9 @@ POST request.
 [[docs-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
 
 `op_type`::
 (Optional, enum) Set to `create` to only index the document
@@ -48,19 +48,19 @@ if it does not already exist (_put if absent_). If a document with the specified
 `<index>/_create` endpoint. Valid values: `index`, `create`.
 If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=doc-version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=doc-version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version_type]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 [[docs-index-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -58,21 +58,21 @@ or when a document in the `docs` array does not specify an index.
 [[docs-multi-get-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=realtime]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=stored_fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stored_fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
 [[docs-multi-get-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/docs/multi-termvectors.asciidoc
+++ b/docs/reference/docs/multi-termvectors.asciidoc
@@ -58,27 +58,27 @@ that can be included in the response.
 [[docs-multi-termvectors-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=field_statistics]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=field_statistics]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=offsets]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=offsets]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=payloads]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=payloads]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=positions]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=positions]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=realtime]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=term_statistics]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=term_statistics]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version_type]
 
 [float]
 [[docs-multi-termvectors-api-example]]

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -417,21 +417,21 @@ POST _reindex
 [[docs-reindex-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=slices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=max_docs]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=max_docs]
 
 [[docs-reindex-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/docs/termvectors.asciidoc
+++ b/docs/reference/docs/termvectors.asciidoc
@@ -137,27 +137,27 @@ from is randomly selected. Use `routing` only to hit a particular shard.
 [[docs-termvectors-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=field_statistics]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=field_statistics]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=offsets]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=offsets]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=payloads]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=payloads]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=positions]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=positions]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=realtime]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=realtime]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=term_statistics]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=term_statistics]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version_type]
 
 [[docs-termvectors-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -155,75 +155,75 @@ or omit to search all indices.
 [[docs-update-by-query-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
   
 `conflicts`::
   (Optional, string) What to do if delete by query hits version conflicts: 
   `abort` or `proceed`. Defaults to `abort`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=lenient]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=max_docs]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=max_docs]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=request_cache]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=request_cache]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=requests_per_second]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll_size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll_size]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_type]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_timeout]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=slices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=slices]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=sort]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sort]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=stats]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=stats]
   
-include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=version]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 [[docs-update-by-query-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -46,20 +46,20 @@ automatically if it doesn't exist. For more information, see <<index-creation>>.
 [[docs-update-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_seq_no]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=if_primary_term]
 
 `lang`::
 (Optional, string) The script language. Default: `painless`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=refresh]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=refresh]
 
 `retry_on_conflict`::
 (Optional, integer) Specify how many times should the operation be retried when
  a conflict occurs. Default: 0.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 `_source`::
 (Optional, list) Set to `false` to disable source retrieval (default: `true`).
@@ -71,9 +71,9 @@ You can also specify a comma-separated list of the fields you want to retrieve.
 `_source_includes`::
 (Optional, list) Specify the source fields you want to retrieve.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
 [[update-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -71,15 +71,15 @@ To search all indices, use `_all` or `*`.
 [[eql-search-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 [[eql-search-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -43,7 +43,7 @@ The operation that consists of making changes visible to search - called a
 <<indices-refresh,refresh>> - is costly, and calling it often while there is
 ongoing indexing activity can hurt indexing speed.
 
-include::{docdir}/indices/refresh.asciidoc[tag=refresh-interval-default]
+include::{es-repo-dir}/indices/refresh.asciidoc[tag=refresh-interval-default]
 This is the optimal configuration if you have no or very little search traffic
 (e.g. less than one search request every 5 minutes) and want to optimize for
 indexing speed. This behavior aims to automatically optimize bulk indexing in

--- a/docs/reference/ilm/apis/delete-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/delete-lifecycle.asciidoc
@@ -36,7 +36,7 @@ the request fails and returns an error.
 [[ilm-delete-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-delete-lifecycle-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -46,7 +46,7 @@ about any failures.
   {ilm-init} and are in an error state, either due to an encountering an error while
   executing the policy, or attempting to use a policy that does not exist.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-explain-lifecycle-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/get-status.asciidoc
+++ b/docs/reference/ilm/apis/get-status.asciidoc
@@ -33,7 +33,7 @@ or `STOPPED`. You can change the status of the {ilm-init} plugin with the
 [[ilm-get-status-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-get-status-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -45,7 +45,7 @@ an unexpected step into the next step.
 [[ilm-move-to-step-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [role="child_attributes"]
 [[ilm-move-to-step-request-body]]

--- a/docs/reference/ilm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/put-lifecycle.asciidoc
@@ -41,7 +41,7 @@ previous versions.
 [[ilm-put-lifecycle-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-put-lifecycle-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
+++ b/docs/reference/ilm/apis/remove-policy-from-index.asciidoc
@@ -36,7 +36,7 @@ indices.
 [[ilm-remove-policy-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-remove-policy-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/retry-policy.asciidoc
+++ b/docs/reference/ilm/apis/retry-policy.asciidoc
@@ -36,7 +36,7 @@ step.
 [[ilm-retry-policy-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-retry-policy-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/start.asciidoc
+++ b/docs/reference/ilm/apis/start.asciidoc
@@ -32,7 +32,7 @@ necessary if it has been stopped using the <<ilm-stop, Stop {ilm-init} API>>.
 [[ilm-start-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-start-example]]
 ==== {api-examples-title}

--- a/docs/reference/ilm/apis/stop.asciidoc
+++ b/docs/reference/ilm/apis/stop.asciidoc
@@ -37,7 +37,7 @@ if {ilm-init} is running.
 [[ilm-stop-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[ilm-stop-example]]
 ==== {api-examples-title}

--- a/docs/reference/indices/add-alias.asciidoc
+++ b/docs/reference/indices/add-alias.asciidoc
@@ -6,7 +6,7 @@
 
 Creates or updates an index alias.
 
-include::{docdir}/glossary.asciidoc[tag=index-alias-desc]
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-desc]
 
 [source,console]
 ----
@@ -46,7 +46,7 @@ Name of the index alias to create or update.
 [[add-alias-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[add-alias-api-request-body]]
@@ -54,9 +54,9 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `filter`::
 (Required, query object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-alias-filter]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias-filter]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-routing]
 
 [[add-alias-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/indices/alias-exists.asciidoc
+++ b/docs/reference/indices/alias-exists.asciidoc
@@ -6,7 +6,7 @@
 
 Checks if an index alias exists.
 
-include::{docdir}/glossary.asciidoc[tag=index-alias-desc]
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-desc]
 
 [source,console]
 ----
@@ -29,20 +29,20 @@ HEAD /_alias/alias1
 
 `<alias>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-alias]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 [[alias-exists-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `all`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
 
 [[alias-exists-api-response-codes]]

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -6,7 +6,7 @@
 
 Adds or removes index aliases.
 
-include::{docdir}/glossary.asciidoc[tag=index-alias-desc]
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-desc]
 
 [source,console]
 ----
@@ -42,7 +42,7 @@ searching, and routing values. An alias cannot have the same name as an index.
 [[indices-aliases-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[indices-aliases-api-request-body]]
@@ -102,7 +102,7 @@ this parameter is required for the `add` or `remove` action.
 
 `filter`::
 (Optional, query object)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-alias-filter]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias-filter]
 +
 See <<filtered>> for an example.
 
@@ -130,7 +130,7 @@ until an additional index is referenced. At that point, there will be no write i
 writes will be rejected.
 ====
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-routing]
 +
 See <<aliases-routing>> for an example.
 

--- a/docs/reference/indices/apis/reload-analyzers.asciidoc
+++ b/docs/reference/indices/apis/reload-analyzers.asciidoc
@@ -73,15 +73,15 @@ used to limit the request.
 [[indices-reload-analyzers-api-query-params]]
 === {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 
 [discrete]

--- a/docs/reference/indices/clearcache.asciidoc
+++ b/docs/reference/indices/clearcache.asciidoc
@@ -24,17 +24,17 @@ POST /twitter/_cache/clear
 [[clear-cache-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[clear-cache-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
@@ -68,7 +68,7 @@ or field aliases.
 Comma-separated list of index names
 used to limit the request.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `query`::
 (Optional, boolean)

--- a/docs/reference/indices/clone-index.asciidoc
+++ b/docs/reference/indices/clone-index.asciidoc
@@ -155,20 +155,20 @@ on index creation applies to the clone index action as well.
 (Required, string)
 Name of the source index to clone.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index]
 
 
 [[clone-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[clone-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/indices/close.asciidoc
+++ b/docs/reference/indices/close.asciidoc
@@ -24,13 +24,13 @@ POST /twitter/_close
 
 You use the close index API to close open indices.
 
-include::{docdir}/indices/open-close.asciidoc[tag=closed-index]
+include::{es-repo-dir}/indices/open-close.asciidoc[tag=closed-index]
 
 
 [[close-index-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To close all indices, use `_all` or `*`.
 To disallow the closing of indices with `_all` or wildcard expressions,
@@ -42,19 +42,19 @@ or using the <<cluster-update-settings,cluster update settings>> API.
 [[close-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[close-index-api-example]]

--- a/docs/reference/indices/component-templates.asciidoc
+++ b/docs/reference/indices/component-templates.asciidoc
@@ -98,7 +98,7 @@ GET /_component_template/template_1
 [[get-component-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-template]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-template]
 +
 To return all component templates, omit this parameter or use a value of `*`.
 
@@ -106,11 +106,11 @@ To return all component templates, omit this parameter or use a value of `*`.
 [[get-component-template-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[get-component-template-api-example]]
@@ -150,7 +150,7 @@ Name of the component template to create.
 If `true`, this request cannot replace or update existing component templates.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 [[put-component-template-api-request-body]]
 ==== {api-request-body-title}
@@ -160,11 +160,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 This is the template to be applied, may optionally include a `mappings`,
 `settings`, or `aliases` configuration.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=mappings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=settings]
 
 `version`::
 (Optional, integer)

--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -52,9 +52,9 @@ Index names must meet the following criteria:
 [[indices-create-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[indices-create-api-request-body]]
@@ -64,9 +64,9 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 (Optional, <<indices-aliases,alias object>>) Index aliases which include the
 index. See <<indices-aliases>>.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=mappings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=settings]
 
 [[indices-create-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/indices/delete-alias.asciidoc
+++ b/docs/reference/indices/delete-alias.asciidoc
@@ -6,7 +6,7 @@
 
 Deletes an existing index alias.
 
-include::{docdir}/glossary.asciidoc[tag=index-alias-desc]
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-desc]
 
 [source,console]
 ----
@@ -36,7 +36,7 @@ use a value of `_all` or `*`.
 
 `<alias>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-alias]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
 +
 To delete all aliases,
 use a value of `_all` or `*`.
@@ -45,4 +45,4 @@ use a value of `_all` or `*`.
 [[delete-alias-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/indices/delete-index-template.asciidoc
+++ b/docs/reference/indices/delete-index-template.asciidoc
@@ -43,10 +43,10 @@ include::templates.asciidoc[tag=index-template-def]
 [[delete-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-template]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-template]
 
 
 [[delete-template-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/indices/delete-index.asciidoc
+++ b/docs/reference/indices/delete-index.asciidoc
@@ -42,14 +42,14 @@ this setting in the `elasticsearch.yml` file or using the
 [[delete-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]

--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -52,7 +52,7 @@ flush API was called.
 [[flush-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To flush all indices,
 omit this parameter
@@ -62,11 +62,11 @@ or use a value of `_all` or `*`.
 [[flush-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
@@ -86,7 +86,7 @@ This parameter is considered internal.
 --
 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `wait_if_ongoing`::
 +

--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -61,7 +61,7 @@ is set to `1`, as all segments need to be rewritten into a new one.
 [[forcemerge-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To force merge all indices in the cluster,
 omit this parameter
@@ -71,11 +71,11 @@ or use a value of `_all` or `*`.
 [[forcemerge-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
@@ -86,7 +86,7 @@ If `true`,
 after the force merge.
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `max_num_segments`::
 +

--- a/docs/reference/indices/get-alias.asciidoc
+++ b/docs/reference/indices/get-alias.asciidoc
@@ -6,7 +6,7 @@
 
 Returns information about one or more index aliases.
 
-include::{docdir}/glossary.asciidoc[tag=index-alias-desc]
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-desc]
 
 [source,console]
 ----
@@ -31,28 +31,28 @@ GET /twitter/_alias/alias1
 
 `<alias>`::
 (Optional, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-alias]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-alias]
 +
 To retrieve information for all index aliases,
 use a value of `_all` or `*`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[get-alias-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `all`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
 
 [[get-alias-api-example]]

--- a/docs/reference/indices/get-field-mapping.asciidoc
+++ b/docs/reference/indices/get-field-mapping.asciidoc
@@ -26,7 +26,7 @@ GET /twitter/_mapping/field/user
 [[get-field-mapping-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 `<field>`::
 (Optional, string) Comma-separated list or wildcard expression of fields used to
@@ -36,13 +36,13 @@ limit returned information.
 [[get-field-mapping-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `include_defaults`::
 (Optional, boolean) If `true`, the response includes default mapping values.

--- a/docs/reference/indices/get-index-template.asciidoc
+++ b/docs/reference/indices/get-index-template.asciidoc
@@ -42,7 +42,7 @@ GET /_template/template_1
 [[get-template-v1-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-template]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-template]
 +
 To return all index templates, omit this parameter
 or use a value of `_all` or `*`.
@@ -51,11 +51,11 @@ or use a value of `_all` or `*`.
 [[get-template-v1-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[get-template-v1-api-example]]

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -34,20 +34,20 @@ Use a value of `_all` to retrieve information for all indices in the cluster.
 [[get-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-defaults]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]

--- a/docs/reference/indices/get-mapping.asciidoc
+++ b/docs/reference/indices/get-mapping.asciidoc
@@ -23,25 +23,25 @@ GET /twitter/_mapping
 [[get-mapping-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[get-mapping-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[get-mapping-api-example]]

--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -24,7 +24,7 @@ GET /twitter/_settings
 [[get-index-settings-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 Use a value of `_all` to retrieve information for all indices in the cluster.
 
@@ -36,23 +36,23 @@ used to limit the request.
 [[get-index-settings-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `all`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-defaults]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[get-index-settings-api-example]]

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -154,7 +154,7 @@ GET /_index_template/template_1
 [[get-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-template]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-template]
 +
 To return all index templates, omit this parameter or use a value of `*`.
 
@@ -162,11 +162,11 @@ To return all index templates, omit this parameter or use a value of `*`.
 [[get-template-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[get-template-api-example]]
@@ -205,7 +205,7 @@ Name of the index template to create.
 (Optional, boolean)
 If `true`, this request cannot replace or update existing index templates. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[put-index-template-api-request-body]]
@@ -216,11 +216,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 Array of wildcard expressions
 used to match the names of indices during creation.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=mappings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=settings]
 
 `template`::
 (Optional, object)

--- a/docs/reference/indices/indices-exists.asciidoc
+++ b/docs/reference/indices/indices-exists.asciidoc
@@ -24,7 +24,7 @@ HEAD /twitter
 [[indices-exists-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 IMPORTANT: This parameter does not distinguish between an index name and <<indices-aliases,alias>>,
 i.e. status code `200` is also returned if an alias exists with that name.
@@ -33,21 +33,21 @@ i.e. status code `200` is also returned if an alias exists with that name.
 [[indices-exists-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-defaults]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-defaults]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
 
 [[indices-exists-api-response-codes]]

--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -67,7 +67,7 @@ index creation applies to the `_open` and `_close` index actions as well.
 [[open-index-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To open all indices, use `_all` or `*`.
 To disallow the opening of indices with `_all` or wildcard expressions,
@@ -79,19 +79,19 @@ or using the <<cluster-update-settings,cluster update settings>> API.
 [[open-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `closed`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[open-index-api-example]]

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -31,7 +31,7 @@ PUT /twitter/_mapping
 [[put-mapping-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To update the mapping of all indices, omit this parameter or use a value of
 `_all`.
@@ -40,17 +40,17 @@ To update the mapping of all indices, omit this parameter or use a value of
 [[put-mapping-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[put-mapping-api-request-body]]

--- a/docs/reference/indices/recovery.asciidoc
+++ b/docs/reference/indices/recovery.asciidoc
@@ -34,14 +34,14 @@ of syncing a replica shard from a primary shard.
 Upon completion,
 the replica shard is available for search.
 
-include::{docdir}/glossary.asciidoc[tag=recovery-triggers]
+include::{es-repo-dir}/glossary.asciidoc[tag=recovery-triggers]
 
 // end::shard-recovery-desc[]
 
 [[index-recovery-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 Use a value of `_all` to retrieve information for all indices in the cluster.
 
@@ -49,11 +49,11 @@ Use a value of `_all` to retrieve information for all indices in the cluster.
 [[index-recovery-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=active-only]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=active-only]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=detailed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-query-parm]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-query-parm]
 
 
 [[index-recovery-api-response-body]]

--- a/docs/reference/indices/refresh.asciidoc
+++ b/docs/reference/indices/refresh.asciidoc
@@ -61,7 +61,7 @@ before running the search.
 [[refresh-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To refresh all indices in the cluster,
 omit this parameter
@@ -71,15 +71,15 @@ or use a value of `_all` or `*`.
 [[refresh-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 
 [[refresh-api-example]]

--- a/docs/reference/indices/rollover-index.asciidoc
+++ b/docs/reference/indices/rollover-index.asciidoc
@@ -94,7 +94,7 @@ perform the rollover.
 (Optional*, string)
 Name of the target index to create and assign the index alias.
 
-include::{docdir}/indices/create-index.asciidoc[tag=index-name-reqs]
+include::{es-repo-dir}/indices/create-index.asciidoc[tag=index-name-reqs]
 
 *This parameter is not permitted if `rollover-target` is a data stream. In
 that case, the new index name will be in the form `<rollover-target>-000001`
@@ -121,15 +121,15 @@ the request checks whether the index matches provided conditions
 but does not perform a rollover.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[rollover-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
 `conditions`::
 +
@@ -160,9 +160,9 @@ TIP: To see the current index size, use the <<cat-indices, _cat indices>> API.
 The `pri.store.size` value shows the combined size of all primary shards.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=mappings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=settings]
 
 
 [[rollover-index-api-example]]

--- a/docs/reference/indices/segments.asciidoc
+++ b/docs/reference/indices/segments.asciidoc
@@ -25,21 +25,21 @@ GET /twitter/_segments
 [[index-segments-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[index-segments-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `verbose`::
 experimental:[]
@@ -54,39 +54,39 @@ Defaults to `false`.
 
 `<segment>`::
 (String)       
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment]
 
 `generation`::
 (Integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=generation]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=generation]
 
 `num_docs`::
 (Integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-count]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-count]
 
 `deleted_docs`::
 (Integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=docs-deleted]
 
 `size_in_bytes`::
 (Integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment-size]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-size]
 
 `memory_in_bytes`::
 (Integer)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=memory]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=memory]
 
 `committed`:: 
 (Boolean)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=committed]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=committed]
 
 `search`::
 (Boolean)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment-search]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-search]
 
 `version`::
 (String)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=segment-version]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=segment-version]
 
 `compound`::
 (Boolean)

--- a/docs/reference/indices/shard-stores.asciidoc
+++ b/docs/reference/indices/shard-stores.asciidoc
@@ -45,7 +45,7 @@ or have one or more unassigned replica shards.
 [[index-shard-stores-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To retrieve information for all indices in the cluster,
 use a value of `_all` or `*`
@@ -55,15 +55,15 @@ or omit this parameter.
 [[index-shard-stores-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `status`::
 +

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -198,19 +198,19 @@ on index creation applies to the shrink index action as well.
 (Required, string)
 Name of the source index to shrink.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index]
 
 [[shrink-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[shrink-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -233,20 +233,20 @@ on index creation applies to the split index action as well.
 (Required, string)
 Name of the source index to split.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index]
 
 
 [[split-index-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_active_shards]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[split-index-api-request-body]]
 ==== {api-request-body-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-aliases]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=target-index-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=target-index-settings]

--- a/docs/reference/indices/stats.asciidoc
+++ b/docs/reference/indices/stats.asciidoc
@@ -51,39 +51,39 @@ to which the shard contributed.
 [[index-stats-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To retrieve statistics for all indices,
 use a value of `_all` or `*` or omit this parameter.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-metric]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-metric]
 
 
 [[index-stats-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=completion-fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=completion-fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fielddata-fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fielddata-fields]
 
 `forbid_closed_indices`::
 (Optional, boolean)
 If `true`, statistics are *not* collected from closed indices.
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=groups]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=groups]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=level]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=level]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-segment-file-sizes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-segment-file-sizes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=include-unloaded-segments]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=include-unloaded-segments]
 
 
 [[index-stats-api-example]]

--- a/docs/reference/indices/template-exists.asciidoc
+++ b/docs/reference/indices/template-exists.asciidoc
@@ -32,17 +32,17 @@ include::templates.asciidoc[tag=index-template-def]
 [[template-exists-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-template]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-template]
 
 
 [[template-exists-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[template-exists-api-response-codes]]

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -112,7 +112,7 @@ Templates with lower `order` values are merged first.
 Templates with higher `order` values are merged later,
 overriding templates with lower values.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[put-index-template-v1-api-request-body]]
@@ -123,11 +123,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 Array of wildcard expressions
 used to match the names of indices during creation.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=aliases]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=aliases]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=mappings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=mappings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=settings]
 
 `version`::
 (Optional, integer)

--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -27,7 +27,7 @@ PUT /twitter/_settings
 [[update-index-settings-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To update a setting for all indices,
 use `_all` or exclude this parameter.
@@ -36,23 +36,23 @@ use `_all` or exclude this parameter.
 [[update-index-settings-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=flat-settings]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `preserve_existing`::
 (Optional, boolean) If `true`, existing index settings remain unchanged.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[update-index-settings-api-request-body]]

--- a/docs/reference/ingest/apis/delete-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/delete-pipeline.asciidoc
@@ -53,7 +53,7 @@ use a value of `*`.
 [[delete-pipeline-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 
 [[delete-pipeline-api-api-example]]

--- a/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
+++ b/docs/reference/ingest/apis/enrich/put-enrich-policy.asciidoc
@@ -79,7 +79,7 @@ include::../../enrich.asciidoc[tag=update-enrich-policy]
 
 `<enrich-policy>`::
 (Required, string)
-include::{docdir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=enrich-policy]
 
 
 [[put-enrich-policy-api-request-body]]

--- a/docs/reference/ingest/apis/get-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/get-pipeline.asciidoc
@@ -45,14 +45,14 @@ GET /_ingest/pipeline/my-pipeline-id
 [[get-pipeline-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=path-pipeline]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=path-pipeline]
 
 
 
 [[get-pipeline-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[get-pipeline-api-api-example]]

--- a/docs/reference/ingest/apis/put-pipeline.asciidoc
+++ b/docs/reference/ingest/apis/put-pipeline.asciidoc
@@ -40,7 +40,7 @@ PUT _ingest/pipeline/my-pipeline-id
 [[put-pipeline-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 
 [[put-pipeline-api-response-body]]

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -122,7 +122,7 @@ that doesn't change frequently.
 [[enrich-prereqs]]
 ==== Prerequisites
 
-include::{docdir}/ingest/apis/enrich/put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
+include::{es-repo-dir}/ingest/apis/enrich/put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
 
 [[create-enrich-source-index]]
 ==== Add enrich data
@@ -209,7 +209,7 @@ documents first and verifying enrich data was added correctly using the
 [[update-enrich-data]]
 ==== Update an enrich index
 
-include::{docdir}/ingest/apis/enrich/execute-enrich-policy.asciidoc[tag=update-enrich-index]
+include::{es-repo-dir}/ingest/apis/enrich/execute-enrich-policy.asciidoc[tag=update-enrich-index]
 
 If wanted, you can <<docs-reindex,reindex>>
 or <<docs-update-by-query,update>> any already ingested documents

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -42,11 +42,11 @@ Regression configuration for inference.
 
 `results_field`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 
 `num_top_feature_importance_values`::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-regression-num-top-feature-importance-values]
 
 
 [discrete]
@@ -57,23 +57,23 @@ Classification configuration for inference.
 
 `num_top_classes`::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-classes]
 
 `num_top_feature_importance_values`::
 (Optional, integer)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-num-top-feature-importance-values]
 
 `results_field`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
 
 `top_classes_results_field`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-top-classes-results-field]
 
 `prediction_field_type`::
 (Optional, string)
-include::{docdir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification-prediction-field-type]
 
 [discrete]
 [[inference-processor-config-example]]

--- a/docs/reference/mapping.asciidoc
+++ b/docs/reference/mapping.asciidoc
@@ -190,9 +190,9 @@ PUT /my-index/_mapping
 [[update-mapping]]
 === Update the mapping of a field
 
-include::{docdir}/indices/put-mapping.asciidoc[tag=change-field-mapping]
+include::{es-repo-dir}/indices/put-mapping.asciidoc[tag=change-field-mapping]
 
-include::{docdir}/indices/put-mapping.asciidoc[tag=rename-field]
+include::{es-repo-dir}/indices/put-mapping.asciidoc[tag=rename-field]
 
 [float]
 [[view-mapping]]

--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -220,11 +220,11 @@ then 101 Lucene documents would be created: one for the parent document, and one
 nested object. Because of the expense associated with `nested` mappings, Elasticsearch puts
 settings in place to guard against performance problems:
 
-include::{docdir}/mapping.asciidoc[tag=nested-fields-limit]
+include::{es-repo-dir}/mapping.asciidoc[tag=nested-fields-limit]
 
 In the previous example, the `user` mapping would count as only 1 towards this limit.
 
-include::{docdir}/mapping.asciidoc[tag=nested-objects-limit]
+include::{es-repo-dir}/mapping.asciidoc[tag=nested-objects-limit]
 
 To illustrate how this setting works, consider adding another `nested` type called `comments`
 to the previous example mapping. For each document, the combined number of `user` and `comment`

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -946,7 +946,7 @@ tag::target-index[]
 (Required, string)
 Name of the target index to create.
 
-include::{docdir}/indices/create-index.asciidoc[tag=index-name-reqs]
+include::{es-repo-dir}/indices/create-index.asciidoc[tag=index-name-reqs]
 --
 end::target-index[]
 

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -22,7 +22,7 @@ available under the current license and some usage statistics.
 [[usage-api-query-parms]]
 === {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
 [discrete]
 [[usage-api-example]]

--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -37,52 +37,52 @@ scalability of count.
 [[search-count-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[search-count-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=lenient]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
 
 `min_score`::
 (Optional, float)
   Sets the minimum `_score` value that documents must have to be included in the 
   result.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 
 
 [[search-count-request-body]]
 ==== {api-request-body-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=query]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=query]
 
 
 [[search-count-api-example]]

--- a/docs/reference/search/explain.asciidoc
+++ b/docs/reference/search/explain.asciidoc
@@ -49,37 +49,37 @@ Only a single index name can be provided to this parameter.
 [[sample-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=lenient]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
 `stored_fields`::
   (Optional, string) A comma-separated list of stored fields to return in the 
   response.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
 
 [[sample-api-request-body]]
 ==== {api-request-body-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=query]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=query]
 
 
 [[sample-api-example]]

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -32,25 +32,25 @@ fields among multiple indices.
 [[search-field-caps-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[search-field-caps-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 --
 Defaults to `open`.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=fields]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=fields]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `include_unmapped`::
   (Optional, boolean) If `true`, unmapped fields are included in the response. 

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -50,14 +50,14 @@ this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 [[search-multi-search-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 +
 To search all indices, use `_all` or omit this parameter.
 
 [[search-multi-search-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 
 `ccs_minimize_roundtrips`::
 (Optional, boolean)
@@ -65,7 +65,7 @@ If `true`, network roundtrips between the coordinating node and remote clusters
 are minimized for {ccs} requests. Defaults to `true`. See
 <<ccs-network-delays>>.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
@@ -74,7 +74,7 @@ Defaults to `open`.
 If `true`, concrete, expanded or aliased indices are ignored when frozen.
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `max_concurrent_searches`::
 (Optional, integer)
@@ -170,7 +170,7 @@ If `true`, the request does *not* return an error if a wildcard expression or
 This parameter also applies to <<indices-aliases,index aliases>> that point to a
 missing or closed index.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 

--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -68,17 +68,17 @@ generation in your application.
 [[search-rank-eval-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 --
 Defaults to `open`.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 
 [[search-rank-eval-api-example]]

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -34,7 +34,7 @@ The search request can be executed with a search DSL, which includes the
 [[search-request-body-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 [[search-request-body-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/search/search-shards.asciidoc
+++ b/docs/reference/search/search-shards.asciidoc
@@ -28,29 +28,29 @@ are used, the filter is returned as part of the `indices` section.
 [[search-shards-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[search-shards-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 --
 Defaults to `open`.
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=local]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 
 [[search-shards-api-example]]

--- a/docs/reference/search/search-template.asciidoc
+++ b/docs/reference/search/search-template.asciidoc
@@ -46,13 +46,13 @@ per type and context as described in the
 [[search-template-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 
 [[search-template-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
@@ -60,7 +60,7 @@ Defaults to `true`.
   (Optional, boolean) If `true`, network round-trips are minimized for 
  cross-cluster search requests. Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 `explain`::
   (Optional, boolean) If `true`, the response includes additional details about 
@@ -70,9 +70,9 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
   (Optional, boolean) If `true`, specified concrete, expanded or aliased indices 
   are not included in the response when throttled. Defaults to `false`. 
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=preference]
 
 `profile`::
   (Optional, boolean) If `true`, the query execution is profiled. Defaults 
@@ -82,11 +82,11 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=preference]
   (Optional, boolean) If `true`, `hits.total` are rendered as an integer in 
   the response. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=routing]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=scroll]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=scroll]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_type]
 
 `typed_keys`::
   (Optional, boolean) If `true`, aggregation and suggester names are 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -33,12 +33,12 @@ query string parameter>> or <<search-request-body,request body>>.
 [[search-search-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
 [[search-search-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
@@ -68,7 +68,7 @@ coordinating node and the remote clusters are minimized when executing
   (Optional, string) A comma-separated list of fields to return as the docvalue
   representation of a field for each hit.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
@@ -84,7 +84,7 @@ both parameters are specified, only the query parameter is used.
 ====
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from]
 +
 --
 By default, you cannot page through more than 10,000 documents using the `from`
@@ -112,7 +112,7 @@ both parameters are specified, only the query parameter is used.
   (Optional, boolean) If `true`, concrete, expanded or aliased indices will be
   ignored when frozen. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `max_concurrent_shard_requests`::
   (Optional, integer) Defines the number of concurrent shard requests per node
@@ -137,7 +137,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
   performed on. Random by default.
 
 [[search-api-query-params-q]]
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 +
 --
 You can use the `q` parameter to run a query parameter search. Query parameter
@@ -165,7 +165,7 @@ level settings.
   (Optional, <<time-units, time units>>) Specifies how long a consistent view of
   the index should be maintained for scrolled search.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search_type]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search_type]
 
 `seq_no_primary_term`::
 +
@@ -213,9 +213,9 @@ both parameters are specified, only the query parameter is used.
 If `true`, the response includes the `_source` of matching documents under
 `hits`. Defaults to `true`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_excludes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_includes]
 
 `stats`::
   (Optional, string) Specific `tag` of the request for logging and statistical
@@ -233,7 +233,7 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=source_includes]
   (Optional, string) The source text for which the suggestions should be
   returned.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 +
 --
 Defaults to `0`, which does not terminate query execution early.
@@ -304,7 +304,7 @@ both parameters are specified, only the query parameter is used.
 ====
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=from]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from]
 +
 --
 By default, you cannot page through more than 10,000 documents using the `from`
@@ -372,7 +372,7 @@ parameters are specified, only the query parameter is used.
 ====
 --
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=terminate_after]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 +
 --
 Defaults to `0`, which does not terminate query execution early.

--- a/docs/reference/search/validate.asciidoc
+++ b/docs/reference/search/validate.asciidoc
@@ -27,9 +27,9 @@ request body.
 [[search-validate-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=query]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=query]
   
 
 [[search-validate-api-query-params]]
@@ -39,33 +39,33 @@ include::{docdir}/rest-api/common-parms.asciidoc[tag=query]
   (Optional, boolean) If `true`, the validation is executed on all shards 
   instead of one random shard per index. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyzer]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyzer]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=analyze_wildcard]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=default_operator]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=default_operator]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=df]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=df]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 
 `explain`::
   (Optional, boolean) If `true`, the response returns detailed information if an 
   error has occurred. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=lenient]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]
 
 `rewrite`::
   (Optional, boolean) If `true`, returns a more detailed explanation showing the 
   actual Lucene query that will be executed. Defaults to `false`.
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=search-q]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=search-q]
 
 
 [[search-validate-api-example]]

--- a/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
+++ b/docs/reference/searchable-snapshots/apis/mount-snapshot.asciidoc
@@ -43,9 +43,9 @@ to mount.
 [[searchable-snapshots-api-mount-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=wait_for_completion]
 
 [[searchable-snapshots-api-mount-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -460,72 +460,72 @@ An `s` at the end indicates seconds, or `ms` indicates milliseconds.
 Defaults to `5s` (5 seconds ).
 
 `ssl.key`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
 +
 If the LDAP server requires client authentication, it uses this file. You cannot
 use this setting and `ssl.keystore.path` at the same time.
 
 `ssl.key_passphrase`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
 
 `ssl.secure_key_passphrase` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
 
 `ssl.certificate`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 +
 This certificate is presented to clients when they connect.
 
 `ssl.certificate_authorities`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
 +
 You cannot use this setting and `ssl.truststore.path` at the same time.
 
 `ssl.keystore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
 +
 You cannot use this setting and `ssl.key` at the same time.
 
 `ssl.keystore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
 
 `ssl.keystore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
 
 `ssl.keystore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
 
 `ssl.keystore.key_password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
 
 `ssl.keystore.secure_key_password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
 
 `ssl.truststore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 +
 You cannot use this setting and `ssl.certificate_authorities` at the same time.
 
 `ssl.truststore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 
 `ssl.truststore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 
 `ssl.truststore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
 
 `ssl.verification_mode`::
 Indicates the type of verification when using `ldaps` to protect against man
 in the middle attacks and certificate forgery.
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 
 `ssl.supported_protocols`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
 
 `ssl.cipher_suites`:: Specifies the cipher suites that should be supported when 
 communicating with the LDAP server. 
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 //TBD: Can this be updated to using the Java 11 URL instead or does it have to stay java8?
 
 `cache.ttl`::
@@ -712,73 +712,73 @@ An `s` at the end indicates seconds, or `ms` indicates milliseconds.
 Defaults to `5s` (5 seconds ).
 
 `ssl.certificate`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 +
 This certificate is presented to clients when they connect. 
 
 `ssl.certificate_authorities`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
 +
 You cannot use this setting and `ssl.truststore.path` at the same time.
 
 `ssl.key`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
 +
 If the Active Directory server requires client authentication, it uses this file.
 You cannot use this setting and `ssl.keystore.path` at the same time.
 
 `ssl.key_passphrase`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
 
 `ssl.secure_key_passphrase` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
 
 `ssl.keystore.key_password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
 
 `ssl.keystore.secure_key_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
 
 `ssl.keystore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
 
 `ssl.secure_keystore.password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
 //TBD: Why/how is this different than `ssl.keystore.secure_password`?
 
 `ssl.keystore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
 +
 You cannot use this setting and `ssl.key` at the same time.
 
 `ssl.keystore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
 
 `ssl.truststore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 
 `ssl.truststore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 
 `ssl.truststore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 +
 You cannot use this setting and `ssl.certificate_authorities` at the same time.
 
 `ssl.truststore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
 
 `ssl.verification_mode`::
 Indicates the type of verification when using `ldaps` to protect against man
 in the middle attacks and certificate forgery.
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 
 `ssl.supported_protocols`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
 
 `ssl.cipher_suites`:: Specifies the cipher suites that should be supported when 
 communicating with the Active Directory server.
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 //TBD: Can this be updated to using the Java 11 URL instead or does it have to stay java8?
 
 `cache.ttl`::
@@ -828,11 +828,11 @@ for SSL. This setting cannot be used with `truststore.path`.
 Algorithm for the truststore. Defaults to `SunX509`.
 
 `truststore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 If `truststore.path` is set, this setting is required.
 
 `truststore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 
 `truststore.path`::
 The path of a truststore to use. Defaults to the trusted certificates configured
@@ -1108,90 +1108,90 @@ NOTE: These settings are not used for any purpose other than loading metadata
 over https.
 
 `ssl.key`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
 +
 If HTTP client authentication is required, it uses this file. You cannot use
 this setting and `ssl.keystore.path` at the same time.
 
 `ssl.key_passphrase`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
 +
 You cannot use this setting and `ssl.secure_key_passphrase` at the same time. 
 
 `ssl.secure_key_passphrase` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
 +
 You cannot use this setting and `ssl.key_passphrase` at the same time.
 
 `ssl.certificate`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 +
 This setting can be used only if `ssl.key` is set.
 
 `ssl.certificate_authorities`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
 +
 This setting and `ssl.truststore.path` cannot be used at the same time.
 
 `ssl.keystore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
 +
 It must be either a Java keystore (jks) or a PKCS#12 file. You cannot use this
 setting and `ssl.key` at the same time.
 
 `ssl.keystore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
 
 `ssl.keystore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
 +
 You cannot use this setting and `ssl.keystore.secure_password` at the same time.
 
 `ssl.keystore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
 +
 You cannot use this setting and `ssl.keystore.password` at the same time.
 //TBD: Why is this different name than `ssl.secure_keystore.password` elsewhere in this file?
 
 `ssl.keystore.key_password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
 +
 You cannot use this setting and `ssl.keystore.secure_key_password` at the same
 time.
 
 `ssl.keystore.secure_key_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
 You cannot use this setting and `ssl.keystore.key_password` at the same time.
 
 `ssl.truststore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 +
 You cannot use this setting and `ssl.certificate_authorities` at the same time.
 
 
 `ssl.truststore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-type]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type]
 
 `ssl.truststore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 +
 You cannot use this setting and `ssl.truststore.secure_password` at the same
 time.
 
 `ssl.truststore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 +
 This setting cannot be used with `ssl.truststore.password`.
 
 `ssl.verification_mode`::
 Controls the verification of certificates.
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 
 `ssl.supported_protocols`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
 
 `ssl.cipher_suites`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 
 [float]
 [[ref-kerberos-settings]]
@@ -1385,90 +1385,90 @@ NOTE: These settings are _only_ used for the back-channel communication between
 {es} and the OpenID Connect Provider
 
 `ssl.key`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
 +
 If HTTP client authentication is required, it uses this file. You cannot use
 this setting and `ssl.keystore.path` at the same time.
 
 `ssl.key_passphrase`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
 +
 You cannot use this setting and `ssl.secure_key_passphrase` at the same
 time.
 
 `ssl.secure_key_passphrase` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
 +
 You cannot use this setting and `ssl.key_passphrase` at the same time.
 
 `ssl.certificate`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 +
 This setting can be used only if `ssl.key` is set.
 
 `ssl.certificate_authorities`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
 +
 This setting and `ssl.truststore.path` cannot be used at the same time.
 
 `ssl.keystore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
 +
 It must be either a Java keystore (jks) or a PKCS#12 file. You cannot use this
 setting and `ssl.key` at the same time.
 
 `ssl.keystore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
 
 `ssl.keystore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
 +
 You cannot use this setting and `ssl.keystore.secure_password` at the same time.
 
 `ssl.keystore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
 +
 You cannot use this setting and `ssl.keystore.password` at the same time.
 
 `ssl.keystore.key_password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
 +
 You cannot use this setting and `ssl.keystore.secure_key_password` at the same
 time.
 
 `ssl.keystore.secure_key_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
 +
 You cannot use this setting and `ssl.keystore.key_password` at the same time.
 
 `ssl.truststore.path`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 +
 You cannot use this setting and `ssl.certificate_authorities` at the same time.
 
 `ssl.truststore.type`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-type]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type]
 
 `ssl.truststore.password`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 +
 You cannot use this setting and `ssl.truststore.secure_password` at the same
 time.
 
 `ssl.truststore.secure_password` (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 +
 You cannot use this setting and `ssl.truststore.password` at the same time.
 
 `ssl.verification_mode`::
 Controls the verification of certificates.
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 
 `ssl.supported_protocols`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
 
 `ssl.cipher_suites`::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 
 [float]
 [[load-balancing]]

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -7,7 +7,7 @@ Used to enable or disable TLS/SSL. The default is `false`.
 endif::server[]
 
 +{ssl-prefix}.ssl.supported_protocols+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-supported-protocols]
 
 ifdef::server[]
 +{ssl-prefix}.ssl.client_authentication+::
@@ -26,11 +26,11 @@ endif::server[]
 ifdef::verifies[]
 +{ssl-prefix}.ssl.verification_mode+::
 Controls the verification of certificates.
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 endif::verifies[]
 
 +{ssl-prefix}.ssl.cipher_suites+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-cipher-suites-values]
 
 [#{ssl-context}-tls-ssl-key-trusted-certificate-settings]
 ===== {component} TLS/SSL key and trusted certificate settings
@@ -50,19 +50,19 @@ endif::server[]
 When using PEM encoded files, use the following settings:
 
 +{ssl-prefix}.ssl.key+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-pem]
 
 +{ssl-prefix}.ssl.key_passphrase+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-key-passphrase]
 
 +{ssl-prefix}.ssl.secure_key_passphrase+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-secure-key-passphrase]
 
 +{ssl-prefix}.ssl.certificate+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 
 +{ssl-prefix}.ssl.certificate_authorities+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
 
 ===== Java keystore files
 
@@ -70,28 +70,28 @@ When using Java keystore files (JKS), which contain the private key, certificate
 and certificates that should be trusted, use the following settings:
 
 +{ssl-prefix}.ssl.keystore.path+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
 
 +{ssl-prefix}.ssl.keystore.password+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
 
 +{ssl-prefix}.ssl.keystore.secure_password+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
 
 +{ssl-prefix}.ssl.keystore.key_password+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
 
 +{ssl-prefix}.ssl.keystore.secure_key_password+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
 
 +{ssl-prefix}.ssl.truststore.path+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 
 +{ssl-prefix}.ssl.truststore.password+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 
 [#{ssl-context}-pkcs12-files]
 ===== PKCS#12 files
@@ -102,35 +102,35 @@ that contain the private key, certificate and certificates that should be truste
 PKCS#12 files are configured in the same way as Java keystore files:
 
 +{ssl-prefix}.ssl.keystore.path+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-path]
 
 +{ssl-prefix}.ssl.keystore.type+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-type-pkcs12]
 
 +{ssl-prefix}.ssl.keystore.password+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-password]
 
 +{ssl-prefix}.ssl.keystore.secure_password+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-password]
 
 +{ssl-prefix}.ssl.keystore.key_password+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-key-password]
 
 +{ssl-prefix}.ssl.keystore.secure_key_password+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-keystore-secure-key-password]
 
 +{ssl-prefix}.ssl.truststore.path+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-path]
 
 +{ssl-prefix}.ssl.truststore.type+::
 Set this to `PKCS12` to indicate that the truststore is a PKCS#12 file.
 //TBD:Should this use the ssl-truststore-type-pkcs11 or ssl-truststore-type definition and default values?
 
 +{ssl-prefix}.ssl.truststore.password+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-password]
 
 +{ssl-prefix}.ssl.truststore.secure_password+ (<<secure-settings,Secure>>)::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-secure-password]
 
 [#{ssl-context}-pkcs11-tokens]
 ===== PKCS#11 tokens
@@ -146,7 +146,7 @@ Set this to `PKCS11` to indicate that the PKCS#11 token should be used as a keys
 //TBD: Is the default value `jks`?
 
 +{ssl-prefix}.truststore.type+::
-include::{docdir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-truststore-type-pkcs11]
 
 [NOTE]
 When configuring the PKCS#11 token that your JVM is configured to use as

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -17,7 +17,7 @@ time, so the service remains uninterrupted.
 . *Disable shard allocation.*
 +
 --
-include::{docdir}/upgrade/disable-shard-alloc.asciidoc[]
+include::{es-repo-dir}/upgrade/disable-shard-alloc.asciidoc[]
 --
 // end::disable_shard_alloc[]
 // tag::stop_indexing[]
@@ -68,7 +68,7 @@ or jobs with large model states.
 . *Shut down all nodes.*
 +
 --
-include::{docdir}/upgrade/shut-down-node.asciidoc[]
+include::{es-repo-dir}/upgrade/shut-down-node.asciidoc[]
 --
 
 . *Perform any needed changes.*
@@ -172,11 +172,11 @@ the datafeeds from {kib} or with the <<ml-open-job,open jobs>> and
 === Rolling restart
 
 
-include::{docdir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
+include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=disable_shard_alloc]
 
-include::{docdir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
+include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_indexing]
 
-include::{docdir}/setup/restart-cluster.asciidoc[tag=stop_ml]
+include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=stop_ml]
 +
 --
 * If you perform a rolling restart, you can also leave your machine learning
@@ -189,7 +189,7 @@ cluster.
 . *Shut down a single node in case of rolling restart.*
 +
 --
-include::{docdir}/upgrade/shut-down-node.asciidoc[]
+include::{es-repo-dir}/upgrade/shut-down-node.asciidoc[]
 --
 
 . *Perform any needed changes.*
@@ -233,4 +233,4 @@ When the node has recovered and the cluster is stable, repeat these steps
 for each node that needs to be changed.
 --
 
-include::{docdir}/setup/restart-cluster.asciidoc[tag=restart_ml]
+include::{es-repo-dir}/setup/restart-cluster.asciidoc[tag=restart_ml]

--- a/docs/reference/slm/apis/slm-get-status.asciidoc
+++ b/docs/reference/slm/apis/slm-get-status.asciidoc
@@ -26,7 +26,7 @@ You halt and restart the {slm-init} plugin with the
 
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[slm-api-get-status-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/slm/apis/slm-put.asciidoc
+++ b/docs/reference/slm/apis/slm-put.asciidoc
@@ -41,7 +41,7 @@ you want to create or update.
 [[slm-api-put-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [role="child_attributes"]
 [[slm-api-put-request-body]]

--- a/docs/reference/slm/apis/slm-start.asciidoc
+++ b/docs/reference/slm/apis/slm-start.asciidoc
@@ -31,7 +31,7 @@ Manually starting {slm-init} is only necessary if it has been stopped using the 
 
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[slm-api-start-example]]
 ==== {api-examples-title}

--- a/docs/reference/slm/apis/slm-stop.asciidoc
+++ b/docs/reference/slm/apis/slm-stop.asciidoc
@@ -38,7 +38,7 @@ Use the  <<slm-api-get-status>> to see if {slm-init} is running.
 
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [[slm-api-stop-example]]
 ==== {api-examples-title}

--- a/docs/reference/snapshot-restore/apis/clean-up-repo-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/clean-up-repo-api.asciidoc
@@ -62,7 +62,7 @@ Name of the snapshot repository to review and clean up.
 [[clean-up-snapshot-repo-api-query-params]]
 ==== {api-query-parms-title}
 
-include::{docdir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [role="child_attributes"]
 [[clean-up-snapshot-repo-api-response-body]]


### PR DESCRIPTION
This PR replace the use of the `{docdir}` intrinsic attribute (which refers to the full path of the directory that contains the index.asciidoc source document) with the `{es-repo-dir}` attribute. Otherwise, the relative paths fail when files are built from an index.asciidoc file in a different path.