### PR TITLE
[ML] inference performance optimizations

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.ml.utils.ToXContentParams;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -606,6 +607,14 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
             }
             if (input != null && input.getFieldNames().isEmpty()) {
                 validationException = addValidationError("[input.field_names] must not be empty", validationException);
+            }
+            if (input != null && input.getFieldNames()
+                .stream()
+                .filter(s -> s.contains("."))
+                .flatMap(s -> Arrays.stream(Strings.delimitedListToStringArray(s, ".")))
+                .anyMatch(String::isEmpty)) {
+                validationException = addValidationError("[input.field_names] must only contain valid dot delimited field names",
+                    validationException);
             }
             if (forCreation) {
                 validationException = checkIllegalSetting(version, VERSION.getPreferredName(), validationException);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -109,7 +108,7 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
 
     @Override
     public void process(Map<String, Object> fields) {
-        Object value = MapHelper.dig(field, fields);
+        Object value = fields.get(field);
         if (value == null) {
             return;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -94,7 +93,7 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
 
     @Override
     public void process(Map<String, Object> fields) {
-        Object value = MapHelper.dig(field, fields);
+        Object value = fields.get(field);
         if (value == null) {
             return;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -120,7 +119,7 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
 
     @Override
     public void process(Map<String, Object> fields) {
-        Object value = MapHelper.dig(field, fields);
+        Object value = fields.get(field);
         if (value == null) {
             return;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TrainedModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TrainedModel.java
@@ -31,6 +31,25 @@ public interface TrainedModel extends NamedXContentObject, NamedWriteable, Accou
     InferenceResults infer(Map<String, Object> fields, InferenceConfig config, @Nullable Map<String, String> featureDecoderMap);
 
     /**
+     * Same as {@link TrainedModel#infer(Map, InferenceConfig, Map)} but the features are already extracted.
+     */
+    InferenceResults infer(double[] features, InferenceConfig config);
+
+    /**
+     * This optimizes the model for inference.
+     *
+     * WARNING: Some models may not be serializable after being optimized
+     * @param isTopLevelModel Indicates if this model is nested under another model
+     * @param newFeatureIndexMapping New feature index mapping so that features can be extracted by a parent model
+     */
+    void optimizeForInference(boolean isTopLevelModel, Map<String, Integer> newFeatureIndexMapping);
+
+    /**
+     * @return The feature names in their desired order
+     */
+    String[] getFeatureNames();
+
+    /**
      * @return {@link TargetType} for the model.
      */
     TargetType targetType();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/langident/LangIdentNeuralNetwork.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/langident/LangIdentNeuralNetwork.java
@@ -149,6 +149,23 @@ public class LangIdentNeuralNetwork implements StrictlyParsedTrainedModel, Lenie
     }
 
     @Override
+    public InferenceResults infer(double[] embeddedVector, InferenceConfig config) {
+        throw new UnsupportedOperationException("[lang_ident] does not support nested inference");
+    }
+
+    @Override
+    public void optimizeForInference(boolean isTopLevelModel, Map<String, Integer> newFeatureIndexMapping) {
+        if (isTopLevelModel == false) {
+            throw new UnsupportedOperationException("[lang_ident] does not support nested inference");
+        }
+    }
+
+    @Override
+    public String[] getFeatureNames() {
+        return new String[] {embeddedVectorFeatureName};
+    }
+
+    @Override
     public TargetType targetType() {
         return TargetType.CLASSIFICATION;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/TreeNode.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/TreeNode.java
@@ -73,7 +73,8 @@ public class TreeNode implements ToXContentObject, Writeable, Accountable {
 
     private final Operator operator;
     private final double threshold;
-    private final int splitFeature;
+    // Allowed to be adjusted for inference optimization
+    private int splitFeature;
     private final int nodeIndex;
     private final double splitGain;
     private final double[] leafValue;
@@ -81,7 +82,6 @@ public class TreeNode implements ToXContentObject, Writeable, Accountable {
     private final int leftChild;
     private final int rightChild;
     private final long numberSamples;
-
 
     private TreeNode(Operator operator,
                      Double threshold,
@@ -129,6 +129,10 @@ public class TreeNode implements ToXContentObject, Writeable, Accountable {
         }
     }
 
+    // Package private as Tree needs access
+    void setSplitFeature(int splitFeature) {
+        this.splitFeature = splitFeature;
+    }
 
     public Operator getOperator() {
         return operator;
@@ -174,19 +178,19 @@ public class TreeNode implements ToXContentObject, Writeable, Accountable {
         return numberSamples;
     }
 
-    public int compare(List<Double> features) {
+    public int compare(double[] features) {
         if (isLeaf()) {
             throw new IllegalArgumentException("cannot call compare against a leaf node.");
         }
-        Double feature = features.get(splitFeature);
+        double feature = features[splitFeature];
         if (isMissing(feature)) {
             return defaultLeft ? leftChild : rightChild;
         }
         return operator.test(feature, threshold) ? leftChild : rightChild;
     }
 
-    private boolean isMissing(Double feature) {
-        return feature == null;
+    private boolean isMissing(double feature) {
+        return Numbers.isValidDouble(feature) == false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/Statistics.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/utils/Statistics.java
@@ -7,8 +7,6 @@ package org.elasticsearch.xpack.core.ml.inference.utils;
 
 import org.elasticsearch.common.Numbers;
 
-import java.util.Arrays;
-
 public final class Statistics {
 
     private Statistics(){}
@@ -23,7 +21,12 @@ public final class Statistics {
      */
     public static double[] softMax(double[] values) {
         double expSum = 0.0;
-        double max = Arrays.stream(values).filter(Statistics::isValid).max().orElse(Double.NaN);
+        double max = Double.NEGATIVE_INFINITY;
+        for (double val : values) {
+            if (isValid(val)) {
+                max = Math.max(max, val);
+            }
+        }
         if (isValid(max) == false) {
             throw new IllegalArgumentException("no valid values present");
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MapHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MapHelper.java
@@ -6,8 +6,10 @@
 package org.elasticsearch.xpack.core.ml.utils;
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
 
-import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
@@ -57,23 +59,49 @@ public final class MapHelper {
      *
      * Instead we lazily create potential paths once we know that they are possibilities.
      *
-     * @param path Dot delimited path containing the field desired
+     * @param path Dot delimited path containing the field desired. Assumes that the path contains no empty strings
      * @param map The {@link Map} map to dig
      * @return The found object. Returns {@code null} if not found
      */
     @Nullable
     public static Object dig(String path, Map<String, Object> map) {
         // short cut before search
-        if (map.keySet().contains(path)) {
-            return map.get(path);
+        Object obj = map.get(path);
+        if (obj != null) {
+            return obj;
         }
-        String[] fields = path.split("\\.");
-        if (Arrays.stream(fields).anyMatch(String::isEmpty)) {
-            throw new IllegalArgumentException("Empty path detected. Invalid field name");
-        }
+        String[] fields = Strings.delimitedListToStringArray(path, ".");
         Stack<PotentialPath> pathStack = new Stack<>();
         pathStack.push(new PotentialPath(map, 0));
         return explore(fields, pathStack);
+    }
+
+    /**
+     * Collapses dot delimited fields so that the map is a single layer.
+     *
+     * Example:
+     * {
+     *     "a" :{"b": {"c": {"d" : 2}}}
+     * }
+     * becomes:
+     * {
+     *     "a.b.c.d": 2
+     * }
+     *
+     * @param map The map that has nested and/or collapsed paths
+     * @param pathsToCollapse The desired paths to collapse
+     * @return A fully collapsed map
+     */
+    public static Map<String, Object> dotCollapse(Map<String, Object> map, Collection<String> pathsToCollapse) {
+        // default load factor is 0.75 (3/4).
+        Map<String, Object> collapsed = new HashMap<>(((pathsToCollapse.size() * 4)/3) + 1);
+        for (String path : pathsToCollapse) {
+            Object dug = dig(path, map);
+            if (dug != null) {
+                collapsed.put(path, dug);
+            }
+        }
+        return collapsed;
     }
 
     @SuppressWarnings("unchecked")
@@ -95,8 +123,11 @@ public final class MapHelper {
                 }
                 endPos++;
             }
-            if (candidateKey != null && map.containsKey(candidateKey)) { //exit early
-                return map.get(candidateKey);
+            if (candidateKey != null) { // exit early
+                Object val = map.get(candidateKey);
+                if (val != null) {
+                    return val;
+                }
             }
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncodingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncodingTests.java
@@ -65,22 +65,4 @@ public class FrequencyEncodingTests extends PreProcessingTests<FrequencyEncoding
         testProcess(encoding, fieldValues, matchers);
     }
 
-    public void testProcessWithNestedField() {
-        String field = "categorical.child";
-        List<Object> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote", 1.5);
-        Map<String, Double> valueMap = values.stream().collect(Collectors.toMap(Object::toString,
-            v -> randomDoubleBetween(0.0, 1.0, false)));
-        String encodedFeatureName = "encoded";
-        FrequencyEncoding encoding = new FrequencyEncoding(field, encodedFeatureName, valueMap);
-
-        Map<String, Object> fieldValues = new HashMap<>() {{
-            put("categorical", new HashMap<>(){{
-                put("child", "farequote");
-            }});
-        }};
-
-        encoding.process(fieldValues);
-        assertThat(fieldValues.get("encoded"), equalTo(valueMap.get("farequote")));
-    }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncodingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncodingTests.java
@@ -67,19 +67,4 @@ public class OneHotEncodingTests extends PreProcessingTests<OneHotEncoding> {
         testProcess(encoding, fieldValues, matchers);
     }
 
-    public void testProcessWithNestedField() {
-        String field = "categorical.child";
-        List<Object> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote", 1.5);
-        Map<String, String> valueMap = values.stream().collect(Collectors.toMap(Object::toString, v -> "Column_" + v.toString()));
-        OneHotEncoding encoding = new OneHotEncoding(field, valueMap);
-        Map<String, Object> fieldValues = new HashMap<>() {{
-            put("categorical", new HashMap<>(){{
-                put("child", "farequote");
-            }});
-        }};
-
-        encoding.process(fieldValues);
-        assertThat(fieldValues.get("Column_farequote"), equalTo(1));
-    }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncodingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncodingTests.java
@@ -68,24 +68,4 @@ public class TargetMeanEncodingTests extends PreProcessingTests<TargetMeanEncodi
         testProcess(encoding, fieldValues, matchers);
     }
 
-    public void testProcessWithNestedField() {
-        String field = "categorical.child";
-        List<Object> values = Arrays.asList("foo", "bar", "foobar", "baz", "farequote", 1.5);
-        Map<String, Double> valueMap = values.stream().collect(Collectors.toMap(Object::toString,
-            v -> randomDoubleBetween(0.0, 1.0, false)));
-        String encodedFeatureName = "encoded";
-        Double defaultvalue = randomDouble();
-        TargetMeanEncoding encoding = new TargetMeanEncoding(field, encodedFeatureName, valueMap, defaultvalue);
-
-        Map<String, Object> fieldValues = new HashMap<>() {{
-            put("categorical", new HashMap<>(){{
-                put("child", "farequote");
-            }});
-        }};
-
-        encoding.process(fieldValues);
-
-        assertThat(fieldValues.get("encoded"), equalTo(valueMap.get("farequote")));
-    }
-
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/OptimizableModelTestsUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/OptimizableModelTestsUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
+
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomDouble;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class OptimizableModelTestsUtils {
+
+    private OptimizableModelTestsUtils() {}
+
+    public static void testModelOptimization(BiFunction<TargetType, List<String>, TrainedModel> modelProvider, int numberOfRuns) {
+        for (int i = 0; i < numberOfRuns; ++i) {
+            TargetType targetType = TargetType.REGRESSION;
+            int numberOfFeatures = randomIntBetween(2, 10);
+            List<String> featureNames = Stream.generate(
+                () -> randomAlphaOfLength(10)).limit(numberOfFeatures).collect(Collectors.toList());
+            TrainedModel model = modelProvider.apply(targetType, featureNames);
+
+            InferenceConfig config = RegressionConfig.EMPTY_PARAMS;
+            Map<String, Object> fields = randomStringDoubleMap(featureNames);
+            InferenceResults unoptimizedResults = model.infer(fields, config, Collections.emptyMap());
+            model.optimizeForInference(true, Collections.emptyMap());
+            InferenceResults optimizedResults = model.infer(fields, config, Collections.emptyMap());
+            assertThat(unoptimizedResults, equalTo(optimizedResults));
+        }
+    }
+
+    public static void testModelOptimizationsNotTopLevel(BiFunction<TargetType, List<String>, TrainedModel> modelProvider,
+                                                         int numberOfRuns) {
+        for (int i = 0; i < numberOfRuns; ++i) {
+            TargetType targetType = TargetType.REGRESSION;
+            int numberOfFeatures = randomIntBetween(2, 10);
+            List<String> featureNames = Stream.generate(
+                () -> randomAlphaOfLength(10)).limit(numberOfFeatures).collect(Collectors.toList());
+            TrainedModel model = modelProvider.apply(targetType, featureNames);
+
+            InferenceConfig config = RegressionConfig.EMPTY_PARAMS;
+
+            Map<String, Object> fields = randomStringDoubleMap(featureNames);
+            int fieldIndex = 0;
+            Map<String, Integer> fieldIndices = new HashMap<>();
+            double[] fieldValues = new double[fields.size()];
+            for (Map.Entry<String, Object> field : fields.entrySet()) {
+                fieldIndices.put(field.getKey(), fieldIndex);
+                fieldValues[fieldIndex++] = InferenceHelpers.toDouble(field.getValue());
+            }
+            InferenceResults unoptimizedResults = model.infer(fields, config, Collections.emptyMap());
+            model.optimizeForInference(false, fieldIndices);
+            InferenceResults optimizedResults = model.infer(fieldValues, config);
+            assertThat(unoptimizedResults, equalTo(optimizedResults));
+        }
+    }
+
+    public static Map<String, Object> randomStringDoubleMap(List<String> keys) {
+        return keys.stream().collect(Collectors.toMap(Function.identity(), (v) -> randomDouble()));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/TreeNodeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/TreeNodeTests.java
@@ -12,9 +12,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Operator;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -85,9 +83,9 @@ public class TreeNodeTests extends AbstractSerializingTestCase<TreeNode> {
 
     public void testCompare() {
         expectThrows(IllegalArgumentException.class,
-            () -> createRandomLeafNode(randomDouble()).compare(Collections.singletonList(randomDouble())));
+            () -> createRandomLeafNode(randomDouble()).compare(new double[]{randomDouble()}));
 
-        List<Double> featureValues = Arrays.asList(0.1, null);
+        double[] featureValues = new double[]{0.1, Double.NaN};
         assertThat(createRandom(0, 2, 3, 0.0, 0, null).build().compare(featureValues),
             equalTo(3));
         assertThat(createRandom(0, 2, 3, 0.0, 0, Operator.GT).build().compare(featureValues),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MapHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MapHelperTests.java
@@ -7,16 +7,38 @@ package org.elasticsearch.xpack.core.ml.utils;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class MapHelperTests extends ESTestCase {
+
+    public void testCollapseFields() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("a", Collections.singletonMap("b.c", 1));
+        map.put("d", Collections.singletonMap("e", Collections.singletonMap("f", 2)));
+        map.put("g.h.i", 3);
+        {
+           assertThat(MapHelper.dotCollapse(map, Collections.emptyList()), is(anEmptyMap()));
+        }
+        {
+            Map<String, Object> collapsed = MapHelper.dotCollapse(map, Arrays.asList("a.b.c", "d.e.f", "g.h.i", "m.i.s.s.i.n.g"));
+            assertThat(collapsed, hasEntry("a.b.c", 1));
+            assertThat(collapsed, hasEntry("d.e.f", 2));
+            assertThat(collapsed, hasEntry("g.h.i", 3));
+            assertThat(collapsed, not(hasKey("m.i.s.s.i.n.g")));
+        }
+    }
 
     public void testAbsolutePathStringAsKey() {
         String path = "a.b.c.d";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResu
 import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 import org.elasticsearch.xpack.ml.inference.TrainedModelStatsService;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -61,6 +62,10 @@ public class LocalModel implements Model {
 
     long ramBytesUsed() {
         return trainedModelDefinition.ramBytesUsed();
+    }
+
+    void optimizeForInference() {
+        trainedModelDefinition.getTrainedModel().optimizeForInference(true, Collections.emptyMap());
     }
 
     @Override
@@ -111,10 +116,12 @@ public class LocalModel implements Model {
             statsAccumulator.incInference();
             currentInferenceCount.increment();
 
+            // Needs to happen before collapse as defaultFieldMap might resolve fields to their appropriate name
             Model.mapFieldsIfNecessary(fields, defaultFieldMap);
 
+            Map<String, Object> flattenedFields = MapHelper.dotCollapse(fields, fieldNames);
             boolean shouldPersistStats = ((currentInferenceCount.sum() + 1) % persistenceQuotient == 0);
-            if (fieldNames.stream().allMatch(f -> MapHelper.dig(f, fields) == null)) {
+            if (flattenedFields.isEmpty()) {
                 statsAccumulator.incMissingFields();
                 if (shouldPersistStats) {
                     persistStats(false);
@@ -122,7 +129,7 @@ public class LocalModel implements Model {
                 listener.onResponse(new WarningInferenceResults(Messages.getMessage(INFERENCE_WARNING_ALL_FIELDS_MISSING, modelId)));
                 return;
             }
-            InferenceResults inferenceResults = trainedModelDefinition.infer(fields, update.apply(inferenceConfig));
+            InferenceResults inferenceResults = trainedModelDefinition.infer(flattenedFields, update.apply(inferenceConfig));
             if (shouldPersistStats) {
                 persistStats(false);
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -232,6 +232,7 @@ public class ModelLoadingService implements ClusterStateListener {
             trainedModelConfig.getDefaultFieldMap(),
             inferenceConfig,
             modelStatsService);
+        loadedModel.optimizeForInference();
         synchronized (loadingListeners) {
             listeners = loadingListeners.remove(modelId);
             // If there is no loadingListener that means the loading was canceled and the listener was already notified as such

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.ml.inference.TrainedModelStatsService;
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
@@ -373,6 +374,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
     private void withTrainedModel(String modelId, long size) throws IOException {
         TrainedModelDefinition definition = mock(TrainedModelDefinition.class);
         when(definition.ramBytesUsed()).thenReturn(size);
+        TrainedModel model = mock(TrainedModel.class);
+        doAnswer((i) -> null).when(model).optimizeForInference(anyBoolean(), any());
+        when(definition.getTrainedModel()).thenReturn(model);
         TrainedModelConfig trainedModelConfig = mock(TrainedModelConfig.class);
         when(trainedModelConfig.getModelDefinition()).thenReturn(definition);
         when(trainedModelConfig.getModelId()).thenReturn(modelId);


### PR DESCRIPTION
This optimizes performance for inference models in the following ways:

 - When a model is loaded by the model loading service, feature extraction now only takes place at the top level model (most cases, the ensemble)
 - Flattens out the field map before feature extraction. This allows us to only "dig" the desired fields only once.
 - changes some data structures to be actual arrays instead of unmodifiable lists

All this significantly reduces runtime along with some minor memory improvements.