### PR TITLE
Simplify Serialization of ForceMergeRequest

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1041,7 +1041,7 @@ public abstract class Engine implements Closeable {
      */
     public abstract void forceMerge(boolean flush, int maxNumSegments, boolean onlyExpungeDeletes,
                                     boolean upgrade, boolean upgradeOnlyAncientSegments,
-                                    @Nullable String forceMergeUUID) throws EngineException, IOException;
+                                    String forceMergeUUID) throws EngineException, IOException;
 
     /**
      * Snapshots the most recent index and returns a handle to it. If needed will try and "commit" the


### PR DESCRIPTION
We can use a normal string for the uuid when we don't have any nodes in the cluster that could have
created the request with a `null` force merge uuid in it in the cluster any longer (nodes before 7.7).
