### PR TITLE
Add include_data_streams flag for authorization

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexValidator.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/ReindexValidator.java
@@ -117,9 +117,9 @@ class ReindexValidator {
              * it. This is the same sort of dance that TransportIndexRequest
              * uses to decide to autocreate the index.
              */
-            target = indexNameExpressionResolver.concreteWriteIndex(clusterState, destination, true).getName();
+            target = indexNameExpressionResolver.concreteWriteIndex(clusterState, destination).getName();
         }
-        for (String sourceIndex : indexNameExpressionResolver.concreteIndexNames(clusterState, source, true)) {
+        for (String sourceIndex : indexNameExpressionResolver.concreteIndexNames(clusterState, source)) {
             if (sourceIndex.equals(target)) {
                 ActionRequestValidationException e = new ActionRequestValidationException();
                 e.addValidationError("reindex cannot write into an index its reading from [" + target + ']');

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/20_unsupported_apis.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.data_stream/20_unsupported_apis.yml
@@ -51,3 +51,14 @@
       indices.delete_data_stream:
         name: logs-foobar
   - is_true: acknowledged
+
+---
+"APIs temporarily muted":
+  - skip:
+      version: "all"
+      reason: "restore to above test after data stream resolution PRs have been merged"
+
+  - do:
+      catch: bad_request
+      indices.close:
+        index: logs-*

--- a/server/src/main/java/org/elasticsearch/action/IndicesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/IndicesRequest.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 /**
  * Needs to be implemented by all {@link org.elasticsearch.action.ActionRequest} subclasses that relate to
  * one or more indices. Allows to retrieve which indices the action relates to.
- * In case of internal requests  originated during the distributed execution of an external request,
+ * In case of internal requests originated during the distributed execution of an external request,
  * they will still return the indices that the original request related to.
  */
 public interface IndicesRequest {

--- a/server/src/main/java/org/elasticsearch/action/OriginalIndices.java
+++ b/server/src/main/java/org/elasticsearch/action/OriginalIndices.java
@@ -56,6 +56,11 @@ public final class OriginalIndices implements IndicesRequest {
         return indicesOptions;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     public static OriginalIndices readOriginalIndices(StreamInput in) throws IOException {
         return new OriginalIndices(in.readStringArray(), IndicesOptions.readIndicesOptions(in));
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -143,6 +143,11 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         return this;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     public TimeValue timeout() {
         return timeout;
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -293,7 +293,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         }
         if (CollectionUtils.isEmpty(request.indices()) == false) {
             try {
-                indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), true, request.indices());
+                indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), request);
                 waitForCounter++;
             } catch (IndexNotFoundException e) {
                 response.setStatus(ClusterHealthStatus.RED); // no indices, make sure its RED
@@ -360,7 +360,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
 
         String[] concreteIndices;
         try {
-            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request, true);
+            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
         } catch (IndexNotFoundException e) {
             // one of the specified indices is not there - treat it as RED.
             ClusterHealthResponse response = new ClusterHealthResponse(clusterState.getClusterName().value(), Strings.EMPTY_ARRAY,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -69,7 +69,7 @@ public class TransportClusterSearchShardsAction extends
     @Override
     protected ClusterBlockException checkBlock(ClusterSearchShardsRequest request, ClusterState state) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ,
-                indexNameExpressionResolver.concreteIndexNames(state, request, true));
+                indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
     @Override
@@ -81,7 +81,7 @@ public class TransportClusterSearchShardsAction extends
     protected void masterOperation(Task task, final ClusterSearchShardsRequest request, final ClusterState state,
                                    final ActionListener<ClusterSearchShardsResponse> listener) {
         ClusterState clusterState = clusterService.state();
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request, true);
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
         Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(state, request.routing(), request.indices());
         Map<String, AliasFilter> indicesAndFilters = new HashMap<>();
         Set<String> indicesAndAliases = indexNameExpressionResolver.resolveExpressions(clusterState, request.indices());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -271,6 +271,10 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
         return this;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
 
     /**
      * Returns true if indices with unavailable shards should be be partially snapshotted.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -156,6 +156,11 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         return this;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     public ClusterStateRequest customs(boolean customs) {
         this.customs = customs;
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -137,7 +137,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
         if (request.routingTable()) {
             if (request.indices().length > 0) {
                 RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
-                String[] indices = indexNameExpressionResolver.concreteIndexNames(currentState, request, true);
+                String[] indices = indexNameExpressionResolver.concreteIndexNames(currentState, request);
                 for (String filteredIndex : indices) {
                     if (currentState.routingTable().getIndicesRouting().containsKey(filteredIndex)) {
                         routingTableBuilder.add(currentState.routingTable().getIndicesRouting().get(filteredIndex));
@@ -159,7 +159,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
         if (request.metadata()) {
             if (request.indices().length > 0) {
                 mdBuilder.version(currentState.metadata().version());
-                String[] indices = indexNameExpressionResolver.concreteIndexNames(currentState, request, true);
+                String[] indices = indexNameExpressionResolver.concreteIndexNames(currentState, request);
                 for (String filteredIndex : indices) {
                     IndexMetadata indexMetadata = currentState.metadata().index(filteredIndex);
                     if (indexMetadata != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequest.java
@@ -89,6 +89,11 @@ public class GetFieldMappingsRequest extends ActionRequest implements IndicesReq
         return indicesOptions;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     /** @param fields a list of fields to retrieve the mapping for */
     public GetFieldMappingsRequest fields(String... fields) {
         this.fields = fields;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsAction.java
@@ -57,7 +57,7 @@ public class TransportGetFieldMappingsAction extends HandledTransportAction<GetF
     @Override
     protected void doExecute(Task task, GetFieldMappingsRequest request, final ActionListener<GetFieldMappingsResponse> listener) {
         ClusterState clusterState = clusterService.state();
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request, true);
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
         final AtomicInteger indexCounter = new AtomicInteger();
         final AtomicInteger completionCounter = new AtomicInteger(concreteIndices.length);
         final AtomicReferenceArray<Object> indexResponses = new AtomicReferenceArray<>(concreteIndices.length);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -159,6 +159,11 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         return this;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     /**
      * The mapping source definition.
      */

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -87,7 +87,7 @@ public class TransportPutMappingAction extends TransportMasterNodeAction<PutMapp
     protected ClusterBlockException checkBlock(PutMappingRequest request, ClusterState state) {
         String[] indices;
         if (request.getConcreteIndex() == null) {
-            indices = indexNameExpressionResolver.concreteIndexNames(state, request, true);
+            indices = indexNameExpressionResolver.concreteIndexNames(state, request);
         } else {
             indices = new String[] {request.getConcreteIndex().getName()};
         }
@@ -99,7 +99,7 @@ public class TransportPutMappingAction extends TransportMasterNodeAction<PutMapp
                                    final ActionListener<AcknowledgedResponse> listener) {
         try {
             final Index[] concreteIndices = request.getConcreteIndex() == null ?
-                indexNameExpressionResolver.concreteIndices(state, request, true)
+                indexNameExpressionResolver.concreteIndices(state, request)
                 : new Index[] {request.getConcreteIndex()};
             final Optional<Exception> maybeValidationException = requestValidators.validateRequest(request, state, concreteIndices);
             if (maybeValidationException.isPresent()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -110,6 +110,11 @@ public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> impl
         return this;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     public ActiveShardCount waitForActiveShards() {
         return waitForActiveShards;
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -83,13 +83,13 @@ public class TransportOpenIndexAction extends TransportMasterNodeAction<OpenInde
     @Override
     protected ClusterBlockException checkBlock(OpenIndexRequest request, ClusterState state) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, request, true));
+            indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
     @Override
     protected void masterOperation(Task task, final OpenIndexRequest request, final ClusterState state,
                                    final ActionListener<OpenIndexResponse> listener) {
-        final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request, true);
+        final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         if (concreteIndices == null || concreteIndices.length == 0) {
             listener.onResponse(new OpenIndexResponse(true, true));
             return;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -140,6 +140,11 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
             this.names = indices;
             return this;
         }
+
+        @Override
+        public boolean includeDataStreams() {
+            return true;
+        }
     }
 
     public static class ResolvedIndexAbstraction {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -140,6 +140,11 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
         return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     /**
      * Sets the rollover target to rollover to another index
      */

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -91,7 +91,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             request.indicesOptions().expandWildcardsOpen(), request.indicesOptions().expandWildcardsClosed());
 
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, indicesOptions, true, request.indices()));
+            indexNameExpressionResolver.concreteIndexNames(state, indicesOptions, request));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -60,7 +60,6 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         return this;
     }
 
-
     public GetSettingsRequest() {
     }
 
@@ -91,6 +90,11 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
     @Override
     public IndicesOptions indicesOptions() {
         return indicesOptions;
+    }
+
+    @Override
+    public boolean includeDataStreams() {
+        return true;
     }
 
     public String[] names() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -69,7 +69,7 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
     @Override
     protected ClusterBlockException checkBlock(GetSettingsRequest request, ClusterState state) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ,
-            indexNameExpressionResolver.concreteIndexNames(state, request, true));
+            indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
 
@@ -85,7 +85,7 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
     @Override
     protected void masterOperation(Task task, GetSettingsRequest request, ClusterState state,
                                    ActionListener<GetSettingsResponse> listener) {
-        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request, true);
+        Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         ImmutableOpenMap.Builder<String, Settings> indexToSettingsBuilder = ImmutableOpenMap.builder();
         ImmutableOpenMap.Builder<String, Settings> indexToDefaultSettingsBuilder = ImmutableOpenMap.builder();
         for (Index concreteIndex : concreteIndices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -78,7 +78,7 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeAction<Upd
             return null;
         }
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
-            indexNameExpressionResolver.concreteIndexNames(state, request, true));
+            indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
     @Override
