### PR TITLE
Split internal distribution handling into separate internal plugin

### DIFF
--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/InternalDistributionDownloadPluginFuncTest.groovy
@@ -1,0 +1,174 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.lang.management.ManagementFactory
+
+class InternalDistributionDownloadPluginFuncTest extends Specification {
+
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile = testProjectDir.newFile('build.gradle')
+        buildFile << """plugins {
+          id 'elasticsearch.global-build-info'
+        }
+        import org.elasticsearch.gradle.Architecture
+        import org.elasticsearch.gradle.info.BuildParams
+
+        BuildParams.init { it.setIsInternal(true) }
+
+        import org.elasticsearch.gradle.BwcVersions
+        import org.elasticsearch.gradle.Version
+
+        Version currentVersion = Version.fromString("9.0.0")
+        BwcVersions versions = new BwcVersions(new TreeSet<>(
+        Arrays.asList(Version.fromString("8.0.0"), Version.fromString("8.0.1"), Version.fromString("8.1.0"), currentVersion)),
+            currentVersion)
+
+        BuildParams.init { it.setBwcVersions(versions) }
+
+        """
+    }
+
+    def testCurrent() {
+        given:
+        localDistroSetup()
+        def distroVersion = VersionProperties.getElasticsearch()
+        buildFile << """
+            apply plugin: 'elasticsearch.internal-distribution-download'
+
+            elasticsearch_distributions {
+              test_distro {
+                  version = "$distroVersion"
+                  type = "archive"
+                  platform = "linux"
+                  architecture = Architecture.current();
+              }
+            }
+            tasks.register("createExtractedTestDistro") {
+                dependsOn elasticsearch_distributions.test_distro.extracted
+            }
+        """
+        when:
+        def buildOutput = gradleRunner("createExtractedTestDistro").build()
+        then:
+        buildOutput.task(":distribution:archives:linux-tar:buildTar").outcome == TaskOutcome.SUCCESS
+        buildOutput.task(":extractElasticsearchLinux$distroVersion").outcome == TaskOutcome.SUCCESS
+        assertExtractedDistroIsCreated(distroVersion, 'current-marker.txt')
+    }
+
+    def testBwc() {
+        given:
+        bwcMinorProjectSetup()
+        def distroVersion = "8.1.0"
+        buildFile << """
+            apply plugin: 'elasticsearch.internal-distribution-download'
+
+            elasticsearch_distributions {
+              test_distro {
+                  version = "8.1.0"
+                  type = "archive"
+                  platform = "linux"
+                  architecture = Architecture.current();
+              }
+            }
+            tasks.register("createExtractedTestDistro") {
+                dependsOn elasticsearch_distributions.test_distro.extracted
+            }
+        """
+        when:
+        def buildOutput = gradleRunner("createExtractedTestDistro").build()
+        then:
+        buildOutput.task(":distribution:bwc:minor:buildBwcTask").outcome == TaskOutcome.SUCCESS
+        buildOutput.task(":extractElasticsearchLinux8.1.0").outcome == TaskOutcome.SUCCESS
+        assertExtractedDistroIsCreated(distroVersion,'bwc-marker.txt')
+    }
+
+    private GradleRunner gradleRunner(String... arguments) {
+        GradleRunner.create()
+            .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
+            .withProjectDir(testProjectDir.root)
+            .withArguments(arguments)
+            .withPluginClasspath()
+            .forwardOutput()
+    }
+
+    private void bwcMinorProjectSetup() {
+        settingsFile << """
+        include ':distribution:bwc:minor'
+        """
+        def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "bwc", "minor")
+        new File(bwcSubProjectFolder, 'bwc-marker.txt') << "bwc=minor"
+        new File(bwcSubProjectFolder, 'build.gradle') << """
+            apply plugin:'base'
+            configurations.create("linux-tar")
+            tasks.register("buildBwcTask", Tar) {
+                from('bwc-marker.txt')
+                archiveExtension = "tar.gz"
+                compression = Compression.GZIP
+            }
+            artifacts {
+                it.add("linux-tar", buildBwcTask)
+            }
+        """
+    }
+
+    private void localDistroSetup() {
+        settingsFile << """
+        include ":distribution:archives:linux-tar"
+        """
+        def bwcSubProjectFolder = testProjectDir.newFolder("distribution", "archives", "linux-tar")
+        new File(bwcSubProjectFolder, 'current-marker.txt') << "current"
+        new File(bwcSubProjectFolder, 'build.gradle') << """
+            apply plugin:'distribution'
+            tasks.register("buildTar", Tar) {
+                from('current-marker.txt')
+                archiveExtension = "tar.gz"
+                compression = Compression.GZIP
+            }
+            artifacts {
+                it.add("default", buildTar)
+            }
+        """
+        buildFile << """
+        """
+
+    }
+
+    boolean assertExtractedDistroIsCreated(String version, String markerFileName) {
+        File extractedFolder = new File(testProjectDir.root, "build/elasticsearch-distros/extracted_elasticsearch_${version}_archive_linux_default")
+        assert extractedFolder.exists()
+        assert new File(extractedFolder, markerFileName).exists()
+        true
+    }
+}

