### PR TITLE
[DOCS] Adds scope to monitoring

### DIFF
--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -14,9 +14,7 @@ as described in <<collecting-monitoring-data>>.
 
 image::monitoring/images/metricbeat.png[Example monitoring architecture]
 
-//NOTE: The tagged regions are re-used in the Stack Overview.
-
-. Enable the collection of monitoring data. +
+. Enable the collection of monitoring data.
 +
 --
 // tag::enable-collection[]
@@ -39,54 +37,49 @@ PUT _cluster/settings
 
 If {es} {security-features} are enabled, you must have `monitor` cluster privileges to 
 view the cluster settings and `manage` cluster privileges to change them.
-
 // end::enable-collection[]
+
 For more information, see <<monitoring-settings>> and <<cluster-update-settings>>.
 --
 
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
 {es} node in the production cluster.
 
-. Enable the {es} {xpack} module in {metricbeat} on each {es} node. +
+. Enable the {es} module in {metricbeat} on each {es} node.
 +
 --
-// tag::enable-es-module[]
 For example, to enable the default configuration in the `modules.d` directory, 
 run the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-metricbeat modules enable elasticsearch-xpack
+metricbeat modules enable elasticsearch
 ----------------------------------------------------------------------
 
 For more information, see 
 {metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
 {metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
 
-// end::enable-es-module[]
 --
 
-. Configure the {es} {xpack} module in {metricbeat} on each {es} node. +
+. Configure the {es} module in {metricbeat} on each {es} node.
 +
 --
-// tag::configure-es-module[]
-The `modules.d/elasticsearch-xpack.yml` file contains the following settings:
+Set `xpack.enabled: true` and remove any `metricsets` from the module’s configuration. Alternatively, use the {es} {xpack} module; run
+`metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.
+
+The `modules.d/elasticsearch.yml` file contains the following settings:
 
 [source,yaml]
 ----------------------------------
   - module: elasticsearch
-    metricsets:
-      - ccr
-      - cluster_stats
-      - index
-      - index_recovery
-      - index_summary
-      - ml_job
-      - node_stats
-      - shard
-      - enrich
+    #metricsets:
+    #  - node
+    #  - node_stats
     period: 10s
     hosts: ["http://localhost:9200"]
+    #scope: node
     #username: "user"
     #password: "secret"
     xpack.enabled: true
@@ -96,10 +89,13 @@ By default, the module collects {es} monitoring metrics from
 `http://localhost:9200`. If that host and port number are not correct, you must
 update the `hosts` setting. If you configured {es} to use encrypted
 communications, you must access it via HTTPS. For example, use a `hosts` setting
-like `https://localhost:9200`.
-// end::configure-es-module[]
+like `https://localhost:9200`. By default, `scope` is set to `node` and each
+entry in the `hosts` list indicates a distinct node in an {es} cluster. If you
+set `scope` to `cluster`, each entry in the `hosts` list indicates a single 
+endpoint for a distinct {es} cluster (for example, a load-balancing proxy
+fronting the cluster). For more information, refer to
+{metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module].
 
-// tag::remote-monitoring-user[]
 If Elastic {security-features} are enabled, you must also provide a user ID
 and password so that {metricbeat} can collect metrics successfully: 
 
@@ -110,13 +106,11 @@ Alternatively, use the
 
 .. Add the `username` and `password` settings to the {es} module configuration
 file. 
-// end::remote-monitoring-user[]
 --
 
 . Optional: Disable the system module in {metricbeat}.
 +
 --
-// tag::disable-system-module[]
 By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
 enabled. The information it collects, however, is not shown on the *Monitoring*
 page in {kib}. Unless you want to use that information for other purposes, run
@@ -127,7 +121,6 @@ the following command:
 metricbeat modules disable system
 ----------------------------------------------------------------------
 
-// end::disable-system-module[] 
 --
 
 . Identify where to send the monitoring data. +
@@ -185,7 +178,6 @@ For more information about these configuration options, see
 . Disable the default collection of {es} monitoring metrics. +
 +
 --
-// tag::disable-default-collection[]
 Set `xpack.monitoring.elasticsearch.collection.enabled` to `false` on the 
 production cluster.
 
@@ -204,8 +196,6 @@ PUT _cluster/settings
 If {es} {security-features} are enabled, you must have `monitor` cluster
 privileges to  view the cluster settings and `manage` cluster privileges
 to change them.
-
-// end::disable-default-collection[]
 --
 
 . {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -33,7 +33,7 @@ PUT _cluster/settings
     "xpack.monitoring.collection.enabled": true
   }
 }
----------------------------------- 
+----------------------------------
 
 If {es} {security-features} are enabled, you must have `monitor` cluster privileges to 
 view the cluster settings and `manage` cluster privileges to change them.
@@ -45,7 +45,7 @@ For more information, see <<monitoring-settings>> and <<cluster-update-settings>
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
 {es} node in the production cluster.
 
-. Enable the {es} module in {metricbeat} on each {es} node.
+. Enable the {es} {xpack} module in {metricbeat} on each {es} node.
 +
 --
 For example, to enable the default configuration in the `modules.d` directory, 
@@ -53,36 +53,27 @@ run the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-metricbeat modules enable elasticsearch
+metricbeat modules enable elasticsearch-xpack
 ----------------------------------------------------------------------
 
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
-{metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
-
+Alternatively, you can use the {es} module, as described in the
+{metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module usage for {stack} monitoring]. 
 --
 
-. Configure the {es} module in {metricbeat} on each {es} node.
+. Configure the {es} {xpack} module in {metricbeat} on each {es} node.
 +
 --
-Set `xpack.enabled: true` and remove any `metricsets` from the module’s configuration. Alternatively, use the {es} {xpack} module; run
-`metricbeat modules disable elasticsearch` and
-`metricbeat modules enable elasticsearch-xpack`.
-
-The `modules.d/elasticsearch.yml` file contains the following settings:
+The `modules.d/elasticsearch-xpack.yml` file contains the following settings:
 
 [source,yaml]
 ----------------------------------
   - module: elasticsearch
-    #metricsets:
-    #  - node
-    #  - node_stats
+    xpack.enabled: true
     period: 10s
     hosts: ["http://localhost:9200"]
     #scope: node
     #username: "user"
     #password: "secret"
-    xpack.enabled: true
 ----------------------------------
 
 By default, the module collects {es} monitoring metrics from
@@ -93,8 +84,7 @@ like `https://localhost:9200`. By default, `scope` is set to `node` and each
 entry in the `hosts` list indicates a distinct node in an {es} cluster. If you
 set `scope` to `cluster`, each entry in the `hosts` list indicates a single 
 endpoint for a distinct {es} cluster (for example, a load-balancing proxy
-fronting the cluster). For more information, refer to
-{metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module].
+fronting the cluster).
 
 If Elastic {security-features} are enabled, you must also provide a user ID
 and password so that {metricbeat} can collect metrics successfully: 
@@ -123,7 +113,7 @@ metricbeat modules disable system
 
 --
 
-. Identify where to send the monitoring data. +
+. Identify where to send the monitoring data.
 +
 --
 TIP: In production environments, we strongly recommend using a separate cluster 
@@ -175,7 +165,7 @@ For more information about these configuration options, see
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}] on each node. 
 
