### PR TITLE
Deprecte Rounding#round (backport #57845)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -240,9 +240,9 @@ public abstract class Rounding implements Writeable {
 
     /**
      * Rounds the given value.
-     * <p>
-     * Prefer {@link #prepare(long, long)} if rounding many values.
+     * @deprecated Prefer {@link #prepare} and then {@link Prepared#round(long)}
      */
+    @Deprecated
     public final long round(long utcMillis) {
         return prepare(utcMillis, utcMillis).round(utcMillis);
     }
@@ -252,9 +252,9 @@ public abstract class Rounding implements Writeable {
      * {@link #round(long)}, returns the next rounding value. For
      * example, with interval based rounding, if the interval is
      * 3, {@code nextRoundValue(6) = 9}.
-     * <p>
-     * Prefer {@link #prepare(long, long)} if rounding many values.
+     * @deprecated Prefer {@link #prepare} and then {@link Prepared#nextRoundingValue(long)}
      */
+    @Deprecated
     public final long nextRoundingValue(long utcMillis) {
         return prepare(utcMillis, utcMillis).nextRoundingValue(utcMillis);
     }

--- a/server/src/test/java/org/elasticsearch/common/rounding/RoundingDuelTests.java
+++ b/server/src/test/java/org/elasticsearch/common/rounding/RoundingDuelTests.java
@@ -60,16 +60,16 @@ public class RoundingDuelTests extends ESTestCase  {
     public void testDuellingImplementations() {
         org.elasticsearch.common.Rounding.DateTimeUnit randomDateTimeUnit =
             randomFrom(org.elasticsearch.common.Rounding.DateTimeUnit.values());
-        org.elasticsearch.common.Rounding rounding;
+        org.elasticsearch.common.Rounding.Prepared rounding;
         Rounding roundingJoda;
 
         if (randomBoolean()) {
-            rounding = org.elasticsearch.common.Rounding.builder(randomDateTimeUnit).timeZone(ZoneOffset.UTC).build();
+            rounding = org.elasticsearch.common.Rounding.builder(randomDateTimeUnit).timeZone(ZoneOffset.UTC).build().prepareForUnknown();
             DateTimeUnit dateTimeUnit = DateTimeUnit.resolve(randomDateTimeUnit.getId());
             roundingJoda = Rounding.builder(dateTimeUnit).timeZone(DateTimeZone.UTC).build();
         } else {
             TimeValue interval = timeValue();
-            rounding = org.elasticsearch.common.Rounding.builder(interval).timeZone(ZoneOffset.UTC).build();
+            rounding = org.elasticsearch.common.Rounding.builder(interval).timeZone(ZoneOffset.UTC).build().prepareForUnknown();
             roundingJoda = Rounding.builder(interval).timeZone(DateTimeZone.UTC).build();
         }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -58,7 +58,8 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
         long interval = randomIntBetween(1, 3);
         intervalMillis = randomFrom(timeValueSeconds(interval), timeValueMinutes(interval), timeValueHours(interval)).getMillis();
         Rounding rounding = Rounding.builder(TimeValue.timeValueMillis(intervalMillis)).build();
-        baseMillis = rounding.round(System.currentTimeMillis());
+        long now = System.currentTimeMillis();
+        baseMillis = rounding.prepare(now, now).round(now);
         if (randomBoolean()) {
             minDocCount = randomIntBetween(1, 10);
             emptyBucketInfo = null;
@@ -108,8 +109,12 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
             long minBound = -1;
             long maxBound = -1;
             if (emptyBucketInfo.bounds != null) {
-                minBound = emptyBucketInfo.rounding.round(emptyBucketInfo.bounds.getMin());
-                maxBound = emptyBucketInfo.rounding.round(emptyBucketInfo.bounds.getMax());
+                Rounding.Prepared prepared = emptyBucketInfo.rounding.prepare(
+                    emptyBucketInfo.bounds.getMin(),
+                    emptyBucketInfo.bounds.getMax()
+                );
+                minBound = prepared.round(emptyBucketInfo.bounds.getMin());
+                maxBound = prepared.round(emptyBucketInfo.bounds.getMax());
                 if (expectedCounts.isEmpty() && minBound <= maxBound) {
                     expectedCounts.put(minBound, 0L);
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/DateHistogramGroupConfig.java
@@ -304,7 +304,7 @@ public class DateHistogramGroupConfig implements Writeable, ToXContentObject {
     /**
      * Create the rounding for this date histogram
      */
-    public Rounding createRounding() {
+    public Rounding.Prepared createRounding() {
         return createRounding(interval.toString(), timeZone);
     }
 
@@ -363,7 +363,7 @@ public class DateHistogramGroupConfig implements Writeable, ToXContentObject {
         return PARSER.parse(parser, null);
     }
 
-    private static Rounding createRounding(final String expr, final String timeZone) {
+    private static Rounding.Prepared createRounding(final String expr, final String timeZone) {
         Rounding.DateTimeUnit timeUnit = DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(expr);
         final Rounding.Builder rounding;
         if (timeUnit != null) {
@@ -372,6 +372,6 @@ public class DateHistogramGroupConfig implements Writeable, ToXContentObject {
             rounding = new Rounding.Builder(TimeValue.parseTimeValue(expr, "createRounding"));
         }
         rounding.timeZone(ZoneId.of(timeZone, ZoneId.SHORT_IDS));
-        return rounding.build();
+        return rounding.build().prepareForUnknown();
     }
 }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -283,7 +283,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                         asMap("the_histo", now)
                 )
         );
-        final Rounding rounding = dateHistoConfig.createRounding();
+        final Rounding.Prepared rounding = dateHistoConfig.createRounding();
         executeTestCase(dataset, job, now, (resp) -> {
             assertThat(resp.size(), equalTo(3));
             IndexRequest request = resp.get(0);
@@ -350,7 +350,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                 asMap("the_histo", now)
             )
         );
-        final Rounding rounding = dateHistoConfig.createRounding();
+        final Rounding.Prepared rounding = dateHistoConfig.createRounding();
         executeTestCase(dataset, job, now, (resp) -> {
             assertThat(resp.size(), equalTo(2));
             IndexRequest request = resp.get(0);


### PR DESCRIPTION
This deprecates `Rounding#round` and `Rounding#nextRoundingValue` in
favor of calling
```
Rounding.Prepared prepared = rounding.prepare(min, max);
...
prepared.round(val)

```

because it is always going to be faster to prepare once. There
are going to be some cases where we won't know what to prepare *for*
and in those cases you can call `prepareForUnknown` and stil be faster
than calling the deprecated method over and over and over again.

Ultimately, this is important because it doesn't look like there is an
easy way to cache `Rounding.Prepared` or any of its precursors like
`LocalTimeOffset.Lookup`. Instead, we can just build it at most once per
request.

Relates to #56124