@@ -89,7 +89,7 @@ public class TransportUpdateSettingsAction extends TransportMasterNodeAction<Upd
     @Override
     protected void masterOperation(Task task, final UpdateSettingsRequest request, final ClusterState state,
                                    final ActionListener<AcknowledgedResponse> listener) {
-        final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request, true);
+        final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
         UpdateSettingsClusterStateUpdateRequest clusterStateUpdateRequest = new UpdateSettingsClusterStateUpdateRequest()
                 .indices(concreteIndices)
                 .settings(request.settings())

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -119,6 +119,11 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
         return this;
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
     /**
      * Sets the settings to be updated
      */

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -721,7 +721,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
             Index concreteIndex = indices.get(request.index());
             if (concreteIndex == null) {
                 boolean includeDataStreams = request.opType() == DocWriteRequest.OpType.CREATE;
-                concreteIndex = indexNameExpressionResolver.concreteWriteIndex(state, request, includeDataStreams);
+                concreteIndex = indexNameExpressionResolver.concreteWriteIndex(state, request.indicesOptions(), request.indices()[0],
+                    false, includeDataStreams);
                 indices.put(request.index(), concreteIndex);
             }
             return concreteIndex;

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -78,7 +78,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             // in the case we have one or more remote indices but no local we don't expand to all local indices and just do remote indices
             concreteIndices = Strings.EMPTY_ARRAY;
         } else {
-            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, localIndices, true);
+            concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, localIndices);
         }
         final int totalNumRequest = concreteIndices.length + remoteClusterIndices.size();
         final CountDown completionCounter = new CountDown(totalNumRequest);

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -674,6 +674,10 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         return "index {[" + index + "][" + id + "], source[" + sSource + "]}";
     }
 
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
 
     /**
      * Returns <code>true</code> if this request has been sent to a shard copy more than once.

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -451,14 +451,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     }
 
     private Index[] resolveLocalIndices(OriginalIndices localIndices,
-                                IndicesOptions indicesOptions,
                                 ClusterState clusterState,
                                 SearchTimeProvider timeProvider) {
         if (localIndices == null) {
             return Index.EMPTY_ARRAY; //don't search on any local index (happens when only remote indices were specified)
         }
-        return indexNameExpressionResolver.concreteIndices(clusterState, indicesOptions, true,
-            timeProvider.getAbsoluteStartMillis(), localIndices.indices());
+        return indexNameExpressionResolver.concreteIndices(clusterState, localIndices, timeProvider.getAbsoluteStartMillis());
     }
 
     private void executeSearch(SearchTask task, SearchTimeProvider timeProvider, SearchRequest searchRequest,
@@ -471,7 +469,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         // TODO: I think startTime() should become part of ActionRequest and that should be used both for index name
         // date math expressions and $now in scripts. This way all apis will deal with now in the same way instead
         // of just for the _search api
-        final Index[] indices = resolveLocalIndices(localIndices, searchRequest.indicesOptions(), clusterState, timeProvider);
+        final Index[] indices = resolveLocalIndices(localIndices, clusterState, timeProvider);
         Map<String, AliasFilter> aliasFilter = buildPerIndexAliasFilter(searchRequest, clusterState, indices, remoteAliasMap);
         Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(clusterState, searchRequest.routing(),
             searchRequest.indices());

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -77,6 +77,11 @@ public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends
     }
 
     @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArrayNullable(indices);

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -225,10 +225,6 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
         new AsyncAction(task, request, listener).start();
     }
 
-    protected boolean shouldIncludeDataStreams() {
-        return true;
-    }
-
     protected class AsyncAction {
         private final Task task;
         private final Request request;
@@ -253,7 +249,7 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
                 throw globalBlockException;
             }
 
-            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request, shouldIncludeDataStreams());
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
             ClusterBlockException requestBlockException = checkRequestBlock(clusterState, request, concreteIndices);
             if (requestBlockException != null) {
                 throw requestBlockException;

--- a/server/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/info/ClusterInfoRequest.java
@@ -80,4 +80,9 @@ public abstract class ClusterInfoRequest<Request extends ClusterInfoRequest<Requ
     public IndicesOptions indicesOptions() {
         return indicesOptions;
     }
+
+    @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -50,13 +50,13 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
     @Override
     protected ClusterBlockException checkBlock(Request request, ClusterState state) {
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_READ,
-            indexNameExpressionResolver.concreteIndexNames(state, request, true));
+            indexNameExpressionResolver.concreteIndexNames(state, request));
     }
 
     @Override
     protected final void masterOperation(Task task, final Request request, final ClusterState state,
                                          final ActionListener<Response> listener) {
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request, true);
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request);
         doMasterOperation(request, concreteIndices, state, listener);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -127,7 +127,7 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
      */
     protected List<ShardId> shards(Request request, ClusterState clusterState) {
         List<ShardId> shardIds = new ArrayList<>();
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request, shouldIncludeDataStreams());
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(clusterState, request);
         for (String index : concreteIndices) {
             IndexMetadata indexMetadata = clusterState.metadata().getIndices().get(index);
             if (indexMetadata != null) {
@@ -138,10 +138,6 @@ public abstract class TransportBroadcastReplicationAction<Request extends Broadc
             }
         }
         return shardIds;