--- a/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/buildSrc/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.fixtures
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.lang.management.ManagementFactory
+
+abstract class AbstractGradleFuncTest extends Specification{
+
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    GradleRunner gradleRunner(String... arguments) {
+        GradleRunner.create()
+            .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
+            .withProjectDir(testProjectDir.root)
+            .withArguments(arguments)
+            .withPluginClasspath()
+            .forwardOutput()
+    }
+
+    def assertOutputContains(String givenOutput, String expected) {
+        assert normalizedString(givenOutput).contains(normalizedString(expected))
+        true
+    }
+
+    String normalizedString(String input) {
+        return input.readLines().join("\n")
+    }
+
+}

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/DistributionDownloadPluginIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/DistributionDownloadPluginIT.java
@@ -41,21 +41,6 @@ public class DistributionDownloadPluginIT extends GradleIntegrationTestCase {
 
     // TODO: check reuse of root task across projects MOVE TO UNIT TEST
     // TODO: future: check integ-test-zip to maven, snapshots to snapshot service for external project
-    public void testCurrent() throws Exception {
-        String projectName = ":distribution:archives:linux-tar";
-        assertExtractedDistro(
-            VersionProperties.getElasticsearch(),
-            "archive",
-            "linux",
-            null,
-            null,
-            "tests.local_distro.config",
-            "default",
-            "tests.local_distro.project",
-            projectName
-        );
-    }
-
     public void testCurrentExternal() throws Exception {
         checkService(
             VersionProperties.getElasticsearch(),

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/DistributionDownloadPluginIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/DistributionDownloadPluginIT.java
@@ -156,7 +156,6 @@ public class DistributionDownloadPluginIT extends GradleIntegrationTestCase {
             args.add("-D" + sysProps[i] + "=" + sysProps[i + 1]);
         }
         args.add("-i");
-        args.add("--stacktrace");
         GradleRunner runner = getGradleRunner("distribution-download").withArguments(args);
 
         BuildResult result = runner.build();

--- a/buildSrc/src/integTest/java/org/elasticsearch/gradle/DistributionDownloadPluginIT.java
+++ b/buildSrc/src/integTest/java/org/elasticsearch/gradle/DistributionDownloadPluginIT.java
@@ -41,7 +41,6 @@ public class DistributionDownloadPluginIT extends GradleIntegrationTestCase {
 
     // TODO: check reuse of root task across projects MOVE TO UNIT TEST
     // TODO: future: check integ-test-zip to maven, snapshots to snapshot service for external project
-
     public void testCurrent() throws Exception {
         String projectName = ":distribution:archives:linux-tar";
         assertExtractedDistro(
@@ -67,22 +66,6 @@ public class DistributionDownloadPluginIT extends GradleIntegrationTestCase {
             "/downloads/elasticsearch/elasticsearch-" + VersionProperties.getElasticsearch() + "-linux-x86_64.tar.gz",
             "tests.internal",
             "false"
-        );
-    }
-
-    public void testBwc() throws Exception {
-        assertExtractedDistro(
-            "8.1.0",
-            "archive",
-            "linux",
-            null,
-            null,
-            "tests.local_distro.config",
-            "linux-tar",
-            "tests.local_distro.project",
-            ":distribution:bwc:minor",
-            "tests.current_version",
-            "8.0.0"
         );
     }
 
@@ -188,6 +171,7 @@ public class DistributionDownloadPluginIT extends GradleIntegrationTestCase {
             args.add("-D" + sysProps[i] + "=" + sysProps[i + 1]);
         }
         args.add("-i");
+        args.add("--stacktrace");
         GradleRunner runner = getGradleRunner("distribution-download").withArguments(args);
 
         BuildResult result = runner.build();

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -24,8 +24,6 @@ import org.elasticsearch.gradle.ElasticsearchDistribution.Platform;
 import org.elasticsearch.gradle.ElasticsearchDistribution.Type;
 import org.elasticsearch.gradle.docker.DockerSupportPlugin;
 import org.elasticsearch.gradle.docker.DockerSupportService;
-import org.elasticsearch.gradle.info.BuildParams;
-import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
@@ -72,10 +70,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        // this is needed for isInternal
-        project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
-
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(
             project.getGradle().getSharedServices(),
             DockerSupportPlugin.DOCKER_SUPPORT_SERVICE_NAME
@@ -216,10 +211,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
             return;
         }
         addIvyRepo(project, DOWNLOAD_REPO_NAME, "https://artifacts.elastic.co", FAKE_IVY_GROUP);
-        if (BuildParams.isInternal() == false) {
-            // external, so add snapshot repo as well
-            addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots.elastic.co", FAKE_SNAPSHOT_IVY_GROUP);
-        }
+        addIvyRepo(project, SNAPSHOT_REPO_NAME, "https://snapshots.elastic.co", FAKE_SNAPSHOT_IVY_GROUP);
     }
 
     /**

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -44,9 +44,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.authentication.http.HttpHeaderAuthentication;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
@@ -101,7 +99,9 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
     private void setupResolutionsContainer(Project project) {
         distributionsResolutionStrategiesContainer = project.container(DistributionResolution.class);
         // We want this ordered in the same resolution strategies are added
-        distributionsResolutionStrategiesContainer.whenObjectAdded(resolveDependencyNotation -> resolveDependencyNotation.setPriority(distributionsResolutionStrategiesContainer.size()));
+        distributionsResolutionStrategiesContainer.whenObjectAdded(
+            resolveDependencyNotation -> resolveDependencyNotation.setPriority(distributionsResolutionStrategiesContainer.size())
+        );
         project.getExtensions().add(RESOLUTION_CONTAINER_NAME, distributionsResolutionStrategiesContainer);
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -58,7 +58,7 @@ import static org.elasticsearch.gradle.util.Util.capitalize;
  */
 public class DistributionDownloadPlugin implements Plugin<Project> {
 
-    static final String RESOLUTION_CONTAINER_NAME = "elasticsearch_distributions-resolutions";
+    static final String RESOLUTION_CONTAINER_NAME = "elasticsearch_distributions_resolutions";
     private static final String CONTAINER_NAME = "elasticsearch_distributions";
     private static final String FAKE_IVY_GROUP = "elasticsearch-distribution";
     private static final String FAKE_SNAPSHOT_IVY_GROUP = "elasticsearch-distribution-snapshot";

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionResolution.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionResolution.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle;
+
+import org.gradle.api.Project;
+
+public class DistributionResolution {
+    private Resolver resolver;
+    private String name;
+
+    public DistributionResolution(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Resolver getResolver() {
+        return resolver;
+    }
+
+    public void setResolver(Resolver resolver) {
+        this.resolver = resolver;
+    }
+
+    public interface Resolver {
+        Object resolve(Project project, ElasticsearchDistribution distribution);
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionResolution.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/DistributionResolution.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 public class DistributionResolution {
     private Resolver resolver;
     private String name;
+    private int priority;
 
     public DistributionResolution(String name) {
         this.name = name;
@@ -39,6 +40,14 @@ public class DistributionResolution {
 
     public void setResolver(Resolver resolver) {
         this.resolver = resolver;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
     }
 
     public interface Resolver {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -27,7 +27,6 @@ import org.elasticsearch.gradle.ElasticsearchDistribution;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.info.BuildParams;
-import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -27,6 +27,8 @@ import org.elasticsearch.gradle.ElasticsearchDistribution;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.info.BuildParams;
+import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
+import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -39,6 +41,14 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        // this is needed for isInternal
+        project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
+        if (!BuildParams.isInternal()) {
+            throw new GradleException(
+                "Plugin 'elasticsearch.internal-distribution-download' is not supported. "
+                    + "Use 'elasticsearch.distribution-download' plugin instead."
+            );
+        }
         project.getPluginManager().apply(DistributionDownloadPlugin.class);
         this.bwcVersions = BuildParams.getBwcVersions();
         registerInternalDistributionResolutions(DistributionDownloadPlugin.getRegistrationsContainer(project));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -35,6 +35,11 @@ import org.gradle.api.Project;
 
 import static org.elasticsearch.gradle.util.GradleUtils.projectDependency;
 
+/**
+ * An internal elasticsearch build plugin that registers additional
+ * distribution resolution strategies to the 'elasticsearch.download-distribution' plugin
+ * to resolve distributions from a local snapshot or a locally built bwc snapshot.
+ */
 public class InternalDistributionDownloadPlugin implements Plugin<Project> {
 
     private BwcVersions bwcVersions = null;
@@ -54,7 +59,16 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
         registerInternalDistributionResolutions(DistributionDownloadPlugin.getRegistrationsContainer(project));
     }
 
+    /**
+     * Registers internal distribution resolutions.
+     *
+     * Elasticsearch distributions are resolved as project dependencies either representing
+     * the current version pointing to a project either under `:distribution:archives` or :distribution:packages`.
+     *
+     * BWC versions are resolved as project to projects under `:distribution:bwc`.
+     * */
     private void registerInternalDistributionResolutions(NamedDomainObjectContainer<DistributionResolution> resolutions) {
+
         resolutions.register("localBuild", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
             if (VersionProperties.getElasticsearch().equals(distribution.getVersion())) {
                 // non-external project, so depend on local build

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import org.elasticsearch.gradle.Architecture;
+import org.elasticsearch.gradle.BwcVersions;
+import org.elasticsearch.gradle.DistributionDownloadPlugin;
+import org.elasticsearch.gradle.DistributionResolution;
+import org.elasticsearch.gradle.ElasticsearchDistribution;
+import org.elasticsearch.gradle.Version;
+import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.info.BuildParams;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+import static org.elasticsearch.gradle.util.GradleUtils.projectDependency;
+
+public class InternalDistributionDownloadPlugin implements Plugin<Project> {
+
+    private BwcVersions bwcVersions = null;
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(DistributionDownloadPlugin.class);
+        if (BuildParams.isInternal()) {
+            this.bwcVersions = BuildParams.getBwcVersions();
+        }
+        registerInternalDistributionResolutions(project);
+    }
+
+    private void registerInternalDistributionResolutions(Project project) {
+        NamedDomainObjectContainer<DistributionResolution> resolutions = DistributionDownloadPlugin.getRegistrationsContainer(project);
+        DistributionResolution localBuild = resolutions.create("localBuild");
+        localBuild.setResolver((project1, distribution) -> {
+            if (BuildParams.isInternal() && VersionProperties.getElasticsearch().equals(distribution.getVersion())) {
+                // non-external project, so depend on local build
+                return projectDependency(project1, distributionProjectPath(distribution), "default");
+            }
+            return null;
+        });
+
+        DistributionResolution bwb = resolutions.create("bwb");
+        bwb.setResolver((project1, distribution) -> {
+            if (BuildParams.isInternal()) {
+                BwcVersions.UnreleasedVersionInfo unreleasedInfo = bwcVersions.unreleasedInfo(
+                    Version.fromString(distribution.getVersion())
+                );
+                if (unreleasedInfo != null) {
+                    assert distribution.getBundledJdk();
+                    return projectDependency(project1, unreleasedInfo.gradleProjectPath, distributionProjectName(distribution));
+                }
+            }
+            return null;
+        });
+    }
+
+    private static String distributionProjectPath(ElasticsearchDistribution distribution) {
+        String projectPath = ":distribution";
+        switch (distribution.getType()) {
+            case INTEG_TEST_ZIP:
+                projectPath += ":archives:integ-test-zip";
+                break;
+
+            case DOCKER:
+                projectPath += ":docker:";
+                projectPath += distributionProjectName(distribution);
+                break;
+
+            default:
+                projectPath += distribution.getType() == ElasticsearchDistribution.Type.ARCHIVE ? ":archives:" : ":packages:";
+                projectPath += distributionProjectName(distribution);
+                break;
+        }
+        return projectPath;
+    }
+
+    /**
+     * Works out the gradle project name that provides a distribution artifact.
+     *
+     * @param distribution the distribution from which to derive a project name
+     * @return the name of a project. It is not the full project path, only the name.
+     */
+    private static String distributionProjectName(ElasticsearchDistribution distribution) {
+        ElasticsearchDistribution.Platform platform = distribution.getPlatform();
+        Architecture architecture = distribution.getArchitecture();
+        String projectName = "";
+
+        final String archString = platform == ElasticsearchDistribution.Platform.WINDOWS || architecture == Architecture.X64
+            ? ""
+            : "-" + architecture.toString().toLowerCase();
+
+        if (distribution.getFlavor() == ElasticsearchDistribution.Flavor.OSS) {
+            projectName += "oss-";
+        }
+
+        if (distribution.getBundledJdk() == false) {
+            projectName += "no-jdk-";
+        }
+
+        switch (distribution.getType()) {
+            case ARCHIVE:
+                projectName += platform.toString() + archString + (platform == ElasticsearchDistribution.Platform.WINDOWS
+                    ? "-zip"
+                    : "-tar");
+                break;
+
+            case DOCKER:
+                projectName += "docker" + archString + "-export";
+                break;
+
+            default:
+                projectName += distribution.getType();
+                break;
+        }
+        return projectName;
+    }
+}

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -40,15 +40,13 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(DistributionDownloadPlugin.class);
-        if (BuildParams.isInternal()) {
-            this.bwcVersions = BuildParams.getBwcVersions();
-        }
+        this.bwcVersions = BuildParams.getBwcVersions();
         registerInternalDistributionResolutions(DistributionDownloadPlugin.getRegistrationsContainer(project));
     }
 
     private void registerInternalDistributionResolutions(NamedDomainObjectContainer<DistributionResolution> resolutions) {
         resolutions.register("localBuild", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
-            if (BuildParams.isInternal() && VersionProperties.getElasticsearch().equals(distribution.getVersion())) {
+            if (VersionProperties.getElasticsearch().equals(distribution.getVersion())) {
                 // non-external project, so depend on local build
                 return projectDependency(project, distributionProjectPath(distribution), "default");
             }
@@ -56,14 +54,10 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
         }));
 
         resolutions.register("bwb", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
-            if (BuildParams.isInternal()) {
-                BwcVersions.UnreleasedVersionInfo unreleasedInfo = bwcVersions.unreleasedInfo(
-                    Version.fromString(distribution.getVersion())
-                );
-                if (unreleasedInfo != null) {
-                    assert distribution.getBundledJdk();
-                    return projectDependency(project, unreleasedInfo.gradleProjectPath, distributionProjectName(distribution));
-                }
+            BwcVersions.UnreleasedVersionInfo unreleasedInfo = bwcVersions.unreleasedInfo(Version.fromString(distribution.getVersion()));
+            if (unreleasedInfo != null) {
+                assert distribution.getBundledJdk();
+                return projectDependency(project, unreleasedInfo.gradleProjectPath, distributionProjectName(distribution));
             }
             return null;
         }));

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -77,10 +77,17 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
             return null;
         }));
 
-        resolutions.register("bwb", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
+        resolutions.register("bwc", distributionResolution -> distributionResolution.setResolver((project, distribution) -> {
             BwcVersions.UnreleasedVersionInfo unreleasedInfo = bwcVersions.unreleasedInfo(Version.fromString(distribution.getVersion()));
             if (unreleasedInfo != null) {
-                assert distribution.getBundledJdk();
+                if (!distribution.getBundledJdk()) {
+                    throw new GradleException(
+                        "Configuring a snapshot bwc distribution ('"
+                            + distribution.getName()
+                            + "') "
+                            + "without a bundled JDK is not supported."
+                    );
+                }
                 return projectDependency(project, unreleasedInfo.gradleProjectPath, distributionProjectName(distribution));
             }
             return null;

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -90,7 +90,11 @@ public class DistroTestPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
-        project.getPluginManager().apply(InternalDistributionDownloadPlugin.class);
+        if (BuildParams.isInternal()) {
+            project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
+        } else {
+            project.getPlugins().apply(DistributionDownloadPlugin.class);
+        }
         project.getPluginManager().apply("elasticsearch.build");
 
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -90,11 +90,7 @@ public class DistroTestPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
-        if (BuildParams.isInternal()) {
-            project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
-        } else {
-            project.getPlugins().apply(DistributionDownloadPlugin.class);
-        }
+        project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
         project.getPluginManager().apply("elasticsearch.build");
 
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/test/DistroTestPlugin.java
@@ -33,6 +33,7 @@ import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.docker.DockerSupportPlugin;
 import org.elasticsearch.gradle.docker.DockerSupportService;
 import org.elasticsearch.gradle.info.BuildParams;
+import org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.elasticsearch.gradle.vagrant.BatsProgressLogger;
 import org.elasticsearch.gradle.vagrant.VagrantBasePlugin;
@@ -89,7 +90,7 @@ public class DistroTestPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getRootProject().getPluginManager().apply(DockerSupportPlugin.class);
-        project.getPluginManager().apply(DistributionDownloadPlugin.class);
+        project.getPluginManager().apply(InternalDistributionDownloadPlugin.class);
         project.getPluginManager().apply("elasticsearch.build");
 
         Provider<DockerSupportService> dockerSupport = GradleUtils.getBuildService(

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -21,6 +21,9 @@ package org.elasticsearch.gradle.testclusters;
 import org.elasticsearch.gradle.DistributionDownloadPlugin;
 import org.elasticsearch.gradle.ReaperPlugin;
 import org.elasticsearch.gradle.ReaperService;
+import org.elasticsearch.gradle.info.BuildParams;
+import org.elasticsearch.gradle.info.GlobalBuildInfoPlugin;
+import org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin;
 import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
@@ -49,7 +52,13 @@ public class TestClustersPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPlugins().apply(DistributionDownloadPlugin.class);
+        project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
+        if (BuildParams.isInternal()) {
+            project.getPlugins().apply(InternalDistributionDownloadPlugin.class);
+        } else {
+            project.getPlugins().apply(DistributionDownloadPlugin.class);
+        }
+
         project.getRootProject().getPluginManager().apply(ReaperPlugin.class);
 
         ReaperService reaper = project.getRootProject().getExtensions().getByType(ReaperService.class);
@@ -148,7 +157,8 @@ public class TestClustersPlugin implements Plugin<Project> {
                 }
 
                 @Override
-                public void afterActions(Task task) {}
+                public void afterActions(Task task) {
+                }
             });
         }
 
@@ -165,7 +175,8 @@ public class TestClustersPlugin implements Plugin<Project> {
                 }
 
                 @Override
-                public void beforeExecute(Task task) {}
+                public void beforeExecute(Task task) {
+                }
             });
         }
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -157,8 +157,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                 }
 
                 @Override
-                public void afterActions(Task task) {
-                }
+                public void afterActions(Task task) {}
             });
         }
 
@@ -175,8 +174,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                 }
 
                 @Override
-                public void beforeExecute(Task task) {
-                }
+                public void beforeExecute(Task task) {}
             });
         }
     }

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -27,6 +27,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Provider;
@@ -43,6 +44,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -217,5 +219,15 @@ public abstract class GradleUtils {
         // tie this new test source set to the main and test source sets
         child.setCompileClasspath(project.getObjects().fileCollection().from(child.getCompileClasspath(), parent.getOutput()));
         child.setRuntimeClasspath(project.getObjects().fileCollection().from(child.getRuntimeClasspath(), parent.getOutput()));
+    }
+
+    public static Dependency projectDependency(Project project, String projectPath, String projectConfig) {
+        if (project.findProject(projectPath) == null) {
+            throw new GradleException("no project [" + projectPath + "], project names: " + project.getRootProject().getAllprojects());
+        }
+        Map<String, Object> depConfig = new HashMap<>();
+        depConfig.put("path", projectPath);
+        depConfig.put("configuration", projectConfig);
+        return project.getDependencies().project(depConfig);
     }
 }

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.internal-distribution-download.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/elasticsearch.internal-distribution-download.properties
@@ -7,7 +7,7 @@
 # not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-implementation-class=org.elasticsearch.gradle.DistributionDownloadPlugin
