### PR TITLE
Disable testing conventions for idp in fips

### DIFF
--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -370,4 +370,6 @@ gradle.projectsEvaluated {
 if (BuildParams.inFipsJvm) {
   // We don't support the IDP in FIPS-140 mode, so no need to run tests
   test.enabled = false
+  // We run neither integTests nor unit tests in FIPS-140 mode
+  testingConventions.enabled = false
 }


### PR DESCRIPTION
Since we disable both integTest and test tasks. This should have
been part of #57048 but we missed it.

Similar to #57357