### PR TITLE
[7.8] Fix incorrect stats warning when swap is disabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -221,7 +221,9 @@ public class OsStats implements Writeable, ToXContentFragment {
                 //
                 // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
                 // cases where (free > total) which would be a different bug.
-                logger.warn("cannot compute used swap when total swap is 0 and free swap is " + free);
+                if (free > 0) {
+                    logger.warn("cannot compute used swap when total swap is 0 and free swap is " + free);
+                }
                 return new ByteSizeValue(0);
             }
             return new ByteSizeValue(total - free);
@@ -281,7 +283,9 @@ public class OsStats implements Writeable, ToXContentFragment {
                 //
                 // We intentionally check for (total == 0) rather than (total - free < 0) so as not to hide
                 // cases where (free > total) which would be a different bug.
-                logger.warn("cannot compute used memory when total memory is 0 and free memory is " + free);
+                if (free > 0) {
+                    logger.warn("cannot compute used memory when total memory is 0 and free memory is " + free);
+                }
                 return new ByteSizeValue(0);
             }
             return new ByteSizeValue(total - free);


### PR DESCRIPTION
Eliminates a log warning when both free and used swap or system memory is reported as zero. This can happen under normal circumstances such as when swap is disabled and should not produce a warning.

Backport of #57983
