### PR TITLE
Make ModelPlotConfig.annotations_enabled default to ModelPlotConfig.enabled if unset

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/ModelPlotConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/ModelPlotConfig.java
@@ -45,12 +45,12 @@ public class ModelPlotConfig implements ToXContentObject {
 
     private final boolean enabled;
     private final String terms;
-    private final boolean annotationsEnabled;
+    private final Boolean annotationsEnabled;
 
     public ModelPlotConfig(boolean enabled, String terms, Boolean annotationsEnabled) {
         this.enabled = enabled;
         this.terms = terms;
-        this.annotationsEnabled = Boolean.TRUE.equals(annotationsEnabled);
+        this.annotationsEnabled = annotationsEnabled;
     }
 
     @Override
@@ -60,7 +60,9 @@ public class ModelPlotConfig implements ToXContentObject {
         if (terms != null) {
             builder.field(TERMS_FIELD.getPreferredName(), terms);
         }
-        builder.field(ANNOTATIONS_ENABLED_FIELD.getPreferredName(), annotationsEnabled);
+        if (annotationsEnabled != null) {
+            builder.field(ANNOTATIONS_ENABLED_FIELD.getPreferredName(), annotationsEnabled);
+        }
         builder.endObject();
         return builder;
     }
@@ -73,7 +75,7 @@ public class ModelPlotConfig implements ToXContentObject {
         return this.terms;
     }
 
-    public boolean annotationsEnabled() {
+    public Boolean annotationsEnabled() {
         return annotationsEnabled;
     }
 
@@ -88,7 +90,9 @@ public class ModelPlotConfig implements ToXContentObject {
         }
 
         ModelPlotConfig that = (ModelPlotConfig) other;
-        return this.enabled == that.enabled && Objects.equals(this.terms, that.terms) && this.annotationsEnabled == that.annotationsEnabled;
+        return this.enabled == that.enabled
+            && Objects.equals(this.terms, that.terms)
+            && Objects.equals(this.annotationsEnabled, that.annotationsEnabled);
     }
 
     @Override

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -988,6 +988,11 @@ must be disabled if performance issues are experienced.
 --
 end::model-plot-config[]
 
+tag::model-plot-config-annotations-enabled[]
+If true, enables calculation and storage of the model change annotations
+for each entity that is being analyzed. By default, this is not enabled.
+end::model-plot-config-annotations-enabled[]
+
 tag::model-plot-config-enabled[]
 If true, enables calculation and storage of the model bounds for each entity
 that is being analyzed. By default, this is not enabled.
@@ -999,11 +1004,6 @@ values. If terms are not specified or it is an empty string, no filtering is
 applied. For example, "CPU,NetworkIn,DiskWrites". Wildcards are not supported.
 Only the specified `terms` can be viewed when using the Single Metric Viewer.
 end::model-plot-config-terms[]
-
-tag::model-plot-config-annotations-enabled[]
-If true, enables calculation and storage of the model change annotations
-for each entity that is being analyzed. By default, this is not enabled.
-end::model-plot-config-annotations-enabled[]
 
 tag::model-snapshot-id[]
 A numerical character string that uniquely identifies the model snapshot. For 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -990,7 +990,7 @@ end::model-plot-config[]
 
 tag::model-plot-config-annotations-enabled[]
 If true, enables calculation and storage of the model change annotations
-for each entity that is being analyzed. By default, this is not enabled.
+for each entity that is being analyzed. Defaults to `enabled`.
 end::model-plot-config-annotations-enabled[]
 
 tag::model-plot-config-enabled[]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -42,7 +42,8 @@ public class Annotation implements ToXContentObject, Writeable {
     public enum Event {
         USER,
         DELAYED_DATA,
-        MODEL_SNAPSHOT_STORED;
+        MODEL_SNAPSHOT_STORED,
+        MODEL_CHANGE;
 
         public static Event fromString(String value) {
             return valueOf(value.toUpperCase(Locale.ROOT));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
@@ -43,13 +43,13 @@ public class ModelPlotConfig implements ToXContentObject, Writeable {
     private final boolean annotationsEnabled;
 
     public ModelPlotConfig() {
-        this(true, null, true);
+        this(true, null, null);
     }
 
     public ModelPlotConfig(boolean enabled, String terms, Boolean annotationsEnabled) {
         this.enabled = enabled;
         this.terms = terms;
-        this.annotationsEnabled = Boolean.TRUE.equals(annotationsEnabled);
+        this.annotationsEnabled = annotationsEnabled != null ? annotationsEnabled : enabled;
     }
 
     public ModelPlotConfig(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfigTests.java
@@ -21,6 +21,14 @@ public class ModelPlotConfigTests extends AbstractSerializingTestCase<ModelPlotC
         assertThat(modelPlotConfig.annotationsEnabled(), is(true));
     }
 
+    public void testAnnotationEnabledDefaultsToEnabled() {
+        ModelPlotConfig modelPlotConfig = new ModelPlotConfig(false, null, null);
+        assertThat(modelPlotConfig.annotationsEnabled(), is(false));
+
+        modelPlotConfig = new ModelPlotConfig(true, null, null);
+        assertThat(modelPlotConfig.annotationsEnabled(), is(true));
+    }
+
     @Override
     protected ModelPlotConfig createTestInstance() {
         return createRandomized();


### PR DESCRIPTION
This PR uses the value of `ModelPlotConfig.enabled` field as a default value for `ModelPlotConfig.annotations_enabled` field.

Additionally, this PR adds a missing enum value `Annotation.Event.MODEL_CHANGE`.

Relates https://github.com/elastic/elasticsearch/issues/55781