### PR TITLE
[ML] allow feature_names to be optional in ensemble inference model

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModel.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -60,7 +61,7 @@ public class EnsembleInferenceModel implements InferenceModel {
             (List<String>)a[4],
             (List<Double>)a[5]));
     static {
-        PARSER.declareStringArray(constructorArg(), FEATURE_NAMES);
+        PARSER.declareStringArray(optionalConstructorArg(), FEATURE_NAMES);
         PARSER.declareNamedObjects(constructorArg(),
             (p, c, n) -> p.namedObject(InferenceModel.class, n, null),
             (ensembleBuilder) -> {},
@@ -84,13 +85,13 @@ public class EnsembleInferenceModel implements InferenceModel {
     private final List<String> classificationLabels;
     private final double[] classificationWeights;
 
-    EnsembleInferenceModel(List<String> featureNames,
+    EnsembleInferenceModel(@Nullable List<String> featureNames,
                            List<InferenceModel> models,
                            OutputAggregator outputAggregator,
                            TargetType targetType,
                            List<String> classificationLabels,
                            List<Double> classificationWeights) {
-        this.featureNames = ExceptionsHelper.requireNonNull(featureNames, FEATURE_NAMES).toArray(String[]::new);
+        this.featureNames = featureNames == null ? new String[0] : featureNames.toArray(String[]::new);
         this.models = ExceptionsHelper.requireNonNull(models, TRAINED_MODELS);
         this.outputAggregator = ExceptionsHelper.requireNonNull(outputAggregator, AGGREGATE_OUTPUT);
         this.targetType = ExceptionsHelper.requireNonNull(targetType, TARGET_TYPE);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/EnsembleTests.java
@@ -66,7 +66,10 @@ public class EnsembleTests extends AbstractSerializingTestCase<Ensemble> {
 
     public static Ensemble createRandom(TargetType targetType, List<String> featureNames) {
         int numberOfModels = randomIntBetween(1, 10);
-        List<TrainedModel> models = Stream.generate(() -> TreeTests.buildRandomTree(featureNames, 6))
+        List<String> treeFeatureNames = featureNames.isEmpty() ?
+            Stream.generate(() -> randomAlphaOfLength(10)).limit(5).collect(Collectors.toList()) :
+            featureNames;
+        List<TrainedModel> models = Stream.generate(() -> TreeTests.buildRandomTree(treeFeatureNames, 6))
             .limit(numberOfModels)
             .collect(Collectors.toList());
         double[] weights = randomBoolean() ?

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModelTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.search.SearchModule;
@@ -18,6 +19,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.Tree;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.TreeNode;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.tree.TreeTests;
 import org.elasticsearch.xpack.core.ml.job.config.Operator;
 
 import java.io.IOException;
@@ -33,16 +35,22 @@ import java.util.stream.IntStream;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference.InferenceModelTestUtils.deserializeFromTrainedModel;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class TreeInferenceModelTests extends ESTestCase {
 
+    private static final int NUMBER_OF_TEST_RUNS = 20;
     private final double eps = 1.0E-8;
 
     public static TreeInferenceModel serializeFromTrainedModel(Tree tree) throws IOException {
         NamedXContentRegistry registry = new NamedXContentRegistry(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
-        return deserializeFromTrainedModel(tree,
+        TreeInferenceModel model = deserializeFromTrainedModel(tree,
             registry,
             TreeInferenceModel::fromXContent);
+        model.rewriteFeatureIndices(Collections.emptyMap());
+        return model;
     }
 
     @Override
@@ -51,6 +59,22 @@ public class TreeInferenceModelTests extends ESTestCase {
         namedXContent.addAll(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
         namedXContent.addAll(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents());
         return new NamedXContentRegistry(namedXContent);
+    }
+
+    public void testSerializationFromEnsemble() throws Exception {
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; ++i) {
+            Tree tree = TreeTests.createRandom(randomFrom(TargetType.values()));
+            assertThat(serializeFromTrainedModel(tree), is(not(nullValue())));
+        }
+    }
+
+    public void testInferenceWithoutPreparing() throws IOException {
+        Tree tree = TreeTests.createRandom(randomFrom(TargetType.values()));
+
+        TreeInferenceModel model = deserializeFromTrainedModel(tree,
+            xContentRegistry(),
+            TreeInferenceModel::fromXContent);
+        expectThrows(ElasticsearchException.class, () -> model.infer(Collections.emptyMap(), RegressionConfig.EMPTY_PARAMS, null));
     }
 
     public void testInferWithStump() throws IOException {
@@ -62,6 +86,7 @@ public class TreeInferenceModelTests extends ESTestCase {
         TreeInferenceModel tree = deserializeFromTrainedModel(treeObject,
             xContentRegistry(),
             TreeInferenceModel::fromXContent);
+        tree.rewriteFeatureIndices(Collections.emptyMap());
         List<String> featureNames = Arrays.asList("foo", "bar");
         List<Double> featureVector = Arrays.asList(0.6, 0.0);
         Map<String, Object> featureMap = zipObjMap(featureNames, featureVector); // does not really matter as this is a stump
@@ -85,6 +110,7 @@ public class TreeInferenceModelTests extends ESTestCase {
         TreeInferenceModel tree = deserializeFromTrainedModel(treeObject,
             xContentRegistry(),
             TreeInferenceModel::fromXContent);
+        tree.rewriteFeatureIndices(Collections.emptyMap());
         // This feature vector should hit the right child of the root node
         List<Double> featureVector = Arrays.asList(0.6, 0.0);
         Map<String, Object> featureMap = zipObjMap(featureNames, featureVector);
@@ -140,6 +166,7 @@ public class TreeInferenceModelTests extends ESTestCase {
         TreeInferenceModel tree = deserializeFromTrainedModel(treeObject,
             xContentRegistry(),
             TreeInferenceModel::fromXContent);
+        tree.rewriteFeatureIndices(Collections.emptyMap());
         double eps = 0.000001;
         // This feature vector should hit the right child of the root node
         List<Double> featureVector = Arrays.asList(0.6, 0.0);
@@ -214,6 +241,7 @@ public class TreeInferenceModelTests extends ESTestCase {
         TreeInferenceModel tree = deserializeFromTrainedModel(treeObject,
             xContentRegistry(),
             TreeInferenceModel::fromXContent);
+        tree.rewriteFeatureIndices(Collections.emptyMap());
 
         double[][] featureImportance = tree.featureImportance(new double[]{0.25, 0.25});
         assertThat(featureImportance[0][0], closeTo(-5.0, eps));


### PR DESCRIPTION
This has `EnsembleInferenceModel` not parse feature_names from the XContent.

Instead, it will rely on `rewriteFeatureIndices` to be called ahead time. 

Consequently, protections are made for a fail fast path if `rewriteFeatureIndices` has not been called before `infer`.