### PR TITLE
Restore xpack.ilm.enabled and xpack.slm.enabled settings (#57383)

### DIFF
--- a/docs/reference/migration/migrate_7_8.asciidoc
+++ b/docs/reference/migration/migrate_7_8.asciidoc
@@ -94,25 +94,29 @@ setting.
 
 [[deprecate-basic-license-feature-enabled]]
 
-.Several {xpack} settings no longer have any effect and are deprecated. 
+.Several {xpack} settings no longer have any effect and are deprecated.
 
 [%collapsible]
 ====
 *Details* +
-Basic {xpack} license features are always enabled for the {default-dist} 
-and the following settings no longer have any effect: 
+Basic {xpack} license features are always enabled for the {default-dist}
+and the following settings no longer have any effect:
 
 * `xpack.enrich.enabled`
 * `xpack.flattened.enabled`
-* `xpack.ilm.enabled`
 * `xpack.monitoring.enabled`
 * `xpack.rollup.enabled`
-* `xpack.slm.enabled`
 * `xpack.sql.enabled`
 * `xpack.transform.enabled`
 * `xpack.vectors.enabled`
 
 Previously, they could be set to `false` to disable the feature's APIs in a cluster.
+
+The ILM and SLM settings have been deprecated, but still have the effect of disabling
+their respective APIs:
+
+* `xpack.ilm.enabled`
+* `xpack.slm.enabled`
 
 *Impact* +
 To avoid deprecation warnings, discontinue use of these settings.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -118,8 +118,6 @@ public class XPackSettings {
 
     /**
      * Setting for enabling or disabling the index lifecycle extension. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
      */
     @Deprecated // since 7.8.0
     public static final Setting<Boolean> INDEX_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.ilm.enabled", true,
@@ -127,8 +125,6 @@ public class XPackSettings {
 
     /**
      * Setting for enabling or disabling the snapshot lifecycle extension. Defaults to true.
-     * <p>
-     * This setting is now a no-op: setting it to false is permitted, but does nothing.
      */
     @Deprecated // since = "7.8.0"
     public static final Setting<Boolean> SNAPSHOT_LIFECYCLE_ENABLED = Setting.boolSetting("xpack.slm.enabled", true,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -49,12 +49,12 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
         }
     }
 
-    public IndexLifecycleFeatureSetUsage(boolean available) {
-        this(available, null);
+    public IndexLifecycleFeatureSetUsage(boolean available, boolean enabled) {
+        this(available, enabled, null);
     }
 
-    public IndexLifecycleFeatureSetUsage(boolean available, List<PolicyStats> policyStats) {
-        super(XPackField.INDEX_LIFECYCLE, available, true);
+    public IndexLifecycleFeatureSetUsage(boolean available, boolean enabled, List<PolicyStats> policyStats) {
+        super(XPackField.INDEX_LIFECYCLE, available, enabled);
         this.policyStats = policyStats;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SLMFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SLMFeatureSetUsage.java
@@ -33,8 +33,8 @@ public class SLMFeatureSetUsage extends XPackFeatureSet.Usage {
         out.writeOptionalWriteable(this.slmStats);
     }
 
-    public SLMFeatureSetUsage(boolean available, @Nullable SnapshotLifecycleStats slmStats) {
-        super(XPackField.SNAPSHOT_LIFECYCLE, available, true);
+    public SLMFeatureSetUsage(boolean available, boolean enabled, @Nullable SnapshotLifecycleStats slmStats) {
+        super(XPackField.SNAPSHOT_LIFECYCLE, available, enabled);
         this.slmStats = slmStats;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.XPackClient;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
@@ -202,26 +203,29 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     }
 
     private void addIndexLifecyclePoliciesIfMissing(ClusterState state) {
+        boolean ilmSupported = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
 
-        Optional<IndexLifecycleMetadata> maybeMeta = Optional.ofNullable(state.metadata().custom(IndexLifecycleMetadata.TYPE));
-        List<LifecyclePolicy> policies = getPolicyConfigs().stream()
-            .map(policyConfig -> policyConfig.load(xContentRegistry))
-            .collect(Collectors.toList());
+        if (ilmSupported) {
+            Optional<IndexLifecycleMetadata> maybeMeta = Optional.ofNullable(state.metadata().custom(IndexLifecycleMetadata.TYPE));
+            List<LifecyclePolicy> policies = getPolicyConfigs().stream()
+                .map(policyConfig -> policyConfig.load(xContentRegistry))
+                .collect(Collectors.toList());
 
-        for (LifecyclePolicy policy : policies) {
-            final AtomicBoolean creationCheck = policyCreationsInProgress.computeIfAbsent(policy.getName(),
-                key -> new AtomicBoolean(false));
-            if (creationCheck.compareAndSet(false, true)) {
-                final boolean policyNeedsToBeCreated = maybeMeta
-                    .flatMap(ilmMeta -> Optional.ofNullable(ilmMeta.getPolicies().get(policy.getName())))
-                    .isPresent() == false;
-                if (policyNeedsToBeCreated) {
-                    logger.debug("adding lifecycle policy [{}] for [{}], because it doesn't exist", policy.getName(), getOrigin());
-                    putPolicy(policy, creationCheck);
-                } else {
-                    logger.trace("not adding lifecycle policy [{}] for [{}], because it already exists",
-                        policy.getName(), getOrigin());
-                    creationCheck.set(false);
+            for (LifecyclePolicy policy : policies) {
+                final AtomicBoolean creationCheck = policyCreationsInProgress.computeIfAbsent(policy.getName(),
+                    key -> new AtomicBoolean(false));
+                if (creationCheck.compareAndSet(false, true)) {
+                    final boolean policyNeedsToBeCreated = maybeMeta
+                        .flatMap(ilmMeta -> Optional.ofNullable(ilmMeta.getPolicies().get(policy.getName())))
+                        .isPresent() == false;
+                    if (policyNeedsToBeCreated) {
+                        logger.debug("adding lifecycle policy [{}] for [{}], because it doesn't exist", policy.getName(), getOrigin());
+                        putPolicy(policy, creationCheck);
+                    } else {
+                        logger.trace("not adding lifecycle policy [{}] for [{}], because it already exists",
+                            policy.getName(), getOrigin());
+                        creationCheck.set(false);
+                    }
                 }
             }
         }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/anomalydetection/state_index_template.json
@@ -8,9 +8,8 @@
     "index" : {
       "auto_expand_replicas" : "0-1",
       "hidden": true
-    },
-    "index.lifecycle.name": "${xpack.ml.index.lifecycle.name}",
-    "index.lifecycle.rollover_alias": "${xpack.ml.index.lifecycle.rollover_alias}"
+    }
+    ${xpack.ml.index.lifecycle.settings}
   },
   "mappings" : {
     "_doc": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/stats_index_template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/stats_index_template.json
@@ -9,9 +9,8 @@
       "number_of_shards" : "1",
       "auto_expand_replicas" : "0-1",
       "hidden": true
-    },
-    "index.lifecycle.name": "${xpack.ml.index.lifecycle.name}",
-    "index.lifecycle.rollover_alias": "${xpack.ml.index.lifecycle.rollover_alias}"
+    }
+    ${xpack.ml.index.lifecycle.settings}
   },
   "mappings" : ${xpack.ml.stats.mappings},
   "aliases" : {}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsageTests.java
@@ -28,18 +28,22 @@ public class IndexLifecycleFeatureSetUsageTests extends AbstractWireSerializingT
                 policyStats.add(PolicyStatsTests.createRandomInstance());
             }
         }
-        return new IndexLifecycleFeatureSetUsage(available, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
     }
 
     @Override
     protected IndexLifecycleFeatureSetUsage mutateInstance(IndexLifecycleFeatureSetUsage instance) throws IOException {
         boolean available = instance.available();
+        boolean enabled = instance.enabled();
         List<PolicyStats> policyStats = instance.getPolicyStats();
-        switch (between(0, 1)) {
+        switch (between(0, 2)) {
         case 0:
             available = available == false;
             break;
         case 1:
+            enabled = enabled == false;
+            break;
+        case 2:
             if (policyStats == null) {
                 policyStats = new ArrayList<>();
                 policyStats.add(PolicyStatsTests.createRandomInstance());
@@ -53,7 +57,7 @@ public class IndexLifecycleFeatureSetUsageTests extends AbstractWireSerializingT
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new IndexLifecycleFeatureSetUsage(available, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -38,6 +38,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.AllocateAction;
 import org.elasticsearch.xpack.core.ilm.DeleteAction;
 import org.elasticsearch.xpack.core.ilm.ForceMergeAction;
@@ -140,10 +141,14 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
     private final SetOnce<SnapshotRetentionService> snapshotRetentionService = new SetOnce<>();
     private final SetOnce<SnapshotHistoryStore> snapshotHistoryStore = new SetOnce<>();
     private Settings settings;
+    private boolean ilmEnabled;
+    private boolean slmEnabled;
     private boolean transportClientMode;
 
     public IndexLifecycle(Settings settings) {
         this.settings = settings;
+        this.ilmEnabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
+        this.slmEnabled = XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED.get(settings);
         this.transportClientMode = XPackPlugin.transportClientMode(settings);
     }
 
@@ -192,29 +197,31 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             return Collections.emptyList();
         }
         final List<Object> components = new ArrayList<>();
-        // This registers a cluster state listener, so appears unused but is not.
-        @SuppressWarnings("unused")
-        ILMHistoryTemplateRegistry ilmTemplateRegistry =
-            new ILMHistoryTemplateRegistry(settings, clusterService, threadPool, client, xContentRegistry);
-        ilmHistoryStore.set(new ILMHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
-            clusterService, threadPool));
-        indexLifecycleInitialisationService.set(new IndexLifecycleService(settings, client, clusterService, threadPool,
-            getClock(), System::currentTimeMillis, xContentRegistry, ilmHistoryStore.get()));
-        components.add(indexLifecycleInitialisationService.get());
-
-        // the template registry is a cluster state listener
-        @SuppressWarnings("unused")
-        SnapshotLifecycleTemplateRegistry templateRegistry = new SnapshotLifecycleTemplateRegistry(settings, clusterService, threadPool,
-            client, xContentRegistry);
-        snapshotHistoryStore.set(new SnapshotHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
-            clusterService));
-        snapshotLifecycleService.set(new SnapshotLifecycleService(settings,
-            () -> new SnapshotLifecycleTask(client, clusterService, snapshotHistoryStore.get()), clusterService, getClock()));
-        snapshotRetentionService.set(new SnapshotRetentionService(settings,
-            () -> new SnapshotRetentionTask(client, clusterService, System::nanoTime, snapshotHistoryStore.get(), threadPool),
-            clusterService, getClock()));
-        components.addAll(Arrays.asList(snapshotLifecycleService.get(), snapshotHistoryStore.get(), snapshotRetentionService.get()));
-
+        if (ilmEnabled) {
+            // This registers a cluster state listener, so appears unused but is not.
+            @SuppressWarnings("unused")
+            ILMHistoryTemplateRegistry ilmTemplateRegistry =
+                new ILMHistoryTemplateRegistry(settings, clusterService, threadPool, client, xContentRegistry);
+            ilmHistoryStore.set(new ILMHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
+                clusterService, threadPool));
+            indexLifecycleInitialisationService.set(new IndexLifecycleService(settings, client, clusterService, threadPool,
+                getClock(), System::currentTimeMillis, xContentRegistry, ilmHistoryStore.get()));
+            components.add(indexLifecycleInitialisationService.get());
+        }
+        if (slmEnabled) {
+            // the template registry is a cluster state listener
+            @SuppressWarnings("unused")
+            SnapshotLifecycleTemplateRegistry templateRegistry = new SnapshotLifecycleTemplateRegistry(settings, clusterService, threadPool,
+                client, xContentRegistry);
+            snapshotHistoryStore.set(new SnapshotHistoryStore(settings, new OriginSettingClient(client, INDEX_LIFECYCLE_ORIGIN),
+                clusterService));
+            snapshotLifecycleService.set(new SnapshotLifecycleService(settings,
+                () -> new SnapshotLifecycleTask(client, clusterService, snapshotHistoryStore.get()), clusterService, getClock()));
+            snapshotRetentionService.set(new SnapshotRetentionService(settings,
+                () -> new SnapshotRetentionTask(client, clusterService, System::nanoTime, snapshotHistoryStore.get(), threadPool),
+                clusterService, getClock()));
+            components.addAll(Arrays.asList(snapshotLifecycleService.get(), snapshotHistoryStore.get(), snapshotRetentionService.get()));
+        }
         return components;
     }
 
@@ -256,69 +263,75 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             IndexScopedSettings indexScopedSettings, SettingsFilter settingsFilter, IndexNameExpressionResolver indexNameExpressionResolver,
             Supplier<DiscoveryNodes> nodesInCluster) {
         List<RestHandler> handlers = new ArrayList<>();
-        handlers.addAll(Arrays.asList(
-
-            // add ILM rest handlers
-            new RestPutLifecycleAction(),
-            new RestGetLifecycleAction(),
-            new RestDeleteLifecycleAction(),
-            new RestExplainLifecycleAction(),
-            new RestRemoveIndexLifecyclePolicyAction(),
-            new RestMoveToStepAction(),
-            new RestRetryAction(),
-            new RestStopAction(),
-            new RestStartILMAction(),
-            new RestGetStatusAction(),
-
-            // add SLM rest headers
-            new RestPutSnapshotLifecycleAction(),
-            new RestDeleteSnapshotLifecycleAction(),
-            new RestGetSnapshotLifecycleAction(),
-            new RestExecuteSnapshotLifecycleAction(),
-            new RestGetSnapshotLifecycleStatsAction(),
-            new RestExecuteSnapshotRetentionAction(),
-            new RestStopSLMAction(),
-            new RestStartSLMAction(),
-            new RestGetSLMStatusAction()
-        ));
+        if (ilmEnabled) {
+            handlers.addAll(Arrays.asList(
+                new RestPutLifecycleAction(),
+                new RestGetLifecycleAction(),
+                new RestDeleteLifecycleAction(),
+                new RestExplainLifecycleAction(),
+                new RestRemoveIndexLifecyclePolicyAction(),
+                new RestMoveToStepAction(),
+                new RestRetryAction(),
+                new RestStopAction(),
+                new RestStartILMAction(),
+                new RestGetStatusAction()
+            ));
+        }
+        if (slmEnabled) {
+            handlers.addAll(Arrays.asList(
+                new RestPutSnapshotLifecycleAction(),
+                new RestDeleteSnapshotLifecycleAction(),
+                new RestGetSnapshotLifecycleAction(),
+                new RestExecuteSnapshotLifecycleAction(),
+                new RestGetSnapshotLifecycleStatsAction(),
+                new RestExecuteSnapshotRetentionAction(),
+                new RestStopSLMAction(),
+                new RestStartSLMAction(),
+                new RestGetSLMStatusAction()
+            ));
+        }
         return handlers;
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>();
-        // add ILM actions
-        actions.addAll(Arrays.asList(
-            // add ILM actions
-            new ActionHandler<>(PutLifecycleAction.INSTANCE, TransportPutLifecycleAction.class),
-            new ActionHandler<>(GetLifecycleAction.INSTANCE, TransportGetLifecycleAction.class),
-            new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifecycleAction.class),
-            new ActionHandler<>(ExplainLifecycleAction.INSTANCE, TransportExplainLifecycleAction.class),
-            new ActionHandler<>(RemoveIndexLifecyclePolicyAction.INSTANCE, TransportRemoveIndexLifecyclePolicyAction.class),
-            new ActionHandler<>(MoveToStepAction.INSTANCE, TransportMoveToStepAction.class),
-            new ActionHandler<>(RetryAction.INSTANCE, TransportRetryAction.class),
-            new ActionHandler<>(StartILMAction.INSTANCE, TransportStartILMAction.class),
-            new ActionHandler<>(StopILMAction.INSTANCE, TransportStopILMAction.class),
-            new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class),
-
-            // add SLM actions
-            new ActionHandler<>(PutSnapshotLifecycleAction.INSTANCE, TransportPutSnapshotLifecycleAction.class),
-            new ActionHandler<>(DeleteSnapshotLifecycleAction.INSTANCE, TransportDeleteSnapshotLifecycleAction.class),
-            new ActionHandler<>(GetSnapshotLifecycleAction.INSTANCE, TransportGetSnapshotLifecycleAction.class),
-            new ActionHandler<>(ExecuteSnapshotLifecycleAction.INSTANCE, TransportExecuteSnapshotLifecycleAction.class),
-            new ActionHandler<>(GetSnapshotLifecycleStatsAction.INSTANCE, TransportGetSnapshotLifecycleStatsAction.class),
-            new ActionHandler<>(ExecuteSnapshotRetentionAction.INSTANCE, TransportExecuteSnapshotRetentionAction.class),
-            new ActionHandler<>(StartSLMAction.INSTANCE, TransportStartSLMAction.class),
-            new ActionHandler<>(StopSLMAction.INSTANCE, TransportStopSLMAction.class),
-            new ActionHandler<>(GetSLMStatusAction.INSTANCE, TransportGetSLMStatusAction.class)
+        if (ilmEnabled) {
+            actions.addAll(Arrays.asList(
+                new ActionHandler<>(PutLifecycleAction.INSTANCE, TransportPutLifecycleAction.class),
+                new ActionHandler<>(GetLifecycleAction.INSTANCE, TransportGetLifecycleAction.class),
+                new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifecycleAction.class),
+                new ActionHandler<>(ExplainLifecycleAction.INSTANCE, TransportExplainLifecycleAction.class),
+                new ActionHandler<>(RemoveIndexLifecyclePolicyAction.INSTANCE, TransportRemoveIndexLifecyclePolicyAction.class),
+                new ActionHandler<>(MoveToStepAction.INSTANCE, TransportMoveToStepAction.class),
+                new ActionHandler<>(RetryAction.INSTANCE, TransportRetryAction.class),
+                new ActionHandler<>(StartILMAction.INSTANCE, TransportStartILMAction.class),
+                new ActionHandler<>(StopILMAction.INSTANCE, TransportStopILMAction.class),
+                new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class)
             ));
+        }
+        if (slmEnabled) {
+            actions.addAll(Arrays.asList(
+                new ActionHandler<>(PutSnapshotLifecycleAction.INSTANCE, TransportPutSnapshotLifecycleAction.class),
+                new ActionHandler<>(DeleteSnapshotLifecycleAction.INSTANCE, TransportDeleteSnapshotLifecycleAction.class),
+                new ActionHandler<>(GetSnapshotLifecycleAction.INSTANCE, TransportGetSnapshotLifecycleAction.class),
+                new ActionHandler<>(ExecuteSnapshotLifecycleAction.INSTANCE, TransportExecuteSnapshotLifecycleAction.class),
+                new ActionHandler<>(GetSnapshotLifecycleStatsAction.INSTANCE, TransportGetSnapshotLifecycleStatsAction.class),
+                new ActionHandler<>(ExecuteSnapshotRetentionAction.INSTANCE, TransportExecuteSnapshotRetentionAction.class),
+                new ActionHandler<>(StartSLMAction.INSTANCE, TransportStartSLMAction.class),
+                new ActionHandler<>(StopSLMAction.INSTANCE, TransportStopSLMAction.class),
+                new ActionHandler<>(GetSLMStatusAction.INSTANCE, TransportGetSLMStatusAction.class)
+            ));
+        }
         return actions;
     }
 
     @Override
     public void onIndexModule(IndexModule indexModule) {
-        assert indexLifecycleInitialisationService.get() != null;
-        indexModule.addIndexEventListener(indexLifecycleInitialisationService.get());
+        if (ilmEnabled) {
+            assert indexLifecycleInitialisationService.get() != null;
+            indexModule.addIndexEventListener(indexLifecycleInitialisationService.get());
+        }
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSet.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSet.java
@@ -11,9 +11,11 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PhaseStats;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PolicyStats;
@@ -27,12 +29,14 @@ import java.util.stream.Collectors;
 
 public class IndexLifecycleFeatureSet implements XPackFeatureSet {
 
+    private final boolean enabled;
     private final XPackLicenseState licenseState;
     private ClusterService clusterService;
 
     @Inject
-    public IndexLifecycleFeatureSet(@Nullable XPackLicenseState licenseState, ClusterService clusterService) {
+    public IndexLifecycleFeatureSet(Settings settings, @Nullable XPackLicenseState licenseState, ClusterService clusterService) {
         this.clusterService = clusterService;
+        this.enabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
         this.licenseState = licenseState;
     }
 
@@ -48,7 +52,7 @@ public class IndexLifecycleFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean enabled() {
-        return true;
+        return enabled;
     }
 
     @Override
@@ -79,9 +83,9 @@ public class IndexLifecycleFeatureSet implements XPackFeatureSet {
                 }).collect(Collectors.toMap(Tuple::v1, Tuple::v2));
                 return new PolicyStats(phaseStats, policyUsage.getOrDefault(policy.getName(), 0));
             }).collect(Collectors.toList());
-            listener.onResponse(new IndexLifecycleFeatureSetUsage(available(), policyStats));
+            listener.onResponse(new IndexLifecycleFeatureSetUsage(available(), enabled(), policyStats));
         } else {
-            listener.onResponse(new IndexLifecycleFeatureSetUsage(available()));
+            listener.onResponse(new IndexLifecycleFeatureSetUsage(available(), enabled()));
         }
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SLMFeatureSet.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SLMFeatureSet.java
@@ -11,9 +11,11 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.slm.SLMFeatureSetUsage;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 
@@ -21,12 +23,14 @@ import java.util.Map;
 
 public class SLMFeatureSet implements XPackFeatureSet {
 
+    private final boolean enabled;
     private final XPackLicenseState licenseState;
     private ClusterService clusterService;
 
     @Inject
-    public SLMFeatureSet(@Nullable XPackLicenseState licenseState, ClusterService clusterService) {
+    public SLMFeatureSet(Settings settings, @Nullable XPackLicenseState licenseState, ClusterService clusterService) {
         this.clusterService = clusterService;
+        this.enabled = XPackSettings.SNAPSHOT_LIFECYCLE_ENABLED.get(settings);
         this.licenseState = licenseState;
     }
 
@@ -42,7 +46,7 @@ public class SLMFeatureSet implements XPackFeatureSet {
 
     @Override
     public boolean enabled() {
-        return true;
+        return enabled;
     }
 
     @Override
@@ -55,7 +59,8 @@ public class SLMFeatureSet implements XPackFeatureSet {
         final ClusterState state = clusterService.state();
         boolean available = licenseState.isAllowed(XPackLicenseState.Feature.ILM);
         final SnapshotLifecycleMetadata slmMeta = state.metadata().custom(SnapshotLifecycleMetadata.TYPE);
-        final SLMFeatureSetUsage usage = new SLMFeatureSetUsage(available, slmMeta == null ? null : slmMeta.getStats());
+        final SLMFeatureSetUsage usage = new SLMFeatureSetUsage(available, enabled,
+            slmMeta == null ? null : slmMeta.getStats());
         listener.onResponse(usage);
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetTests.java
@@ -13,9 +13,11 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleFeatureSetUsage.PolicyStats;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
@@ -51,7 +53,7 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
     }
 
     public void testAvailable() {
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
 
         when(licenseState.isAllowed(XPackLicenseState.Feature.ILM)).thenReturn(false);
         assertThat(featureSet.available(), equalTo(false));
@@ -59,17 +61,28 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
         when(licenseState.isAllowed(XPackLicenseState.Feature.ILM)).thenReturn(true);
         assertThat(featureSet.available(), equalTo(true));
 
-        featureSet = new IndexLifecycleFeatureSet(null, clusterService);
+        featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, null, clusterService);
         assertThat(featureSet.available(), equalTo(false));
     }
 
+    public void testEnabled() {
+        Settings.Builder settings = Settings.builder().put("xpack.ilm.enabled", false);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(settings.build(), licenseState, clusterService);
+        assertThat(featureSet.enabled(), equalTo(false));
+
+        settings = Settings.builder().put("xpack.ilm.enabled", true);
+        featureSet = new IndexLifecycleFeatureSet(settings.build(), licenseState, clusterService);
+        assertThat(featureSet.enabled(), equalTo(true));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
+    }
+
     public void testName() {
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
         assertThat(featureSet.name(), equalTo("ilm"));
     }
 
     public void testNativeCodeInfo() {
-        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
+        IndexLifecycleFeatureSet featureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
         assertNull(featureSet.nativeCodeInfo());
     }
 
@@ -101,7 +114,7 @@ public class IndexLifecycleFeatureSetTests extends ESTestCase {
         Mockito.when(clusterService.state()).thenReturn(clusterState);
 
         PlainActionFuture<IndexLifecycleFeatureSet.Usage> future = new PlainActionFuture<>();
-        IndexLifecycleFeatureSet ilmFeatureSet = new IndexLifecycleFeatureSet(licenseState, clusterService);
+        IndexLifecycleFeatureSet ilmFeatureSet = new IndexLifecycleFeatureSet(Settings.EMPTY, licenseState, clusterService);
         ilmFeatureSet.usage(future);
         IndexLifecycleFeatureSetUsage ilmUsage = (IndexLifecycleFeatureSetUsage) future.get();
         assertThat(ilmUsage.enabled(), equalTo(ilmFeatureSet.enabled()));

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatureSetUsageTests.java
@@ -20,30 +20,35 @@ public class IndexLifecycleFeatureSetUsageTests extends AbstractWireSerializingT
     @Override
     protected IndexLifecycleFeatureSetUsage createTestInstance() {
         boolean available = randomBoolean();
+        boolean enabled = randomBoolean();
         List<PolicyStats> policyStats = new ArrayList<>();
         int size = randomIntBetween(0, 10);
         for (int i = 0; i < size; i++) {
             policyStats.add(PolicyStatsTests.randomPolicyStats());
         }
-        return new IndexLifecycleFeatureSetUsage(available, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
     }
 
     @Override
     protected IndexLifecycleFeatureSetUsage mutateInstance(IndexLifecycleFeatureSetUsage instance) throws IOException {
         boolean available = instance.available();
+        boolean enabled = instance.enabled();
         List<PolicyStats> policyStats = instance.getPolicyStats();
-        switch (between(0, 1)) {
+        switch (between(0, 2)) {
         case 0:
             available = available == false;
             break;
         case 1:
+            enabled = enabled == false;
+            break;
+        case 2:
             policyStats = new ArrayList<>(policyStats);
             policyStats.add(PolicyStatsTests.randomPolicyStats());
             break;
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new IndexLifecycleFeatureSetUsage(available, policyStats);
+        return new IndexLifecycleFeatureSetUsage(available, enabled, policyStats);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ml.MlConfigIndex;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
@@ -35,12 +36,11 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
     private static final String ANOMALY_DETECTION_PATH = ROOT_RESOURCE_PATH + "anomalydetection/";
     private static final String VERSION_PATTERN = "xpack.ml.version";
     private static final String VERSION_ID_PATTERN = "xpack.ml.version.id";
-    private static final String INDEX_LIFECYCLE_NAME = "xpack.ml.index.lifecycle.name";
-    private static final String INDEX_LIFECYCLE_ROLLOVER_ALIAS = "xpack.ml.index.lifecycle.rollover_alias";
 
     private static final IndexTemplateConfig ANOMALY_DETECTION_RESULTS_TEMPLATE = anomalyDetectionResultsTemplate();
 
-    private static final IndexTemplateConfig ANOMALY_DETECTION_STATE_TEMPLATE = stateTemplate();
+    private static final IndexTemplateConfig ANOMALY_DETECTION_STATE_TEMPLATE = stateTemplate(true);
+    private static final IndexTemplateConfig ANOMALY_DETECTION_STATE_TEMPLATE_NO_ILM = stateTemplate(false);
 
     private static final IndexTemplateConfig META_TEMPLATE = new IndexTemplateConfig(MlMetaIndex.INDEX_NAME,
         ROOT_RESOURCE_PATH + "meta_index_template.json", Version.CURRENT.id, VERSION_PATTERN,
@@ -56,7 +56,8 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
         ROOT_RESOURCE_PATH + "inference_index_template.json", Version.CURRENT.id, VERSION_PATTERN,
         Collections.singletonMap(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id)));
 
-    private static final IndexTemplateConfig STATS_TEMPLATE = statsTemplate();
+    private static final IndexTemplateConfig STATS_TEMPLATE = statsTemplate(true);
+    private static final IndexTemplateConfig STATS_TEMPLATE_NO_ILM = statsTemplate(false);
 
     private static final String ML_SIZE_BASED_ILM_POLICY_NAME = "ml-size-based-ilm-policy";
     private static final LifecyclePolicyConfig ML_SIZE_BASED_ILM_POLICY =
@@ -75,11 +76,15 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
             variables);
     }
 
-    private static IndexTemplateConfig stateTemplate() {
+    private static IndexTemplateConfig stateTemplate(boolean ilmEnabled) {
         Map<String, String> variables = new HashMap<>();
         variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
-        variables.put(INDEX_LIFECYCLE_NAME, ML_SIZE_BASED_ILM_POLICY_NAME);
-        variables.put(INDEX_LIFECYCLE_ROLLOVER_ALIAS, AnomalyDetectorsIndex.jobStateIndexWriteAlias());
+        variables.put(
+            "xpack.ml.index.lifecycle.settings",
+            ilmEnabled
+                ? ",\"index.lifecycle.name\": \"" + ML_SIZE_BASED_ILM_POLICY_NAME + "\"\n" +
+                  ",\"index.lifecycle.rollover_alias\": \"" + AnomalyDetectorsIndex.jobStateIndexWriteAlias() + "\"\n"
+                : "");
 
         return new IndexTemplateConfig(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX,
             ANOMALY_DETECTION_PATH + "state_index_template.json",
@@ -98,12 +103,16 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
             variables);
     }
 
-    private static IndexTemplateConfig statsTemplate() {
+    private static IndexTemplateConfig statsTemplate(boolean ilmEnabled) {
         Map<String, String> variables = new HashMap<>();
         variables.put(VERSION_ID_PATTERN, String.valueOf(Version.CURRENT.id));
         variables.put("xpack.ml.stats.mappings", MlStatsIndex.mapping());
-        variables.put(INDEX_LIFECYCLE_NAME, ML_SIZE_BASED_ILM_POLICY_NAME);
-        variables.put(INDEX_LIFECYCLE_ROLLOVER_ALIAS, MlStatsIndex.writeAlias());
+        variables.put(
+            "xpack.ml.index.lifecycle.settings",
+            ilmEnabled
+                ? ",\"index.lifecycle.name\": \"" + ML_SIZE_BASED_ILM_POLICY_NAME + "\"\n" +
+                ",\"index.lifecycle.rollover_alias\": \"" + MlStatsIndex.writeAlias() + "\"\n"
+                : "");
 
         return new IndexTemplateConfig(MlStatsIndex.TEMPLATE_NAME,
             ROOT_RESOURCE_PATH + "stats_index_template.json",
@@ -116,14 +125,15 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
     public MlIndexTemplateRegistry(Settings nodeSettings, ClusterService clusterService, ThreadPool threadPool, Client client,
                                    NamedXContentRegistry xContentRegistry) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        boolean ilmEnabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings);
         templatesToUse = Arrays.asList(
             ANOMALY_DETECTION_RESULTS_TEMPLATE,
-            ANOMALY_DETECTION_STATE_TEMPLATE,
+            ilmEnabled ? ANOMALY_DETECTION_STATE_TEMPLATE : ANOMALY_DETECTION_STATE_TEMPLATE_NO_ILM,
             CONFIG_TEMPLATE,
             INFERENCE_TEMPLATE,
             META_TEMPLATE,
             NOTIFICATIONS_TEMPLATE,
-            STATS_TEMPLATE);
+            ilmEnabled ? STATS_TEMPLATE : STATS_TEMPLATE_NO_ILM);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -20,12 +20,14 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ml.MlStatsIndex;
@@ -40,6 +42,8 @@ import java.util.List;
 import static org.elasticsearch.mock.orig.Mockito.verify;
 import static org.elasticsearch.mock.orig.Mockito.when;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
@@ -80,7 +84,7 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
         putIndexTemplateRequestCaptor = ArgumentCaptor.forClass(PutIndexTemplateRequest.class);
     }
 
-    public void testStateTemplate() {
+    public void testStateTemplateWithIlm() {
         MlIndexTemplateRegistry registry =
             new MlIndexTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
 
@@ -96,7 +100,29 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
         assertThat(req.settings().get("index.lifecycle.rollover_alias"), equalTo(".ml-state-write"));
     }
 
-    public void testStatsTemplate() {
+    public void testStateTemplateWithNoIlm() {
+        MlIndexTemplateRegistry registry =
+            new MlIndexTemplateRegistry(
+                Settings.builder()
+                    .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false)
+                    .build(),
+                clusterService, threadPool, client, xContentRegistry);
+
+        registry.clusterChanged(createClusterChangedEvent(nodes));
+
+        verify(client.admin().indices(), times(7)).putTemplate(putIndexTemplateRequestCaptor.capture(), anyObject());
+
+        PutIndexTemplateRequest req = putIndexTemplateRequestCaptor.getAllValues().stream()
+            .filter(r -> r.name().equals(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected the ml state index template to be put"));
+        assertThat(req.settings().get("index.lifecycle.name"), is(nullValue()));
+        assertThat(req.settings().get("index.lifecycle.rollover_alias"), is(nullValue()));
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
+    }
+
+    public void testStatsTemplateWithIlm() {
         MlIndexTemplateRegistry registry =
             new MlIndexTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
 
@@ -110,6 +136,28 @@ public class MlIndexTemplateRegistryTests extends ESTestCase {
             .orElseThrow(() -> new AssertionError("expected the ml stats index template to be put"));
         assertThat(req.settings().get("index.lifecycle.name"), equalTo("ml-size-based-ilm-policy"));
         assertThat(req.settings().get("index.lifecycle.rollover_alias"), equalTo(".ml-stats-write"));
+    }
+
+    public void testStatsTemplateWithNoIlm() {
+        MlIndexTemplateRegistry registry =
+            new MlIndexTemplateRegistry(
+                Settings.builder()
+                    .put(XPackSettings.INDEX_LIFECYCLE_ENABLED.getKey(), false)
+                    .build(),
+                clusterService, threadPool, client, xContentRegistry);
+
+        registry.clusterChanged(createClusterChangedEvent(nodes));
+
+        verify(client.admin().indices(), times(7)).putTemplate(putIndexTemplateRequestCaptor.capture(), anyObject());
+
+        PutIndexTemplateRequest req = putIndexTemplateRequestCaptor.getAllValues().stream()
+            .filter(r -> r.name().equals(MlStatsIndex.TEMPLATE_NAME))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected the ml stats index template to be put"));
+        assertThat(req.settings().get("index.lifecycle.name"), is(nullValue()));
+        assertThat(req.settings().get("index.lifecycle.rollover_alias"), is(nullValue()));
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { XPackSettings.INDEX_LIFECYCLE_ENABLED } );
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
 import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
@@ -66,7 +67,8 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
     public WatcherIndexTemplateRegistry(Settings nodeSettings, ClusterService clusterService, ThreadPool threadPool, Client client,
                                         NamedXContentRegistry xContentRegistry) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
-        ilmManagementEnabled = Watcher.USE_ILM_INDEX_MANAGEMENT.get(nodeSettings);
+        this.ilmManagementEnabled = XPackSettings.INDEX_LIFECYCLE_ENABLED.get(settings)
+            && Watcher.USE_ILM_INDEX_MANAGEMENT.get(settings);
     }
 
     @Override
@@ -86,9 +88,6 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
         }
     }
 
-    /**
-     * If Watcher is configured not to use ILM, we don't return a policy.
-     */
     @Override
     protected List<LifecyclePolicyConfig> getPolicyConfigs() {
         if (Watcher.USE_ILM_INDEX_MANAGEMENT.get(settings) == false) {


### PR DESCRIPTION
In #55592 and #55416, we deprecated the settings for enabling and disabling
basic license features and turned those settings into no-ops. Since doing so,
we've had feedback that this change may not give users enough time to cleanly
switch from non-ILM index management tools to ILM. If two index managers
operate simultaneously, results could be strange and difficult to
reconstruct. We don't know of any cases where SLM will cause a problem, but we
are restoring that setting as well, to be on the safe side.

This PR is not a strict commit reversion. First, we are keeping the new
xpack.watcher.use_ilm_index_management setting, introduced when
xpack.ilm.enabled was made a no-op, so that users can begin migrating to using
it. Second, the SLM setting was modified in the same commit as a group of other
settings, so I have taken just the changes relating to SLM.