### PR TITLE
[7.7] Ensure default watches are updated for rolling upgrades. (#57185)

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -21,6 +21,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.sniff.ElasticsearchNodesSniffer;
 import org.elasticsearch.client.sniff.Sniffer;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -414,7 +415,7 @@ public class HttpExporter extends Exporter {
     private static final ConcurrentHashMap<String, SecureString> SECURE_AUTH_PASSWORDS = new ConcurrentHashMap<>();
     private final ThreadContext threadContext;
     private final DateFormatter dateTimeFormatter;
-
+    private final ClusterStateListener onLocalMasterListener;
     /**
      * Create an {@link HttpExporter}.
      *
@@ -475,6 +476,14 @@ public class HttpExporter extends Exporter {
 
         // mark resources as dirty after any node failure or license change
         listener.setResource(resource);
+
+        //for a mixed cluster upgrade, ensure that if master changes and this is the master, allow the resources to re-publish
+        onLocalMasterListener = clusterChangedEvent -> {
+            if (clusterChangedEvent.nodesDelta().masterNodeChanged() && clusterChangedEvent.localNodeMaster()) {
+                resource.markDirty();
+            }
+        };
+        config.clusterService().addListener(onLocalMasterListener);
     }
 
     /**
@@ -934,9 +943,11 @@ public class HttpExporter extends Exporter {
     @Override
     public void doClose() {
         try {
+            config.clusterService().removeListener(onLocalMasterListener);
             if (sniffer != null) {
                 sniffer.close();
             }
+
         } catch (Exception e) {
             logger.error("an error occurred while closing the internal client sniffer", e);
         } finally {


### PR DESCRIPTION
Backports the following commits to 7.7:
 - Ensure default watches are updated for rolling upgrades. (#57185)