### PR TITLE
Unify dependency licenses task configuration

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -51,7 +51,7 @@ run.executable = "${BuildParams.runtimeJavaHome}/bin/java"
 disableTasks('forbiddenApisMain')
 
 // No licenses for our benchmark deps (we don't ship benchmarks)
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 thirdPartyAudit.ignoreViolations(

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -168,7 +168,7 @@ if (project != rootProject) {
   groovydoc.enabled = false
 
   // build-tools is not ready for primetime with these...
-  dependencyLicenses.enabled = false
+  tasks.named("dependencyLicenses").configure { it.enabled = false }
   dependenciesInfo.enabled = false
   disableTasks('forbiddenApisMain', 'forbiddenApisMinimumRuntime',
     'forbiddenApisTest', 'forbiddenApisIntegTest', 'forbiddenApisTestFixtures')

--- a/client/benchmark/build.gradle
+++ b/client/benchmark/build.gradle
@@ -41,5 +41,5 @@ dependencies {
 }
 
 // No licenses for our benchmark deps (we don't ship benchmarks)
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false

--- a/client/client-benchmark-noop-api-plugin/build.gradle
+++ b/client/client-benchmark-noop-api-plugin/build.gradle
@@ -30,7 +30,7 @@ esplugin {
 // Not published so no need to assemble
 assemble.enabled = false
 
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 // no unit tests

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -65,14 +65,6 @@ processTestResources {
   from(project(':client:rest-high-level').file('src/test/resources'))
 }
 
-dependencyLicenses {
-  // Don't check licenses for dependency that are part of the elasticsearch project
-  // But any other dependency should have its license/notice/sha1
-  dependencies = project.configurations.runtime.fileCollection {
-    it.group.startsWith('org.elasticsearch') == false
-  }
-}
-
 tasks.named('forbiddenApisMain').configure {
   // core does not depend on the httpclient for compile so we add the signatures here. We don't add them for test as they are already
   // specified

--- a/client/sniffer/build.gradle
+++ b/client/sniffer/build.gradle
@@ -53,7 +53,7 @@ tasks.named('forbiddenApisTest').configure {
   replaceSignatureFiles 'jdk-signatures'
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /http.*/, to: 'httpclient'
   mapping from: /commons-.*/, to: 'commons'
 }
@@ -68,12 +68,6 @@ testingConventions {
     Tests {
       baseClass 'org.elasticsearch.client.RestClientTestCase'
     }
-  }
-}
-
-dependencyLicenses {
-  dependencies = project.configurations.runtime.fileCollection {
-    it.group.startsWith('org.elasticsearch') == false
   }
 }
 

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -48,7 +48,7 @@ tasks.named('forbiddenApisTest').configure {
 jarHell.enabled = false
 
 // TODO: should we have licenses for our test deps?
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 //we aren't releasing this jar

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   testRuntimeOnly 'com.google.guava:guava:18.0'
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /bc.*/, to: 'bouncycastle'
 }
 

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -51,7 +51,7 @@ thirdPartyAudit.ignoreMissingClasses(
   'com.fasterxml.jackson.databind.cfg.MapperBuilder'
 )
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
 }
 

--- a/modules/lang-expression/build.gradle
+++ b/modules/lang-expression/build.gradle
@@ -35,7 +35,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
   mapping from: /asm-.*/, to: 'asm'
 }

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   compile project('spi')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /asm-.*/, to: 'asm'
 }
 
@@ -193,4 +193,3 @@ task regen {
     }
   }
 }
-

--- a/modules/percolator/build.gradle
+++ b/modules/percolator/build.gradle
@@ -44,10 +44,3 @@ restResources {
     includeCore '_common', 'indices', 'index', 'search', 'msearch'
   }
 }
-
-dependencyLicenses {
-  // Don't check the client's license. We know it.
-  dependencies = project.configurations.runtime.fileCollection {
-    it.group.startsWith('org.elasticsearch') == false
-  } - project.configurations.compileOnly
-}

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -49,7 +49,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /netty-.*/, to: 'netty'
 }
 

--- a/plugins/analysis-icu/build.gradle
+++ b/plugins/analysis-icu/build.gradle
@@ -41,7 +41,6 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }
-

