### PR TITLE
Remove version check after backport

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.job.results;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -127,12 +126,8 @@ public class AutodetectResult implements ToXContentObject, Writeable {
         } else {
             this.modelPlot = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
-            if (in.readBoolean()) {
-                this.annotation = new Annotation(in);
-            } else {
-                this.annotation = null;
-            }
+        if (in.readBoolean()) {
+            this.annotation = new Annotation(in);
         } else {
             this.annotation = null;
         }
@@ -168,9 +163,7 @@ public class AutodetectResult implements ToXContentObject, Writeable {
         writeNullable(modelSnapshot, out);
         writeNullable(modelSizeStats, out);
         writeNullable(modelPlot, out);
-        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
-            writeNullable(annotation, out);
-        }
+        writeNullable(annotation, out);
         writeNullable(categoryDefinition, out);
         writeNullable(flushAcknowledgement, out);
         writeNullable(forecast, out);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/results/AutodetectResult.java
@@ -127,7 +127,7 @@ public class AutodetectResult implements ToXContentObject, Writeable {
         } else {
             this.modelPlot = null;
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
             if (in.readBoolean()) {
                 this.annotation = new Annotation(in);
             } else {
@@ -168,7 +168,7 @@ public class AutodetectResult implements ToXContentObject, Writeable {
         writeNullable(modelSnapshot, out);
         writeNullable(modelSizeStats, out);
         writeNullable(modelPlot, out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             writeNullable(annotation, out);
         }
         writeNullable(categoryDefinition, out);


### PR DESCRIPTION
This PR removes BWC version check for the new field in class `AnnotationResult`.
The field was introduced in PR https://github.com/elastic/elasticsearch/pull/56342 which has already been backported to 7.9