### PR TITLE
[DOCS] Add data streams to search docs

### DIFF
--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -141,6 +141,69 @@ GET /logs/_search
 // TEST[continued]
 ====
 
+You can use a comma-separated list or wildcard (`*`) expression to search
+multiple data streams, indices, and index aliases in the same request.
+
+.*Example*
+[%collapsible]
+====
+////
+[source,console]
+----
+PUT /_data_stream/logs_alt
+----
+// TEST[continued]
+////
+
+The following request searches the `logs` and `logs_alt` data streams, which are
+specified as a comma-separated list in the request path.
+
+[source,console]
+----
+GET /logs,logs_alt/_search
+{
+  "query": {
+    "match": {
+      "user.id": "8a4f500d"
+    }
+  }
+}
+----
+// TEST[continued]
+
+The following request uses the `logs*` wildcard expression to search any data
+stream, index, or index alias beginning with `logs`.
+
+[source,console]
+----
+GET /logs*/_search
+{
+  "query": {
+    "match": {
+      "user.id": "vlb44hny"
+    }
+  }
+}
+----
+// TEST[continued]
+
+The following search request omits a target in the request path. The request
+searches all data streams and indices in the cluster.
+
+[source,console]
+----
+GET /_search
+{
+  "query": {
+    "match": {
+      "user.id": "l7gk7f82"
+    }
+  }
+}
+----
+// TEST[continued]
+====
+
 [discrete]
 [[manually-roll-over-a-data-stream]]
 === Manually roll over a data stream
@@ -480,6 +543,8 @@ PUT /_bulk?refresh
 [source,console]
 ----
 DELETE /_data_stream/logs
+
+DELETE /_data_stream/logs_alt
 
 DELETE /_index_template/logs_data_stream
 ----

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -90,7 +90,7 @@ as this will slow things down.
 ===== Client support for bulk requests
 
 Some of the officially supported clients provide helpers to assist with
-bulk requests and reindexing of documents from one index to another:
+bulk requests and reindexing:
 
 Go::
 

--- a/docs/reference/search/index.asciidoc
+++ b/docs/reference/search/index.asciidoc
@@ -5,8 +5,8 @@
 --
 
 [[search-query]]
