### PR TITLE
Fix DanglingIndicesIT Failures from MasterNotDiscoveredException

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -240,8 +240,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
         final String danglingIndexUUID = findDanglingIndexForNode(stoppedNodeName, INDEX_NAME);
 
         final ImportDanglingIndexRequest request = new ImportDanglingIndexRequest(danglingIndexUUID, true);
-
-        client().admin().cluster().importDanglingIndex(request).actionGet();
+        client().admin().cluster().importDanglingIndex(request).get();
 
         assertTrue("Expected dangling index " + INDEX_NAME + " to be recovered", indexExists(INDEX_NAME));
     }
@@ -480,6 +479,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
 
         AtomicReference<String> stoppedNodeName = new AtomicReference<>();
 
+        final int nodes = internalCluster().size();
         // Restart node, deleting the indices in its absence, so that there is a dangling index to recover
         internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
 
@@ -493,6 +493,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
                 return super.onNodeStopped(nodeName);
             }
         });
+        ensureStableCluster(nodes);
 
         return stoppedNodeName.get();
     }


### PR DESCRIPTION
The dangling indices action is not a proper master node action (I guess part of it could be made one to avoid this kind of issue but for now I just fixed the test instead) so it does not retry when executed while the cluster hasn't fully formed yet.
Since we use node restarts when setting up the dangling indices state we need
to manually ensure a fully formed cluster before moving on with the tests to avoid
failures.

example failure:
https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request-1/1570/testReport/junit/org.elasticsearch.indices.recovery/DanglingIndicesIT/testDanglingIndicesCanBeImported/