-    }
-
-    protected boolean shouldIncludeDataStreams() {
-        return true;
     }
 
     protected abstract ShardResponse newShardResponse();

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -143,7 +143,7 @@ public abstract class TransportInstanceSingleOperationAction<
                         throw blockException;
                     }
                 }
-                request.concreteIndex(indexNameExpressionResolver.concreteWriteIndex(clusterState, request, false).getName());
+                request.concreteIndex(indexNameExpressionResolver.concreteWriteIndex(clusterState, request).getName());
                 resolveRequest(clusterState, request);
                 blockException = checkRequestBlock(clusterState, request);
                 if (blockException != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -68,28 +68,16 @@ public class IndexNameExpressionResolver {
      * are encapsulated in the specified request.
      */
     public String[] concreteIndexNames(ClusterState state, IndicesRequest request) {
-        return concreteIndexNames(state, request, false);
-    }
-
-    public String[] concreteIndexNames(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
-        Context context = new Context(state, request.indicesOptions(), false, false, includeDataStreams);
+        Context context = new Context(state, request.indicesOptions(), false, false, request.includeDataStreams());
         return concreteIndexNames(context, request.indices());
-    }
-
-    /**
-     * Same as {@link #concreteIndices(ClusterState, IndicesOptions, String...)}, but the index expressions and options
-     * are encapsulated in the specified request.
-     */
-    public Index[] concreteIndices(ClusterState state, IndicesRequest request) {
-        return concreteIndices(state, request, false);
     }
 
     /**
      * Same as {@link #concreteIndices(ClusterState, IndicesOptions, String...)}, but the index expressions and options
      * are encapsulated in the specified request and resolves data streams.
      */
-    public Index[] concreteIndices(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
-        Context context = new Context(state, request.indicesOptions(), false, false, includeDataStreams);
+    public Index[] concreteIndices(ClusterState state, IndicesRequest request) {
+        Context context = new Context(state, request.indicesOptions(), false, false, request.includeDataStreams());
         return concreteIndices(context, request.indices());
     }
 
@@ -111,10 +99,14 @@ public class IndexNameExpressionResolver {
         return concreteIndexNames(context, indexExpressions);
     }
 
-    public String[] concreteIndexNames(ClusterState state, IndicesOptions options, boolean includeDataStreams,
-                                       String... indexExpressions) {
+    public String[] concreteIndexNames(ClusterState state, IndicesOptions options, boolean includeDataStreams, String... indexExpressions) {
         Context context = new Context(state, options, false, false, includeDataStreams);
         return concreteIndexNames(context, indexExpressions);
+    }
+
+    public String[] concreteIndexNames(ClusterState state, IndicesOptions options, IndicesRequest request) {
+        Context context = new Context(state, options, false, false, request.includeDataStreams());
+        return concreteIndexNames(context, request.indices());
     }
 
     public List<String> dataStreamNames(ClusterState state, IndicesOptions options, String... indexExpressions) {
@@ -151,20 +143,18 @@ public class IndexNameExpressionResolver {
     /**
      * Translates the provided index expression into actual concrete indices, properly deduplicated.
      *
-     * @param state             the cluster state containing all the data to resolve to expressions to concrete indices
-     * @param options           defines how the aliases or indices need to be resolved to concrete indices
-     * @param startTime         The start of the request where concrete indices is being invoked for
-     * @param indexExpressions  expressions that can be resolved to alias or index names.
+     * @param state      the cluster state containing all the data to resolve to expressions to concrete indices
+     * @param startTime  The start of the request where concrete indices is being invoked for
+     * @param request    request containing expressions that can be resolved to alias, index, or data stream names.
      * @return the resolved concrete indices based on the cluster state, indices options and index expressions
      * provided indices options in the context don't allow such a case, or if the final result of the indices resolution
      * contains no indices and the indices options in the context don't allow such a case.
      * @throws IllegalArgumentException if one of the aliases resolve to multiple indices and the provided
      * indices options in the context don't allow such a case.
      */
-    public Index[] concreteIndices(ClusterState state, IndicesOptions options, boolean includeDataStreams, long startTime,
-                                   String... indexExpressions) {
-        Context context = new Context(state, options, startTime, false, false, includeDataStreams);
-        return concreteIndices(context, indexExpressions);
+    public Index[] concreteIndices(ClusterState state, IndicesRequest request, long startTime) {
+        Context context = new Context(state, request.indicesOptions(), startTime, false, false, request.includeDataStreams());
+        return concreteIndices(context, request.indices());
     }
 
     String[] concreteIndexNames(Context context, String... indexExpressions) {
@@ -340,15 +330,14 @@ public class IndexNameExpressionResolver {
      * @param state             the cluster state containing all the data to resolve to expression to a concrete index
      * @param request           The request that defines how the an alias or an index need to be resolved to a concrete index
      *                          and the expression that can be resolved to an alias or an index name.
-     * @param includeDataStreams Whether data streams should be included in the evaluation.
      * @throws IllegalArgumentException if the index resolution does not lead to an index, or leads to more than one index
      * @return the write index obtained as a result of the index resolution
      */
-    public Index concreteWriteIndex(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
+    public Index concreteWriteIndex(ClusterState state, IndicesRequest request) {
         if (request.indices() == null || (request.indices() != null && request.indices().length != 1)) {
             throw new IllegalArgumentException("indices request must specify a single index expression");
         }
-        return concreteWriteIndex(state, request.indicesOptions(), request.indices()[0], false, includeDataStreams);
+        return concreteWriteIndex(state, request.indicesOptions(), request.indices()[0], false, request.includeDataStreams());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -225,8 +225,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     throw new ConcurrentSnapshotExecutionException(repositoryName, snapshotName, " a snapshot is already running");
                 }
                 // Store newSnapshot here to be processed in clusterStateProcessed
-                List<String> indices = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(currentState,
-                    request.indicesOptions(), true, request.indices()));
+                List<String> indices = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(currentState, request));
 
                 final List<String> dataStreams =
                         indexNameExpressionResolver.dataStreamNames(currentState, request.indicesOptions(), request.indices());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
@@ -123,12 +123,12 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
 
     static class Resolver extends IndexNameExpressionResolver {
         @Override
-        public String[] concreteIndexNames(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
+        public String[] concreteIndexNames(ClusterState state, IndicesRequest request) {
             return request.indices();
         }
 
         @Override
-        public Index[] concreteIndices(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
+        public Index[] concreteIndices(ClusterState state, IndicesRequest request) {
             Index[] out = new Index[request.indices().length];
             for (int x = 0; x < out.length; x++) {
                 out[x] = new Index(request.indices()[x], "_na_");

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -133,12 +133,12 @@ public class GetSettingsActionTests extends ESTestCase {
 
     static class Resolver extends IndexNameExpressionResolver {
         @Override
-        public String[] concreteIndexNames(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
+        public String[] concreteIndexNames(ClusterState state, IndicesRequest request) {
             return request.indices();
         }
 
         @Override
-        public Index[] concreteIndices(ClusterState state, IndicesRequest request, boolean includeDataStreams) {
+        public Index[] concreteIndices(ClusterState state, IndicesRequest request) {
             Index[] out = new Index[request.indices().length];
             for (int x = 0; x < out.length; x++) {
                 out[x] = new Index(request.indices()[x], "_na_");

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1432,14 +1432,19 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             public IndicesOptions indicesOptions() {
                 return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
             }
+
+            @Override
+            public boolean includeDataStreams() {
+                return false;
+            }
         };
-        Index writeIndex = indexNameExpressionResolver.concreteWriteIndex(state, request, false);
+        Index writeIndex = indexNameExpressionResolver.concreteWriteIndex(state, request);
         assertThat(writeIndex.getName(), equalTo("test-0"));
 
         state = ClusterState.builder(state).metadata(Metadata.builder(state.metadata())
             .put(indexBuilder("test-1").putAlias(AliasMetadata.builder("test-alias")
                 .writeIndex(testZeroWriteIndex ? randomFrom(false, null) : true)))).build();
-        writeIndex = indexNameExpressionResolver.concreteWriteIndex(state, request, false);
+        writeIndex = indexNameExpressionResolver.concreteWriteIndex(state, request);
         assertThat(writeIndex.getName(), equalTo(testZeroWriteIndex ? "test-0" : "test-1"));
     }
 
@@ -1459,12 +1464,17 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             public IndicesOptions indicesOptions() {
                 return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
             }
+
+            @Override
+            public boolean includeDataStreams() {
+                return false;
+            }
         };
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-            () -> indexNameExpressionResolver.concreteWriteIndex(state, requestGen.apply(null), false));
+            () -> indexNameExpressionResolver.concreteWriteIndex(state, requestGen.apply(null)));
         assertThat(exception.getMessage(), equalTo("indices request must specify a single index expression"));
         exception = expectThrows(IllegalArgumentException.class,
-            () -> indexNameExpressionResolver.concreteWriteIndex(state, requestGen.apply(new String[] {"too", "many"}), false));
+            () -> indexNameExpressionResolver.concreteWriteIndex(state, requestGen.apply(new String[] {"too", "many"})));
         assertThat(exception.getMessage(), equalTo("indices request must specify a single index expression"));
 
 
@@ -1493,10 +1503,15 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             public IndicesOptions indicesOptions() {
                 return IndicesOptions.strictExpandOpenAndForbidClosed();
             }
+
+            @Override
+            public boolean includeDataStreams() {
+                return false;
+            }
         };
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-            () -> indexNameExpressionResolver.concreteWriteIndex(state, request, false));
+            () -> indexNameExpressionResolver.concreteWriteIndex(state, request));
         assertThat(exception.getMessage(),
             equalTo("The index expression [test-*] and options provided did not point to a single write-index"));
     }
@@ -1513,7 +1528,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         DocWriteRequest request = randomFrom(new IndexRequest("test-alias"),
             new UpdateRequest("test-alias", "_id"), new DeleteRequest("test-alias"));
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-            () -> indexNameExpressionResolver.concreteWriteIndex(state, request, false));
+            () -> indexNameExpressionResolver.concreteWriteIndex(state, request.indicesOptions(), request.indices()[0], false, false));
         assertThat(exception.getMessage(), equalTo("no write index is defined for alias [test-alias]." +
                 " The write index may be explicitly disabled using is_write_index=false or the alias points to multiple" +
                 " indices without one being designated as a write index"));
@@ -1533,7 +1548,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         DocWriteRequest request = randomFrom(new IndexRequest("test-alias"),
             new UpdateRequest("test-alias", "_id"), new DeleteRequest("test-alias"));
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-            () -> indexNameExpressionResolver.concreteWriteIndex(state, request, false));
+            () -> indexNameExpressionResolver.concreteWriteIndex(state, request.indicesOptions(), request.indices()[0], false, false));
         assertThat(exception.getMessage(), equalTo("no write index is defined for alias [test-alias]." +
             " The write index may be explicitly disabled using is_write_index=false or the alias points to multiple" +
             " indices without one being designated as a write index"));
@@ -1701,7 +1716,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         {
             IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index(dataStreamName);
             IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
-                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions, false));
+                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions));
             assertEquals("The provided expression [" + dataStreamName + "] matches a data stream, specify the corresponding " +
                 "concrete indices instead.", iae.getMessage());
         }
@@ -1709,18 +1724,18 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         {
             IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index("my-data-*").alias("my-data");
             IllegalArgumentException iae = expectThrows(IllegalArgumentException.class,
-                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions, false));
+                () -> indexNameExpressionResolver.concreteIndexNames(state, aliasActions));
             assertEquals("The provided expression [my-data-*] matches a data stream, specify the corresponding concrete indices instead.",
                 iae.getMessage());
         }
 
