### PR TITLE
Mute EmailSslTests test case in fips

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailSslTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailSslTests.java
@@ -149,8 +149,8 @@ public class EmailSslTests extends ESTestCase {
      * over the account level "smtp.ssl.trust" setting) but smtp.ssl.trust was ignored for a period of time (see #52153)
      * so this is the least breaking way to resolve that.
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/49094")
     public void testNotificationSslSettingsOverrideSmtpSslTrust() throws Exception {
-        assumeFalse("BouncyCastle FIPS provider throws an org.bouncycastle.tls.TLSFatalAlert instead of an SSLException", inFipsJvm());
         List<MimeMessage> messages = new ArrayList<>();
         server.addListener(messages::add);
         try {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailSslTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/actions/email/EmailSslTests.java
@@ -145,11 +145,12 @@ public class EmailSslTests extends ESTestCase {
     }
 
     /**
-     * This orderining could be considered to be backwards (the global "notification" settings take precedence
+     * This ordering could be considered to be backwards (the global "notification" settings take precedence
      * over the account level "smtp.ssl.trust" setting) but smtp.ssl.trust was ignored for a period of time (see #52153)
      * so this is the least breaking way to resolve that.
      */
     public void testNotificationSslSettingsOverrideSmtpSslTrust() throws Exception {
+        assumeFalse("BouncyCastle FIPS provider throws an org.bouncycastle.tls.TLSFatalAlert instead of an SSLException", inFipsJvm());
         List<MimeMessage> messages = new ArrayList<>();
         server.addListener(messages::add);
         try {


### PR DESCRIPTION
We test expected TLS failures by catching SSLException, but other
security providers ( i.e. BCFIPS ) might throw a different one. In
this case, BCFIPS throws org.bouncycastle.tls.TlsFatalAlert

The test was introduced recently in #56090. We are tracking this
test issue already in #49094