### PR TITLE
[DOCS] Prohibit deletion of composable template in use by data stream

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -183,6 +183,9 @@ PUT /_index_template/logs_data_stream
 // TEST[continued]
 ====
 
+NOTE: You cannot delete a composable template that's in use by data stream. This
+would prevent the data stream from creating new backing indices.
+
 [discrete]
 [[create-a-data-stream]]
 === Create a data stream

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -183,8 +183,8 @@ PUT /_index_template/logs_data_stream
 // TEST[continued]
 ====
 
-NOTE: You cannot delete a composable template that's in use by data stream. This
-would prevent the data stream from creating new backing indices.
+NOTE: You cannot delete a composable template that's in use by a data stream.
+This would prevent the data stream from creating new backing indices.
 
 [discrete]
 [[create-a-data-stream]]


### PR DESCRIPTION
Notes that you cannot delete a composable template currently in use
by a data stream. Relates to #57957.