### PR TITLE
[DOCS] Updates pull and issue release attributes

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -8,10 +8,6 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 :build_flavor:          default
 :build_type:            tar
 
-:issue:           https://github.com/elastic/elasticsearch/issues/
-:ml-issue:        https://github.com/elastic/ml-cpp/issues/
-:pull:            https://github.com/elastic/elasticsearch/pull/
-:ml-pull:         https://github.com/elastic/ml-cpp/pull/
 :docker-repo:     docker.elastic.co/elasticsearch/elasticsearch
 :docker-image:    {docker-repo}:{version}
 :plugin_url:      https://artifacts.elastic.co/downloads/elasticsearch-plugins

--- a/docs/reference/cat/tasks.asciidoc
+++ b/docs/reference/cat/tasks.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>cat task management</titleabbrev>
 ++++
 
-beta::["The cat task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{issue}51628]
+beta::["The cat task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{es-issue}51628]
 
 Returns information about tasks currently executing in the cluster,
 similar to the <<tasks,task management>> API.

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Task management</titleabbrev>
 ++++
 
-beta::["The task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{issue}51628]
+beta::["The task management API is new and should still be considered a beta feature. The API may change in ways that are not backwards compatible.",{es-issue}51628]
 
 Returns information about the tasks currently executing in the cluster.
 

--- a/docs/reference/release-notes/8.0.0-alpha1.asciidoc
+++ b/docs/reference/release-notes/8.0.0-alpha1.asciidoc
@@ -11,20 +11,20 @@ The changes listed below have been released for the first time in {es}
 === Breaking changes
 
 Aggregations::
-* Disallow specifying the same percentile multiple times in percentiles aggregation {pull}52257[#52257]
+* Disallow specifying the same percentile multiple times in percentiles aggregation {es-pull}52257[#52257]
 
 Mapping::
 * Dynamic mappings in indices created on 8.0 and later have stricter validation at mapping update time.
-  (e.g. incorrect analyzer settings or unknown field types). {pull}51233[#51233]
+  (e.g. incorrect analyzer settings or unknown field types). {es-pull}51233[#51233]
 
 Deprecations::
-* Remove undocumented endpoints of hot threads API {pull}55109[#55109]
+* Remove undocumented endpoints of hot threads API {es-pull}55109[#55109]
 
 Slow loggers::
 * `index.indexing.slowlog.level` and `index.search.slowlog.level` are removed. These settings can be worked around
 by using appropriate thresholds. If for instance we want to simulate `index.indexing.slowlog.level` = `INFO` then
 all we need to do is to set `index.indexing.slowlog.threshold.index.debug` and
-`index.indexing.slowlog.threshold.index.trace` to `-1` {pull}57591[#57591]
+`index.indexing.slowlog.threshold.index.trace` to `-1` {es-pull}57591[#57591]
 
 
 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/69554 and https://github.com/elastic/docs/pull/1872

This PR shifts the existing release docs to the use of shared attributes "es-pull" and "es-issue" instead of the overloaded "pull" and "issue" attributes. 

There is a separate PR to fix the release note script so that it uses these new attributes too.

