### PR TITLE
Save Shard ID Serializations in Bulk Requests (#56209)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/DocWriteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteRequest.java
@@ -22,10 +22,12 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -216,16 +218,22 @@ public interface DocWriteRequest<T> extends IndicesRequest {
         }
     }
 
-    /** read a document write (index/delete/update) request */
-    static DocWriteRequest<?> readDocumentRequest(StreamInput in) throws IOException {
+    /**
+     * Read a document write (index/delete/update) request
+     *
+     * @param shardId shard id of the request. {@code null} when reading as part of a {@link org.elasticsearch.action.bulk.BulkRequest}
+     *                that does not have a unique shard id or when reading from a stream of version older than
+     *                {@link org.elasticsearch.action.bulk.BulkShardRequest#COMPACT_SHARD_ID_VERSION}
+     */
+    static DocWriteRequest<?> readDocumentRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
         byte type = in.readByte();
         DocWriteRequest<?> docWriteRequest;
         if (type == 0) {
-            docWriteRequest = new IndexRequest(in);
+            docWriteRequest = new IndexRequest(shardId, in);
         } else if (type == 1) {
-            docWriteRequest = new DeleteRequest(in);
+            docWriteRequest = new DeleteRequest(shardId, in);
         } else if (type == 2) {
-            docWriteRequest = new UpdateRequest(in);
+            docWriteRequest = new UpdateRequest(shardId, in);
         } else {
             throw new IllegalStateException("invalid request type [" + type+ " ]");
         }
@@ -243,6 +251,22 @@ public interface DocWriteRequest<T> extends IndicesRequest {
         } else if (request instanceof UpdateRequest) {
             out.writeByte((byte) 2);
             ((UpdateRequest) request).writeTo(out);
+        } else {
+            throw new IllegalStateException("invalid request [" + request.getClass().getSimpleName() + " ]");
+        }
+    }
+
+    /** write a document write (index/delete/update) request without shard id*/
+    static void writeDocumentRequestThin(StreamOutput out, DocWriteRequest<?> request)  throws IOException {
+        if (request instanceof IndexRequest) {
+            out.writeByte((byte) 0);
+            ((IndexRequest) request).writeThin(out);
+        } else if (request instanceof DeleteRequest) {
+            out.writeByte((byte) 1);
+            ((DeleteRequest) request).writeThin(out);
+        } else if (request instanceof UpdateRequest) {
+            out.writeByte((byte) 2);
+            ((UpdateRequest) request).writeThin(out);
         } else {
             throw new IllegalStateException("invalid request [" + request.getClass().getSimpleName() + " ]");
         }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -85,7 +85,7 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
         waitForActiveShards = ActiveShardCount.readFrom(in);
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
-            requests.add(DocWriteRequest.readDocumentRequest(in));
+            requests.add(DocWriteRequest.readDocumentRequest(null, in));
         }
         refreshPolicy = RefreshPolicy.readFrom(in);
         timeout = in.readTimeValue();

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
@@ -71,6 +71,7 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
 
     public DeleteRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
         super(shardId, in);
