### PR TITLE
[DOCS] Fix source-related search API params

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -846,14 +846,28 @@ end::source[]
 
 tag::source_excludes[]
 `_source_excludes`::
-(Optional, string) A list of fields to exclude from the returned `_source`
-field.
+(Optional, string)
+A comma-separated list of <<mapping-source-field,source fields>> to exclude from
+the response.
++
+If the `_source` parameter is not `false` and the `_source_includes` query
+parameter is not specified, the entire source document is returned, excluding
+fields specified in this parameter.
++
+If the `_source` parameter is `false`, this parameter is ignored.
 end::source_excludes[]
 
 tag::source_includes[]
 `_source_includes`::
-(Optional, string) A list of fields to extract and return from the `_source`
-field.
+(Optional, string)
+A comma-separated list of <<mapping-source-field,source fields>> to
+include in the response.
++
+If  the `_source` parameter is not `false` and this parameter is specified, only
+these source fields are returned. You can exclude fields from this subset using
+the `_source_excludes` query parameter.
++
+If the `_source` parameter is `false`, this parameter is ignored.
 end::source_includes[]
 
 tag::source-transforms[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -850,9 +850,8 @@ tag::source_excludes[]
 A comma-separated list of <<mapping-source-field,source fields>> to exclude from
 the response.
 +
-If the `_source` parameter is not `false` and the `_source_includes` query
-parameter is not specified, the entire source document is returned, excluding
-fields specified in this parameter.
+You can also use this parameter to exclude fields from the subset specified in
+`_source_includes` query parameter.
 +
 If the `_source` parameter is `false`, this parameter is ignored.
 end::source_excludes[]
@@ -863,9 +862,8 @@ tag::source_includes[]
 A comma-separated list of <<mapping-source-field,source fields>> to
 include in the response.
 +
-If  the `_source` parameter is not `false` and this parameter is specified, only
-these source fields are returned. You can exclude fields from this subset using
-the `_source_excludes` query parameter.
+If this parameter is specified, only these source fields are returned. You can
+exclude fields from this subset using the `_source_excludes` query parameter.
 +
 If the `_source` parameter is `false`, this parameter is ignored.
 end::source_includes[]
@@ -942,7 +940,7 @@ end::transform-settings[]
 
 tag::transform-settings-docs-per-second[]
 Specifies a limit on the number of input documents per second. This setting
-throttles the {transform} by adding a wait time between search requests. The 
+throttles the {transform} by adding a wait time between search requests. The
 default value is `null`, which disables throttling.
 end::transform-settings-docs-per-second[]
 
@@ -1018,7 +1016,7 @@ information for all {transforms}.
 end::transform-id-wildcard[]
 
 tag::trigger-count[]
-The number of times the {transform} has been triggered by the scheduler. For 
+The number of times the {transform} has been triggered by the scheduler. For
 example, the scheduler triggers the {transform} indexer to check for updates
 or ingest new data at an interval specified in the
 <<put-transform-request-body,`frequency` property>>.

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -228,7 +228,7 @@ of a hit. If no fields are specified, no stored fields are included in the
 response.
 +
 If this field is specified, the `_source` parameter defaults to `false`. You can
-specify a value in the `_source` parameter to return both source fields and
+pass `_source: true` to return both source fields and
 stored fields in the search response.
 
 `suggest_field`::

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -202,10 +202,7 @@ the search response. Defaults to `true`.
 ====
 `true`::
 (boolean)
-The entire document source is returned. This does not include:
-* <<multi-fields,multi-fields>>
-* <<alias,field aliases>>
-* Values copied using the <<copy-to,`copy_to`>> mapping parameter
+The entire document source is returned.
 
 `false`::
 (boolean)

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -356,20 +356,20 @@ Object containing a list of source fields to include or exclude.
 .Properties for `<object>`
 [%collapsible%open]
 =====
-`includes`::
-(array of strings)
-Array of wildcard (`*`) patterns containing source fields to return.
-+
-If this property is specified, only source fields that match these patterns are
-returned. You can exclude fields from this subset using the `excludes` property.
-
 `excludes`::
-(array of strings)
-Array of wildcard (`*`) pattern containing source fields to exclude from the
-response.
+(string or array of strings)
+Wildcard (`*`) pattern or array of patterns containing source fields to exclude
+from the response.
 +
-If the `includes` property is not specified, the entire document source is returned,
-excluding fields specified in this parameter.
+You can also use this property to exclude fields from the subset specified in
+`includes` property.
+
+`includes`::
+(string or array of strings)
+Wildcard (`*`) pattern or array of patterns containing source fields to return.
++
+If this property is specified, only these source fields are returned. You can
+exclude fields from this subset using the `excludes` property.
 =====
 ====
 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -346,12 +346,8 @@ The entire document source is returned. This does not include:
 The document source is not returned.
 
 `<wildcard_pattern>`::
-(string)
-Wildcard (`*`) patterns containing source fields to return.
-
-`<wildcard_pattern_array>`::
-(array of strings)
-Array of wildcard (`*`) patterns containing source fields to return.
+(string or array of strings)
+Wildcard (`*`) pattern or array of patterns containing source fields to return.
 
 `<object>`::
 (object)

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -35,6 +35,7 @@ query string parameter>> or <<search-request-body,request body>>.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 
+[role="child_attributes"]
 [[search-search-api-query-params]]
 ==== {api-query-parms-title}
 
@@ -53,7 +54,7 @@ If `true`, returns partial results if there are request timeouts or
 <<shard-failures,shard failures>>. If `false`, returns an error with
 no partial results. Defaults to `true`.
 +
-To override the default for this field, set the 
+To override the default for this field, set the
 `search.default_allow_partial_results` cluster setting to `false`.
 
 `batched_reduce_size`::
@@ -64,8 +65,8 @@ shards in the request can be large. Defaults to `512`.
 
 [[ccs-minimize-roundtrips]]
 `ccs_minimize_roundtrips`::
-(Optional, boolean) If `true`, network round-trips between the 
-coordinating node and the remote clusters are minimized when executing 
+(Optional, boolean) If `true`, network round-trips between the
+coordinating node and the remote clusters are minimized when executing
 {ccs} (CCS) requests. See <<ccs-network-delays>>. Defaults to `true`.
 
 `docvalue_fields`::
@@ -135,8 +136,7 @@ testing.
 +
 IMPORTANT: The `q` parameter overrides the <<request-body-search-query,`query`>>
 parameter in the request body. If both parameters are specified, documents
-matching the `query` request body parameter are not returned.	
-
+matching the `query` request body parameter are not returned.
 
 `request_cache`::
 (Optional, boolean) If `true`, the caching of search results is enabled for
@@ -192,9 +192,29 @@ value cannot be `0`.
 (Optional, string) A comma-separated list of <field>:<direction> pairs.
 
 `_source`::
-(Optional, boolean)
-If `true`, the response includes the `_source` of matching documents under
-`hits`. Defaults to `true`.
+(Optional)
+Indicates which <<mapping-source-field,source fields>> are returned for matching
+documents. These fields are returned in the `hits._source` property of
+the search response. Defaults to `true`.
++
+.Valid values for `_source`
+[%collapsible%open]
+====
+`true`::
+(boolean)
+The entire document source is returned. This does not include:
+* <<multi-fields,multi-fields>>
+* <<alias,field aliases>>
+* Values copied using the <<copy-to,`copy_to`>> mapping parameter
+
+`false`::
+(boolean)
+The document source is not returned.
+
+`<string>`::
+(string)
+Comma-separated list of source fields to return.
+====
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]
 
