### PR TITLE
[7.8] [ML] fix setting forecasts to failed method (#57654)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1310,7 +1310,7 @@ public class JobResultsProvider {
             .setScript(new Script("ctx._source.forecast_status='failed';" +
                 "ctx._source.forecast_messages=['" + JOB_FORECAST_NATIVE_PROCESS_KILLED + "']"));
 
-        client.execute(UpdateByQueryAction.INSTANCE, request, ActionListener.wrap(
+        executeAsyncWithOrigin(client, ML_ORIGIN, UpdateByQueryAction.INSTANCE, request, ActionListener.wrap(
             response -> {
                 LOGGER.info("[{}] set [{}] forecasts to failed", jobId, response.getUpdated());
                 if (response.getBulkFailures().size() > 0) {


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [ML] fix setting forecasts to failed method (#57654)