-        {
-            IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index(dataStreamName)
-                .alias("my-data");
-            String[] indices = indexNameExpressionResolver.concreteIndexNames(state, aliasActions, true);
-            assertEquals(1, indices.length);
-            assertEquals(backingIndex.getIndex().getName(), indices[0]);
-        }
+        //{
+        //    IndicesAliasesRequest.AliasActions aliasActions = IndicesAliasesRequest.AliasActions.add().index(dataStreamName)
+        //        .alias("my-data");
+        //    String[] indices = indexNameExpressionResolver.concreteIndexNames(state, aliasActions);
+        //    assertEquals(1, indices.length);
+        //    assertEquals(backingIndex.getIndex().getName(), indices[0]);
+        //}
     }
 
     public void testInvalidIndex() {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportForgetFollowerAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportForgetFollowerAction.java
@@ -147,9 +147,4 @@ public class TransportForgetFollowerAction extends TransportBroadcastByNodeActio
             final String[] concreteIndices) {
         return null;
     }
-
-    @Override
-    protected boolean shouldIncludeDataStreams() {
-        return false;
-    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ForgetFollowerAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ForgetFollowerAction.java
@@ -157,6 +157,11 @@ public class ForgetFollowerAction extends ActionType<BroadcastResponse> {
             return null;
         }
 
+        @Override
+        public boolean includeDataStreams() {
+            return false;
+        }
+
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidator.java
@@ -209,7 +209,7 @@ public final class SourceDestValidator {
                             state,
                             DEFAULT_INDICES_OPTIONS_FOR_VALIDATION,
                             true,
-                            resolvedSource.toArray(new String[0])
+                            resolvedSource.toArray(Strings.EMPTY_ARRAY)
                         )
                     )
                 );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoAction.java
