### PR TITLE
[7.x] [ML] wait for yellow state for stats index in tests (#58436)

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
@@ -96,6 +96,12 @@ setup:
               }
             ]
           }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      cluster.health:
+        wait_for_status: yellow
+        index: .ml-stats*
 ---
 "Test get stats given missing trained model":
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] wait for yellow state for stats index in tests (#58436)