### PR TITLE
Improve cluster health waiting not found index

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterRequestConverters.java
@@ -73,6 +73,7 @@ final class ClusterRequestConverters {
             .withWaitForStatus(healthRequest.waitForStatus())
             .withWaitForNoRelocatingShards(healthRequest.waitForNoRelocatingShards())
             .withWaitForNoInitializingShards(healthRequest.waitForNoInitializingShards())
+            .withWaitForIndicesExists(healthRequest.waitForIndicesExists())
             .withWaitForActiveShards(healthRequest.waitForActiveShards(), ActiveShardCount.NONE)
             .withWaitForNodes(healthRequest.waitForNodes())
             .withWaitForEvents(healthRequest.waitForEvents())

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -1143,6 +1143,13 @@ final class RequestConverters {
             return this;
         }
 
+        Params withWaitForIndicesExists(boolean waitForIndicesExists) {
+            if (waitForIndicesExists) {
+                return putParam("wait_for_indices_exists", Boolean.TRUE.toString());
+            }
+            return this;
+        }
+
         Params withWaitForNodes(String waitForNodes) {
             return putParam("wait_for_nodes", waitForNodes);
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterRequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterRequestConvertersTests.java
@@ -136,6 +136,13 @@ public class ClusterRequestConvertersTests extends ESTestCase {
                 expectedParams.put("wait_for_no_relocating_shards", Boolean.TRUE.toString());
             }
         }
+        if (ESTestCase.randomBoolean()) {
+            boolean waitForIndicesExists = ESTestCase.randomBoolean();
+            healthRequest.waitForIndicesExists(waitForIndicesExists);
+            if (waitForIndicesExists) {
+                expectedParams.put("wait_for_indices_exists", Boolean.TRUE.toString());
+            }
+        }
         String[] indices = ESTestCase.randomBoolean() ? null : RequestConvertersTests.randomIndicesNames(0, 5);
         healthRequest.indices(indices);
 

--- a/docs/reference/cluster/health.asciidoc
+++ b/docs/reference/cluster/health.asciidoc
@@ -14,21 +14,21 @@ Returns the health status of a cluster.
 [[cluster-health-api-desc]]
 ==== {api-description-title}
 
-The cluster health API returns a simple status on the health of the 
-cluster. The API can also be executed against one or more indices to get just 
+The cluster health API returns a simple status on the health of the
+cluster. The API can also be executed against one or more indices to get just
 the specified indices health.
 
-The cluster health status is: `green`, `yellow` or `red`. On the shard level, a 
-`red` status indicates that the specific shard is not allocated in the cluster, 
-`yellow` means that the primary shard is allocated but replicas are not, and 
-`green` means that all shards are allocated. The index level status is 
-controlled by the worst shard status. The cluster status is controlled by the 
+The cluster health status is: `green`, `yellow` or `red`. On the shard level, a
+`red` status indicates that the specific shard is not allocated in the cluster,
+`yellow` means that the primary shard is allocated but replicas are not, and
+`green` means that all shards are allocated. The index level status is
+controlled by the worst shard status. The cluster status is controlled by the
 worst index status.
 
-One of the main benefits of the API is the ability to wait until the cluster 
-reaches a certain high water-mark health level. For example, the following will 
-wait for 50 seconds for the cluster to reach the `yellow` level (if it reaches 
-the `green` or `yellow` status before 50 seconds elapse, it will return at that 
+One of the main benefits of the API is the ability to wait until the cluster
+reaches a certain high water-mark health level. For example, the following will
+wait for 50 seconds for the cluster to reach the `yellow` level (if it reaches
+the `green` or `yellow` status before 50 seconds elapse, it will return at that
 point):
 
 [source,console]
@@ -45,32 +45,36 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
 ==== {api-query-parms-title}
 
 `level`::
-    (Optional, string) Can be one of `cluster`, `indices` or `shards`. Controls 
+    (Optional, string) Can be one of `cluster`, `indices` or `shards`. Controls
     the details level of the health information returned. Defaults to `cluster`.
-    
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
-    
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `wait_for_active_shards`::
-    (Optional, string) A number controlling to how many active shards to wait 
-    for, `all` to wait for all shards in the cluster to be active, or `0` to not 
+    (Optional, string) A number controlling to how many active shards to wait
+    for, `all` to wait for all shards in the cluster to be active, or `0` to not
     wait. Defaults to `0`.
-    
+
 `wait_for_events`::
-    (Optional, string) Can be one of `immediate`, `urgent`, `high`, `normal`, 
-    `low`, `languid`. Wait until all currently queued events with the given 
+    (Optional, string) Can be one of `immediate`, `urgent`, `high`, `normal`,
+    `low`, `languid`. Wait until all currently queued events with the given
     priority are processed.
 
 `wait_for_no_initializing_shards`::
-    (Optional, boolean) A boolean value which controls whether to wait (until 
-    the timeout provided) for the cluster to have no shard initializations. 
+    (Optional, boolean) A boolean value which controls whether to wait (until
+    the timeout provided) for the cluster to have no shard initializations.
     Defaults to false, which means it will not wait for initializing shards.
 
 `wait_for_no_relocating_shards`::
-    (Optional, boolean) A boolean value which controls whether to wait (until 
-    the timeout provided) for the cluster to have no shard relocations. Defaults 
+    (Optional, boolean) A boolean value which controls whether to wait (until
+    the timeout provided) for the cluster to have no shard relocations. Defaults
     to false, which means it will not wait for relocating shards.
+
+`wait_for_indices_exists`::
+    (Optional, boolean) If sets indices, and indices not exists, set true to  wait until
+    the timeout. Defaults to false`, which means it will not wait for indices exists.
 
 `wait_for_nodes`::
     (Optional, string) The request waits until the specified number `N` of
@@ -79,7 +83,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
     `lt(N)` notation.
 
 `wait_for_status`::
-    (Optional, string) One of `green`, `yellow` or `red`. Will wait (until the 
+    (Optional, string) One of `green`, `yellow` or `red`. Will wait (until the
     timeout provided) until the status of the cluster changes to the one
     provided or better, i.e. `green` > `yellow` > `red`. By default, will not
     wait for any status.
@@ -94,7 +98,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
 
 `timed_out`::
-    (boolean) If `false` the response returned within the period of 
+    (boolean) If `false` the response returned within the period of
     time that is specified by the `timeout` parameter (`30s` by default).
 
 `number_of_nodes`::
@@ -119,22 +123,22 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
     (integer) The number of shards that are not allocated.
 
 `delayed_unassigned_shards`::
-    (integer) The number of shards whose allocation has been delayed by the 
+    (integer) The number of shards whose allocation has been delayed by the
     timeout settings.
 
 `number_of_pending_tasks`::
-    (integer) The number of cluster-level changes that have not yet been 
+    (integer) The number of cluster-level changes that have not yet been
     executed.
 
 `number_of_in_flight_fetch`::
     (integer) The number of unfinished fetches.
 
 `task_max_waiting_in_queue_millis`::
-    (integer) The time expressed in milliseconds since the earliest initiated task 
+    (integer) The time expressed in milliseconds since the earliest initiated task
     is waiting for being performed.
 
 `active_shards_percent_as_number`::
-    (float) The ratio of active shards in the cluster expressed as a percentage. 
+    (float) The ratio of active shards in the cluster expressed as a percentage.
 
 [[cluster-health-api-example]]
 ==== {api-examples-title}
@@ -145,7 +149,7 @@ GET _cluster/health
 --------------------------------------------------
 // TEST[s/^/PUT test1\n/]
 
-The API returns the following response in case of a quiet single node cluster 
+The API returns the following response in case of a quiet single node cluster
 with a single index with one shard and one replica:
 
 [source,console-result]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -90,6 +90,10 @@
         "type":"boolean",
         "description":"Whether to wait until there are no initializing shards in the cluster"
       },
+      "wait_for_indices_exists":{
+        "type":"boolean",
+        "description":"Whether to wait until indices exists"
+      },
       "wait_for_status":{
         "type":"enum",
         "options":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.health/10_basic.yml
@@ -276,3 +276,19 @@
       cluster.health:
         index: index-2
   - match:     { status:     yellow }
+
+---
+"cluster health basic test, index not found test":
+  - do:
+      cluster.health:
+        index: test_index
+
+  - is_false:  timed_out
+
+  - do:
+      cluster.health:
+        index: test_index
+        wait_for_indices_exists: true
+        timeout: 1s
+
+  - is_false:  timed_out

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -44,6 +44,7 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
     private ClusterHealthStatus waitForStatus;
     private boolean waitForNoRelocatingShards = false;
     private boolean waitForNoInitializingShards = false;
+    private boolean waitForIndicesExists = false;
     private ActiveShardCount waitForActiveShards = ActiveShardCount.NONE;
     private String waitForNodes = "";
     private Priority waitForEvents = null;
@@ -87,6 +88,9 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         } else {
             indicesOptions = IndicesOptions.lenientExpandOpen();
         }
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+            waitForIndicesExists = in.readBoolean();
+        }
     }
 
     @Override
@@ -119,6 +123,9 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         out.writeBoolean(waitForNoInitializingShards);
         if (out.getVersion().onOrAfter(Version.V_7_2_0)) {
             indicesOptions.writeIndicesOptions(out);
+        }
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+            out.writeBoolean(waitForIndicesExists);
         }
     }
 
@@ -203,6 +210,21 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
      */
     public ClusterHealthRequest waitForNoInitializingShards(boolean waitForNoInitializingShards) {
         this.waitForNoInitializingShards = waitForNoInitializingShards;
+        return this;
+    }
+
+    public boolean waitForIndicesExists() {
+        return waitForIndicesExists;
+    }
+
+    /**
+     * Sets whether the request should wait for indices exists if indices is not empty before
+     * retrieving the cluster health status.  Defaults to {@code false}, meaning the
+     * operation does not wait on if indices not found.  Set to <code>true</code>
+     * to wait until the indices exists.
+     */
+    public ClusterHealthRequest waitForIndicesExists(boolean waitForIndicesExists) {
+        this.waitForIndicesExists = waitForIndicesExists;
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -233,7 +233,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
         if (request.waitForNodes().isEmpty() == false) {
             waitCount++;
         }
-        if (CollectionUtils.isEmpty(request.indices()) == false) { // check that they actually exists in the meta data
+        if (request.waitForIndicesExists() && CollectionUtils.isEmpty(request.indices()) == false) { // check that they actually exists in the meta data
             waitCount++;
         }
         return waitCount;
@@ -291,7 +291,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                 waitForCounter++;
             }
         }
-        if (CollectionUtils.isEmpty(request.indices()) == false) {
+        if (request.waitForIndicesExists() && CollectionUtils.isEmpty(request.indices()) == false) {
             try {
                 indexNameExpressionResolver.concreteIndexNames(clusterState, IndicesOptions.strictExpand(), true, request.indices());
                 waitForCounter++;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterHealthAction.java
@@ -72,6 +72,8 @@ public class RestClusterHealthAction extends BaseRestHandler {
             throw new IllegalArgumentException("wait_for_relocating_shards has been removed, " +
                                                "use wait_for_no_relocating_shards [true/false] instead");
         }
+        clusterHealthRequest.waitForIndicesExists(
+            request.paramAsBoolean("wait_for_indices_exists", clusterHealthRequest.waitForIndicesExists()));
         String waitForActiveShards = request.param("wait_for_active_shards");
         if (waitForActiveShards != null) {
             clusterHealthRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));


### PR DESCRIPTION
when calling cluster health with a not found index, request will block until timeout.
e.g GET /_cluster/health/xxx.
I add a param to control this blocked action. Default case, request will not block. set `wait_for_indices_exists` to true, to block request.