### PR TITLE
[DOCS] Reformat data stream API docs

### DIFF
--- a/docs/reference/data-streams/data-stream-apis.asciidoc
+++ b/docs/reference/data-streams/data-stream-apis.asciidoc
@@ -1,14 +1,16 @@
 [[data-stream-apis]]
 == Data stream APIs
 
-The following APIs are available for managing data streams:
+The following APIs are available for managing <<data-streams,data streams>>:
 
-* To get information about data streams, use the <<indices-get-data-stream, get data stream API>>.
-* To delete data streams, use the <<indices-delete-data-stream, delete data stream API>>.
-* To manually create a data stream, use the <<indices-create-data-stream, create data stream API>>.
+* <<indices-create-data-stream>>
+* <<indices-delete-data-stream>>
+* <<indices-get-data-stream>>
+
+For concepts and tutorials, see <<data-streams>>.
 
 include::{es-repo-dir}/indices/create-data-stream.asciidoc[]
 
-include::{es-repo-dir}/indices/get-data-stream.asciidoc[]
-
 include::{es-repo-dir}/indices/delete-data-stream.asciidoc[]
+
+include::{es-repo-dir}/indices/get-data-stream.asciidoc[]

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -6,8 +6,8 @@
 
 Creates a new <<data-streams,data stream>>.
 
-Data streams require an associated <<<<indices-templates,composable index
-template>>. See <<set-up-a-data-stream>>.
+Data streams require an associated <<indices-templates,composable template>>.
+See <<set-up-a-data-stream>>.
 
 ////
 [source,console]

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -4,14 +4,15 @@
 <titleabbrev>Create data stream</titleabbrev>
 ++++
 
-Creates a new data stream.
+Creates a new <<data-streams,data stream>>.
 
-A data stream can only be created if the namespace it targets has a composable
-index template with a `data_stream` definition.
+Data streams require an associated <<<<indices-templates,composable index
+template>>. See <<set-up-a-data-stream>>.
 
+////
 [source,console]
------------------------------------
-PUT _index_template/template
+----
+PUT /_index_template/template
 {
   "index_patterns": ["my-data-stream*"],
   "template": {
@@ -27,13 +28,13 @@ PUT _index_template/template
     "timestamp_field": "@timestamp"
   }
 }
------------------------------------
-// TEST
+----
+////
 
 [source,console]
---------------------------------------------------
-PUT _data_stream/my-data-stream
---------------------------------------------------
+----
+PUT /_data_stream/my-data-stream
+----
 // TEST[continued]
 
 ////
@@ -48,15 +49,7 @@ DELETE /_index_template/template
 [[indices-create-data-stream-request]]
 ==== {api-request-title}
 
