### PR TITLE
Mark Component template APIs as experimental

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Deletes a component template"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns information about whether a particular component template exist"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns one or more component templates"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Creates or updates a component template"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Deletes an index template."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Returns information about whether a particular index template exists."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Returns an index template."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description":"Creates or updates an index template."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description": "Simulate matching the given index name against the index templates in the system"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates.html",
       "description": "Simulate resolving the given template name or body"
     },
-    "stability":"stable",
+    "stability":"experimental",
     "url":{
       "paths":[
         {


### PR DESCRIPTION
This commit marks the Component template APIs as experimental.

