### PR TITLE
Mute kerberos mutual auth test on JDK 15

### DIFF
--- a/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
+++ b/x-pack/qa/evil-tests/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/SimpleKdcLdapServerTests.java
@@ -11,6 +11,7 @@ import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchScope;
 
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.bootstrap.JavaVersion;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.env.Environment;
@@ -50,6 +51,9 @@ public class SimpleKdcLdapServerTests extends KerberosTestCase {
     }
 
     public void testClientServiceMutualAuthentication() throws PrivilegedActionException, GSSException, LoginException, ParseException {
+        assumeFalse("Java 15-ea causes issues with this test, see https://github.com/elastic/elasticsearch/issues/57749",
+            JavaVersion.current().compareTo(JavaVersion.parse("15")) >= 0);
+
         final String serviceUserName = randomFrom(serviceUserNames);
         // Client login and init token preparation
         final String clientUserName = randomFrom(clientUserNames);


### PR DESCRIPTION
This change mutes SimpleKdcLdapServerTests
testClientServiceMutualAuthentication when the runtime jdk is 15.

See #57749