### PR TITLE
Fix replication operation transient retry test

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -561,8 +561,8 @@ public class ReplicationOperationTests extends ESTestCase {
         final long maxSeqNoOfUpdatesOrDeletes;
         final Supplier<ReplicationGroup> replicationGroupSupplier;
         final PendingReplicationActions pendingReplicationActions;
-        final Map<String, Long> knownLocalCheckpoints = new HashMap<>();
-        final Map<String, Long> knownGlobalCheckpoints = new HashMap<>();
+        final Map<String, Long> knownLocalCheckpoints = Collections.synchronizedMap(new HashMap<>());
+        final Map<String, Long> knownGlobalCheckpoints = Collections.synchronizedMap(new HashMap<>());
 
         TestPrimary(ShardRouting routing, Supplier<ReplicationGroup> replicationGroupSupplier, ThreadPool threadPool) {
             this.routing = routing;


### PR DESCRIPTION
After the work to retry transient replication failures, the local and
global checkpoint test metadata can be incremented on a different thread
than the test thread. This appears to introduce an extremely rare
scenario where this data is not visible for later test assertions. This
commit fixes the issue by using synchronized maps.

Fixes #57938.