### PR TITLE
Rollover avoid reroute during dry-run/pre-result

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -19,11 +19,18 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -32,6 +39,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.MockLogAppender;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -180,10 +188,34 @@ public class RolloverIT extends ESIntegTestCase {
     }
 
     public void testRolloverDryRun() throws Exception {
+        if (randomBoolean()) {
+            PutIndexTemplateRequestBuilder putTemplate = client().admin().indices()
+                .preparePutTemplate("test_index")
+                .setPatterns(List.of("test_index-*"))
+                .setOrder(-1)
+                .setSettings(Settings.builder().put(AutoExpandReplicas.SETTING.getKey(), "0-all"));
+            assertAcked(putTemplate.get());
+        }
         assertAcked(prepareCreate("test_index-1").addAlias(new Alias("test_alias")).get());
         indexDoc("test_index-1", "1", "field", "value");
         flush("test_index-1");
+        ensureGreen();
+        Logger allocationServiceLogger = LogManager.getLogger(AllocationService.class);
+
+        MockLogAppender appender = new MockLogAppender();
+        appender.start();
+        appender.addExpectation(
+            new MockLogAppender.UnseenEventExpectation("no related message logged on dry run",
+                AllocationService.class.getName(), Level.INFO, "*test_index*")
+        );
+        Loggers.addAppender(allocationServiceLogger, appender);
+
         final RolloverResponse response = client().admin().indices().prepareRolloverIndex("test_alias").dryRun(true).get();
+
+        appender.assertAllExpectationsMatched();
+        appender.stop();
+        Loggers.removeAppender(allocationServiceLogger, appender);
+
         assertThat(response.getOldIndex(), equalTo("test_index-1"));
         assertThat(response.getNewIndex(), equalTo("test_index-000002"));
         assertThat(response.isDryRun(), equalTo(true));


### PR DESCRIPTION
Fixed two newly introduced issues with rollover:
1. Using auto-expand replicas could result in unexpected log messages on
future indexes.
2. It did a reroute on the network thread. Reroute can be heavy and
should not be run on network threads.

Closes #57706
Relates #53965

Tentatively marked this non-issue, in case it makes it into 7.8.0