### PR TITLE
Fix off-by-one on CCR leases

### DIFF
--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -603,7 +603,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                 // we assert that retention leases are being advanced
                 assertThat(
                         retentionLease.retainingSequenceNumber(),
-                        equalTo(leaderGlobalCheckpoints.get(shardsStats.get(i).getShardRouting().id())));
+                        equalTo(leaderGlobalCheckpoints.get(shardsStats.get(i).getShardRouting().id()) + 1));
             }
         });
     }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -452,7 +452,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                                     CcrRetentionLeases.asyncAddRetentionLease(
                                         params.getLeaderShardId(),
                                         retentionLeaseId,
-                                        followerGlobalCheckpoint.getAsLong(),
+                                        followerGlobalCheckpoint.getAsLong() + 1,
                                         remoteClient(params),
                                         wrappedListener);
                                 } catch (NoSuchRemoteClusterException rce) {
@@ -477,7 +477,7 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
                                 CcrRetentionLeases.asyncRenewRetentionLease(
                                         params.getLeaderShardId(),
                                         retentionLeaseId,
-                                        followerGlobalCheckpoint.getAsLong(),
+                                        followerGlobalCheckpoint.getAsLong() + 1,
                                         remoteClient(params),
                                         listener);
                             }


### PR DESCRIPTION
The leases issued by CCR keep one extra operation around on the leader shards. This is not harmful to the leader cluster, but means that there's potentially one delete that can't be cleaned up.

I've noticed this while looking at the diagnostics output of a cluster and seeing CCR and peer recovery retention leases side-by-side.