@@ -208,6 +228,10 @@ purposes.
 (Optional, string) A comma-separated list of stored fields to return as part
 of a hit. If no fields are specified, no stored fields are included in the
 response.
++
+If this field is specified, the `_source` parameter defaults to `false`. You can
+specify a value in the `_source` parameter to return both source fields and
+stored fields in the search response.
 
 `suggest_field`::
 (Optional, string) Specifies which field to use for suggestions.
@@ -244,6 +268,7 @@ by their respective types in the response. Defaults to `true`.
 (Optional, boolean)
 If `true`, returns document version as part of a hit. Defaults to `false`.
 
+[role="child_attributes"]
 [[search-search-api-request-body]]
 ==== {api-request-body-title}
 
@@ -280,7 +305,7 @@ As an alternative to deep paging, we recommend using
 (Optional, boolean) If `true`, returns sequence number and primary term of the
 last modification of each hit. See <<optimistic-concurrency-control>>.
 
-`size`:: 
+`size`::
 (Optional, integer) The number of hits to return. Needs to be non-negative and defaults to `10`.
 +
 --
@@ -301,6 +326,58 @@ As an alternative to deep paging, we recommend using
 If the <<search-api-scroll-query-param,`scroll` parameter>> is specified, this
 value cannot be `0`.
 --
