### PR TITLE
Fix Geo grid aggregation circuit breaker tests

### DIFF
--- a/x-pack/plugin/spatial/src/test/resources/rest-api-spec/test/30_geotile_grid.yml
+++ b/x-pack/plugin/spatial/src/test/resources/rest-api-spec/test/30_geotile_grid.yml
@@ -58,13 +58,13 @@
 
 ---
 "Test geotile_grid aggregation circuit breaker":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/56257"
   - do:
       indices.create:
         index: locations
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               location:


### PR DESCRIPTION
This commit makes sure we create index with only one shard.

fixes #56257