### PR TITLE
Minor Snapshot Code Cleanups

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -54,7 +54,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
     }
 
     public SnapshotDeletionsInProgress(StreamInput in) throws IOException {
-        this.entries = Collections.unmodifiableList(in.readList(Entry::new));
+        this(Collections.unmodifiableList(in.readList(Entry::new)));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -335,6 +335,8 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
     public static class ShardSnapshotStatus {
         private final ShardState state;
+
+        @Nullable
         private final String nodeId;
 
         @Nullable
@@ -347,11 +349,11 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             this(nodeId, ShardState.INIT, generation);
         }
 
-        public ShardSnapshotStatus(String nodeId, ShardState state, String generation) {
+        public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, @Nullable String generation) {
             this(nodeId, state, null, generation);
         }
 
-        public ShardSnapshotStatus(String nodeId, ShardState state, String reason, String generation) {
+        public ShardSnapshotStatus(@Nullable String nodeId, ShardState state, @Nullable String reason, @Nullable String generation) {
             this.nodeId = nodeId;
             this.state = state;
             this.reason = reason;
@@ -375,14 +377,17 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             return state;
         }
 
+        @Nullable
         public String nodeId() {
             return nodeId;
         }
 
+        @Nullable
         public String generation() {
             return this.generation;
         }
 
+        @Nullable
         public String reason() {
             return reason;
         }
@@ -469,7 +474,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
     }
 
     public SnapshotsInProgress(Entry... entries) {
-        this.entries = Arrays.asList(entries);
+        this(Arrays.asList(entries));
     }
 
     public List<Entry> entries() {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -655,9 +655,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     }
 
     /**
-     * Finalizes the shard in repository and then removes it from cluster state
-     * <p>
-     * This is non-blocking method that runs on a thread from SNAPSHOT thread pool
+     * Finalizes the snapshot in the repository.
      *
      * @param entry snapshot
      */


### PR DESCRIPTION
Adding some missing nullable annotations, move to single primary
constructor in two spots and simplify listener handling in snapshot delete.

Mainly motivated by reducing the size of the diff in #56911
