### PR TITLE
ILM add data stream support to searchable snapshot action

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DeleteStep.java
@@ -5,17 +5,23 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+
+import java.util.Locale;
 
 /**
  * Deletes a single index.
  */
 public class DeleteStep extends AsyncRetryDuringSnapshotActionStep {
     public static final String NAME = "delete";
+    private static final Logger logger = LogManager.getLogger(DeleteStep.class);
 
     public DeleteStep(StepKey key, StepKey nextStepKey, Client client) {
         super(key, nextStepKey, client);
@@ -23,8 +29,26 @@ public class DeleteStep extends AsyncRetryDuringSnapshotActionStep {
 
     @Override
     public void performDuringNoSnapshot(IndexMetadata indexMetadata, ClusterState currentState, Listener listener) {
+        String policyName = indexMetadata.getSettings().get(LifecycleSettings.LIFECYCLE_NAME);
+        String indexName = indexMetadata.getIndex().getName();
+        IndexAbstraction indexAbstraction = currentState.metadata().getIndicesLookup().get(indexName);
+        assert indexAbstraction != null : "invalid cluster metadata. index [" + indexName + "] was not found";
+        IndexAbstraction.DataStream dataStream = indexAbstraction.getParentDataStream();
+
+        if (dataStream != null) {
+            assert dataStream.getWriteIndex() != null : dataStream.getName() + " has no write index";
+            if (dataStream.getWriteIndex().getIndex().getName().equals(indexName)) {
+                String errorMessage = String.format(Locale.ROOT, "index [%s] is the write index for data stream [%s]. " +
+                        "stopping execution of lifecycle [%s] as a data stream's write index cannot be deleted. manually rolling over the" +
+                        " index will resume the execution of the policy as the index will not be the data stream's write index anymore",
+                    indexName, dataStream.getName(), policyName);
+                logger.debug(errorMessage);
+                throw new IllegalStateException(errorMessage);
+            }
+        }
+
         getClient().admin().indices()
-            .delete(new DeleteIndexRequest(indexMetadata.getIndex().getName()).masterNodeTimeout(getMasterTimeout(currentState)),
+            .delete(new DeleteIndexRequest(indexName).masterNodeTimeout(getMasterTimeout(currentState)),
                 ActionListener.wrap(response -> listener.onResponse(true), listener::onFailure));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
@@ -11,11 +11,17 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.mockito.Mockito;
 
+import java.util.List;
+
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteStep> {
 
@@ -78,7 +84,10 @@ public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteSte
         SetOnce<Boolean> actionCompleted = new SetOnce<>();
 
         DeleteStep step = createRandomInstance();
-        step.performAction(indexMetadata, emptyClusterState(), null, new AsyncActionStep.Listener() {
+        ClusterState clusterState = ClusterState.builder(emptyClusterState()).metadata(
+            Metadata.builder().put(indexMetadata, true).build()
+        ).build();
+        step.performAction(indexMetadata, clusterState, null, new AsyncActionStep.Listener() {
             @Override
             public void onResponse(boolean complete) {
                 actionCompleted.set(complete);
@@ -114,7 +123,10 @@ public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteSte
 
         SetOnce<Boolean> exceptionThrown = new SetOnce<>();
         DeleteStep step = createRandomInstance();
-        step.performAction(indexMetadata, emptyClusterState(), null, new AsyncActionStep.Listener() {
+        ClusterState clusterState = ClusterState.builder(emptyClusterState()).metadata(
+            Metadata.builder().put(indexMetadata, true).build()
+        ).build();
+        step.performAction(indexMetadata, clusterState, null, new AsyncActionStep.Listener() {
             @Override
             public void onResponse(boolean complete) {
                 throw new AssertionError("Unexpected method call");
@@ -128,5 +140,36 @@ public class DeleteStepTests extends AbstractStepMasterTimeoutTestCase<DeleteSte
         });
 
         assertThat(exceptionThrown.get(), equalTo(true));
+    }
+
+    public void testPerformActionThrowsExceptionIfIndexIsTheDataStreamWriteIndex() {
+        String dataStreamName = randomAlphaOfLength(10);
+        String indexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1);
+        String policyName = "test-ilm-policy";
+        IndexMetadata sourceIndexMetadata =
+            IndexMetadata.builder(indexName).settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
+                .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+
+        DataStream dataStream = new DataStream(dataStreamName, "timestamp", List.of(sourceIndexMetadata.getIndex()));
+        ClusterState clusterState = ClusterState.builder(emptyClusterState()).metadata(
+            Metadata.builder().put(sourceIndexMetadata, true).put(dataStream).build()
+        ).build();
+
+        IllegalStateException illegalStateException = expectThrows(IllegalStateException.class,
+            () -> createRandomInstance().performDuringNoSnapshot(sourceIndexMetadata, clusterState, new AsyncActionStep.Listener() {
+                @Override
+                public void onResponse(boolean complete) {
+                    fail("unexpected listener callback");
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("unexpected listener callback");
+                }
+            }));
+        assertThat(illegalStateException.getMessage(),
+            is("index [" + indexName + "] is the write index for data stream [" + dataStreamName + "]. stopping execution of lifecycle" +
+                " [test-ilm-policy] as a data stream's write index cannot be deleted. manually rolling over the index will resume the " +
+                "execution of the policy as the index will not be the data stream's write index anymore"));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -28,13 +28,16 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         StepKey expectedSixthStep = new StepKey(phase, NAME, WaitForIndexColorStep.NAME);
         StepKey expectedSeventhStep = new StepKey(phase, NAME, CopyExecutionStateStep.NAME);
         StepKey expectedEighthStep = new StepKey(phase, NAME, CopySettingsStep.NAME);
-        StepKey expectedNinthStep = new StepKey(phase, NAME, SwapAliasesAndDeleteSourceIndexStep.NAME);
+        StepKey expectedNinthStep = new StepKey(phase, NAME, SearchableSnapshotAction.CONDITIONAL_DATASTREAM_CHECK_KEY);
+        StepKey expectedTenthStep = new StepKey(phase, NAME, ReplaceDataStreamBackingIndexStep.NAME);
+        StepKey expectedElevenStep = new StepKey(phase, NAME, DeleteStep.NAME);
+        StepKey expectedTwelveStep = new StepKey(phase, NAME, SwapAliasesAndDeleteSourceIndexStep.NAME);
 
         SearchableSnapshotAction action = createTestInstance();
         StepKey nextStepKey = new StepKey(phase, randomAlphaOfLengthBetween(1, 5), randomAlphaOfLengthBetween(1, 5));
 
         List<Step> steps = action.toSteps(null, phase, nextStepKey);
-        assertThat(steps.size(), is(9));
+        assertThat(steps.size(), is(12));
 
         assertThat(steps.get(0).getKey(), is(expectedFirstStep));
         assertThat(steps.get(1).getKey(), is(expectedSecondStep));
@@ -45,6 +48,9 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
         assertThat(steps.get(6).getKey(), is(expectedSeventhStep));
         assertThat(steps.get(7).getKey(), is(expectedEighthStep));
         assertThat(steps.get(8).getKey(), is(expectedNinthStep));
+        assertThat(steps.get(9).getKey(), is(expectedTenthStep));
+        assertThat(steps.get(10).getKey(), is(expectedElevenStep));
+        assertThat(steps.get(11).getKey(), is(expectedTwelveStep));
 
         AsyncActionBranchingStep branchStep = (AsyncActionBranchingStep) steps.get(3);
         assertThat(branchStep.getNextKeyOnIncompleteResponse(), is(expectedThirdStep));

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
@@ -6,15 +6,17 @@
 
 package org.elasticsearch.xpack.ilm;
 
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
+import org.elasticsearch.xpack.core.ilm.ReplaceDataStreamBackingIndexStep;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
 
 import java.util.concurrent.TimeUnit;
@@ -22,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createComposableTemplate;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createFullPolicy;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.createSnapshotRepo;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.indexDocument;
@@ -104,5 +107,37 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
             60, TimeUnit.SECONDS);
         assertBusy(() -> assertFalse("the shrunken index was deleted by the delete action", indexExists(shrunkenIndex)),
             30, TimeUnit.SECONDS);
+    }
+
+    public void testSearchableSnapshotAction() throws Exception {
+        String snapshotRepo = randomAlphaOfLengthBetween(5, 10);
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+        String policyName = "logs-policy";
+        createNewSingletonPolicy(client(), policyName, "cold", new SearchableSnapshotAction(snapshotRepo));
+
+        Settings settings = Settings.builder()
+            .put(LifecycleSettings.LIFECYCLE_NAME, policyName)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+            .build();
+        Template template = new Template(settings, null, null);
+        createComposableTemplate(client(), "logs-template", "logs-foo*", template);
+        String dataStream = "logs-foo";
+        indexDocument(client(), dataStream, true);
+
+        String backingIndexName = "logs-foo-000001";
+        String restoredIndexName = SearchableSnapshotAction.RESTORED_INDEX_PREFIX + backingIndexName;
+
+        assertBusy(() -> assertThat(indexExists(restoredIndexName), is(true)));
+        assertBusy(() -> assertThat(
+            "original index must wait in the " + ReplaceDataStreamBackingIndexStep.NAME + " until it is not the write index anymore",
+            (Integer) explainIndex(client(), backingIndexName).get(FAILED_STEP_RETRY_COUNT_FIELD), greaterThanOrEqualTo(1)),
+            30, TimeUnit.SECONDS);
+
+        // Manual rollover the original index such that it's not the write index in the data stream anymore
+        rolloverMaxOneDocCondition(client(), dataStream);
+
+        assertBusy(() -> assertFalse(indexExists(backingIndexName)), 60, TimeUnit.SECONDS);
+        assertBusy(() -> assertThat(explainIndex(client(), restoredIndexName).get("step"), is(PhaseCompleteStep.NAME)), 30,
+            TimeUnit.SECONDS);
     }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/test/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
@@ -124,7 +124,7 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
         String dataStream = "logs-foo";
         indexDocument(client(), dataStream, true);
 
-        String backingIndexName = "logs-foo-000001";
+        String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1);
         String restoredIndexName = SearchableSnapshotAction.RESTORED_INDEX_PREFIX + backingIndexName;
 
         assertBusy(() -> assertThat(indexExists(restoredIndexName), is(true)));


### PR DESCRIPTION
The searchable snapshot action creates an index backed by a snapshot.
This makes the searchable snapshot action data stream aware. If the ILM managed index is
part of a data stream the action will make sure to swap the original managed index with the snapshot backed one as part of the data stream's backing indices and then delete the
original index.

Relates to #53100