### PR TITLE
[Docs] Rename kibana user to kibana_system

### DIFF
--- a/x-pack/docs/en/security/authentication/built-in-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/built-in-users.asciidoc
@@ -8,7 +8,7 @@ authenticated until their passwords have been set. The `elastic` user can be
 used to <<set-built-in-user-passwords,set all of the built-in user passwords>>.
 
 `elastic`:: A built-in <<built-in-roles,superuser>>.
-`kibana`:: The user Kibana uses to connect and communicate with {es}.
+`kibana_system`:: The user Kibana uses to connect and communicate with {es}.
 `logstash_system`:: The user Logstash uses when storing monitoring information in {es}.
 `beats_system`:: The user the Beats use when storing monitoring information in {es}.
 `apm_system`:: The user the APM server uses when storing monitoring information in {es}.


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/58422 - we had a stray reference to the `kibana` user, which has now been renamed to `kibana_system`.