### PR TITLE
Fix rolling restart case in node version allocation decider test.

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -270,7 +270,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = stabilize(clusterState, service);
 
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder()
-                .add(newNode("node0", VersionUtils.getPreviousVersion()))
+                .add(newNode("old0", VersionUtils.getPreviousVersion()))
                 .add(newNode("new1"))
                 .add(newNode("new0"))).build();
 


### PR DESCRIPTION
The rolling restart case should not introduce non-known node. This should be a typo issue.