### PR TITLE
[DOCS] Add safeguard directory attributes

### DIFF
--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -6,6 +6,8 @@
 :plugins-examples-dir:  {elasticsearch-root}/plugins/examples
 :xes-repo-dir:          {elasticsearch-root}/x-pack/docs/{lang}
 :es-repo-dir:           {elasticsearch-root}/docs/reference
+:docdir:                {es-repo-dir}
+:asciidoc-dir:          {es-repo-dir}
 
 
 include::../Versions.asciidoc[]


### PR DESCRIPTION
PRs #57390 and #57489 swapped all instances of the `{docdir}` and
`{asciidoc-dir}` attributes to `{es-repo-dir}`. Using `{es-repo-dir}`
exclusively prevents issues when content from the ES refernce is reused
in other doc books.

This adds related safeguard attributes, which fall back to `{es-repo-dir}`. This
should curb future problems if a contributor accidentally uses `{docdir}` or
`{asciidoc-dir}`.