### PR TITLE
Adapt bwc version after backport of #58299

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,8 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
-final String bwc_tests_disabled_issue = "" /* place a PR link here when committing bwc changes */
+boolean bwc_tests_enabled = false
+final String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/58299" /* place a PR link here when committing bwc changes */
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yml
@@ -76,9 +76,8 @@
 ---
 "Get field caps from remote cluster with index filter":
   - skip:
-      version: " - 7.99.99"
-      # TODO: Adapt version after backport
-      reason: Index filter support was added in 8.0
+      version: " - 7.8.99"
+      reason: Index filter support was added in 7.9
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/30_filter.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/30_filter.yml
@@ -60,9 +60,8 @@ setup:
 ---
 "Field caps with index filter":
   - skip:
-      version: " - 7.99.99"
-      # TODO: Adapt version after backport
-      reason: Index filter support was added in 8.0
+      version: " - 7.8.99"
+      reason: Index filter support was added in 7.9
 
   - do:
       field_caps:

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -52,8 +52,8 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         index = in.readOptionalString();
         fields = in.readStringArray();
         originalIndices = OriginalIndices.readOriginalIndices(in);
-        indexFilter = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
-        nowInMillis =  in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readLong() : 0L;
+        indexFilter = in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
+        nowInMillis =  in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readLong() : 0L;
     }
 
     FieldCapabilitiesIndexRequest(String[] fields,
@@ -113,7 +113,7 @@ public class FieldCapabilitiesIndexRequest extends ActionRequest implements Indi
         out.writeOptionalString(index);
         out.writeStringArray(fields);
         OriginalIndices.writeOriginalIndices(originalIndices, out);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             out.writeOptionalNamedWriteable(indexFilter);
             out.writeLong(nowInMillis);
         }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -47,7 +47,7 @@ public class FieldCapabilitiesIndexResponse extends ActionResponse implements Wr
         super(in);
         this.indexName = in.readString();
         this.responseMap = in.readMap(StreamInput::readString, IndexFieldCapabilities::new);
-        this.canMatch = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readBoolean() : true;
+        this.canMatch = in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readBoolean() : true;
     }
 
     /**
@@ -80,7 +80,7 @@ public class FieldCapabilitiesIndexResponse extends ActionResponse implements Wr
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(indexName);
         out.writeMap(responseMap, StreamOutput::writeString, (valueOut, fc) -> fc.writeTo(valueOut));
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             out.writeBoolean(canMatch);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -61,8 +61,8 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         } else {
             includeUnmapped = false;
         }
-        indexFilter = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
-        nowInMillis = in.getVersion().onOrAfter(Version.V_8_0_0) ? in.readOptionalLong() : null;
+        indexFilter = in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readOptionalNamedWriteable(QueryBuilder.class) : null;
+        nowInMillis = in.getVersion().onOrAfter(Version.V_7_9_0) ? in.readOptionalLong() : null;
     }
 
     public FieldCapabilitiesRequest() {
@@ -97,7 +97,7 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         if (out.getVersion().onOrAfter(Version.V_7_2_0)) {
             out.writeBoolean(includeUnmapped);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_9_0)) {
             out.writeOptionalNamedWriteable(indexFilter);
             out.writeOptionalLong(nowInMillis);
         }


### PR DESCRIPTION
This commit adapts the bwc version in preparation of the backport
to 7.x. The bwc tests are disabled in order to allow the merge of #58299.

Relates #58299 