### PR TITLE
[Draft] Early releasing of read operations for searchable snapshots cached files

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/SearchableSnapshotDirectory.java
@@ -363,10 +363,14 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         return this.getClass().getSimpleName() + "@snapshotId=" + snapshotId + " lockFactory=" + lockFactory;
     }
 
+    public Executor executor() {
+        return threadPool.executor(SEARCHABLE_SNAPSHOTS_THREAD_POOL_NAME);
+    }
+
     private void prewarmCache() {
         if (prewarmCache) {
             final BlockingQueue<Tuple<ActionListener<Void>, CheckedRunnable<Exception>>> queue = new LinkedBlockingQueue<>();
-            final Executor executor = threadPool.executor(SEARCHABLE_SNAPSHOTS_THREAD_POOL_NAME);
+            final Executor executor = executor();
 
             for (BlobStoreIndexShardSnapshot.FileInfo file : snapshot().indexFiles()) {
                 if (file.metadata().hashEqualsContents() || isExcludedFromCache(file.physicalName())) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
@@ -30,6 +30,7 @@ import java.nio.channels.FileChannel;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
@@ -138,15 +139,19 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
             final long pos = position + totalBytesRead;
             final int len = length - totalBytesRead;
             int bytesRead = 0;
+
+            final Tuple<Long, Long> range = computeRange(pos);
             try {
                 final CacheFile cacheFile = getCacheFileSafe();
-                try (ReleasableLock ignored = cacheFile.fileLock()) {
-                    final Tuple<Long, Long> range = computeRange(pos);
-                    bytesRead = cacheFile.fetchRange(
+                try (ReleasableLock lock = cacheFile.fileLock()) {
+                    bytesRead = cacheFile.fetchAsync(
                         range.v1(),
                         range.v2(),
-                        (start, end) -> readCacheFile(cacheFile.getChannel(), end, pos, b, len),
-                        (start, end) -> writeCacheFile(cacheFile.getChannel(), start, end)
+                        pos,
+                        Math.min(pos + len, range.v2()),
+                        (channel) -> readCacheFile(channel, pos, b),
+                        this::writeCacheFile,
+                        directory.executor()
                     ).get();
                 }
             } catch (final Exception e) {
@@ -225,21 +230,22 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                         assert totalBytesRead + remainingBytes == rangeLength;
                         final int bytesRead = readSafe(input, copyBuffer, rangeStart, rangeEnd, remainingBytes, cacheFileReference);
                         final long readStart = rangeStart + totalBytesRead;
-                        cacheFile.fetchRange(readStart, readStart + bytesRead, (start, end) -> {
+                        final long readEnd = readStart + bytesRead;
+                        cacheFile.fetch(readStart, readEnd, (channel) -> {
                             logger.trace(
                                 "prefetchPart: range [{}-{}] of file [{}] is available in cache",
-                                start,
-                                end,
+                                readStart,
+                                readEnd,
                                 fileInfo.physicalName()
                             );
-                            return Math.toIntExact(end - start);
-                        }, (start, end) -> {
+                            return Math.toIntExact(readEnd - readStart);
+                        }, (channel, start, end, monitor) -> {
                             final ByteBuffer byteBuffer = ByteBuffer.wrap(
                                 copyBuffer,
                                 Math.toIntExact(start - readStart),
                                 Math.toIntExact(end - start)
                             );
-                            final int writtenBytes = positionalWrite(fc, start, byteBuffer);
+                            final int writtenBytes = positionalWrite(channel, start, byteBuffer);
                             logger.trace(
                                 "prefetchPart: writing range [{}-{}] of file [{}], [{}] bytes written",
                                 start,
@@ -248,6 +254,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                                 writtenBytes
                             );
                             totalBytesWritten.addAndGet(writtenBytes);
+                            monitor.accept(start + writtenBytes);
                         });
                         totalBytesRead += bytesRead;
                         remainingBytes -= bytesRead;
@@ -318,30 +325,33 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
         return true;
     }
 
-    private int readCacheFile(FileChannel fc, long end, long position, ByteBuffer b, long length) throws IOException {
+    private int readCacheFile(FileChannel fc, long position, ByteBuffer buffer) throws IOException {
         assert assertFileChannelOpen(fc);
-        final int bytesRead;
-
-        assert b.remaining() == length;
-        if (end - position < b.remaining()) {
-            final ByteBuffer duplicate = b.duplicate();
-            duplicate.limit(b.position() + Math.toIntExact(end - position));
-            bytesRead = Channels.readFromFileChannel(fc, position, duplicate);
-            assert duplicate.position() < b.limit();
-            b.position(duplicate.position());
-        } else {
-            bytesRead = Channels.readFromFileChannel(fc, position, b);
-        }
+        logger.trace(
+            () -> new ParameterizedMessage(
+                "reading range [{}-{}] from cache file [{}]",
+                position,
+                position + buffer.remaining(),
+                cacheFileReference
+            )
+        );
+        final int bytesRead = Channels.readFromFileChannel(fc, position, buffer);
         if (bytesRead == -1) {
             throw new EOFException(
-                String.format(Locale.ROOT, "unexpected EOF reading [%d-%d] from %s", position, position + length, cacheFileReference)
+                String.format(
+                    Locale.ROOT,
+                    "unexpected EOF reading [%d-%d] from %s",
+                    position,
+                    position + buffer.remaining(),
+                    cacheFileReference
+                )
             );
         }
         stats.addCachedBytesRead(bytesRead);
         return bytesRead;
     }
 
-    private void writeCacheFile(FileChannel fc, long start, long end) throws IOException {
+    private void writeCacheFile(FileChannel fc, long start, long end, Consumer<Long> progressUpdater) throws IOException {
         assert assertFileChannelOpen(fc);
         final long length = end - start;
         final byte[] copyBuffer = new byte[Math.toIntExact(Math.min(COPY_BUFFER_SIZE, length))];
@@ -356,6 +366,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
                 positionalWrite(fc, start + bytesCopied, ByteBuffer.wrap(copyBuffer, 0, bytesRead));
                 bytesCopied += bytesRead;
                 remaining -= bytesRead;
+                progressUpdater.accept(start + bytesCopied);
             }
             final long endTimeNanos = stats.currentTimeNanos();
             stats.addCachedBytesWritten(bytesCopied, endTimeNanos - startTimeNanos);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/ProgressListenableActionFuture.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/ProgressListenableActionFuture.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.index.store.cache;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.support.AdapterActionFuture;
+import org.elasticsearch.common.collect.Tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProgressListenableActionFuture<T> extends AdapterActionFuture<T, T> implements ListenableActionFuture<T> {
+
+    private final long start;
+    private final long end;
+
+    // modified under 'this' mutex
+    private volatile List<Tuple<Long, ActionListener<T>>> listeners;
+    private boolean executedListeners;
+    private long current;
+
+    private ProgressListenableActionFuture(final long start, final long end) {
+        super();
+        assert start < end : start + '-' + end;
+        this.executedListeners = false;
+        this.start = start;
+        this.end = end;
+        this.current = start;
+    }
+
+    public static <T> ProgressListenableActionFuture<T> newProgressListenableActionFuture(long start, long end) {
+        return new ProgressListenableActionFuture<>(start, end);
+    }
+
+    public void onProgress(final long progress) {
+        assert executedListeners == false;
+        assert start <= progress : start + "<=" + progress;
+        assert progress < end : progress + '<' + end;
+
+        List<ActionListener<T>> listenersToExecute = null;
+        synchronized (this) {
+            current = progress;
+
+            final List<Tuple<Long, ActionListener<T>>> listeners = this.listeners;
+            if (listeners == null || listeners.isEmpty()) {
+                return;
+            }
+
+            List<Tuple<Long, ActionListener<T>>> listenersToKeep = null;
+            for(Tuple<Long, ActionListener<T>> listener : listeners) {
+                if (listener.v1() <= current) {
+                    if (listenersToExecute == null) {
+                        listenersToExecute = new ArrayList<>();
+                    }
+                    listenersToExecute.add(listener.v2());
+                } else {
+                    if (listenersToKeep == null) {
+                        listenersToKeep = new ArrayList<>();
+                    }
+                    listenersToKeep.add(listener);
+                }
+            }
+            this.listeners = listenersToKeep;
+            assert this.listeners == null || this.listeners.stream().allMatch(listener -> this.current < listener.v1());
+        }
+
+        if (listenersToExecute != null) {
+            listenersToExecute.forEach(this::executeListener);
+        }
+    }
+
+    @Override
+    protected void done() {
+        super.done();
+        synchronized (this) {
+            executedListeners = true;
+        }
+        listeners.stream().map(Tuple::v2).forEach(this::executeListener);
+    }
+
+    @Override
+    public void addListener(final ActionListener<T> listener) {
+        addListener(end, listener);
+    }
+
+    public void addListener(long position, ActionListener<T> listener) {
+        boolean executeImmediate = false;
+        synchronized (this) {
+            if (executedListeners) {
+                executeImmediate = true;
+            } else if (position <= current) {
+                executeImmediate = true;
+            } else {
+                List<Tuple<Long, ActionListener<T>>> listeners = this.listeners;
+                if (listeners == null) {
+                    listeners = new ArrayList<>();
+                }
+                listeners.add(Tuple.tuple(position, listener));
+                this.listeners = listeners;
+            }
+        }
+        if (executeImmediate) {
+            executeListener(listener);
+        }
+    }
+
+    private void executeListener(final ActionListener<T> listener) {
+        try {
+            // we use a timeout of 0 to by pass assertion forbidding to call actionGet() (blocking) on a network thread.
+            // here we know we will never block
+            listener.onResponse(actionGet(0));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    @Override
+    protected T convert(T listenerResponse) {
+        return listenerResponse;
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/index/store/cache/SparseFileTrackerTests.java
@@ -111,7 +111,7 @@ public class SparseFileTrackerTests extends ESTestCase {
                 if (gapIndex == gaps.size() - 1) {
                     expectNotification.set(true);
                 }
-                gap.onResponse(null);
+                gap.onCompletion();
             }
             assertTrue(wasNotified.get());
         }
@@ -270,8 +270,9 @@ public class SparseFileTrackerTests extends ESTestCase {
         } else {
             for (long i = gap.start; i < gap.end; i++) {
                 fileContents[Math.toIntExact(i)] = AVAILABLE;
+                gap.onProgress(i);
             }
-            gap.onResponse(null);
+            gap.onCompletion();
         }
     }
 }


### PR DESCRIPTION
Today when a searchable snapshot directory wants to read few bytes from a cached index input, it has to wait for a full 32MB range to be downloaded and written to disk before being able to read the bytes it wants. It makes the opening of a searchable snapshot directory pretty slow every time a large file needs to be read for a header or a footer checksum. It is also not optimized for the case the range of bytes to read are already cached but still have to wait for the complete gap(s) to be filled until the read be processed.

This pull request proposes to allow read operations to be released earlier, as soon as the required bytes to satisfy the operation have been written on disk (while the downloading/writing to cache still continue in the background). 

In order to do that, the `SparseFileTracker` has been modified so that it allows to compute available or missing ranges on a large range (ie the range to write) while registering the listener to call as soon as a smaller range is available (ie the range to read). The writing method must then update the progress during writing so that listeners call be released sooner.

Manual tests show the following results when mounting the usual testing snapshots (max restore by per sec set to -1):

Snapshot | # shards | master (no prewarm) | draft (no prewarm) | master (prewarm) | draft (prewarm) |
--|--|--|--|--|--|
geonames | 1 |5779ms|3398ms|9132ms|9199ms|
nyc_taxis | 1 |75627ms|49996ms|87194ms|87783ms|
pmc | 6 |3167ms 3654ms 3238ms 3344ms 3015ms 3228ms|2397ms 2429ms 2211ms 2584ms 2001ms 2312ms|15349ms 13766ms 14459ms 15544ms 28587ms 28306ms|23613ms 24241ms 24391ms 23895ms 19117ms 19186ms|

Note: this is lacking of tests and some corners were cut but I opened this draft to show what I had in mind. Some search requests can also benefit from early releasing of read operations.