### PR TITLE
[7.x] Throw exception on duplicate mappings metadata fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -591,8 +591,7 @@ public class MetadataCreateIndexService {
                 Map<String, Object> innerTemplateNonProperties = new HashMap<>(innerTemplateMapping);
                 Map<String, Object> maybeProperties = (Map<String, Object>) innerTemplateNonProperties.remove("properties");
 
-                XContentHelper.mergeDefaults(innerTemplateNonProperties, nonProperties);
-                nonProperties = innerTemplateNonProperties;
+                nonProperties = mergeFailingOnReplacement(nonProperties, innerTemplateNonProperties);
 
                 if (maybeProperties != null) {
                     properties = mergeFailingOnReplacement(properties, maybeProperties);
@@ -605,8 +604,7 @@ public class MetadataCreateIndexService {
             Map<String, Object> innerRequestNonProperties = new HashMap<>(innerRequestMappings);
             Map<String, Object> maybeRequestProperties = (Map<String, Object>) innerRequestNonProperties.remove("properties");
 
-            XContentHelper.mergeDefaults(innerRequestNonProperties, nonProperties);
-            nonProperties = innerRequestNonProperties;
+            nonProperties = mergeFailingOnReplacement(nonProperties, innerRequestNonProperties);
 
             if (maybeRequestProperties != null) {
                 properties = mergeFailingOnReplacement(properties, maybeRequestProperties);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -987,14 +987,12 @@ public class MetadataIndexTemplateService {
 
                 // Parse mappings to ensure they are valid after being composed
                 List<CompressedXContent> mappings = resolveMappings(stateWithIndex, templateName);
-                final Map<String, Map<String, Object>> finalMappings;
                 try {
+                    Map<String, Map<String, Object>> finalMappings =
+                        MetadataCreateIndexService.parseV2Mappings("{}", mappings, xContentRegistry);
                     MapperService dummyMapperService = tempIndexService.mapperService();
-                    for (CompressedXContent mapping : mappings) {
-                        // TODO: Eventually change this to:
-                        // dummyMapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
-                        dummyMapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.MAPPING_UPDATE);
-                    }
+                        // TODO: Eventually change this to use MergeReason.INDEX_TEMPLATE
+                        dummyMapperService.merge(finalMappings, MergeReason.MAPPING_UPDATE);
                 } catch (Exception e) {
                     throw new IllegalArgumentException("invalid composite mappings for [" + templateName + "]", e);
                 }


### PR DESCRIPTION
This is a backport of #57835.

In #57701 we changed mappings merging so that duplicate fields specified in mappings caused an
exception during validation. This change makes the same exception thrown when metadata fields are
duplicated. This will allow us to be strict currently with plans to make the merging more
fine-grained in a later release.
