### PR TITLE
Add a reference on returning fields during a search.

### DIFF
--- a/docs/reference/search/run-a-search.asciidoc
+++ b/docs/reference/search/run-a-search.asciidoc
@@ -285,3 +285,5 @@ GET /*/_search
 ====
 
 include::request/from-size.asciidoc[]
+
+include::search-fields.asciidoc[]

--- a/docs/reference/search/search-fields.asciidoc
+++ b/docs/reference/search/search-fields.asciidoc
@@ -5,7 +5,7 @@
 By default, each hit in the search response includes the document
 <<mapping-source-field,`_source`>>, which is the entire JSON object that was
 provided when indexing the document. If you only need certain fields in the
-search API's response, you can use
+search response, you can use
 <<request-body-search-source-filtering,source filtering>> to restrict what
 parts of the source are returned.
 

--- a/docs/reference/search/search-fields.asciidoc
+++ b/docs/reference/search/search-fields.asciidoc
@@ -1,0 +1,30 @@
+[discrete]
+[[search-fields]]
+=== Return fields in a search
+
+By default, each hit in the search response includes the document
+<<mapping-source-field,`_source`>>, which is the entire JSON object that was
+provided when indexing the document. Often only certain fields are required in
+the response. In this case you can use
+<<request-body-search-source-filtering,source filtering>> to restrict what
+parts of the source are returned.
+
+Returning fields using the document source has some limitations:
+
+* The `_source` field does not include <<multi-fields, multi-fields>> or
+<<alias, field aliases>>. Likewise, a field in the source will not contain
+values that were copied into it through `copy_to`.
+* Since the `_source` is stored as a single field in Lucene, the whole source
+object must be loaded and parsed, even if only a small number of fields is needed.
+
+Elasticsearch supports some alternative methods for returning fields that help
+avoid these downsides:
+
+* The <<request-body-search-docvalue-fields, docvalue fields>>
+parameter allows for loading fields from their docvalues. This can be a good
+choice when returning a fairly small number of fields that support docvalues,
+such as keywords and dates.
+* It's also possible to store an individual field's values by using the
+<<mapping-store,`store`>> mapping option. These stored values can then be
+returned in a search through the
+<<request-body-search-stored-fields, `stored_fields`>> parameter.

--- a/docs/reference/search/search-fields.asciidoc
+++ b/docs/reference/search/search-fields.asciidoc
@@ -4,27 +4,28 @@
 
 By default, each hit in the search response includes the document
 <<mapping-source-field,`_source`>>, which is the entire JSON object that was
-provided when indexing the document. Often only certain fields are required in
-the response. In this case you can use
+provided when indexing the document. If you only need certain fields in the
+search API's response, you can use
 <<request-body-search-source-filtering,source filtering>> to restrict what
 parts of the source are returned.
 
-Returning fields using the document source has some limitations:
+Returning fields using only the document source has some limitations:
 
 * The `_source` field does not include <<multi-fields, multi-fields>> or
-<<alias, field aliases>>. Likewise, a field in the source will not contain
-values that were copied into it through `copy_to`.
+<<alias, field aliases>>. Likewise, a field in the source does not contain
+values copied using the <<copy-to,`copy_to`>> mapping parameter.
 * Since the `_source` is stored as a single field in Lucene, the whole source
-object must be loaded and parsed, even if only a small number of fields is needed.
+object must be loaded and parsed, even if only a small number of fields are
+needed.
 
-Elasticsearch supports some alternative methods for returning fields that help
-avoid these downsides:
+{es} supports some alternative methods for returning fields that help avoid
+these downsides:
 
-* The <<request-body-search-docvalue-fields, docvalue fields>>
-parameter allows for loading fields from their docvalues. This can be a good
-choice when returning a fairly small number of fields that support docvalues,
+* The <<request-body-search-docvalue-fields, `docvalue_fields`>>
+parameter allows for loading fields from their doc values. This can be a good
+choice when returning a fairly small number of fields that support doc values,
 such as keywords and dates.
 * It's also possible to store an individual field's values by using the
-<<mapping-store,`store`>> mapping option. These stored values can then be
-returned in a search through the
-<<request-body-search-stored-fields, `stored_fields`>> parameter.
+<<mapping-store,`store`>> mapping option. You can use the
+<<request-body-search-stored-fields, `stored_fields`>> parameter to return
+these stored values in the search response.


### PR DESCRIPTION
This PR adds a section to the new 'run a search' reference that explains
the options for returning fields. Previously each option was only listed as a
separate request parameter and it was hard to know what was available.
