### PR TITLE
Support TerminateEarly even if tracktotalhits<TE

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -131,7 +131,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                         this.hitCountSupplier = () -> new TotalHits(hitCountCollector.getTotalHits(), TotalHits.Relation.EQUAL_TO);
                     } else {
                         EarlyTerminatingCollector col =
-                            new EarlyTerminatingCollector(hitCountCollector, trackTotalHitsUpTo, false);
+                            new EarlyTerminatingCollector(hitCountCollector, trackTotalHitsUpTo, true);
                         this.collector = col;
                         this.hitCountSupplier = () -> new TotalHits(hitCountCollector.getTotalHits(),
                             col.hasEarlyTerminated() ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO : TotalHits.Relation.EQUAL_TO);


### PR DESCRIPTION
👋  howdy!  This PR should fix #57624 

The bug described in #57624 can be explained as "if track_total_hits < terminate_after, we never terminate_after".  I believed this was simply because forceTermination=false in our particular scenario here (where hitCount isn't an accurate count, because the default is 10K GTE).

By setting this to true, I get much better results.

Unfortunately I'm not much of a java developer.  I'd love tips on how to add a unit test for this.  Instead, I ran a script and compared output before & after my change.

Creating my test environment
```
curl http://elastic-admin:elastic-password@localhost:9200/myindex -XPUT
curl http://elastic-admin:elastic-password@localhost:9200/myindex/_doc -XPOST -H 'Content-Type: application/json' -d '{"hello": 1}'
curl http://elastic-admin:elastic-password@localhost:9200/myindex/_doc -XPOST -H 'Content-Type: application/json' -d '{"hello": 2}'
curl http://elastic-admin:elastic-password@localhost:9200/myindex/_doc -XPOST -H 'Content-Type: application/json' -d '{"hello": 3}'
curl http://elastic-admin:elastic-password@localhost:9200/myindex/_doc -XPOST -H 'Content-Type: application/json' -d '{"hello": 4}'
curl http://elastic-admin:elastic-password@localhost:9200/myindex/_doc -XPOST -H 'Content-Type: application/json' -d '{"hello": 5}'
```

Then the actual query results

BEFORE change:
```
 $ curl -s http://elastic-admin:elastic-password@localhost:9200/_search -XPOST -H 'Content-Type: application/json' -d '{"size": 0, "terminate_after": 4, "track_total_hits": 1} '
{"took":35,"timed_out":false,"terminated_early":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"gte"},"max_score":null,"hits":[]}}%
```

(Note how terminated_early: false)

AFTER change:

```
➜  dev  $ curl -s http://elastic-admin:elastic-password@localhost:9200/_search -XPOST -H 'Content-Type: application/json' -d '{"size": 0, "terminate_after": 4, "track_total_hits": 1} '
{"took":3,"timed_out":false,"terminated_early":true,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"gte"},"max_score":null,"hits":[]}}%
```

(Note terminated_early: true)