-A _search query_, or _query_, is a request for information about data in one or
-more {es} indices.
+A _search query_, or _query_, is a request for information about data in 
+{es} data streams or indices.
 
 You can think of a query as a question, written in a way {es} understands.
 Depending on your data, you can use a query to get answers to questions like:

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -18,7 +18,7 @@ GET /twitter/_search
 [[search-request-body-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_search
+`GET /<target>/_search
 {
   "query": {<parameters>}
 }`
@@ -34,7 +34,13 @@ The search request can be executed with a search DSL, which includes the
 [[search-request-body-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list or wildcard (`*`) expression of data streams, indices,
+and index aliases used to limit the request.
++
+To search all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 [[search-request-body-api-request-body]]
 ==== {api-request-body-title}

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -8,13 +8,14 @@ on a traditional database.
 
 Scrolling is not intended for real time user requests, but rather for
 processing large amounts of data, e.g. in order to reindex the contents of one
-index into a new index with a different configuration.
+data stream or index into a new data stream or index with a different
+configuration.
 
 .Client support for scrolling and reindexing
 *********************************************
 
 Some of the officially supported clients provide helpers to assist with
-scrolled searches and reindexing of documents from one index to another:
+scrolled searches and reindexing:
 
 Perl::
 
@@ -32,7 +33,7 @@ JavaScript::
 *********************************************
 
 NOTE: The results that are returned from a scroll request reflect the state of
-the index at the time that the initial `search` request was  made, like a
+the data stream or index at the time that the initial `search` request was  made, like a
 snapshot in time. Subsequent changes to documents (index, update or delete)
 will only affect later search requests.
 

--- a/docs/reference/search/request/sort.asciidoc
+++ b/docs/reference/search/request/sort.asciidoc
@@ -114,8 +114,7 @@ POST /_search
 For numeric fields it is also possible to cast the values from one type
 to another using the `numeric_type` option.
 This option accepts the following values: [`"double", "long", "date", "date_nanos"`]
-and can be useful for cross-index search if the sort field is mapped differently on some
-indices.
+and can be useful for searches across multiple data streams or indices where the sort field is mapped differently.
 
 Consider for instance these two indices:
 

--- a/docs/reference/search/run-a-search.asciidoc
+++ b/docs/reference/search/run-a-search.asciidoc
@@ -2,9 +2,9 @@
 == Run a search
 
 You can use the <<search-search,search API>> to search data stored in
-one or more {es} indices.
+{es} data streams or indices.
 
-The API can runs two types of searches, depending on how you provide
+The API can run two types of searches, depending on how you provide
 <<search-query,queries>>:
 
 <<run-uri-search,URI searches>>::
@@ -197,10 +197,10 @@ score>> that measures how well each document matches the query.
 
 [discrete]
 [[search-multiple-indices]]
-=== Search multiple indices
+=== Search multiple data streams and indices
 
-To search multiple indices, add them as comma-separated values in the search API
-request path.
+To search multiple data streams and indices, add them as comma-separated values
+in the search API request path.
 
 .*Example*
 [%collapsible]
@@ -223,14 +223,14 @@ GET /user_logs_000001,user_logs_000002/_search
 // TEST[s/^/PUT user_logs_000002\n/]
 ====
 
-You can also search multiple indices using an index pattern.
+You can also search multiple data streams and indices using a wildcard (`*`)
+pattern.
 
 .*Example*
 [%collapsible]
 ====
-The following request uses the index pattern `user_logs*` in place of the index
-name. The request searches any indices in the cluster that start with
-`user_logs`.
+The following request targets the wildcard pattern `user_logs*`. The request
+searches any data streams or indices in the cluster that start with `user_logs`.
 
 [source,console]
 ----
@@ -246,13 +246,13 @@ GET /user_logs*/_search
 // TEST[continued]
 ====
 
-To search all indices in a cluster, omit the index name from the request path.
-Alternatively, you can use `_all` or `*` in place of the index name.
+To search all data streams and indices in a cluster, omit the target from the
+request path. Alternatively, you can use `_all` or `*`.
 
 .*Example*
 [%collapsible]
 ====
-The following requests are equivalent and search all indices in the cluster.
+The following requests are equivalent and search all data streams and indices in the cluster.
 
 [source,console]
 ----

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -15,11 +15,11 @@ GET /twitter/_search
 [[search-search-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_search`
+`GET /<target>/_search`
 
 `GET /_search`
 
-`POST /<index>/_search`
+`POST /<target>/_search`
 
 `POST /_search`
 
@@ -33,7 +33,13 @@ query string parameter>> or <<search-request-body,request body>>.
 [[search-search-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list or wildcard (`*`) expression of data streams, indices,
+and index aliases used to limit the request.
++
+To search all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 [role="child_attributes"]
 [[search-search-api-query-params]]
@@ -586,7 +592,7 @@ Key is the field name. Value is the value for the field.
 ==== {api-examples-title}
 
 [[search-api-specific-ex]]
-===== Search an index using the `q` query parameter
+===== Search a single data stream or index using the `q` query parameter
 
 [source,console]
 ----
@@ -632,7 +638,7 @@ The API returns the following response:
 // TESTRESPONSE[s/"took": 5/"took": $body.took/]
 
 [[search-multi-index]]
-===== Search several indices using the `q` query parameter
+===== Search several data streams and indices using the `q` query parameter
 
 [source,console]
 ----
@@ -641,10 +647,10 @@ GET /kimchy,elasticsearch/_search?q=user:kimchy
 // TEST[s/^/PUT kimchy\nPUT elasticsearch\n/]
 
 [[search-api-all-ex]]
-===== Search all indices using the `q` query parameter
+===== Search a cluster using the `q` query parameter
 
-To search all indices in a cluster,
-omit the `<index>` parameter.
+To search all data streams and indices in a cluster,
+omit the `<target>` parameter.
 
 [source,console]
 ----
@@ -653,7 +659,7 @@ GET /_search?q=user:kimchy
 // TEST[continued]
 
 Alternatively,
-you can use the `_all` or `*` value in the `<index>` parameter.
+you can use the `_all` or `*` value in the `<target>` parameter.
 
 [source,console]
 ----
@@ -668,7 +674,7 @@ GET /*/_search?q=user:kimchy
 // TEST[continued]
 
 [[search-request-body-api-example]]
-===== Search an index using the `query` request body parameter
+===== Search using the `query` request body parameter
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Changes:

* Adds additional examples to the `Search a data stream` section of
  `Use a data stream`
* Updates existing search docs to make them aware of data streams