### PR TITLE
Handle Class.getProtectionDomain() returning null

### DIFF
--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 import java.net.URL;
 import java.security.CodeSource;
+import java.security.ProtectionDomain;
 import java.util.Objects;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
@@ -191,7 +192,8 @@ public class Build {
      * @return the location of the code source for Elasticsearch which may be null
      */
     static URL getElasticsearchCodeSourceLocation() {
-        final CodeSource codeSource = Build.class.getProtectionDomain().getCodeSource();
+        final ProtectionDomain protectionDomain = Build.class.getProtectionDomain();
+        final CodeSource codeSource = protectionDomain == null ? null : protectionDomain.getCodeSource();
         return codeSource == null ? null : codeSource.getLocation();
     }
 

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -192,6 +192,8 @@ public class Build {
      * @return the location of the code source for Elasticsearch which may be null
      */
     static URL getElasticsearchCodeSourceLocation() {
+        // getProtectionDomain() is not implemented in Android's version of Java.
+        // https://stackoverflow.com/q/27790348
         final ProtectionDomain protectionDomain = Build.class.getProtectionDomain();
         final CodeSource codeSource = protectionDomain == null ? null : protectionDomain.getCodeSource();
         return codeSource == null ? null : codeSource.getLocation();


### PR DESCRIPTION
Closes #58075. This method isn't implemented on the Android JVM, and
always returns null.
