### PR TITLE
Bump XPackRestIT timeout to allow for macos builds to finish

### DIFF
--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -7,7 +7,9 @@ package org.elasticsearch.xpack.test.rest;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import org.apache.http.HttpStatus;
+import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -50,6 +52,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 /** Runs rest tests against external cluster */
+// TODO: Remove this timeout increase once this test suite is broken up
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE)
 public class XPackRestIT extends ESClientYamlSuiteTestCase {
     private static final String BASIC_AUTH_VALUE =
             basicAuthHeaderValue("x_pack_rest_user", SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING);


### PR DESCRIPTION
Our MacOS builds are timing out on XPackRestIT because it task over 30 minutes on those machines. This is admittedly a very large test suite that takes 20+ minutes even locally using NVMe storage. Our long term intention is to start breaking this suite up, and moving some of the tests from here into the individual x-pack subprojects, however, until that happens we want to get our MacOS builds green again and bumping this _should_ give us enough cushion.