### PR TITLE
Fix test failure in RangeQueryBuilderTests.testToQuery

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -83,7 +83,13 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
                 // otherwise we could trigger exception.
                 if (createShardContext().getMapperService().fieldType(DATE_FIELD_NAME) != null) {
                     if (randomBoolean()) {
-                        query.timeZone(randomZone().getId());
+                        // drawing a truly random zoneId here can rarely fail under the following conditons:
+                        // - index versionCreated before V_7_0_0
+                        // - no "forced" date parser through a format parameter
+                        // - one of the SystemV* time zones that Jodas DateTimeZone parser doesn't know about
+                        // thats why we exlude it here (see #58431)
+                        String zoneId = randomValueOtherThanMany(zi -> zi.getId().startsWith("SystemV"), () -> randomZone()).getId();
+                        query.timeZone(zoneId);
                     }
                     if (randomBoolean()) {
                         String format = "strict_date_optional_time";


### PR DESCRIPTION
Very rarely this test can fail if we draw a random TimeZone id that we cannot
parse with the legacy joda DateMathParser and get an IllegalArgumentException.
In addition to a "SystemV/*" time zone we also need an index "versionCreated"
before V_7_0_0 and no "format" setting in the query builder. Given how unlikely
this combination is, we should simply dissallow those time zone ids when
generating the random query builder for RangeQueryBuilderTests.

Closes #58431