--- a/plugins/analysis-kuromoji/build.gradle
+++ b/plugins/analysis-kuromoji/build.gradle
@@ -32,7 +32,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }
 

--- a/plugins/analysis-nori/build.gradle
+++ b/plugins/analysis-nori/build.gradle
@@ -31,7 +31,6 @@ restResources {
     includeCore '_common', 'indices', 'index', 'search'
   }
 }
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }
-

--- a/plugins/analysis-phonetic/build.gradle
+++ b/plugins/analysis-phonetic/build.gradle
@@ -33,6 +33,6 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }

--- a/plugins/analysis-smartcn/build.gradle
+++ b/plugins/analysis-smartcn/build.gradle
@@ -32,7 +32,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }
 

--- a/plugins/analysis-stempel/build.gradle
+++ b/plugins/analysis-stempel/build.gradle
@@ -32,6 +32,6 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }

--- a/plugins/analysis-ukrainian/build.gradle
+++ b/plugins/analysis-ukrainian/build.gradle
@@ -35,7 +35,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
   mapping from: /morfologik-.*/, to: 'lucene'
 }

--- a/plugins/discovery-azure-classic/build.gradle
+++ b/plugins/discovery-azure-classic/build.gradle
@@ -99,7 +99,7 @@ normalization {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /azure-.*/, to: 'azure'
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /jersey-.*/, to: 'jersey'

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -46,7 +46,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /aws-java-sdk-.*/, to: 'aws-java-sdk'
   mapping from: /jackson-.*/, to: 'jackson'
 }

--- a/plugins/discovery-gce/build.gradle
+++ b/plugins/discovery-gce/build.gradle
@@ -27,7 +27,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /google-.*/, to: 'google'
 }
 

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -82,7 +82,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /apache-mime4j-.*/, to: 'apache-mime4j'
 }
 

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -42,7 +42,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /azure-.*/, to: 'azure'
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /jersey-.*/, to: 'jersey'

--- a/plugins/repository-gcs/build.gradle
+++ b/plugins/repository-gcs/build.gradle
@@ -72,7 +72,7 @@ restResources {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /google-cloud-.*/, to: 'google-cloud'
   mapping from: /google-auth-.*/, to: 'google-auth'
   mapping from: /google-http-.*/, to: 'google-http'

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -89,7 +89,7 @@ normalization {
   }
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /hadoop-.*/, to: 'hadoop'
 }
 

--- a/plugins/repository-s3/build.gradle
+++ b/plugins/repository-s3/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   testImplementation project(':test:fixtures:s3-fixture')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /aws-java-sdk-.*/, to: 'aws-java-sdk'
   mapping from: /jmespath-java.*/, to: 'aws-java-sdk'
   mapping from: /jackson-.*/, to: 'jackson'

--- a/plugins/transport-nio/build.gradle
+++ b/plugins/transport-nio/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   compile "io.netty:netty-transport:${versions.netty}"
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /netty-.*/, to: 'netty'
 }
 

--- a/qa/os/build.gradle
+++ b/qa/os/build.gradle
@@ -52,7 +52,7 @@ tasks.test.enabled = false
 testingConventions.enabled = false
 
 // this project doesn't get published
