### PR TITLE
Allow interchangeability between camelcase and snake case for patterns

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatter.java
@@ -137,11 +137,27 @@ public interface DateFormatter {
         // support the 6.x BWC compatible way of parsing java 8 dates
         String format = strip8Prefix(input);
         List<String> patterns = splitCombinedPatterns(format);
+
         List<DateFormatter> formatters = patterns.stream()
                                                  .map(DateFormatters::forPattern)
                                                  .collect(Collectors.toList());
-
+        input = toSnakeCase(input, patterns);
         return JavaDateFormatter.combined(input, formatters);
+    }
+
+    static String toSnakeCase(String input, List<String> patterns) {
+        String regex = "([a-z])([A-Z]+)";
+        String replacement = "$1_$2";
+
+        String snakeCased = patterns.stream()
+            .map(p -> p.replaceAll(regex, replacement))
+            .collect(Collectors.joining("||"))
+            .toLowerCase(Locale.ROOT);
+
+        if(input.startsWith("8")) {
+            return "8"+snakeCased;
+        }
+        return snakeCased;
     }
 
     static String strip8Prefix(String input) {

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -41,6 +41,39 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class DateFormattersTests extends ESTestCase {
 
+    public void testCaseEquality() {
+        DateFormatter camelCaseFormatter = DateFormatter.forPattern("dateOptionalTime");
+        DateFormatter snakeCaseFormatter = DateFormatter.forPattern("date_optional_time");
+        assertThat(snakeCaseFormatter, equalTo(camelCaseFormatter));
+
+
+        camelCaseFormatter = DateFormatter.forPattern("date_optional_time||strict_date_optional_time");
+        snakeCaseFormatter = DateFormatter.forPattern("dateOptionalTime||strictDateOptionalTime");
+        assertThat(snakeCaseFormatter, equalTo(camelCaseFormatter));
+    }
+
+    public void testCamelAndSnakeFormats(){
+        assertThat(DateFormatter.forPattern("dateOptionalTime").pattern(), equalTo("date_optional_time"));
+        assertThat(DateFormatter.forPattern("date_optional_time").pattern(), equalTo("date_optional_time"));
+
+        assertThat(DateFormatter.forPattern("date_optional_time||strict_date_optional_time").pattern(),
+            equalTo("date_optional_time||strict_date_optional_time"));
+        assertThat(DateFormatter.forPattern("dateOptionalTime||strictDateOptionalTime").pattern(),
+            equalTo("date_optional_time||strict_date_optional_time"));
+
+        assertThat(DateFormatter.forPattern("8dateOptionalTime").pattern(), equalTo("8date_optional_time"));
+        assertThat(DateFormatter.forPattern("8date_optional_time").pattern(), equalTo("8date_optional_time"));
+
+        assertThat(DateFormatter.forPattern("8date_optional_time||strict_date_optional_time").pattern(),
+            equalTo("8date_optional_time||strict_date_optional_time"));
+        assertThat(DateFormatter.forPattern("8dateOptionalTime||strictDateOptionalTime").pattern(),
+            equalTo("8date_optional_time||strict_date_optional_time"));
+
+        //TODO slightly artificial testcase
+//        assertThat(DateFormatter.forPattern("'dateOptionalTime'").pattern(), equalTo("'dateOptionalTime'"));
+//        assertThat(DateFormatter.forPattern("'date_optional_time'").pattern(), equalTo("'date_optional_time'"));
+    }
+
     public void testWeekBasedDates() {
         assumeFalse("won't work in jdk8 " +
                 "because SPI mechanism is not looking at classpath - needs ISOCalendarDataProvider in jre's ext/libs",


### PR DESCRIPTION
We did previously allow for interchangeability for single formats like `dateOptionalTime` and `date_optional_time` because we were storing these as `date_optional_time`
The behaviour has changed because of https://github.com/elastic/elasticsearch/issues/57672
This should also be fixed for combined patterns.

closes https://github.com/elastic/elasticsearch/issues/57672