+        type = in.readString();
         id = in.readString();
         routing = in.readOptionalString();
         if (in.getVersion().before(Version.V_7_0_0)) {

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteRequest.java
@@ -66,8 +66,11 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
     private long ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
 
     public DeleteRequest(StreamInput in) throws IOException {
-        super(in);
-        type = in.readString();
+        this(null, in);
+    }
+
+    public DeleteRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
+        super(shardId, in);
         id = in.readString();
         routing = in.readOptionalString();
         if (in.getVersion().before(Version.V_7_0_0)) {
@@ -301,8 +304,18 @@ public class DeleteRequest extends ReplicatedWriteRequest<DeleteRequest>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        // A 7.x request allows null types but if deserialized in a 6.x node will cause nullpointer exceptions. 
-        // So we use the type accessor method here to make the type non-null (will default it to "_doc"). 
+        writeBody(out);
+    }
+
+    @Override
+    public void writeThin(StreamOutput out) throws IOException {
+        super.writeThin(out);
+        writeBody(out);
+    }
+
+    private void writeBody(StreamOutput out) throws IOException {
+        // A 7.x request allows null types but if deserialized in a 6.x node will cause nullpointer exceptions.
+        // So we use the type accessor method here to make the type non-null (will default it to "_doc").
         out.writeString(type());
         out.writeString(id);
         out.writeOptionalString(routing());

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -119,7 +119,11 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     private long ifPrimaryTerm = UNASSIGNED_PRIMARY_TERM;
 
     public IndexRequest(StreamInput in) throws IOException {
-        super(in);
+        this(null, in);
+    }
+
+    public IndexRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
+        super(shardId, in);
         type = in.readOptionalString();
         id = in.readOptionalString();
         routing = in.readOptionalString();
@@ -699,6 +703,17 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
     public void writeTo(StreamOutput out) throws IOException {
         checkAutoIdWithOpTypeCreateSupportedByVersion(out.getVersion());
         super.writeTo(out);
+        writeBody(out);
+    }
+
+    @Override
+    public void writeThin(StreamOutput out) throws IOException {
+        checkAutoIdWithOpTypeCreateSupportedByVersion(out.getVersion());
+        super.writeThin(out);
+        writeBody(out);
+    }
+
+    private void writeBody(StreamOutput out) throws IOException {
         // A 7.x request allows null types but if deserialized in a 6.x node will cause nullpointer exceptions.
         // So we use the type accessor method here to make the type non-null (will default it to "_doc").
         out.writeOptionalString(type());

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicatedWriteRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicatedWriteRequest.java
@@ -38,6 +38,14 @@ public abstract class ReplicatedWriteRequest<R extends ReplicatedWriteRequest<R>
     private RefreshPolicy refreshPolicy = RefreshPolicy.NONE;
 
     /**
+     * Constructor for thin deserialization.
+     */
+    public ReplicatedWriteRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
+        super(shardId, in);
+        refreshPolicy = RefreshPolicy.readFrom(in);
+    }
+
+    /**
      * Constructor for deserialization.
      */
     public ReplicatedWriteRequest(StreamInput in) throws IOException {
@@ -64,6 +72,12 @@ public abstract class ReplicatedWriteRequest<R extends ReplicatedWriteRequest<R>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        refreshPolicy.writeTo(out);
+    }
+
+    @Override
+    public void writeThin(StreamOutput out) throws IOException {
+        super.writeThin(out);
         refreshPolicy.writeTo(out);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -67,15 +67,28 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     private long routedBasedOnClusterVersion = 0;
 
     public ReplicationRequest(StreamInput in) throws IOException {
+        this(null, in);
+    }
+
+    public ReplicationRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
         super(in);
-        if (in.readBoolean()) {
-            shardId = new ShardId(in);
+        final boolean thinRead = shardId != null;
+        if (thinRead) {
+            this.shardId = shardId;
         } else {
-            shardId = null;
-        }
+            this.shardId = in.readOptionalWriteable(ShardId::new);
+       }
         waitForActiveShards = ActiveShardCount.readFrom(in);
         timeout = in.readTimeValue();
-        index = in.readString();
+        if (thinRead) {
+            if (in.readBoolean()) {
+                index = in.readString();
+            } else {
+                index = shardId.getIndexName();
+            }
+        } else {
+            index = in.readString();
+        }
         routedBasedOnClusterVersion = in.readVLong();
     }
 
@@ -194,6 +207,23 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
         waitForActiveShards.writeTo(out);
         out.writeTimeValue(timeout);
         out.writeString(index);
+        out.writeVLong(routedBasedOnClusterVersion);
+    }
+
+    /**
+     * Thin serialization that does not write {@link #shardId} and will only write {@link #index} if it is different from the index name in
+     * {@link #shardId}.
+     */
+    public void writeThin(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        waitForActiveShards.writeTo(out);
+        out.writeTimeValue(timeout);
+        if (shardId != null && index.equals(shardId.getIndexName())) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeString(index);
+        }
         out.writeVLong(routedBasedOnClusterVersion);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -129,7 +129,11 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
     public UpdateRequest() {}
 
     public UpdateRequest(StreamInput in) throws IOException {
-        super(in);
+        this(null, in);
+    }
+
+    public UpdateRequest(@Nullable ShardId shardId, StreamInput in) throws IOException {
+        super(shardId, in);
         waitForActiveShards = ActiveShardCount.readFrom(in);
         type = in.readString();
         id = in.readString();
@@ -143,7 +147,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         retryOnConflict = in.readVInt();
         refreshPolicy = RefreshPolicy.readFrom(in);
         if (in.readBoolean()) {
-            doc = new IndexRequest(in);
+            doc = new IndexRequest(shardId, in);
         }
         if (in.getVersion().before(Version.V_7_0_0)) {
             String[] fields = in.readOptionalStringArray();
@@ -153,7 +157,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         }
         fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
         if (in.readBoolean()) {
-            upsertRequest = new IndexRequest(in);
+            upsertRequest = new IndexRequest(shardId, in);
         }
         docAsUpsert = in.readBoolean();
         if (in.getVersion().before(Version.V_7_0_0)) {
@@ -872,6 +876,16 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        doWrite(out, false);
+    }
+
+    @Override
+    public void writeThin(StreamOutput out) throws IOException {
+        super.writeThin(out);
+        doWrite(out, true);
+    }
+
+    private void doWrite(StreamOutput out, boolean thin) throws IOException {
         waitForActiveShards.writeTo(out);
         // A 7.x request allows null types but if deserialized in a 6.x node will cause nullpointer exceptions.
         // So we use the type accessor method here to make the type non-null (will default it to "_doc").
@@ -897,7 +911,11 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
             doc.index(index);
             doc.type(type);
             doc.id(id);
-            doc.writeTo(out);
+            if (thin) {
+                doc.writeThin(out);
+            } else {
+                doc.writeTo(out);
+            }
         }
         if (out.getVersion().before(Version.V_7_0_0)) {
             out.writeOptionalStringArray(null);
@@ -911,7 +929,11 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
             upsertRequest.index(index);
             upsertRequest.type(type);
             upsertRequest.id(id);
-            upsertRequest.writeTo(out);
+            if (thin) {
+                upsertRequest.writeThin(out);
+            } else {
+                upsertRequest.writeTo(out);
+            }
         }
         out.writeBoolean(docAsUpsert);
         if (out.getVersion().before(Version.V_7_0_0)) {

--- a/server/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
@@ -81,7 +81,7 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
         public Request() {}
 
         public Request(StreamInput in) throws IOException {
-            super(in);
+            super(null, in);
         }
     }
 


### PR DESCRIPTION
Just like #56094 but for the request side.
Removes a lot of redundant `ShardId` instances from bulk shard requests as well as stops serializing index names when they're not needed because they're not different from what is in the shard id.

Even ignoring the index name serialization savings here, this change saves one `ShardId` instance per bulk shard request at least. This means it saves approximately:

* 8 bytes for the `ShardId` object (itself + one field)
   * + another 4 bytes for the `int` in the `ShardId`
* 16 bytes (two fields + the instance itself + the padding) for the `Index` object
   * + 30 bytes for the `Index` uuid string
   * + all the bytes in the index name string

=> 60+ bytes per bulk request item saved on heap and over the wire

backport of #56209 