-`PUT _data_stream/<data-stream>`
-
-[[indices-create-data-stream-desc]]
-==== {api-description-title}
-You can use the create data stream API to add a new data stream to an {es}
-cluster. When creating a data stream, you must specify the following:
-
-* The name of the data stream
-* The name of the timestamp field.
+`PUT /_data_stream/<data-stream>`
 
 [[indices-create-data-stream-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>Delete data stream</titleabbrev>
 ++++
 
-Deletes an existing <<<<data-streams,data stream>> and its backing indices.
-See <<delete-a-data-stream>>.
+Deletes an one or more <<<<data-streams,data streams>> and their backing
+indices. See <<delete-a-data-stream>>.
 
 ////
 [source,console]
@@ -56,5 +56,5 @@ DELETE /_index_template/template
 
 `<data-stream>`::
 (Required, string)
-Name for the data stream to delete.
+Name of the data stream to delete.
 Wildcard (`*`) expressions are supported.

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete data stream</titleabbrev>
 ++++
 
-Deletes one or more <<<<data-streams,data streams>> and their backing
+Deletes one or more <<data-streams,data streams>> and their backing
 indices. See <<delete-a-data-stream>>.
 
 ////

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete data stream</titleabbrev>
 ++++
 
-Deletes an one or more <<<<data-streams,data streams>> and their backing
+Deletes one or more <<<<data-streams,data streams>> and their backing
 indices. See <<delete-a-data-stream>>.
 
 ////

--- a/docs/reference/indices/delete-data-stream.asciidoc
+++ b/docs/reference/indices/delete-data-stream.asciidoc
@@ -4,12 +4,13 @@
 <titleabbrev>Delete data stream</titleabbrev>
 ++++
 
-Deletes an existing data stream along with its backing indices.
+Deletes an existing <<<<data-streams,data stream>> and its backing indices.
+See <<delete-a-data-stream>>.
 
 ////
 [source,console]
------------------------------------
-PUT _index_template/template
+----
+PUT /_index_template/template
 {
   "index_patterns": ["my-data-stream*"],
   "template": {
@@ -27,31 +28,33 @@ PUT _index_template/template
 }
 
 PUT /_data_stream/my-data-stream
------------------------------------
+----
 // TESTSETUP
 ////
 
 [source,console]
---------------------------------------------------
-DELETE _data_stream/my-data-stream
---------------------------------------------------
+----
+DELETE /_data_stream/my-data-stream
+----
 
 ////
 [source,console]
------------------------------------
+----
 DELETE /_index_template/template
------------------------------------
+----
 // TEST[continued]
 ////
 
 [[delete-data-stream-api-request]]
 ==== {api-request-title}
 
-`DELETE _data_stream/<data-stream>`
+`DELETE /_data_stream/<data-stream>`
 
 
 [[delete-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 
 `<data-stream>`::
-(Required, string) Name or wildcard expression of data stream(s) to delete.
+(Required, string)
+Name for the data stream to delete.
+Wildcard (`*`) expressions are supported.

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get data stream</titleabbrev>
 ++++
 
-Returns information about one or more <<<<data-streams,data streams>>.
+Returns information about one or more <<data-streams,data streams>>.
 See <<get-info-about-a-data-stream>>.
 
 ////

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -57,7 +57,8 @@ GET /_data_stream/my-data-stream
 
 `<data-stream>`::
 (Required, string)
-Comma-separated list or wildcard (`*`) expression of data streams to retrieve.
+Name of the data stream to retrieve.
+Wildcard (`*`) expressions are supported.
 
 [[get-data-stream-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get data stream</titleabbrev>
 ++++
 
-Returns information about one or more <<data-streams,data streams>>.
+Retrieves information about one or more <<data-streams,data streams>>.
 See <<get-info-about-a-data-stream>>.
 
 ////

--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -4,11 +4,12 @@
 <titleabbrev>Get data stream</titleabbrev>
 ++++
 
-Returns information about one or more data streams.
+Returns information about one or more <<<<data-streams,data streams>>.
+See <<get-info-about-a-data-stream>>.
 
 ////
 [source,console]
------------------------------------
+----
 PUT _index_template/template
 {
   "index_patterns": ["my-data-stream*"],
@@ -27,63 +28,56 @@ PUT _index_template/template
 }
 
 PUT /_data_stream/my-data-stream
------------------------------------
+----
 // TESTSETUP
 ////
 
 ////
 [source,console]
------------------------------------
+----
 DELETE /_data_stream/my-data-stream
 DELETE /_index_template/template
------------------------------------
+----
 // TEARDOWN
 ////
 
 [source,console]
---------------------------------------------------
-GET _data_stream/my-data-stream
---------------------------------------------------
+----
+GET /_data_stream/my-data-stream
+----
 // TEST[skip_shard_failures]
 
 [[get-data-stream-api-request]]
 ==== {api-request-title}
 
-`GET _data_stream/<data-stream>`
-
+`GET /_data_stream/<data-stream>`
 
 [[get-data-stream-api-path-params]]
 ==== {api-path-parms-title}
 
 `<data-stream>`::
-+
---
-(Required, string) Name or wildcard expression of the data stream(s) to
-retrieve.
---
+(Required, string)
+Comma-separated list or wildcard (`*`) expression of data streams to retrieve.
 
 [[get-data-stream-api-example]]
 ==== {api-examples-title}
 
-[[get-data-stream-basic-example]]
-===== Basic example
-
 [source,console]
---------------------------------------------------
+----
 GET _data_stream/my-data-stream*
---------------------------------------------------
+----
 // TEST[continued]
 // TEST[skip_shard_failures]
 
 The API returns the following response:
 
 [source,console-result]
---------------------------------------------------
+----
 [
   {
-    "name" : "my-data-stream", <1>
-    "timestamp_field" : "@timestamp", <2>
-    "indices" : [ <3>
+    "name" : "my-data-stream",                      <1>
+    "timestamp_field" : "@timestamp",               <2>
+    "indices" : [                                   <3>
       {
         "index_name" : ".ds-my-data-stream-000001",
         "index_uuid" : "DXAE-xcCQTKF93bMm9iawA"
@@ -93,10 +87,10 @@ The API returns the following response:
         "index_uuid" : "Wzxq0VhsQKyPxHhaK3WYAg"
       }
     ],
-    "generation" : 2 <4>
+    "generation" : 2                                <4>
   }
 ]
---------------------------------------------------
+----
 // TESTRESPONSE[skip:unable to assert responses with top level array]
 
 <1> Name of the data stream


### PR DESCRIPTION
Changes:
- Cleans up the data stream API docs for consistency
- Removes some redundant content that's better covered
in the [Data streams section](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html)
- Adds xrefs to relevant tutorials