### PR TITLE
[DOCS] Fix typo in ccr overview doc

### DIFF
--- a/docs/reference/ccr/overview.asciidoc
+++ b/docs/reference/ccr/overview.asciidoc
@@ -126,7 +126,7 @@ as-needed by the follower index. It is not possible to manually modify the
 mapping of a follower index.
 
 Settings updates applied to the leader index that are needed by the follower
-index are automatically retried as-needed by the follower index. Not all
+index are automatically retrieved as-needed by the follower index. Not all
 settings updates are needed by the follower index. For example, changing the
 number of replicas on the leader index is not replicated by the follower index.
 


### PR DESCRIPTION
There is a typo in ccr overview doc.