### PR TITLE
Remove deprecated usage of testCompile configuration (7.8 backport)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -412,7 +412,7 @@ known as "transitive" dependencies".</dd>
 should not be shipped with the project because it is "provided" by the runtime
 somehow. Elasticsearch plugins use this configuration to include dependencies
 that are bundled with Elasticsearch's server.</dd>
-<dt>`testCompile`</dt><dd>Code that is on the classpath for compiling tests
+<dt>`testImplementation`</dt><dd>Code that is on the classpath for compiling tests
 that are part of this project but not production code. The canonical example
 of this is `junit`.</dd>
 </dl>

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -122,13 +122,13 @@ dependencies {
   compile 'org.apache.maven:maven-model:3.6.2'
   compile 'com.networknt:json-schema-validator:1.0.36'
   compileOnly "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
-  testCompile "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
+  testImplementation "com.puppycrawl.tools:checkstyle:${props.getProperty('checkstyle')}"
   testFixturesApi "junit:junit:${props.getProperty('junit')}"
   testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${props.getProperty('randomizedrunner')}"
   testFixturesApi gradleApi()
   testFixturesApi gradleTestKit()
-  testCompile 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-  testCompile 'org.mockito:mockito-core:1.9.5'
+  testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
+  testImplementation 'org.mockito:mockito-core:1.9.5'
   minimumRuntimeCompile "junit:junit:${props.getProperty('junit')}"
   minimumRuntimeCompile localGroovy()
   minimumRuntimeCompile gradleApi()

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -165,10 +165,10 @@ class PluginBuildPlugin implements Plugin<Project> {
         project.dependencies {
             if (BuildParams.internal) {
                 compileOnly project.project(':server')
-                testCompile project.project(':test:framework')
+                testImplementation project.project(':test:framework')
             } else {
                 compileOnly "org.elasticsearch:elasticsearch:${project.versions.elasticsearch}"
-                testCompile "org.elasticsearch.test:framework:${project.versions.elasticsearch}"
+                testImplementation "org.elasticsearch.test:framework:${project.versions.elasticsearch}"
             }
             // we "upgrade" these optional deps to provided for plugins, since they will run
             // with a full elasticsearch server that includes optional deps

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneRestTestPlugin.groovy
@@ -83,7 +83,7 @@ class StandaloneRestTestPlugin implements Plugin<Project> {
 
         // create a compileOnly configuration as others might expect it
         project.configurations.create("compileOnly")
-        project.dependencies.add('testCompile', project.project(':test:framework'))
+        project.dependencies.add('testImplementation', project.project(':test:framework'))
 
         EclipseModel eclipse = project.extensions.getByType(EclipseModel)
         eclipse.classpath.sourceSets = [testSourceSet]

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/TestWithDependenciesPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/TestWithDependenciesPlugin.groovy
@@ -44,7 +44,7 @@ class TestWithDependenciesPlugin implements Plugin<Project> {
             return
         }
 
-        project.configurations.testCompile.dependencies.all { Dependency dep ->
+        project.configurations.testImplementation.dependencies.all { Dependency dep ->
             // this closure is run every time a compile dependency is added
             if (dep instanceof ProjectDependency && dep.dependencyProject.plugins.hasPlugin(PluginBuildPlugin)) {
                 project.gradle.projectsEvaluated {

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.java
@@ -391,7 +391,7 @@ public class ThirdPartyAuditTask extends DefaultTask {
     private Configuration getRuntimeConfiguration() {
         Configuration runtime = getProject().getConfigurations().findByName("runtimeClasspath");
         if (runtime == null) {
-            return getProject().getConfigurations().getByName("testCompile");
+            return getProject().getConfigurations().getByName("testCompileClasspath");
         }
         return runtime;
     }

--- a/buildSrc/src/testKit/testingConventions/build.gradle
+++ b/buildSrc/src/testKit/testingConventions/build.gradle
@@ -10,7 +10,7 @@ allprojects {
     jcenter()
   }
   dependencies {
-    testCompile "junit:junit:4.12"
+    testImplementation "junit:junit:4.12"
   }
 
   ext.licenseFile = file("$buildDir/dummy/license")

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -44,18 +44,18 @@ dependencies {
   compile project(':modules:rank-eval')
   compile project(':modules:lang-mustache')
 
-  testCompile project(':client:test')
-  testCompile project(':test:framework')
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
+  testImplementation project(':client:test')
+  testImplementation project(':test:framework')
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
   //this is needed to make RestHighLevelClientTests#testApiNamingConventions work from IDEs
-  testCompile project(":rest-api-spec")
+  testImplementation project(":rest-api-spec")
   // Needed for serialization tests:
   // (In order to serialize a server side class to a client side class or the other way around)
-  testCompile(project(':x-pack:plugin:core')) {
+  testImplementation(project(':x-pack:plugin:core')) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-rest-high-level-client'
   }
-  testCompile(project(':x-pack:plugin:eql'))
+  testImplementation(project(':x-pack:plugin:eql'))
 }
 
 processTestResources {

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -35,12 +35,12 @@ dependencies {
   compile "commons-codec:commons-codec:${versions.commonscodec}"
   compile "commons-logging:commons-logging:${versions.commonslogging}"
 
-  testCompile project(":client:test")
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
-  testCompile "org.elasticsearch:securemock:${versions.securemock}"
-  testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation project(":client:test")
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "org.elasticsearch:securemock:${versions.securemock}"
+  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }
 
 tasks.withType(CheckForbiddenApis).configureEach {

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -33,11 +33,11 @@ dependencies {
   compile "commons-logging:commons-logging:${versions.commonslogging}"
   compile "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
 
-  testCompile project(":client:test")
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.elasticsearch:securemock:${versions.securemock}"
-  testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation project(":client:test")
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.elasticsearch:securemock:${versions.securemock}"
+  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/client/transport/build.gradle
+++ b/client/transport/build.gradle
@@ -29,9 +29,9 @@ dependencies {
   compile project(":modules:percolator")
   compile project(":modules:parent-join")
   compile project(":modules:rank-eval")
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 dependencyLicenses {

--- a/distribution/tools/keystore-cli/build.gradle
+++ b/distribution/tools/keystore-cli/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'elasticsearch.build'
 dependencies {
   compileOnly project(":server")
   compileOnly project(":libs:elasticsearch-cli")
-  testCompile project(":test:framework")
-  testCompile 'com.google.jimfs:jimfs:1.1'
+  testImplementation project(":test:framework")
+  testImplementation 'com.google.jimfs:jimfs:1.1'
   testRuntimeOnly 'com.google.guava:guava:18.0'
 }

--- a/distribution/tools/launchers/build.gradle
+++ b/distribution/tools/launchers/build.gradle
@@ -22,9 +22,9 @@ apply plugin: 'elasticsearch.build'
 
 dependencies {
   compile parent.project('java-version-checker')
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 archivesBaseName = 'elasticsearch-launchers'

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   compileOnly project(":libs:elasticsearch-cli")
   compile "org.bouncycastle:bcpg-fips:1.0.3"
   compile "org.bouncycastle:bc-fips:1.0.1"
-  testCompile project(":test:framework")
-  testCompile 'com.google.jimfs:jimfs:1.1'
+  testImplementation project(":test:framework")
+  testImplementation 'com.google.jimfs:jimfs:1.1'
   testRuntimeOnly 'com.google.guava:guava:18.0'
 }
 

--- a/gradle/forbidden-dependencies.gradle
+++ b/gradle/forbidden-dependencies.gradle
@@ -5,7 +5,7 @@ List<String> FORBIDDEN_DEPENDENCIES = [
   'guava'
 ]
 
-Closure checkDeps = { Configuration configuration -> 
+Closure checkDeps = { Configuration configuration ->
   configuration.resolutionStrategy.eachDependency {
     String artifactName = it.target.name
     if (FORBIDDEN_DEPENDENCIES.contains(artifactName)) {

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -67,15 +67,15 @@ dependencies {
   // This dependency is used only by :libs:core for null-checking interop with other tools
   compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 
   if (!isEclipse) {
     java11Compile sourceSets.main.output
   }
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-core'
   }
 }

--- a/libs/dissect/build.gradle
+++ b/libs/dissect/build.gradle
@@ -18,12 +18,12 @@
  */
 
 dependencies {
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-dissect'
   }
-  testCompile "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  testCompile "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-  testCompile "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+  testImplementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  testImplementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+  testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/libs/geo/build.gradle
+++ b/libs/geo/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
 dependencies {
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-geo'
   }
 }

--- a/libs/grok/build.gradle
+++ b/libs/grok/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   // joni dependencies:
   compile 'org.jruby.jcodings:jcodings:1.0.44'
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-grok'
   }
 }

--- a/libs/nio/build.gradle
+++ b/libs/nio/build.gradle
@@ -21,11 +21,11 @@ apply plugin: 'elasticsearch.publish'
 dependencies {
   compile project(':libs:elasticsearch-core')
 
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-nio'
   }
 }

--- a/libs/secure-sm/build.gradle
+++ b/libs/secure-sm/build.gradle
@@ -21,11 +21,11 @@ apply plugin: 'elasticsearch.publish'
 dependencies {
   // do not add non-test compile dependencies to secure-sm without a good reason to do so
 
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-secure-sm'
   }
 }

--- a/libs/ssl-config/build.gradle
+++ b/libs/ssl-config/build.gradle
@@ -21,13 +21,13 @@ apply plugin: "elasticsearch.publish"
 dependencies {
   compile project(':libs:elasticsearch-core')
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-ssl-config'
   }
 
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -29,11 +29,11 @@ dependencies {
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.jackson}"
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
 
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-x-content'
   }
 

--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   compile("com.fasterxml.jackson.core:jackson-databind:${versions.jackson}")
   compile('com.maxmind.db:maxmind-db:1.3.1')
 
-  testCompile 'org.elasticsearch:geolite2-databases:20191119'
+  testImplementation 'org.elasticsearch:geolite2-databases:20191119'
 }
 
 restResources {
@@ -41,7 +41,7 @@ restResources {
 }
 
 task copyDefaultGeoIp2DatabaseFiles(type: Copy) {
-  from { zipTree(configurations.testCompile.files.find { it.name.contains('geolite2-databases') }) }
+  from { zipTree(configurations.testCompileClasspath.files.find { it.name.contains('geolite2-databases') }) }
   into "${project.buildDir}/ingest-geoip"
   include "*.mmdb"
 }

--- a/modules/percolator/build.gradle
+++ b/modules/percolator/build.gradle
@@ -24,8 +24,8 @@ esplugin {
 }
 
 dependencies {
-  testCompile project(path: ':modules:parent-join', configuration: 'runtime')
-  testCompile project(path: ':modules:geo', configuration: 'runtime')
+  testImplementation project(path: ':modules:parent-join', configuration: 'runtime')
+  testImplementation project(path: ':modules:geo', configuration: 'runtime')
 }
 
 tasks.named('integTestRunner').configure {

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -52,9 +52,9 @@ dependencies {
   compile project(":client:rest")
   compile project(":libs:elasticsearch-ssl-config")
   // for http - testing reindex from remote
-  testCompile project(path: ':modules:transport-netty4', configuration: 'runtime')
+  testImplementation project(path: ':modules:transport-netty4', configuration: 'runtime')
   // for parent/child testing
-  testCompile project(path: ':modules:parent-join', configuration: 'runtime')
+  testImplementation project(path: ':modules:parent-join', configuration: 'runtime')
 }
 
 restResources {

--- a/plugins/discovery-ec2/qa/amazon-ec2/build.gradle
+++ b/plugins/discovery-ec2/qa/amazon-ec2/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: ':plugins:discovery-ec2', configuration: 'runtime')
+  testImplementation project(path: ':plugins:discovery-ec2', configuration: 'runtime')
 }
 
 restResources {

--- a/plugins/discovery-gce/qa/gce/build.gradle
+++ b/plugins/discovery-gce/qa/gce/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'elasticsearch.rest-test'
 final int gceNumberOfNodes = 3
 
 dependencies {
-  testCompile project(path: ':plugins:discovery-gce', configuration: 'runtime')
+  testImplementation project(path: ':plugins:discovery-gce', configuration: 'runtime')
 }
 
 restResources {

--- a/plugins/examples/security-authorization-engine/build.gradle
+++ b/plugins/examples/security-authorization-engine/build.gradle
@@ -12,7 +12,7 @@ esplugin {
 
 dependencies {
   compileOnly "org.elasticsearch.plugin:x-pack-core:${versions.elasticsearch}"
-  testCompile "org.elasticsearch.client:x-pack-transport:${versions.elasticsearch}"
+  testImplementation "org.elasticsearch.client:x-pack-transport:${versions.elasticsearch}"
 }
 
 integTest {

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile 'com.microsoft.azure:azure-keyvault-core:1.0.0'
   runtimeOnly 'com.google.guava:guava:20.0'
   compile 'org.apache.commons:commons-lang3:3.4'
-  testCompile project(':test:fixtures:azure-fixture')
+  testImplementation project(':test:fixtures:azure-fixture')
 }
 
 restResources {

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -63,7 +63,7 @@ dependencies {
   compile 'io.opencensus:opencensus-contrib-http-util:0.18.0'
   compile 'com.google.apis:google-api-services-storage:v1-rev20200226-1.30.9'
 
-  testCompile project(':test:fixtures:gcs-fixture')
+  testImplementation project(':test:fixtures:gcs-fixture')
 }
 
 restResources {

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   // and whitelist this hack in JarHell
   compile 'javax.xml.bind:jaxb-api:2.2.2'
 
-  testCompile project(':test:fixtures:s3-fixture')
+  testImplementation project(':test:fixtures:s3-fixture')
 }
 
 dependencyLicenses {

--- a/qa/ccs-unavailable-clusters/build.gradle
+++ b/qa/ccs-unavailable-clusters/build.gradle
@@ -22,5 +22,5 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test-with-dependencies'
 
 dependencies {
-  testCompile project(":client:rest-high-level")
+  testImplementation project(":client:rest-high-level")
 }

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile 'com.google.jimfs:jimfs:1.1'
+  testImplementation 'com.google.jimfs:jimfs:1.1'
 }
 
 // TODO: give each evil test its own fresh JVM for more isolation.

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -75,6 +75,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 
 task testJar(type: Jar) {

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(":client:rest-high-level")
+  testImplementation project(":client:rest-high-level")
 }
 
 task 'remote-cluster'(type: RestIntegTestTask) {

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -37,9 +37,9 @@ dependencies {
 
   compile project(':libs:elasticsearch-core')
 
-  testCompile "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-  testCompile "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  testCompile "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+  testImplementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+  testImplementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
 }
 
 tasks.named('forbiddenApisTest').configure {

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'elasticsearch.distribution-download'
 testFixtures.useFixture()
 
 dependencies {
-  testCompile project(':client:rest-high-level')
+  testImplementation project(':client:rest-high-level')
 }
 
 task copyKeystore(type: Sync) {

--- a/qa/repository-multi-version/build.gradle
+++ b/qa/repository-multi-version/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
 dependencies {
-  testCompile project(':client:rest-high-level')
+  testImplementation project(':client:rest-high-level')
 }
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
@@ -89,6 +89,7 @@ for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 
 task testJar(type: Jar) {

--- a/qa/smoke-test-client/build.gradle
+++ b/qa/smoke-test-client/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'elasticsearch.rest-test'
 // TODO: this test works, but it isn't really a rest test...should we have another plugin for "non rest test that just needs N clusters?"
 
 dependencies {
-  testCompile project(path: ':client:transport', configuration: 'runtime') // randomly swapped in as a transport
+  testImplementation project(path: ':client:transport', configuration: 'runtime') // randomly swapped in as a transport
 }
 
 task singleNodeIntegTest(type: RestIntegTestTask) {

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test-with-dependencies'
 
 dependencies {
-  testCompile project(path: ':modules:transport-netty4', configuration: 'runtime') // for http
-  testCompile project(path: ':plugins:transport-nio', configuration: 'runtime') // for http
+  testImplementation project(path: ':modules:transport-netty4', configuration: 'runtime') // for http
+  testImplementation project(path: ':plugins:transport-nio', configuration: 'runtime') // for http
 }
 
 integTest.runner {

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: ':modules:ingest-common', configuration: 'runtime')
+  testImplementation project(path: ':modules:ingest-common', configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/qa/smoke-test-ingest-with-all-dependencies/build.gradle
+++ b/qa/smoke-test-ingest-with-all-dependencies/build.gradle
@@ -22,11 +22,11 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: ':modules:ingest-common', configuration: 'runtime')
-  testCompile project(path: ':modules:ingest-geoip', configuration: 'runtime')
-  testCompile project(path: ':modules:lang-mustache', configuration: 'runtime')
-  testCompile project(path: ':modules:lang-painless', configuration: 'runtime')
-  testCompile project(path: ':modules:reindex', configuration: 'runtime')
+  testImplementation project(path: ':modules:ingest-common', configuration: 'runtime')
+  testImplementation project(path: ':modules:ingest-geoip', configuration: 'runtime')
+  testImplementation project(path: ':modules:lang-mustache', configuration: 'runtime')
+  testImplementation project(path: ':modules:lang-painless', configuration: 'runtime')
+  testImplementation project(path: ':modules:reindex', configuration: 'runtime')
 }
 
 testingConventions {

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   compile "org.apache.logging.log4j:log4j-core:${versions.log4j}"
   compile project(path: ':client:rest-high-level')
-  testCompile project(':test:framework')
+  testImplementation project(':test:framework')
 }
 
 war {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -127,11 +127,11 @@ dependencies {
     java11Compile sourceSets.main.output
   }
 
-  testCompile(project(":test:framework")) {
+  testImplementation(project(":test:framework")) {
     // tests use the locally compiled version of server
     exclude group: 'org.elasticsearch', module: 'server'
   }
-  internalClusterTestCompile(project(":test:framework")) {
+  internalClusterTestImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'server'
   }
 }

--- a/test/logger-usage/build.gradle
+++ b/test/logger-usage/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   compile 'org.ow2.asm:asm-tree:7.1'
   compile 'org.ow2.asm:asm-analysis:7.1'
   compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-  testCompile project(":test:framework")
+  testImplementation project(":test:framework")
 }
 
 loggerUsageCheck.enabled = false

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -14,9 +14,9 @@ buildRestTests.expectedUnconvertedCandidates = [
 ]
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
 }
 
 restResources {

--- a/x-pack/license-tools/build.gradle
+++ b/x-pack/license-tools/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.build'
 dependencies {
   compile project(':x-pack:plugin:core')
   compile project(':server')
-  testCompile project(':test:framework')
+  testImplementation project(':test:framework')
 }
 
 project.forbiddenPatterns {

--- a/x-pack/plugin/analytics/build.gradle
+++ b/x-pack/plugin/analytics/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   compileOnly project(":server")
 
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 
   compile 'org.apache.commons:commons-math3:3.2'
 }

--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   compileOnly project(":server")
 
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ilm'))
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ilm'))
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/async-search/qa/security/build.gradle
+++ b/x-pack/plugin/async-search/qa/security/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('async-search'), configuration: 'runtime')
-  testCompile project(':x-pack:plugin:async-search:qa')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('async-search'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:async-search:qa')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/autoscaling/build.gradle
+++ b/x-pack/plugin/autoscaling/build.gradle
@@ -25,7 +25,7 @@ tasks.named('internalClusterTest').configure {
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 // add all sub-projects of the qa sub-project

--- a/x-pack/plugin/autoscaling/qa/rest/build.gradle
+++ b/x-pack/plugin/autoscaling/qa/rest/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('autoscaling'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('autoscaling'), configuration: 'runtime')
 }
 
 restResources {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -13,8 +13,8 @@ apply plugin: 'elasticsearch.validate-rest-spec'
 archivesBaseName = 'x-pack'
 
 dependencies {
-  testCompile project(xpackModule('core')) // this redundant dependency is here to make IntelliJ happy
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(xpackModule('core')) // this redundant dependency is here to make IntelliJ happy
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 subprojects {
@@ -60,6 +60,7 @@ subprojects {
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 
 artifacts {

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -42,8 +42,8 @@ dependencies {
   compileOnly project(":server")
 
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/downgrade-to-basic-license/build.gradle
@@ -4,9 +4,9 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
-  testCompile project(':x-pack:plugin:ccr:qa')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ccr'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
 task "leader-cluster"(type: RestIntegTestTask) {

--- a/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ccr/qa/multi-cluster/build.gradle
@@ -4,9 +4,9 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
-  testCompile project(':x-pack:plugin:ccr:qa')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ccr'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
 task "leader-cluster"(type: RestIntegTestTask) {

--- a/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
+++ b/x-pack/plugin/ccr/qa/non-compliant-license/build.gradle
@@ -4,9 +4,9 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
-  testCompile project(':x-pack:plugin:ccr:qa:')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ccr'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:ccr:qa:')
 }
 
 task 'leader-cluster'(type: RestIntegTestTask) {

--- a/x-pack/plugin/ccr/qa/rest/build.gradle
+++ b/x-pack/plugin/ccr/qa/rest/build.gradle
@@ -11,8 +11,8 @@ restResources {
 }
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ccr'), configuration: 'runtime')
 }
 
 task restTest(type: RestIntegTestTask) {

--- a/x-pack/plugin/ccr/qa/restart/build.gradle
+++ b/x-pack/plugin/ccr/qa/restart/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(':x-pack:plugin:ccr:qa')
+  testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
 task 'leader-cluster'(type: RestIntegTestTask) {

--- a/x-pack/plugin/ccr/qa/security/build.gradle
+++ b/x-pack/plugin/ccr/qa/security/build.gradle
@@ -4,9 +4,9 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ccr'), configuration: 'runtime')
-  testCompile project(':x-pack:plugin:ccr:qa')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ccr'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:ccr:qa')
 }
 
 task 'leader-cluster'(type: RestIntegTestTask) {

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -43,16 +43,16 @@ dependencies {
     exclude group: "org.elasticsearch", module: "elasticsearch-core"
   }
 
-  testCompile 'org.elasticsearch:securemock:1.2'
-  testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
-  testCompile "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
-  testCompile "org.slf4j:slf4j-api:${versions.slf4j}"
-  testCompile project(path: ':modules:reindex', configuration: 'runtime')
-  testCompile project(path: ':modules:parent-join', configuration: 'runtime')
-  testCompile project(path: ':modules:lang-mustache', configuration: 'runtime')
-  testCompile project(path: ':modules:analysis-common', configuration: 'runtime')
-  testCompile project(':client:rest-high-level')
-  testCompile(project(':x-pack:license-tools')) {
+  testImplementation 'org.elasticsearch:securemock:1.2'
+  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+  testImplementation "org.slf4j:slf4j-api:${versions.slf4j}"
+  testImplementation project(path: ':modules:reindex', configuration: 'runtime')
+  testImplementation project(path: ':modules:parent-join', configuration: 'runtime')
+  testImplementation project(path: ':modules:lang-mustache', configuration: 'runtime')
+  testImplementation project(path: ':modules:analysis-common', configuration: 'runtime')
+  testImplementation project(':client:rest-high-level')
+  testImplementation(project(':x-pack:license-tools')) {
     transitive = false
   }
 
@@ -115,6 +115,7 @@ test {
 // https://github.com/elastic/x-plugins/issues/724
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 task testJar(type: Jar) {
   appendix 'test'
@@ -141,4 +142,3 @@ thirdPartyAudit.ignoreMissingClasses(
 // installing them as individual plugins for integ tests doesn't make sense,
 // so we disable integ tests
 integTest.enabled = false
-

--- a/x-pack/plugin/enrich/build.gradle
+++ b/x-pack/plugin/enrich/build.gradle
@@ -12,11 +12,11 @@ archivesBaseName = 'x-pack-enrich'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: ':modules:ingest-common')
-  testCompile project(path: ':modules:lang-mustache')
-  testCompile project(path: ':modules:geo')
-  testCompile project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: ':modules:ingest-common')
+  testImplementation project(path: ':modules:lang-mustache')
+  testImplementation project(path: ':modules:geo')
+  testImplementation project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }
 
 // No real integ tests in the module:

--- a/x-pack/plugin/enrich/qa/rest-with-security/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest-with-security/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('enrich'), configuration: 'runtime')
-  testCompile project(path: xpackModule('core'), configuration: 'runtime')
-  testCompile project(path: xpackModule('enrich:qa:common'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('enrich'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('core'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('enrich:qa:common'), configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/enrich/qa/rest/build.gradle
+++ b/x-pack/plugin/enrich/qa/rest/build.gradle
@@ -10,8 +10,8 @@ restResources {
 }
 
 dependencies {
-  testCompile project(path: xpackModule('enrich'), configuration: 'runtime')
-  testCompile project(path: xpackModule('enrich:qa:common'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('enrich'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('enrich:qa:common'), configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/eql/build.gradle
+++ b/x-pack/plugin/eql/build.gradle
@@ -34,13 +34,13 @@ dependencies {
   }
   compile "org.antlr:antlr4-runtime:${antlrVersion}"
   compileOnly project(path: xpackModule('ql'), configuration: 'default')
-  testCompile project(':test:framework')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ql'), configuration: 'testArtifacts')
-  testCompile project(path: ':modules:reindex', configuration: 'runtime')
-  testCompile project(path: ':modules:parent-join', configuration: 'runtime')
-  testCompile project(path: ':modules:analysis-common', configuration: 'runtime')
+  testImplementation project(':test:framework')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ql'), configuration: 'testArtifacts')
+  testImplementation project(path: ':modules:reindex', configuration: 'runtime')
+  testImplementation project(path: ':modules:parent-join', configuration: 'runtime')
+  testImplementation project(path: ':modules:analysis-common', configuration: 'runtime')
 }
 
 

--- a/x-pack/plugin/eql/qa/rest/build.gradle
+++ b/x-pack/plugin/eql/qa/rest/build.gradle
@@ -12,8 +12,8 @@ restResources {
 }
 
 dependencies {
-  testCompile project(path: xpackModule('eql'), configuration: 'runtime')
-  testCompile project(path: xpackModule('eql:qa:common'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('eql'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('eql:qa:common'), configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/frozen-indices/build.gradle
+++ b/x-pack/plugin/frozen-indices/build.gradle
@@ -11,7 +11,7 @@ archivesBaseName = 'x-pack-frozen-indices'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 // xpack modules are installed in real clusters as the meta plugin, so

--- a/x-pack/plugin/graph/build.gradle
+++ b/x-pack/plugin/graph/build.gradle
@@ -11,7 +11,7 @@ archivesBaseName = 'x-pack-graph'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 // add all sub-projects of the qa sub-project

--- a/x-pack/plugin/graph/qa/with-security/build.gradle
+++ b/x-pack/plugin/graph/qa/with-security/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(":x-pack:plugin:core")
+  testImplementation project(":x-pack:plugin:core")
 }
 
 // bring in graph rest test suite

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -15,9 +15,9 @@ archivesBaseName = 'x-pack-identity-provider'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   // So that we can extend LocalStateCompositeXPackPlugin
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 
   // the following are all SAML dependencies - might as well download the whole internet
   compile "org.opensaml:opensaml-core:3.4.5"
@@ -50,8 +50,8 @@ dependencies {
   compile "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
   runtimeOnly 'com.google.guava:guava:19.0'
 
-  testCompile 'org.elasticsearch:securemock:1.2'
-  testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
+  testImplementation 'org.elasticsearch:securemock:1.2'
+  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
 }
 
 compileJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('identity-provider'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('identity-provider'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -14,7 +14,7 @@ archivesBaseName = 'x-pack-ilm'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 // add all sub-projects of the qa sub-project

--- a/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-cluster/build.gradle
@@ -4,9 +4,9 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(':x-pack:plugin:ccr:qa')
-  testCompile project(':x-pack:plugin:core')
-  testCompile project(':x-pack:plugin:ilm')
+  testImplementation project(':x-pack:plugin:ccr:qa')
+  testImplementation project(':x-pack:plugin:core')
+  testImplementation project(':x-pack:plugin:ilm')
 }
 
 File repoDir = file("$buildDir/testclusters/repo")

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
+  testImplementation project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
 }
 
 File repoDir = file("$buildDir/testclusters/repo")

--- a/x-pack/plugin/ilm/qa/rest/build.gradle
+++ b/x-pack/plugin/ilm/qa/rest/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ilm'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ilm'), configuration: 'runtime')
 }
 
 restResources {

--- a/x-pack/plugin/ilm/qa/with-security/build.gradle
+++ b/x-pack/plugin/ilm/qa/with-security/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
-  testCompile project(":client:rest-high-level")
+  testImplementation project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
+  testImplementation project(":client:rest-high-level")
 }
 
 def clusterCredentials = [username: System.getProperty('tests.rest.cluster.username', 'test_admin'),

--- a/x-pack/plugin/logstash/build.gradle
+++ b/x-pack/plugin/logstash/build.gradle
@@ -11,7 +11,7 @@ archivesBaseName = 'x-pack-logstash'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest.enabled = false

--- a/x-pack/plugin/mapper-constant-keyword/build.gradle
+++ b/x-pack/plugin/mapper-constant-keyword/build.gradle
@@ -18,7 +18,7 @@ archivesBaseName = 'x-pack-constant-keyword'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest.enabled = false

--- a/x-pack/plugin/mapper-flattened/build.gradle
+++ b/x-pack/plugin/mapper-flattened/build.gradle
@@ -18,7 +18,7 @@ archivesBaseName = 'x-pack-flattened'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest.enabled = false

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -50,10 +50,10 @@ bundlePlugin {
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ilm'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ilm'), configuration: 'default')
   // This should not be here
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 
   // ml deps
   compile project(':libs:elasticsearch-grok')
@@ -62,11 +62,12 @@ dependencies {
   nativeBundle("org.elasticsearch.ml:ml-cpp:${project.version}@zip") {
     changing = true
   }
-  testCompile 'org.ini4j:ini4j:0.5.2'
+  testImplementation 'org.ini4j:ini4j:0.5.2'
 }
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 task testJar(type: Jar) {
   appendix 'test'

--- a/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
+++ b/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(":x-pack:plugin:core")
-  testCompile project(path: xpackModule('ml'), configuration: 'runtime')
+  testImplementation project(":x-pack:plugin:core")
+  testImplementation project(path: xpackModule('ml'), configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/ml/qa/disabled/build.gradle
+++ b/x-pack/plugin/ml/qa/disabled/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(":x-pack:plugin:core")
-  testCompile project(path: xpackModule('ml'), configuration: 'runtime')
+  testImplementation project(":x-pack:plugin:core")
+  testImplementation project(path: xpackModule('ml'), configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
 }
 
 // bring in machine learning rest test suite

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ml'), configuration: 'runtime')
-  testCompile project(path: xpackModule('ml'), configuration: 'testArtifacts')
-  testCompile project(path: ':modules:ingest-common')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ml'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('ml'), configuration: 'testArtifacts')
+  testImplementation project(path: ':modules:ingest-common')
 }
 
 // location for keys and certificates

--- a/x-pack/plugin/ml/qa/no-bootstrap-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/no-bootstrap-tests/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(":x-pack:plugin:core")
-  testCompile project(path: xpackModule('ml'), configuration: 'runtime')
+  testImplementation project(":x-pack:plugin:core")
+  testImplementation project(path: xpackModule('ml'), configuration: 'runtime')
 }

--- a/x-pack/plugin/ml/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/single-node-tests/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(":x-pack:plugin:core")
-  testCompile project(path: xpackModule('ml'), configuration: 'runtime')
+  testImplementation project(":x-pack:plugin:core")
+  testImplementation project(path: xpackModule('ml'), configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -12,20 +12,21 @@ archivesBaseName = 'x-pack-monitoring'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 
   // monitoring deps
   compile project(':client:rest')
   compile project(':client:sniffer')
 
   // baz - this goes away after we separate out the actions #27759
-  testCompile project(xpackModule('watcher'))
+  testImplementation project(xpackModule('watcher'))
 
-  testCompile project(xpackModule('ilm'))
+  testImplementation project(xpackModule('ilm'))
 }
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 task testJar(type: Jar) {
   appendix 'test'

--- a/x-pack/plugin/ql/build.gradle
+++ b/x-pack/plugin/ql/build.gradle
@@ -12,12 +12,13 @@ archivesBaseName = 'x-pack-ql'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(':test:framework')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(':test:framework')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 
 task testJar(type: Jar) {

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   compileOnly project(":server")
 
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest.enabled = false

--- a/x-pack/plugin/search-business-rules/build.gradle
+++ b/x-pack/plugin/search-business-rules/build.gradle
@@ -16,8 +16,8 @@ integTest.enabled = false
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(":test:framework")
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(":test:framework")
 }
 
 // copied from CCR

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -13,7 +13,7 @@ archivesBaseName = 'x-pack-searchable-snapshots'
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 // xpack modules are installed in real clusters as the meta plugin, so
@@ -32,6 +32,7 @@ gradle.projectsEvaluated {
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 
 task testJar(type: Jar) {

--- a/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/build.gradle
@@ -26,8 +26,8 @@ final Project fixture = project(':test:fixtures:azure-fixture')
 final Project repositoryPlugin = project(':plugins:repository-azure')
 
 dependencies {
-  testCompile project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
-  testCompile repositoryPlugin
+  testImplementation project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
+  testImplementation repositoryPlugin
 }
 
 restResources {

--- a/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/gcs/build.gradle
@@ -32,8 +32,8 @@ final Project fixture = project(':test:fixtures:gcs-fixture')
 final Project repositoryPlugin = project(':plugins:repository-gcs')
 
 dependencies {
-  testCompile project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
-  testCompile repositoryPlugin
+  testImplementation project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
+  testImplementation repositoryPlugin
 }
 
 restResources {

--- a/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/minio/build.gradle
@@ -9,8 +9,8 @@ final Project fixture = project(':test:fixtures:minio-fixture')
 final Project repositoryPlugin = project(':plugins:repository-s3')
 
 dependencies {
-  testCompile project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
-  testCompile repositoryPlugin
+  testImplementation project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
+  testImplementation repositoryPlugin
 }
 
 restResources {

--- a/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
 }
 
 final File repoDir = file("$buildDir/testclusters/repo")

--- a/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/s3/build.gradle
@@ -8,8 +8,8 @@ final Project fixture = project(':test:fixtures:s3-fixture')
 final Project repositoryPlugin = project(':plugins:repository-s3')
 
 dependencies {
-  testCompile project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
-  testCompile repositoryPlugin
+  testImplementation project(path: xpackModule('searchable-snapshots'), configuration: 'testArtifacts')
+  testImplementation repositoryPlugin
 }
 
 restResources {

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -19,12 +19,12 @@ dependencies {
   compileOnly project(path: ':modules:transport-netty4', configuration: 'runtime')
   compileOnly project(path: ':plugins:transport-nio', configuration: 'runtime')
 
-  testCompile project(path: xpackModule('monitoring'))
-  testCompile project(path: xpackModule('sql:sql-action'))
+  testImplementation project(path: xpackModule('monitoring'))
+  testImplementation project(path: xpackModule('sql:sql-action'))
 
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 
-    compile 'com.unboundid:unboundid-ldapsdk:4.0.8'
+  compile 'com.unboundid:unboundid-ldapsdk:4.0.8'
 
   // the following are all SAML dependencies - might as well download the whole internet
   compile "org.opensaml:opensaml-core:3.4.5"
@@ -67,71 +67,70 @@ dependencies {
   compile "net.minidev:accessors-smart:1.2"
   compile "org.ow2.asm:asm:7.3.1"
 
-  testCompile 'org.elasticsearch:securemock:1.2'
-  testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
-  //testCompile "org.yaml:snakeyaml:${versions.snakeyaml}"
+  testImplementation 'org.elasticsearch:securemock:1.2'
+  testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
 
   // Test dependencies for Kerberos (MiniKdc)
-  testCompile('commons-io:commons-io:2.5')
-  testCompile('org.apache.kerby:kerb-simplekdc:1.1.1')
-  testCompile('org.apache.kerby:kerb-client:1.1.1')
-  testCompile('org.apache.kerby:kerby-config:1.1.1')
-  testCompile('org.apache.kerby:kerb-core:1.1.1')
-  testCompile('org.apache.kerby:kerby-pkix:1.1.1')
-  testCompile('org.apache.kerby:kerby-asn1:1.1.1')
-  testCompile('org.apache.kerby:kerby-util:1.1.1')
-  testCompile('org.apache.kerby:kerb-common:1.1.1')
-  testCompile('org.apache.kerby:kerb-crypto:1.1.1')
-  testCompile('org.apache.kerby:kerb-util:1.1.1')
-  testCompile('org.apache.kerby:token-provider:1.1.1')
-  testCompile('com.nimbusds:nimbus-jose-jwt:8.6')
-  testCompile('net.jcip:jcip-annotations:1.0')
-  testCompile('org.apache.kerby:kerb-admin:1.1.1')
-  testCompile('org.apache.kerby:kerb-server:1.1.1')
-  testCompile('org.apache.kerby:kerb-identity:1.1.1')
-  testCompile('org.apache.kerby:kerby-xdr:1.1.1')
+  testImplementation('commons-io:commons-io:2.5')
+  testImplementation('org.apache.kerby:kerb-simplekdc:1.1.1')
+  testImplementation('org.apache.kerby:kerb-client:1.1.1')
+  testImplementation('org.apache.kerby:kerby-config:1.1.1')
+  testImplementation('org.apache.kerby:kerb-core:1.1.1')
+  testImplementation('org.apache.kerby:kerby-pkix:1.1.1')
+  testImplementation('org.apache.kerby:kerby-asn1:1.1.1')
+  testImplementation('org.apache.kerby:kerby-util:1.1.1')
+  testImplementation('org.apache.kerby:kerb-common:1.1.1')
+  testImplementation('org.apache.kerby:kerb-crypto:1.1.1')
+  testImplementation('org.apache.kerby:kerb-util:1.1.1')
+  testImplementation('org.apache.kerby:token-provider:1.1.1')
+  testImplementation('com.nimbusds:nimbus-jose-jwt:8.6')
+  testImplementation('net.jcip:jcip-annotations:1.0')
+  testImplementation('org.apache.kerby:kerb-admin:1.1.1')
+  testImplementation('org.apache.kerby:kerb-server:1.1.1')
+  testImplementation('org.apache.kerby:kerb-identity:1.1.1')
+  testImplementation('org.apache.kerby:kerby-xdr:1.1.1')
 
   // LDAP backend support for SimpleKdcServer
-  testCompile('org.apache.kerby:kerby-backend:1.1.1')
-  testCompile('org.apache.kerby:ldap-backend:1.1.1')
-  testCompile('org.apache.kerby:kerb-identity:1.1.1')
-  testCompile('org.apache.directory.api:api-ldap-client-api:1.0.0')
-  testCompile('org.apache.directory.api:api-ldap-schema-data:1.0.0')
-  testCompile('org.apache.directory.api:api-ldap-codec-core:1.0.0')
-  testCompile('org.apache.directory.api:api-ldap-extras-aci:1.0.0')
-  testCompile('org.apache.directory.api:api-ldap-extras-codec:1.0.0')
-  testCompile('org.apache.directory.api:api-ldap-extras-codec-api:1.0.0')
-  testCompile('commons-pool:commons-pool:1.6')
-  testCompile('commons-collections:commons-collections:3.2.2')
-  testCompile('org.apache.mina:mina-core:2.0.17')
-  testCompile('org.apache.directory.api:api-util:1.0.1')
-  testCompile('org.apache.directory.api:api-i18n:1.0.1')
-  testCompile('org.apache.directory.api:api-ldap-model:1.0.1')
-  testCompile('org.apache.directory.api:api-asn1-api:1.0.1')
-  testCompile('org.apache.directory.api:api-asn1-ber:1.0.1')
-  testCompile('org.apache.servicemix.bundles:org.apache.servicemix.bundles.antlr:2.7.7_5')
-  testCompile('org.apache.directory.server:apacheds-core-api:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-i18n:2.0.0-M24')
-  testCompile('org.apache.directory.api:api-ldap-extras-util:1.0.0')
-  testCompile('net.sf.ehcache:ehcache:2.10.4')
-  testCompile('org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-protocol-ldap:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-protocol-shared:2.0.0-M24')
-  testCompile('org.apache.directory.jdbm:apacheds-jdbm1:2.0.0-M3')
-  testCompile('org.apache.directory.server:apacheds-jdbm-partition:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-xdbm-partition:2.0.0-M24')
-  testCompile('org.apache.directory.api:api-ldap-extras-sp:1.0.0')
-  testCompile('org.apache.directory.server:apacheds-test-framework:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-core-annotations:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-ldif-partition:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-mavibot-partition:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-protocol-kerberos:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-server-annotations:2.0.0-M24')
-  testCompile('org.apache.directory.api:api-ldap-codec-standalone:1.0.0')
-  testCompile('org.apache.directory.api:api-ldap-net-mina:1.0.0')
-  testCompile('org.apache.directory.server:ldap-client-test:2.0.0-M24')
-  testCompile('org.apache.directory.server:apacheds-interceptor-kerberos:2.0.0-M24')
-  testCompile('org.apache.directory.mavibot:mavibot:1.0.0-M8')
+  testImplementation('org.apache.kerby:kerby-backend:1.1.1')
+  testImplementation('org.apache.kerby:ldap-backend:1.1.1')
+  testImplementation('org.apache.kerby:kerb-identity:1.1.1')
+  testImplementation('org.apache.directory.api:api-ldap-client-api:1.0.0')
+  testImplementation('org.apache.directory.api:api-ldap-schema-data:1.0.0')
+  testImplementation('org.apache.directory.api:api-ldap-codec-core:1.0.0')
+  testImplementation('org.apache.directory.api:api-ldap-extras-aci:1.0.0')
+  testImplementation('org.apache.directory.api:api-ldap-extras-codec:1.0.0')
+  testImplementation('org.apache.directory.api:api-ldap-extras-codec-api:1.0.0')
+  testImplementation('commons-pool:commons-pool:1.6')
+  testImplementation('commons-collections:commons-collections:3.2.2')
+  testImplementation('org.apache.mina:mina-core:2.0.17')
+  testImplementation('org.apache.directory.api:api-util:1.0.1')
+  testImplementation('org.apache.directory.api:api-i18n:1.0.1')
+  testImplementation('org.apache.directory.api:api-ldap-model:1.0.1')
+  testImplementation('org.apache.directory.api:api-asn1-api:1.0.1')
+  testImplementation('org.apache.directory.api:api-asn1-ber:1.0.1')
+  testImplementation('org.apache.servicemix.bundles:org.apache.servicemix.bundles.antlr:2.7.7_5')
+  testImplementation('org.apache.directory.server:apacheds-core-api:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-i18n:2.0.0-M24')
+  testImplementation('org.apache.directory.api:api-ldap-extras-util:1.0.0')
+  testImplementation('net.sf.ehcache:ehcache:2.10.4')
+  testImplementation('org.apache.directory.server:apacheds-kerberos-codec:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-protocol-ldap:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-protocol-shared:2.0.0-M24')
+  testImplementation('org.apache.directory.jdbm:apacheds-jdbm1:2.0.0-M3')
+  testImplementation('org.apache.directory.server:apacheds-jdbm-partition:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-xdbm-partition:2.0.0-M24')
+  testImplementation('org.apache.directory.api:api-ldap-extras-sp:1.0.0')
+  testImplementation('org.apache.directory.server:apacheds-test-framework:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-core-annotations:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-ldif-partition:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-mavibot-partition:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-protocol-kerberos:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-server-annotations:2.0.0-M24')
+  testImplementation('org.apache.directory.api:api-ldap-codec-standalone:1.0.0')
+  testImplementation('org.apache.directory.api:api-ldap-net-mina:1.0.0')
+  testImplementation('org.apache.directory.server:ldap-client-test:2.0.0-M24')
+  testImplementation('org.apache.directory.server:apacheds-interceptor-kerberos:2.0.0-M24')
+  testImplementation('org.apache.directory.mavibot:mavibot:1.0.0-M8')
 }
 
 compileJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
@@ -144,6 +143,7 @@ processTestResources {
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 task testJar(type: Jar) {
   appendix 'test'
@@ -493,4 +493,3 @@ gradle.projectsEvaluated {
     .findAll { it.path.startsWith(project.path + ":qa") }
     .each { check.dependsOn it.check }
 }
-

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     exclude group: 'com.google.guava', module: 'guava'
   }
   testRuntimeOnly 'com.google.guava:guava:19.0'
-  testCompile project(":test:framework")
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(":test:framework")
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/security/qa/basic-enable-security/build.gradle
+++ b/x-pack/plugin/security/qa/basic-enable-security/build.gradle
@@ -5,9 +5,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest {

--- a/x-pack/plugin/security/qa/security-basic/build.gradle
+++ b/x-pack/plugin/security/qa/security-basic/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/security/qa/security-disabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-disabled/build.gradle
@@ -11,9 +11,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/security/qa/security-not-enabled/build.gradle
+++ b/x-pack/plugin/security/qa/security-not-enabled/build.gradle
@@ -11,9 +11,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/security/qa/security-trial/build.gradle
+++ b/x-pack/plugin/security/qa/security-trial/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/security/qa/tls-basic/build.gradle
+++ b/x-pack/plugin/security/qa/tls-basic/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 forbiddenPatterns {

--- a/x-pack/plugin/spatial/build.gradle
+++ b/x-pack/plugin/spatial/build.gradle
@@ -11,7 +11,7 @@ esplugin {
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   compile project(path: ':modules:geo', configuration: 'default')
   restTestConfig project(path: ':modules:geo', configuration: 'restTests')
 }

--- a/x-pack/plugin/sql/build.gradle
+++ b/x-pack/plugin/sql/build.gradle
@@ -40,13 +40,13 @@ dependencies {
   compile project(':modules:aggs-matrix-stats')
   compile "org.antlr:antlr4-runtime:${antlrVersion}"
   compileOnly project(path: xpackModule('ql'), configuration: 'default')
-  testCompile project(':test:framework')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('ql'), configuration: 'testArtifacts')
-  testCompile project(path: ':modules:reindex', configuration: 'runtime')
-  testCompile project(path: ':modules:parent-join', configuration: 'runtime')
-  testCompile project(path: ':modules:analysis-common', configuration: 'runtime')
+  testImplementation project(':test:framework')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('ql'), configuration: 'testArtifacts')
+  testImplementation project(path: ':modules:reindex', configuration: 'runtime')
+  testImplementation project(path: ':modules:parent-join', configuration: 'runtime')
+  testImplementation project(path: ':modules:analysis-common', configuration: 'runtime')
   bin(project(path: xpackModule('sql:sql-cli'), configuration: 'shadow'))
 }
 

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   compile project(':libs:elasticsearch-core')
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
   runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  testCompile project(":test:framework")
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(":test:framework")
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -39,10 +39,10 @@ subprojects {
          * dependencies but we don't really want them because they cause
          * all kinds of trouble with the jar hell checks. So we suppress
          * them explicitly for non-es projects. */
-        testCompile(xpackProject('plugin:sql:qa:jdbc')) {
+        testImplementation(xpackProject('plugin:sql:qa:jdbc')) {
             transitive = false
         }
-        testCompile project(":test:framework")
+        testImplementation project(":test:framework")
 
         testRuntime project(path: xpackModule('sql:jdbc'))
     }

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    testCompile project(':x-pack:plugin:core')
+    testImplementation project(':x-pack:plugin:core')
 }
 
 Project mainProject = project
@@ -23,7 +23,7 @@ subprojects {
     configurations.create('testArtifacts')
 
     dependencies {
-        testCompile project(":x-pack:plugin:core")
+        testImplementation project(":x-pack:plugin:core")
         testArtifacts project(path: mainProject.path, configuration: 'testArtifacts')
     }
 

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -64,10 +64,10 @@ subprojects {
      * dependencies but we don't really want them because they cause
      * all kinds of trouble with the jar hell checks. So we suppress
      * them explicitly for non-es projects. */
-    testCompile(xpackProject('plugin:sql:qa:server')) {
+    testImplementation(xpackProject('plugin:sql:qa:server')) {
       transitive = false
     }
-    testCompile project(":test:framework")
+    testImplementation project(":test:framework")
 
     // JDBC testing dependencies
     testRuntime "net.sourceforge.csvjdbc:csvjdbc:${csvjdbcVersion}"

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  testCompile project(':x-pack:plugin:core')
+  testImplementation project(':x-pack:plugin:core')
 }
 
 Project mainProject = project
@@ -23,7 +23,7 @@ subprojects {
   configurations.create('testArtifacts')
 
   dependencies {
-    testCompile project(":x-pack:plugin:core")
+    testImplementation project(":x-pack:plugin:core")
     testArtifacts project(path: mainProject.path, configuration: 'testArtifacts')
   }
 

--- a/x-pack/plugin/sql/sql-action/build.gradle
+++ b/x-pack/plugin/sql/sql-action/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   runtime "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   runtime "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
-  testCompile project(":test:framework")
+  testImplementation project(":test:framework")
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   compile project(":libs:elasticsearch-cli")
   compile project(':libs:elasticsearch-x-content')
   runtime "org.elasticsearch:jna:${versions.jna}"
-  testCompile project(":test:framework")
+  testImplementation project(":test:framework")
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -9,8 +9,8 @@ description = 'Code shared between jdbc and cli'
 dependencies {
   compile xpackProject('plugin:sql:sql-proto')
   compile "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-  testCompile project(":test:framework")
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(":test:framework")
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 dependencyLicenses {

--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   }
   runtime "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
 
-  testCompile project(":test:framework")
+  testImplementation project(":test:framework")
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/x-pack/plugin/transform/build.gradle
+++ b/x-pack/plugin/transform/build.gradle
@@ -12,9 +12,9 @@ dependencies {
   compileOnly project(":server")
 
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('analytics'), configuration: 'runtime')
-  testCompile project(path: ':modules:aggs-matrix-stats', configuration: 'runtime')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('analytics'), configuration: 'runtime')
+  testImplementation project(path: ':modules:aggs-matrix-stats', configuration: 'runtime')
 }
 
 // xpack modules are installed in real clusters as the meta plugin, so

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('transform'), configuration: 'runtime')
-  testCompile project(':client:rest-high-level')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('transform'), configuration: 'runtime')
+  testImplementation project(':client:rest-high-level')
 }
 
 // location for keys and certificates

--- a/x-pack/plugin/transform/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/single-node-tests/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('transform'), configuration: 'runtime')
-  testCompile project(':client:rest-high-level')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('transform'), configuration: 'runtime')
+  testImplementation project(':client:rest-high-level')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/vectors/build.gradle
+++ b/x-pack/plugin/vectors/build.gradle
@@ -13,7 +13,7 @@ archivesBaseName = 'x-pack-vectors'
 dependencies {
   compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest.enabled = false

--- a/x-pack/plugin/voting-only-node/build.gradle
+++ b/x-pack/plugin/voting-only-node/build.gradle
@@ -10,7 +10,7 @@ esplugin {
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 // xpack modules are installed in real clusters as the meta plugin, so

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -30,8 +30,8 @@ dependencies {
   compileOnly project(path: ':modules:transport-netty4', configuration: 'runtime')
   compileOnly project(path: ':plugins:transport-nio', configuration: 'runtime')
 
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(xpackModule('ilm'))
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(xpackModule('ilm'))
 
   // watcher deps
   compile 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20191001.1'
@@ -42,9 +42,9 @@ dependencies {
   compileOnly "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   compileOnly "org.apache.httpcomponents:httpcore:${versions.httpcore}"
 
-  testCompile 'org.subethamail:subethasmtp:3.1.7'
+  testImplementation 'org.subethamail:subethasmtp:3.1.7'
   // needed for subethasmtp, has @GuardedBy annotation
-  testCompile 'com.google.code.findbugs:jsr305:3.0.2'
+  testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 // classes are missing, e.g. com.ibm.icu.lang.UCharacter

--- a/x-pack/plugin/watcher/qa/rest/build.gradle
+++ b/x-pack/plugin/watcher/qa/rest/build.gradle
@@ -3,11 +3,12 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 configurations {
   testArtifacts.extendsFrom testRuntime
+  testArtifacts.extendsFrom testImplementation
 }
 
 task testJar(type: Jar) {

--- a/x-pack/plugin/watcher/qa/with-monitoring/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-monitoring/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 testClusters.integTest {

--- a/x-pack/plugin/watcher/qa/with-security/build.gradle
+++ b/x-pack/plugin/watcher/qa/with-security/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
-  testCompile project(path: ':x-pack:plugin:watcher:qa:rest', configuration: 'testArtifacts')
+  testImplementation project(':x-pack:qa')
+  testImplementation project(path: ':x-pack:plugin:watcher:qa:rest', configuration: 'testArtifacts')
   restXpackTestConfig project(path: ':x-pack:plugin:watcher:qa:rest', configuration: 'restXpackTests')
 }
 

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 restResources {

--- a/x-pack/qa/evil-tests/build.gradle
+++ b/x-pack/qa/evil-tests/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 
 test {

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -9,10 +9,10 @@ apply from : "$rootDir/gradle/bwc-test.gradle"
 dependencies {
   // TODO: Remove core dependency and change tests to not use builders that are part of xpack-core.
   // Currently needed for ml tests are using the building for datafeed and job config)
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 
-  testCompile project(path: ':qa:full-cluster-restart', configuration: 'testArtifacts')
-  testCompile project(':x-pack:qa')
+  testImplementation project(path: ':qa:full-cluster-restart', configuration: 'testArtifacts')
+  testImplementation project(':x-pack:qa')
 }
 
 licenseHeaders {

--- a/x-pack/qa/kerberos-tests/build.gradle
+++ b/x-pack/qa/kerberos-tests/build.gradle
@@ -9,9 +9,9 @@ apply plugin: 'elasticsearch.test.fixtures'
 testFixtures.useFixture ":test:fixtures:krb5kdc-fixture", "peppa"
 
 dependencies {
-  testCompile project(':x-pack:plugin:core')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(':x-pack:plugin:core')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 
 testClusters.integTest {

--- a/x-pack/qa/multi-cluster-search-security/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 restResources {

--- a/x-pack/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/qa/multi-cluster-tests-with-security/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
-  testCompile project(':client:rest-high-level')
+  testImplementation project(':x-pack:qa')
+  testImplementation project(':client:rest-high-level')
 }
 
 restResources {

--- a/x-pack/qa/multi-node/build.gradle
+++ b/x-pack/qa/multi-node/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 testClusters.integTest {

--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -6,9 +6,9 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 testFixtures.useFixture ":x-pack:test:idp-fixture", "oidc-provider"
 

--- a/x-pack/qa/openldap-tests/build.gradle
+++ b/x-pack/qa/openldap-tests/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 testFixtures.useFixture ":x-pack:test:idp-fixture", "openldap"

--- a/x-pack/qa/password-protected-keystore/build.gradle
+++ b/x-pack/qa/password-protected-keystore/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
 }
 
 testClusters.integTest {

--- a/x-pack/qa/reindex-tests-with-security/build.gradle
+++ b/x-pack/qa/reindex-tests-with-security/build.gradle
@@ -5,10 +5,10 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile project(path: ':modules:reindex')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: ':modules:reindex')
 }
 
 forbiddenPatterns {

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {

--- a/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -7,8 +7,8 @@ apply plugin: 'elasticsearch.standalone-test'
 apply from : "$rootDir/gradle/bwc-test.gradle"
 
 dependencies {
-  testCompile project(':x-pack:qa')
-  testCompile project(':client:rest-high-level')
+  testImplementation project(':x-pack:qa')
+  testImplementation project(':client:rest-high-level')
 }
 
 restResources {

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'elasticsearch.rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
-  testCompile 'com.google.jimfs:jimfs:1.1'
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation 'com.google.jimfs:jimfs:1.1'
 }
 testFixtures.useFixture ":x-pack:test:idp-fixture"
 

--- a/x-pack/qa/security-client-tests/build.gradle
+++ b/x-pack/qa/security-client-tests/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(xpackModule('core'))
-  testCompile project(path: xpackProject('transport-client').path, configuration: 'runtime')
+  testImplementation project(xpackModule('core'))
+  testImplementation project(path: xpackProject('transport-client').path, configuration: 'runtime')
 }
 
 String outputDir = "${buildDir}/generated-resources/${project.name}"

--- a/x-pack/qa/security-example-spi-extension/build.gradle
+++ b/x-pack/qa/security-example-spi-extension/build.gradle
@@ -10,7 +10,7 @@ esplugin {
 
 dependencies {
   compileOnly project(':x-pack:plugin:core')
-  testCompile project(path: xpackProject('transport-client').path, configuration: 'runtime')
+  testImplementation project(path: xpackProject('transport-client').path, configuration: 'runtime')
 }
 
 

--- a/x-pack/qa/security-migrate-tests/build.gradle
+++ b/x-pack/qa/security-migrate-tests/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(xpackModule('core'))
-  testCompile project(path: xpackModule('security'), configuration: 'runtime')
-  testCompile project(path: xpackProject('transport-client').path, configuration: 'runtime')
+  testImplementation project(xpackModule('core'))
+  testImplementation project(path: xpackModule('security'), configuration: 'runtime')
+  testImplementation project(path: xpackProject('transport-client').path, configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/qa/security-setup-password-tests/build.gradle
+++ b/x-pack/qa/security-setup-password-tests/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(path: xpackModule('core'), configuration: 'default')
-  testCompile project(path: xpackModule('security'), configuration: 'runtime')
-  testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+  testImplementation project(path: xpackModule('core'), configuration: 'default')
+  testImplementation project(path: xpackModule('security'), configuration: 'runtime')
+  testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
 integTest.runner {

--- a/x-pack/qa/security-tools-tests/build.gradle
+++ b/x-pack/qa/security-tools-tests/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile project(xpackModule('security'))
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
-  testCompile 'com.google.jimfs:jimfs:1.1'
+  testImplementation project(xpackModule('security'))
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation 'com.google.jimfs:jimfs:1.1'
   testRuntimeOnly 'com.google.guava:guava:16.0.1'
 }
 

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:plugin:core')
+  testImplementation project(':x-pack:plugin:core')
 }
 
 String outputDir = "${buildDir}/generated-resources/${project.name}"

--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 int pluginsCount = 0

--- a/x-pack/qa/smoke-test-security-with-mustache/build.gradle
+++ b/x-pack/qa/smoke-test-security-with-mustache/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:qa')
+  testImplementation project(':x-pack:qa')
 }
 
 restResources {

--- a/x-pack/qa/third-party/active-directory/build.gradle
+++ b/x-pack/qa/third-party/active-directory/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'elasticsearch.standalone-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  testCompile project(xpackModule('security'))
-  testCompile project(path: xpackModule('security'), configuration: 'testArtifacts')
+  testImplementation project(xpackModule('security'))
+  testImplementation project(path: xpackModule('security'), configuration: 'testArtifacts')
 }
 
 testFixtures.useFixture ":x-pack:test:smb-fixture"

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -8,8 +8,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:plugin:core')
-  testCompile project(path: xpackModule('watcher'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:core')
+  testImplementation project(path: xpackModule('watcher'), configuration: 'runtime')
 }
 
 restResources {

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:plugin:core')
-  testCompile project(path: xpackModule('watcher'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:core')
+  testImplementation project(path: xpackModule('watcher'), configuration: 'runtime')
 }
 
 String pagerDutyServiceKey = System.getenv('pagerduty_service_api_key')

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(':x-pack:plugin:core')
-  testCompile project(path: xpackModule('watcher'), configuration: 'runtime')
+  testImplementation project(':x-pack:plugin:core')
+  testImplementation project(path: xpackModule('watcher'), configuration: 'runtime')
 }
 
 restResources {

--- a/x-pack/qa/transport-client-tests/build.gradle
+++ b/x-pack/qa/transport-client-tests/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
-  testCompile project(xpackModule('core'))
-  testCompile project(path: xpackProject('transport-client').path, configuration: 'runtime')
+  testImplementation project(xpackModule('core'))
+  testImplementation project(path: xpackProject('transport-client').path, configuration: 'runtime')
 }
 
 testClusters.integTest {

--- a/x-pack/snapshot-tool/build.gradle
+++ b/x-pack/snapshot-tool/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'elasticsearch.build'
 dependencies {
   compile project(":server")
   compile project(":libs:elasticsearch-cli")
-  testCompile project(":test:framework")
+  testImplementation project(":test:framework")
 
   compile "com.amazonaws:aws-java-sdk-s3:${versions.aws}"
   compile "com.amazonaws:aws-java-sdk-core:${versions.aws}"

--- a/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
+++ b/x-pack/snapshot-tool/qa/google-cloud-storage/build.gradle
@@ -9,9 +9,9 @@ apply plugin: 'elasticsearch.build'
 
 dependencies {
   compile project(":plugins:repository-gcs")
-  testCompile project(":test:framework")
-  testCompile project(':x-pack:snapshot-tool')
-  testCompile files(project(':x-pack:snapshot-tool').sourceSets.test.output)
+  testImplementation project(":test:framework")
+  testImplementation project(':x-pack:snapshot-tool')
+  testImplementation files(project(':x-pack:snapshot-tool').sourceSets.test.output)
 }
 
 test.enabled = false

--- a/x-pack/snapshot-tool/qa/s3/build.gradle
+++ b/x-pack/snapshot-tool/qa/s3/build.gradle
@@ -7,9 +7,9 @@ apply plugin: 'elasticsearch.build'
 
 dependencies {
   compile project(":plugins:repository-s3")
-  testCompile project(":test:framework")
-  testCompile project(':x-pack:snapshot-tool')
-  testCompile files(project(':x-pack:snapshot-tool').sourceSets.test.output)
+  testImplementation project(":test:framework")
+  testImplementation project(':x-pack:snapshot-tool')
+  testImplementation files(project(':x-pack:snapshot-tool').sourceSets.test.output)
 }
 
 test.enabled = false

--- a/x-pack/test/feature-aware/build.gradle
+++ b/x-pack/test/feature-aware/build.gradle
@@ -4,7 +4,7 @@ dependencies {
   compile 'org.ow2.asm:asm:7.3.1'
   compile project(':server')
   compile project(':x-pack:plugin:core')
-  testCompile project(':test:framework')
+  testImplementation project(':test:framework')
 }
 
 forbiddenApisMain.enabled = true

--- a/x-pack/transport-client/build.gradle
+++ b/x-pack/transport-client/build.gradle
@@ -9,9 +9,9 @@ dependencies {
   // all of x-pack for now, and transport client will be going away in the future.
   compile project(xpackModule('core'))
   compile project(':client:transport')
-  testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  testCompile "junit:junit:${versions.junit}"
-  testCompile "org.hamcrest:hamcrest:${versions.hamcrest}"
+  testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "org.hamcrest:hamcrest:${versions.hamcrest}"
 }
 
 dependencyLicenses.enabled = false


### PR DESCRIPTION
Backporting https://github.com/elastic/elasticsearch/pull/57921 to 7.8