### PR TITLE
Fix info message for starting RunTask in debug mode

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -99,7 +99,7 @@ public class RunTask extends DefaultTestClustersTask {
                     node.setDataPath(getDataPath.apply(node));
                 }
                 if (debug) {
-                    logger.lifecycle("Running elasticsearch in debug mode, {} suspending until connected on debugPort {}", node, debugPort);
+                    logger.lifecycle("Running elasticsearch in debug mode, {} expecting running debug server on port {}", node, debugPort);
                     node.jvmArgs("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=" + debugPort);
                     debugPort += 1;
                 }


### PR DESCRIPTION
The lifecycle log messages was misleading and outdated causing some confusion for community members. This fixes the emitted message when starting with --debug-jvm flag.

Fixes #57860