### PR TITLE
[7.x] Make ModelPlotConfig.annotations_enabled default to ModelPlotConfig.enabled if unset (#57808)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/ModelPlotConfig.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/job/config/ModelPlotConfig.java
@@ -45,12 +45,12 @@ public class ModelPlotConfig implements ToXContentObject {
 
     private final boolean enabled;
     private final String terms;
-    private final boolean annotationsEnabled;
+    private final Boolean annotationsEnabled;
 
     public ModelPlotConfig(boolean enabled, String terms, Boolean annotationsEnabled) {
         this.enabled = enabled;
         this.terms = terms;
-        this.annotationsEnabled = Boolean.TRUE.equals(annotationsEnabled);
+        this.annotationsEnabled = annotationsEnabled;
     }
 
     @Override
@@ -60,7 +60,9 @@ public class ModelPlotConfig implements ToXContentObject {
         if (terms != null) {
             builder.field(TERMS_FIELD.getPreferredName(), terms);
         }
-        builder.field(ANNOTATIONS_ENABLED_FIELD.getPreferredName(), annotationsEnabled);
+        if (annotationsEnabled != null) {
+            builder.field(ANNOTATIONS_ENABLED_FIELD.getPreferredName(), annotationsEnabled);
+        }
         builder.endObject();
         return builder;
     }
@@ -73,7 +75,7 @@ public class ModelPlotConfig implements ToXContentObject {
         return this.terms;
     }
 
-    public boolean annotationsEnabled() {
+    public Boolean annotationsEnabled() {
         return annotationsEnabled;
     }
 
@@ -88,7 +90,9 @@ public class ModelPlotConfig implements ToXContentObject {
         }
 
         ModelPlotConfig that = (ModelPlotConfig) other;
-        return this.enabled == that.enabled && Objects.equals(this.terms, that.terms) && this.annotationsEnabled == that.annotationsEnabled;
+        return this.enabled == that.enabled
+            && Objects.equals(this.terms, that.terms)
+            && Objects.equals(this.annotationsEnabled, that.annotationsEnabled);
     }
 
     @Override

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1005,11 +1005,6 @@ applied. For example, "CPU,NetworkIn,DiskWrites". Wildcards are not supported.
 Only the specified `terms` can be viewed when using the Single Metric Viewer.
 end::model-plot-config-terms[]
 
-tag::model-snapshot-id[]
-A numerical character string that uniquely identifies the model snapshot. For 
-example, `1575402236000 `.
-end::model-snapshot-id[]
-
 tag::model-snapshot-retention-days[]
 Advanced configuration option, which affects the automatic removal of old model
 snapshots for this job. It specifies the maximum period of time (in days) that

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -988,6 +988,11 @@ must be disabled if performance issues are experienced.
 --
 end::model-plot-config[]
 
+tag::model-plot-config-annotations-enabled[]
+If true, enables calculation and storage of the model change annotations
+for each entity that is being analyzed. Defaults to `enabled`.
+end::model-plot-config-annotations-enabled[]
+
 tag::model-plot-config-enabled[]
 If true, enables calculation and storage of the model bounds for each entity
 that is being analyzed. By default, this is not enabled.
@@ -1000,10 +1005,10 @@ applied. For example, "CPU,NetworkIn,DiskWrites". Wildcards are not supported.
 Only the specified `terms` can be viewed when using the Single Metric Viewer.
 end::model-plot-config-terms[]
 
-tag::model-plot-config-annotations-enabled[]
-If true, enables calculation and storage of the model change annotations
-for each entity that is being analyzed. By default, this is not enabled.
-end::model-plot-config-annotations-enabled[]
+tag::model-snapshot-id[]
+A numerical character string that uniquely identifies the model snapshot. For 
+example, `1575402236000 `.
+end::model-snapshot-id[]
 
 tag::model-snapshot-retention-days[]
 Advanced configuration option, which affects the automatic removal of old model

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -42,7 +42,8 @@ public class Annotation implements ToXContentObject, Writeable {
     public enum Event {
         USER,
         DELAYED_DATA,
-        MODEL_SNAPSHOT_STORED;
+        MODEL_SNAPSHOT_STORED,
+        MODEL_CHANGE;
 
         public static Event fromString(String value) {
             return valueOf(value.toUpperCase(Locale.ROOT));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfig.java
@@ -44,13 +44,13 @@ public class ModelPlotConfig implements ToXContentObject, Writeable {
     private final boolean annotationsEnabled;
 
     public ModelPlotConfig() {
-        this(true, null, true);
+        this(true, null, null);
     }
 
     public ModelPlotConfig(boolean enabled, String terms, Boolean annotationsEnabled) {
         this.enabled = enabled;
         this.terms = terms;
-        this.annotationsEnabled = Boolean.TRUE.equals(annotationsEnabled);
+        this.annotationsEnabled = annotationsEnabled != null ? annotationsEnabled : enabled;
     }
 
     public ModelPlotConfig(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/ModelPlotConfigTests.java
@@ -21,6 +21,14 @@ public class ModelPlotConfigTests extends AbstractSerializingTestCase<ModelPlotC
         assertThat(modelPlotConfig.annotationsEnabled(), is(true));
     }
 
+    public void testAnnotationEnabledDefaultsToEnabled() {
+        ModelPlotConfig modelPlotConfig = new ModelPlotConfig(false, null, null);
+        assertThat(modelPlotConfig.annotationsEnabled(), is(false));
+
+        modelPlotConfig = new ModelPlotConfig(true, null, null);
+        assertThat(modelPlotConfig.annotationsEnabled(), is(true));
+    }
+
     @Override
     protected ModelPlotConfig createTestInstance() {
         return createRandomized();


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make ModelPlotConfig.annotations_enabled default to ModelPlotConfig.enabled if unset  (#57808)