-tasks.dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 tasks.dependenciesInfo.enabled = false
 
 tasks.thirdPartyAudit.ignoreMissingClasses()

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -85,7 +85,7 @@ check.dependsOn integTest
 
 test.enabled = false
 
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 thirdPartyAudit.enabled = false

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -326,7 +326,7 @@ thirdPartyAudit.ignoreMissingClasses(
 
 thirdPartyAudit.ignoreMissingClasses 'javax.xml.bind.DatatypeConverter'
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
   dependencies = project.configurations.runtime.fileCollection {
     it.group.startsWith('org.elasticsearch') == false ||

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -26,7 +26,7 @@ subprojects {
   apply plugin: 'elasticsearch.publish'
 
   // TODO: should we have licenses for our test deps?
-  dependencyLicenses.enabled = false
+  tasks.named("dependencyLicenses").configure { it.enabled = false }
   dependenciesInfo.enabled = false
 
   // TODO: why is the test framework pulled in...

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -44,7 +44,7 @@ tasks.named('forbiddenApisMain').configure {
 }
 
 // TODO: should we have licenses for our test deps?
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 thirdPartyAudit.ignoreMissingClasses(

--- a/x-pack/license-tools/build.gradle
+++ b/x-pack/license-tools/build.gradle
@@ -10,7 +10,7 @@ project.forbiddenPatterns {
   exclude '**/*.key'
 }
 
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 
 task buildZip(type: Zip, dependsOn: jar) {
   String parentDir = "license-tools-${version}"

--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -30,9 +30,5 @@ dependencies {
   testImplementation project(path: xpackModule('ilm'))
 }
 
-tasks.named("dependencyLicenses").configure {
-  ignoreSha 'x-pack-core'
-}
-
 integTest.enabled = false
 

--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   testImplementation project(path: xpackModule('ilm'))
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   ignoreSha 'x-pack-core'
 }
 

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -46,10 +46,6 @@ dependencies {
   testImplementation project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }
 
-tasks.named("dependencyLicenses").configure {
-  ignoreSha 'x-pack-core'
-}
-
 testingConventions.naming {
   IT {
     baseClass "org.elasticsearch.xpack.CcrIntegTestCase"

--- a/x-pack/plugin/ccr/build.gradle
+++ b/x-pack/plugin/ccr/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   testImplementation project(path: xpackModule('monitoring'), configuration: 'testArtifacts')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   ignoreSha 'x-pack-core'
 }
 

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -18,7 +18,7 @@ esplugin {
   requiresKeystore false
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /http.*/, to: 'httpclient' // pulled in by rest client
   mapping from: /commons-.*/, to: 'commons' // pulled in by rest client
 }

--- a/x-pack/plugin/identity-provider/build.gradle
+++ b/x-pack/plugin/identity-provider/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 compileJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
 compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /java-support|opensaml-.*/, to: 'shibboleth'
   mapping from: /http.*/, to: 'httpclient'
 }

--- a/x-pack/plugin/monitoring/build.gradle
+++ b/x-pack/plugin/monitoring/build.gradle
@@ -38,7 +38,7 @@ artifacts {
   testArtifacts testJar
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /http.*/, to: 'httpclient' // pulled in by rest client
   mapping from: /commons-.*/, to: 'commons' // pulled in by rest client
 }

--- a/x-pack/plugin/search-business-rules/build.gradle
+++ b/x-pack/plugin/search-business-rules/build.gradle
@@ -11,17 +11,11 @@ esplugin {
 }
 archivesBaseName = 'x-pack-searchbusinessrules'
 
-
 integTest.enabled = false
 
 dependencies {
   compileOnly project(path: xpackModule('core'), configuration: 'default')
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
   testImplementation project(":test:framework")
-}
-
-// copied from CCR
-tasks.named("dependencyLicenses").configure {
-  ignoreSha 'x-pack-core'
 }
 

--- a/x-pack/plugin/search-business-rules/build.gradle
+++ b/x-pack/plugin/search-business-rules/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 // copied from CCR
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   ignoreSha 'x-pack-core'
 }
 

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -153,7 +153,7 @@ artifacts {
   testArtifacts testJar
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /java-support|opensaml-.*/, to: 'shibboleth'
   mapping from: /http.*/, to: 'httpclient'
 }

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /bc.*/, to: 'bouncycastle'
 }
 

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /sql-proto.*/, to: 'elasticsearch'
   mapping from: /sql-client.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'

--- a/x-pack/plugin/sql/jdbc/build.gradle
+++ b/x-pack/plugin/sql/jdbc/build.gradle
@@ -31,13 +31,7 @@ dependencies {
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /sql-proto.*/, to: 'elasticsearch'
-  mapping from: /sql-client.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'
-  mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
-  ignoreSha 'sql-proto'
-  ignoreSha 'sql-client'
-  ignoreSha 'elasticsearch'
 }
 
 shadowJar {

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
  * other qa projects. */
 test.enabled = false
 
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 // the main files are actually test files, so use the appropriate forbidden api sigs

--- a/x-pack/plugin/sql/qa/server/build.gradle
+++ b/x-pack/plugin/sql/qa/server/build.gradle
@@ -37,7 +37,7 @@ dependencies {
  * other qa projects. */
 test.enabled = false
 
-dependencyLicenses.enabled = false
+tasks.named("dependencyLicenses").configure { it.enabled = false }
 dependenciesInfo.enabled = false
 
 // just a test fixture: we aren't using this jars in releases and H2GIS requires disabling a lot of checks

--- a/x-pack/plugin/sql/sql-action/build.gradle
+++ b/x-pack/plugin/sql/sql-action/build.gradle
@@ -33,7 +33,7 @@ tasks.named('forbiddenApisMain').configure {
   replaceSignatureFiles 'jdk-signatures'
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /lucene-.*/, to: 'lucene'

--- a/x-pack/plugin/sql/sql-action/build.gradle
+++ b/x-pack/plugin/sql/sql-action/build.gradle
@@ -34,11 +34,8 @@ tasks.named('forbiddenApisMain').configure {
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /lucene-.*/, to: 'lucene'
-  ignoreSha 'elasticsearch'
-  ignoreSha 'elasticsearch-core'
 }
 
 thirdPartyAudit.ignoreMissingClasses(

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   testImplementation project(":test:framework")
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /elasticsearch-cli.*/, to: 'elasticsearch'
   mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'

--- a/x-pack/plugin/sql/sql-cli/build.gradle
+++ b/x-pack/plugin/sql/sql-cli/build.gradle
@@ -35,18 +35,11 @@ dependencies {
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /elasticsearch-cli.*/, to: 'elasticsearch'
-  mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /lucene-.*/, to: 'lucene'
   mapping from: /sql-action.*/, to: 'elasticsearch'
   mapping from: /sql-client.*/, to: 'elasticsearch'
   mapping from: /jline-.*/, to: 'jline'
-  ignoreSha 'elasticsearch-cli'
-  ignoreSha 'elasticsearch-core'
-  ignoreSha 'elasticsearch'
-  ignoreSha 'sql-action'
-  ignoreSha 'sql-client'
 }
 
 shadowJar {

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -15,10 +15,6 @@ dependencies {
 
 tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
-  mapping from: /sql-proto.*/, to: 'elasticsearch'
-  mapping from: /elasticsearch-cli.*/, to: 'elasticsearch'
-  mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
-  ignoreSha 'elasticsearch-core'
 }
 
 tasks.named('forbiddenApisMain').configure {

--- a/x-pack/plugin/sql/sql-client/build.gradle
+++ b/x-pack/plugin/sql/sql-client/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   testImplementation project(path: xpackModule('core'), configuration: 'testArtifacts')
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
   mapping from: /sql-proto.*/, to: 'elasticsearch'
   mapping from: /elasticsearch-cli.*/, to: 'elasticsearch'

--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -24,7 +24,5 @@ tasks.named('forbiddenApisMain').configure {
 }
 
 tasks.named("dependencyLicenses").configure {
-  mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'
-  ignoreSha 'elasticsearch-core'
 }

--- a/x-pack/plugin/sql/sql-proto/build.gradle
+++ b/x-pack/plugin/sql/sql-proto/build.gradle
@@ -23,7 +23,7 @@ tasks.named('forbiddenApisMain').configure {
   replaceSignatureFiles 'jdk-signatures'
 }
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /elasticsearch-core.*/, to: 'elasticsearch'
   mapping from: /jackson-.*/, to: 'jackson'
   ignoreSha 'elasticsearch-core'

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -19,7 +19,6 @@ compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
 
 tasks.named("dependencyLicenses").configure {
   mapping from: /owasp-java-html-sanitizer.*/, to: 'owasp-java-html-sanitizer'
-  ignoreSha 'x-pack-core'
 }
 
 dependencies {

--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -17,7 +17,7 @@ ext.compactProfile = 'full'
 compileJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
 compileTestJava.options.compilerArgs << "-Xlint:-rawtypes,-unchecked"
 
-dependencyLicenses {
+tasks.named("dependencyLicenses").configure {
   mapping from: /owasp-java-html-sanitizer.*/, to: 'owasp-java-html-sanitizer'
   ignoreSha 'x-pack-core'
 }


### PR DESCRIPTION
While going through deprecated gradle api usage I noticed some unrequired duplicate
task configuration. This unifies the configuration of the different dependencyLicense task
configuration accross the es build. With this PR we

- Remove duplicate dependency configuration in different subprojects
- Use task avoidance api accross the build when referencing the task