### PR TITLE
[7.x] Prohibit freezing the write index of a data stream

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
@@ -132,3 +132,36 @@
             foo: hello
 
 - match: {hits.total: 1}
+
+---
+"Cannot freeze write index for data stream":
+  - skip:
+      version: " - 7.99.99"
+      reason: "change to 7.8.99 after backporting"
+      features: allowed_warnings
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [simple-data-stream1]
+          data_stream:
+            timestamp_field: '@timestamp'
+
+  - do:
+      indices.create_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+
+  - do:
+      catch: bad_request
+      indices.freeze:
+        index: ".ds-simple-data-stream1-000001"
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-data-stream1
+  - is_true: acknowledged
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/indices.freeze/10_basic.yml
@@ -147,6 +147,11 @@
         name: my-template1
         body:
           index_patterns: [simple-data-stream1]
+          template:
+            mappings:
+              properties:
+                '@timestamp':
+                  type: date
           data_stream:
             timestamp_field: '@timestamp'
 


### PR DESCRIPTION
Note that the prohibition on closing the write index already effectively blocked the freezing of write indices. This PR formalizes that requirement with a test to verify that behavior.

Relates to #53100

Backport of #57931 
Also includes backport of #58115