### PR TITLE
Muting testUpdateComponentTemplateFailsIfResolvedIndexTemplatesWouldBeInvalid

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -920,6 +920,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
      * Tests that we check that settings/mappings/etc are valid even after template composition,
      * when updating a component template
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/57842")
     public void testUpdateComponentTemplateFailsIfResolvedIndexTemplatesWouldBeInvalid() throws Exception {
         final MetadataIndexTemplateService service = getMetadataIndexTemplateService();
         ClusterState state = ClusterState.EMPTY_STATE;


### PR DESCRIPTION
Test mute for issue https://github.com/elastic/elasticsearch/issues/57842