### PR TITLE
Scope index templates put during cluster upgrade tests

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -25,20 +25,16 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.action.document.RestBulkAction;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_AS_INT_PARAM;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Basic test that indexed documents survive the rolling restart. See
@@ -74,25 +70,6 @@ public class IndexingIT extends AbstractRollingTestCase {
         }
 
         if (CLUSTER_TYPE == ClusterType.OLD) {
-            {
-                Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
-                assertThat("this branch is not needed if we aren't compatible with 6.0",
-                        minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
-                if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
-                    XContentBuilder template = jsonBuilder();
-                    template.startObject();
-                    {
-                        template.field("index_patterns", "*");
-                        template.startObject("settings");
-                        template.field("number_of_shards", 5);
-                        template.endObject();
-                    }
-                    template.endObject();
-                    Request createTemplate = new Request("PUT", "/_template/template");
-                    createTemplate.setJsonEntity(Strings.toString(template));
-                    client().performRequest(createTemplate);
-                }
-            }
 
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -88,7 +88,7 @@ public class IndexingIT extends AbstractRollingTestCase {
                         template.endObject();
                     }
                     template.endObject();
-                    Request createTemplate = new Request("PUT", "/_template/template");
+                    Request createTemplate = new Request("PUT", "/_template/prevent-bwc-deprecation-template");
                     createTemplate.setJsonEntity(Strings.toString(template));
                     client().performRequest(createTemplate);
                 }

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -25,16 +25,20 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.action.document.RestBulkAction;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_AS_INT_PARAM;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Basic test that indexed documents survive the rolling restart. See
@@ -70,7 +74,25 @@ public class IndexingIT extends AbstractRollingTestCase {
         }
 
         if (CLUSTER_TYPE == ClusterType.OLD) {
-
+            {
+                Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
+                assertThat("this branch is not needed if we aren't compatible with 6.0",
+                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
+                    XContentBuilder template = jsonBuilder();
+                    template.startObject();
+                    {
+                        template.array("index_patterns", "test_index", "index_with_replicas", "empty_index");
+                        template.startObject("settings");
+                        template.field("number_of_shards", 5);
+                        template.endObject();
+                    }
+                    template.endObject();
+                    Request createTemplate = new Request("PUT", "/_template/template");
+                    createTemplate.setJsonEntity(Strings.toString(template));
+                    client().performRequest(createTemplate);
+                }
+            }
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
             client().performRequest(createTestIndex);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -6,15 +6,20 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.action.document.RestBulkAction;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_AS_INT_PARAM;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Basic test that indexed documents survive the rolling restart.
@@ -48,6 +53,25 @@ public class IndexingIT extends AbstractUpgradeTestCase {
         }
 
         if (CLUSTER_TYPE == ClusterType.OLD) {
+            {
+                Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
+                assertThat("this branch is not needed if we aren't compatible with 6.0",
+                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
+                    XContentBuilder template = jsonBuilder();
+                    template.startObject();
+                    {
+                        template.array("index_patterns", "test_index", "index_with_replicas", "empty_index");
+                        template.startObject("settings");
+                        template.field("number_of_shards", 5);
+                        template.endObject();
+                    }
+                    template.endObject();
+                    Request createTemplate = new Request("PUT", "/_template/xpack-prevent-bwc-deprecation-template");
+                    createTemplate.setJsonEntity(Strings.toString(template));
+                    client().performRequest(createTemplate);
+                }
+            }
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
             client().performRequest(createTestIndex);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -6,20 +6,15 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.common.Booleans;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.action.document.RestBulkAction;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Booleans;
+import org.elasticsearch.rest.action.document.RestBulkAction;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_AS_INT_PARAM;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Basic test that indexed documents survive the rolling restart.
@@ -53,26 +48,6 @@ public class IndexingIT extends AbstractUpgradeTestCase {
         }
 
         if (CLUSTER_TYPE == ClusterType.OLD) {
-            {
-                Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
-                assertThat("this branch is not needed if we aren't compatible with 6.0",
-                        minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
-                if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
-                    XContentBuilder template = jsonBuilder();
-                    template.startObject();
-                    {
-                        template.field("index_patterns", "*");
-                        template.startObject("settings");
-                        template.field("number_of_shards", 5);
-                        template.endObject();
-                    }
-                    template.endObject();
-                    Request createTemplate = new Request("PUT", "/_template/template");
-                    createTemplate.setJsonEntity(Strings.toString(template));
-                    client().performRequest(createTemplate);
-                }
-            }
-
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
             client().performRequest(createTestIndex);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -13,8 +13,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
 import org.junit.After;
 import org.junit.Before;
@@ -26,9 +24,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.Matchers.equalTo;
 
 public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
 
@@ -60,25 +55,6 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
 
     public void testGeneratingTokensInOldCluster() throws Exception {
         assumeTrue("this test should only run against the old cluster", CLUSTER_TYPE == ClusterType.OLD);
-        {
-            Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
-            assertThat("this branch is not needed if we aren't compatible with 6.0",
-                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
-            if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
-                XContentBuilder template = jsonBuilder();
-                template.startObject();
-                {
-                    template.field("index_patterns", "*");
-                    template.startObject("settings");
-                    template.field("number_of_shards", 5);
-                    template.endObject();
-                }
-                template.endObject();
-                Request createTemplate = new Request("PUT", "/_template/template");
-                createTemplate.setJsonEntity(Strings.toString(template));
-                client().performRequest(createTemplate);
-            }
-        }
         // Creates two access and refresh tokens and stores them in the token_backwards_compatibility_it index to be used for tests in the
         // mixed/upgraded clusters
         Map<String, Object> responseMap = createTokens(client(), "test_user", "x-pack-test-password");
@@ -102,25 +78,6 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
 
     public void testRefreshingTokensInOldCluster() throws Exception {
         assumeTrue("this test should only run against the old cluster", CLUSTER_TYPE == ClusterType.OLD);
-        {
-            Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
-            assertThat("this branch is not needed if we aren't compatible with 6.0",
-                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
-            if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
-                XContentBuilder template = jsonBuilder();
-                template.startObject();
-                {
-                    template.field("index_patterns", "*");
-                    template.startObject("settings");
-                    template.field("number_of_shards", 5);
-                    template.endObject();
-                }
-                template.endObject();
-                Request createTemplate = new Request("PUT", "/_template/template");
-                createTemplate.setJsonEntity(Strings.toString(template));
-                client().performRequest(createTemplate);
-            }
-        }
         // Creates access and refresh tokens and uses the refresh token. The new resulting tokens are used in different phases
         Map<String, Object> responseMap = createTokens(client(), "test_user", "x-pack-test-password");
         String accessToken = (String) responseMap.get("access_token");
@@ -147,25 +104,6 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
 
     public void testInvalidatingTokensInOldCluster() throws Exception {
         assumeTrue("this test should only run against the old cluster", CLUSTER_TYPE == ClusterType.OLD);
-        {
-            Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
-            assertThat("this branch is not needed if we aren't compatible with 6.0",
-                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
-            if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
-                XContentBuilder template = jsonBuilder();
-                template.startObject();
-                {
-                    template.field("index_patterns", "*");
-                    template.startObject("settings");
-                    template.field("number_of_shards", 5);
-                    template.endObject();
-                }
-                template.endObject();
-                Request createTemplate = new Request("PUT", "/_template/template");
-                createTemplate.setJsonEntity(Strings.toString(template));
-                client().performRequest(createTemplate);
-            }
-        }
         // Creates access and refresh tokens and tries to use the access tokens several times
         Map<String, Object> responseMap = createTokens(client(), "test_user", "x-pack-test-password");
         String accessToken = (String) responseMap.get("access_token");


### PR DESCRIPTION
This template was added for 7.0 for what I am guessing is a BWC issue related to deprecation
warnings. It unfortunately seems to cause failures because templates for these tests are not cleared
after the test (because these are upgrade tests).

Resolves #56363
