### PR TITLE
Increase timeout for GlobalCheckpointSyncIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -207,7 +207,7 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
                 }
             }
         }, 60, TimeUnit.SECONDS);
-
+        ensureGreen("test");
         for (final Thread thread : threads) {
             thread.join();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -19,10 +19,6 @@
 
 package org.elasticsearch.index.seqno;
 
-import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
-import org.elasticsearch.action.admin.indices.stats.IndexStats;
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
-import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -43,7 +39,6 @@ import org.elasticsearch.transport.TransportService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -200,28 +195,18 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
         afterIndexing.accept(client());
 
         assertBusy(() -> {
-            final IndicesStatsResponse stats = client().admin().indices().prepareStats().clear().get();
-            final IndexStats indexStats = stats.getIndex("test");
-            for (final IndexShardStats indexShardStats : indexStats.getIndexShards().values()) {
-                Optional<ShardStats> maybePrimary =
-                        Stream.of(indexShardStats.getShards())
-                                .filter(s -> s.getShardRouting().active() && s.getShardRouting().primary())
-                                .findFirst();
-                if (!maybePrimary.isPresent()) {
-                    continue;
-                }
-                final ShardStats primary = maybePrimary.get();
-                final SeqNoStats primarySeqNoStats = primary.getSeqNoStats();
-                for (final ShardStats shardStats : indexShardStats) {
-                    final SeqNoStats seqNoStats = shardStats.getSeqNoStats();
-                    if (seqNoStats == null) {
-                        // the shard is initializing
-                        continue;
+            for (IndicesService indicesService : internalCluster().getDataNodeInstances(IndicesService.class)) {
+                for (IndexService indexService : indicesService) {
+                    for (IndexShard shard : indexService) {
+                        if (shard.routingEntry().primary()) {
+                            final SeqNoStats seqNoStats = shard.seqNoStats();
+                            assertThat("shard " + shard.routingEntry() + " seq_no [" + seqNoStats + "]",
+                                seqNoStats.getGlobalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
+                        }
                     }
-                    assertThat(seqNoStats.getGlobalCheckpoint(), equalTo(primarySeqNoStats.getGlobalCheckpoint()));
                 }
             }
-        }, 30, TimeUnit.SECONDS);
+        }, 60, TimeUnit.SECONDS);
 
         for (final Thread thread : threads) {
             thread.join();


### PR DESCRIPTION
The test failed when it was running with 4 replicas and 3 indexing threads. The recovering replicas can prevent the global checkpoint from advancing. This commit increases the timeout to 60 seconds for this suite and the check for no inflight requests.

Closes #57204