@@ -160,8 +160,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
          *
          * @param state The cluster state
          * @param indexNameExpressionResolver Used to resolve indices into their concrete names
-         * @param indices The list of index expressions to evaluate using `indexNameExpressionResolver`
-         * @param indicesOptions The options to use when resolving and filtering which indices to check
+         * @param request The originating request containing the index expressions to evaluate
          * @param datafeeds The ml datafeed configurations
          * @param nodeDeprecationResponse The response containing the deprecation issues found on each node
          * @param indexSettingsChecks The list of index-level checks that will be run across all specified
@@ -173,8 +172,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         public static DeprecationInfoAction.Response from(ClusterState state,
                                                           NamedXContentRegistry xContentRegistry,
                                                           IndexNameExpressionResolver indexNameExpressionResolver,
-                                                          String[] indices, IndicesOptions indicesOptions,
-                                                          List<DatafeedConfig> datafeeds,
+                                                          Request request, List<DatafeedConfig> datafeeds,
                                                           NodesDeprecationCheckResponse nodeDeprecationResponse,
                                                           List<Function<IndexMetadata, DeprecationIssue>> indexSettingsChecks,
                                                           List<Function<ClusterState, DeprecationIssue>> clusterSettingsChecks,
@@ -188,7 +186,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
                 mlSettingsIssues.addAll(filterChecks(mlSettingsCheck, (c) -> c.apply(config, xContentRegistry)));
             }
 
