### PR TITLE
[7.x] [ML] only log if forecasts are set to failed (#58421)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1356,7 +1356,9 @@ public class JobResultsProvider {
 
         executeAsyncWithOrigin(client, ML_ORIGIN, UpdateByQueryAction.INSTANCE, request, ActionListener.wrap(
             response -> {
-                LOGGER.info("[{}] set [{}] forecasts to failed", jobId, response.getUpdated());
+                if (response.getUpdated() > 0) {
+                    LOGGER.warn("[{}] set [{}] forecasts to failed", jobId, response.getUpdated());
+                }
                 if (response.getBulkFailures().size() > 0) {
                     LOGGER.warn(
                         "[{}] failed to set [{}] forecasts to failed. Bulk failures experienced {}",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] only log if forecasts are set to failed (#58421)