### PR TITLE
Add range query support to wildcard field

### DIFF
--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -30,15 +30,19 @@ import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.apache.lucene.util.automaton.RegExp.Kind;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -70,6 +74,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -613,6 +618,12 @@ public class WildcardFieldMapper extends FieldMapper {
         static boolean isMatchAll(Query q) {
             return q instanceof MatchAllDocsQuery || q instanceof MatchAllButRequireVerificationQuery;
         }
+        
+        protected String firstNgramToken(String fragment) {
+            LinkedHashSet<String> tokens = new LinkedHashSet<>();
+            getNgramTokens(tokens, fragment);
+            return tokens.iterator().next();
+        }
 
         protected void getNgramTokens(Set<String> tokens, String fragment) {
             if (fragment.equals(TOKEN_START_STRING) || fragment.equals(TOKEN_END_STRING)) {
@@ -676,6 +687,90 @@ public class WildcardFieldMapper extends FieldMapper {
                 wq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
                 bqBuilder.add(new BooleanClause(wq, occur));
             }
+        }
+
+        @Override
+        public Query rangeQuery(
+            Object lowerTerm,
+            Object upperTerm,
+            boolean includeLower,
+            boolean includeUpper,
+            ShapeRelation relation,
+            ZoneId timeZone,
+            DateMathParser parser,
+            QueryShardContext context
+        ) {
+            if (context.allowExpensiveQueries() == false) {
+                throw new ElasticsearchException("[range] queries on [wildcard] fields cannot be executed when '" +
+                        ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
+            }
+            BytesRef lower = lowerTerm == null ? null : BytesRefs.toBytesRef(lowerTerm);
+            BytesRef upper = lowerTerm == null ? null : BytesRefs.toBytesRef(upperTerm);
+            Query accelerationQuery = null;
+            if (lowerTerm != null && upperTerm != null) {
+                // Long common prefixes e.g. "C:/Program Files/a,txt" to "C:/Program Files/z,txt"
+                // can be accelerated by searching for all the common leading ngrams e.g. c:/, /pr, rog, gra etc 
+                StringBuilder commonPrefix = new StringBuilder();
+                String lowerS = addLineEndChars(toLowerCase(lower.utf8ToString()));
+                String upperS = addLineEndChars(toLowerCase(upper.utf8ToString()));
+                for (int i = 0; i < Math.min(lowerS.length(), upperS.length());) {
+                    final int cL = lowerS.codePointAt(i);
+                    final int cU = upperS.codePointAt(i);
+                    if (cL == cU) {
+                        commonPrefix.append(Character.toChars(cL));
+                    } else {
+                        break;
+                    }
+                    int length = Character.charCount(cL);
+                    i += length;
+                }
+
+                if (commonPrefix.length() > 0) {
+                    Set<String> tokens = new HashSet<>();
+                    getNgramTokens(tokens, commonPrefix.toString());
+                    BooleanQuery.Builder bqBuilder = new BooleanQuery.Builder();
+                    for (String token : tokens) {
+                        int tokenSize = token.codePointCount(0, token.length());
+                        if (tokenSize < 2 || token.equals(WildcardFieldMapper.TOKEN_END_STRING)) {
+                            continue;
+                        }
+
+                        if (tokenSize == NGRAM_SIZE) {
+                            TermQuery tq = new TermQuery(new Term(name(), token));
+                            bqBuilder.add(new BooleanClause(tq, Occur.MUST));
+                        } else {
+                            PrefixQuery wq = new PrefixQuery(new Term(name(), token));
+                            wq.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_REWRITE);
+                            bqBuilder.add(new BooleanClause(wq, Occur.MUST));
+                        }
+                    }
+                    BooleanQuery bq = bqBuilder.build();
+                    if (bq.clauses().size() > 0) {
+                        accelerationQuery = bq;
+                    }                     
+                }                
+            }
+            if (accelerationQuery == null) {
+                // Fallback - if there is no common prefix sequence then we look for the range of ngrams that appear at the start
+                // of the string e.g. given 100 to 999 we would search for ngrams in the range
+                //   TOKEN_START_OR_END_CHAR + "10" to 
+                //   TOKEN_START_OR_END_CHAR + "99"
+                BytesRef lowerNgram = lower == null ? null : new BytesRef(firstNgramToken(
+                    addLineEndChars(toLowerCase(lower.utf8ToString()))));
+                BytesRef upperNgram = upper == null ? null : new BytesRef(firstNgramToken(
+                    addLineEndChars(toLowerCase(upper.utf8ToString()))));
+                accelerationQuery = new TermRangeQuery(name(), lowerNgram, upperNgram, true, true);                
+            }
+            
+            Supplier <Automaton> deferredAutomatonSupplier = ()->{
+                return TermRangeQuery.toAutomaton(lower, upper, includeLower, includeUpper);
+            };
+            AutomatonQueryOnBinaryDv slowQuery = new AutomatonQueryOnBinaryDv(name(), lower + "-" + upper, deferredAutomatonSupplier);
+            
+            BooleanQuery.Builder qBuilder = new BooleanQuery.Builder();
+            qBuilder.add(accelerationQuery, Occur.MUST);
+            qBuilder.add(slowQuery, Occur.MUST);
+            return qBuilder.build();
         }
 
         @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -705,7 +705,7 @@ public class WildcardFieldMapper extends FieldMapper {
                         ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
             }
             BytesRef lower = lowerTerm == null ? null : BytesRefs.toBytesRef(lowerTerm);
-            BytesRef upper = lowerTerm == null ? null : BytesRefs.toBytesRef(upperTerm);
+            BytesRef upper = upperTerm == null ? null : BytesRefs.toBytesRef(upperTerm);
             Query accelerationQuery = null;
             if (lowerTerm != null && upperTerm != null) {
                 // Long common prefixes e.g. "C:/Program Files/a,txt" to "C:/Program Files/z,txt"


### PR DESCRIPTION
The last query type required for parity with keyword field.
Closes #57816 