### PR TITLE
Remove more //NORELEASE tags in searchable snapshots codebase

### DIFF
--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -113,6 +113,11 @@ public class URLBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -106,6 +106,11 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
         store.execute((Operation<Void>) fileContext -> {
             Path blob = new Path(path, blobName);

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -61,9 +61,7 @@ public interface BlobContainer {
      * @throws NoSuchFileException if the blob does not exist
      * @throws IOException         if the blob can not be read.
      */
-    default InputStream readBlob(final String blobName, final long position, final long length) throws IOException {
-        throw new UnsupportedOperationException(); // NORELEASE
-    }
+    InputStream readBlob(String blobName, long position, long length) throws IOException;
 
     /**
      * Provides a hint to clients for a suitable length to use with {@link BlobContainer#readBlob(String, long, long)}.

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepository.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.DeleteResult;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -203,6 +204,15 @@ public class MockEventuallyConsistentRepository extends BlobStoreRepository {
                     }
                     throw new AssertionError("Inconsistent read on [" + blobPath + ']');
                 }
+            }
+
+            @Override
+            public InputStream readBlob(String blobName, long position, long length) throws IOException {
+                final InputStream stream = readBlob(blobName);
+                if (position > 0) {
+                    stream.skip(position);
+                }
+                return Streams.limitStream(stream, length);
             }
 
             private List<BlobStoreAction> relevantActions(String blobPath) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/BaseSearchableSnapshotIndexInput.java
@@ -139,10 +139,6 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
             // Cache prewarming runs on a dedicated thread pool.
             || threadName.contains('[' + SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOTS_THREAD_POOL_NAME + ']')
 
-            // Today processExistingRecoveries considers all shards and constructs a shard store snapshot on this thread, this needs
-            // addressing. TODO NORELEASE
-            || threadName.contains('[' + ThreadPool.Names.FETCH_SHARD_STORE + ']')
-
             // Unit tests access the blob store on the main test thread; simplest just to permit this rather than have them override this
             // method somehow.
             || threadName.startsWith("TEST-")

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -154,9 +154,10 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
             }
             final SnapshotId snapshotId = matchingSnapshotId.get();
 
+            // TODO validate IDs in the restore:
             // We must fail the restore if it obtains different IDs from the ones we just obtained (e.g. the target snapshot was replaced
             // by one with the same name while we are restoring it) or else the index metadata might bear no relation to the snapshot we're
-            // searching. TODO NORELEASE validate IDs in the restore.
+            // searching.
 
             client.admin()
                 .cluster()

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/TestUtils.java
@@ -158,6 +158,11 @@ public final class TestUtils {
         }
 
         @Override
+        public InputStream readBlob(String blobName, long position, long length) throws IOException {
+            throw unsupportedException();
+        }
+
+        @Override
         public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) {
             throw unsupportedException();
         }


### PR DESCRIPTION
We agreed on removing the following `//NORELEASE`  tags.