### PR TITLE
Relax permissions check in start up scripts.

### DIFF
--- a/distribution/src/bin/elasticsearch-env-from-file
+++ b/distribution/src/bin/elasticsearch-env-from-file
@@ -55,11 +55,11 @@ for VAR_NAME_FILE in ELASTIC_PASSWORD_FILE KEYSTORE_PASSWORD_FILE ; do
 
     FILE_PERMS="$(stat -L -c '%a' ${!VAR_NAME_FILE})"
 
-    if [[ "$FILE_PERMS" != "400" && "$FILE_PERMS" != "600" ]]; then
+    if [[ "$FILE_PERMS" != "400" && "$FILE_PERMS" != "440" && "$FILE_PERMS" != "600" && "$FILE_PERMS" != "640" ]]; then
       if [[ -L "${!VAR_NAME_FILE}" ]]; then
-        echo "ERROR: File $(readlink "${!VAR_NAME_FILE}") (target of symlink ${!VAR_NAME_FILE} from $VAR_NAME_FILE) must have file permissions 400 or 600, but actually has: $FILE_PERMS" >&2
+        echo "ERROR: File $(readlink "${!VAR_NAME_FILE}") (target of symlink ${!VAR_NAME_FILE} from $VAR_NAME_FILE) must have file permissions 400, 440, 600, or 640, but actually has: $FILE_PERMS" >&2
       else
-        echo "ERROR: File ${!VAR_NAME_FILE} from $VAR_NAME_FILE must have file permissions 400 or 600, but actually has: $FILE_PERMS" >&2
+        echo "ERROR: File ${!VAR_NAME_FILE} from $VAR_NAME_FILE must have file permissions 400, 440, 600, or 640, but actually has: $FILE_PERMS" >&2
       fi
       exit 1
     fi


### PR DESCRIPTION
Allow group read permission on the env files in the start up scripts.

See: https://github.com/elastic/elasticsearch/issues/52625#issuecomment-632587920

Signed-off-by: Jim Barber <jim.barber@healthengine.com.au>