-            String[] concreteIndexNames = indexNameExpressionResolver.concreteIndexNames(state, indicesOptions, true, indices);
+            String[] concreteIndexNames = indexNameExpressionResolver.concreteIndexNames(state, request);
 
             Map<String, List<DeprecationIssue>> indexSettingsIssues = new HashMap<>();
             for (String concreteIndex : concreteIndexNames) {
@@ -242,6 +240,11 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         @Override
         public IndicesOptions indicesOptions() {
             return INDICES_OPTIONS;
+        }
+
+        @Override
+        public boolean includeDataStreams() {
+            return true;
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -84,6 +84,11 @@ public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsActio
         }
 
         @Override
+        public boolean includeDataStreams() {
+            return true;
+        }
+
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeStringArray(indices);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/deprecation/DeprecationInfoActionResponseTests.java
@@ -99,8 +99,9 @@ public class DeprecationInfoActionResponseTests extends AbstractWireSerializingT
                 : emptyList(),
             emptyList());
 
+        DeprecationInfoAction.Request request = new DeprecationInfoAction.Request(Strings.EMPTY_ARRAY);
         DeprecationInfoAction.Response response = DeprecationInfoAction.Response.from(state, NamedXContentRegistry.EMPTY,
-            resolver, Strings.EMPTY_ARRAY, indicesOptions, datafeeds,
+            resolver, request, datafeeds,
             nodeDeprecationIssues, indexSettingsChecks, clusterSettingsChecks, mlSettingsChecks);
 
         if (clusterIssueFound) {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -106,8 +106,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                     datafeeds -> {
                         listener.onResponse(
                             DeprecationInfoAction.Response.from(state, xContentRegistry, indexNameExpressionResolver,
-                                request.indices(), request.indicesOptions(), datafeeds,
-                                response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS,
+                                request, datafeeds, response, INDEX_SETTINGS_CHECKS, CLUSTER_SETTINGS_CHECKS,
                                 ML_SETTINGS_CHECKS));
                     },
                     listener::onFailure

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
@@ -46,7 +46,7 @@ public class TransportGetRollupIndexCapsAction extends HandledTransportAction<Ge
                              ActionListener<GetRollupIndexCapsAction.Response> listener) {
 
         String[] indices = resolver.concreteIndexNames(clusterService.state(),
-            request.indicesOptions(), true, request.indices());
+            request.indicesOptions(), request);
         Map<String, RollableIndexCaps> allCaps = getCapsByRollupIndex(Arrays.asList(indices),
             clusterService.state().getMetadata().indices());
         listener.onResponse(new GetRollupIndexCapsAction.Response(allCaps));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
