### PR TITLE
[DOCS] Move some docs about data streams from the create page to the intro page

### DIFF
--- a/docs/reference/data-streams.asciidoc
+++ b/docs/reference/data-streams.asciidoc
@@ -36,6 +36,14 @@ as a maximum age or size. A rollover creates a new backing index and updates the
 data stream's list of backing indices. This new index then becomes the stream's
 new write index. See <<rollover-data-stream-ex>>.
 
+Backing indices are generated with the naming convention
+`.ds-<data-stream-name>-zzzzzz` where `zzzzzz` is the six-digit, zero-padded
+generation of the data stream. For example, a data stream named
+`web-server-logs` with a generation of 34 would have a write index named
+`.ds-web-server-logs-000034`. Data streams may have backing indices that do not
+conform to this naming convention if operations such as
+<<indices-shrink-index,shrink>> have been performed on them.
+
 [discrete]
 [[create-data-stream]]
 == Create a data stream

--- a/docs/reference/data-streams.asciidoc
+++ b/docs/reference/data-streams.asciidoc
@@ -37,7 +37,7 @@ data stream's list of backing indices. This new index then becomes the stream's
 new write index. See <<rollover-data-stream-ex>>.
 
 Backing indices are generated with the naming convention
-`.ds-<data-stream-name>-zzzzzz` where `zzzzzz` is the six-digit, zero-padded
+`.ds-<data-stream-name>-zzzzzz`, where `zzzzzz` is the six-digit, zero-padded
 generation of the data stream. For example, a data stream named
 `web-server-logs` with a generation of 34 would have a write index named
 `.ds-web-server-logs-000034`. Data streams may have backing indices that do not

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -6,25 +6,8 @@
 
 Creates a new data stream.
 
-Data streams provide a convenient way to ingest, search, and manage time series
-data. Documents containing time series data may be indexed directly into a data
-stream and searched through the data stream. Behind the scenes, data streams
-contain one or more hidden backing indices and a generation attribute that
-indicates which of the backing indices is the write index, the index into which
-documents will be ingested.
-
-Backing indices are generated with the naming convention
-`<data-stream-name>-zzzzzz` where `zzzzzz` is the six-digit, zero-padded
-generation of the data stream. For example, a data stream named
-`web-server-logs` with a generation of 34 would have a write index named
-`web-server-logs-000034`. While nothing prevents backing indices from being
-addressed directly, data streams are integrated with the
-<<indices-rollover-index, rollover index API>> and
-<<index-lifecycle-management, index lifecycle management (ILM)>> to facilitate
-the management of the time series data contained in their backing indices.
-
 A data stream can only be created if the namespace it targets has a component
-template exists with a `data_stream` definition.
+template that exists with a `data_stream` definition.
 
 [source,console]
 -----------------------------------


### PR DESCRIPTION
Some of the explanatory text about data streams on the "Create data stream API" page was better suited for the data stream intro page.

Relates to #53100
