### PR TITLE
GeometryTestUtils should always generate valid polygons

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -40,6 +40,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.elasticsearch.test.ESTestCase.randomValueOtherThanMany;
+
 public class GeometryTestUtils {
 
     public static double randomLat() {
@@ -96,10 +98,7 @@ public class GeometryTestUtils {
     }
 
     public static Polygon randomPolygon(boolean hasAlt) {
-        org.apache.lucene.geo.Polygon lucenePolygon = GeoTestUtil.nextPolygon();
-        while(area(lucenePolygon) == 0) {
-            lucenePolygon = GeoTestUtil.nextPolygon();
-        }
+        org.apache.lucene.geo.Polygon lucenePolygon = randomValueOtherThanMany(p -> area(p) == 0, GeoTestUtil::nextPolygon);
         if (lucenePolygon.numHoles() > 0) {
             org.apache.lucene.geo.Polygon[] luceneHoles = lucenePolygon.getHoles();
             List<LinearRing> holes = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/geo/GeometryTestUtils.java
@@ -97,6 +97,9 @@ public class GeometryTestUtils {
 
     public static Polygon randomPolygon(boolean hasAlt) {
         org.apache.lucene.geo.Polygon lucenePolygon = GeoTestUtil.nextPolygon();
+        while(area(lucenePolygon) == 0) {
+            lucenePolygon = GeoTestUtil.nextPolygon();
+        }
         if (lucenePolygon.numHoles() > 0) {
             org.apache.lucene.geo.Polygon[] luceneHoles = lucenePolygon.getHoles();
             List<LinearRing> holes = new ArrayList<>();
@@ -107,6 +110,17 @@ public class GeometryTestUtils {
             return new Polygon(linearRing(lucenePolygon.getPolyLons(), lucenePolygon.getPolyLats(), hasAlt), holes);
         }
         return new Polygon(linearRing(lucenePolygon.getPolyLons(), lucenePolygon.getPolyLats(), hasAlt));
+    }
+
+    private static double area(org.apache.lucene.geo.Polygon lucenePolygon) {
+        double windingSum = 0;
+        final int numPts = lucenePolygon.numPoints() - 1;
+        for (int i = 0; i < numPts; i++) {
+            // compute signed area
+            windingSum += lucenePolygon.getPolyLon(i) * lucenePolygon.getPolyLat(i + 1) -
+                lucenePolygon.getPolyLat(i) * lucenePolygon.getPolyLon(i + 1);
+        }
+       return Math.abs(windingSum / 2);
     }
 
 


### PR DESCRIPTION
Make sure we always generate legal polygons, e.g they have area.

fixes #58032