### PR TITLE
[DOCS] Update aliases to indicate array

### DIFF
--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -93,7 +93,7 @@ If the `aliases` parameter is not specified,
 this parameter is required for the `add` or `remove` action.
 
 `aliases`::
-(Array)
+(Array of strings)
 Array of index alias names to
 add, remove, or delete.
 +

--- a/docs/reference/indices/aliases.asciidoc
+++ b/docs/reference/indices/aliases.asciidoc
@@ -93,8 +93,8 @@ If the `aliases` parameter is not specified,
 this parameter is required for the `add` or `remove` action.
 
 `aliases`::
-(String)
-Comma-separated list or wildcard expression of index alias names to
+(Array)
+Array of index alias names to
 add, remove, or delete.
 +
 If the `alias` parameter is not specified,


### PR DESCRIPTION
This commit updates the aliases documentation
to correct the parameter to an array. See https://github.com/elastic/elasticsearch/blob/f0674af132ba6c137673994e3583b21d74cc1dd5/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java#L174-L179


