### PR TITLE
SQL: Use java String methods for LTRIM/RTRIM

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/string-functions.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/string-functions.sql-spec
@@ -70,11 +70,8 @@ SELECT LEFT('Elasticsearch', LENGTH('abcdefghijklmnop')) leftchars;
 ltrimFilter
 SELECT LTRIM(first_name) lt FROM "test_emp" WHERE LTRIM(first_name) = 'Bob';
 
-ltrimInline1
-SELECT LTRIM('   Elastic   ') trimmed;
-
-ltrimInline2
-SELECT LTRIM('             ') trimmed;
+ltrimInline
+SELECT LTRIM('   Elastic   ') lt1, LTRIM('             ') lt2;
 
 locateInline1
 SELECT LOCATE('a', 'Elasticsearch', 8) location;
@@ -127,11 +124,8 @@ SELECT LTRIM("first_name") lt FROM "test_emp" WHERE LTRIM("first_name") LIKE '%a
 rtrimFilter
 SELECT RTRIM(first_name) rt FROM "test_emp" WHERE RTRIM(first_name) = 'Johnny';
 
-rtrimInline1
-SELECT RTRIM('   Elastic   ') trimmed;
-
-rtrimInline2
-SELECT RTRIM('             ') trimmed;
+rtrimInline
+SELECT RTRIM('   Elastic   ') rt1, RTRIM('             ') rt2;
 
 spaceFilter
 SELECT SPACE(languages) spaces, languages FROM "test_emp" WHERE SPACE(languages) = '   ';

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringFunctionUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringFunctionUtils.java
@@ -34,42 +34,4 @@ final class StringFunctionUtils {
         
         return (start + length > s.length()) ? s.substring(start) : s.substring(start, start + length);
     }
-
-    /**
-     * Trims the trailing whitespace characters from the given String. Uses {@link Character#isWhitespace(char)}
-     * to determine if a character is whitespace or not.
-     *
-     * @param s       the original String
-     * @return the resulting String
-     */
-    static String trimTrailingWhitespaces(String s) {
-        if (hasLength(s) == false) {
-            return s;
-        }
-
-        StringBuilder sb = new StringBuilder(s);
-        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1))) {
-            sb.deleteCharAt(sb.length() - 1);
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Trims the leading whitespace characters from the given String. Uses {@link Character#isWhitespace(char)}
-     * to determine if a character is whitespace or not.
-     *
-     * @param s       the original String
-     * @return the resulting String
-     */
-    static String trimLeadingWhitespaces(String s) {
-        if (hasLength(s) == false) {
-            return s;
-        }
-
-        StringBuilder sb = new StringBuilder(s);
-        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(0))) {
-            sb.deleteCharAt(0);
-        }
-        return sb.toString();
-    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringProcessor.java
@@ -50,9 +50,9 @@ public class StringProcessor implements Processor {
         }),
         LCASE((String s) -> s.toLowerCase(Locale.ROOT)),
         UCASE((String s) -> s.toUpperCase(Locale.ROOT)),
-        LENGTH((String s) -> StringFunctionUtils.trimTrailingWhitespaces(s).length()),
-        RTRIM((String s) -> StringFunctionUtils.trimTrailingWhitespaces(s)),
-        LTRIM((String s) -> StringFunctionUtils.trimLeadingWhitespaces(s)),
+        LENGTH((String s) -> s.stripTrailing().length()),
+        RTRIM(String::stripTrailing),
+        LTRIM(String::stripLeading),
         TRIM(String::trim),
         SPACE((Number n) -> {
             int i = n.intValue();

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringFunctionProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/string/StringFunctionProcessorTests.java
@@ -134,10 +134,10 @@ public class StringFunctionProcessorTests extends AbstractWireSerializingTestCas
         StringProcessor proc = new StringProcessor(StringOperation.LENGTH);
         assertNull(proc.process(null));
         assertEquals(7, proc.process("foo bar"));
-        assertEquals(0, proc.process(""));
-        assertEquals(0, proc.process("    "));
-        assertEquals(7, proc.process("foo bar   "));
-        assertEquals(10, proc.process("   foo bar   "));
+        assertEquals(0, proc.process(withRandomWhitespaces(" \t  \r\n \n ", true, true)));
+        assertEquals(0, proc.process(withRandomWhitespaces("    ", true, true)));
+        assertEquals(7, proc.process(withRandomWhitespaces("foo bar", false, true)));
+        assertEquals(10, proc.process(withRandomWhitespaces("   foo bar   ", false, true)));
         assertEquals(1, proc.process('f'));
 
         stringCharInputValidation(proc);


### PR DESCRIPTION
Previously, we had our own implementation for stripping leading and
trailing whitespaces which substantially less performant than the java's
String stripLeading & stripTrailingMethods:

```
Benchmark                         Mode  Cnt      Score     Error  Units
StringTrim.testWithJavaStrip      avgt   25   1186.120 ±  10.374  ns/op
StringTrim.testWithStringBuilder  avgt   25  82547.575 ±  66.244  ns/op
```

Enhance LENGTH unit tests and combine a couple of LTRIM/RTRIM 
integ tests.
