### PR TITLE
Update hh to HH in date processor example (#58089)

### DIFF
--- a/docs/reference/ingest/processors/date.asciidoc
+++ b/docs/reference/ingest/processors/date.asciidoc
@@ -14,7 +14,7 @@ in the same order they were defined as part of the processor definition.
 | Name                   | Required  | Default             | Description
 | `field`                | yes       | -                   | The field to get the date from.
 | `target_field`         | no        | @timestamp          | The field that will hold the parsed date.
-| `formats`              | yes       | -                   | An array of the expected date formats. Can be a java time pattern or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
+| `formats`              | yes       | -                   | An array of the expected date formats. Can be a <<mapping-date-format,java time pattern>> or one of the following formats: ISO8601, UNIX, UNIX_MS, or TAI64N.
 | `timezone`        | no        | UTC                 | The timezone to use when parsing the date. Supports <<accessing-template-fields,template snippets>>.
 | `locale`          | no        | ENGLISH             | The locale to use when parsing the date, relevant when parsing month names or week days. Supports <<accessing-template-fields,template snippets>>.
 include::common-options.asciidoc[]
@@ -31,7 +31,7 @@ Here is an example that adds the parsed date to the `timestamp` field based on t
       "date" : {
         "field" : "initial_date",
         "target_field" : "timestamp",
-        "formats" : ["dd/MM/yyyy hh:mm:ss"],
+        "formats" : ["dd/MM/yyyy HH:mm:ss"],
         "timezone" : "Europe/Amsterdam"
       }
     }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update hh to HH in date processor example (#58089)