### PR TITLE
Fix Memory Leak From Master Failover During Snapshot

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFutureThrows;
@@ -65,7 +66,7 @@ import static org.hamcrest.Matchers.is;
  * Tests snapshot operations during disruptions.
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-public class SnapshotDisruptionIT extends ESIntegTestCase {
+public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
@@ -228,6 +229,48 @@ public class SnapshotDisruptionIT extends ESIntegTestCase {
                 client(masterNode).admin().cluster().prepareCreateSnapshot(repoName, "snapshot-2").setWaitForCompletion(true).get();
         final SnapshotInfo successfulSnapshotInfo = successfulSnapshot.getSnapshotInfo();
         assertThat(successfulSnapshotInfo.state(), is(SnapshotState.SUCCESS));
+
+        logger.info("--> making sure snapshot delete works out cleanly");
+        assertAcked(client().admin().cluster().prepareDeleteSnapshot(repoName, "snapshot-2").get());
+    }
+
+    public void testMasterFailOverDuringShardSnapshots() throws Exception {
+        internalCluster().startMasterOnlyNodes(3);
+        final String dataNode = internalCluster().startDataOnlyNode();
+        ensureStableCluster(4);
+        final String repoName = "test-repo";
+        createRepository(repoName, "mock", randomRepoPath());
+
+        final String indexName = "index-one";
+        createIndex(indexName);
+        client().prepareIndex(indexName).setSource("foo", "bar").get();
+
+        blockDataNode(repoName, dataNode);
+
+        logger.info("--> create snapshot via master node client");
+        final ActionFuture<CreateSnapshotResponse> snapshotResponse = internalCluster().masterClient().admin().cluster()
+                .prepareCreateSnapshot(repoName, "test-snap").setWaitForCompletion(true).execute();
+
+        waitForBlock(dataNode, repoName, TimeValue.timeValueSeconds(30L));
+
+        final String masterNode = internalCluster().getMasterName();
+        final NetworkDisruption networkDisruption = new NetworkDisruption(
+                new NetworkDisruption.TwoPartitions(Collections.singleton(masterNode),
+                        Arrays.stream(internalCluster().getNodeNames()).filter(name -> masterNode.equals(name) == false)
+                                .collect(Collectors.toSet())),
+                new NetworkDisruption.NetworkDisconnect());
+        internalCluster().setDisruptionScheme(networkDisruption);
+        networkDisruption.startDisrupting();
+        ensureStableCluster(3, dataNode);
+        unblockNode(repoName, dataNode);
+
+        networkDisruption.stopDisrupting();
+        assertAllSnapshotsCompleted();
+
+        logger.info("--> make sure isolated master responds to snapshot request");
+        final SnapshotException sne =
+                expectThrows(SnapshotException.class, () -> snapshotResponse.actionGet(TimeValue.timeValueSeconds(30L)));
+        assertThat(sne.getMessage(), endsWith("no longer master"));
     }
 
     private void assertAllSnapshotsCompleted() throws Exception {


### PR DESCRIPTION
If we failed over while the data nodes were doing their work we would never resolve the listener and leak it.
This change fails all pending listeners on the previous master on fail-over to prevent the leak and adds a reproducing test (as well as some test infrastructure taken from #56911 to enable these tests).