+implementation-class=org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -8,7 +8,7 @@ import org.elasticsearch.gradle.testfixtures.TestFixturesPlugin
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
-apply plugin: 'elasticsearch.distribution-download'
+apply plugin: 'elasticsearch.internal-distribution-download'
 apply plugin: 'elasticsearch.rest-resources'
 
 testFixtures.useFixture()

--- a/gradle/local-distribution.gradle
+++ b/gradle/local-distribution.gradle
@@ -25,7 +25,7 @@
  * */
 import org.elasticsearch.gradle.Architecture
 
-apply plugin:'elasticsearch.distribution-download'
+apply plugin:'elasticsearch.internal-distribution-download'
 
 elasticsearch_distributions {
   local {

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -23,7 +23,7 @@ import org.elasticsearch.gradle.testfixtures.TestFixturesPlugin
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
-apply plugin: 'elasticsearch.distribution-download'
+apply plugin: 'elasticsearch.internal-distribution-download'
 
 testFixtures.useFixture()
 

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -23,7 +23,7 @@ import org.elasticsearch.gradle.VersionProperties
 apply plugin: 'war'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.test.fixtures'
-apply plugin: 'elasticsearch.distribution-download'
+apply plugin: 'elasticsearch.internal-distribution-download'
 
 testFixtures.useFixture()
 


### PR DESCRIPTION
This PR was originally named "Extract distribution definition from dist-download plugin" but changed after the discussions and feedback I got on this below.

This PR extracts the internal distribution resolving logic out of the distribution download plugin. In general I think that for plugins used by external builds we should aim to not mix their logic with additional requirements of our internal builds and instead follow that pattern potentially with other plugins too.
One potential follow up might be to not even package internal only plugins and logic with build tools. 

The motivation behind this is:

1. Makes plugins used by external builds easier
2. Doesn't mix internal logic only into general purpose plugins.
3. This makes testing different concerns of distribution resolution simpler.
4. Make further improvements in handling distributions easier. I think there's potential for further improvements of the distribution handling (e.g. see https://github.com/elastic/elasticsearch/pull/57730) or revisit the distribution type per project approach as the reason this was introduced (see https://github.com/elastic/elasticsearch/blob/2899e03217a264d9819d3d46bd7e9c82a4b2a0bf/distribution/packages/build.gradle#L429-L430) seems not valid anymore as dependency substitution is not in use anymore.
