### PR TITLE
[DOCS] Fixes license management links

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -20,7 +20,7 @@ This getting-started guide for {ccr} shows you how to:
 
 . Obtain a license that includes the {ccr} features. See
   https://www.elastic.co/subscriptions[subscriptions] and
-  {stack-ov}/license-management.html[License-management].
+  {kibana-ref}/managing-licenses.html[License management].
 
 . If the Elastic {security-features} are enabled in your local and remote
   clusters, you need a user that has appropriate authority to perform the steps

--- a/docs/reference/high-availability/cluster-design.asciidoc
+++ b/docs/reference/high-availability/cluster-design.asciidoc
@@ -260,12 +260,11 @@ more than one zone.
 
 You should consider all node roles and ensure that each role is split
 redundantly across two or more zones. For instance, if you are using
-<<ingest,ingest pipelines>> or {stack-ov}/xpack-ml.html[{ml}],
-you should have ingest or {ml} nodes in two or more zones. However,
-the placement of master-eligible nodes requires a little more care because a
-resilient cluster needs at least two of the three master-eligible nodes in
-order to function. The following sections explore the options for placing
-master-eligible nodes across multiple zones.
+<<ingest,ingest pipelines>> or {ml}, you should have ingest or {ml} nodes in two
+or more zones. However, the placement of master-eligible nodes requires a little
+more care because a resilient cluster needs at least two of the three
+master-eligible nodes in order to function. The following sections explore the
+options for placing master-eligible nodes across multiple zones.
 
 [[high-availability-cluster-design-two-zones]]
 ==== Two-zone clusters

--- a/docs/reference/settings/license-settings.asciidoc
+++ b/docs/reference/settings/license-settings.asciidoc
@@ -4,7 +4,7 @@
 
 You can configure this licensing setting in the `elasticsearch.yml` file.
 For more information, see
-{stack-ov}/license-management.html[License management].
+{kibana-ref}/managing-licenses.html[License management].
 
 `xpack.license.self_generated.type`::
 Set to `basic` (default) to enable basic {xpack} features. +

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -11,7 +11,7 @@ https://github.com/elastic/elasticsearch/blob/{branch}/distribution/docker[Githu
 
 These images are free to use under the Elastic license. They contain open source
 and free commercial features and access to paid commercial features.
-{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the
+{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the
 paid commercial features. See the
 https://www.elastic.co/subscriptions[Subscriptions] page for information about
 Elastic license levels.

--- a/docs/reference/setup/install/license.asciidoc
+++ b/docs/reference/setup/install/license.asciidoc
@@ -1,6 +1,6 @@
 This package is free to use under the Elastic license. It contains open source 
 and free commercial features and access to paid commercial features.  
-{stack-ov}/license-management.html[Start a 30-day trial] to try out all of the 
+{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -16,7 +16,7 @@ auditing. For more information, see
 +
 --
 For more information, see https://www.elastic.co/subscriptions and
-{stack-ov}/license-management.html[License management].
+{kibana-ref}/managing-licenses.html[License management].
 --
 
 . Verify that the `xpack.security.enabled` setting is `true` on each node in

--- a/x-pack/docs/en/security/get-started-security.asciidoc
+++ b/x-pack/docs/en/security/get-started-security.asciidoc
@@ -20,7 +20,7 @@ authentication {security-features}. When you install these products, they apply
 basic licenses with no expiration dates. All of the subsequent steps in this
 tutorial assume that you are using a basic license. For more information, see
 {subscriptions} and
-{stack-ov}/license-management.html[License-management].
+{kibana-ref}/managing-licenses.html[License management].
 
 --
 

--- a/x-pack/docs/en/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -40,7 +40,7 @@ IMPORTANT: To complete this tutorial, you must install the default {es} and
 When you install these products, they apply basic licenses with no expiration
 dates. All of the subsequent steps in this tutorial assume that you are using a
 basic license. For more information, see {subscriptions} and
-{stack-ov}/license-management.html[License-management].
+{kibana-ref}/managing-licenses.html[License management].
 
 include::tutorial-tls-certificates.asciidoc[]
 include::tutorial-tls-internode.asciidoc[]

--- a/x-pack/docs/en/watcher/getting-started.asciidoc
+++ b/x-pack/docs/en/watcher/getting-started.asciidoc
@@ -5,7 +5,7 @@
 TIP: To complete these steps, you must obtain a license that includes the
 {alert-features}. For more information about Elastic license levels, see 
 https://www.elastic.co/subscriptions and
-{stack-ov}/license-management.html[License management].
+{kibana-ref}/managing-licenses.html[License management].
 
 [[watch-log-data]]
 To set up a watch to start sending alerts:


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1870

This PR fixes out-dated links to the Stack Overview book, which is no longer used.

### Preview

https://elasticsearch_58213.docs-preview.app.elstc.co/diff
