### PR TITLE
Save memory when string terms are not on top (#57758)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -45,6 +45,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.SuiteScopeTestCase
@@ -59,7 +60,12 @@ public class AggregationProfilerIT extends ESIntegTestCase {
 
     private static final String TOTAL_BUCKETS = "total_buckets";
     private static final String WRAPPED = "wrapped_in_multi_bucket_aggregator";
-    private static final Object DEFERRED = "deferred_aggregators";
+    private static final String DEFERRED = "deferred_aggregators";
+    private static final String COLLECTION_STRAT = "collection_strategy";
+    private static final String RESULT_STRAT = "result_strategy";
+    private static final String HAS_FILTER = "has_filter";
+    private static final String SEGMENTS_WITH_SINGLE = "segments_with_single_valued_ords";
+    private static final String SEGMENTS_WITH_MULTI = "segments_with_multi_valued_ords";
 
     private static final String NUMBER_FIELD = "number";
     private static final String TAG_FIELD = "tag";
@@ -73,6 +79,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("idx")
+                .setSettings(Map.of("number_of_shards", 1, "number_of_replicas", 0))
                 .addMapping("type", STRING_FIELD, "type=keyword", NUMBER_FIELD, "type=integer", TAG_FIELD, "type=keyword").get());
         List<IndexRequestBuilder> builders = new ArrayList<>();
 
@@ -90,7 +97,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
                         .endObject()));
         }
 
-        indexRandom(true, builders);
+        indexRandom(true, false, builders);
         createIndex("idx_unmapped");
     }
 
@@ -184,7 +191,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             assertThat(termsBreakdown.get(COLLECT), greaterThan(0L));
             assertThat(termsBreakdown.get(BUILD_AGGREGATION), greaterThan(0L));
             assertThat(termsBreakdown.get(REDUCE), equalTo(0L));
-            assertThat(termsAggResult.getDebugInfo(), equalTo(org.elasticsearch.common.collect.Map.of(WRAPPED, true)));
+            assertRemapTermsDebugInfo(termsAggResult);
             assertThat(termsAggResult.getProfiledChildren().size(), equalTo(1));
 
             ProfileResult avgAggResult = termsAggResult.getProfiledChildren().get(0);
@@ -202,6 +209,18 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             assertThat(avgAggResult.getDebugInfo(), equalTo(org.elasticsearch.common.collect.Map.of()));
             assertThat(avgAggResult.getProfiledChildren().size(), equalTo(0));
         }
