### PR TITLE
[7.8] Disable testing conventions for idp in fips (#57663)

### DIFF
--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -371,4 +371,6 @@ gradle.projectsEvaluated {
 if (BuildParams.inFipsJvm) {
   // We don't support the IDP in FIPS-140 mode, so no need to run tests
   test.enabled = false
+  // We run neither integTests nor unit tests in FIPS-140 mode
+  testingConventions.enabled = false
 }


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Disable testing conventions for idp in fips (#57663)