### PR TITLE
Clarify `expand_wildcard` option in snapshot docs

### DIFF
--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -52,12 +52,14 @@ PUT /_snapshot/my_backup/snapshot_2?wait_for_completion=true
 // TEST[skip:cannot complete subsequent snapshot]
 
 The list of indices that should be included into the snapshot can be specified using the `indices` parameter that
-supports <<multi-index,multi index syntax>>. The snapshot request also supports the
+supports <<multi-index,multi index syntax>>, although the options which control the behavior of multi index syntax
+must be supplied in the body of the request, rather than as request parameters. The snapshot request also supports the
 `ignore_unavailable` option. Setting it to `true` will cause indices that do not exist to be ignored during snapshot
 creation. By default, when `ignore_unavailable` option is not set and an index is missing the snapshot request will fail.
 By setting `include_global_state` to false it's possible to prevent the cluster global state to be stored as part of
 the snapshot. By default, the entire snapshot will fail if one or more indices participating in the snapshot don't have
-all primary shards available. This behaviour can be changed by setting `partial` to `true`.
+all primary shards available. This behaviour can be changed by setting `partial` to `true`. The `expand_wildcards`
+option can be used to control whether hidden and closed indices will be included in the snapshot, and defaults to `all`.
 
 The `metadata` field can be used to attach arbitrary metadata to the snapshot. This may be a record of who took the snapshot,
 why it was taken, or any other data that might be useful.


### PR DESCRIPTION
This commit clarifies that the `expand_wildcards` option (as well as other
`IndicesOptions` parameters) can be used with the Create Snapshot API, but that
they must be in the body of the request.

Also clarifies the connection between `expand_wildcards` and hidden indices as
it relates to snapshots.

Relates https://github.com/elastic/elasticsearch/issues/57208