### PR TITLE
Handle failures with no explicit cause in async search

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -130,7 +130,17 @@ class MutableSearchResponse {
         //note that when search fails, we may have gotten partial results before the failure. In that case async
         // search will return an error plus the last partial results that were collected.
         this.isPartial = true;
-        this.failure = ElasticsearchException.guessRootCauses(exc)[0];
+        ElasticsearchException[] rootCauses = ElasticsearchException.guessRootCauses(exc);
+        if (rootCauses == null || rootCauses.length == 0) {
+            this.failure = new ElasticsearchException(exc.getMessage(), exc) {
+                @Override
+                protected String getExceptionName() {
+                    return getExceptionName(getCause());
+                }
+            };
+        } else {
+            this.failure = rootCauses[0];
+        }
         this.frozen = true;
     }
 

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -64,7 +64,12 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
 
         @Override
         public List<QuerySpec<?>> getQueries() {
-            return Collections.singletonList(new QuerySpec<>(BlockingQueryBuilder.NAME, in -> new BlockingQueryBuilder(in),
+            return Arrays.asList(
+                new QuerySpec<>(BlockingQueryBuilder.NAME, in -> new BlockingQueryBuilder(in),
+                    p -> {
+                    throw new IllegalStateException("not implemented");
+                }),
+                new QuerySpec<>(ThrowingQueryBuilder.NAME, in -> new ThrowingQueryBuilder(in),
                 p -> {
                     throw new IllegalStateException("not implemented");
                 }));

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.search;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchShard;
 import org.elasticsearch.action.search.ShardSearchFailure;
@@ -212,7 +213,8 @@ public class AsyncSearchTaskTests extends ESTestCase {
                 new IOException("boum"));
         }
         assertCompletionListeners(task, totalShards, totalShards, numSkippedShards, numShards, true);
-        ((AsyncSearchTask.Listener)task.getProgressListener()).onFailure(new IOException("boum"));
+        AsyncSearchTask.Listener listener = task.getSearchProgressActionListener();
+        listener.onFailure(new SearchPhaseExecutionException("fetch", "boum", ShardSearchFailure.EMPTY_ARRAY));
         assertCompletionListeners(task, totalShards, totalShards, numSkippedShards, numShards, true);
     }
 

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/ThrowingQueryBuilder.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/ThrowingQueryBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.search;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+
+class ThrowingQueryBuilder extends AbstractQueryBuilder<ThrowingQueryBuilder> {
+    public static final String NAME = "throw";
+
+    private final long randomUID;
+    private final int shardId;
+
+    /**
+     * Creates a {@link ThrowingQueryBuilder} with the provided <code>randomUID</code>.
+     */
+    ThrowingQueryBuilder(long randomUID, int shardId) {
+        super();
+        this.randomUID = randomUID;
+        this.shardId = shardId;
+    }
+
+    ThrowingQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.randomUID = in.readLong();
+        this.shardId = in.readVInt();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeLong(randomUID);
+        out.writeVInt(shardId);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) {
+        final Query delegate = Queries.newMatchAllQuery();
+        return new Query() {
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+                if (context.getShardId() == shardId) {
+                    throw new AlreadyClosedException("boom");
+                }
+                return delegate.createWeight(searcher, scoreMode, boost);
+            }
+
+            @Override
+            public String toString(String field) {
+                return delegate.toString(field);
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 0;
+            }
+        };
+    }
+
+    @Override
+    protected boolean doEquals(ThrowingQueryBuilder other) {
+        return false;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return 0;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+}


### PR DESCRIPTION
This commit fixes an AOOBE in the handling of fatal failures in _async_search. 
If the underlying cause is not found, this change uses the root failure instead of throwing an uncaught exception.

Closes #58311
Relates #57925