### PR TITLE
[7.x] Disable testingConventions in build tools in fips (#57357)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -182,8 +182,11 @@ if (project != rootProject) {
     'forbiddenApisTest', 'forbiddenApisIntegTest', 'forbiddenApisTestFixtures')
   jarHell.enabled = false
   thirdPartyAudit.enabled = false
-  if (Boolean.parseBoolean(System.getProperty("tests.fips.enabled"))) {
+  if (org.elasticsearch.gradle.info.BuildParams.inFipsJvm) {
+    // We don't support running gradle with a JVM that is in FIPS 140 mode, so we don't test it.
+    // WaitForHttpResourceTests tests would fail as they use JKS/PKCS12 keystores
     test.enabled = false
+    testingConventions.enabled = false
   }
 
   configurations {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disable testingConventions in build tools in fips (#57357)