+
+`_source`::
+(Optional)
+Indicates which <<mapping-source-field,source fields>> are returned for matching
+documents. These fields are returned in the `hits._source` property of
+the search response. Defaults to `true`.
++
+.Valid values for `_source`
+[%collapsible%open]
+====
+`true`::
+(boolean)
+The entire document source is returned. This does not include:
+* <<multi-fields,multi-fields>>
+* <<alias,field aliases>>
+* Values copied using the <<copy-to,`copy_to`>> mapping parameter
+
+`false`::
+(boolean)
+The document source is not returned.
+
+`<wildcard_pattern>`::
+(string)
+Wildcard (`*`) patterns containing source fields to return.
+
+`<wildcard_pattern_array>`::
+(array of strings)
+Array of wildcard (`*`) patterns containing source fields to return.
+
+`<object>`::
+(object)
+Object containing a list of source fields to include or exclude.
++
+.Properties for `<object>`
+[%collapsible%open]
+=====
+`includes`::
+(array of strings)
+Array of wildcard (`*`) patterns containing source fields to return.
++
+If this property is specified, only source fields that match these patterns are
+returned. You can exclude fields from this subset using the `excludes` property.
+
+`excludes`::
+(array of strings)
+Array of wildcard (`*`) pattern containing source fields to exclude from the
+response.
++
+If the `includes` property is not specified, the entire document source is returned,
+excluding fields specified in this parameter.
+=====
+====
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 +
@@ -457,6 +534,9 @@ returned document.
 `_source`::
 (object)
 Original JSON body passed for the document at index time.
++
+You can use the `_source` parameter to exclude this property from the response
+or specify which source fields to return.
 =====
 ====
 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -211,7 +211,7 @@ The document source is not returned.
 `<string>`::
 (string)
 Comma-separated list of source fields to return.
-Wildcard (`*`) expressions are supported.
+Wildcard (`*`) patterns are supported.
 ====
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -336,10 +336,7 @@ the search response. Defaults to `true`.
 ====
 `true`::
 (boolean)
-The entire document source is returned. This does not include:
-* <<multi-fields,multi-fields>>
-* <<alias,field aliases>>
-* Values copied using the <<copy-to,`copy_to`>> mapping parameter
+The entire document source is returned.
 
 `false`::
 (boolean)

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -211,6 +211,7 @@ The document source is not returned.
 `<string>`::
 (string)
 Comma-separated list of source fields to return.
+Wildcard (`*`) expressions are supported.
 ====
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source_excludes]


### PR DESCRIPTION
Cleans up the reference documentation for the following
search API parameters:

* `_source` query parameter
* `_source_excludes` query parameter
* `_source_includes` query parameter
* `_source` request body parameter
* `hits._source` response property