### PR TITLE
Return clear error message if aggregation type is invalid (backport of #58255)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfigTests.java
@@ -6,9 +6,9 @@
 
 package org.elasticsearch.xpack.core.transform.transforms.pivot;
 
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
-import org.elasticsearch.common.xcontent.NamedObjectNotFoundException;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -119,7 +119,7 @@ public class AggregationConfigTests extends AbstractSerializingTransformTestCase
 
         // strict throws
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
-            expectThrows(NamedObjectNotFoundException.class, () -> AggregationConfig.fromXContent(parser, false));
+            expectThrows(ParsingException.class, () -> AggregationConfig.fromXContent(parser, false));
         }
     }
 


### PR DESCRIPTION
The main changes are:

1. Catch the `NamedObjectNotFoundException` when parsing aggregation
   type, and then throw a `ParsingException` with clear error message with hint.
2. Add a unit test method: AggregatorFactoriesTests#testInvalidType().

Closes #58146.