@@ -240,7 +240,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
         AuthorizationEngine.RequestInfo requestInfo = new AuthorizationEngine.RequestInfo(null, request, SearchAction.NAME);
         List<String> list =
             RBACEngine.resolveAuthorizedIndicesFromRole(roles, requestInfo, metadata.getIndicesLookup());
-        assertThat(list, containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab", "adatastream1"));
+        assertThat(list, containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab", "adatastream1", backingIndex));
         assertFalse(list.contains("bbbbb"));
         assertFalse(list.contains("ba"));
         assertThat(list, not(contains(internalSecurityIndex)));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
@@ -6,13 +6,16 @@
 package org.elasticsearch.xpack.security.authz;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
@@ -29,6 +32,7 @@ import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.cluster.DataStreamTestHelper.createTimestampField;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.not;
@@ -150,6 +154,97 @@ public class AuthorizedIndicesTests extends ESTestCase {
             RBACEngine.resolveAuthorizedIndicesFromRole(role, getRequestInfo(SearchAction.NAME), metadata.getIndicesLookup());
         assertThat(authorizedIndicesSuperUser, containsInAnyOrder(
             "an-index", "another-index", RestrictedIndicesNames.SECURITY_MAIN_ALIAS, internalSecurityIndex));
+    }
+
+    public void testDataStreamsAreNotIncludedInAuthorizedIndices() {
+        RoleDescriptor aStarRole = new RoleDescriptor("a_star", null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("all").build() }, null);
+        RoleDescriptor bRole = new RoleDescriptor("b", null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("b").privileges("READ").build() }, null);
+        Settings indexSettings = Settings.builder().put("index.version.created", Version.CURRENT).build();
+        final String internalSecurityIndex = randomFrom(RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_6,
+            RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_7);
+        String backingIndex = DataStream.getDefaultBackingIndexName("adatastream1", 1);
+        Metadata metadata = Metadata.builder()
+            .put(new IndexMetadata.Builder("a1").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("a2").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("aaaaaa").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("bbbbb").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("b")
+                .settings(indexSettings)
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(new AliasMetadata.Builder("ab").build())
+                .putAlias(new AliasMetadata.Builder("ba").build())
+                .build(), true)
+            .put(new IndexMetadata.Builder(internalSecurityIndex)
+                .settings(indexSettings)
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(new AliasMetadata.Builder(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).build())
+                .build(), true)
+            .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new DataStream("adatastream1", createTimestampField("@timestamp"),
+                List.of(new Index(DataStream.getDefaultBackingIndexName("adatastream1", 1), "_na_"))))
+            .build();
+        final PlainActionFuture<Role> future = new PlainActionFuture<>();
+        final Set<RoleDescriptor> descriptors = Sets.newHashSet(aStarRole, bRole);
+        CompositeRolesStore.buildRoleFromDescriptors(descriptors, new FieldPermissionsCache(Settings.EMPTY), null, future);
+        Role roles = future.actionGet();
+        List<String> list =
+            RBACEngine.resolveAuthorizedIndicesFromRole(roles, getRequestInfo(SearchAction.NAME), metadata.getIndicesLookup());
+        assertThat(list, containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab"));
+        assertFalse(list.contains("bbbbb"));
+        assertFalse(list.contains("ba"));
+        assertFalse(list.contains("adatastream1"));
+        assertThat(list, not(contains(internalSecurityIndex)));
+        assertThat(list, not(contains(RestrictedIndicesNames.SECURITY_MAIN_ALIAS)));
+    }
+
+    public void testDataStreamsAreIncludedInAuthorizedIndices() {
+        RoleDescriptor aStarRole = new RoleDescriptor("a_star", null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a*").privileges("all").build() }, null);
+        RoleDescriptor bRole = new RoleDescriptor("b", null,
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("b").privileges("READ").build() }, null);
+        Settings indexSettings = Settings.builder().put("index.version.created", Version.CURRENT).build();
+        final String internalSecurityIndex = randomFrom(RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_6,
+            RestrictedIndicesNames.INTERNAL_SECURITY_MAIN_INDEX_7);
+        String backingIndex = DataStream.getDefaultBackingIndexName("adatastream1", 1);
+        Metadata metadata = Metadata.builder()
+            .put(new IndexMetadata.Builder("a1").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("a2").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("aaaaaa").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("bbbbb").settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new IndexMetadata.Builder("b")
+                .settings(indexSettings)
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(new AliasMetadata.Builder("ab").build())
+                .putAlias(new AliasMetadata.Builder("ba").build())
+                .build(), true)
+            .put(new IndexMetadata.Builder(internalSecurityIndex)
+                .settings(indexSettings)
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(new AliasMetadata.Builder(RestrictedIndicesNames.SECURITY_MAIN_ALIAS).build())
+                .build(), true)
+            .put(new IndexMetadata.Builder(backingIndex).settings(indexSettings).numberOfShards(1).numberOfReplicas(0).build(), true)
+            .put(new DataStream("adatastream1", createTimestampField("@timestamp"),
+                List.of(new Index(DataStream.getDefaultBackingIndexName("adatastream1", 1), "_na_"))))
+            .build();
+        final PlainActionFuture<Role> future = new PlainActionFuture<>();
+        final Set<RoleDescriptor> descriptors = Sets.newHashSet(aStarRole, bRole);
+        CompositeRolesStore.buildRoleFromDescriptors(descriptors, new FieldPermissionsCache(Settings.EMPTY), null, future);
+        Role roles = future.actionGet();
+        TransportRequest request = new ResolveIndexAction.Request(new String[]{"a*"});
+        AuthorizationEngine.RequestInfo requestInfo = new AuthorizationEngine.RequestInfo(null, request, SearchAction.NAME);
+        List<String> list =
+            RBACEngine.resolveAuthorizedIndicesFromRole(roles, requestInfo, metadata.getIndicesLookup());
+        assertThat(list, containsInAnyOrder("a1", "a2", "aaaaaa", "b", "ab", "adatastream1"));
+        assertFalse(list.contains("bbbbb"));
+        assertFalse(list.contains("ba"));
+        assertThat(list, not(contains(internalSecurityIndex)));
+        assertThat(list, not(contains(RestrictedIndicesNames.SECURITY_MAIN_ALIAS)));
     }
 
     public static AuthorizationEngine.RequestInfo getRequestInfo(String action) {


### PR DESCRIPTION
Most of the work around the addition of an `includeDataStreams` flag was done in #58381. The remainder of this PR adds the flag to the appropriate request classes, updates `IndexNameExpressionResolver` to rely on the flag rather than a separate boolean flag, and updates tests.

~~This PR adds an `includeDataStreams` flag to the `IndicesRequest` interface so that it is available when `AuthorizationEngine::loadAuthorizedIndices` is called. This is necessary to avoid different behaviors when security is enabled and disabled.~~

~~The disparate behavior is described in the referenced issue. When a `GET */_alias` request (or any other request that does not operate on data streams) is sent without security enabled, any data streams present are ignored by the `IndexNameExpressionResolver` class and the correct HTTP 200 response is returned.~~

~~When security _is_ enabled, the star in `GET */_alias` is first resolved to all authorized indices, aliases, and data streams. Because the `_alias` endpoint does not understand data streams, the first data stream it encounters among the list of authorized indices is treated as an alias and an incorrect 404 for "unknown alias" is returned.~~

~~This PR changes `AuthorizationService` to selectively exclude (in the case of most requests) or include (and the case of `ResolveIndexAction.Request` and other requests that opt in) data streams during the authorized index resolution phase.~~

~~Especially interested in feedback from @elastic/es-security.~~

Fixes https://github.com/elastic/elasticsearch/issues/57712

Relates to #53100 
