### PR TITLE
Do not wrap CacheFile reentrant r/w locks with ReleasableLock

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -48,8 +48,8 @@ public class CacheFile {
         }
     };
 
-    private final ReleasableLock evictionLock;
-    private final ReleasableLock readLock;
+    private final ReentrantReadWriteLock.WriteLock evictionLock;
+    private final ReentrantReadWriteLock.ReadLock readLock;
 
     private final SparseFileTracker tracker;
     private final String description;
@@ -69,8 +69,8 @@ public class CacheFile {
         this.evicted = false;
 
         final ReentrantReadWriteLock cacheLock = new ReentrantReadWriteLock();
-        this.evictionLock = new ReleasableLock(cacheLock.writeLock());
-        this.readLock = new ReleasableLock(cacheLock.readLock());
+        this.evictionLock = cacheLock.writeLock();
+        this.readLock = cacheLock.readLock();
 
         assert invariant();
     }
@@ -85,7 +85,8 @@ public class CacheFile {
 
     ReleasableLock fileLock() {
         boolean success = false;
-        final ReleasableLock fileLock = readLock.acquire();
+        final ReleasableLock fileLock = new ReleasableLock(readLock);
+        fileLock.acquire();
         try {
             ensureOpen();
             // check if we have a channel while holding the read lock
@@ -112,7 +113,8 @@ public class CacheFile {
         ensureOpen();
         boolean success = false;
         if (refCounter.tryIncRef()) {
-            try (ReleasableLock ignored = evictionLock.acquire()) {
+            try {
+                evictionLock.lock();
                 try {
                     ensureOpen();
                     final Set<EvictionListener> newListeners = new HashSet<>(listeners);
@@ -122,9 +124,11 @@ public class CacheFile {
                     listeners = Collections.unmodifiableSet(newListeners);
                     success = true;
                 } finally {
-                    if (success == false) {
-                        refCounter.decRef();
-                    }
+                    evictionLock.unlock();
+                }
+            } finally {
+                if (success == false) {
+                    refCounter.decRef();
                 }
             }
         }
@@ -136,7 +140,8 @@ public class CacheFile {
         assert listener != null;
 
         boolean success = false;
-        try (ReleasableLock ignored = evictionLock.acquire()) {
+        evictionLock.lock();
+        try {
             try {
                 final Set<EvictionListener> newListeners = new HashSet<>(listeners);
                 final boolean removed = newListeners.remove(Objects.requireNonNull(listener));
@@ -152,6 +157,8 @@ public class CacheFile {
                     refCounter.decRef();
                 }
             }
+        } finally {
+            evictionLock.unlock();
         }
         assert invariant();
         return success;
@@ -171,12 +178,15 @@ public class CacheFile {
     public void startEviction() {
         if (evicted == false) {
             final Set<EvictionListener> evictionListeners = new HashSet<>();
-            try (ReleasableLock ignored = evictionLock.acquire()) {
+            evictionLock.lock();
+            try {
                 if (evicted == false) {
                     evicted = true;
                     evictionListeners.addAll(listeners);
                     refCounter.decRef();
                 }
+            } finally {
+                evictionLock.unlock();
             }
             evictionListeners.forEach(listener -> listener.onEviction(this));
         }
@@ -206,7 +216,8 @@ public class CacheFile {
     }
 
     private boolean invariant() {
-        try (ReleasableLock ignored = readLock.acquire()) {
+        readLock.lock();
+        try {
             assert listeners != null;
             if (listeners.isEmpty()) {
                 assert channel == null;
@@ -217,6 +228,8 @@ public class CacheFile {
                 assert channel.isOpen();
                 assert Files.exists(file);
             }
+        } finally {
+            readLock.unlock();
         }
         return true;
     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CacheFile.java
@@ -122,10 +122,13 @@ public class CacheFile {
                 listeners = Collections.unmodifiableSet(newListeners);
                 success = true;
             } finally {
-                if (success == false) {
-                    refCounter.decRef();
+                try {
+                    if (success == false) {
+                        refCounter.decRef();
+                    }
+                } finally {
+                    evictionLock.unlock();
                 }
-                evictionLock.unlock();
             }
         }
         assert invariant();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/index/store/cache/CachedBlobContainerIndexInput.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.Channels;
-import org.elasticsearch.common.util.concurrent.ReleasableLock;
+import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.store.BaseSearchableSnapshotIndexInput;
 import org.elasticsearch.index.store.IndexInputStats;
@@ -140,7 +140,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
             int bytesRead = 0;
             try {
                 final CacheFile cacheFile = getCacheFileSafe();
-                try (ReleasableLock ignored = cacheFile.fileLock()) {
+                try (Releasable ignored = cacheFile.fileLock()) {
                     final Tuple<Long, Long> range = computeRange(pos);
                     bytesRead = cacheFile.fetchRange(
                         range.v1(),
@@ -184,7 +184,7 @@ public class CachedBlobContainerIndexInput extends BaseSearchableSnapshotIndexIn
 
         try {
             final CacheFile cacheFile = getCacheFileSafe();
-            try (ReleasableLock ignored = cacheFile.fileLock()) {
+            try (Releasable ignored = cacheFile.fileLock()) {
 
                 final Tuple<Long, Long> range = cacheFile.getAbsentRangeWithin(partRange.v1(), partRange.v2());
                 if (range == null) {


### PR DESCRIPTION
Today the read/write locks used internally by `CacheFile` object are wrapped into a `ReleasableLock`. This is not strictly required and also prevents usage of the `tryLock()` methods which we would like to use for early releasing of read operations (#58164).