+    }
+
+    private void assertRemapTermsDebugInfo(ProfileResult termsAggResult) {
+        assertThat(termsAggResult.getDebugInfo(), hasEntry(COLLECTION_STRAT, "remap"));
+        assertThat(termsAggResult.getDebugInfo(), hasEntry(RESULT_STRAT, "terms"));
+        assertThat(termsAggResult.getDebugInfo(), hasEntry(HAS_FILTER, false));
+        // TODO we only index single valued docs but the ordinals ends up with multi valued sometimes
+        assertThat(
+            termsAggResult.getDebugInfo().toString(),
+            (int) termsAggResult.getDebugInfo().get(SEGMENTS_WITH_SINGLE) + (int) termsAggResult.getDebugInfo().get(SEGMENTS_WITH_MULTI),
+            greaterThan(0)
+        );
     }
 
     public void testMultiLevelProfileBreadthFirst() {
@@ -251,7 +270,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             assertThat(termsBreakdown.get(COLLECT), greaterThan(0L));
             assertThat(termsBreakdown.get(BUILD_AGGREGATION), greaterThan(0L));
             assertThat(termsBreakdown.get(REDUCE), equalTo(0L));
-            assertThat(termsAggResult.getDebugInfo(), equalTo(org.elasticsearch.common.collect.Map.of(WRAPPED, true)));
+            assertRemapTermsDebugInfo(termsAggResult);
             assertThat(termsAggResult.getProfiledChildren().size(), equalTo(1));
 
             ProfileResult avgAggResult = termsAggResult.getProfiledChildren().get(0);
@@ -378,7 +397,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             assertThat(tagsBreakdown.get(COLLECT), greaterThan(0L));
             assertThat(tagsBreakdown.get(BUILD_AGGREGATION), greaterThan(0L));
             assertThat(tagsBreakdown.get(REDUCE), equalTo(0L));
-            assertThat(tagsAggResult.getDebugInfo(), equalTo(org.elasticsearch.common.collect.Map.of(WRAPPED, true)));
+            assertRemapTermsDebugInfo(tagsAggResult);
             assertThat(tagsAggResult.getProfiledChildren().size(), equalTo(2));
 
             Map<String, ProfileResult> tagsAggResultSubAggregations = tagsAggResult.getProfiledChildren().stream()
@@ -423,7 +442,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             assertThat(stringsBreakdown.get(COLLECT), greaterThan(0L));
             assertThat(stringsBreakdown.get(BUILD_AGGREGATION), greaterThan(0L));
             assertThat(stringsBreakdown.get(REDUCE), equalTo(0L));
-            assertThat(stringsAggResult.getDebugInfo(), equalTo(org.elasticsearch.common.collect.Map.of(WRAPPED, true)));
+            assertRemapTermsDebugInfo(stringsAggResult);
             assertThat(stringsAggResult.getProfiledChildren().size(), equalTo(3));
 
             Map<String, ProfileResult> stringsAggResultSubAggregations = stringsAggResult.getProfiledChildren().stream()
@@ -469,7 +488,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
             assertThat(tagsBreakdown.get(COLLECT), greaterThan(0L));
             assertThat(tagsBreakdown.get(BUILD_AGGREGATION), greaterThan(0L));
             assertThat(tagsBreakdown.get(REDUCE), equalTo(0L));
-            assertThat(tagsAggResult.getDebugInfo(), equalTo(org.elasticsearch.common.collect.Map.of(WRAPPED, true)));
+            assertRemapTermsDebugInfo(tagsAggResult);
             assertThat(tagsAggResult.getProfiledChildren().size(), equalTo(2));
 
             tagsAggResultSubAggregations = tagsAggResult.getProfiledChildren().stream()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -79,7 +79,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
     @Override
     protected void setupSuiteScopeCluster() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("idx")
-                .setSettings(Map.of("number_of_shards", 1, "number_of_replicas", 0))
+                .setSettings(org.elasticsearch.common.collect.Map.of("number_of_shards", 1, "number_of_replicas", 0))
                 .addMapping("type", STRING_FIELD, "type=keyword", NUMBER_FIELD, "type=integer", TAG_FIELD, "type=keyword").get());
         List<IndexRequestBuilder> builders = new ArrayList<>();
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -180,7 +180,7 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
     public abstract InternalAggregation buildEmptyAggregation();
 
     /**
-     * Collect debug information to add to the profiling results.. This will
+     * Collect debug information to add to the profiling results. This will
      * only be called if the aggregation is being profiled.
      * <p>
      * Well behaved implementations will always call the superclass

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BytesKeyedBucketOrds.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefHash;
+
+/**
+ * Maps {@link BytesRef} bucket keys to bucket ordinals.
+ */
+public abstract class BytesKeyedBucketOrds implements Releasable {
+    /**
+     * Build a {@link LongKeyedBucketOrds}.
+     */
+    public static BytesKeyedBucketOrds build(BigArrays bigArrays, boolean collectsFromSingleBucket) {
+        return collectsFromSingleBucket ? new FromSingle(bigArrays) : new FromMany(bigArrays);
+    }
+
+    private BytesKeyedBucketOrds() {}
+
+    /**
+     * Add the {@code owningBucketOrd, value} pair. Return the ord for
+     * their bucket if they have yet to be added, or {@code -1-ord}
+     * if they were already present.
+     */
+    public abstract long add(long owningBucketOrd, BytesRef value);
+
+    /**
+     * Count the buckets in {@code owningBucketOrd}.
+     */
+    public abstract long bucketsInOrd(long owningBucketOrd);
+
+    /**
+     * The number of collected buckets.
+     */
+    public abstract long size();
+
+    /**
+     * Build an iterator for buckets inside {@code owningBucketOrd} in order
+     * of increasing ord.
+     * <p>
+     * When this is first returns it is "unpositioned" and you must call
+     * {@link BucketOrdsEnum#next()} to move it to the first value.
+     */
+    public abstract BucketOrdsEnum ordsEnum(long owningBucketOrd);
+
+    /**
+     * An iterator for buckets inside a particular {@code owningBucketOrd}.
+     */
+    public interface BucketOrdsEnum {
+        /**
+         * Advance to the next value.
+         * @return {@code true} if there *is* a next value,
+         *         {@code false} if there isn't
+         */
+        boolean next();
+
+        /**
+         * The ordinal of the current value.
+         */
+        long ord();
+
+        /**
+         * Read the current value.
+         */
+        void readValue(BytesRef dest);
+
+        /**
+         * An {@linkplain BucketOrdsEnum} that is empty. 
+         */
+        BucketOrdsEnum EMPTY = new BucketOrdsEnum() {
+            @Override
+            public boolean next() {
+                return false;
+            }
+
+            @Override
+            public long ord() {
+                return 0;
+            }
+
+            @Override
+            public void readValue(BytesRef dest) {}
+        };
+    }
+
+    /**
+     * Implementation that only works if it is collecting from a single bucket.
+     */
+    private static class FromSingle extends BytesKeyedBucketOrds {
+        private final BytesRefHash ords;
+
+        private FromSingle(BigArrays bigArrays) {
+            ords = new BytesRefHash(1, bigArrays);
+        }
+
+        @Override
+        public long add(long owningBucketOrd, BytesRef value) {
+            assert owningBucketOrd == 0;
+            return ords.add(value);
+        }
+
+        @Override
+        public long bucketsInOrd(long owningBucketOrd) {
+            return ords.size();
+        }
+
+        @Override
+        public long size() {
+            return ords.size();
+        }
+
+        @Override
+        public BucketOrdsEnum ordsEnum(long owningBucketOrd) {
+            return new BucketOrdsEnum() {
+                private int ord = -1;
+
+                @Override
+                public boolean next() {
+                    ord++;
+                    return ord < ords.size();
+                }
+
+                @Override
+                public long ord() {
+                    return ord;
+                }
+
+                @Override
+                public void readValue(BytesRef dest) {
+                    ords.get(ord, dest);
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+            ords.close();
+        }
+    }
+
+    /**
+     * Implementation that works properly when collecting from many buckets.
+     */
+    private static class FromMany extends BytesKeyedBucketOrds {
+        // TODO we can almost certainly do better here by building something fit for purpose rather than trying to lego together stuff
+        private final BytesRefHash bytesToLong;
+        private final LongKeyedBucketOrds longToBucketOrds;
+
+        private FromMany(BigArrays bigArrays) {
+            bytesToLong = new BytesRefHash(1, bigArrays);
+            longToBucketOrds = LongKeyedBucketOrds.build(bigArrays, false);
+        }
+
+        @Override
+        public long add(long owningBucketOrd, BytesRef value) {
+            long l = bytesToLong.add(value);
+            if (l < 0) {
+                l = -1 - l;
+            }
+            return longToBucketOrds.add(owningBucketOrd, l);
+        }
+
+        @Override
+        public long bucketsInOrd(long owningBucketOrd) {
+            return longToBucketOrds.bucketsInOrd(owningBucketOrd);
+        }
+
+        @Override
+        public long size() {
+            return longToBucketOrds.size();
+        }
+
+        @Override
+        public BucketOrdsEnum ordsEnum(long owningBucketOrd) {
+            LongKeyedBucketOrds.BucketOrdsEnum delegate = longToBucketOrds.ordsEnum(owningBucketOrd);
+            return new BucketOrdsEnum() {
+                @Override
+                public boolean next() {
+                    return delegate.next();
+                }
+
+                @Override
+                public long ord() {
+                    return delegate.ord();
+                }
+
+                @Override
+                public void readValue(BytesRef dest) {
+                    bytesToLong.get(delegate.value(), dest);
+                }
+            };
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(bytesToLong, longToBucketOrds);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -25,7 +25,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
-import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * An aggregator of string values that hashes the strings on the fly rather
@@ -53,7 +54,7 @@ import java.util.function.Function;
 public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
     private final ResultStrategy<?, ?> resultStrategy;
     private final ValuesSource valuesSource;
-    private final BytesRefHash bucketOrds;
+    private final BytesKeyedBucketOrds bucketOrds;
     private final IncludeExclude.StringFilter includeExclude;
 
     public MapStringTermsAggregator(
@@ -69,13 +70,14 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         Aggregator parent,
         SubAggCollectionMode collectionMode,
         boolean showTermDocCountError,
+        boolean collectsFromSingleBucket,
         Map<String, Object> metadata
     ) throws IOException {
         super(name, factories, context, parent, order, format, bucketCountThresholds, collectionMode, showTermDocCountError, metadata);
         this.resultStrategy = resultStrategy.apply(this); // ResultStrategy needs a reference to the Aggregator to do its job.
         this.valuesSource = valuesSource;
         this.includeExclude = includeExclude;
-        bucketOrds = new BytesRefHash(1, context.bigArrays());
+        bucketOrds = BytesKeyedBucketOrds.build(context.bigArrays(), collectsFromSingleBucket);
     }
 
     @Override
@@ -94,31 +96,31 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
             final BytesRefBuilder previous = new BytesRefBuilder();
 
             @Override
-            public void collect(int doc, long bucket) throws IOException {
-                assert bucket == 0;
-                if (values.advanceExact(doc)) {
-                    final int valuesCount = values.docValueCount();
+            public void collect(int doc, long owningBucketOrd) throws IOException {
+                if (false == values.advanceExact(doc)) {
+                    return;
+                }
+                int valuesCount = values.docValueCount();
 
-                    // SortedBinaryDocValues don't guarantee uniqueness so we
-                    // need to take care of dups
-                    previous.clear();
-                    for (int i = 0; i < valuesCount; ++i) {
-                        final BytesRef bytes = values.nextValue();
-                        if (includeExclude != null && false == includeExclude.accept(bytes)) {
-                            continue;
-                        }
-                        if (i > 0 && previous.get().equals(bytes)) {
-                            continue;
-                        }
-                        long bucketOrdinal = bucketOrds.add(bytes);
-                        if (bucketOrdinal < 0) { // already seen
-                            bucketOrdinal = -1 - bucketOrdinal;
-                            collectExistingBucket(sub, doc, bucketOrdinal);
-                        } else {
-                            collectBucket(sub, doc, bucketOrdinal);
-                        }
-                        previous.copyBytes(bytes);
+                // SortedBinaryDocValues don't guarantee uniqueness so we
+                // need to take care of dups
+                previous.clear();
+                for (int i = 0; i < valuesCount; ++i) {
+                    final BytesRef bytes = values.nextValue();
+                    if (includeExclude != null && false == includeExclude.accept(bytes)) {
+                        continue;
                     }
+                    if (i > 0 && previous.get().equals(bytes)) {
+                        continue;
+                    }
+                    long bucketOrdinal = bucketOrds.add(owningBucketOrd, bytes);
+                    if (bucketOrdinal < 0) { // already seen
+                        bucketOrdinal = -1 - bucketOrdinal;
+                        collectExistingBucket(sub, doc, bucketOrdinal);
+                    } else {
+                        collectBucket(sub, doc, bucketOrdinal);
+                    }
+                    previous.copyBytes(bytes);
                 }
             }
         });
@@ -131,12 +133,13 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return buildEmptyTermsAggregation();
+        return resultStrategy.buildEmptyResult();
     }
 
     @Override
     public void collectDebugInfo(BiConsumer<String, Object> add) {
         super.collectDebugInfo(add);
+        add.accept("total_buckets", bucketOrds.size());
         add.accept("result_strategy", resultStrategy.describe());
     }
 
@@ -153,39 +156,43 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
             Releasable {
 
         private InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
-            assert owningBucketOrds.length == 1 && owningBucketOrds[0] == 0;
+            B[][] topBucketsPerOrd = buildTopBucketsPerOrd(owningBucketOrds.length);
+            long[] otherDocCounts = new long[owningBucketOrds.length];
+            for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
+                collectZeroDocEntriesIfNeeded(owningBucketOrds[ordIdx]);
+                int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
 
-            collectZeroDocEntriesIfNeeded();
-
-            int size = (int) Math.min(bucketOrds.size(), bucketCountThresholds.getShardSize());
-
-            long otherDocCount = 0;
-            PriorityQueue<B> ordered = buildPriorityQueue(size);
-            B spare = null;
-            for (int bucketOrd = 0; bucketOrd < bucketOrds.size(); bucketOrd++) {
-                long docCount = bucketDocCount(bucketOrd);
-                otherDocCount += docCount;
-                if (docCount < bucketCountThresholds.getShardMinDocCount()) {
-                    continue;
+                PriorityQueue<B> ordered = buildPriorityQueue(size);
+                B spare = null;
+                BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds[ordIdx]);
+                Supplier<B> emptyBucketBuilder = emptyBucketBuilder(owningBucketOrds[ordIdx]); 
+                while (ordsEnum.next()) {
+                    long docCount = bucketDocCount(ordsEnum.ord());
+                    otherDocCounts[ordIdx] += docCount;
+                    if (docCount < bucketCountThresholds.getShardMinDocCount()) {
+                        continue;
+                    }
+                    if (spare == null) {
+                        spare = emptyBucketBuilder.get();
+                    }
+                    updateBucket(spare, ordsEnum, docCount);
+                    spare = ordered.insertWithOverflow(spare);
                 }
-                if (spare == null) {
-                    spare = buildEmptyBucket();
+
+                topBucketsPerOrd[ordIdx] = buildBuckets(ordered.size());
+                for (int i = ordered.size() - 1; i >= 0; --i) {
+                    topBucketsPerOrd[ordIdx][i] = ordered.pop();
+                    otherDocCounts[ordIdx] -= topBucketsPerOrd[ordIdx][i].getDocCount();
+                    finalizeBucket(topBucketsPerOrd[ordIdx][i]);
                 }
-                updateBucket(spare, bucketOrd, docCount);
-                spare = ordered.insertWithOverflow(spare);
             }
 
-            B[] topBuckets = buildBuckets(ordered.size());
-            for (int i = ordered.size() - 1; i >= 0; --i) {
-                topBuckets[i] = ordered.pop();
-                otherDocCount -= topBuckets[i].getDocCount();
-                finalizeBucket(topBuckets[i]);
+            buildSubAggs(topBucketsPerOrd);
+            InternalAggregation[] result = new InternalAggregation[owningBucketOrds.length];
+            for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
+                result[ordIdx] = buildResult(owningBucketOrds[ordIdx], otherDocCounts[ordIdx], topBucketsPerOrd[ordIdx]);
             }
-
-            buildSubAggs(topBuckets);
-            return new InternalAggregation[] {
-                buildResult(topBuckets, otherDocCount)
-            };
+            return result;
         }
 
         /**
@@ -204,12 +211,12 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
          * Collect extra entries for "zero" hit documents if they were requested
          * and required.
          */
-        abstract void collectZeroDocEntriesIfNeeded() throws IOException;
+        abstract void collectZeroDocEntriesIfNeeded(long owningBucketOrd) throws IOException;
 
         /**
          * Build an empty temporary bucket.
          */
-        abstract B buildEmptyBucket();
+        abstract Supplier<B> emptyBucketBuilder(long owningBucketOrd);
 
         /**
          * Build a {@link PriorityQueue} to sort the buckets. After we've
@@ -221,7 +228,12 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
          * Update fields in {@code spare} to reflect information collected for
          * this bucket ordinal.
          */
-        abstract void updateBucket(B spare, long bucketOrd, long docCount) throws IOException;
+        abstract void updateBucket(B spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount) throws IOException;
+
+        /**
+         * Build an array to hold the "top" buckets for each ordinal.
+         */
+        abstract B[][] buildTopBucketsPerOrd(int size);
 
         /**
          * Build an array of buckets for a particular ordinal to collect the
@@ -239,12 +251,12 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
          * Build the sub-aggregations into the buckets. This will usually
          * delegate to {@link #buildSubAggsForAllBuckets}.
          */
-        abstract void buildSubAggs(B[] topBuckets) throws IOException;
+        abstract void buildSubAggs(B[][] topBucketsPerOrd) throws IOException;
 
         /**
          * Turn the buckets into an aggregation result.
          */
-        abstract R buildResult(B[] topBuckets, long otherDocCount);
+        abstract R buildResult(long owningBucketOrd, long otherDocCount, B[] topBuckets);
 
         /**
          * Build an "empty" result. Only called if there isn't any data on this
@@ -268,11 +280,11 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        void collectZeroDocEntriesIfNeeded() throws IOException {
+        void collectZeroDocEntriesIfNeeded(long owningBucketOrd) throws IOException {
             if (bucketCountThresholds.getMinDocCount() != 0) {
                 return;
             }
-            if (InternalOrder.isCountDesc(order) && bucketOrds.size() >= bucketCountThresholds.getRequiredSize()) {
+            if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
                 return;
             }
             // we need to fill-in the blanks
@@ -285,7 +297,7 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
                         for (int i = 0; i < valueCount; ++i) {
                             BytesRef term = values.nextValue();
                             if (includeExclude == null || includeExclude.accept(term)) {
-                                bucketOrds.add(term);
+                                bucketOrds.add(owningBucketOrd, term);
                             }
                         }
                     }
@@ -294,8 +306,8 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        StringTerms.Bucket buildEmptyBucket() {
-            return new StringTerms.Bucket(new BytesRef(), 0, null, showTermDocCountError, 0, format);
+        Supplier<StringTerms.Bucket> emptyBucketBuilder(long owningBucketOrd) {
+            return () -> new StringTerms.Bucket(new BytesRef(), 0, null, showTermDocCountError, 0, format);
         }
 
         @Override
@@ -304,10 +316,15 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        void updateBucket(StringTerms.Bucket spare, long bucketOrd, long docCount) throws IOException {
-            bucketOrds.get(bucketOrd, spare.termBytes);
+        void updateBucket(StringTerms.Bucket spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount) throws IOException {
+            ordsEnum.readValue(spare.termBytes);
             spare.docCount = docCount;
-            spare.bucketOrd = bucketOrd;
+            spare.bucketOrd = ordsEnum.ord();
+        }
+
+        @Override
+        StringTerms.Bucket[][] buildTopBucketsPerOrd(int size) {
+            return new StringTerms.Bucket[size][];
         }
 
         @Override
@@ -326,12 +343,12 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        void buildSubAggs(StringTerms.Bucket[] topBuckets) throws IOException {
-            buildSubAggsForBuckets(topBuckets, b -> b.bucketOrd, (b, a) -> b.aggregations = a);
+        void buildSubAggs(StringTerms.Bucket[][] topBucketsPerOrd) throws IOException {
+            buildSubAggsForAllBuckets(topBucketsPerOrd, b -> b.bucketOrd, (b, a) -> b.aggregations = a);
         }
 
         @Override
-        StringTerms buildResult(StringTerms.Bucket[] topBuckets, long otherDocCount) {
+        StringTerms buildResult(long owningBucketOrd, long otherDocCount, StringTerms.Bucket[] topBuckets) {
             return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(),
                 metadata(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, otherDocCount,
                 Arrays.asList(topBuckets), 0);
@@ -354,7 +371,7 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         private final SignificantTermsAggregatorFactory termsAggFactory;
         private final SignificanceHeuristic significanceHeuristic;
 
-        private long subsetSize = 0;
+        private LongArray subsetSizes = context.bigArrays().newLongArray(1, true);
 
         SignificantTermsResults(SignificantTermsAggregatorFactory termsAggFactory, SignificanceHeuristic significanceHeuristic) {
             this.termsAggFactory = termsAggFactory;
@@ -372,17 +389,19 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
                 @Override
                 public void collect(int doc, long owningBucketOrd) throws IOException {
                     super.collect(doc, owningBucketOrd);
-                    subsetSize++;
+                    subsetSizes = context.bigArrays().grow(subsetSizes, owningBucketOrd + 1);
+                    subsetSizes.increment(owningBucketOrd, 1);
                 }
             };
         }
 
         @Override
-        void collectZeroDocEntriesIfNeeded() throws IOException {}
+        void collectZeroDocEntriesIfNeeded(long owningBucketOrd) throws IOException {}
 
         @Override
-        SignificantStringTerms.Bucket buildEmptyBucket() {
-            return new SignificantStringTerms.Bucket(new BytesRef(), 0, 0, 0, 0, null, format, 0);
+        Supplier<SignificantStringTerms.Bucket> emptyBucketBuilder(long owningBucketOrd) {
+            long subsetSize = subsetSizes.get(owningBucketOrd);
+            return () -> new SignificantStringTerms.Bucket(new BytesRef(), 0, subsetSize, 0, 0, null, format, 0);
         }
 
         @Override
@@ -391,11 +410,12 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        void updateBucket(SignificantStringTerms.Bucket spare, long bucketOrd, long docCount) throws IOException {
-            bucketOrds.get(bucketOrd, spare.termBytes);
+        void updateBucket(SignificantStringTerms.Bucket spare, BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum, long docCount)
+            throws IOException {
+
+            ordsEnum.readValue(spare.termBytes);
+            spare.bucketOrd = ordsEnum.ord();
             spare.subsetDf = docCount;
-            spare.bucketOrd = bucketOrd;
-            spare.subsetSize = subsetSize;
             spare.supersetDf = termsAggFactory.getBackgroundFrequency(spare.termBytes);
             spare.supersetSize = termsAggFactory.getSupersetNumDocs();
             /*
@@ -404,6 +424,11 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
              * properties will be updated with global stats.
              */
             spare.updateScore(significanceHeuristic);
+        }
+
+        @Override
+        SignificantStringTerms.Bucket[][] buildTopBucketsPerOrd(int size) {
+            return new SignificantStringTerms.Bucket[size][];
         }
 
         @Override
@@ -422,25 +447,33 @@ public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
         }
 
         @Override
-        void buildSubAggs(SignificantStringTerms.Bucket[] topBuckets) throws IOException {
-            buildSubAggsForBuckets(topBuckets, b -> b.bucketOrd, (b, a) -> b.aggregations = a);
+        void buildSubAggs(SignificantStringTerms.Bucket[][] topBucketsPerOrd) throws IOException {
+            buildSubAggsForAllBuckets(topBucketsPerOrd, b -> b.bucketOrd, (b, a) -> b.aggregations = a);
         }
 
         @Override
-        SignificantStringTerms buildResult(SignificantStringTerms.Bucket[] topBuckets, long otherDocCount) {
-            return new SignificantStringTerms(name, bucketCountThresholds.getRequiredSize(),
+        SignificantStringTerms buildResult(long owningBucketOrd, long otherDocCount, SignificantStringTerms.Bucket[] topBuckets) {
+            return new SignificantStringTerms(
+                name,
+                bucketCountThresholds.getRequiredSize(),
                 bucketCountThresholds.getMinDocCount(),
-                metadata(), format, subsetSize, termsAggFactory.getSupersetNumDocs(), significanceHeuristic, Arrays.asList(topBuckets));
+                metadata(),
+                format,
+                subsetSizes.get(owningBucketOrd),
+                termsAggFactory.getSupersetNumDocs(),
+                significanceHeuristic,
+                Arrays.asList(topBuckets)
+            );
         }
 
         @Override
         SignificantStringTerms buildEmptyResult() {
-            return buildEmptySignificantTermsAggregation(subsetSize, significanceHeuristic);
+            return buildEmptySignificantTermsAggregation(0, significanceHeuristic);
         }
 
         @Override
         public void close() {
-            termsAggFactory.close();
+            Releasables.close(termsAggFactory, subsetSizes);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -251,7 +251,7 @@ public class NumericTermsAggregator extends TermsAggregator {
          * Collect extra entries for "zero" hit documents if they were requested
          * and required.
          */
-        abstract void collectZeroDocEntriesIfNeeded(long ord) throws IOException;
+        abstract void collectZeroDocEntriesIfNeeded(long owningBucketOrd) throws IOException;
 
         /**
          * Turn the buckets into an aggregation result.
@@ -296,11 +296,11 @@ public class NumericTermsAggregator extends TermsAggregator {
         abstract B buildEmptyBucket();
 
         @Override
-        final void collectZeroDocEntriesIfNeeded(long ord) throws IOException {
+        final void collectZeroDocEntriesIfNeeded(long owningBucketOrd) throws IOException {
             if (bucketCountThresholds.getMinDocCount() != 0) {
                 return;
             }
-            if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(ord) >= bucketCountThresholds.getRequiredSize()) {
+            if (InternalOrder.isCountDesc(order) && bucketOrds.bucketsInOrd(owningBucketOrd) >= bucketCountThresholds.getRequiredSize()) {
                 return;
             }
             // we need to fill-in the blanks
@@ -312,7 +312,7 @@ public class NumericTermsAggregator extends TermsAggregator {
                         for (int v = 0; v < valueCount; ++v) {
                             long value = values.nextValue();
                             if (longFilter == null || longFilter.accept(value)) {
-                                bucketOrds.add(ord, value);
+                                bucketOrds.add(owningBucketOrd, value);
                             }
                         }
                     }
@@ -546,10 +546,10 @@ public class NumericTermsAggregator extends TermsAggregator {
         }
 
         @Override
-        void collectZeroDocEntriesIfNeeded(long ord) throws IOException {}
+        void collectZeroDocEntriesIfNeeded(long owningBucketOrd) throws IOException {}
 
         @Override
-        SignificantLongTerms buildResult(long owningBucketOrd, long otherDocCounts, SignificantLongTerms.Bucket[] topBuckets) {
+        SignificantLongTerms buildResult(long owningBucketOrd, long otherDocCoun, SignificantLongTerms.Bucket[] topBuckets) {
             return new SignificantLongTerms(
                 name,
                 bucketCountThresholds.getRequiredSize(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -106,7 +106,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                                     boolean collectsFromSingleBucket,
                                     Map<String, Object> metadata) throws IOException {
 
-                assert collectsFromSingleBucket;
                 ExecutionMode execution = null;
                 if (executionHint != null) {
                     execution = ExecutionMode.fromString(executionHint, deprecationLogger);
@@ -125,12 +124,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                 }
 
                 return execution.create(name, factories, valuesSource, format, bucketCountThresholds, includeExclude, context, parent,
-                    significanceHeuristic, sigTermsFactory, metadata);
-            }
-
-            @Override
-            public boolean needsToCollectFromSingleBucket() {
-                return true;
+                    significanceHeuristic, sigTermsFactory, collectsFromSingleBucket, metadata);
             }
         };
     }
@@ -176,11 +170,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                     agg -> agg.new SignificantLongTermsResults(sigTermsFactory, significanceHeuristic, collectsFromSingleBucket),
                     numericValuesSource, format, null, bucketCountThresholds, context, parent, SubAggCollectionMode.BREADTH_FIRST,
                     longFilter, collectsFromSingleBucket, metadata);
-            }
-
-            @Override
-            public boolean needsToCollectFromSingleBucket() {
-                return false;
             }
         };
     }
@@ -316,9 +305,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                 aggregatorSupplier.getClass().toString() + "]");
         }
         SignificantTermsAggregatorSupplier sigTermsAggregatorSupplier = (SignificantTermsAggregatorSupplier) aggregatorSupplier;
-        if (collectsFromSingleBucket == false && sigTermsAggregatorSupplier.needsToCollectFromSingleBucket()) {
-            return asMultiBucketAggregator(this, searchContext, parent);
-        }
 
         numberOfAggregatorsCreated++;
         BucketCountThresholds bucketCountThresholds = new BucketCountThresholds(this.bucketCountThresholds);
@@ -359,6 +345,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                               Aggregator parent,
                               SignificanceHeuristic significanceHeuristic,
                               SignificantTermsAggregatorFactory termsAggregatorFactory,
+                              boolean collectsFromSingleBucket,
                               Map<String, Object> metadata) throws IOException {
 
                 final IncludeExclude.StringFilter filter = includeExclude == null ? null : includeExclude.convertToStringFilter(format);
@@ -375,6 +362,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                     parent,
                     SubAggCollectionMode.BREADTH_FIRST,
                     false,
+                    collectsFromSingleBucket,
                     metadata
                 );
 
@@ -394,6 +382,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                               Aggregator parent,
                               SignificanceHeuristic significanceHeuristic,
                               SignificantTermsAggregatorFactory termsAggregatorFactory,
+                              boolean collectsFromSingleBucket,
                               Map<String, Object> metadata) throws IOException {
 
                 final IncludeExclude.OrdinalsFilter filter = includeExclude == null ? null : includeExclude.convertToOrdinalsFilter(format);
@@ -424,6 +413,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                     remapGlobalOrd,
                     SubAggCollectionMode.BREADTH_FIRST,
                     false,
+                    collectsFromSingleBucket,
                     metadata
                 );
             }
@@ -458,6 +448,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                                    Aggregator parent,
                                    SignificanceHeuristic significanceHeuristic,
                                    SignificantTermsAggregatorFactory termsAggregatorFactory,
+                                   boolean collectsFromSingleBucket,
                                    Map<String, Object> metadata) throws IOException;
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorSupplier.java
@@ -43,6 +43,4 @@ interface SignificantTermsAggregatorSupplier extends AggregatorSupplier {
                      SignificantTermsAggregatorFactory sigTermsFactory,
                      boolean collectsFromSingleBucket,
                      Map<String, Object> metadata) throws IOException;
-
-    boolean needsToCollectFromSingleBucket();
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorSupplier.java
@@ -44,6 +44,4 @@ interface TermsAggregatorSupplier extends AggregatorSupplier {
                      boolean showTermDocCountError,
                      boolean collectsFromSingleBucket,
                      Map<String, Object> metadata) throws IOException;
-
-    boolean needsToCollectFromSingleBucket();
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -1307,6 +1307,54 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         }, fieldType);
     }
 
+    public void testThreeLayerStringViaGlobalOrds() throws IOException {
+        threeLayerStringTestCase("global_ordinals");
+    }
+
+    public void testThreeLayerStringViaMap() throws IOException {
+        threeLayerStringTestCase("map");
+    }
+
+    private void threeLayerStringTestCase(String executionHint) throws IOException {
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (int i = 0; i < 10; i++) {
+                    for (int j = 0; j < 10; j++) {
+                        for (int k = 0; k < 10; k++) {
+                            Document d = new Document();
+                            d.add(new SortedDocValuesField("i", new BytesRef(Integer.toString(i))));
+                            d.add(new SortedDocValuesField("j", new BytesRef(Integer.toString(j))));
+                            d.add(new SortedDocValuesField("k", new BytesRef(Integer.toString(k))));
+                            writer.addDocument(d);
+                        }
+                    }
+                }
+                try (IndexReader reader = maybeWrapReaderEs(writer.getReader())) {
+                    IndexSearcher searcher = newIndexSearcher(reader);
+                    TermsAggregationBuilder request = new TermsAggregationBuilder("i").field("i").executionHint(executionHint)
+                        .subAggregation(new TermsAggregationBuilder("j").field("j").executionHint(executionHint)
+                            .subAggregation(new TermsAggregationBuilder("k").field("k").executionHint(executionHint)));
+                    StringTerms result = search(searcher, new MatchAllDocsQuery(), request,
+                        keywordField("i"), keywordField("j"), keywordField("k"));
+                    for (int i = 0; i < 10; i++) {
+                        StringTerms.Bucket iBucket = result.getBucketByKey(Integer.toString(i));
+                        assertThat(iBucket.getDocCount(), equalTo(100L));
+                        StringTerms jAgg = iBucket.getAggregations().get("j");
+                        for (int j = 0; j < 10; j++) {
+                            StringTerms.Bucket jBucket = jAgg.getBucketByKey(Integer.toString(j));
+                            assertThat(jBucket.getDocCount(), equalTo(10L));
+                            StringTerms kAgg = jBucket.getAggregations().get("k");
+                            for (int k = 0; k < 10; k++) {
+                                StringTerms.Bucket kBucket = kAgg.getBucketByKey(Integer.toString(k));
+                                assertThat(kBucket.getDocCount(), equalTo(1L));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public void testThreeLayerLong() throws IOException {
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {


### PR DESCRIPTION
This reworks string flavored implementations of the `terms` aggregation
to save memory when it is under another bucket by dropping the usage of
`asMultiBucketAggregator`.
