### PR TITLE
Change vm.max_map_count on Docker WSL2 backend

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -199,6 +199,18 @@ sudo sysctl -w vm.max_map_count=262144
 --------------------------------------------
 --
 
+* Windows with https://docs.docker.com/docker-for-windows/wsl[Docker Desktop WSL 2 backend]
++
+--
+The `vm.max_map_count` setting must be set in the docker-desktop container:
+
+[source,sh]
+--------------------------------------------
+wsl -d docker-desktop
+sysctl -w vm.max_map_count=262144
+--------------------------------------------
+--
+
 ===== Configuration files must be readable by the `elasticsearch` user
 
 By default, {es} runs inside the container as user `elasticsearch` using


### PR DESCRIPTION
This commit adds docs for how to change
vm.max_map_count when running on Docker
Desktop with WSL2 backend on Windows.
