### PR TITLE
Added caveat about the number of file realms

### DIFF
--- a/x-pack/docs/en/security/authentication/file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/file-realm.asciidoc
@@ -21,7 +21,7 @@ credentials of all other users.
 
 IMPORTANT: When you configure realms in `elasticsearch.yml`, only the realms you
 specify are used for authentication. To use the `file` realm you must explicitly
-include it in the realm chain.  While it is possible to define multiple instances
+include it in the realm chain. While it is possible to define multiple instances
 of some other realms, you can define only _one_ file realm per node.
 
 To define users, the {security-features} provide the

--- a/x-pack/docs/en/security/authentication/file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/file-realm.asciidoc
@@ -22,7 +22,7 @@ credentials of all other users.
 IMPORTANT: When you configure realms in `elasticsearch.yml`, only the realms you
 specify are used for authentication. To use the `file` realm you must explicitly
 include it in the realm chain.  While it is possible to define multiple instances
-of some other realms, it is only possible to define _one_ file realm per node.
+of some other realms, you can define only _one_ file realm per node.
 
 To define users, the {security-features} provide the
 {ref}/users-command.html[users] command-line tool. This tool enables you to add

--- a/x-pack/docs/en/security/authentication/file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/file-realm.asciidoc
@@ -21,7 +21,8 @@ credentials of all other users.
 
 IMPORTANT: When you configure realms in `elasticsearch.yml`, only the realms you
 specify are used for authentication. To use the `file` realm you must explicitly
-include it in the realm chain.
+include it in the realm chain.  While it is possible to define multiple instances
+of some other realms, it is only possible to define _one_ file realm per node.
 
 To define users, the {security-features} provide the
 {ref}/users-command.html[users] command-line tool. This tool enables you to add


### PR DESCRIPTION
There is sometimes confusion as it is possible to define multiple instances of some other realms (e.g. ldap), but only one file realm can be defined  (https://github.com/elastic/elasticsearch/blob/ef48eb35cf30adf4db14086e8aabd07ef6fb113f/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/file/FileUserRolesStore.java#L83).  As there are some situations where for ease of management users may want to define multiple file realms, it may be useful to explicitly note here that the file realm can have only one instance defined.

Preview: https://elasticsearch_58369.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.7/file-realm.html