### PR TITLE
[DOCS] Add manage_ilm privilege to monitoring steps

### DIFF
--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -35,7 +35,7 @@ PUT _cluster/settings
     "xpack.monitoring.collection.enabled": true
   }
 }
----------------------------------- 
+----------------------------------
 
 If {es} {security-features} are enabled, you must have `monitor` cluster privileges to 
 view the cluster settings and `manage` cluster privileges to change them.
@@ -169,9 +169,13 @@ provide a valid user ID and password so that {metricbeat} can send metrics
 successfully: 
 
 .. Create a user on the monitoring cluster that has the 
-<<built-in-roles,`remote_monitoring_agent` built-in role>>. 
-Alternatively, use the 
-<<built-in-users,`remote_monitoring_user` built-in user>>.
+<<built-in-roles,`remote_monitoring_agent` built-in role>> or use the 
+<<built-in-users,`remote_monitoring_user` built-in user>>. If you want to use
+{ilm} features on your {metricbeat} indices, the user must also have
+<<security-privileges,`manage_ilm` cluster privileges>>. If {metricbeat} is
+monitoring only the {stack}, {ilm-init} is not required. Disable it by adding
+`setup.ilm.enabled: false` to your {metricbeat} configuration file. For more
+information, refer to {metricbeat-ref}/ilm.html[Configure {ilm} in {metricbeat}].
 
 .. Add the `username` and `password` settings to the {es} output information in 
 the {metricbeat} configuration file.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/57963

This PR adds details about how to grant the necessary ILM privileges when monitoring Elasticsearch via Metricbeat. 

### Preview

https://elasticsearch_58141.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.6/configuring-metricbeat.html