### PR TITLE
[7.7] [DOCS] Fix routing param in search API docs (#58267)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -147,9 +147,7 @@ level settings.
 (Optional, boolean) Indicates whether hits.total should be rendered as an
 integer or an object in the rest search response. Defaults to `false`.
 
-`routing`::
-(Optional, <<time-units, time units>>) Specifies how long a consistent view of
-the index should be maintained for scrolled search.
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 
 [[search-api-scroll-query-param]]
 `scroll`::


### PR DESCRIPTION
7.7 backport of #58267