### PR TITLE
WIP First draft for version field

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -105,6 +106,95 @@ public class SimpleSearchIT extends ESIntegTestCase {
 
         assertHitCount(search, 1L);
     }
+
+    public void testSimpleVersionRange() throws Exception {
+        prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
+        ensureGreen();
+
+        client().admin().indices().preparePutMapping("test")
+
+                .setSource(XContentFactory.jsonBuilder().startObject().startObject("_doc").startObject("properties")
+                        .startObject("versionrange").field("type", "version_range").endObject()
+                        .endObject().endObject().endObject())
+                .get();
+
+        client().prepareIndex("test")
+            .setId("1")
+            .setSource("{\"versionrange\":{\"gte\":\"1.1.0.0.0.0.0.0.0.0.1\",\"lte\":\"2.2.3\"}}", XContentType.JSON)
+            .setRefreshPolicy(IMMEDIATE)
+                .get();
+
+        client().prepareIndex("test")
+        .setId("2")
+        .setSource("{\"versionrange\":{\"gte\":\"4.0.0-beta.2\",\"lte\":\"4.0.0-rc5\"}}", XContentType.JSON)
+        .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        client().prepareIndex("test")
+        .setId("3")
+        .setSource("{\"versionrange\":{\"gte\":\"8.0.0-alpha.1\",\"lte\":\"8.0.0-alpha.9\"}}", XContentType.JSON)
+        .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        client().prepareIndex("test")
+        .setId("4")
+        .setSource("{\"versionrange\":{\"gte\":\"8.0.0-alpha.0\",\"lte\":\"8.0.0-alpha.0.1\"}}", XContentType.JSON)
+        .setRefreshPolicy(IMMEDIATE)
+            .get();
+
+        SearchResponse search = client().prepareSearch()
+                .setQuery(rangeQuery("versionrange").gte("0.1.6").lte("2.7.0").relation("within"))
+                .get();
+
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("1.1.6").lte("1.7.0").relation("contains"))
+            .get();
+
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("1.1.6").lte("3.7.0").relation("contains"))
+            .get();
+
+        assertHitCount(search, 0L);
+
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("1.8.6").lte("3.7.0").relation("intersects"))
+            .get();
+
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("3.0.0").lte("4.0.0").relation("within"))
+            .get();
+
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("3.0.0").lte("4.0.0-rc3").relation("within"))
+            .get();
+
+        assertHitCount(search, 0L);
+
+        search = client().prepareSearch()
+            .setQuery(termQuery("versionrange", "4.0.0-rc3"))
+            .get();
+
+        assertHitCount(search, 1L);
+
+        search = client().prepareSearch()
+            .setQuery(rangeQuery("versionrange").gte("8.0.0-alpha.2").lte("8.0.0-alpha.4").relation("contains"))
+            .get();
+
+        assertHitCount(search, 1L);
+    }
+
+
+
+
 
     public void testIpCidr() throws Exception {
         createIndex("test");

--- a/server/src/main/java/org/apache/lucene/document/VersionRangeField.java
+++ b/server/src/main/java/org/apache/lucene/document/VersionRangeField.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.lucene.document;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.FutureArrays;
+import org.elasticsearch.index.mapper.VersionEncoder;
+import org.elasticsearch.index.mapper.VersionEncoder.SortMode;
+
+public class VersionRangeField extends Field {
+
+    public static final int BYTES = 16;
+
+    private static final FieldType TYPE;
+    static {
+        TYPE = new FieldType();
+        TYPE.setDimensions(2, BYTES);
+        TYPE.freeze();
+    }
+
+    public VersionRangeField(String name, final BytesRef min, final BytesRef max) {
+        super(name, TYPE);
+        setRangeValues(min, max);
+    }
+
+    /**
+     * Change (or set) the min/max values of the field.
+     * @param min range min value
+     * @param max range max value
+     */
+    public void setRangeValues(BytesRef min, BytesRef max) {
+        final byte[] bytes;
+        if (fieldsData == null) {
+            bytes = new byte[BYTES * 2];
+            fieldsData = new BytesRef(bytes);
+        } else {
+            bytes = ((BytesRef) fieldsData).bytes;
+        }
+        encode(min, max, bytes);
+    }
+
+    /** encode the min/max range into the provided byte array */
+    private static void encode(final BytesRef min, final BytesRef max, final byte[] bytes) {
+        if (FutureArrays.compareUnsigned(min.bytes, 0, BYTES, max.bytes, 0, BYTES) > 0) {
+            throw new IllegalArgumentException("min value cannot be greater than max value for version field");
+        }
+        System.arraycopy(min.bytes, 0, bytes, 0, BYTES);
+        System.arraycopy(max.bytes, 0, bytes, BYTES, BYTES);
+    }
+
+    /** encode the min/max range and return the byte array */
+    private static byte[] encode(BytesRef min, BytesRef max) {
+      byte[] b = new byte[BYTES*2];
+      encode(min, max, b);
+      return b;
+    }
+
+    public static Query newIntersectsQuery(String field, BytesRef from, BytesRef to, Query dvQuery) {
+        return newRelationQuery(field, from, to, RangeFieldQuery.QueryType.INTERSECTS, dvQuery);
+    }
+
+    public static Query newWithinQuery(String field, BytesRef from, BytesRef to, Query dvQuery) {
+        return newRelationQuery(field, from, to, RangeFieldQuery.QueryType.WITHIN, dvQuery);
+    }
+
+    public static Query newContainsQuery(String field, BytesRef from, BytesRef to, Query dvQuery) {
+        return newRelationQuery(field, from, to, RangeFieldQuery.QueryType.CONTAINS, dvQuery);
+    }
+
+    /** helper method for creating the desired relational query */
+    private static Query newRelationQuery(
+        String field,
+        final BytesRef min,
+        final BytesRef max,
+        RangeFieldQuery.QueryType relation,
+        Query dvQuery
+    ) {
+        RangeFieldQuery rangeFieldQuery = new RangeFieldQuery(field, encode(min, max), 1, relation) {
+            @Override
+            protected String toString(byte[] ranges, int dimension) {
+                return VersionRangeField.toString(ranges, dimension);
+            }
+        };
+        BooleanQuery conjunctionQuery = new BooleanQuery.Builder().add(new BooleanClause(rangeFieldQuery, Occur.MUST))
+            .add(new BooleanClause(dvQuery, Occur.MUST)).build();
+        return conjunctionQuery;
+    }
+
+    /**
+     * Returns the String representation for the range at the given dimension
+     * @param ranges the encoded ranges, never null
+     * @param dimension the dimension of interest (not used for this field)
+     * @return The string representation for the range at the provided dimension
+     */
+    private static String toString(byte[] ranges, int dimension) {
+      byte[] min = new byte[BYTES];
+      System.arraycopy(ranges, 0, min, 0, BYTES);
+      byte[] max = new byte[BYTES];
+      System.arraycopy(ranges, BYTES, max, 0, BYTES);
+      return "["
+          + VersionEncoder.decodeVersion(new BytesRef(min), SortMode.SEMVER)
+          + " : "
+          + VersionEncoder.decodeVersion(new BytesRef(max), SortMode.SEMVER)
+          + "]";
+    }
+
+}

--- a/server/src/main/java/org/apache/lucene/queries/BinaryDocValuesRangeQuery.java
+++ b/server/src/main/java/org/apache/lucene/queries/BinaryDocValuesRangeQuery.java
@@ -87,11 +87,13 @@ public final class BinaryDocValuesRangeQuery extends Query {
                         int offset = in.getPosition();
                         for (int i = 0; i < numRanges; i++) {
                             int length = lengthType.readLength(bytes, offset);
+                            offset += lengthType.advanceBy();
                             otherFrom.offset = offset;
                             otherFrom.length = length;
                             offset += length;
 
                             length = lengthType.readLength(bytes, offset);
+                            offset += lengthType.advanceBy();
                             otherTo.offset = offset;
                             otherTo.length = length;
                             offset += length;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryRangeUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryRangeUtil.java
@@ -130,11 +130,11 @@ enum BinaryRangeUtil {
         for (int i = 0; i < numRanges; i++) {
             int length = lengthType.readLength(bytes, offset);
             Object from = decodeBytes.apply(bytes, offset, length);
-            offset += length;
+            offset += length + lengthType.advanceBy();
 
             length = lengthType.readLength(bytes, offset);
             Object to = decodeBytes.apply(bytes, offset, length);
-            offset += length;
+            offset += length + lengthType.advanceBy();
             // TODO: Support for exclusive ranges, pending resolution of #40601
             RangeFieldMapper.Range decodedRange = new RangeFieldMapper.Range(rangeType, from, to, true, true);
             ranges.add(decodedRange);

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -489,6 +489,7 @@ public class RangeFieldMapper extends FieldMapper {
             sb.append(includeFrom ? '[' : '(');
             Object f = includeFrom || from.equals(type.minValue()) ? from : type.nextDown(from);
             Object t = includeTo || to.equals(type.maxValue()) ? to : type.nextUp(to);
+            // TODO also handle new VERSION range type, maybe move "toString" to RangeType?
             sb.append(type == RangeType.IP ? InetAddresses.toAddrString((InetAddress)f) : f.toString());
             sb.append(" : ");
             sb.append(type == RangeType.IP ? InetAddresses.toAddrString((InetAddress)t) : t.toString());

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionEncoder.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/**
+ * Encodes a version string to a {@link BytesRef} while ensuring an ordering that makes sense for
+ * software versions.
+ *
+ * Version strings are considered to consist of three parts in this order:
+ * <ul>
+ *  <li> a numeric major.minor.patch part starting the version string (e.g. 1.2.3)
+ *  <li> an optional "pre-release" part that starts with a `-` character and can consist of several alpha-numerical sections
+ *  separated by dots (e.g. "-alpha.2.3")
+ *  <li> an optional "build" part that starts with a `+` character. This will simply be treated as a prefix with no guaranteed ordering,
+ *  (although the ordering should be alphabetical in most cases).
+ * </ul>
+ *
+ * In the default mode (@link {@link SortMode#SEMVER}, the version string is encoded such that the ordering works like the following:
+ * <ul>
+ *  <li> Major, minor, and patch versions are always compared numerically
+ *  <li> pre-release version have lower precedence than a normal version. (e.g 1.0.0-alpha &lt; 1.0.0)
+ *  <li> the precedence for pre-release versions with same main version is calculated comparing each dot separated identifier from
+ *  left to right. Identifiers consisting of only digits are compared numerically and identifiers with letters or hyphens are compared
+ *  lexically in ASCII sort order. Numeric identifiers always have lower precedence than non-numeric identifiers.
+ * </ul>
+ *
+ * The sorting for the main version part in {@link SortMode#HONOUR_NUMERALS} is the same except that in the pre-release part,
+ * mixed alpha-numerical identifiers are compared grouping all consecutive digits and treating them as a number with numerical ordering.
+ * For example, "alpha2" would sort _before" "alpha11" in this mode.
+ */
+public class VersionEncoder {
+
+    private static final byte NUMERIC_MARKER_BYTE = (byte) 0x01;
+    private static final char PRERELESE_SEPARATOR = '-';
+    private static final byte PRERELESE_SEPARATOR_BYTE = (byte) 0x02;
+    private static final byte NO_PRERELESE_SEPARATOR_BYTE = (byte) 0x03;
+    private static final String DOT_SEPARATOR_REGEX = "\\.";
+    private static final char DOT_SEPARATOR = '.';
+    private static final byte DOT_SEPARATOR_BYTE = (byte) 0x04;
+    private static final char BUILD_SEPARATOR = '+';
+    private static final byte BUILD_SEPARATOR_BYTE = (byte) BUILD_SEPARATOR;
+
+    // Regex to test version validity: \d+(\.\d+)*(-[\-\dA-Za-z]+){0,1}(\.[-\dA-Za-z]+)*(\+[\.\-\dA-Za-z]+)?
+    private static Pattern LEGAL_VERSION_PATTERN = Pattern.compile(
+        "\\d+(\\.\\d+)*(-[\\-\\dA-Za-z]+){0,1}(\\.[\\-\\dA-Za-z]+)*(\\+[\\.\\-\\dA-Za-z]+)?"
+    );
+
+    /**
+     * Defines how version parts consisting of both alphabetical and numerical characters are ordered
+     */
+    public enum SortMode {
+        /**
+         * strict semver precedence treats everything alphabetically, e.g. "rc11" &lt; "rc2"
+         */
+        SEMVER
+        {
+            @Override
+            public void encode(String part, BytesRefBuilder result) {
+                result.append(new BytesRef(part));
+            }
+
+            @Override
+            public DocValueFormat docValueFormat() {
+                return DocValueFormat.VERSION_SEMVER;
+            }
+
+        },
+        /**
+         * This mode will order mixed strings so that the numeric parts are treated with numeric ordering,
+         * e.g. "rc2" &lt; "rc11", "alpha523" &lt; "alpha1234"
+         */
+        HONOUR_NUMERALS
+        {
+            @Override
+            public void encode(String part, BytesRefBuilder result) {
+                prefixDigitGroupsWithLength(part, result);
+            }
+
+            @Override
+            public DocValueFormat docValueFormat() {
+                return DocValueFormat.VERSION_NUMERIC;
+            }
+        };
+
+        public abstract void encode(String part, BytesRefBuilder result);
+        public abstract DocValueFormat docValueFormat();
+
+        public static SortMode fromString(String mode) {
+            switch (mode) {
+                case "semver":
+                    return SEMVER;
+                case "numeric":
+                    return HONOUR_NUMERALS;
+                default:
+                    throw new IllegalArgumentException("Unknown version field mode: " + mode);
+            }
+        }
+
+    }
+
+    /**
+     * Encodes a version string given the given {@link SortMode}.
+     * First, the input version string is split into the following parts:
+     * <p>
+     * mainVersion(-preReleasePart)(+buildId)
+     *
+     */
+    public static BytesRef encodeVersion(String versionString, SortMode mode) {
+        //System.out.println("encoding: " + versionString);
+        if (legalVersionString(versionString) == false) {
+            throw new IllegalArgumentException("Illegal version string: " + versionString);
+        }
+        // extract "build" suffix starting with "+"
+        String buildSuffixPart = extractSuffix(versionString, BUILD_SEPARATOR);
+        if (buildSuffixPart != null) {
+           versionString = versionString.substring(0, versionString.length() - buildSuffixPart.length());
+        }
+
+        // extract "pre-release" suffix starting with "-"
+        String preReleaseId = extractSuffix(versionString, PRERELESE_SEPARATOR);
+        if (preReleaseId != null) {
+            versionString = versionString.substring(0, versionString.length() - preReleaseId.length());
+        }
+
+        // pad all digit groups in main part with numeric marker and length bytes
+        BytesRefBuilder encodedVersion = new BytesRefBuilder();
+        prefixDigitGroupsWithLength(versionString, encodedVersion);
+
+        // encode whether version has pre-release parts
+        if (preReleaseId != null) {
+            encodedVersion.append(PRERELESE_SEPARATOR_BYTE);  // versions with pre-release part sort before ones without
+            String[] preReleaseParts = preReleaseId.substring(1).split(DOT_SEPARATOR_REGEX);
+            boolean first = true;
+            for (String preReleasePart : preReleaseParts) {
+                if (first == false) {
+                    encodedVersion.append(DOT_SEPARATOR_BYTE);
+                }
+                boolean isNumeric = preReleasePart.chars().allMatch(x -> Character.isDigit(x));
+                if (isNumeric) {
+                    prefixDigitGroupsWithLength(preReleasePart, encodedVersion);
+                } else {
+                    mode.encode(preReleasePart, encodedVersion);
+                }
+                first = false;
+            }
+        } else {
+            encodedVersion.append(NO_PRERELESE_SEPARATOR_BYTE);
+        }
+
+        // append build part at the end
+        if (buildSuffixPart != null) {
+            encodedVersion.append(new BytesRef(buildSuffixPart));
+        }
+        //System.out.println("encoded: " + encodedVersion.get());
+        return encodedVersion.get();
+    }
+
+    private static String extractSuffix(String input, char separator) {
+        int start = input.indexOf(separator);
+        return start > 0 ? input.substring(start) : null;
+    }
+
+    private static void prefixDigitGroupsWithLength(String input, BytesRefBuilder result) {
+        int pos = 0;
+        while (pos < input.length()) {
+                if (Character.isDigit(input.charAt(pos))) {
+                    // found beginning of number block, so get its length
+                    int start = pos;
+                    BytesRefBuilder number = new BytesRefBuilder();
+                    while (pos < input.length() && Character.isDigit(input.charAt(pos))) {
+                        number.append((byte) input.charAt(pos));
+                        pos++;
+                    }
+                    int length = pos - start;
+                    result.append(NUMERIC_MARKER_BYTE); // ensure length byte does cause higher sort order comparing to other byte[]
+                    result.append((byte) (length | 0x80)); // add upper bit to mark as length
+                    result.append(number);
+                } else {
+                    if (input.charAt(pos) == DOT_SEPARATOR) {
+                        result.append(DOT_SEPARATOR_BYTE);
+                    } else {
+                        result.append((byte) input.charAt(pos));
+                    }
+                    pos++;
+                }
+        }
+    }
+
+    public static String decodeVersion(BytesRef version, SortMode mode) {
+        //System.out.println("decoding: " + version);
+        int pos = 0;
+        StringBuilder sb = new StringBuilder();
+        while (pos < version.length && version.bytes[pos] != BUILD_SEPARATOR_BYTE) {
+            pos++;
+        }
+        sb.append(decodeVersionString(version.bytes, 0, pos));
+
+        // add build part if present
+        if (pos < version.length && version.bytes[pos] == BUILD_SEPARATOR_BYTE) {
+            sb.append(new BytesRef(Arrays.copyOfRange(version.bytes, pos, version.length)).utf8ToString());
+        }
+        return sb.toString();
+    }
+
+    private static char[] decodeVersionString(byte[] input, int startPos, int endPos) {
+        int inputPos = startPos;
+        int resultPos = 0;
+        char[] result = new char[input.length];
+        while (inputPos < endPos) {
+            byte inputByte = input[inputPos];
+            if (inputByte >= 0x30 && ((inputByte & 0x80) == 0)) {
+                result[resultPos] = (char) inputByte;
+                resultPos++;
+            } else if (inputByte == DOT_SEPARATOR_BYTE) {
+                result[resultPos] = DOT_SEPARATOR;
+                resultPos++;
+            } else if (inputByte == PRERELESE_SEPARATOR_BYTE) {
+                result[resultPos] = PRERELESE_SEPARATOR;
+                resultPos++;
+            } else if (inputByte == BUILD_SEPARATOR_BYTE) {
+                result[resultPos] = BUILD_SEPARATOR;
+                resultPos++;
+            }
+            inputPos++;
+        }
+        return Arrays.copyOf(result, resultPos);
+    }
+
+    static boolean legalVersionString(String versionString) {
+        return LEGAL_VERSION_PATTERN.matcher(versionString).matches();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionStringFieldMapper.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
+import org.elasticsearch.index.mapper.VersionEncoder.SortMode;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.index.mapper.VersionEncoder.encodeVersion;
+import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
+
+/** A {@link FieldMapper} for software versions. */
+public class VersionStringFieldMapper extends FieldMapper {
+
+    // TODO naming etc... wrt VersionFieldMapper
+    public static final String CONTENT_TYPE = "version";
+
+    public static class Defaults {
+        public static final FieldType FIELD_TYPE = new FieldType();
+
+        static {
+            FIELD_TYPE.setTokenized(false);
+            FIELD_TYPE.setOmitNorms(true);
+            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE.freeze();
+        }
+
+        public static final Explicit<Boolean> IGNORE_MALFORMED = new Explicit<>(false, false);
+        public static final String NULL_VALUE = null;
+        public static final int IGNORE_ABOVE = Integer.MAX_VALUE;
+    }
+
+    public static class Builder extends FieldMapper.Builder<Builder> {
+
+        private Explicit<Boolean> ignoreMalformed = new Explicit<Boolean>(false, false);
+        protected String nullValue = Defaults.NULL_VALUE;
+        protected int ignoreAbove = Defaults.IGNORE_ABOVE;
+        private SortMode mode;
+
+        public Builder(String name) {
+            super(name, Defaults.FIELD_TYPE);
+            builder = this;
+        }
+
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = new Explicit<Boolean>(ignoreMalformed, true);
+            return builder;
+        }
+
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return ignoreMalformed;
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
+        }
+
+        public Builder nullValue(String nullValue) {
+            this.nullValue = nullValue;
+            return builder;
+        }
+
+        public Builder ignoreAbove(int ignoreAbove) {
+            if (ignoreAbove < 0) {
+                throw new IllegalArgumentException("[ignore_above] must be positive, got " + ignoreAbove);
+            }
+            this.ignoreAbove = ignoreAbove;
+            return this;
+        }
+
+        private VersionStringFieldType buildFieldType(BuilderContext context) {
+            return new VersionStringFieldType(buildFullName(context), indexed, hasDocValues, meta, boost, mode);
+        }
+
+        public void mode(SortMode mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public VersionStringFieldMapper build(BuilderContext context) {
+            return new VersionStringFieldMapper(
+                name,
+                fieldType,
+                buildFieldType(context),
+                ignoreMalformed,
+                ignoreAbove,
+                nullValue,
+                context.indexSettings(),
+                multiFieldsBuilder.build(this, context),
+                copyTo,
+                mode
+            );
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        public TypeParser() {
+        }
+
+        @Override
+        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+            Builder builder = new Builder(name);
+            TypeParsers.parseField(builder, name, node, parserContext);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = entry.getKey();
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(propNode.toString());
+                    iterator.remove();
+                } else if (propName.equals("ignore_malformed")) {
+                    builder.ignoreMalformed(XContentMapValues.nodeBooleanValue(propNode, name + ".ignore_malformed"));
+                    iterator.remove();
+                } else if (propName.equals("mode")) {
+                    builder.mode(SortMode.fromString(propNode.toString()));
+                    iterator.remove();
+                } else if (TypeParsers.parseMultiField(builder, name, parserContext, propName, propNode)) {
+                    iterator.remove();
+                }
+            }
+            return builder;
+        }
+    }
+
+    public static final class VersionStringFieldType extends TermBasedFieldType {
+
+        private final SortMode mode;
+
+        public VersionStringFieldType(
+            String name,
+            boolean isSearchable,
+            boolean hasDocValues,
+            Map<String, String> meta,
+            float boost,
+            SortMode mode
+        ) {
+            super(name, isSearchable, hasDocValues, meta);
+            setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
+            setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
+            setBoost(boost);
+            this.mode = mode;
+        }
+
+        VersionStringFieldType(VersionStringFieldType other) {
+            super(other);
+            this.mode = other.mode;
+        }
+
+        @Override
+        public MappedFieldType clone() {
+            return new VersionStringFieldType(this);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (hasDocValues()) {
+                return new DocValuesFieldExistsQuery(name());
+            } else {
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
+            }
+        }
+
+        @Override
+        protected BytesRef indexedValueForSearch(Object value) {
+            if (value instanceof String) {
+                return encodeVersion((String) value, mode);
+            } else if (value instanceof BytesRef) {
+                // encoded string, need to re-encode
+                return encodeVersion(((BytesRef) value).utf8ToString(), mode);
+            } else {
+                throw new IllegalArgumentException("Illegal value type: " + value.getClass());
+            }
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
+            failIfNoDocValues();
+            return new SortedSetOrdinalsIndexFieldData.Builder(CoreValuesSourceType.BYTES);
+        }
+
+        @Override
+        public Object valueForDisplay(Object value) {
+            if (value == null) {
+                return null;
+            }
+            // keywords are internally stored as utf8 bytes
+            BytesRef binaryValue = (BytesRef) value;
+            return binaryValue.utf8ToString();
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(@Nullable String format, ZoneId timeZone) {
+            if (format != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support custom formats");
+            }
+            if (timeZone != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName()
+                    + "] does not support custom time zones");
+            }
+            return mode.docValueFormat();
+        }
+
+        @Override
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+            if (context.allowExpensiveQueries() == false) {
+                throw new ElasticsearchException("[range] queries on [version] fields cannot be executed when '" +
+                        ALLOW_EXPENSIVE_QUERIES.getKey() + "' is set to false.");
+            }
+            failIfNotIndexed();
+            return new TermRangeQuery(name(),
+                lowerTerm == null ? null : indexedValueForSearch(lowerTerm),
+                upperTerm == null ? null : indexedValueForSearch(upperTerm),
+                includeLower, includeUpper);
+        }
+    }
+
+    private Explicit<Boolean> ignoreMalformed;
+    private int ignoreAbove;
+    private String nullValue;
+    private SortMode mode;
+
+    VersionStringFieldMapper(
+            String simpleName,
+            FieldType fieldType,
+            MappedFieldType mappedFieldType,
+            Explicit<Boolean> ignoreMalformed,
+            int ignoreAbove,
+            String nullValue,
+            Settings indexSettings,
+            MultiFields multiFields,
+            CopyTo copyTo,
+            SortMode mode) {
+        super(simpleName, fieldType, mappedFieldType, indexSettings, multiFields, copyTo);
+        this.ignoreMalformed = ignoreMalformed;
+        this.ignoreAbove = ignoreAbove;
+        this.nullValue = nullValue;
+        this.mode = mode;
+    }
+
+    @Override
+    public VersionStringFieldType fieldType() {
+        return (VersionStringFieldType) super.fieldType();
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    protected VersionStringFieldMapper clone() {
+        return (VersionStringFieldMapper) super.clone();
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context) throws IOException {
+        String versionString;
+        if (context.externalValueSet()) {
+            versionString = context.externalValue().toString();
+        } else {
+            XContentParser parser = context.parser();
+            if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+                versionString = nullValue;
+            } else {
+                versionString =  parser.textOrNull();
+            }
+        }
+
+        if (versionString == null) {
+            return;
+        }
+
+        BytesRef encodedVersion = null;
+        try {
+            encodedVersion = encodeVersion(versionString, mode);
+        } catch (IllegalArgumentException e) {
+            if (ignoreMalformed.value()) {
+                context.addIgnoredField(name());
+                return;
+            } else {
+                throw e;
+            }
+        }
+        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored())  {
+            Field field = new Field(fieldType().name(), encodedVersion, fieldType);
+            context.doc().add(field);
+
+            if (fieldType().hasDocValues() == false && fieldType.omitNorms()) {
+                createFieldNamesField(context);
+            }
+        }
+
+        if (fieldType().hasDocValues()) {
+            context.doc().add(new SortedSetDocValuesField(fieldType().name(), encodedVersion));
+        }
+
+    }
+
+
+
+    @Override
+    protected void mergeOptions(FieldMapper other, List<String> conflicts) {
+        VersionStringFieldMapper mergeWith = (VersionStringFieldMapper) other;
+        if (mergeWith.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = mergeWith.ignoreMalformed;
+        }
+        this.ignoreAbove = mergeWith.ignoreAbove;
+        this.nullValue = mergeWith.nullValue;
+        this.mode = mergeWith.mode;
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (nullValue != null) {
+            builder.field("null_value", nullValue);
+        }
+
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field("ignore_malformed", ignoreMalformed.value());
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -50,6 +50,7 @@ import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
+import org.elasticsearch.index.mapper.VersionStringFieldMapper;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -128,6 +129,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser());
         mappers.put(FieldAliasMapper.CONTENT_TYPE, new FieldAliasMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
+        mappers.put(VersionStringFieldMapper.CONTENT_TYPE, new VersionStringFieldMapper.TypeParser());
 
         for (MapperPlugin mapperPlugin : mapperPlugins) {
             for (Map.Entry<String, Mapper.TypeParser> entry : mapperPlugin.getMappers().entrySet()) {

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -31,6 +31,8 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.VersionEncoder;
+import org.elasticsearch.index.mapper.VersionEncoder.SortMode;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 
 import java.io.IOException;
@@ -365,6 +367,61 @@ public interface DocValueFormat extends NamedWriteable {
             return "ip";
         }
     };
+
+    DocValueFormat VERSION_SEMVER = new DocValueFormat() {
+
+        @Override
+        public String getWriteableName() {
+            return "version_semver";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {
+        }
+
+        @Override
+        public String format(BytesRef value) {
+            return VersionEncoder.decodeVersion(value, SortMode.SEMVER);
+        }
+
+        @Override
+        public BytesRef parseBytesRef(String value) {
+            return VersionEncoder.encodeVersion(value, SortMode.SEMVER);
+        }
+
+        @Override
+        public String toString() {
+            return getWriteableName();
+        }
+    };
+
+    DocValueFormat VERSION_NUMERIC = new DocValueFormat() {
+
+        @Override
+        public String getWriteableName() {
+            return "version_numeric";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) {
+        }
+
+        @Override
+        public String format(BytesRef value) {
+            return VersionEncoder.decodeVersion(value, SortMode.HONOUR_NUMERALS);
+        }
+
+        @Override
+        public BytesRef parseBytesRef(String value) {
+            return VersionEncoder.encodeVersion(value, SortMode.HONOUR_NUMERALS);
+        }
+
+        @Override
+        public String toString() {
+            return getWriteableName();
+        }
+    };
+
 
     final class Decimal implements DocValueFormat {
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -61,7 +61,8 @@ public class RangeFieldTypeTests extends FieldTypeTestCase<RangeFieldType> {
 
     @Before
     public void setupProperties() {
-        type = randomFrom(RangeType.values());
+        // TODO make this test work with RangeType.VERSION
+        type = randomValueOtherThan(RangeType.VERSION, () -> randomFrom(RangeType.values()));
         nowInMillis = randomNonNegativeLong();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/VersionEncoderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/VersionEncoderTests.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.VersionEncoder.SortMode;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.index.mapper.VersionEncoder.decodeVersion;
+
+public class VersionEncoderTests extends ESTestCase {
+
+    public void testEncodingOrderingSemver() {
+        assertTrue(encSemver("1.0.0").compareTo(encSemver("2.0.0")) < 0);
+        assertTrue(encSemver("2.0.0").compareTo(encSemver("11.0.0")) < 0);
+        assertTrue(encSemver("2.0.0").compareTo(encSemver("2.1.0")) < 0);
+        assertTrue(encSemver("2.1.0").compareTo(encSemver("2.1.1")) < 0);
+        assertTrue(encSemver("2.1.1").compareTo(encSemver("2.1.1.0")) < 0);
+        assertTrue(encSemver("1.0.0").compareTo(encSemver("2.0")) < 0);
+        assertTrue(encSemver("1.0.0-a").compareTo(encSemver("1.0.0-b")) < 0);
+        assertTrue(encSemver("1.0.0-1.0.0").compareTo(encSemver("1.0.0-2.0")) < 0);
+        assertTrue(encSemver("1.0.0-alpha").compareTo(encSemver("1.0.0-alpha.1")) < 0);
+        assertTrue(encSemver("1.0.0-alpha.1").compareTo(encSemver("1.0.0-alpha.beta")) < 0);
+        assertTrue(encSemver("1.0.0-alpha.beta").compareTo(encSemver("1.0.0-beta")) < 0);
+        assertTrue(encSemver("1.0.0-beta").compareTo(encSemver("1.0.0-beta.2")) < 0);
+        assertTrue(encSemver("1.0.0-beta.2").compareTo(encSemver("1.0.0-beta.11")) < 0);
+        assertTrue(encSemver("1.0.0-beta11").compareTo(encSemver("1.0.0-beta2")) < 0); // correct according to Semver specs
+        assertTrue(encSemver("1.0.0-beta.11").compareTo(encSemver("1.0.0-rc.1")) < 0);
+        assertTrue(encSemver("1.0.0-rc.1").compareTo(encSemver("1.0.0")) < 0);
+        assertTrue(encSemver("1.0.0").compareTo(encSemver("2.0.0-pre127")) < 0);
+        assertTrue(encSemver("2.0.0-pre127").compareTo(encSemver("2.0.0-pre128")) < 0);
+        assertTrue(encSemver("2.0.0-pre20201231z110026").compareTo(encSemver("2.0.0-pre227")) < 0);
+    }
+
+    private BytesRef encSemver(String s) {
+        return VersionEncoder.encodeVersion(s, SortMode.SEMVER);
+    };
+
+    public void testDecodingSemver() {
+        for (String version : List.of(
+            "1",
+            "1.1",
+            "1.0.0",
+            "1.2.3.4",
+            "1.0.0-alpha",
+            "1-alpha.11",
+            "1-a1234.12.13278.beta",
+            "1.0.0-beta+someBuildNumber-123456-open",
+            "1.3.0+build1234567"
+        )) {
+            String decoded = decodeVersion(encSemver(version), SortMode.SEMVER);
+            assertEquals(version, decoded);
+        }
+    }
+
+    public void testEncodingOrderingNumerical() {
+        assertTrue(encNumeric("1.0.0").compareTo(encNumeric("2.0.0")) < 0);
+        assertTrue(encNumeric("2.0.0").compareTo(encNumeric("11.0.0")) < 0);
+        assertTrue(encNumeric("2.0.0").compareTo(encNumeric("2.1.0")) < 0);
+        assertTrue(encNumeric("2.1.0").compareTo(encNumeric("2.1.1")) < 0);
+        assertTrue(encNumeric("2.1.1").compareTo(encNumeric("2.1.1.0")) < 0);
+        assertTrue(encNumeric("1.0.0").compareTo(encNumeric("2.0")) < 0);
+        assertTrue(encNumeric("1.0.0-a").compareTo(encNumeric("1.0.0-b")) < 0);
+        assertTrue(encNumeric("1.0.0-1.0.0").compareTo(encNumeric("1.0.0-2.0")) < 0);
+        assertTrue(encNumeric("1.0.0-alpha").compareTo(encNumeric("1.0.0-alpha.1")) < 0);
+        assertTrue(encNumeric("1.0.0-123u11").compareTo(encNumeric("1.0.0-234u11")) < 0);
+        assertTrue(encNumeric("1.0.0-alpha.1").compareTo(encNumeric("1.0.0-alpha.beta")) < 0);
+        assertTrue(encNumeric("1.0.0-alpha.beta").compareTo(encNumeric("1.0.0-beta")) < 0);
+        assertTrue(encNumeric("1.0.0-beta").compareTo(encNumeric("1.0.0-beta.2")) < 0);
+        assertTrue(encNumeric("1.0.0-beta.2").compareTo(encNumeric("1.0.0-beta.11")) < 0);
+        assertTrue(encNumeric("1.0.0-beta2").compareTo(encNumeric("1.0.0-beta11")) < 0);
+        assertTrue(encNumeric("1.0.0-beta.11").compareTo(encNumeric("1.0.0-rc.1")) < 0);
+        assertTrue(encNumeric("1.0.0-rc.1").compareTo(encNumeric("1.0.0")) < 0);
+        assertTrue(encNumeric("1.0.0").compareTo(encNumeric("2.0.0-pre127")) < 0);
+        assertTrue(encNumeric("2.0.0-pre127").compareTo(encNumeric("2.0.0-pre128")) < 0);
+        assertTrue(encNumeric("2.0.0-pre227").compareTo(encNumeric("2.0.0-pre20201231z110026")) < 0);
+    }
+
+    private BytesRef encNumeric(String s) {
+        return VersionEncoder.encodeVersion(s, SortMode.HONOUR_NUMERALS);
+    };
+
+    public void testDecodingHonourNumeral() {
+        for (String version : List.of(
+            "1",
+            "1.1",
+            "1.0.0",
+            "1.2.3.4",
+            "1.0.0-alpha",
+            "1-alpha.11",
+            "1-a1234.12.13278.beta",
+            "1.0.0-beta+someBuildNumber-123456-open",
+            "1.3.0+build1234567"
+        )) {
+            String decoded = decodeVersion(encSemver(version), SortMode.HONOUR_NUMERALS);
+            assertEquals(version, decoded);
+        }
+    }
+
+    /**
+     * test that encoding and decoding leads back to the same version string
+     */
+    public void testRandomRoundtrip() {
+        String versionString = randomVersionString();
+        assertEquals(versionString, decodeVersion(encSemver(versionString), SortMode.SEMVER));
+    }
+
+    private String randomVersionString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(randomIntBetween(0, 1000));
+        int releaseNumerals = randomIntBetween(0, 4);
+        for (int i = 0; i < releaseNumerals; i++) {
+            sb.append(".");
+            sb.append(randomIntBetween(0, 10000));
+        }
+        // optional pre-release part
+        if (randomBoolean()) {
+            sb.append("-");
+            int preReleaseParts = randomIntBetween(1, 5);
+            for (int i = 0; i < preReleaseParts; i++) {
+                if (randomBoolean()) {
+                    sb.append(randomIntBetween(0, 1000));
+                } else {
+                    int alphanumParts = 3;
+                    for (int j = 0; j < alphanumParts; j++) {
+                        if (randomBoolean()) {
+                            sb.append(randomAlphaOfLengthBetween(1, 2));
+                        } else {
+                            sb.append(randomIntBetween(1, 99));
+                        }
+                        if (rarely()) {
+                            sb.append(randomFrom(Arrays.asList("-")));
+                        }
+                    }
+                }
+                sb.append(".");
+            }
+            sb.deleteCharAt(sb.length() - 1);  // remove trailing dot
+        }
+        // optional build part
+        if (randomBoolean()) {
+            sb.append("+").append(randomAlphaOfLengthBetween(1,15));
+        }
+        return sb.toString();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/VersionStringFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/VersionStringFieldMapperTests.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+public class VersionStringFieldMapperTests extends ESSingleNodeTestCase {
+
+    public void testQueries() throws Exception {
+        String indexName = "test";
+        createIndex(indexName, Settings.builder().put("index.number_of_shards", 1).build(), "_doc",
+            "version", "type=version");
+        ensureGreen("test");
+
+        client().prepareIndex(indexName).setId("1")
+            .setSource(jsonBuilder().startObject().field("version", "1.0.0").endObject())
+            .get();
+        client().prepareIndex(indexName).setId("2")
+            .setSource(jsonBuilder().startObject().field("version", "1.3.0+build1234567").endObject())
+        .get();
+        client().prepareIndex(indexName).setId("3")
+        .setSource(jsonBuilder().startObject().field("version", "2.1.0-alpha").endObject())
+            .get();
+        client().prepareIndex(indexName).setId("4")
+            .setSource(jsonBuilder().startObject().field("version", "2.1.0").endObject())
+        .get();
+        client().admin().indices().prepareRefresh("test").get();
+
+        SearchResponse response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.matchQuery("version", ("1.0.0"))).get();
+        assertEquals(1, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.matchQuery("version", ("1.4.0"))).get();
+        assertEquals(0, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.matchQuery("version", ("1.3.0"))).get();
+        assertEquals(0, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.matchQuery("version", ("1.3.0+build1234567"))).get();
+        assertEquals(1, response.getHits().getTotalHits().value);
+
+        // ranges
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("1.0.0").to("3.0.0"))
+            .get();
+        assertEquals(4, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("1.1.0").to("3.0.0"))
+            .get();
+        assertEquals(3, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("0.1.0").to("2.1.0-alpha"))
+            .get();
+        assertEquals(3, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("2.1.0").to("3.0.0"))
+            .get();
+        assertEquals(1, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("3.0.0").to("4.0.0"))
+            .get();
+        assertEquals(0, response.getHits().getTotalHits().value);
+
+        // ranges excluding edges
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("1.0.0", false).to("3.0.0"))
+            .get();
+        assertEquals(3, response.getHits().getTotalHits().value);
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("1.0.0").to("2.1.0", false))
+            .get();
+        assertEquals(3, response.getHits().getTotalHits().value);
+
+        // open ranges
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").from("1.4.0"))
+            .get();
+        assertEquals(2, response.getHits().getTotalHits().value);
+
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.rangeQuery("version").to("1.4.0"))
+            .get();
+        assertEquals(2, response.getHits().getTotalHits().value);
+
+        // prefix won't work, would need to encode this differently
+//        response = client().prepareSearch(indexName)
+//            .setQuery(QueryBuilders.prefixQuery("version","1"))
+//            .get();
+//        assertEquals(2, response.getHits().getTotalHits().value);
+//
+//        response = client().prepareSearch(indexName)
+//            .setQuery(QueryBuilders.prefixQuery("version","2.0"))
+//            .get();
+//        assertEquals(1, response.getHits().getTotalHits().value);
+
+        // sort based on version field
+        response = client().prepareSearch(indexName)
+            .setQuery(QueryBuilders.matchAllQuery()).addSort("version", SortOrder.DESC).get();
+        assertEquals(4, response.getHits().getTotalHits().value);
+        SearchHit[] hits = response.getHits().getHits();
+        assertEquals("2.1.0", hits[0].getSortValues()[0]);
+        assertEquals("2.1.0-alpha", hits[1].getSortValues()[0]);
+        assertEquals("1.3.0+build1234567", hits[2].getSortValues()[0]);
+        assertEquals("1.0.0", hits[3].getSortValues()[0]);
+    }
+
+    public void testIgnoreMalformed() throws Exception {
+        String indexName = "test";
+        createIndex(indexName, Settings.builder().put("index.number_of_shards", 1).build(), "_doc",
+            "version", "type=version,ignore_malformed=true");
+        ensureGreen("test");
+
+        client().prepareIndex(indexName).setId("1")
+            .setSource(jsonBuilder().startObject().field("version", "1...0.0").endObject())
+            .get();
+        client().prepareIndex(indexName).setId("2")
+        .setSource(jsonBuilder().startObject().field("version", "1.2.0").endObject())
+        .get();
+        client().admin().indices().prepareRefresh("test").get();
+
+        SearchResponse response = client().prepareSearch(indexName).addDocValueField("version").get();
+        assertEquals(2, response.getHits().getTotalHits().value);
+        assertEquals("1", response.getHits().getAt(0).getId());
+        assertEquals("version", response.getHits().getAt(0).field("_ignored").getValue());
+        assertNull(response.getHits().getAt(0).field("version").getValue());
+
+        assertEquals("2", response.getHits().getAt(1).getId());
+        assertNull(response.getHits().getAt(1).field("_ignored"));
+        assertEquals("1.2.0", response.getHits().getAt(1).field("version").getValue());
+    }
+
+    public void testAggs() throws Exception {
+        String indexName = "test";
+        createIndex(indexName, Settings.builder().put("index.number_of_shards", 1).build(), "_doc",
+            "version", "type=version");
+        ensureGreen("test");
+
+        client().prepareIndex(indexName).setId("1")
+            .setSource(jsonBuilder().startObject().field("version", "1.0.0").endObject())
+            .get();
+        client().prepareIndex(indexName).setId("2")
+            .setSource(jsonBuilder().startObject().field("version", "1.3.0").endObject())
+        .get();
+        client().prepareIndex(indexName).setId("3")
+        .setSource(jsonBuilder().startObject().field("version", "2.1.0-alpha").endObject())
+            .get();
+        client().prepareIndex(indexName).setId("4")
+            .setSource(jsonBuilder().startObject().field("version", "2.1.0").endObject())
+        .get();
+        client().admin().indices().prepareRefresh("test").get();
+
+        // range aggs
+        SearchResponse response = client().prepareSearch(indexName)
+            .addAggregation(AggregationBuilders.terms("myterms").field("version")).get();
+        Terms terms = response.getAggregations().get("myterms");
+        List<? extends Bucket> buckets = terms.getBuckets();;
+        assertEquals(4, buckets.size());
+        assertEquals("1.0.0", buckets.get(0).getKey());
+        assertEquals("1.3.0", buckets.get(1).getKey());
+        assertEquals("2.1.0-alpha", buckets.get(2).getKey());
+        assertEquals("2.1.0", buckets.get(3).getKey());
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -89,6 +89,9 @@ import org.elasticsearch.index.mapper.ObjectMapper.Nested;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.index.mapper.VersionEncoder;
+import org.elasticsearch.index.mapper.VersionEncoder.SortMode;
+import org.elasticsearch.index.mapper.VersionStringFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -158,7 +161,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
         ObjectMapper.NESTED_CONTENT_TYPE, // TODO support for nested
         CompletionFieldMapper.CONTENT_TYPE, // TODO support completion
-        FieldAliasMapper.CONTENT_TYPE // TODO support alias
+        FieldAliasMapper.CONTENT_TYPE, // TODO support alias
+        VersionStringFieldMapper.CONTENT_TYPE // TODO support alias
     );
 
     /**
@@ -830,6 +834,11 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 start = randomNonNegativeLong();
                 end = RangeType.DATE.nextUp(start);
                 rangeType = RangeType.DATE;
+            } else if (typeName.equals(RangeType.VERSION.typeName())) {
+                // TODO test this
+                start = VersionEncoder.encodeVersion("1.0.0", SortMode.SEMVER);
+                end = VersionEncoder.encodeVersion("2.0.0", SortMode.SEMVER);
+                rangeType = RangeType.VERSION;
             } else {
                 throw new IllegalStateException("Unknown type of range [" + typeName + "]");
             }


### PR DESCRIPTION
This is a first draft of a new field type aimed at storing software version strings like e.g. versions following the [Semantic Versioning](https://semver.org/) scheme. The field should offer exact matching and range queries similar to e.g. what we currently have for IP fields.
This POC contains of some early ideas about how we could encode the version strings into a binary representation that would allow ordering according to e.g. the Semantiv Versioning specification (i.e. precedence in part 11. in https://semver.org) but also potentially allow for more flexibility. Early tests for a "version" field type and a "version_range" range type show how basic search and aggs are possible with this encoding.