### PR TITLE
Fix resolveAllDependencies to ignore testCompile (7.7 backport)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -477,7 +477,7 @@ allprojects {
       dependsOn tasks.withType(ComposePull)
     }
     doLast {
-      configurations.findAll { it.isCanBeResolved() }.each { it.resolve() }
+      configurations.findAll { it.isCanBeResolved() && !it.name.equals("testCompile") }.each { it.resolve() }
     }
   }
 


### PR DESCRIPTION
backports #58080 to 7.7 branch