### PR TITLE
Re-enable windows archives packaging tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -53,7 +53,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -61,9 +60,6 @@ public class ArchiveTests extends PackagingTestCase {
 
     @BeforeClass
     public static void filterDistros() {
-        // Muted on Windows see: https://github.com/elastic/elasticsearch/issues/50825
-        assumeFalse(System.getProperty("os.name").startsWith("Windows"));
-
         assumeTrue("only archives", distribution.isArchive());
     }
 


### PR DESCRIPTION
This commit re-enables windows testing for archives packaging tests.
These were disabled previously because of constant failure due to
windows file locks, but the failure does not occur outside of CI, so
they are being re-enabled to further investigate the failure.

relates #50825