### PR TITLE
[7.x] Document that data stream write indices cannot be closed (#57770)

### DIFF
--- a/docs/reference/indices/open-close.asciidoc
+++ b/docs/reference/indices/open-close.asciidoc
@@ -52,8 +52,14 @@ Identifying indices via wildcards or `_all` can be disabled by setting the
 `action.destructive_requires_name` flag in the config file to `true`.
 This setting can also be changed via the cluster update settings api.
 
-Closed indices consume a significant amount of disk-space which can cause problems in managed environments. Closing indices can be disabled via the cluster settings
+Closed indices consume a significant amount of disk-space which can cause
+problems in managed environments. Closing indices can be disabled via the cluster settings
 API by setting `cluster.indices.close.enable` to `false`. The default is `true`.
+
+The current write index on a data stream cannot be closed. In order to close
+the current write index, the data stream must first be
+<<rollover-data-stream-ex,rolled over>> so that a new write index is created
+and then the previous write index can be closed.
 
 ===== Wait For active shards
 


### PR DESCRIPTION
Relates to #53100

Backport of #57770
