### PR TITLE
[7.x] Fix missing null values for std_deviation_bounds in ext. stats aggs

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -329,6 +329,10 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
             {
                 builder.nullField(Fields.UPPER);
                 builder.nullField(Fields.LOWER);
+                builder.nullField(Fields.UPPER_POPULATION);
+                builder.nullField(Fields.LOWER_POPULATION);
+                builder.nullField(Fields.UPPER_SAMPLING);
+                builder.nullField(Fields.LOWER_SAMPLING);
             }
             builder.endObject();
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedExtendedStats.java
@@ -95,14 +95,12 @@ public class ParsedExtendedStats extends ParsedStats implements ExtendedStats {
     }
 
     private void setStdDeviationBounds(List<Double> bounds) {
-        int i = 0;
-        this.stdDeviationBoundUpper = bounds.get(i++);
-        this.stdDeviationBoundLower = bounds.get(i++);
-        this.stdDeviationBoundUpperPopulation = bounds.get(i++);
-        this.stdDeviationBoundLowerPopulation = bounds.get(i++);
-        this.stdDeviationBoundUpperSampling = bounds.get(i++);
-        this.stdDeviationBoundLowerSampling = bounds.get(i);
-
+        this.stdDeviationBoundUpper = bounds.get(0);
+        this.stdDeviationBoundLower = bounds.get(1);
+        this.stdDeviationBoundUpperPopulation = bounds.get(2) == null ? 0 : bounds.get(2);
+        this.stdDeviationBoundLowerPopulation = bounds.get(3) == null ? 0 : bounds.get(3);
+        this.stdDeviationBoundUpperSampling = bounds.get(4) == null ? 0 : bounds.get(4);
+        this.stdDeviationBoundLowerSampling = bounds.get(5) == null ? 0 : bounds.get(5);
     }
 
     @Override
@@ -126,13 +124,20 @@ public class ParsedExtendedStats extends ParsedStats implements ExtendedStats {
     }
 
     private void setStdDeviationBoundsAsString(List<String> boundsAsString) {
-        int i = 0;
-        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_upper", boundsAsString.get(i++));
-        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_lower", boundsAsString.get(i++));
-        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_upper_population", boundsAsString.get(i++));
-        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_lower_population", boundsAsString.get(i++));
-        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_upper_sampling", boundsAsString.get(i++));
-        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_lower_sampling", boundsAsString.get(i));
+        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_upper", boundsAsString.get(0));
+        this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_lower", boundsAsString.get(1));
+        if (boundsAsString.get(2) != null) {
+            this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_upper_population", boundsAsString.get(2));
+        }
+        if (boundsAsString.get(3) != null) {
+            this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_lower_population", boundsAsString.get(3));
+        }
+        if (boundsAsString.get(4) != null) {
+            this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_upper_sampling", boundsAsString.get(4));
+        }
+        if (boundsAsString.get(5) != null) {
+            this.valueAsString.put(Fields.STD_DEVIATION_BOUNDS_AS_STRING + "_lower_sampling", boundsAsString.get(5));
+        }
     }
 
     @Override


### PR DESCRIPTION
Adds missing null values for std_deviation_bounds in extended stats aggs and
improves null handling in parsed extended stats.
