### PR TITLE
Restore ThreadContext after Serializing OutboundMessage

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
@@ -40,32 +40,35 @@ abstract class OutboundMessage extends NetworkMessage {
     }
 
     BytesReference serialize(BytesStreamOutput bytesStream) throws IOException {
-        storedContext.restore();
-        bytesStream.setVersion(version);
-        bytesStream.skip(TcpHeader.headerSize(version));
+        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+            storedContext.restore();
+            bytesStream.setVersion(version);
+            bytesStream.skip(TcpHeader.headerSize(version));
 
-        // The compressible bytes stream will not close the underlying bytes stream
-        BytesReference reference;
-        int variableHeaderLength = -1;
-        final long preHeaderPosition = bytesStream.position();
+            // The compressible bytes stream will not close the underlying bytes stream
+            BytesReference reference;
+            int variableHeaderLength = -1;
+            final long preHeaderPosition = bytesStream.position();
 
-        if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
-            writeVariableHeader(bytesStream);
-            variableHeaderLength = Math.toIntExact(bytesStream.position() - preHeaderPosition);
-        }
-
-        try (CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bytesStream, TransportStatus.isCompress(status))) {
-            stream.setVersion(version);
-            if (variableHeaderLength == -1) {
-                writeVariableHeader(stream);
+            if (version.onOrAfter(TcpHeader.VERSION_WITH_HEADER_SIZE)) {
+                writeVariableHeader(bytesStream);
+                variableHeaderLength = Math.toIntExact(bytesStream.position() - preHeaderPosition);
             }
-            reference = writeMessage(stream);
-        }
 
-        bytesStream.seek(0);
-        final int contentSize = reference.length() - TcpHeader.headerSize(version);
-        TcpHeader.writeHeader(bytesStream, requestId, status, version, contentSize, variableHeaderLength);
-        return reference;
+            try (CompressibleBytesOutputStream stream =
+                     new CompressibleBytesOutputStream(bytesStream, TransportStatus.isCompress(status))) {
+                stream.setVersion(version);
+                if (variableHeaderLength == -1) {
+                    writeVariableHeader(stream);
+                }
+                reference = writeMessage(stream);
+            }
+
+            bytesStream.seek(0);
+            final int contentSize = reference.length() - TcpHeader.headerSize(version);
+            TcpHeader.writeHeader(bytesStream, requestId, status, version, contentSize, variableHeaderLength);
+            return reference;
+        }
     }
 
     protected void writeVariableHeader(StreamOutput stream) throws IOException {


### PR DESCRIPTION
Stash the current context before restoring the stored context on the IO thread
so that its thread context does not get polluted.

Closes #57554
