### PR TITLE
Remove version check after backport 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.core.ml.job.config;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -56,20 +55,14 @@ public class ModelPlotConfig implements ToXContentObject, Writeable {
     public ModelPlotConfig(StreamInput in) throws IOException {
         enabled = in.readBoolean();
         terms = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
-            annotationsEnabled = in.readBoolean();
-        } else {
-            annotationsEnabled = enabled;
-        }
+        annotationsEnabled = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(enabled);
         out.writeOptionalString(terms);
-        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
-            out.writeBoolean(annotationsEnabled);
-        }
+        out.writeBoolean(annotationsEnabled);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
@@ -56,7 +56,7 @@ public class ModelPlotConfig implements ToXContentObject, Writeable {
     public ModelPlotConfig(StreamInput in) throws IOException {
         enabled = in.readBoolean();
         terms = in.readOptionalString();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
             annotationsEnabled = in.readBoolean();
         } else {
             annotationsEnabled = enabled;
@@ -67,7 +67,7 @@ public class ModelPlotConfig implements ToXContentObject, Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(enabled);
         out.writeOptionalString(terms);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             out.writeBoolean(annotationsEnabled);
         }
     }


### PR DESCRIPTION
This PR removes BWC version for the new field `ModelPlotConfig.annotations_enabled`.
The field was introduced in PR https://github.com/elastic/elasticsearch/pull/57539 which has already been backported to 7.9

