### PR TITLE
Check for degenerated lines when calculating the centroid

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/CentroidCalculatorTests.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.xpack.spatial.index.fielddata.DimensionalShapeTy
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class CentroidCalculatorTests extends ESTestCase {
     private static final double DELTA = 0.000000001;
@@ -190,6 +191,13 @@ public class CentroidCalculatorTests extends ESTestCase {
         }
     }
 
+    public void testRectangle() {
+        for (int i = 0; i < 100; i++) {
+            CentroidCalculator calculator = new CentroidCalculator(GeometryTestUtils.randomRectangle());
+            assertThat(calculator.sumWeight(), greaterThan(0.0));
+        }
+    }
+
     public void testLineAsClosedPoint() {
         double lon = GeometryTestUtils.randomLon();
         double lat = GeometryTestUtils.randomLat();
@@ -250,7 +258,7 @@ public class CentroidCalculatorTests extends ESTestCase {
         CentroidCalculator calculator = new CentroidCalculator(polygon);
         assertThat(calculator.getX(), equalTo(GeoUtils.normalizeLon(point.getX())));
         assertThat(calculator.getY(), equalTo(GeoUtils.normalizeLat(point.getY())));
-        assertThat(calculator.sumWeight(), equalTo(1.0));
+        assertThat(calculator.sumWeight(), equalTo(3.0));
         assertThat(calculator.getDimensionalShapeType(), equalTo(POINT));
     }
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
@@ -255,7 +255,6 @@ public class TriangleTreeTests extends ESTestCase {
         assertRelation(GeoRelation.QUERY_CROSSES, reader, getExtentFromBox(xMin, yMin, xMax, yMax));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/56755")
     public void testRandomMultiLineIntersections() throws IOException {
         GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
         MultiLine geometry = randomMultiLine(false);


### PR DESCRIPTION
Check that the weight of a line centroid is bigger than 0. In case it is 0, the centroid is calculated as if the line is a point.

backport #58027
fixes #56755