### PR TITLE
EQL: tests update

### DIFF
--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
@@ -65,8 +65,7 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
         }
 
         CreateIndexRequest request = new CreateIndexRequest(testIndexName)
-                .mapping(Streams.readFully(CommonEqlActionTestCase.class.getResourceAsStream("/mapping-default.json")),
-                        XContentType.JSON);
+                .mapping(Streams.readFully(CommonEqlActionTestCase.class.getResourceAsStream("/mapping-default.json")), XContentType.JSON);
 
         tc.highLevelClient().indices().create(request, RequestOptions.DEFAULT);
 

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.test.eql;
+
+import org.apache.http.HttpHost;
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+public class DataLoader {
+
+    public static void main(String[] args) throws IOException {
+        try (RestClient client = RestClient.builder(new HttpHost("localhost", 9200)).build()) {
+            loadDatasetIntoEs(new RestHighLevelClient(
+                client,
+                ignore -> {
+                },
+                List.of()) {
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static void loadDatasetIntoEs(RestHighLevelClient client) throws IOException {
+        CreateIndexRequest request = new CreateIndexRequest(CommonEqlActionTestCase.testIndexName)
+            .mapping(Streams.readFully(CommonEqlActionTestCase.class.getResourceAsStream("/mapping-default.json")), XContentType.JSON);
+
+        client.indices().create(request, RequestOptions.DEFAULT);
+    
+        BulkRequest bulk = new BulkRequest();
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+    
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent,
+                CommonEqlActionTestCase.class.getResourceAsStream("/test_data.json"))) {
+            List<Object> list = parser.list();
+            for (Object item : list) {
+                bulk.add(new IndexRequest(CommonEqlActionTestCase.testIndexName).source((Map<String, Object>) item, XContentType.JSON));
+            }
+        }
+    
+        if (bulk.numberOfActions() > 0) {
+            BulkResponse bulkResponse = client.bulk(bulk, RequestOptions.DEFAULT);
+            if (bulkResponse.hasFailures()) {
+                LogManager.getLogger(DataLoader.class).info("Data FAILED loading");
+            } else {
+                LogManager.getLogger(DataLoader.class).info("Data loaded");
+            }
+        }
+    }
+
+    private static XContentParser createParser(XContent xContent, InputStream data) throws IOException {
+        NamedXContentRegistry contentRegistry = new NamedXContentRegistry(ClusterModule.getNamedXWriteables());
+        return xContent.createParser(contentRegistry, LoggingDeprecationHandler.INSTANCE, data);
+    }
+}

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
@@ -848,31 +848,31 @@ registry where bytes_written_string_list[1] == 'EN'
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+localgroup\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+localgroup\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w+\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w+\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 expected_event_ids  = [98]
 query = '''
-process where match(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where match(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+[localgrup]{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+[localgrup]{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
@@ -947,14 +947,14 @@ description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plore') == 2 and not indexOf(file_name, '.pf')
+file where opcode=0 and indexOf(file_name, 'plore') == 2 and indexOf(file_name, '.pf') == null
 '''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.') and indexOf(file_name, 'plore', 100)
+file where opcode=0 and indexOf(file_name, 'explorer.') != null and indexOf(file_name, 'plore', 100) != null
 '''
 expected_event_ids = []
 description = "check built-in string functions"
@@ -967,19 +967,19 @@ description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2)'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) != null'''
 expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 4)'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 4) != null'''
 expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'thing that never happened')'''
+file where opcode=0 and indexOf(file_name, 'thing that never happened') != null'''
 expected_event_ids = []
 description = "check built-in string functions"
 
@@ -1067,13 +1067,14 @@ process where serial_event_id == number('32', 16)'''
 
 [[queries]]
 query = '''
-process where number(serial_event_id) == number(5)'''
+process where concat(serial_event_id, ':', process_name, opcode) == '5:winINIT.exe3'
+'''
 expected_event_ids  = [5]
-description = "test string/number conversions"
+description = "test string concatenation"
 
 [[queries]]
 query = '''
-process where concat(serial_event_id, ':', process_name, opcode) == '5:winINIT.exe3'
+process where concat(serial_event_id, ':', process_name, opcode) == '5:wininit.exe3'
 '''
 expected_event_ids  = [5]
 description = "test string concatenation"
@@ -1178,6 +1179,13 @@ network where safe(divide(process_name, process_name))
 [[queries]]
 query = '''
 file where serial_event_id == 82 and (true == (process_name in ('svchost.EXE', 'bad.exe', 'bad2.exe')))
+'''
+expected_event_ids  = [82]
+description = "nested set comparisons"
+
+[[queries]]
+query = '''
+file where serial_event_id == 82 and (true == (process_name in ('svchost.exe', 'bad.exe', 'bad2.exe')))
 '''
 expected_event_ids  = [82]
 description = "nested set comparisons"

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
@@ -667,31 +667,31 @@ registry where bytes_written_string_list[1] == 'EN'
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+localgroup\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+localgroup\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w+\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w+\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 expected_event_ids  = [98]
 query = '''
-process where match(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where match(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+[localgrup]{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+[localgrup]{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
@@ -727,38 +727,6 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plore') == 2 and not indexOf(file_name, '.pf')
-'''
-expected_event_ids  = [88]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.') and indexOf(file_name, 'plore', 100)
-'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2)'''
-expected_event_ids  = [88, 92]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 4)'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'thing that never happened')'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
 # This query give a different result with ES EQL implementation because it doesn't convert to float data types for division
 expected_event_ids = [82]
 query = "file where serial_event_id / 2 == 41"
@@ -769,14 +737,6 @@ query = '''
 process where modulo(11, add(serial_event_id, 1)) == serial_event_id'''
 expected_event_ids  = [1, 2, 3, 5, 11]
 description = "test built-in math functions"
-
-
-# this should be removed and the number function should be updated to take only strings
-[[queries]]
-query = '''
-process where number(serial_event_id) == number(5)'''
-expected_event_ids  = [5]
-description = "test string/number conversions"
 
 [[queries]]
 query = '''
@@ -916,17 +876,5 @@ file where between(file_path, "dev", ".json", false) == "\\testlogs\\something"
 expected_event_ids = [95]
 query = '''
 file where between(file_path, "dev", ".json", true) == "\\testlogs\\something"
-'''
-
-[[queries]]
-expected_event_ids = [7, 14, 22, 29, 44]
-query = '''
-process where length(between(process_name, 'g', 'e')) > 0
-'''
-
-[[queries]]
-expected_event_ids = []
-query = '''
-process where length(between(process_name, 'g', 'z')) > 0
 '''
 


### PR DESCRIPTION
* whitelist some toml tests
* cleanup some `indexOf` tests following the decision in https://github.com/elastic/elasticsearch/issues/54544#issuecomment-611579645
* add a DataLoader class to load the test data in a debug-mode ES node