### PR TITLE
Fix realtime get of numeric fields from translog

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -255,12 +255,12 @@ public final class ShardGetService extends AbstractIndexShardComponent {
                                 DocValuesType.NONE, -1, Collections.emptyMap(), 0, 0, 0, false);
                             StoredFieldVisitor.Status status = fieldVisitor.needsField(fieldInfo);
                             if (status == StoredFieldVisitor.Status.YES) {
-                                if (indexableField.binaryValue() != null) {
+                                if (indexableField.numericValue() != null) {
+                                    fieldVisitor.objectField(fieldInfo, indexableField.numericValue());
+                                } else if (indexableField.binaryValue() != null) {
                                     fieldVisitor.binaryField(fieldInfo, indexableField.binaryValue());
                                 } else if (indexableField.stringValue() != null) {
                                     fieldVisitor.objectField(fieldInfo, indexableField.stringValue());
-                                } else if (indexableField.numericValue() != null) {
-                                    fieldVisitor.objectField(fieldInfo, indexableField.numericValue());
                                 }
                             } else if (status == StoredFieldVisitor.Status.STOP) {
                                 break;


### PR DESCRIPTION
Using realtime get on numeric fields when reading from the translog would yield a  ClassCastException:

```
Exception in thread "main" NotSerializableExceptionWrapper[class_cast_exception: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')]
	at org.elasticsearch.index.mapper.NumberFieldMapper$NumberFieldType.valueForDisplay(NumberFieldMapper.java:966)
	at org.elasticsearch.index.fieldvisitor.FieldsVisitor.postProcess(FieldsVisitor.java:104)
	at org.elasticsearch.index.get.ShardGetService.innerGetLoadFromStoredFields(ShardGetService.java:284)
	at org.elasticsearch.index.get.ShardGetService.innerGet(ShardGetService.java:194)
	at org.elasticsearch.index.get.ShardGetService.get(ShardGetService.java:104)
	at org.elasticsearch.index.get.ShardGetService.get(ShardGetService.java:95)
	at org.elasticsearch.action.get.TransportGetAction.shardOperation(TransportGetAction.java:106)
	at org.elasticsearch.action.get.TransportGetAction.shardOperation(TransportGetAction.java:45)
	at org.elasticsearch.action.support.single.shard.TransportSingleShardAction.lambda$asyncShardOperation$0(TransportSingleShardAction.java:110)
	at org.elasticsearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:58)
	at org.elasticsearch.action.ActionRunnable$2.doRun(ActionRunnable.java:73)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:692)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(Thread.java:830)
```

Closes #57462