### PR TITLE
[DOCS] Adds security privileges to _scripts endpoint docs

### DIFF
--- a/docs/reference/scripting/using.asciidoc
+++ b/docs/reference/scripting/using.asciidoc
@@ -137,6 +137,14 @@ The same script in the normal form:
 Scripts may be stored in and retrieved from the cluster state using the
 `_scripts` end-point.
 
+If the {es} {security-features} are enabled, you must have the following 
+privileges to create, retrieve, and delete stored scripts:
+
+* cluster: `all` or `manage`
+
+For more information, see <<security-privileges>>.
+
+
 [float]
 ==== Request examples
 


### PR DESCRIPTION
## Overview

This PR adds information on the necessary security privileges to the _scripts API docs.

Related issue: https://github.com/elastic/elasticsearch/issues/48474

### Preview

[Stored scripts](https://elasticsearch_57795.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/modules-scripting-using.html#modules-scripting-stored-scripts)