### PR TITLE
[DOCS] [7.7] Clarifying env variable substitution (#57370)

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -71,13 +71,20 @@ path.logs: /var/log/elasticsearch
 
 Environment variables referenced with the `${...}` notation within the
 configuration file will be replaced with the value of the environment
-variable, for instance:
+variable. For example:
 
 [source,yaml]
 --------------------------------------------------
 node.name:    ${HOSTNAME}
 network.host: ${ES_NETWORK_HOST}
 --------------------------------------------------
+
+Values for environment variables must be simple strings. Use a comma-separated string to provide values that Elasticsearch will parse as a list. For example, Elasticsearch will split the following string into a list of values for the `${HOSTNAME}` environment variable:
+
+[source,yaml]
+----
+export HOSTNAME=“host1,host2"
+----
 
 [discrete]
 [[cluster-setting-types]]
@@ -88,7 +95,7 @@ Cluster and node settings can be categorized based on how they are configured:
 [[dynamic-cluster-setting]]
 Dynamic::
 You can configure and update dynamic settings on a running cluster using the
-<<cluster-update-settings,cluster update settings API>>. 
+<<cluster-update-settings,cluster update settings API>>.
 +
 You can also configure dynamic settings locally on an unstarted or shut down
 node using `elasticsearch.yml`.


### PR DESCRIPTION
* Clarifying environment variable substitution in the ES configuration YAML
* Update code snippet
* Remove extraneous quotes from string example
* Incorporating review feedback

Co-authored-by: James Rodewig <james.rodewig@elastic.co>
Co-authored-by: David Turner <david.turner@elastic.co>

Backport for #6352 