### PR TITLE
Fix name of template in allowed warning for DS YML test

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/data_stream/10_data_stream_resolvability.yml
@@ -123,7 +123,7 @@
 
   - do:
       allowed_warnings:
-        - "index template [my-template] has index patterns [logs-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+        - "index template [my-ds-rolluptemplate] has index patterns [logs-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-ds-rolluptemplate] will take precedence during new index creation"
       indices.put_index_template:
         name: my-ds-rolluptemplate
         body:


### PR DESCRIPTION
The warning was present, but had the incorrect template name, leading to a test failure.
