### PR TITLE
Add new extensions for Lucene86 points codec to FsDirectoryFactory

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -160,7 +160,10 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 // We want to open the terms index and KD-tree index off-heap to save memory, but this only performs
                 // well if using mmap.
                 case "tip":
+                // dim files only apply up to lucene 8.x indices. It can be removed once we are in lucene 10
                 case "dim":
+                case "kdd":
+                case "kdi":
                 // Compound files are tricky because they store all the information for the segment. Benchmarks
                 // suggested that not mapping them hurts performance.
                 case "cfs":

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -64,6 +64,8 @@ public class FsDirectoryFactoryTests extends ESTestCase {
             assertTrue(hybridDirectory.useDelegate("foo.tip"));
             assertTrue(hybridDirectory.useDelegate("foo.cfs"));
             assertTrue(hybridDirectory.useDelegate("foo.dim"));
+            assertTrue(hybridDirectory.useDelegate("foo.kdd"));
+            assertTrue(hybridDirectory.useDelegate("foo.kdi"));
             assertFalse(hybridDirectory.useDelegate("foo.bar"));
             MMapDirectory delegate = hybridDirectory.getDelegate();
             assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));


### PR DESCRIPTION
LUCENE-9148 introduces a new codec for points which changes the extension of the files generated by the BKD index. In order to be MMAP we should update the mapping in the FsDirectoryFactory.

backport #58226