### PR TITLE
[Transform] use old roles only together with old endpoints

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -53,12 +53,12 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
         indicesCreated = true;
 
         // at random test the old deprecated roles, to be removed in 9.0.0
-        if (randomBoolean()) {
-            setupUser(TEST_USER_NAME, Collections.singletonList("transform_user"));
-            setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("transform_admin"));
-        } else {
+        if (useDeprecatedEndpoints() && randomBoolean()) {
             setupUser(TEST_USER_NAME, Collections.singletonList("data_frame_transforms_user"));
             setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("data_frame_transforms_admin"));
+        } else {
+            setupUser(TEST_USER_NAME, Collections.singletonList("transform_user"));
+            setupUser(TEST_ADMIN_USER_NAME, Collections.singletonList("transform_admin"));
         }
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -67,10 +67,10 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
 
         // at random test the old deprecated roles, to be removed in 9.0.0
-        if (randomBoolean()) {
-            setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
-        } else {
+        if (useDeprecatedEndpoints() && randomBoolean()) {
             setupUser(TEST_USER_NAME, Arrays.asList("data_frame_transforms_admin", DATA_ACCESS_ROLE));
+        } else {
+            setupUser(TEST_USER_NAME, Arrays.asList("transform_admin", DATA_ACCESS_ROLE));
         }
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -54,6 +54,10 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
 
     private static boolean useDeprecatedEndpoints;
 
+    protected boolean useDeprecatedEndpoints() {
+        return useDeprecatedEndpoints;
+    }
+
     @BeforeClass
     public static void init() {
         // randomly return the old or the new endpoints, old endpoints to be removed for 8.0.0


### PR DESCRIPTION
avoids a CI failure if new endpoints used together with old roles and warnings are asserted.