### PR TITLE
[ML] wait for yellow state for stats index in tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
@@ -96,6 +96,12 @@ setup:
               }
             ]
           }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      cluster.health:
+        wait_for_status: yellow
+        index: .ml-stats*
 ---
 "Test get stats given missing trained model":
 
@@ -129,11 +135,6 @@ setup:
         model_id: "a-unused-regression-model"
 
   - match: { count: 1 }
-
-  - do:
-      cluster.health:
-        wait_for_status: yellow
-        index: .ml-stats*
 
   - do:
       ml.get_trained_models_stats:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
@@ -131,6 +131,11 @@ setup:
   - match: { count: 1 }
 
   - do:
+      cluster.health:
+        wait_for_status: yellow
+        index: .ml-stats*
+
+  - do:
       ml.get_trained_models_stats:
         model_id: "_all"
   - match: { count: 4 }


### PR DESCRIPTION
GET inference stats now reads from the .ml-stats index. 

Our tests should wait for yellow state before attempting to query the index for stat information.