### PR TITLE
Correct default formatting of binary fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -67,6 +67,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
+            hasDocValues = false;
             builder = this;
         }
 
@@ -205,6 +206,16 @@ public class BinaryFieldMapper extends FieldMapper {
             createFieldNamesField(context);
         }
 
+    }
+
+    @Override
+    protected boolean indexedByDefault() {
+        return false;
+    }
+
+    @Override
+    protected boolean docValuesByDefault() {
+        return false;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -74,6 +74,8 @@ public class BinaryFieldMapperTests extends FieldMapperTestCase<BinaryFieldMappe
 
         assertThat(mapper, instanceOf(BinaryFieldMapper.class));
         assertThat(mapper.fieldType.stored(), equalTo(false));
+
+        assertEquals(Strings.toString(mapping), Strings.toString(mapperService.documentMapper()));
     }
 
     public void testStoredValue() throws IOException {


### PR DESCRIPTION
This was picked up in the backport of #57666 but missed in the original commit
on master, leading to failures such as #58282 