### PR TITLE
Fix deprecated property usage in archive tasks

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -106,8 +106,8 @@ CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String pla
 tasks.withType(AbstractArchiveTask).configureEach {
   dependsOn createLogsDir, createPluginsDir, createJvmOptionsDir
   String subdir = it.name.substring('build'.size()).replaceAll(/[A-Z]/) { '-' + it.toLowerCase() }.substring(1)
-  destinationDir = file("${subdir}/build/distributions")
-  baseName = "elasticsearch${subdir.contains('oss') ? '-oss' : ''}"
+  destinationDirectory = file("${subdir}/build/distributions")
+  archiveBaseName = "elasticsearch${subdir.contains('oss') ? '-oss' : ''}"
 }
 
 Closure commonZipConfig = {

--- a/distribution/docker/docker-build-context/build.gradle
+++ b/distribution/docker/docker-build-context/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'base'
 
 task buildDockerBuildContext(type: Tar) {
-  extension = 'tar.gz'
+  archiveExtension = 'tar.gz'
   compression = Compression.GZIP
   archiveClassifier = "docker-build-context"
   archiveBaseName = "elasticsearch"

--- a/distribution/docker/oss-docker-build-context/build.gradle
+++ b/distribution/docker/oss-docker-build-context/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'base'
 
 task buildOssDockerBuildContext(type: Tar) {
-  extension = 'tar.gz'
+  archiveExtension = 'tar.gz'
   compression = Compression.GZIP
   archiveClassifier = "docker-build-context"
   archiveBaseName = "elasticsearch-oss"

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 }
 
 war {
-  archiveName 'example-app.war'
+  archiveFileName = 'example-app.war'
 }
 
 elasticsearch_distributions {

--- a/x-pack/license-tools/build.gradle
+++ b/x-pack/license-tools/build.gradle
@@ -13,7 +13,7 @@ project.forbiddenPatterns {
 dependencyLicenses.enabled = false
 
 task buildZip(type: Zip, dependsOn: jar) {
-  String parentDir = "license-tools-${version}"
+  String parentDir = "license-tools-${archiveVersion}"
   into(parentDir + '/lib') {
     from jar
     from configurations.runtime


### PR DESCRIPTION
Removing more simple deprecation warnings from our build. Gets us closer on getting https://github.com/elastic/elasticsearch/issues/57920 done