### PR TITLE
[ML] Add a new annotation type for categorization status changes

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/Annotation.java
@@ -43,7 +43,8 @@ public class Annotation implements ToXContentObject, Writeable {
         USER,
         DELAYED_DATA,
         MODEL_SNAPSHOT_STORED,
-        MODEL_CHANGE;
+        MODEL_CHANGE,
+        CATEGORIZATION_STATUS_CHANGE;
 
         public static Event fromString(String value) {
             return valueOf(value.toUpperCase(Locale.ROOT));


### PR DESCRIPTION
Adds a new value to the "event" enum of ML annotations, namely
"categorization_status_change".

This will allow users to see when categorization was found to
be performing poorly.  Once per-partition categorization is
available, it will allow users to see when categorization is
performing poorly for a specific partition.

It does not make sense to reuse the "model_change" event that
annotations already have, because categorizer state is separate
to model state ("model" state is really anomaly detector state),
and is not reverted by the revert model snapshot API.
Therefore annotations related to categorization need to be
treated differently to annotations related to anomaly detection.