### PR TITLE
Adjust version after backports

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -182,7 +182,7 @@ public class Annotation implements ToXContentObject, Writeable {
         }
         modifiedUsername = in.readOptionalString();
         type = Type.fromString(in.readString());
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
             event = in.readBoolean() ? in.readEnum(Event.class) : null;
             detectorIndex = in.readOptionalInt();
             partitionFieldName = in.readOptionalString();
@@ -224,7 +224,7 @@ public class Annotation implements ToXContentObject, Writeable {
         }
         out.writeOptionalString(modifiedUsername);
         out.writeString(type.toString());
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             if (event != null) {
                 out.writeBoolean(true);
                 out.writeEnum(event);


### PR DESCRIPTION
This PR changes BWC version for the new fields in class `Annotation`.
The fields were introduced in PRs https://github.com/elastic/elasticsearch/pull/56417 and https://github.com/elastic/elasticsearch/pull/57144 which have already been backported to 7.9
