### PR TITLE
[DOCS] Note that DS timestamp field mapping changes require reindex

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -133,6 +133,11 @@ POST /logs/_rollover/
 ----
 // TEST[continued]
 ====
++
+IMPORTANT: You cannot use these methods to change the mapping of a data stream's
+<<create-a-data-stream-template,timestamp field>>. To change the timestamp
+field's mapping, you must reindex the data stream. See
+<<data-streams-use-reindex-to-change-mappings-settings>>.
 
 * To apply mapping and setting changes to all existing backing indices and
 future ones, you must create a new data stream and reindex your data into it.

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -138,7 +138,13 @@ this pattern.
   stream.
 
 * A <<date,`date`>> or <<date_nanos,`date_nanos`>> field mapping for the
-  timestamp field specified in the `timestamp_field` property.
+timestamp field specified in the `timestamp_field` property.
++
+IMPORTANT: Carefully consider the timestamp field's mapping, including
+<<mapping-params,mapping parameters>> such as <<mapping-date-format,`format`>>.
+Once the stream is created, you can only update the timestamp field's mapping by
+reindexing the data stream. See
+<<data-streams-use-reindex-to-change-mappings-settings>>.
 
 * If you intend to use {ilm-init}, you must specify the
   <<configure-a-data-stream-ilm-policy,lifecycle policy>> in the


### PR DESCRIPTION
With #58096, data streams now track the timestamp field mapping outside
of the template associated with the stream. This means you can no longer
update the timestamp field mapping using template changes.

This updates the associated data stream docs.