### PR TITLE
Add OpenJDK distribution to external dependency report

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/ConcatFilesTask.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/ConcatFilesTask.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileTree;
@@ -49,6 +51,8 @@ public class ConcatFilesTask extends DefaultTask {
     private String headerLine;
 
     private File target;
+
+    private List<String> additionalLines = new ArrayList<>();
 
     public void setFiles(FileTree files) {
         this.files = files;
@@ -78,6 +82,15 @@ public class ConcatFilesTask extends DefaultTask {
         return target;
     }
 
+    @Input
+    public List<String> getAdditionalLines() {
+        return additionalLines;
+    }
+
+    public void setAdditionalLines(List<String> additionalLines) {
+        this.additionalLines = additionalLines;
+    }
+
     @TaskAction
     public void concatFiles() throws IOException {
         if (getHeaderLine() != null) {
@@ -90,6 +103,10 @@ public class ConcatFilesTask extends DefaultTask {
             uniqueLines.addAll(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8));
         }
         Files.write(getTarget().toPath(), uniqueLines, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+
+        for (String additionalLine : additionalLines) {
+            Files.write(getTarget().toPath(), (additionalLine + '\n').getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+        }
     }
 
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -43,9 +43,9 @@ tasks.register("generateDependenciesReport", ConcatFilesTask) {
   target = new File(System.getProperty('csv') ?: "${project.buildDir}/reports/dependencies/es-dependencies.csv")
 
   // explicitly add our dependency on the JDK
-  def jdkVersion = VersionProperties.versions.get('bundled_jdk')
-  def jdkMajorVersion = jdkVersion.split('[+.]')[0]
-  def sourceUrl = "http://hg.openjdk.java.net/jdk-updates/jdk${jdkMajorVersion}u/archive/jdk-${jdkVersion}.tar.gz"
+  String jdkVersion = VersionProperties.versions.get('bundled_jdk')
+  String jdkMajorVersion = jdkVersion.split('[+.]')[0]
+  String sourceUrl = "http://hg.openjdk.java.net/jdk-updates/jdk${jdkMajorVersion}u/archive/jdk-${jdkVersion}.tar.gz"
   additionalLines << "OpenJDK,${jdkVersion},https://openjdk.java.net/,GPL-2.0-with-classpath-exception,${sourceUrl}".toString()
 }
 

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -41,6 +41,12 @@ tasks.register("generateDependenciesReport", ConcatFilesTask) {
   files = fileTree(dir: project.rootDir, include: '**/dependencies.csv')
   headerLine = "name,version,url,license,sourceURL"
   target = new File(System.getProperty('csv') ?: "${project.buildDir}/reports/dependencies/es-dependencies.csv")
+
+  // explicitly add our dependency on the JDK
+  def jdkVersion = VersionProperties.versions.get('bundled_jdk')
+  def jdkMajorVersion = jdkVersion.split('[+.]')[0]
+  def sourceUrl = "http://hg.openjdk.java.net/jdk-updates/jdk${jdkMajorVersion}u/archive/jdk-${jdkVersion}.tar.gz"
+  additionalLines << "OpenJDK,${jdkVersion},https://openjdk.java.net/,GPL-2.0-with-classpath-exception,${sourceUrl}".toString()
 }
 
 /*****************************************************************************


### PR DESCRIPTION
As described in [this comment](https://github.com/elastic/infra/issues/17085#issuecomment-644851457) we now want to leverage our new method of reporting third party dependencies for distributing bundled JDK sources. This PR appends the OpenJDK dependency to our dependency report so that the new release-manager infrastructure will fetch the sources archive as defined in the CSV file and make it available from the dependency report page.

Relates to https://github.com/elastic/infra/issues/17085

CC @tomcallahan 