### PR TITLE
[7.x] [DOCS] Fix typo in RoutingNode comment (#58079)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -121,7 +121,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
 
     /**
      * Add a new shard to this node
-     * @param shard Shard to crate on this Node
+     * @param shard Shard to create on this Node
      */
     void add(ShardRouting shard) {
         assert invariant();


### PR DESCRIPTION
7.x backport of #58079