### PR TITLE
Rename SearchContext#smartNameFieldType.

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -774,7 +774,7 @@ final class DefaultSearchContext extends SearchContext {
     }
 
     @Override
-    public MappedFieldType smartNameFieldType(String name) {
+    public MappedFieldType fieldType(String name) {
         return mapperService().fieldType(name);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -116,7 +116,7 @@ public class FetchPhase implements SearchPhase {
 
                 Collection<String> fieldNames = context.mapperService().simpleMatchToFullName(fieldNameOrPattern);
                 for (String fieldName : fieldNames) {
-                    MappedFieldType fieldType = context.smartNameFieldType(fieldName);
+                    MappedFieldType fieldType = context.fieldType(fieldName);
                     if (fieldType == null) {
                         // Only fail if we know it is a object field, missing paths / fields shouldn't fail.
                         if (context.getObjectMapper(fieldName) != null) {

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -497,8 +497,8 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public MappedFieldType smartNameFieldType(String name) {
-        return in.smartNameFieldType(name);
+    public MappedFieldType fieldType(String name) {
+        return in.fieldType(name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -388,9 +388,9 @@ public abstract class SearchContext extends AbstractRefCounted implements Releas
     }
 
     /**
-     * Looks up the given field, but does not restrict to fields in the types set on this context.
+     * Given the full name of a field, returns its {@link MappedFieldType}.
      */
-    public abstract MappedFieldType smartNameFieldType(String name);
+    public abstract MappedFieldType fieldType(String name);
 
     public abstract ObjectMapper getObjectMapper(String name);
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -176,7 +176,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             MappedFieldType fieldType = entry.getValue();
 
             when(mapperService.fieldType(fieldName)).thenReturn(fieldType);
-            when(searchContext.smartNameFieldType(fieldName)).thenReturn(fieldType);
+            when(searchContext.fieldType(fieldName)).thenReturn(fieldType);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -578,7 +578,7 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public MappedFieldType smartNameFieldType(String name) {
+    public MappedFieldType fieldType(String name) {
         if (mapperService() != null) {
             return mapperService().fieldType(name);
         }


### PR DESCRIPTION
The concept of a 'smart name' doesn't make sense now that there are no mapping
types.
