### PR TITLE
[7.x] Scope index templates put during cluster upgrade tests (#58065)

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -77,23 +77,22 @@ public class IndexingIT extends AbstractRollingTestCase {
             {
                 Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
                 assertThat("this branch is not needed if we aren't compatible with 6.0",
-                        minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
                 if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
                     XContentBuilder template = jsonBuilder();
                     template.startObject();
                     {
-                        template.field("index_patterns", "*");
+                        template.array("index_patterns", "test_index", "index_with_replicas", "empty_index");
                         template.startObject("settings");
                         template.field("number_of_shards", 5);
                         template.endObject();
                     }
                     template.endObject();
-                    Request createTemplate = new Request("PUT", "/_template/template");
+                    Request createTemplate = new Request("PUT", "/_template/prevent-bwc-deprecation-template");
                     createTemplate.setJsonEntity(Strings.toString(template));
                     client().performRequest(createTemplate);
                 }
             }
-
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
             client().performRequest(createTestIndex);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexingIT.java
@@ -6,13 +6,13 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.action.document.RestBulkAction;
-import org.elasticsearch.Version;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -56,23 +56,22 @@ public class IndexingIT extends AbstractUpgradeTestCase {
             {
                 Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
                 assertThat("this branch is not needed if we aren't compatible with 6.0",
-                        minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
                 if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
                     XContentBuilder template = jsonBuilder();
                     template.startObject();
                     {
-                        template.field("index_patterns", "*");
+                        template.array("index_patterns", "test_index", "index_with_replicas", "empty_index");
                         template.startObject("settings");
                         template.field("number_of_shards", 5);
                         template.endObject();
                     }
                     template.endObject();
-                    Request createTemplate = new Request("PUT", "/_template/template");
+                    Request createTemplate = new Request("PUT", "/_template/xpack-prevent-bwc-deprecation-template");
                     createTemplate.setJsonEntity(Strings.toString(template));
                     client().performRequest(createTemplate);
                 }
             }
-
             Request createTestIndex = new Request("PUT", "/test_index");
             createTestIndex.setJsonEntity("{\"settings\": {\"index.number_of_replicas\": 0}}");
             client().performRequest(createTestIndex);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -63,18 +63,18 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         {
             Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
             assertThat("this branch is not needed if we aren't compatible with 6.0",
-                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
             if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
                 XContentBuilder template = jsonBuilder();
                 template.startObject();
                 {
-                    template.field("index_patterns", "*");
+                    template.field("index_patterns", "token_backwards_compatibility_it");
                     template.startObject("settings");
                     template.field("number_of_shards", 5);
                     template.endObject();
                 }
                 template.endObject();
-                Request createTemplate = new Request("PUT", "/_template/template");
+                Request createTemplate = new Request("PUT", "/_template/gen-tokens-old-cluster-template");
                 createTemplate.setJsonEntity(Strings.toString(template));
                 client().performRequest(createTemplate);
             }
@@ -105,18 +105,18 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         {
             Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
             assertThat("this branch is not needed if we aren't compatible with 6.0",
-                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
             if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
                 XContentBuilder template = jsonBuilder();
                 template.startObject();
                 {
-                    template.field("index_patterns", "*");
+                    template.field("index_patterns", "token_backwards_compatibility_it");
                     template.startObject("settings");
                     template.field("number_of_shards", 5);
                     template.endObject();
                 }
                 template.endObject();
-                Request createTemplate = new Request("PUT", "/_template/template");
+                Request createTemplate = new Request("PUT", "/_template/refresh-tokens-old-cluster-template");
                 createTemplate.setJsonEntity(Strings.toString(template));
                 client().performRequest(createTemplate);
             }
@@ -150,18 +150,18 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         {
             Version minimumIndexCompatibilityVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
             assertThat("this branch is not needed if we aren't compatible with 6.0",
-                    minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
+                minimumIndexCompatibilityVersion.onOrBefore(Version.V_6_0_0), equalTo(true));
             if (minimumIndexCompatibilityVersion.before(Version.V_7_0_0)) {
                 XContentBuilder template = jsonBuilder();
                 template.startObject();
                 {
-                    template.field("index_patterns", "*");
+                    template.field("index_patterns", "token_backwards_compatibility_it");
                     template.startObject("settings");
                     template.field("number_of_shards", 5);
                     template.endObject();
                 }
                 template.endObject();
-                Request createTemplate = new Request("PUT", "/_template/template");
+                Request createTemplate = new Request("PUT", "/_template/invalid-tokens-old-cluster-template");
                 createTemplate.setJsonEntity(Strings.toString(template));
                 client().performRequest(createTemplate);
             }
@@ -228,7 +228,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
     }
 
     public void testRefreshingTokensInMixedCluster() throws Exception {
-        // verify new nodes can refresh tokens created by old nodes and vice versa 
+        // verify new nodes can refresh tokens created by old nodes and vice versa
         assumeTrue("this test should only run against the mixed cluster", CLUSTER_TYPE == ClusterType.MIXED);
         for (RestClient client1 : twoClients) {
             Map<String, Object> responseMap = createTokens(client1, "test_user", "x-pack-test-password");


### PR DESCRIPTION
This template was added for 7.0 for what I am guessing is a BWC issue related to deprecation
warnings. It unfortunately seems to cause failures because templates for these tests are not cleared
after the test (because these are upgrade tests).

Resolves #56363
