### PR TITLE
[DOCS] Add 7.8 release notes entry for #55858

### DIFF
--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -14,7 +14,5 @@ Search::
   {pull}54854[#54854]
 
 Features/Indices APIs::
-*  Add auto create action that the bulk action redirects to when new indices
-   need to be auto created. This means that action name `indices:admin/create`
-   can no longer be used as privilege to allow auto creation of indices and
-   instead `create_index` built in privilege should be used. {pull}55858[#55858]
+*  The privilege named `indices:admin/create` will no longer allow the auto 
+   creation of indices.  Use `create_index` instead. {pull}55858[#55858]

--- a/docs/reference/release-notes/7.8.asciidoc
+++ b/docs/reference/release-notes/7.8.asciidoc
@@ -12,3 +12,9 @@ Search::
   a numeric field and a `GeoPoint` if they are counting a `geo_point` fields.
   They used to always receive the `String` representation of those values.
   {pull}54854[#54854]
+
+Features/Indices APIs::
+*  Add auto create action that the bulk action redirects to when new indices
+   need to be auto created. This means that action name `indices:admin/create`
+   can no longer be used as privilege to allow auto creation of indices and
+   instead `create_index` built in privilege should be used. {pull}55858[#55858]


### PR DESCRIPTION
The create index action name (`indices:admin/create`) can no longer be used to grant privileges to auto create indices and
instead the `create_index` builtin privilege should be used.