### PR TITLE
Make Gradle IT tests debuggable

### DIFF
--- a/buildSrc/src/testFixtures/java/org/elasticsearch/gradle/test/GradleIntegrationTestCase.java
+++ b/buildSrc/src/testFixtures/java/org/elasticsearch/gradle/test/GradleIntegrationTestCase.java
@@ -10,6 +10,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -43,7 +44,11 @@ public abstract class GradleIntegrationTestCase extends GradleUnitTestCase {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        return GradleRunner.create().withProjectDir(getProjectDir(sampleProject)).withPluginClasspath().withTestKitDir(testkit);
+        return GradleRunner.create()
+            .withProjectDir(getProjectDir(sampleProject))
+            .withPluginClasspath()
+            .withTestKitDir(testkit)
+            .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0);
     }
 
     protected File getBuildDir(String name) {


### PR DESCRIPTION
This is a small PR that should make debugging Gradle IT tests easier

- Configures the testkit gradle runner to run with debug enabled automatically when
test is executed in debug mode (e.g. from the IDE)
- Allows step by step debugging of GradleIntegrationTestCase tests