### PR TITLE
Throw exception on duplicate mappings metadata fields when merging templates

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -569,9 +569,7 @@ public class MetadataCreateIndexService {
                 Map<String, Object> innerTemplateNonProperties = new HashMap<>(innerTemplateMapping);
                 Map<String, Object> maybeProperties = (Map<String, Object>) innerTemplateNonProperties.remove("properties");
 
-                nonProperties = removeDuplicatedDynamicTemplates(nonProperties, innerTemplateNonProperties);
-                XContentHelper.mergeDefaults(innerTemplateNonProperties, nonProperties);
-                nonProperties = innerTemplateNonProperties;
+                nonProperties = mergeFailingOnReplacement(nonProperties, innerTemplateNonProperties);
 
                 if (maybeProperties != null) {
                     properties = mergeFailingOnReplacement(properties, maybeProperties);
@@ -584,9 +582,7 @@ public class MetadataCreateIndexService {
             Map<String, Object> innerRequestNonProperties = new HashMap<>(innerRequestMappings);
             Map<String, Object> maybeRequestProperties = (Map<String, Object>) innerRequestNonProperties.remove("properties");
 
-            nonProperties = removeDuplicatedDynamicTemplates(nonProperties, innerRequestMappings);
-            XContentHelper.mergeDefaults(innerRequestNonProperties, nonProperties);
-            nonProperties = innerRequestNonProperties;
+            nonProperties = mergeFailingOnReplacement(nonProperties, innerRequestNonProperties);
 
             if (maybeRequestProperties != null) {
                 properties = mergeFailingOnReplacement(properties, maybeRequestProperties);
@@ -596,71 +592,6 @@ public class MetadataCreateIndexService {
         Map<String, Object> finalMappings = dedupDynamicTemplates(nonProperties);
         finalMappings.put("properties", properties);
         return Collections.singletonMap(MapperService.SINGLE_MAPPING_NAME, finalMappings);
-    }
-
-    /**
-     * Removes the already seen/processed dynamic templates from the previouslySeenMapping if they are defined (we're
-     * identifying the dynamic templates based on the name only, *not* on the full definition) in the newMapping we are about to
-     * process (and merge)
-     */
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> removeDuplicatedDynamicTemplates(Map<String, Object> previouslySeenMapping,
-                                                                        Map<String, Object> newMapping) {
-        Map<String, Object> result = new HashMap<>(previouslySeenMapping);
-        List<Map<String, Object>> newDynamicTemplates = (List<Map<String, Object>>) newMapping.get("dynamic_templates");
-        List<Map<String, Object>> previouslySeenDynamicTemplates =
-            (List<Map<String, Object>>) previouslySeenMapping.get("dynamic_templates");
-
-        List<Map<String, Object>> filteredDynamicTemplates = removeOverlapping(previouslySeenDynamicTemplates, newDynamicTemplates);
-
-        // if we removed any mappings from the previously seen ones, we'll re-add them on merge time, see
-        // {@link XContentHelper#mergeDefaults}, so update the result to contain the filtered ones
-        if (filteredDynamicTemplates != previouslySeenDynamicTemplates) {
-            result.put("dynamic_templates", filteredDynamicTemplates);
-        }
-        return result;
-    }
-
-    /**
-     * Removes all the items from the first list that are already present in the second list
-     *
-     * Similar to {@link List#removeAll(Collection)} but the list parameters are not modified.
-     *
-     * This expects both list values to be Maps of size one and the "contains" operation that will determine if a value
-     * from the second list is present in the first list (and be removed from the first list) is based on key name.
-     *
-     * eg.
-     *      removeAll([ {"key1" : {}}, {"key2" : {}} ], [ {"key1" : {}}, {"key3" : {}} ])
-     * Returns:
-     *     [ {"key2" : {}} ]
-     */
-    private static List<Map<String, Object>> removeOverlapping(List<Map<String, Object>> first, List<Map<String, Object>> second) {
-        if (first == null) {
-            return first;
-        } else {
-            validateValuesAreMapsOfSizeOne(first);
-        }
-
-        if (second == null) {
-            return first;
-        } else {
-            validateValuesAreMapsOfSizeOne(second);
-        }
-
-        Set<String> keys = second.stream()
-            .map(value -> value.keySet().iterator().next())
-            .collect(Collectors.toSet());
-
-        return first.stream().filter(value -> keys.contains(value.keySet().iterator().next()) == false).collect(toList());
-    }
-
-    private static void validateValuesAreMapsOfSizeOne(List<Map<String, Object>> second) {
-        for (Map<String, Object> map : second) {
-            // all are in the form of [ {"key1" : {}}, {"key2" : {}} ]
-            if (map.size() != 1) {
-                throw new IllegalArgumentException("unexpected argument, expected maps with one key, but got " + map);
-            }
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1003,9 +1003,8 @@ public class MetadataIndexTemplateService {
 
                 // Parse mappings to ensure they are valid after being composed
                 List<CompressedXContent> mappings = resolveMappings(stateWithIndex, templateName);
-                final Map<String, Object> finalMappings;
                 try {
-                    finalMappings = MetadataCreateIndexService.parseV2Mappings("{}", mappings, xContentRegistry);
+                    Map<String, Object> finalMappings = MetadataCreateIndexService.parseV2Mappings("{}", mappings, xContentRegistry);
 
                     MapperService dummyMapperService = tempIndexService.mapperService();
                     if (finalMappings.isEmpty() == false) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1118,6 +1118,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             dynamicMapping.get("path_match"), is("docker.container.labels.*"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/57393")
     public void testDedupRequestDynamicTemplates() throws Exception {
         String requestMappingJson = "{\"_doc\":{\"_source\":{\"enabled\": false}, \"dynamic_templates\": [" +
             "{\n" +
@@ -1179,6 +1180,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         assertThat(mapping.get("type"), is("keyword"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/57393")
     public void testMultipleComponentTemplatesDefineSameDynamicTemplate() throws Exception {
         String ct1Mapping = "{\"_doc\":{\"_source\":{\"enabled\": false}, \"dynamic_templates\": [" +
             "{\n" +


### PR DESCRIPTION
In #57701 we changed mappings merging so that duplicate fields specified in mappings caused an
exception during validation. This change makes the same exception thrown when metadata fields are
duplicated. This will allow us to be strict currently with plans to make the merging more
fine-grained in a later release.

The tests are marked as `@AwaitsFix` as we intend to change the behavior soon to be finer-grained, and they will be beneficial once we do have the fine-grained merging.