### PR TITLE
[DOCS] EQL: Add `dev` admonition to EQL pages

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>EQL search</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 

--- a/docs/reference/eql/functions.asciidoc
+++ b/docs/reference/eql/functions.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Function reference</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 {es} supports the following EQL functions:
 

--- a/docs/reference/eql/index.asciidoc
+++ b/docs/reference/eql/index.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>EQL</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 {eql-ref}/index.html[Event Query Language (EQL)] is a query language used for
 logs and other event-based data.

--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Limitations</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 [discrete]
 [[eql-nested-fields]]

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Requirements</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 EQL is schema-less and works well with most common log formats.
 

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -3,7 +3,7 @@
 [[eql-search]]
 == Run an EQL search
 
-experimental::[]
+dev::[]
 
 To start using EQL in {es}, first ensure your event data meets
 <<eql-requirements,EQL requirements>>. You can then use the <<eql-search-api,EQL

--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Syntax reference</titleabbrev>
 ++++
 
-experimental::[]
+dev::[]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Adds the `dev` admonition to EQL features, which are in development
under a feature flag.