### PR TITLE
Fix PersistedClusterStateServiceTests.testSlowLogging

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -856,7 +856,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     "writing cluster state took [*] which is above the warn threshold of [*]; " +
                         "wrote global metadata [false] and metadata for [1] indices and skipped [0] unchanged indices"));
 
-                writeDurationMillis.set(randomLongBetween(1, writeDurationMillis.get() - 1));
+                writeDurationMillis.set(randomLongBetween(0, writeDurationMillis.get() - 1));
                 assertExpectedLogs(1L, clusterState, newClusterState, writer, new MockLogAppender.UnseenEventExpectation(
                     "should not see warning below threshold",
                     PersistedClusterStateService.class.getCanonicalName(),


### PR DESCRIPTION
The range in the last writeDurationMillis selection could be empty, as it could prior to the call be set to 1.

Closes #57940