### PR TITLE
[8.0] [DOCS] Document `doc_as_upsert` does not support ingest pipelines (#57649)

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -332,3 +332,7 @@ POST test/_update/1
 }
 --------------------------------------------------
 // TEST[continued]
+[NOTE]
+====
+Using <<ingest,ingest pipelines>> with `doc_as_upsert` is not supported.
+====


### PR DESCRIPTION
Master port of #57649