### PR TITLE
EQL: Fix race condition in RestEqlCancellationIT

### DIFF
--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
@@ -6,7 +6,6 @@
 
 package org.elasticsearch.xpack.eql.action;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Request;
@@ -18,8 +17,10 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.nio.NioTransportPlugin;
 import org.junit.BeforeClass;
 
@@ -80,7 +81,6 @@ public class RestEqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
     }
 
     public void testRestCancellation() throws Exception {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/58270", Constants.WINDOWS);
         assertAcked(client().admin().indices().prepareCreate("test")
             .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date")
             .get());
@@ -129,9 +129,28 @@ public class RestEqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
         logger.trace("Waiting for block to be established");
         awaitForBlockedFieldCaps(plugins);
         logger.trace("Block is established");
-        assertThat(getTaskInfoWithXOpaqueId(id, EqlSearchAction.NAME), notNullValue());
+        TaskInfo blockedTaskInfo = getTaskInfoWithXOpaqueId(id, EqlSearchAction.NAME);
+        assertThat(blockedTaskInfo, notNullValue());
         cancellable.cancel();
         logger.trace("Request is cancelled");
+
+        assertBusy(() -> {
+            for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
+                if (transportService.getLocalNode().getId().equals(blockedTaskInfo.getTaskId().getNodeId())) {
+                    Task task = transportService.getTaskManager().getTask(blockedTaskInfo.getId());
+                    if (task != null) {
+                        assertThat(task, instanceOf(EqlSearchTask.class));
+                        EqlSearchTask eqlSearchTask = (EqlSearchTask) task;
+                        logger.trace("Waiting for cancellation to be propagated {} ", eqlSearchTask.isCancelled());
+                        assertThat(eqlSearchTask.isCancelled(), equalTo(true));
+                    }
+                    return;
+                }
+            }
+            fail("Task not found");
+        });
+
+        logger.trace("Disabling field cap blocks");
         disableFieldCapBlocks(plugins);
         // The task should be cancelled before ever reaching search blocks
         assertBusy(() -> {


### PR DESCRIPTION
Makes RestEqlCancellationIT more deterministic by adding an assertBusy for the
cancellation propagation. It also refactors the SearchBlockPlugin to block
after the field caps are received, which prevents the test to block on the
transport thread. Blocking on transport thread was preventing the cancellation
on disconnect from cancelling the task until after the block on the transport
thread was released.

Since I cannot reporduce this issue, I will leave the trace logging for now
and will remove it after observing this test for a while in CI.

Relates to #58270
