### PR TITLE
A Closed Curly Bracket

### DIFF
--- a/x-pack/docs/en/watcher/actions/webhook.asciidoc
+++ b/x-pack/docs/en/watcher/actions/webhook.asciidoc
@@ -24,7 +24,7 @@ The following snippet shows a simple webhook action definition:
       "method" : "POST", <4>
       "host" : "mylisteningserver", <5>
       "port" : 9200, <6>
-      "path": ":/{{ctx.watch_id}", <7>
+      "path": ":/{{ctx.watch_id}}", <7>
       "body" : "{{ctx.watch_id}}:{{ctx.payload.hits.total.value}}" <8>
     }
   }


### PR DESCRIPTION
In the snippet, a closed curly bracket is missed. It leads to raise an error when Elasticsearch tries to fire an action.