### PR TITLE
Fix refresh behavior in MockDiskUsagesIT

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -42,13 +42,23 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
     public static class TestPlugin extends Plugin {}
 
     @Nullable // if no fakery should take place
-    public volatile Function<ShardRouting, Long> shardSizeFunction;
+    private volatile Function<ShardRouting, Long> shardSizeFunction;
 
     @Nullable // if no fakery should take place
-    public volatile BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction;
+    private volatile BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction;
 
     public MockInternalClusterInfoService(Settings settings, ClusterService clusterService, ThreadPool threadPool, NodeClient client) {
         super(settings, clusterService, threadPool, client);
+    }
+
+    public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction) {
+        this.diskUsageFunction = diskUsageFunction;
+        refresh();
+    }
+
+    public void setShardSizeFunctionAndRefresh(Function<ShardRouting, Long> shardSizeFunction) {
+        this.shardSizeFunction = shardSizeFunction;
+        refresh();
     }
 
     @Override


### PR DESCRIPTION
Ensures that `InternalClusterInfoService`'s internally cached stats are refreshed whenever the shard size or disk usage function (to mock out disk usage) are overridden.

Closes #57888