### PR TITLE
[DOCS] Fix analyzer page titles

### DIFF
--- a/docs/reference/analysis/analyzers/fingerprint-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/fingerprint-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-fingerprint-analyzer]]
-=== Fingerprint Analyzer
+=== Fingerprint analyzer
+++++
+<titleabbrev>Fingerprint</titleabbrev>
+++++
 
 The `fingerprint` analyzer implements a
 https://github.com/OpenRefine/OpenRefine/wiki/Clustering-In-Depth#fingerprint[fingerprinting algorithm]

--- a/docs/reference/analysis/analyzers/keyword-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/keyword-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-keyword-analyzer]]
-=== Keyword Analyzer
+=== Keyword analyzer
+++++
+<titleabbrev>Keyword</titleabbrev>
+++++
 
 The `keyword` analyzer is a ``noop'' analyzer which returns the entire input
 string as a single token.

--- a/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-lang-analyzer]]
-=== Language Analyzers
+=== Language analyzers
+++++
+<titleabbrev>Language</titleabbrev>
+++++
 
 A set of analyzers aimed at analyzing specific language text. The
 following types are supported:

--- a/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-pattern-analyzer]]
-=== Pattern snalyzer
+=== Pattern analyzer
 ++++
 <titleabbrev>Pattern</titleabbrev>
 ++++

--- a/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/pattern-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-pattern-analyzer]]
-=== Pattern Analyzer
+=== Pattern snalyzer
+++++
+<titleabbrev>Pattern</titleabbrev>
+++++
 
 The `pattern` analyzer uses a regular expression to split the text into terms.
 The regular expression should match the *token separators*  not the tokens

--- a/docs/reference/analysis/analyzers/simple-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/simple-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-simple-analyzer]]
-=== Simple Analyzer
+=== Simple snalyzer
+++++
+<titleabbrev>Simple</titleabbrev>
+++++
 
 The `simple` analyzer breaks text into terms at any non-letter character, such
 as numbers, spaces, hyphens and apostrophes, discards non-letter characters, 

--- a/docs/reference/analysis/analyzers/simple-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/simple-analyzer.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-simple-analyzer]]
-=== Simple snalyzer
+=== Simple analyzer
 ++++
 <titleabbrev>Simple</titleabbrev>
 ++++

--- a/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-standard-analyzer]]
-=== Standard Analyzer
+=== Standard snalyzer
+++++
+<titleabbrev>Standard</titleabbrev>
+++++
 
 The `standard` analyzer is the default analyzer which is used if none is
 specified. It provides grammar based tokenization (based on the Unicode Text

--- a/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/standard-analyzer.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-standard-analyzer]]
-=== Standard snalyzer
+=== Standard analyzer
 ++++
 <titleabbrev>Standard</titleabbrev>
 ++++

--- a/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/stop-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-stop-analyzer]]
-=== Stop Analyzer
+=== Stop analyzer
+++++
+<titleabbrev>Stop</titleabbrev>
+++++
 
 The `stop` analyzer is the same as the <<analysis-simple-analyzer,`simple` analyzer>>
 but adds support for removing stop words.  It defaults to using the

--- a/docs/reference/analysis/analyzers/whitespace-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/whitespace-analyzer.asciidoc
@@ -1,5 +1,5 @@
 [[analysis-whitespace-analyzer]]
-=== Whitespace snalyzer
+=== Whitespace analyzer
 ++++
 <titleabbrev>Whitespace</titleabbrev>
 ++++

--- a/docs/reference/analysis/analyzers/whitespace-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/whitespace-analyzer.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-whitespace-analyzer]]
-=== Whitespace Analyzer
+=== Whitespace snalyzer
+++++
+<titleabbrev>Whitespace</titleabbrev>
+++++
 
 The `whitespace` analyzer breaks text into terms whenever it encounters a
 whitespace character.

--- a/docs/reference/analysis/charfilters/pattern-replace-charfilter.asciidoc
+++ b/docs/reference/analysis/charfilters/pattern-replace-charfilter.asciidoc
@@ -1,5 +1,8 @@
 [[analysis-pattern-replace-charfilter]]
-=== Pattern Replace Char Filter
+=== Pattern replace character filter
+++++
+<titleabbrev>Pattern replace</titleabbrev>
+++++
 
 The `pattern_replace` character filter uses a regular expression to match
 characters which should be replaced with the specified replacement string.


### PR DESCRIPTION
Changes the titles for analyzer pages to sentence case.

Also changes the 'Pattern character filter' page title to sentence case.