### PR TITLE
[DOCS] Changes parameter order in model_plot_config

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -243,6 +243,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config]
 .Properties of `model_plot_config`
 [%collapsible%open]
 ====
+`annotations_enabled`:::
+(boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-annotations-enabled]
+
 `enabled`:::
 (boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
@@ -250,10 +254,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 `terms`:::
 experimental[] (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
-
-`annotations_enabled`:::
-(boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-annotations-enabled]
 ====
 //End model_plot_config
 

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -180,6 +180,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config]
 .Properties of `model_plot_config`
 [%collapsible%open]
 ====
+`annotations_enabled`:::
+(boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-annotations-enabled]
+
 `enabled`:::
 (boolean)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
@@ -187,10 +191,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-enabled]
 `terms`:::
 experimental[] (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-terms]
-
-`annotations_enabled`:::
-(boolean)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-plot-config-annotations-enabled]
 ====
 //End model_plot_config
 


### PR DESCRIPTION
## Overview

This PR applies a minor change in the order of the parameters of `model_plot_config` to keep alphabetical order.

### Preview

[PUT AD job API](https://elasticsearch_57642.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-put-job.html)
[Update AD job API](https://elasticsearch_57642.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-update-job.html)
