### PR TITLE
Fix resolveAllDependencies to ignore testCompile (7.8 backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -439,7 +439,7 @@ allprojects {
       dependsOn tasks.withType(ComposePull)
     }
     doLast {
-      configurations.findAll { it.isCanBeResolved() }.each { it.resolve() }
+      configurations.findAll { it.isCanBeResolved() && !it.name.equals("testCompile") }.each { it.resolve() }
     }
   }
 


### PR DESCRIPTION
backports #58080 to 7.8 branch