### PR TITLE
[7.x] [ML] unify usages of _all and wildcard <*> (#58460)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -742,8 +742,14 @@ public class Strings {
      * which is usually used as everything
      */
     public static boolean isAllOrWildcard(String[] data) {
-        return CollectionUtils.isEmpty(data) ||
-               data.length == 1 && ("_all".equals(data[0]) || "*".equals(data[0]));
+        return CollectionUtils.isEmpty(data) || data.length == 1 && isAllOrWildcard(data[0]);
+    }
+
+    /**
+     * Returns `true` if the string is `_all` or `*`.
+     */
+    public static boolean isAllOrWildcard(String data) {
+        return "_all".equals(data) || "*".equals(data);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -25,8 +25,17 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 public class StringsTests extends ESTestCase {
+
+    public void testIsAllOrWildCardString() {
+        assertThat(Strings.isAllOrWildcard("_all"), is(true));
+        assertThat(Strings.isAllOrWildcard("*"), is(true));
+        assertThat(Strings.isAllOrWildcard("foo"), is(false));
+        assertThat(Strings.isAllOrWildcard(""), is(false));
+        assertThat(Strings.isAllOrWildcard((String)null), is(false));
+    }
 
     public void testSubstring() {
         assertEquals(null, Strings.substring(null, 0, 1000));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetCalendarEventsAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
@@ -125,8 +126,7 @@ public class GetCalendarEventsAction extends ActionType<GetCalendarEventsAction.
         public ActionRequestValidationException validate() {
             ActionRequestValidationException e = null;
 
-            boolean calendarIdIsAll = GetCalendarsAction.Request.ALL.equals(calendarId);
-            if (jobId != null && calendarIdIsAll == false) {
+            if (jobId != null && Strings.isAllOrWildcard(calendarId) == false) {
                 e = ValidateActions.addValidationError("If " + Job.ID.getPreferredName() + " is used " +
                         Calendar.ID.getPreferredName() + " must be '" + GetCalendarsAction.Request.ALL + "'", e);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/OpenJobAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -250,7 +249,7 @@ public class OpenJobAction extends ActionType<NodeAcknowledgedResponse> {
 
         static boolean match(Task task, String expectedJobId) {
             if (task instanceof JobTaskMatcher) {
-                if (Metadata.ALL.equals(expectedJobId)) {
+                if (Strings.isAllOrWildcard(expectedJobId)) {
                     return true;
                 }
                 String expectedDescription = "job-" + expectedJobId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDataFrameAnalyticsAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -273,7 +272,7 @@ public class StartDataFrameAnalyticsAction extends ActionType<NodeAcknowledgedRe
 
         static boolean match(Task task, String expectedId) {
             if (task instanceof TaskMatcher) {
-                if (Metadata.ALL.equals(expectedId)) {
+                if (Strings.isAllOrWildcard(expectedId)) {
                     return true;
                 }
                 String expectedDescription = MlTasks.DATA_FRAME_ANALYTICS_TASK_ID_PREFIX + expectedId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -53,7 +52,7 @@ public class UpdateJobAction extends ActionType<PutJobAction.Response> {
             this.jobId = jobId;
             this.update = update;
             this.isInternal = isInternal;
-            if (Metadata.ALL.equals(jobId)) {
+            if (Strings.isAllOrWildcard(jobId)) {
                 throw ExceptionsHelper.badRequestException("Cannot update more than 1 job at a time");
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/NameResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/NameResolver.java
@@ -6,7 +6,6 @@
 package org.elasticsearch.xpack.core.ml.utils;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 
@@ -53,7 +52,7 @@ public abstract class NameResolver {
      */
     public SortedSet<String> expand(String expression, boolean allowNoMatch) {
         SortedSet<String> result = new TreeSet<>();
-        if (Metadata.ALL.equals(expression) || Regex.isMatchAllPattern(expression)) {
+        if (Strings.isAllOrWildcard(expression)) {
             result.addAll(nameSet());
         } else {
             String[] tokens = Strings.tokenizeToStringArray(expression, ",");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarEventsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarEventsAction.java
@@ -8,12 +8,12 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.action.GetCalendarEventsAction;
-import org.elasticsearch.xpack.core.ml.action.GetCalendarsAction;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
@@ -49,7 +49,7 @@ public class TransportGetCalendarEventsAction extends HandledTransportAction<Get
                             .from(request.getPageParams().getFrom())
                             .size(request.getPageParams().getSize());
 
-                    if (GetCalendarsAction.Request.ALL.equals(request.getCalendarId()) == false) {
+                    if (Strings.isAllOrWildcard(request.getCalendarId()) == false) {
                         query.calendarIds(Collections.singletonList(request.getCalendarId()));
                     }
 
@@ -93,7 +93,7 @@ public class TransportGetCalendarEventsAction extends HandledTransportAction<Get
     }
 
     private void checkCalendarExists(String calendarId, ActionListener<Boolean> listener) {
-        if (GetCalendarsAction.Request.ALL.equals(calendarId)) {
+        if (Strings.isAllOrWildcard(calendarId)) {
             listener.onResponse(true);
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetCalendarsAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
@@ -34,7 +35,7 @@ public class TransportGetCalendarsAction extends HandledTransportAction<GetCalen
     @Override
     protected void doExecute(Task task, GetCalendarsAction.Request request, ActionListener<GetCalendarsAction.Response> listener) {
         final String calendarId = request.getCalendarId();
-        if (request.getCalendarId() != null && GetCalendarsAction.Request.ALL.equals(request.getCalendarId()) == false) {
+        if (request.getCalendarId() != null && Strings.isAllOrWildcard(request.getCalendarId()) == false) {
             getCalendar(calendarId, listener);
         } else {
             PageParams pageParams = request.getPageParams();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/modelsnapshots/RestGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/modelsnapshots/RestGetModelSnapshotsAction.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.rest.modelsnapshots;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -26,7 +27,6 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestGetModelSnapshotsAction extends BaseRestHandler {
 
-    private static final String ALL = "_all";
     private static final String ALL_SNAPSHOT_IDS = null;
 
     // Even though these are null, setting up the defaults in case
@@ -73,7 +73,7 @@ public class RestGetModelSnapshotsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String jobId = restRequest.param(Job.ID.getPreferredName());
         String snapshotId = restRequest.param(Request.SNAPSHOT_ID.getPreferredName());
-        if (ALL.equals(snapshotId)) {
+        if (Strings.isAllOrWildcard(snapshotId)) {
             snapshotId = ALL_SNAPSHOT_IDS;
         }
         Request getModelSnapshots;


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ML] unify usages of _all and wildcard <*> (#58460)