### PR TITLE
Update version peer recovery constants to 7_9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
-final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/57827" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = true
+final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1042,12 +1042,11 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 org.elasticsearch.ingest.IngestProcessorException::new,
                 157,
                 Version.V_7_5_0),
-        // TODO: Version after backport
         PEER_RECOVERY_NOT_FOUND_EXCEPTION(
                 org.elasticsearch.indices.recovery.PeerRecoveryNotFound.class,
                 org.elasticsearch.indices.recovery.PeerRecoveryNotFound::new,
                 158,
-                Version.V_8_0_0);
+                Version.V_7_9_0);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -628,8 +628,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
             if (cause instanceof ConnectTransportException) {
                 logger.debug("delaying recovery of {} for [{}] due to networking error [{}]", request.shardId(),
                     recoverySettings.retryDelayNetwork(), cause.getMessage());
-                // TODO: Change after backport
-                if (request.sourceNode().getVersion().onOrAfter(Version.V_8_0_0)) {
+                if (request.sourceNode().getVersion().onOrAfter(Version.V_7_9_0)) {
                     reestablishRecovery(request, cause.getMessage(), recoverySettings.retryDelayNetwork());
                 } else {
                     retryRecovery(recoveryId, cause.getMessage(), recoverySettings.retryDelayNetwork(),

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTransportRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.indices.recovery;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.seqno.SequenceNumbers;
@@ -32,8 +33,7 @@ public abstract class RecoveryTransportRequest extends TransportRequest {
 
     RecoveryTransportRequest(StreamInput in) throws IOException {
         super(in);
-        // TODO: Change after backport
-        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_9_0)) {
             requestSeqNo = in.readLong();
         } else {
             requestSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -51,8 +51,7 @@ public abstract class RecoveryTransportRequest extends TransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        // TODO: Change after backport
-        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             out.writeLong(requestSeqNo);
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RemoteRecoveryTargetHandler.java
@@ -97,8 +97,7 @@ public class RemoteRecoveryTargetHandler implements RecoveryTargetHandler {
                 .withType(TransportRequestOptions.Type.RECOVERY)
                 .withTimeout(recoverySettings.internalActionTimeout())
                 .build();
-        // TODO: Change after backport
-        this.retriesSupported = targetNode.getVersion().onOrAfter(Version.V_8_0_0);
+        this.retriesSupported = targetNode.getVersion().onOrAfter(Version.V_7_9_0);
     }
 
     @Override


### PR DESCRIPTION
The resilient recovery work introduced version dependent behavior and
serialization. This commit updates the version constants to indicate
that this work has been backported to 7.9.