### PR TITLE
Fix Typo in Snapshot Abort Test (#58238)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1388,9 +1388,10 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             public void clusterChanged(ClusterChangedEvent event) {
                 final SnapshotsInProgress snapshotsInProgress = event.state().custom(SnapshotsInProgress.TYPE);
                 if (snapshotsInProgress != null && snapshotsInProgress.entries().stream()
-                        .anyMatch(entry -> entry.state() == SnapshotsInProgress.State.ABORTED))
-                abortVisibleFuture.onResponse(null);
-                clusterService.removeListener(this);
+                        .anyMatch(entry -> entry.state() == SnapshotsInProgress.State.ABORTED)) {
+                    abortVisibleFuture.onResponse(null);
+                    clusterService.removeListener(this);
+                }
             }
         });
 


### PR DESCRIPTION
Forgot the brackets here in #58214 so in the rare case where the
first update seen by the listener doesn't match it will still remove
itself and never be invoked again -> timeout.

backport of #58238 