### PR TITLE
[DOCS] Fix typo in ILM rollover docs

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -16,7 +16,7 @@ For a managed index to be rolled over:
 
 * The index name must match the pattern '^.*-\\d+$', for example (`my_index-000001`).
 * The `index.lifecycle.rollover_alias` must be configured as the alias to roll over. 
-* The index must be the <<<<indices-rollover-is-write-index, write index>> for the alias.
+* The index must be the <<indices-rollover-is-write-index, write index>> for the alias.
 
 For example, if `my_index-000001` has the alias `my_data`, 
 the following settings must be configured. 


### PR DESCRIPTION
Removes extraneous syntax around a cross reference in the ILM rollover docs.

Backport of https://github.com/elastic/elasticsearch/commit/2d21c214cad4728544343762dc7e2d1523816db2, which I accidentally committed straight to master.