-. Disable the default collection of {es} monitoring metrics. +
+. Disable the default collection of {es} monitoring metrics.
 +
 --
 Set `xpack.monitoring.elasticsearch.collection.enabled` to `false` on the 

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -70,21 +70,20 @@ The `modules.d/elasticsearch-xpack.yml` file contains the following settings:
   - module: elasticsearch
     xpack.enabled: true
     period: 10s
-    hosts: ["http://localhost:9200"]
-    #scope: node
+    hosts: ["http://localhost:9200"] <1>
+    #scope: node <2>
     #username: "user"
     #password: "secret"
 ----------------------------------
-
-By default, the module collects {es} monitoring metrics from
+<1> By default, the module collects {es} monitoring metrics from
 `http://localhost:9200`. If that host and port number are not correct, you must
 update the `hosts` setting. If you configured {es} to use encrypted
 communications, you must access it via HTTPS. For example, use a `hosts` setting
-like `https://localhost:9200`. By default, `scope` is set to `node` and each
-entry in the `hosts` list indicates a distinct node in an {es} cluster. If you
-set `scope` to `cluster`, each entry in the `hosts` list indicates a single 
-endpoint for a distinct {es} cluster (for example, a load-balancing proxy
-fronting the cluster).
+like `https://localhost:9200`.
+<2> By default, `scope` is set to `node` and each entry in the `hosts` list
+indicates a distinct node in an {es} cluster. If you set `scope` to `cluster`,
+each entry in the `hosts` list indicates a single endpoint for a distinct {es}
+cluster (for example, a load-balancing proxy fronting the cluster).
 
 If Elastic {security-features} are enabled, you must also provide a user ID
 and password so that {metricbeat} can collect metrics successfully: 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/57217

Related to https://github.com/elastic/beats/pull/18547

This PR also switches the instructions in https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-metricbeat.html so that it matches https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
and recommends the Elasticsearch module instead of the Elasticsearch X-Pack module. 

## Preview
https://elasticsearch_57852.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/configuring-metricbeat.html