### PR TITLE
Introduce node.roles setting

### DIFF
--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -62,17 +62,16 @@ after repurposing it.
 The intended use is:
 
 * Stop the node
-* Update `elasticsearch.yml` by setting `node.master` and `node.data` as
-  desired.
+* Update `elasticsearch.yml` by setting `node.roles` as desired.
 * Run `elasticsearch-node repurpose` on the node
 * Start the node
 
-If you run `elasticsearch-node repurpose` on a node with `node.data: false` and
-`node.master: true` then it will delete any remaining shard data on that node,
-but it will leave the index and cluster metadata alone. If you run
-`elasticsearch-node repurpose` on a node with `node.data: false` and
-`node.master: false` then it will delete any remaining shard data and index
-metadata, but it will leave the cluster metadata alone.
+If you run `elasticsearch-node repurpose` on a node without the `data` role and
+with the `master` role then it will delete any remaining shard data on that
+node, but it will leave the index and cluster metadata alone. If you run
+`elasticsearch-node repurpose` on a node without the `data` and `master` roles
+then it will delete any remaining shard data and index metadata, but it will
+leave the cluster metadata alone.
 
 [WARNING]
 Running this command can lead to data loss for the indices mentioned if the
@@ -355,12 +354,12 @@ to `0`, meaning to use the first node in the data path.
 === Examples
 
 [float]
-==== Repurposing a node as a dedicated master node (master: true, data: false)
+==== Repurposing a node as a dedicated master node
 
 In this example, a former data node is repurposed as a dedicated master node.
-First update the node's settings to `node.master: true` and `node.data: false`
-in its `elasticsearch.yml` config file. Then run the `elasticsearch-node
-repurpose` command to find and remove excess shard data:
+First update the node's settings to `node.roles: [ "master" ]` in its
+`elasticsearch.yml` config file. Then run the `elasticsearch-node repurpose`
+command to find and remove excess shard data:
 
 [source,txt]
 ----
@@ -377,13 +376,13 @@ Node successfully repurposed to master and no-data.
 ----
 
 [float]
-==== Repurposing a node as a coordinating-only node (master: false, data: false)
+==== Repurposing a node as a coordinating-only node
 
 In this example, a node that previously held data is repurposed as a
-coordinating-only node. First update the node's settings to `node.master:
-false` and `node.data: false` in its `elasticsearch.yml` config file. Then run
-the `elasticsearch-node repurpose` command to find and remove excess shard data
-and index metadata:
+coordinating-only node. First update the node's settings to `node.roles: []` in
+its `elasticsearch.yml` config file. Then run the `elasticsearch-node repurpose`
+command to find and remove excess shard data and index metadata:
+
 
 [source,txt]
 ----

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -22,39 +22,37 @@ dedicated data nodes, {ml} nodes, and {transform} nodes.
 
 <<master-node,Master-eligible node>>::
 
-A node that has `node.master` set to `true` (default), which makes it eligible
-to be <<modules-discovery,elected as the _master_ node>>, which controls the
-cluster.
+A node that has the `master` role (default), which makes it eligible to be
+<<modules-discovery,elected as the _master_ node>>, which controls the cluster.
 
 <<data-node,Data node>>::
 
-A node that has `node.data` set to `true` (default). Data nodes hold data and
-perform data related operations such as CRUD, search, and aggregations.
+A node that has the `data` role (default). Data nodes hold data and perform data
+related operations such as CRUD, search, and aggregations.
 
 <<ingest,Ingest node>>::
 
-A node that has `node.ingest` set to `true` (default). Ingest nodes are able
-to apply an <<pipeline,ingest pipeline>> to a document in order to transform
-and enrich the document before indexing. With a heavy ingest load, it makes
-sense to use dedicated ingest nodes and to mark the master and data nodes as
-`node.ingest: false`.
+A node that has the `ingest` role (default). Ingest nodes are able to apply an
+<<pipeline,ingest pipeline>> to a document in order to transform and enrich the
+document before indexing. With a heavy ingest load, it makes sense to use
+dedicated ingest nodes and to not include the `ingest` role from nodes that have
+the `master` or `data` roles.
 
 <<ml-node,Machine learning node>>::
 
-A node that has `xpack.ml.enabled` and `node.ml` set to `true`, which is the
-default behavior in the {es} {default-dist}. If you want to use {ml-features},
-there must be at least one {ml} node in your cluster. For more information about
-{ml-features}, see
-{ml-docs}/index.html[Machine learning in the {stack}].
+A node that has `xpack.ml.enabled` and the `ml` role, which is the default
+behavior in the {es} {default-dist}. If you want to use {ml-features}, there
+must be at least one {ml} node in your cluster. For more information about
+{ml-features}, see {ml-docs}/index.html[Machine learning in the {stack}].
 +
-IMPORTANT: If you use the {oss-dist}, do not set `node.ml`. Otherwise, the node
-fails to start.
+IMPORTANT: If you use the {oss-dist}, do not add the `ml` role. Otherwise, the
+node fails to start.
 
 <<transform-node,{transform-cap} node>>::
 
-A node that has `node.transform` set to `true`. If you want to use {transforms},
-there must be at least one {transform} node in your cluster. For more
-information, see <<transform-settings>> and <<transforms>>.
+A node that has the `transform` role. If you want to use {transforms}, there
+be at least one {transform} node in your cluster. For more information, see
+<<transform-settings>> and <<transforms>>.
 
 [NOTE]
 [[coordinating-node]]
@@ -73,10 +71,9 @@ coordinating node reduces each data node's results into a single global
 resultset.
 
 Every node is implicitly a coordinating node. This means that a node that has
-all three `node.master`, `node.data` and `node.ingest` set to `false` will
-only act as a coordinating node, which cannot be disabled. As a result, such
-a node needs to have enough memory and CPU in order to deal with the gather
-phase.
+an explicit empty list of roles via `node.roles` will only act as a coordinating
+node, which cannot be disabled. As a result, such a node needs to have enough
+memory and CPU in order to deal with the gather phase.
 
 ===============================================
 
@@ -112,41 +109,12 @@ focus on managing the cluster. While master nodes can also behave as
 from clients to data nodes, it is better _not_ to use dedicated master nodes for
 this purpose.
 
-To create a dedicated master-eligible node in the {default-dist}, set:
+To create a dedicated master-eligible node, set:
 
 [source,yaml]
 -------------------
-node.master: true <1>
-node.voting_only: false <2>
-node.data: false <3>
-node.ingest: false <4>
-node.ml: false <5>
-xpack.ml.enabled: true <6>
-node.transform: false <7>
-node.remote_cluster_client: false <8>
+node.roles: [ master ]
 -------------------
-<1> The `node.master` role is enabled by default.
-<2> The `node.voting_only` role is disabled by default.
-<3> Disable the `node.data` role (enabled by default).
-<4> Disable the `node.ingest` role (enabled by default).
-<5> Disable the `node.ml` role (enabled by default).
-<6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable the `node.transform` role.
-<8> Disable remote cluster connections (enabled by default).
-
-To create a dedicated master-eligible node in the {oss-dist}, set:
-
-[source,yaml]
--------------------
-node.master: true <1>
-node.data: false <2>
-node.ingest: false <3>
-node.remote_cluster_client: false <4>
--------------------
-<1> The `node.master` role is enabled by default.
-<2> Disable the `node.data` role (enabled by default).
-<3> Disable the `node.ingest` role (enabled by default).
-<4> Disable remote cluster connections (enabled by default).
 
 [[voting-only-node]]
 ===== Voting-only master-eligible node
@@ -163,19 +131,19 @@ master-eligible nodes are those nodes that participate in elections and perform
 certain tasks during cluster state publications, and voting-only nodes have the
 same responsibilities even if they can never become the elected master.
 
-To configure a master-eligible node as a voting-only node, set the following
-setting:
+To configure a master-eligible node as a voting-only node, include `master` and
+`voting_only` in the list of roles. For example to create a voting-only data
+node:
 
 [source,yaml]
 -------------------
-node.voting_only: true <1>
+node.roles: [ data, master, voting_only ]
 -------------------
-<1> The default for `node.voting_only` is `false`.
 
 IMPORTANT: The `voting_only` role requires the {default-dist} of {es} and is not
-supported in the {oss-dist}. If you use the {oss-dist} and set
-`node.voting_only` then the node will fail to start.  Also note that only
-master-eligible nodes can be marked as voting-only.
+supported in the {oss-dist}. If you use the {oss-dist} and add the `voting_only`
+role then the node will fail to start.  Also note that only nodes with the
+`master` role can be marked as having the `voting_only` role.
 
 High availability (HA) clusters require at least three master-eligible nodes, at
 least two of which are not voting-only nodes. Such a cluster will be able to
@@ -196,23 +164,8 @@ dedicated voting-only master-eligible node in the {default-dist}, set:
 
 [source,yaml]
 -------------------
-node.master: true <1>
-node.voting_only: true <2>
-node.data: false <3>
-node.ingest: false <4>
-node.ml: false <5>
-xpack.ml.enabled: true <6>
-node.transform: false <7>
-node.remote_cluster_client: false <8>
+node.roles: [ master, voting_only ]
 -------------------
-<1> The `node.master` role is enabled by default.
-<2> Enable the `node.voting_only` role (disabled by default).
-<3> Disable the `node.data` role (enabled by default).
-<4> Disable the `node.ingest` role (enabled by default).
-<5> Disable the `node.ml` role (enabled by default).
-<6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable the `node.transform` role.
-<8> Disable remote cluster connections (enabled by default).
 
 [[data-node]]
 ==== Data node
@@ -225,37 +178,11 @@ monitor these resources and to add more data nodes if they are overloaded.
 The main benefit of having dedicated data nodes is the separation of the master
 and data roles.
 
-To create a dedicated data node in the {default-dist}, set:
+To create a dedicated data node, set:
 [source,yaml]
 -------------------
-node.master: false <1>
-node.voting_only: false <2>
-node.data: true <3>
-node.ingest: false <4>
-node.ml: false <5>
-node.transform: false <6>
-node.remote_cluster_client: false <7>
+node.roles: [ data ]
 -------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> The `node.voting_only` role is disabled by default.
-<3> The `node.data` role is enabled by default.
-<4> Disable the `node.ingest` role (enabled by default).
-<5> Disable the `node.ml` role (enabled by default).
-<6> Disable the `node.transform` role.
-<7> Disable remote cluster connections (enabled by default).
-
-To create a dedicated data node in the {oss-dist}, set:
-[source,yaml]
--------------------
-node.master: false <1>
-node.data: true <2>
-node.ingest: false <3>
-node.remote_cluster_client: false <4>
--------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> The `node.data` role is enabled by default.
-<3> Disable the `node.ingest` role (enabled by default).
-<4> Disable remote cluster connections (enabled by default).
 
 [[node-ingest-node]]
 ==== Ingest node
@@ -265,39 +192,12 @@ ingest processors. Depending on the type of operations performed by the ingest
 processors and the required resources, it may make sense to have dedicated
 ingest nodes, that will only perform this specific task.
 
-To create a dedicated ingest node in the {default-dist}, set:
+To create a dedicated ingest node, set:
 
 [source,yaml]
 -------------------
-node.master: false <1>
-node.voting_only: false <2>
-node.data: false <3>
-node.ingest: true <4>
-node.ml: false <5>
-node.transform: false <6>
-node.remote_cluster_client: false <7>
+node.roles: [ ingest ]
 -------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> The `node.voting_only` role is disabled by default.
-<3> Disable the `node.data` role (enabled by default).
-<4> The `node.ingest` role is enabled by default.
-<5> Disable the `node.ml` role (enabled by default).
-<6> Disable the `node.transform` role.
-<7> Disable remote cluster connections (enabled by default).
-
-To create a dedicated ingest node in the {oss-dist}, set:
-
-[source,yaml]
--------------------
-node.master: false <1>
-node.data: false <2>
-node.ingest: true <3>
-node.remote_cluster_client: false <4>
--------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> Disable the `node.data` role (enabled by default).
-<3> The `node.ingest` role is enabled by default.
-<4> Disable remote cluster connections (enabled by default).
 
 [[coordinating-only-node]]
 ==== Coordinating only node
@@ -319,48 +219,19 @@ acknowledgement of cluster state updates from every node! The benefit of
 coordinating only nodes should not be overstated -- data nodes can happily
 serve the same purpose.
 
-To create a dedicated coordinating node in the {default-dist}, set:
+To create a dedicated coordinating node, set:
 
 [source,yaml]
 -------------------
-node.master: false <1>
-node.voting_only: false <2>
-node.data: false <3>
-node.ingest: false <4>
-node.ml: false <5>
-xpack.ml.enabled: true <6>
-node.transform: false <7>
-node.remote_cluster_client: false <8>
+node.roles: [ ]
 -------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> The `node.voting_only` role is disabled by default.
-<3> Disable the `node.data` role (enabled by default).
-<4> Disable the `node.ingest` role (enabled by default).
-<5> Disable the `node.ml` role (enabled by default).
-<6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable the `node.transform` role.
-<8> Disable remote cluster connections (enabled by default).
-
-To create a dedicated coordinating node in the {oss-dist}, set:
-
-[source,yaml]
--------------------
-node.master: false <1>
-node.data: false <2>
-node.ingest: false <3>
-node.remote_cluster_client: false <4>
--------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> Disable the `node.data` role (enabled by default).
-<3> Disable the `node.ingest` role (enabled by default).
-<4> Disable remote cluster connections (enabled by default).
 
 [[ml-node]]
 ==== [xpack]#Machine learning node#
 
 The {ml-features} provide {ml} nodes, which run jobs and handle {ml} API
-requests. If `xpack.ml.enabled` is set to `true` and `node.ml` is set to `false`,
-the node can service API requests but it cannot run jobs.
+requests. If `xpack.ml.enabled` is set to `true` and the node does not have the
+`ml` role, the node can service API requests but it cannot run jobs.
 
 If you want to use {ml-features} in your cluster, you must enable {ml}
 (set `xpack.ml.enabled` to `true`) on all master-eligible nodes. If you want to
@@ -373,53 +244,27 @@ To create a dedicated {ml} node in the {default-dist}, set:
 
 [source,yaml]
 -------------------
-node.master: false <1>
-node.voting_only: false <2>
-node.data: false <3>
-node.ingest: false <4>
-node.ml: true <5>
-xpack.ml.enabled: true <6>
-node.transform: false <7>
-node.remote_cluster_client: false <8>
+node.roles: [ ml ]
+xpack.ml.enabled: true <1>
 -------------------
-<1> Disable the `node.master` role (enabled by default).
-<2> The `node.voting_only` role is disabled by default.
-<3> Disable the `node.data` role (enabled by default).
-<4> Disable the `node.ingest` role (enabled by default).
-<5> The `node.ml` role is enabled by default.
-<6> The `xpack.ml.enabled` setting is enabled by default.
-<7> Disable the `node.transform` role.
-<8> Disable remote cluster connections (enabled by default).
+<1> The `xpack.ml.enabled` setting is enabled by default.
 
 [[transform-node]]
 ==== [xpack]#{transform-cap} node#
 
 {transform-cap} nodes run {transforms} and handle {transform} API requests.
 
-If you want to use {transforms} in your cluster, you must have `node.transform`
-set to `true` on at least one node. This is the default behavior. If you have
-the {oss-dist}, do not use these settings. For more information, see
-<<transform-settings>>.
+If you want to use {transforms} in clients (including {kib}), it must also be
+enabled on all coordinating nodes. You must also have at least one node with the
+`transform` role. This is the default behavior. If you have the {oss-dist}, do
+not use these settings. For more information, see <<transform-settings>>.
 
 To create a dedicated {transform} node in the {default-dist}, set:
 
 [source,yaml]
 -------------------
-node.master: false <1>
-node.voting_only: false <2>
-node.data: false <3>
-node.ingest: false <4>
-node.ml: false <5>
-node.transform: true <6>
-node.remote_cluster_client: false <7>
+node.roles: [ transform ]
 -------------------
-<1> Disable the `node.master` role.
-<2> Disable the `node.voting_only`.
-<3> Disable the `node.data` role.
-<4> Disable the `node.ingest` role.
-<5> Disable the `node.ml` role.
-<6> Enable the `node.transform` role.
-<7> Disable remote cluster connections.
 
 [[change-node-role]]
 ==== Changing the role of a node
@@ -438,26 +283,25 @@ Similarly, each master-eligible node maintains the following data on disk:
 Each node checks the contents of its data path at startup. If it discovers
 unexpected data then it will refuse to start. This is to avoid importing
 unwanted <<modules-gateway-dangling-indices,dangling indices>> which can lead
-to a red cluster health. To be more precise, nodes with `node.data: false` will
+to a red cluster health. To be more precise, nodes without the `data` role will
 refuse to start if they find any shard data on disk at startup, and nodes with
-both `node.master: false` and `node.data: false` will refuse to start if they
-have any index metadata on disk at startup.
+without both the `master` and `data` roles will refuse to start if they have any index metadata on disk at startup.
 
 It is possible to change the roles of a node by adjusting its
 `elasticsearch.yml` file and restarting it. This is known as _repurposing_ a
 node. In order to satisfy the checks for unexpected data described above, you
-must perform some extra steps to prepare a node for repurposing when setting
-its `node.data` or `node.master` roles to `false`:
+must perform some extra steps to prepare a node for repurposing when starting
+the node without the `data` or `master` roles.
 
-* If you want to repurpose a data node by changing `node.data` to `false` then
-  you should first use an <<allocation-filtering,allocation filter>> to safely
+* If you want to repurpose a data node by removing the `data` role then you
+  should first use an <<allocation-filtering,allocation filter>> to safely
   migrate all the shard data onto other nodes in the cluster.
 
-* If you want to repurpose a node to have both `node.master: false` and
-  `node.data: false` then it is simplest to start a brand-new node with an
-  empty data path and the desired roles. You may find it safest to use an
-  <<allocation-filtering,allocation filter>> to migrate the shard data
-  elsewhere in the cluster first.
+* If you want to repurpose a node to have neither the `data` nor `master` roles
+  then it is simplest to start a brand-new node with an empty data path and the
+  desired roles. You may find it safest to use an
+  <<allocation-filtering,allocation filter>> to migrate the shard data elsewhere
+  in the cluster first.
 
 If it is not possible to follow these extra steps then you may be able to use
 the <<node-tool-repurpose,`elasticsearch-node repurpose`>> tool to delete any

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.test.StreamsUtils;
 
 import java.io.ByteArrayInputStream;
@@ -45,6 +46,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.test.NodeRoles.nonIngestNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -82,7 +84,7 @@ public class GeoIpProcessorNonIngestNodeTests extends ESIntegTestCase {
         }
         return Settings.builder()
                 .put("ingest.geoip.database_path", databasePath)
-                .put("node.ingest", false)
+                .put(nonIngestNode())
                 .put(super.nodeSettings(nodeOrdinal))
                 .build();
     }
@@ -145,7 +147,7 @@ public class GeoIpProcessorNonIngestNodeTests extends ESIntegTestCase {
         Arrays.stream(internalCluster().getNodeNames()).forEach(node -> assertDatabaseLoadStatus(node, false));
 
         // start an ingest node
-        final String ingestNode = internalCluster().startNode(Settings.builder().put("node.ingest", true).build());
+        final String ingestNode = internalCluster().startNode(NodeRoles.ingestNode());
         internalCluster().getInstance(IngestService.class, ingestNode);
         // the geo-IP database should not be loaded yet as we have no indexed any documents using a pipeline that has a geo-IP processor
         assertDatabaseLoadStatus(ingestNode, false);

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -35,7 +35,7 @@ task 'remote-cluster'(type: RestIntegTestTask) {
 
 testClusters.'remote-cluster' {
   numberOfNodes = 2
-  setting 'node.remote_cluster_client', 'false'
+  setting 'node.roles', '[data,ingest,master]'
 }
 
 task mixedClusterTest(type: RestIntegTestTask) {
@@ -50,7 +50,6 @@ testClusters.mixedClusterTest {
   setting 'cluster.remote.my_remote_cluster.seeds',
     { "\"${testClusters.'remote-cluster'.getAllTransportPortURI().get(0)}\"" }
   setting 'cluster.remote.connections_per_cluster', '1'
-  setting 'node.remote_cluster_client', 'true'
 }
 
 

--- a/qa/smoke-test-ingest-disabled/build.gradle
+++ b/qa/smoke-test-ingest-disabled/build.gradle
@@ -26,5 +26,5 @@ dependencies {
 }
 
 testClusters.integTest {
-  setting 'node.ingest', 'false'
+  setting 'node.roles', '[data,master,remote_cluster_client]'
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.monitor.os.OsStats;
-import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -38,8 +38,11 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest.Metric.OS;
 import static org.hamcrest.Matchers.equalTo;
@@ -76,14 +79,27 @@ public class ClusterStatsIT extends ESIntegTestCase {
 
         for (int i = 0; i < numNodes; i++) {
             boolean isDataNode = randomBoolean();
-            boolean isMasterNode = randomBoolean();
             boolean isIngestNode = randomBoolean();
-            boolean isRemoteClusterClientNode = randomBoolean();
+            boolean isMasterNode = randomBoolean();
+            boolean isRemoteClusterClientNode = false;
+            final Set<DiscoveryNodeRole> roles = new HashSet<>();
+            if (isDataNode) {
+                roles.add(DiscoveryNodeRole.DATA_ROLE);
+            }
+            if (isIngestNode) {
+                roles.add(DiscoveryNodeRole.INGEST_ROLE);
+            }
+            if (isMasterNode) {
+                roles.add(DiscoveryNodeRole.MASTER_ROLE);
+            }
+            if (isRemoteClusterClientNode) {
+                roles.add(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
+            }
             Settings settings = Settings.builder()
-                .put(Node.NODE_DATA_SETTING.getKey(), isDataNode)
-                .put(Node.NODE_MASTER_SETTING.getKey(), isMasterNode)
-                .put(Node.NODE_INGEST_SETTING.getKey(), isIngestNode)
-                .put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), isRemoteClusterClientNode)
+                .putList(
+                    NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+                    roles.stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toList())
+                )
                 .build();
             internalCluster().startNode(settings);
             total++;
@@ -92,11 +108,11 @@ public class ClusterStatsIT extends ESIntegTestCase {
             if (isDataNode) {
                 incrementCountForRole(DiscoveryNodeRole.DATA_ROLE.roleName(), expectedCounts);
             }
-            if (isMasterNode) {
-                incrementCountForRole(DiscoveryNodeRole.MASTER_ROLE.roleName(), expectedCounts);
-            }
             if (isIngestNode) {
                 incrementCountForRole(DiscoveryNodeRole.INGEST_ROLE.roleName(), expectedCounts);
+            }
+            if (isMasterNode) {
+                incrementCountForRole(DiscoveryNodeRole.MASTER_ROLE.roleName(), expectedCounts);
             }
             if (isRemoteClusterClientNode) {
                 incrementCountForRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName(), expectedCounts);

--- a/server/src/internalClusterTest/java/org/elasticsearch/client/transport/TransportClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/client/transport/TransportClientIT.java
@@ -40,6 +40,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -49,7 +50,7 @@ import static org.hamcrest.Matchers.startsWith;
 public class TransportClientIT extends ESIntegTestCase {
 
     public void testPickingUpChangesInDiscoveryNode() {
-        String nodeName = internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false));
+        String nodeName = internalCluster().startNode(nonDataNode());
 
         TransportClient client = (TransportClient) internalCluster().client(nodeName);
         assertThat(client.connectedNodes().get(0).isDataNode(), equalTo(false));
@@ -63,7 +64,7 @@ public class TransportClientIT extends ESIntegTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put("node.name", "testNodeVersionIsUpdated")
                 .put("transport.type", getTestTransportType())
-                .put(Node.NODE_DATA_SETTING.getKey(), false)
+                .put(nonDataNode())
                 .put("cluster.name", "foobar")
                 .putList(ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING.getKey(), "testNodeVersionIsUpdated")
                 .build(), Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class)).start()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
@@ -29,13 +29,14 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
 import static org.elasticsearch.client.Requests.createIndexRequest;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
+import static org.elasticsearch.test.NodeRoles.dataNode;
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -44,7 +45,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
     private static final String SOURCE = "{\"type1\":{\"id\":\"1\",\"name\":\"test\"}}";
 
     public void testIndexingBeforeAndAfterDataNodesStart() {
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build());
+        internalCluster().startNode(nonDataNode());
         client().admin().indices().create(createIndexRequest("test").waitForActiveShards(ActiveShardCount.NONE)).actionGet();
         try {
             client().index(Requests.indexRequest("test").id("1").source(SOURCE, XContentType.JSON)
@@ -54,7 +55,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
             // all is well
         }
 
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build());
+        internalCluster().startNode(nonDataNode());
         assertThat(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("2")
             .setLocal(true).execute().actionGet().isTimedOut(), equalTo(false));
 
@@ -68,7 +69,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         }
 
         // now, start a node data, and see that it gets with shards
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), true).build());
+        internalCluster().startNode(dataNode());
         assertThat(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("3")
             .setLocal(true).execute().actionGet().isTimedOut(), equalTo(false));
 
@@ -78,7 +79,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
     }
 
     public void testShardsAllocatedAfterDataNodesStart() {
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build());
+        internalCluster().startNode(nonDataNode());
         client().admin().indices().create(createIndexRequest("test")
             .settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)).waitForActiveShards(ActiveShardCount.NONE))
             .actionGet();
@@ -88,7 +89,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         assertThat(healthResponse1.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse1.getActiveShards(), equalTo(0));
 
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), true).build());
+        internalCluster().startNode(dataNode());
 
         assertThat(client().admin().cluster().prepareHealth()
             .setWaitForEvents(Priority.LANGUID).setWaitForNodes("2").setWaitForGreenStatus().execute().actionGet().isTimedOut(),
@@ -96,7 +97,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
     }
 
     public void testAutoExpandReplicasAdjustedWhenDataNodeJoins() {
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build());
+        internalCluster().startNode(nonDataNode());
         client().admin().indices().create(createIndexRequest("test")
             .settings(Settings.builder().put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all"))
             .waitForActiveShards(ActiveShardCount.NONE))
@@ -111,4 +112,5 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         internalCluster().startNode();
         client().admin().cluster().prepareReroute().setRetryFailed(true).get();
     }
+
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -34,6 +33,9 @@ import org.elasticsearch.test.InternalTestCluster;
 
 import java.io.IOException;
 
+import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
+import static org.elasticsearch.test.NodeRoles.masterNode;
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -44,9 +46,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
     public void testSimpleOnlyMasterNodeElection() throws IOException {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), true)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false)
-            .put("discovery.initial_state_timeout", "1s"));
+        internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
             assertThat(client().admin().cluster().prepareState().setMasterNodeTimeout("100ms")
                 .execute().actionGet().getState().nodes().getMasterNodeId(), nullValue());
@@ -55,8 +55,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
             // all is well, no master elected
         }
         logger.info("--> start master node");
-        final String masterNodeName = internalCluster()
-            .startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_MASTER_SETTING.getKey(), true));
+        final String masterNodeName = internalCluster().startMasterOnlyNode();
         assertThat(internalCluster().nonMasterClient().admin().cluster().prepareState()
             .execute().actionGet().getState().nodes().getMasterNode().getName(), equalTo(masterNodeName));
         assertThat(internalCluster().masterClient().admin().cluster().prepareState()
@@ -76,8 +75,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> start previous master node again");
         final String nextMasterEligibleNodeName = internalCluster()
-            .startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_MASTER_SETTING.getKey(), true)
-                .put(masterDataPathSettings));
+            .startNode(Settings.builder().put(nonDataNode(masterNode())).put(masterDataPathSettings));
         assertThat(internalCluster().nonMasterClient().admin().cluster().prepareState()
             .execute().actionGet().getState().nodes().getMasterNode().getName(), equalTo(nextMasterEligibleNodeName));
         assertThat(internalCluster().masterClient().admin().cluster().prepareState()
@@ -87,8 +85,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
     public void testElectOnlyBetweenMasterNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), true)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false).put("discovery.initial_state_timeout", "1s"));
+        internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
             assertThat(client().admin().cluster().prepareState().setMasterNodeTimeout("100ms")
                 .execute().actionGet().getState().nodes().getMasterNodeId(), nullValue());
@@ -97,16 +94,14 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
             // all is well, no master elected
         }
         logger.info("--> start master node (1)");
-        final String masterNodeName = internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), true));
+        final String masterNodeName = internalCluster().startMasterOnlyNode();
         assertThat(internalCluster().nonMasterClient().admin().cluster().prepareState()
             .execute().actionGet().getState().nodes().getMasterNode().getName(), equalTo(masterNodeName));
         assertThat(internalCluster().masterClient().admin().cluster().prepareState()
             .execute().actionGet().getState().nodes().getMasterNode().getName(), equalTo(masterNodeName));
 
         logger.info("--> start master node (2)");
-        final String nextMasterEligableNodeName = internalCluster().startNode(Settings.builder()
-            .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_MASTER_SETTING.getKey(), true));
+        final String nextMasterEligableNodeName = internalCluster().startMasterOnlyNode();
         assertThat(internalCluster().nonMasterClient().admin().cluster().prepareState()
             .execute().actionGet().getState().nodes().getMasterNode().getName(), equalTo(masterNodeName));
         assertThat(internalCluster().nonMasterClient().admin().cluster().prepareState()
@@ -133,12 +128,10 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
     public void testAliasFilterValidation() {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start master node / non data");
-        internalCluster().startNode(Settings.builder()
-            .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_MASTER_SETTING.getKey(), true));
+        internalCluster().startMasterOnlyNode();
 
         logger.info("--> start data node / non master node");
-        internalCluster().startNode(Settings.builder()
-            .put(Node.NODE_DATA_SETTING.getKey(), true).put(Node.NODE_MASTER_SETTING.getKey(), false));
+        internalCluster().startDataOnlyNode();
 
         assertAcked(prepareCreate("test").addMapping(
             "type1", "{\"type1\" : {\"properties\" : {\"table_a\" : { \"type\" : \"nested\", " +
@@ -146,4 +139,5 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         client().admin().indices().prepareAliases().addAlias("test", "a_test",
             QueryBuilders.nestedQuery("table_a", QueryBuilders.termQuery("table_a.field_b", "y"), ScoreMode.Avg)).get();
     }
+
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
@@ -22,21 +22,18 @@ package org.elasticsearch.cluster;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope= Scope.TEST, numDataNodes =0)
 public class UpdateSettingsValidationIT extends ESIntegTestCase {
     public void testUpdateSettingsValidation() throws Exception {
-        internalCluster().startNodes(
-                Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build(),
-                Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false).build(),
-                Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false).build()
-        );
+        internalCluster().startNodes(nonDataNode(), nonMasterNode(), nonMasterNode());
 
         createIndex("test");
         NumShards test = getNumShards("test");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -45,6 +45,7 @@ import java.util.Locale;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -105,8 +106,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
 
     public void testBootstrapNotMasterEligible() {
         final Environment environment = TestEnvironment.newEnvironment(Settings.builder()
-                .put(internalCluster().getDefaultSettings())
-                .put(Node.NODE_MASTER_SETTING.getKey(), false)
+                .put(nonMasterNode(internalCluster().getDefaultSettings()))
                 .build());
         expectThrows(() -> unsafeBootstrap(environment), UnsafeBootstrapMasterCommand.NOT_MASTER_NODE_MSG);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.discovery.zen.FaultDetection;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.TestCustomMetadata;
 import org.elasticsearch.transport.RemoteTransportException;
@@ -48,6 +47,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest.Metric.DISCOVERY;
+import static org.elasticsearch.test.NodeRoles.dataNode;
+import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -64,15 +65,9 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
                 .put(FaultDetection.PING_RETRIES_SETTING.getKey(), "1")
                 .build();
 
-        Settings masterNodeSettings = Settings.builder()
-                .put(Node.NODE_DATA_SETTING.getKey(), false)
-                .put(defaultSettings)
-                .build();
+        Settings masterNodeSettings = masterOnlyNode();
         internalCluster().startNodes(2, masterNodeSettings);
-        Settings dateNodeSettings = Settings.builder()
-                .put(Node.NODE_MASTER_SETTING.getKey(), false)
-                .put(defaultSettings)
-                .build();
+        Settings dateNodeSettings = dataNode();
         internalCluster().startNodes(2, dateNodeSettings);
         ClusterHealthResponse clusterHealthResponse = client().admin().cluster().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleIT.java
@@ -89,7 +89,7 @@ public class DiscoveryNodeRoleIT extends ESIntegTestCase {
     }
 
     public void testExplicitlyHasAdditionalRoles() {
-        runTestNodeHasAdditionalRole(addRoles(Set.of(AdditionalRolePlugin.ADDITIONAL_ROLE)));
+        runTestNodeHasAdditionalRole(addRoles(Collections.singleton(AdditionalRolePlugin.ADDITIONAL_ROLE)));
     }
 
     public void testDoesNotHaveAdditionalRoleUsingLegacySetting() {
@@ -97,7 +97,7 @@ public class DiscoveryNodeRoleIT extends ESIntegTestCase {
     }
 
     public void testExplicitlyDoesNotHaveAdditionalRole() {
-        runTestNodeHasAdditionalRole(removeRoles(Set.of(AdditionalRolePlugin.ADDITIONAL_ROLE)));
+        runTestNodeHasAdditionalRole(removeRoles(Collections.singleton(AdditionalRolePlugin.ADDITIONAL_ROLE)));
     }
 
     private void runTestNodeHasAdditionalRole(final Settings settings) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cluster.node;
 
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -31,6 +32,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.test.NodeRoles.addRoles;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -44,12 +47,12 @@ public class DiscoveryNodeRoleIT extends ESIntegTestCase {
         }
 
         static final Setting<Boolean> NODE_ADDITIONAL_SETTING =
-                Setting.boolSetting("node.additional", true, Setting.Property.NodeScope);
+                Setting.boolSetting("node.additional", true, Property.Deprecated, Property.NodeScope);
 
         static DiscoveryNodeRole ADDITIONAL_ROLE = new DiscoveryNodeRole("additional", "a") {
 
             @Override
-            protected Setting<Boolean> roleSetting() {
+            public Setting<Boolean> legacySetting() {
                 return NODE_ADDITIONAL_SETTING;
             }
 
@@ -81,12 +84,20 @@ public class DiscoveryNodeRoleIT extends ESIntegTestCase {
         runTestNodeHasAdditionalRole(Settings.EMPTY);
     }
 
-    public void testExplicitlyHasAdditionalRole() {
+    public void testExplicitlyHasAdditionalRoleUsingLegacySetting() {
         runTestNodeHasAdditionalRole(Settings.builder().put(AdditionalRolePlugin.NODE_ADDITIONAL_SETTING.getKey(), true).build());
     }
 
-    public void testDoesNotHaveAdditionalRole() {
+    public void testExplicitlyHasAdditionalRoles() {
+        runTestNodeHasAdditionalRole(addRoles(Set.of(AdditionalRolePlugin.ADDITIONAL_ROLE)));
+    }
+
+    public void testDoesNotHaveAdditionalRoleUsingLegacySetting() {
         runTestNodeHasAdditionalRole(Settings.builder().put(AdditionalRolePlugin.NODE_ADDITIONAL_SETTING.getKey(), false).build());
+    }
+
+    public void testExplicitlyDoesNotHaveAdditionalRole() {
+        runTestNodeHasAdditionalRole(removeRoles(Set.of(AdditionalRolePlugin.ADDITIONAL_ROLE)));
     }
 
     private void runTestNodeHasAdditionalRole(final Settings settings) {
@@ -94,7 +105,7 @@ public class DiscoveryNodeRoleIT extends ESIntegTestCase {
         final NodesInfoResponse response = client().admin().cluster().prepareNodesInfo(name).get();
         assertThat(response.getNodes(), hasSize(1));
         final Matcher<Iterable<? super DiscoveryNodeRole>> matcher;
-        if (AdditionalRolePlugin.NODE_ADDITIONAL_SETTING.get(settings)) {
+        if (DiscoveryNode.hasRole(settings, AdditionalRolePlugin.ADDITIONAL_ROLE)) {
             matcher = hasItem(AdditionalRolePlugin.ADDITIONAL_ROLE);
         } else {
             matcher = not(hasItem(AdditionalRolePlugin.ADDITIONAL_ROLE));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.indices.ShardLimitValidator;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -43,6 +42,7 @@ import java.util.List;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -329,7 +329,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
 
     private int ensureMultipleDataNodes(int dataNodes) {
         if (dataNodes == 1) {
-            internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), true).build());
+            internalCluster().startNode(dataNode());
             assertThat(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").setLocal(true)
                 .execute().actionGet().isTimedOut(), equalTo(false));
             dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -20,20 +20,23 @@
 package org.elasticsearch.env;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.test.NodeRoles;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -61,54 +64,40 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
                 indicesService -> assertTrue(indicesService.allPendingDanglingIndicesWritten())));
         }
 
-        logger.info("--> restarting the node with node.data=false and node.master=false");
+        logger.info("--> restarting the node without the data and master roles");
         IllegalStateException ex = expectThrows(IllegalStateException.class,
-            "Node started with node.data=false and node.master=false while having existing index metadata must fail",
+            "node not having the data and master roles while having existing index metadata must fail",
             () ->
                 internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
                     @Override
                     public Settings onNodeStopped(String nodeName) {
-                        return Settings.builder()
-                            .put(Node.NODE_DATA_SETTING.getKey(), false)
-                            .put(Node.NODE_MASTER_SETTING.getKey(), false)
-                            .build();
+                        return NodeRoles.removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE));
                     }
                 }));
         if (writeDanglingIndices) {
-            assertThat(ex.getMessage(),
-                startsWith("Node is started with "
-                    + Node.NODE_DATA_SETTING.getKey()
-                    + "=false and "
-                    + Node.NODE_MASTER_SETTING.getKey()
-                    + "=false, but has index metadata"));
+            assertThat(ex.getMessage(), startsWith("node does not have the data and master roles but has index metadata"));
         } else {
-            assertThat(ex.getMessage(),
-                startsWith("Node is started with "
-                    + Node.NODE_DATA_SETTING.getKey()
-                    + "=false, but has shard data"));
+            assertThat(ex.getMessage(), startsWith("node does not have the data role but has shard data"));
         }
 
-        logger.info("--> start the node again with node.data=true and node.master=true");
+        logger.info("--> start the node again with data and master roles");
         internalCluster().startNode(dataPathSettings);
 
         logger.info("--> indexing a simple document");
         client().prepareIndex(indexName, "type1", "1").setSource("field1", "value1").get();
 
-        logger.info("--> restarting the node with node.data=false");
+        logger.info("--> restarting the node without the data role");
         ex = expectThrows(IllegalStateException.class,
-            "Node started with node.data=false while having existing shard data must fail",
+            "node not having the data role while having existing shard data must fail",
             () ->
                 internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
                     @Override
                     public Settings onNodeStopped(String nodeName) {
-                        return Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build();
+                        return nonDataNode();
                     }
                 }));
         assertThat(ex.getMessage(), containsString(indexUUID));
-        assertThat(ex.getMessage(),
-            startsWith("Node is started with "
-                + Node.NODE_DATA_SETTING.getKey()
-                + "=false, but has shard data"));
+        assertThat(ex.getMessage(), startsWith("node does not have the data role but has shard data"));
     }
 
     private IllegalStateException expectThrowsOnRestart(CheckedConsumer<Path[], Exception> onNodeStopped) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.hamcrest.Matchers.allOf;

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -33,6 +33,9 @@ import org.elasticsearch.test.NodeRoles;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -71,7 +74,9 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
                 internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
                     @Override
                     public Settings onNodeStopped(String nodeName) {
-                        return NodeRoles.removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE));
+                        return NodeRoles.removeRoles(Collections.unmodifiableSet(
+                            new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE))
+                        ));
                     }
                 }));
         if (writeDanglingIndices) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
@@ -20,11 +20,14 @@ package org.elasticsearch.env;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.NodeRoles;
 import org.hamcrest.Matcher;
+
+import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -56,10 +59,7 @@ public class NodeRepurposeCommandIT extends ESIntegTestCase {
         final Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
         final Settings dataNodeDataPathSettings = internalCluster().dataPathSettings(dataNode);
 
-        final Settings noMasterNoDataSettings = Settings.builder()
-            .put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false)
-            .build();
+        final Settings noMasterNoDataSettings = NodeRoles.removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE));
 
         final Settings noMasterNoDataSettingsForMasterNode = Settings.builder()
             .put(noMasterNoDataSettings)

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
@@ -30,7 +30,6 @@ import org.hamcrest.Matcher;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeRepurposeCommandIT.java
@@ -27,6 +27,9 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.NodeRoles;
 import org.hamcrest.Matcher;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
@@ -59,7 +62,8 @@ public class NodeRepurposeCommandIT extends ESIntegTestCase {
         final Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
         final Settings dataNodeDataPathSettings = internalCluster().dataPathSettings(dataNode);
 
-        final Settings noMasterNoDataSettings = NodeRoles.removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE));
+        final Settings noMasterNoDataSettings = NodeRoles.removeRoles(
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE))));
 
         final Settings noMasterNoDataSettingsForMasterNode = Settings.builder()
             .put(noMasterNoDataSettings)

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -48,7 +48,6 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.ShardLimitValidator;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -65,6 +64,7 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
@@ -218,7 +218,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build());
+        internalCluster().startNode(nonDataNode());
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE).execute().actionGet();
@@ -227,7 +227,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         internalCluster().fullRestart(new RestartCallback(){
             @Override
             public Settings onNodeStopped(String nodeName) {
-                return Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build();
+                return nonDataNode();
             }
         });
 
@@ -245,8 +245,8 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> cleaning nodes");
 
         logger.info("--> starting 1 master node non data");
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false).build());
-        internalCluster().startNode(Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false).build());
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNode();
 
         logger.info("--> create an index");
         client().admin().indices().prepareCreate("test").execute().actionGet();

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoverAfterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoverAfterNodesIT.java
@@ -24,13 +24,14 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
 import java.util.Set;
 
+import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
+import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
@@ -84,17 +85,13 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
     public void testRecoverAfterMasterNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start master_node (1)");
-        Client master1 = startNode(Settings.builder()
-            .put("gateway.recover_after_master_nodes", 2).put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), true));
+        Client master1 = startNode(Settings.builder().put("gateway.recover_after_master_nodes", 2).put(masterOnlyNode()));
         assertThat(master1.admin().cluster().prepareState().setLocal(true).execute().actionGet()
                 .getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         logger.info("--> start data_node (1)");
-        Client data1 = startNode(Settings.builder()
-            .put("gateway.recover_after_master_nodes", 2)
-            .put(Node.NODE_DATA_SETTING.getKey(), true).put(Node.NODE_MASTER_SETTING.getKey(), false));
+        Client data1 = startNode(Settings.builder().put("gateway.recover_after_master_nodes", 2).put(dataOnlyNode()));
         assertThat(master1.admin().cluster().prepareState().setLocal(true).execute().actionGet()
                 .getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
@@ -103,9 +100,7 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         logger.info("--> start data_node (2)");
-        Client data2 = startNode(Settings.builder()
-            .put("gateway.recover_after_master_nodes", 2).put(Node.NODE_DATA_SETTING.getKey(), true)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false));
+        Client data2 = startNode(Settings.builder().put("gateway.recover_after_master_nodes", 2).put(dataOnlyNode()));
         assertThat(master1.admin().cluster().prepareState().setLocal(true).execute().actionGet()
                 .getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
@@ -117,10 +112,7 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         logger.info("--> start master_node (2)");
-        Client master2 = startNode(Settings.builder()
-            .put("gateway.recover_after_master_nodes", 2)
-            .put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), true));
+        Client master2 = startNode(Settings.builder().put("gateway.recover_after_master_nodes", 2).put(masterOnlyNode()));
         assertThat(waitForNoBlocksOnNode(BLOCK_WAIT_TIMEOUT, master1).isEmpty(), equalTo(true));
         assertThat(waitForNoBlocksOnNode(BLOCK_WAIT_TIMEOUT, master2).isEmpty(), equalTo(true));
         assertThat(waitForNoBlocksOnNode(BLOCK_WAIT_TIMEOUT, data1).isEmpty(), equalTo(true));
@@ -130,19 +122,13 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
     public void testRecoverAfterDataNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start master_node (1)");
-        Client master1 = startNode(Settings.builder()
-            .put("gateway.recover_after_data_nodes", 2)
-            .put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), true));
+        Client master1 = startNode(Settings.builder().put("gateway.recover_after_data_nodes", 2).put(masterOnlyNode()));
         assertThat(master1.admin().cluster().prepareState().setLocal(true).execute().actionGet()
                 .getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         logger.info("--> start data_node (1)");
-        Client data1 = startNode(Settings.builder()
-            .put("gateway.recover_after_data_nodes", 2)
-            .put(Node.NODE_DATA_SETTING.getKey(), true)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false));
+        Client data1 = startNode(Settings.builder().put("gateway.recover_after_data_nodes", 2).put(dataOnlyNode()));
         assertThat(master1.admin().cluster().prepareState().setLocal(true).execute().actionGet()
                 .getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
@@ -151,10 +137,7 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         logger.info("--> start master_node (2)");
-        Client master2 = startNode(Settings.builder()
-            .put("gateway.recover_after_data_nodes", 2)
-            .put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), true));
+        Client master2 = startNode(Settings.builder().put("gateway.recover_after_data_nodes", 2).put(masterOnlyNode()));
         assertThat(master2.admin().cluster().prepareState().setLocal(true).execute().actionGet()
                 .getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
@@ -166,10 +149,7 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
                 hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK));
 
         logger.info("--> start data_node (2)");
-        Client data2 = startNode(Settings.builder()
-            .put("gateway.recover_after_data_nodes", 2)
-            .put(Node.NODE_DATA_SETTING.getKey(), true)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false));
+        Client data2 = startNode(Settings.builder().put("gateway.recover_after_data_nodes", 2).put(dataOnlyNode()));
         assertThat(waitForNoBlocksOnNode(BLOCK_WAIT_TIMEOUT, master1).isEmpty(), equalTo(true));
         assertThat(waitForNoBlocksOnNode(BLOCK_WAIT_TIMEOUT, master2).isEmpty(), equalTo(true));
         assertThat(waitForNoBlocksOnNode(BLOCK_WAIT_TIMEOUT, data1).isEmpty(), equalTo(true));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -65,7 +65,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFileChunkRequest;
 import org.elasticsearch.monitor.fs.FsInfo;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.CorruptionUtils;
@@ -390,9 +389,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         int numDocs = scaledRandomIntBetween(100, 1000);
         internalCluster().ensureAtLeastNumDataNodes(2);
         if (cluster().numDataNodes() < 3) {
-            internalCluster().startNode(Settings.builder()
-                .put(Node.NODE_DATA_SETTING.getKey(), true)
-                .put(Node.NODE_MASTER_SETTING.getKey(), false));
+            internalCluster().startDataOnlyNode();
         }
         NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().get();
         List<NodeStats> dataNodeStats = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/DedicatedMasterGetFieldMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/DedicatedMasterGetFieldMappingIT.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.indices.mapping;
 
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
 import org.junit.Before;
 
 import static org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -31,10 +29,8 @@ public class DedicatedMasterGetFieldMappingIT extends SimpleGetFieldMappingsIT {
 
     @Before
     public void before1() throws Exception {
-        Settings settings = Settings.builder()
-                .put(Node.NODE_DATA_SETTING.getKey(), false)
-                .build();
-        internalCluster().startNodes(settings, Settings.EMPTY);
+        internalCluster().startMasterOnlyNode();
+        internalCluster().startNode();
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -45,7 +45,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -67,6 +66,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.Thread.sleep;
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -94,9 +95,9 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
     }
 
     public void testIndexCleanup() throws Exception {
-        internalCluster().startNode(Settings.builder().put(Node.NODE_DATA_SETTING.getKey(), false));
-        final String node_1 = internalCluster().startNode(Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false));
-        final String node_2 = internalCluster().startNode(Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false));
+        internalCluster().startNode(nonDataNode());
+        final String node_1 = internalCluster().startNode(nonMasterNode());
+        final String node_2 = internalCluster().startNode(nonMasterNode());
         logger.info("--> creating index [test] with one shard and on replica");
         assertAcked(prepareCreate("test").setSettings(
                         Settings.builder().put(indexSettings())
@@ -114,7 +115,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertThat(Files.exists(indexDirectory(node_2, index)), equalTo(true));
 
         logger.info("--> starting node server3");
-        final String node_3 = internalCluster().startNode(Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false));
+        final String node_3 = internalCluster().startNode(nonMasterNode());
         logger.info("--> running cluster_health");
         ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth()
                 .setWaitForNodes("4")

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.NodeRoles.nonIngestNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
@@ -64,7 +65,7 @@ public class IngestClientIT extends ESIntegTestCase {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         if (nodeOrdinal % 2 == 0) {
-            return Settings.builder().put("node.ingest", false).put(super.nodeSettings(nodeOrdinal)).build();
+            return Settings.builder().put(nonIngestNode()).put(super.nodeSettings(nodeOrdinal)).build();
         }
         return super.nodeSettings(nodeOrdinal);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -115,6 +115,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFutureThrows;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -735,7 +736,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         internalCluster().startNode();
         logger.info("--> start second node");
         // Make sure the first node is elected as master
-        internalCluster().startNode(Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false));
+        internalCluster().startNode(nonMasterNode());
         // Register mock repositories
         for (int i = 0; i < 5; i++) {
             client().admin().cluster().preparePutRepository("test-repo" + i)

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -141,14 +141,12 @@ public abstract class TransportClient extends AbstractClient {
                         .put(pluginsService.updatedSettings())
                         .put(TransportSettings.FEATURE_PREFIX + "." + TRANSPORT_CLIENT_FEATURE, true)
                         .build();
-        final Set<DiscoveryNodeRole> possibleRoles = Stream.concat(
-                DiscoveryNodeRole.BUILT_IN_ROLES.stream(),
-                pluginsService.filterPlugins(Plugin.class)
-                        .stream()
-                        .map(Plugin::getRoles)
-                        .flatMap(Set::stream))
-                .collect(Collectors.toSet());
-        DiscoveryNode.setPossibleRoles(possibleRoles);
+        final Set<DiscoveryNodeRole> possibleRoles = pluginsService.filterPlugins(Plugin.class)
+            .stream()
+            .map(Plugin::getRoles)
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet());
+        DiscoveryNode.setAdditionalRoles(possibleRoles);
         final List<Closeable> resourcesToClose = new ArrayList<>();
         final ThreadPool threadPool = new ThreadPool(settings);
         resourcesToClose.add(() -> ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.Tuple;
@@ -32,7 +33,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.gateway.PersistedClusterStateService;
-import org.elasticsearch.node.Node;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -72,7 +72,7 @@ public class UnsafeBootstrapMasterCommand extends ElasticsearchNodeCommand {
     protected boolean validateBeforeLock(Terminal terminal, Environment env) {
         Settings settings = env.settings();
         terminal.println(Terminal.Verbosity.VERBOSE, "Checking node.master setting");
-        Boolean master = Node.NODE_MASTER_SETTING.get(settings);
+        Boolean master = DiscoveryNode.isMasterNode(settings);
         if (master == false) {
             throw new ElasticsearchException(NOT_MASTER_NODE_MSG);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -42,6 +43,9 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
 
 
 /**
@@ -53,30 +57,42 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
 
     public static boolean nodeRequiresLocalStorage(Settings settings) {
         boolean localStorageEnable = Node.NODE_LOCAL_STORAGE_SETTING.get(settings);
-        if (localStorageEnable == false &&
-            (Node.NODE_DATA_SETTING.get(settings) ||
-                Node.NODE_MASTER_SETTING.get(settings))
-            ) {
+        if (localStorageEnable == false && (isDataNode(settings) || isMasterNode(settings))) {
             // TODO: make this a proper setting validation logic, requiring multi-settings validation
             throw new IllegalArgumentException("storage can not be disabled for master and data nodes");
         }
         return localStorageEnable;
     }
 
-    public static boolean isMasterNode(Settings settings) {
-        return Node.NODE_MASTER_SETTING.get(settings);
+    public static boolean hasRole(final Settings settings, final DiscoveryNodeRole role) {
+        /*
+         * This method can be called before the o.e.n.NodeRoleSettings.NODE_ROLES_SETTING is initialized. We do not want to trigger
+         * initialization prematurely because that will bake the default roles before plugins have had a chance to register them. Therefore,
+         * to avoid initializing this setting prematurely, we avoid using the actual node roles setting instance here.
+         */
+        if (settings.hasValue("node.roles")) {
+            return settings.getAsList("node.roles").contains(role.roleName());
+        } else if (role.legacySetting() != null && settings.hasValue(role.legacySetting().getKey())) {
+            return role.legacySetting().get(settings);
+        } else {
+            return role.isEnabledByDefault(settings);
+        }
     }
 
-    public static boolean isDataNode(Settings settings) {
-        return Node.NODE_DATA_SETTING.get(settings);
+    public static boolean isMasterNode(Settings settings) {
+        return hasRole(settings, DiscoveryNodeRole.MASTER_ROLE);
+    }
+
+    public static boolean isDataNode(final Settings settings) {
+        return hasRole(settings, DiscoveryNodeRole.DATA_ROLE);
     }
 
     public static boolean isIngestNode(Settings settings) {
-        return Node.NODE_INGEST_SETTING.get(settings);
+        return hasRole(settings, DiscoveryNodeRole.INGEST_ROLE);
     }
 
     public static boolean isRemoteClusterClient(final Settings settings) {
-        return Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings);
+        return hasRole(settings, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
     }
 
     private final String nodeName;
@@ -187,7 +203,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         //verify that no node roles are being provided as attributes
         Predicate<Map<String, String>> predicate =  (attrs) -> {
             boolean success = true;
-            for (final DiscoveryNodeRole role : DiscoveryNode.roleNameToPossibleRoles.values()) {
+            for (final DiscoveryNodeRole role : DiscoveryNode.roleMap.values()) {
                 success &= attrs.containsKey(role.roleName()) == false;
                 assert success : role.roleName();
             }
@@ -206,8 +222,29 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
 
     /** extract node roles from the given settings */
     public static Set<DiscoveryNodeRole> getRolesFromSettings(final Settings settings) {
-        return Collections.unmodifiableSet(
-                roleNameToPossibleRoles.values().stream().filter(s -> s.roleSetting().get(settings)).collect(Collectors.toSet()));
+        if (NODE_ROLES_SETTING.exists(settings)) {
+            validateLegacySettings(settings, roleMap);
+            return Collections.unmodifiableSet(new HashSet<>(NODE_ROLES_SETTING.get(settings)));
+        } else {
+            return roleMap.values()
+                .stream()
+                .filter(s -> s.legacySetting() != null && s.legacySetting().get(settings))
+                .collect(Collectors.toSet());
+        }
+    }
+
+    private static void validateLegacySettings(final Settings settings, final Map<String, DiscoveryNodeRole> roleMap) {
+        for (final DiscoveryNodeRole role : roleMap.values()) {
+            if (role.legacySetting() != null && role.legacySetting().exists(settings)) {
+                final String message = String.format(
+                    Locale.ROOT,
+                    "can not explicitly configure node roles and use legacy role setting [%s]=[%s]",
+                    role.legacySetting().getKey(),
+                    role.legacySetting().get(settings)
+                );
+                throw new IllegalArgumentException(message);
+            }
+        }
     }
 
     /**
@@ -233,13 +270,13 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             for (int i = 0; i < rolesSize; i++) {
                 final String roleName = in.readString();
                 final String roleNameAbbreviation = in.readString();
-                final DiscoveryNodeRole role = roleNameToPossibleRoles.get(roleName);
+                final DiscoveryNodeRole role = roleMap.get(roleName);
                 if (role == null) {
                     roles.add(new DiscoveryNodeRole.UnknownRole(roleName, roleNameAbbreviation));
                 } else {
                     assert roleName.equals(role.roleName()) : "role name [" + roleName + "] does not match role [" + role.roleName() + "]";
                     assert roleNameAbbreviation.equals(role.roleNameAbbreviation())
-                            : "role name abbreviation [" + roleName + "] does not match role [" + role.roleNameAbbreviation() + "]";
+                        : "role name abbreviation [" + roleName + "] does not match role [" + role.roleNameAbbreviation() + "]";
                     roles.add(role);
                 }
             }
@@ -455,11 +492,27 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         return builder;
     }
 
-    private static Map<String, DiscoveryNodeRole> roleNameToPossibleRoles;
+    private static Map<String, DiscoveryNodeRole> rolesToMap(final Stream<DiscoveryNodeRole> roles) {
+        return Collections.unmodifiableMap(roles.collect(Collectors.toMap(DiscoveryNodeRole::roleName, Function.identity())));
+    }
 
-    public static void setPossibleRoles(final Set<DiscoveryNodeRole> possibleRoles) {
-        final Map<String, DiscoveryNodeRole> roleNameToPossibleRoles = Collections.unmodifiableMap(
-                possibleRoles.stream().collect(Collectors.toMap(DiscoveryNodeRole::roleName, Function.identity())));
+    private static Map<String, DiscoveryNodeRole> roleMap = rolesToMap(DiscoveryNodeRole.BUILT_IN_ROLES.stream());
+
+    public static DiscoveryNodeRole getRoleFromRoleName(final String roleName) {
+        if (roleMap.containsKey(roleName) == false) {
+            throw new IllegalArgumentException("unknown role [" + roleName + "]");
+        }
+        return roleMap.get(roleName);
+    }
+
+    public static Set<DiscoveryNodeRole> getPossibleRoles() {
+        return Collections.unmodifiableSet(new HashSet<>(roleMap.values()));
+    }
+
+    public static void setAdditionalRoles(final Set<DiscoveryNodeRole> additionalRoles) {
+        assert additionalRoles.stream().allMatch(r -> r.legacySetting() == null || r.legacySetting().isDeprecated()) : additionalRoles;
+        final Map<String, DiscoveryNodeRole> roleNameToPossibleRoles =
+            rolesToMap(Stream.concat(DiscoveryNodeRole.BUILT_IN_ROLES.stream(), additionalRoles.stream()));
         // collect the abbreviation names into a map to ensure that there are not any duplicate abbreviations
         final Map<String, DiscoveryNodeRole> roleNameAbbreviationToPossibleRoles = Collections.unmodifiableMap(
                 roleNameToPossibleRoles.values()
@@ -467,11 +520,11 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
                         .collect(Collectors.toMap(DiscoveryNodeRole::roleNameAbbreviation, Function.identity())));
         assert roleNameToPossibleRoles.size() == roleNameAbbreviationToPossibleRoles.size() :
                 "roles by name [" + roleNameToPossibleRoles + "], roles by name abbreviation [" + roleNameAbbreviationToPossibleRoles + "]";
-        DiscoveryNode.roleNameToPossibleRoles = roleNameToPossibleRoles;
+        roleMap = roleNameToPossibleRoles;
     }
 
     public static Set<String> getPossibleRoleNames() {
-        return roleNameToPossibleRoles.keySet();
+        return roleMap.keySet();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.node;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.RemoteClusterService;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -155,7 +156,12 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
         @Override
         public Setting<Boolean> legacySetting() {
             // copy the setting here so we can mark it private in org.elasticsearch.node.Node
-            return Setting.boolSetting("node.remote_cluster_client", true, Property.Deprecated, Property.NodeScope);
+            return Setting.boolSetting(
+                "node.remote_cluster_client",
+                RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
+                Property.Deprecated,
+                Property.NodeScope
+            );
         }
 
     };

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeRole.java
@@ -20,7 +20,8 @@
 package org.elasticsearch.cluster.node;
 
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.node.Node;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,6 +66,10 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
         return isKnownRole;
     }
 
+    public boolean isEnabledByDefault(final Settings settings) {
+        return legacySetting() != null && legacySetting().get(settings);
+    }
+
     protected DiscoveryNodeRole(final String roleName, final String roleNameAbbreviation) {
         this(true, roleName, roleNameAbbreviation);
     }
@@ -75,7 +80,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
         this.roleNameAbbreviation = Objects.requireNonNull(roleNameAbbreviation);
     }
 
-    protected abstract Setting<Boolean> roleSetting();
+    public abstract Setting<Boolean> legacySetting();
 
     @Override
     public final boolean equals(Object o) {
@@ -112,8 +117,9 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     public static final DiscoveryNodeRole DATA_ROLE = new DiscoveryNodeRole("data", "d") {
 
         @Override
-        protected Setting<Boolean> roleSetting() {
-            return Node.NODE_DATA_SETTING;
+        public Setting<Boolean> legacySetting() {
+            // copy the setting here so we can mark it private in org.elasticsearch.node.Node
+            return Setting.boolSetting("node.data", true, Property.Deprecated, Property.NodeScope);
         }
 
     };
@@ -124,8 +130,9 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     public static final DiscoveryNodeRole INGEST_ROLE = new DiscoveryNodeRole("ingest", "i") {
 
         @Override
-        protected Setting<Boolean> roleSetting() {
-            return Node.NODE_INGEST_SETTING;
+        public Setting<Boolean> legacySetting() {
+            // copy the setting here so we can mark it private in org.elasticsearch.node.Node
+            return Setting.boolSetting("node.ingest", true, Property.Deprecated, Property.NodeScope);
         }
 
     };
@@ -136,8 +143,9 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     public static final DiscoveryNodeRole MASTER_ROLE = new DiscoveryNodeRole("master", "m") {
 
         @Override
-        protected Setting<Boolean> roleSetting() {
-            return Node.NODE_MASTER_SETTING;
+        public Setting<Boolean> legacySetting() {
+            // copy the setting here so we can mark it private in org.elasticsearch.node.Node
+            return Setting.boolSetting("node.master", true, Property.Deprecated, Property.NodeScope);
         }
 
     };
@@ -145,8 +153,9 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
     public static final DiscoveryNodeRole REMOTE_CLUSTER_CLIENT_ROLE = new DiscoveryNodeRole("remote_cluster_client", "r") {
 
         @Override
-        protected Setting<Boolean> roleSetting() {
-            return Node.NODE_REMOTE_CLUSTER_CLIENT;
+        public Setting<Boolean> legacySetting() {
+            // copy the setting here so we can mark it private in org.elasticsearch.node.Node
+            return Setting.boolSetting("node.remote_cluster_client", true, Property.Deprecated, Property.NodeScope);
         }
 
     };
@@ -177,7 +186,7 @@ public abstract class DiscoveryNodeRole implements Comparable<DiscoveryNodeRole>
         }
 
         @Override
-        protected Setting<Boolean> roleSetting() {
+        public Setting<Boolean> legacySetting() {
             // since this setting is not registered, it will always return false when testing if the local node has the role
             assert false;
             return Setting.boolSetting("node. " + roleName(), false, Setting.Property.NodeScope);

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -103,6 +103,7 @@ import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.process.ProcessService;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.persistent.decider.EnableAssignmentDecider;
 import org.elasticsearch.plugins.PluginsService;
@@ -470,12 +471,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
             SearchService.MAX_OPEN_SCROLL_CONTEXT,
             Node.WRITE_PORTS_FILE_SETTING,
             Node.NODE_NAME_SETTING,
-            Node.NODE_DATA_SETTING,
-            Node.NODE_MASTER_SETTING,
-            Node.NODE_INGEST_SETTING,
-            Node.NODE_REMOTE_CLUSTER_CLIENT,
             Node.NODE_ATTRIBUTES,
             Node.NODE_LOCAL_STORAGE_SETTING,
+            NodeRoleSettings.NODE_ROLES_SETTING,
             AutoCreateIndex.AUTO_CREATE_INDEX_SETTING,
             BaseRestHandler.MULTI_ALLOW_EXPLICIT_INDEX,
             ClusterName.CLUSTER_NAME_SETTING,

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -35,6 +35,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.SuppressForbidden;
@@ -58,7 +59,6 @@ import org.elasticsearch.index.store.FsDirectoryFactory;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.fs.FsProbe;
 import org.elasticsearch.monitor.jvm.JvmInfo;
-import org.elasticsearch.node.Node;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -1079,26 +1079,27 @@ public final class NodeEnvironment  implements Closeable {
     private void ensureNoShardData(final NodePath[] nodePaths) throws IOException {
         List<Path> shardDataPaths = collectShardDataPaths(nodePaths);
         if (shardDataPaths.isEmpty() == false) {
-            throw new IllegalStateException("Node is started with "
-                + Node.NODE_DATA_SETTING.getKey()
-                + "=false, but has shard data: "
-                + shardDataPaths
-                + ". Use 'elasticsearch-node repurpose' tool to clean up"
+            final String message = String.format(
+                Locale.ROOT,
+                "node does not have the %s role but has shard data: %s. Use 'elasticsearch-node repurpose' tool to clean up",
+                DiscoveryNodeRole.DATA_ROLE.roleName(),
+                shardDataPaths
             );
+            throw new IllegalStateException(message);
         }
     }
 
     private void ensureNoIndexMetadata(final NodePath[] nodePaths) throws IOException {
         List<Path> indexMetadataPaths = collectIndexMetadataPaths(nodePaths);
         if (indexMetadataPaths.isEmpty() == false) {
-            throw new IllegalStateException("Node is started with "
-                + Node.NODE_DATA_SETTING.getKey()
-                + "=false and "
-                + Node.NODE_MASTER_SETTING.getKey()
-                + "=false, but has index metadata: "
-                + indexMetadataPaths
-                + ". Use 'elasticsearch-node repurpose' tool to clean up"
+            final String message = String.format(
+                Locale.ROOT,
+                "node does not have the %s and %s roles but has index metadata: %s. Use 'elasticsearch-node repurpose' tool to clean up",
+                DiscoveryNodeRole.DATA_ROLE.roleName(),
+                DiscoveryNodeRole.MASTER_ROLE.roleName(),
+                indexMetadataPaths
             );
+            throw new IllegalStateException(message);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -205,13 +205,17 @@ import static java.util.stream.Collectors.toList;
 public class Node implements Closeable {
     public static final Setting<Boolean> WRITE_PORTS_FILE_SETTING =
         Setting.boolSetting("node.portsfile", false, Property.NodeScope);
-    public static final Setting<Boolean> NODE_DATA_SETTING = Setting.boolSetting("node.data", true, Property.NodeScope);
-    public static final Setting<Boolean> NODE_MASTER_SETTING =
-        Setting.boolSetting("node.master", true, Property.NodeScope);
-    public static final Setting<Boolean> NODE_INGEST_SETTING =
-        Setting.boolSetting("node.ingest", true, Property.NodeScope);
-    public static final Setting<Boolean> NODE_REMOTE_CLUSTER_CLIENT =
-        Setting.boolSetting("node.remote_cluster_client", RemoteClusterService.ENABLE_REMOTE_CLUSTERS, Property.NodeScope);
+    private static final Setting<Boolean> NODE_DATA_SETTING =
+        Setting.boolSetting("node.data", true, Property.Deprecated, Property.NodeScope);
+    private static final Setting<Boolean> NODE_MASTER_SETTING =
+        Setting.boolSetting("node.master", true, Property.Deprecated, Property.NodeScope);
+    private static final Setting<Boolean> NODE_INGEST_SETTING =
+        Setting.boolSetting("node.ingest", true, Property.Deprecated, Property.NodeScope);
+    private static final Setting<Boolean> NODE_REMOTE_CLUSTER_CLIENT = Setting.boolSetting(
+        "node.remote_cluster_client",
+        RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
+        Property.Deprecated,
+        Property.NodeScope);
 
     /**
     * controls whether the node is allowed to persist things like metadata to disk
@@ -322,14 +326,12 @@ public class Node implements Closeable {
                 initialEnvironment.pluginsFile(), classpathPlugins);
             final Settings settings = pluginsService.updatedSettings();
 
-            final Set<DiscoveryNodeRole> possibleRoles = Stream.concat(
-                    DiscoveryNodeRole.BUILT_IN_ROLES.stream(),
-                    pluginsService.filterPlugins(Plugin.class)
-                            .stream()
-                            .map(Plugin::getRoles)
-                            .flatMap(Set::stream))
-                    .collect(Collectors.toSet());
-            DiscoveryNode.setPossibleRoles(possibleRoles);
+            final Set<DiscoveryNodeRole> additionalRoles = pluginsService.filterPlugins(Plugin.class)
+                .stream()
+                .map(Plugin::getRoles)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+            DiscoveryNode.setAdditionalRoles(additionalRoles);
 
             /*
              * Create the environment based on the finalized view of the settings. This is to ensure that components get the same setting
@@ -353,7 +355,13 @@ public class Node implements Closeable {
             DeprecationLogger.setThreadContext(threadPool.getThreadContext());
             resourcesToClose.add(() -> DeprecationLogger.removeThreadContext(threadPool.getThreadContext()));
 
-            final List<Setting<?>> additionalSettings = new ArrayList<>(pluginsService.getPluginSettings());
+            final List<Setting<?>> additionalSettings = new ArrayList<>();
+            // register the node.data, node.ingest, node.master, node.remote_cluster_client settings here so we can mark them private
+            additionalSettings.add(NODE_DATA_SETTING);
+            additionalSettings.add(NODE_INGEST_SETTING);
+            additionalSettings.add(NODE_MASTER_SETTING);
+            additionalSettings.add(NODE_REMOTE_CLUSTER_CLIENT);
+            additionalSettings.addAll(pluginsService.getPluginSettings());
             final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());

--- a/server/src/main/java/org/elasticsearch/node/NodeRoleSettings.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeRoleSettings.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.node;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NodeRoleSettings {
+
+    public static final Setting<List<DiscoveryNodeRole>> NODE_ROLES_SETTING = Setting.listSetting(
+        "node.roles",
+        null,
+        DiscoveryNode::getRoleFromRoleName,
+        settings -> DiscoveryNode.getPossibleRoles()
+            .stream()
+            .filter(role -> role.isEnabledByDefault(settings))
+            .map(DiscoveryNodeRole::roleName)
+            .collect(Collectors.toList()),
+        roles -> {},
+        Property.NodeScope
+    );
+
+}

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -178,7 +177,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
 
     RemoteClusterService(Settings settings, TransportService transportService) {
         super(settings);
-        this.enabled = Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings);
+        this.enabled = DiscoveryNode.isRemoteClusterClient(settings);
         this.transportService = transportService;
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -48,7 +48,6 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.tasks.Task;
@@ -175,7 +174,7 @@ public class TransportService extends AbstractLifecycleComponent implements Repo
         taskManager = createTaskManager(settings, threadPool, taskHeaders);
         this.interceptor = transportInterceptor;
         this.asyncSender = interceptor.interceptSender(this::sendRequestInternal);
-        this.remoteClusterClient = Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings);
+        this.remoteClusterClient = DiscoveryNode.isRemoteClusterClient(settings);
         remoteClusterService = new RemoteClusterService(settings, this);
         responseHandlers = transport.getResponseHandlers();
         if (clusterSettings != null) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoveryModule;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.transport.TransportRequest;
@@ -52,6 +51,7 @@ import static org.elasticsearch.common.settings.Settings.builder;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -551,7 +551,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
         final Settings.Builder settings = Settings.builder()
             .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE)
             .put(NODE_NAME_SETTING.getKey(), localNode.getName())
-            .put(Node.NODE_MASTER_SETTING.getKey(), false);
+            .put(nonMasterNode());
 
         assertThat(expectThrows(IllegalArgumentException.class, () -> new ClusterBootstrapService(settings.build(),
                 transportService, () -> emptyList(), () -> false, vc -> fail())).getMessage(),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -45,7 +45,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.zen.PublishClusterStateStats;
 import org.elasticsearch.gateway.GatewayService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.MockLogAppender;
 
 import java.io.IOException;
@@ -76,6 +75,7 @@ import static org.elasticsearch.cluster.coordination.NoMasterBlockService.NO_MAS
 import static org.elasticsearch.cluster.coordination.NoMasterBlockService.NO_MASTER_BLOCK_WRITES;
 import static org.elasticsearch.cluster.coordination.Reconfigurator.CLUSTER_AUTO_SHRINK_VOTING_CONFIGURATION;
 import static org.elasticsearch.discovery.PeerFinder.DISCOVERY_FIND_PEERS_INTERVAL_SETTING;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -1397,8 +1397,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             logger.info("--> restarting [{}] as a master-ineligible node", chosenNode);
 
             chosenNode.close();
-            cluster.clusterNodes.replaceAll(cn -> cn == chosenNode ? cn.restartedNode(Function.identity(), Function.identity(),
-                Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false).build()) : cn);
+            cluster.clusterNodes.replaceAll(
+                cn -> cn == chosenNode ? cn.restartedNode(Function.identity(), Function.identity(), nonMasterNode()) : cn
+            );
             cluster.stabilise();
 
             if (chosenNodeIsLeader == false) {

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.node;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.test.NodeRoles.onlyRole;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+public class DiscoveryNodeRoleSettingTests extends ESTestCase {
+
+    public void testIsDataNode() {
+        runRoleTest(DiscoveryNode::isDataNode, DiscoveryNodeRole.DATA_ROLE);
+    }
+
+    public void testIsIngestNode() {
+        runRoleTest(DiscoveryNode::isIngestNode, DiscoveryNodeRole.INGEST_ROLE);
+    }
+
+    public void testIsMasterNode() {
+        runRoleTest(DiscoveryNode::isMasterNode, DiscoveryNodeRole.MASTER_ROLE);
+    }
+
+    public void testIsRemoteClusterClient() {
+        runRoleTest(DiscoveryNode::isRemoteClusterClient, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE);
+    }
+
+    private void runRoleTest(final Predicate<Settings> predicate, final DiscoveryNodeRole role) {
+        final Settings legacyTrue = Settings.builder().put(role.legacySetting().getKey(), true).build();
+
+        assertTrue(predicate.test(legacyTrue));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{role.legacySetting()});
+
+        assertThat(DiscoveryNode.getRolesFromSettings(legacyTrue), hasItem(role));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{role.legacySetting()});
+
+        final Settings legacyFalse = Settings.builder().put(role.legacySetting().getKey(), false).build();
+
+        assertFalse(predicate.test(legacyFalse));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{role.legacySetting()});
+
+        assertThat(DiscoveryNode.getRolesFromSettings(legacyFalse), not(hasItem(role)));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{role.legacySetting()});
+
+        assertTrue(predicate.test(onlyRole(role)));
+        assertThat(DiscoveryNode.getRolesFromSettings(onlyRole(role)), hasItem(role));
+
+        assertFalse(predicate.test(removeRoles(Set.of(role))));
+        assertThat(DiscoveryNode.getRolesFromSettings(removeRoles(Set.of(role))), not(hasItem(role)));
+
+        final Settings settings = Settings.builder().put(onlyRole(role)).put(role.legacySetting().getKey(), randomBoolean()).build();
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DiscoveryNode.getRolesFromSettings(settings));
+        assertThat(e.getMessage(), startsWith("can not explicitly configure node roles and use legacy role setting"));
+        assertSettingDeprecationsAndWarnings(new Setting<?>[]{role.legacySetting()});
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Set;
+import java.util.Collections;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.test.NodeRoles.onlyRole;
@@ -70,8 +70,8 @@ public class DiscoveryNodeRoleSettingTests extends ESTestCase {
         assertTrue(predicate.test(onlyRole(role)));
         assertThat(DiscoveryNode.getRolesFromSettings(onlyRole(role)), hasItem(role));
 
-        assertFalse(predicate.test(removeRoles(Set.of(role))));
-        assertThat(DiscoveryNode.getRolesFromSettings(removeRoles(Set.of(role))), not(hasItem(role)));
+        assertFalse(predicate.test(removeRoles(Collections.singleton(role))));
+        assertThat(DiscoveryNode.getRolesFromSettings(removeRoles(Collections.singleton(role))), not(hasItem(role)));
 
         final Settings settings = Settings.builder().put(onlyRole(role)).put(role.legacySetting().getKey(), randomBoolean()).build();
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DiscoveryNode.getRolesFromSettings(settings));

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleTests.java
@@ -34,7 +34,7 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
     public void testDiscoveryNodeSetPossibleRolesRejectsDuplicateRoleNames() {
         final IllegalStateException e = expectThrows(
                 IllegalStateException.class,
-                () -> DiscoveryNode.setPossibleRoles(new HashSet<>(Arrays.asList(
+                () -> DiscoveryNode.setAdditionalRoles(new HashSet<>(Arrays.asList(
                         new DiscoveryNodeRole("foo", "f") {
 
                             @Override
@@ -57,7 +57,7 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
     public void testDiscoveryNodeSetPossibleRolesRejectsDuplicateRoleNameAbbreviations() {
         final IllegalStateException e = expectThrows(
                 IllegalStateException.class,
-                () -> DiscoveryNode.setPossibleRoles(new HashSet<>(Arrays.asList(
+                () -> DiscoveryNode.setAdditionalRoles(new HashSet<>(Arrays.asList(
                         new DiscoveryNodeRole("foo_1", "f") {
 
                             @Override

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleTests.java
@@ -38,7 +38,7 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
                         new DiscoveryNodeRole("foo", "f") {
 
                             @Override
-                            protected Setting<Boolean> roleSetting() {
+                            public Setting<Boolean> legacySetting() {
                                 return null;
                             }
 
@@ -46,7 +46,7 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
                         new DiscoveryNodeRole("foo", "f") {
 
                             @Override
-                            protected Setting<Boolean> roleSetting() {
+                            public Setting<Boolean> legacySetting() {
                                 return null;
                             }
 
@@ -61,7 +61,7 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
                         new DiscoveryNodeRole("foo_1", "f") {
 
                             @Override
-                            protected Setting<Boolean> roleSetting() {
+                            public Setting<Boolean> legacySetting() {
                                 return null;
                             }
 
@@ -69,7 +69,7 @@ public class DiscoveryNodeRoleTests extends ESTestCase {
                         new DiscoveryNodeRole("foo_2", "f") {
 
                             @Override
-                            protected Setting<Boolean> roleSetting() {
+                            public Setting<Boolean> legacySetting() {
                                 return null;
                             }
 

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -274,10 +274,12 @@ public class DiscoveryNodesTests extends ESTestCase {
             final Set<DiscoveryNodeRole> roles = new HashSet<>(randomSubsetOf(DiscoveryNodeRole.BUILT_IN_ROLES));
             if (frequently()) {
                 roles.add(new DiscoveryNodeRole("custom_role", "cr") {
+
                     @Override
-                    protected Setting<Boolean> roleSetting() {
+                    public Setting<Boolean> legacySetting() {
                         return null;
                     }
+
                 });
             }
             final DiscoveryNode node = newNode(idGenerator.getAndIncrement(), attributes, roles);

--- a/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -46,7 +46,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoverySettings;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -76,6 +75,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -533,7 +533,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
             discoveryNodesBuilder.add(createMockNode("node" + i).discoveryNode);
         }
         final int dataNodes = randomIntBetween(0, 5);
-        final Settings dataSettings = Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false).build();
+        final Settings dataSettings = Settings.builder().put(nonMasterNode()).build();
         for (int i = 0; i < dataNodes; i++) {
             discoveryNodesBuilder.add(createMockNode("data_" + i, dataSettings, null).discoveryNode);
         }
@@ -592,7 +592,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
         final int dataNodes = randomIntBetween(0, 3); // data nodes don't matter
         for (int i = 0; i < dataNodes; i++) {
             final MockNode mockNode = createMockNode("data_" + i,
-                Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false).build(), null);
+                Settings.builder().put(nonMasterNode()).build(), null);
             discoveryNodesBuilder.add(mockNode.discoveryNode);
             if (randomBoolean()) {
                 // we really don't care - just chaos monkey

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -427,11 +427,9 @@ public class NodeEnvironmentTests extends ESTestCase {
     }
 
     public void testNodeIdNotPersistedAtInitialization() throws IOException {
-        NodeEnvironment env = newNodeEnvironment(new String[0], Settings.builder()
-            .put("node.local_storage", false)
-            .put("node.master", false)
-            .put("node.data", false)
-            .build());
+        NodeEnvironment env = newNodeEnvironment(
+            new String[0],
+            nonMasterNode(nonDataNode(Settings.builder().put("node.local_storage", false).build())));
         String nodeID = env.nodeId();
         env.close();
         final String[] paths = tmpPaths();

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.NodeRoles;
@@ -40,6 +41,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -481,7 +484,9 @@ public class NodeEnvironmentTests extends ESTestCase {
         // build settings using same path.data as original but without data and master roles
         Settings noDataNoMasterSettings = Settings.builder()
             .put(settings)
-            .put(NodeRoles.removeRoles(settings, Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)))
+            .put(NodeRoles.removeRoles(
+                settings,
+                Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)))))
             .build();
 
         // test that we can create data=false and master=false with no meta information

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.env;
 
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Setting;
@@ -31,9 +32,9 @@ import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.test.NodeRoles;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,6 +49,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
@@ -475,11 +478,10 @@ public class NodeEnvironmentTests extends ESTestCase {
         Settings settings = buildEnvSettings(Settings.EMPTY);
         Index index = new Index("test", "testUUID");
 
-        // build settings using same path.data as original but with node.data=false and node.master=false
+        // build settings using same path.data as original but without data and master roles
         Settings noDataNoMasterSettings = Settings.builder()
             .put(settings)
-            .put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false)
+            .put(NodeRoles.removeRoles(settings, Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)))
             .build();
 
         // test that we can create data=false and master=false with no meta information
@@ -495,10 +497,8 @@ public class NodeEnvironmentTests extends ESTestCase {
 
         verifyFailsOnMetadata(noDataNoMasterSettings, indexPath);
 
-        // build settings using same path.data as original but with node.data=false
-        Settings noDataSettings = Settings.builder()
-            .put(settings)
-            .put(Node.NODE_DATA_SETTING.getKey(), false).build();
+        // build settings using same path.data as original but without data role
+        Settings noDataSettings = nonDataNode(settings);
 
         String shardDataDirName = Integer.toString(randomInt(10));
 
@@ -514,11 +514,8 @@ public class NodeEnvironmentTests extends ESTestCase {
         // assert that we get the stricter message on meta-data when both conditions fail
         verifyFailsOnMetadata(noDataNoMasterSettings, indexPath);
 
-        // build settings using same path.data as original but with node.master=false
-        Settings noMasterSettings = Settings.builder()
-            .put(settings)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false)
-            .build();
+        // build settings using same path.data as original but without master role
+        Settings noMasterSettings = nonMasterNode(settings);
 
         // test that we can create master=false env regardless of data.
         newNodeEnvironment(noMasterSettings).close();
@@ -537,30 +534,22 @@ public class NodeEnvironmentTests extends ESTestCase {
 
     private void verifyFailsOnShardData(Settings settings, Path indexPath, String shardDataDirName) {
         IllegalStateException ex = expectThrows(IllegalStateException.class,
-            "Must fail creating NodeEnvironment on a data path that has shard data if node.data=false",
+            "Must fail creating NodeEnvironment on a data path that has shard data if node does not have data role",
             () -> newNodeEnvironment(settings).close());
 
         assertThat(ex.getMessage(),
             containsString(indexPath.resolve(shardDataDirName).toAbsolutePath().toString()));
-        assertThat(ex.getMessage(),
-            startsWith("Node is started with "
-                + Node.NODE_DATA_SETTING.getKey()
-                + "=false, but has shard data"));
+        assertThat(ex.getMessage(), startsWith("node does not have the data role but has shard data"));
     }
 
     private void verifyFailsOnMetadata(Settings settings, Path indexPath) {
         IllegalStateException ex = expectThrows(IllegalStateException.class,
-            "Must fail creating NodeEnvironment on a data path that has index meta-data if node.data=false and node.master=false",
+            "Must fail creating NodeEnvironment on a data path that has index metadata if node does not have data and master roles",
             () -> newNodeEnvironment(settings).close());
 
         assertThat(ex.getMessage(),
             containsString(indexPath.resolve(MetadataStateFormat.STATE_DIR_NAME).toAbsolutePath().toString()));
-        assertThat(ex.getMessage(),
-            startsWith("Node is started with "
-                + Node.NODE_DATA_SETTING.getKey()
-                + "=false and "
-                + Node.NODE_MASTER_SETTING.getKey()
-                + "=false, but has index metadata"));
+        assertThat(ex.getMessage(), startsWith("node does not have the data and master roles but has index metadata"));
     }
 
     /** Converts an array of Strings to an array of Paths, adding an additional child if specified */

--- a/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
@@ -44,7 +44,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Set;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.env.NodeRepurposeCommand.NO_CLEANUP;
@@ -82,7 +83,9 @@ public class NodeRepurposeCommandTests extends ESTestCase {
             }
         }
         dataNoMasterSettings = nonMasterNode(dataMasterSettings);
-        noDataNoMasterSettings = removeRoles(dataMasterSettings, Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE));
+        noDataNoMasterSettings = removeRoles(
+            dataMasterSettings,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE))));
 
         noDataMasterSettings = masterNode(nonDataNode(dataMasterSettings));
     }

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -334,8 +335,11 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         try {
             DiscoveryNode localNode = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Collections.emptyMap(),
                 Sets.newHashSet(DiscoveryNodeRole.DATA_ROLE), Version.CURRENT);
-            Settings settings = Settings.builder().put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName.value()).put(
-                Node.NODE_MASTER_SETTING.getKey(), false).put(Node.NODE_NAME_SETTING.getKey(), "test").build();
+            Settings settings = Settings.builder()
+                .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName.value())
+                .put(nonMasterNode())
+                .put(Node.NODE_NAME_SETTING.getKey(), "test")
+                .build();
             final MockGatewayMetaState gateway = new MockGatewayMetaState(localNode);
             cleanup.add(gateway);
             final TransportService transportService = mock(TransportService.class);

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.hamcrest.Matchers;
@@ -48,6 +47,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
+import static org.elasticsearch.test.NodeRoles.masterNode;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItem;
 
@@ -101,9 +101,11 @@ public class GatewayServiceTests extends ESTestCase {
         GatewayService service = createService(Settings.builder());
         ClusterStateUpdateTask clusterStateUpdateTask = service.new RecoverStateUpdateTask();
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            settings(Version.CURRENT).put(masterNode()).build(),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId
+        );
         ClusterState stateWithBlock = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build()).
                 blocks(ClusterBlocks.builder().addGlobalBlock(STATE_NOT_RECOVERED_BLOCK).build()).build();

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceCloseTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceCloseTests.java
@@ -55,6 +55,7 @@ import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INI
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 public class IndicesServiceCloseTests extends ESTestCase {
@@ -70,7 +71,7 @@ public class IndicesServiceCloseTests extends ESTestCase {
             .put(Node.NODE_NAME_SETTING.getKey(), nodeName)
             .put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 1) // limit the number of threads created
             .put("transport.type", getTestTransportType())
-            .put(Node.NODE_DATA_SETTING.getKey(), true)
+            .put(dataNode())
             .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), random().nextLong())
             // default the watermarks low values to prevent tests from failing on nodes without enough disk space
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "1b")

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -155,7 +156,7 @@ public class NodeTests extends ESTestCase {
                 .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
                 .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
                 .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
-                .put(Node.NODE_DATA_SETTING.getKey(), true);
+                .put(dataNode());
     }
 
     public void testCloseOnOutstandingTask() throws Exception {

--- a/server/src/test/java/org/elasticsearch/transport/ConnectionProfileTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ConnectionProfileTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.transport;
 
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -27,7 +28,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ConnectionProfileTests extends ESTestCase {
@@ -209,7 +214,7 @@ public class ConnectionProfileTests extends ESTestCase {
         assertEquals(TransportSettings.TRANSPORT_COMPRESS.get(Settings.EMPTY), profile.getCompressionEnabled());
         assertEquals(TransportSettings.PING_SCHEDULE.get(Settings.EMPTY), profile.getPingInterval());
 
-        profile = ConnectionProfile.buildDefaultConnectionProfile(Settings.builder().put("node.master", false).build());
+        profile = ConnectionProfile.buildDefaultConnectionProfile(nonMasterNode());
         assertEquals(12, profile.getNumConnections());
         assertEquals(1, profile.getNumConnectionsPerType(TransportRequestOptions.Type.PING));
         assertEquals(6, profile.getNumConnectionsPerType(TransportRequestOptions.Type.REG));
@@ -217,7 +222,7 @@ public class ConnectionProfileTests extends ESTestCase {
         assertEquals(2, profile.getNumConnectionsPerType(TransportRequestOptions.Type.RECOVERY));
         assertEquals(3, profile.getNumConnectionsPerType(TransportRequestOptions.Type.BULK));
 
-        profile = ConnectionProfile.buildDefaultConnectionProfile(Settings.builder().put("node.data", false).build());
+        profile = ConnectionProfile.buildDefaultConnectionProfile(nonDataNode());
         assertEquals(11, profile.getNumConnections());
         assertEquals(1, profile.getNumConnectionsPerType(TransportRequestOptions.Type.PING));
         assertEquals(6, profile.getNumConnectionsPerType(TransportRequestOptions.Type.REG));
@@ -225,8 +230,9 @@ public class ConnectionProfileTests extends ESTestCase {
         assertEquals(0, profile.getNumConnectionsPerType(TransportRequestOptions.Type.RECOVERY));
         assertEquals(3, profile.getNumConnectionsPerType(TransportRequestOptions.Type.BULK));
 
-        profile = ConnectionProfile.buildDefaultConnectionProfile(Settings.builder().put("node.data", false)
-            .put("node.master", false).build());
+        profile = ConnectionProfile.buildDefaultConnectionProfile(
+            removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE))
+        );
         assertEquals(10, profile.getNumConnections());
         assertEquals(1, profile.getNumConnectionsPerType(TransportRequestOptions.Type.PING));
         assertEquals(6, profile.getNumConnectionsPerType(TransportRequestOptions.Type.REG));

--- a/server/src/test/java/org/elasticsearch/transport/ConnectionProfileTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ConnectionProfileTests.java
@@ -25,10 +25,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.NodeRoles.nonMasterNode;
@@ -231,7 +232,9 @@ public class ConnectionProfileTests extends ESTestCase {
         assertEquals(3, profile.getNumConnectionsPerType(TransportRequestOptions.Type.BULK));
 
         profile = ConnectionProfile.buildDefaultConnectionProfile(
-            removeRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE))
+            removeRoles(
+                Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)))
+            )
         );
         assertEquals(10, profile.getNumConnections());
         assertEquals(1, profile.getNumConnectionsPerType(TransportRequestOptions.Type.PING));

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -24,8 +24,8 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -33,8 +33,11 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.test.NodeRoles.onlyRole;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.elasticsearch.transport.RemoteClusterConnectionTests.startTransport;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -54,7 +57,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             DiscoveryNode remoteNode = remoteTransport.getLocalDiscoNode();
 
             Settings localSettings = Settings.builder()
-                .put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), true)
+                .put(onlyRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE))
                 .put("cluster.remote.test.seeds",
                     remoteNode.getAddress().getAddress() + ":" + remoteNode.getAddress().getPort()).build();
             try (MockTransportService service = MockTransportService.createNewService(localSettings, Version.CURRENT, threadPool, null)) {
@@ -86,7 +89,7 @@ public class RemoteClusterClientTests extends ESTestCase {
             remoteSettings)) {
             DiscoveryNode remoteNode = remoteTransport.getLocalDiscoNode();
             Settings localSettings = Settings.builder()
-                .put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), true)
+                .put(onlyRole(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE))
                 .put("cluster.remote.test.seeds",
                     remoteNode.getAddress().getAddress() + ":" + remoteNode.getAddress().getPort()).build();
             try (MockTransportService service = MockTransportService.createNewService(localSettings, Version.CURRENT, threadPool, null)) {
@@ -117,7 +120,7 @@ public class RemoteClusterClientTests extends ESTestCase {
     }
 
     public void testRemoteClusterServiceNotEnabled() {
-        final Settings settings = Settings.builder().put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), false).build();
+        final Settings settings = removeRoles(Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         try (MockTransportService service = MockTransportService.createNewService(settings, Version.CURRENT, threadPool, null)) {
             service.start();
             service.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.NodeRoles.onlyRole;
@@ -120,7 +119,7 @@ public class RemoteClusterClientTests extends ESTestCase {
     }
 
     public void testRemoteClusterServiceNotEnabled() {
-        final Settings settings = removeRoles(Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+        final Settings settings = removeRoles(Collections.singleton(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         try (MockTransportService service = MockTransportService.createNewService(settings, Version.CURRENT, threadPool, null)) {
             service.start();
             service.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -856,7 +856,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     }
 
     public void testRemoteClusterServiceNotEnabledGetRemoteClusterConnection() {
-        final Settings settings = removeRoles(Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+        final Settings settings = removeRoles(Collections.singleton(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         try (MockTransportService service = MockTransportService.createNewService(settings, Version.CURRENT, threadPool, null)) {
             service.start();
             service.acceptIncomingRequests();
@@ -867,7 +867,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     }
 
     public void testRemoteClusterServiceNotEnabledGetCollectNodes() {
-        final Settings settings = removeRoles(Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+        final Settings settings = removeRoles(Collections.singleton(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         try (MockTransportService service = MockTransportService.createNewService(settings, Version.CURRENT, threadPool, null)) {
             service.start();
             service.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -24,13 +24,13 @@ import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.AbstractScopedSettings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -49,6 +49,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
+import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -454,8 +457,8 @@ public class RemoteClusterServiceTests extends ESTestCase {
     public void testRemoteNodeRoles() throws IOException, InterruptedException {
         final Settings settings = Settings.EMPTY;
         final List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
-        final Settings data = Settings.builder().put("node.master", false).build();
-        final Settings dedicatedMaster = Settings.builder().put("node.data", false).put("node.ingest", "false").build();
+        final Settings data = nonMasterNode();
+        final Settings dedicatedMaster = masterOnlyNode();
         try (MockTransportService c1N1 =
                      startTransport("cluster_1_node_1", knownNodes, Version.CURRENT, dedicatedMaster);
              MockTransportService c1N2 =
@@ -853,7 +856,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     }
 
     public void testRemoteClusterServiceNotEnabledGetRemoteClusterConnection() {
-        final Settings settings = Settings.builder().put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), false).build();
+        final Settings settings = removeRoles(Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         try (MockTransportService service = MockTransportService.createNewService(settings, Version.CURRENT, threadPool, null)) {
             service.start();
             service.acceptIncomingRequests();
@@ -864,7 +867,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     }
 
     public void testRemoteClusterServiceNotEnabledGetCollectNodes() {
-        final Settings settings = Settings.builder().put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), false).build();
+        final Settings settings = removeRoles(Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
         try (MockTransportService service = MockTransportService.createNewService(settings, Version.CURRENT, threadPool, null)) {
             service.start();
             service.acceptIncomingRequests();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterSettingsTests.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.node.Node.NODE_REMOTE_CLUSTER_CLIENT;
 import static org.elasticsearch.test.NodeRoles.nonRemoteClusterClientNode;
 import static org.elasticsearch.test.NodeRoles.remoteClusterClientNode;
 import static org.elasticsearch.transport.RemoteClusterService.ENABLE_REMOTE_CLUSTERS;

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterSettingsTests.java
@@ -19,9 +19,12 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.node.NodeRoleSettings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -29,6 +32,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.node.Node.NODE_REMOTE_CLUSTER_CLIENT;
+import static org.elasticsearch.test.NodeRoles.nonRemoteClusterClientNode;
+import static org.elasticsearch.test.NodeRoles.remoteClusterClientNode;
 import static org.elasticsearch.transport.RemoteClusterService.ENABLE_REMOTE_CLUSTERS;
 import static org.elasticsearch.transport.RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE;
 import static org.elasticsearch.transport.RemoteClusterService.REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING;
@@ -45,6 +50,8 @@ import static org.elasticsearch.transport.SniffConnectionStrategy.SEARCH_REMOTE_
 import static org.elasticsearch.transport.SniffConnectionStrategy.SEARCH_REMOTE_CONNECTIONS_PER_CLUSTER;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 public class RemoteClusterSettingsTests extends ESTestCase {
 
@@ -91,20 +98,29 @@ public class RemoteClusterSettingsTests extends ESTestCase {
     }
 
     public void testRemoteClusterClientDefault() {
-        assertTrue(NODE_REMOTE_CLUSTER_CLIENT.get(Settings.EMPTY));
+        assertTrue(DiscoveryNode.isRemoteClusterClient(Settings.EMPTY));
+        assertThat(NodeRoleSettings.NODE_ROLES_SETTING.get(Settings.EMPTY), hasItem(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
     }
 
-    public void testDisableRemoteClusterClient() {
-        assertFalse(NODE_REMOTE_CLUSTER_CLIENT.get(Settings.builder().put(NODE_REMOTE_CLUSTER_CLIENT.getKey(), false).build()));
+    public void testAddRemoteClusterClientRole() {
+        final Settings settings = remoteClusterClientNode();
+        assertTrue(DiscoveryNode.isRemoteClusterClient(settings));
+        assertThat(NodeRoleSettings.NODE_ROLES_SETTING.get(settings), hasItem(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+    }
+
+    public void testRemoveRemoteClusterClientRole() {
+        final Settings settings = nonRemoteClusterClientNode();
+        assertFalse(DiscoveryNode.isRemoteClusterClient(settings));
+        assertThat(NodeRoleSettings.NODE_ROLES_SETTING.get(settings), not(hasItem(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)));
     }
 
     public void testDisableEnableRemoteClusters() {
-        assertFalse(NODE_REMOTE_CLUSTER_CLIENT.get(Settings.builder().put(ENABLE_REMOTE_CLUSTERS.getKey(), false).build()));
+        assertFalse(DiscoveryNode.isRemoteClusterClient(Settings.builder().put(ENABLE_REMOTE_CLUSTERS.getKey(), false).build()));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{ENABLE_REMOTE_CLUSTERS});
     }
 
     public void testDisableSearchEnableRemoteClusters() {
-        assertFalse(NODE_REMOTE_CLUSTER_CLIENT.get(Settings.builder().put(SEARCH_ENABLE_REMOTE_CLUSTERS.getKey(), false).build()));
+        assertFalse(DiscoveryNode.isRemoteClusterClient(Settings.builder().put(SEARCH_ENABLE_REMOTE_CLUSTERS.getKey(), false).build()));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{SEARCH_ENABLE_REMOTE_CLUSTERS});
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -65,7 +65,6 @@ import org.elasticsearch.gateway.ClusterStateUpdaters;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.gateway.MockGatewayMetaState;
 import org.elasticsearch.gateway.PersistedClusterStateService;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.disruption.DisruptableMockTransport;
 import org.elasticsearch.test.disruption.DisruptableMockTransport.ConnectionStatus;
@@ -982,7 +981,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 final DiscoveryNode newLocalNode = new DiscoveryNode(localNode.getName(), localNode.getId(),
                     UUIDs.randomBase64UUID(random()), // generated deterministically for repeatable tests
                     address.address().getHostString(), address.getAddress(), address, Collections.emptyMap(),
-                    localNode.isMasterNode() && Node.NODE_MASTER_SETTING.get(nodeSettings)
+                    localNode.isMasterNode() && DiscoveryNode.isMasterNode(nodeSettings)
                         ? DiscoveryNodeRole.BUILT_IN_ROLES : emptySet(), Version.CURRENT);
                 return new ClusterNode(nodeIndex, newLocalNode,
                     node -> new MockPersistedState(newLocalNode, persistedState, adaptGlobalMetadata, adaptCurrentTerm), nodeSettings);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -66,6 +66,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.cluster.coordination.ClusterBootstrapService.INITIAL_MASTER_NODES_SETTING;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -207,7 +208,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
             .put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 1) // limit the number of threads created
             .put("transport.type", getTestTransportType())
             .put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange())
-            .put(Node.NODE_DATA_SETTING.getKey(), true)
+            .put(dataNode())
             .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), random().nextLong())
             // default the watermarks low values to prevent tests from failing on nodes without enough disk space
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "1b")

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -53,7 +53,6 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -346,14 +345,9 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
     }
 
-    @BeforeClass
-    public static void setPossibleRoles() {
-        DiscoveryNode.setPossibleRoles(DiscoveryNodeRole.BUILT_IN_ROLES);
-    }
-
     @AfterClass
-    public static void clearPossibleRoles() {
-        DiscoveryNode.setPossibleRoles(Collections.emptySet());
+    public static void clearAdditionalRoles() {
+        DiscoveryNode.setAdditionalRoles(Collections.emptySet());
     }
 
     /**
@@ -1460,4 +1454,5 @@ public abstract class ESTestCase extends LuceneTestCase {
             throw new AssertionError();
         }
     }
+
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -163,6 +163,11 @@ import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.getTestTransportType;
 import static org.elasticsearch.test.ESTestCase.inFipsJvm;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
+import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
+import static org.elasticsearch.test.NodeRoles.noRoles;
+import static org.elasticsearch.test.NodeRoles.onlyRole;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -749,16 +754,18 @@ public final class InternalTestCluster extends TestCluster {
      */
     private static String getRoleSuffix(Settings settings) {
         String suffix = "";
-        if (Node.NODE_MASTER_SETTING.exists(settings) && Node.NODE_MASTER_SETTING.get(settings)) {
-            suffix = suffix + DiscoveryNodeRole.MASTER_ROLE.roleNameAbbreviation();
-        }
-        if (Node.NODE_DATA_SETTING.exists(settings) && Node.NODE_DATA_SETTING.get(settings)) {
-            suffix = suffix + DiscoveryNodeRole.DATA_ROLE.roleNameAbbreviation();
-        }
-        if (Node.NODE_MASTER_SETTING.exists(settings) && Node.NODE_MASTER_SETTING.get(settings) == false &&
-            Node.NODE_DATA_SETTING.exists(settings) && Node.NODE_DATA_SETTING.get(settings) == false
-            ) {
-            suffix = suffix + "c";
+        // only add the suffixes if roles are explicitly defined
+        if (settings.hasValue("nodes.roles")) {
+            if (DiscoveryNode.hasRole(settings, DiscoveryNodeRole.MASTER_ROLE)) {
+                suffix = suffix + DiscoveryNodeRole.MASTER_ROLE.roleNameAbbreviation();
+            }
+            if (DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE)) {
+                suffix = suffix + DiscoveryNodeRole.DATA_ROLE.roleNameAbbreviation();
+            }
+            if (DiscoveryNode.hasRole(settings, DiscoveryNodeRole.MASTER_ROLE) == false
+                && DiscoveryNode.hasRole(settings, DiscoveryNodeRole.DATA_ROLE) == false) {
+                suffix = suffix + "c";
+            }
         }
         return suffix;
     }
@@ -819,9 +826,7 @@ public final class InternalTestCluster extends TestCluster {
 
     public synchronized String startCoordinatingOnlyNode(Settings settings) {
         ensureOpen(); // currently unused
-        Builder builder = Settings.builder().put(settings).put(Node.NODE_MASTER_SETTING.getKey(), false)
-            .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_INGEST_SETTING.getKey(), false);
-        return startNode(builder);
+        return startNode(noRoles(settings));
     }
 
     /**
@@ -906,7 +911,7 @@ public final class InternalTestCluster extends TestCluster {
         }
 
         public boolean isMasterEligible() {
-            return Node.NODE_MASTER_SETTING.get(node.settings());
+            return DiscoveryNode.isMasterNode(node.settings());
         }
 
         Client client(Random random) {
@@ -1200,30 +1205,27 @@ public final class InternalTestCluster extends TestCluster {
         final List<Settings> settings = new ArrayList<>();
 
         for (int i = 0; i < numSharedDedicatedMasterNodes; i++) {
-            final Settings.Builder extraSettings = Settings.builder();
-            extraSettings.put(Node.NODE_MASTER_SETTING.getKey(), true);
-            extraSettings.put(Node.NODE_DATA_SETTING.getKey(), false);
-            settings.add(getNodeSettings(i, sharedNodesSeeds[i], extraSettings.build(), defaultMinMasterNodes));
+            final Settings nodeSettings = getNodeSettings(i, sharedNodesSeeds[i], Settings.EMPTY, defaultMinMasterNodes);
+            settings.add(removeRoles(nodeSettings, Collections.singleton(DiscoveryNodeRole.DATA_ROLE)));
         }
         for (int i = numSharedDedicatedMasterNodes; i < numSharedDedicatedMasterNodes + numSharedDataNodes; i++) {
-            final Settings.Builder extraSettings = Settings.builder();
+            final Settings nodeSettings = getNodeSettings(i, sharedNodesSeeds[i], Settings.EMPTY, defaultMinMasterNodes);
             if (numSharedDedicatedMasterNodes > 0) {
+                settings.add(removeRoles(nodeSettings, Collections.singleton(DiscoveryNodeRole.MASTER_ROLE)));
+            } else {
                 // if we don't have dedicated master nodes, keep things default
-                extraSettings.put(Node.NODE_MASTER_SETTING.getKey(), false).build();
-                extraSettings.put(Node.NODE_DATA_SETTING.getKey(), true).build();
+                settings.add(nodeSettings);
             }
-            settings.add(getNodeSettings(i, sharedNodesSeeds[i], extraSettings.build(), defaultMinMasterNodes));
         }
         for (int i = numSharedDedicatedMasterNodes + numSharedDataNodes;
              i < numSharedDedicatedMasterNodes + numSharedDataNodes + numSharedCoordOnlyNodes; i++) {
-            final Builder extraSettings = Settings.builder().put(Node.NODE_MASTER_SETTING.getKey(), false)
-                .put(Node.NODE_DATA_SETTING.getKey(), false).put(Node.NODE_INGEST_SETTING.getKey(), false);
+            final Builder extraSettings = Settings.builder().put(noRoles());
             settings.add(getNodeSettings(i, sharedNodesSeeds[i], extraSettings.build(), defaultMinMasterNodes));
         }
 
         int autoBootstrapMasterNodeIndex = -1;
         final List<String> masterNodeNames = settings.stream()
-                .filter(Node.NODE_MASTER_SETTING::get)
+                .filter(DiscoveryNode::isMasterNode)
                 .map(Node.NODE_NAME_SETTING::get)
                 .collect(Collectors.toList());
 
@@ -2021,7 +2023,7 @@ public final class InternalTestCluster extends TestCluster {
         List<Settings> newSettings = new ArrayList<>();
 
         for (Settings settings : allNodesSettings) {
-            if (Node.NODE_MASTER_SETTING.get(settings) == false) {
+            if (DiscoveryNode.isMasterNode(settings) == false) {
                 newSettings.add(settings);
             } else {
                 currentNodeId++;
@@ -2031,13 +2033,13 @@ public final class InternalTestCluster extends TestCluster {
                     List<String> nodeNames = new ArrayList<>();
 
                     for (Settings nodeSettings : getDataOrMasterNodeInstances(Settings.class)) {
-                        if (Node.NODE_MASTER_SETTING.get(nodeSettings)) {
+                        if (DiscoveryNode.isMasterNode(nodeSettings)) {
                             nodeNames.add(Node.NODE_NAME_SETTING.get(nodeSettings));
                         }
                     }
 
                     for (Settings nodeSettings : allNodesSettings) {
-                        if (Node.NODE_MASTER_SETTING.get(nodeSettings)) {
+                        if (DiscoveryNode.isMasterNode(nodeSettings)) {
                             nodeNames.add(Node.NODE_NAME_SETTING.get(nodeSettings));
                         }
                     }
@@ -2093,7 +2095,7 @@ public final class InternalTestCluster extends TestCluster {
      * Starts multiple nodes with the given settings and returns their names
      */
     public synchronized List<String> startNodes(Settings... extraSettings) {
-        final int newMasterCount = Math.toIntExact(Stream.of(extraSettings).filter(Node.NODE_MASTER_SETTING::get).count());
+        final int newMasterCount = Math.toIntExact(Stream.of(extraSettings).filter(DiscoveryNode::isMasterNode).count());
         final int defaultMinMasterNodes;
         if (autoManageMasterNodes) {
             defaultMinMasterNodes = getMinMasterNodes(getMasterNodesCount() + newMasterCount);
@@ -2102,10 +2104,9 @@ public final class InternalTestCluster extends TestCluster {
         }
         final List<NodeAndClient> nodes = new ArrayList<>();
         final int prevMasterCount = getMasterNodesCount();
-        int autoBootstrapMasterNodeIndex =
-                prevMasterCount == 0 && autoManageMasterNodes && newMasterCount > 0 && Arrays.stream(extraSettings)
-            .allMatch(s -> Node.NODE_MASTER_SETTING.get(s) == false
-                || ZEN2_DISCOVERY_TYPE.equals(DISCOVERY_TYPE_SETTING.get(s)))
+        int autoBootstrapMasterNodeIndex = autoManageMasterNodes && prevMasterCount == 0 && newMasterCount > 0
+            && Arrays.stream(extraSettings)
+                    .allMatch(s -> DiscoveryNode.isMasterNode(s) == false || ZEN2_DISCOVERY_TYPE.equals(DISCOVERY_TYPE_SETTING.get(s)))
             ? RandomNumbers.randomIntBetween(random, 0, newMasterCount - 1) : -1;
 
         final int numOfNodes = extraSettings.length;
@@ -2117,7 +2118,7 @@ public final class InternalTestCluster extends TestCluster {
         nextNodeId.set(firstNodeId + numOfNodes);
 
         final List<String> initialMasterNodes = settings.stream()
-                .filter(Node.NODE_MASTER_SETTING::get)
+                .filter(DiscoveryNode::isMasterNode)
                 .map(Node.NODE_NAME_SETTING::get)
                 .collect(Collectors.toList());
 
@@ -2126,7 +2127,7 @@ public final class InternalTestCluster extends TestCluster {
         for (int i = 0; i < numOfNodes; i++) {
             final Settings nodeSettings = updatedSettings.get(i);
             final Builder builder = Settings.builder();
-            if (Node.NODE_MASTER_SETTING.get(nodeSettings)) {
+            if (DiscoveryNode.isMasterNode(nodeSettings)) {
                 if (autoBootstrapMasterNodeIndex == 0) {
                     builder.putList(INITIAL_MASTER_NODES_SETTING.getKey(), initialMasterNodes);
                 }
@@ -2149,12 +2150,11 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     public List<String> startMasterOnlyNodes(int numNodes, Settings settings) {
-        Settings settings1 = Settings.builder()
-                .put(settings)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true)
-                .put(Node.NODE_DATA_SETTING.getKey(), false)
-                .build();
-        return startNodes(numNodes, settings1);
+        return startNodes(
+            numNodes,
+            Settings.builder()
+                .put(onlyRole(settings, DiscoveryNodeRole.MASTER_ROLE))
+                .build());
     }
 
     public List<String> startDataOnlyNodes(int numNodes) {
@@ -2164,8 +2164,9 @@ public final class InternalTestCluster extends TestCluster {
     public List<String> startDataOnlyNodes(int numNodes, Settings settings) {
         return startNodes(
             numNodes,
-            Settings.builder().put(settings).put(Node.NODE_MASTER_SETTING.getKey(), false)
-                .put(Node.NODE_DATA_SETTING.getKey(), true).build());
+            Settings.builder()
+                .put(onlyRole(settings, DiscoveryNodeRole.DATA_ROLE))
+                .build());
     }
 
     /**
@@ -2196,7 +2197,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     private int getMasterNodesCount() {
-        return (int) nodes.values().stream().filter(n -> Node.NODE_MASTER_SETTING.get(n.node().settings())).count();
+        return (int) nodes.values().stream().filter(n -> DiscoveryNode.isMasterNode(n.node().settings())).count();
     }
 
     public String startMasterOnlyNode() {
@@ -2206,9 +2207,7 @@ public final class InternalTestCluster extends TestCluster {
     public String startMasterOnlyNode(Settings settings) {
         Settings settings1 = Settings.builder()
                 .put(settings)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true)
-                .put(Node.NODE_DATA_SETTING.getKey(), false)
-                .put(Node.NODE_INGEST_SETTING.getKey(), false)
+                .put(masterOnlyNode(settings))
                 .build();
         return startNode(settings1);
     }
@@ -2220,8 +2219,7 @@ public final class InternalTestCluster extends TestCluster {
     public String startDataOnlyNode(Settings settings) {
         Settings settings1 = Settings.builder()
                 .put(settings)
-                .put(Node.NODE_MASTER_SETTING.getKey(), false)
-                .put(Node.NODE_DATA_SETTING.getKey(), true)
+                .put(dataOnlyNode(settings))
                 .build();
         return startNode(settings1);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/NodeRoles.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NodeRoles.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.NodeRoleSettings;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utility methods for creating {@link Settings} instances defining a set of {@link DiscoveryNodeRole}.
+ */
+public class NodeRoles {
+
+    public static Settings onlyRole(final DiscoveryNodeRole role) {
+        return onlyRole(Settings.EMPTY, role);
+    }
+
+    public static Settings onlyRole(final Settings settings, final DiscoveryNodeRole role) {
+        return onlyRoles(settings, Set.of(role));
+    }
+
+    public static Settings onlyRoles(final Set<DiscoveryNodeRole> roles) {
+        return onlyRoles(Settings.EMPTY, roles);
+    }
+
+    public static Settings onlyRoles(final Settings settings, final Set<DiscoveryNodeRole> roles) {
+        return Settings.builder()
+            .put(settings)
+            .putList(
+                NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+                roles.stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toUnmodifiableList()))
+            .build();
+    }
+
+    public static Settings removeRoles(final Set<DiscoveryNodeRole> roles) {
+        return removeRoles(Settings.EMPTY, roles);
+    }
+
+    public static Settings removeRoles(final Settings settings, final Set<DiscoveryNodeRole> roles) {
+        final Settings.Builder builder = Settings.builder().put(settings);
+        builder.putList(
+            NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+            NodeRoleSettings.NODE_ROLES_SETTING.get(settings)
+                .stream()
+                .filter(Predicate.not(roles::contains))
+                .map(DiscoveryNodeRole::roleName)
+                .collect(Collectors.toUnmodifiableList())
+        );
+        return builder.build();
+    }
+
+    public static Settings addRoles(final Set<DiscoveryNodeRole> roles) {
+        return addRoles(Settings.EMPTY, roles);
+    }
+
+    public static Settings addRoles(final Settings settings, final Set<DiscoveryNodeRole> roles) {
+        final Settings.Builder builder = Settings.builder().put(settings);
+        builder.putList(
+            NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
+            Stream.concat(NodeRoleSettings.NODE_ROLES_SETTING.get(settings).stream(), roles.stream())
+                .map(DiscoveryNodeRole::roleName)
+                .distinct()
+                .collect(Collectors.toUnmodifiableList())
+        );
+        return builder.build();
+    }
+
+    public static Settings noRoles() {
+        return noRoles(Settings.EMPTY);
+    }
+
+    public static Settings noRoles(final Settings settings) {
+        return Settings.builder().put(settings).putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), List.of()).build();
+    }
+
+    public static Settings dataNode() {
+        return dataNode(Settings.EMPTY);
+    }
+
+    public static Settings dataNode(final Settings settings) {
+        return addRoles(settings, Set.of(DiscoveryNodeRole.DATA_ROLE));
+    }
+
+    public static Settings dataOnlyNode() {
+        return dataOnlyNode(Settings.EMPTY);
+    }
+
+    public static Settings dataOnlyNode(final Settings settings) {
+        return onlyRole(settings, DiscoveryNodeRole.DATA_ROLE);
+    }
+
+    public static Settings nonDataNode() {
+        return nonDataNode(Settings.EMPTY);
+    }
+
+    public static Settings nonDataNode(final Settings settings) {
+        return removeRoles(settings, Set.of(DiscoveryNodeRole.DATA_ROLE));
+    }
+
+    public static Settings ingestNode() {
+        return ingestNode(Settings.EMPTY);
+    }
+
+    public static Settings ingestNode(final Settings settings) {
+        return addRoles(settings, Set.of(DiscoveryNodeRole.INGEST_ROLE));
+    }
+
+    public static Settings ingestOnlyNode() {
+        return ingestOnlyNode(Settings.EMPTY);
+    }
+
+    public static Settings ingestOnlyNode(final Settings settings) {
+        return onlyRole(settings, DiscoveryNodeRole.INGEST_ROLE);
+    }
+
+    public static Settings nonIngestNode() {
+        return nonIngestNode(Settings.EMPTY);
+    }
+
+    public static Settings nonIngestNode(final Settings settings) {
+        return removeRoles(settings, Set.of(DiscoveryNodeRole.INGEST_ROLE));
+    }
+
+    public static Settings masterNode() {
+        return masterNode(Settings.EMPTY);
+    }
+
+    public static Settings masterNode(final Settings settings) {
+        return addRoles(settings, Set.of(DiscoveryNodeRole.MASTER_ROLE));
+    }
+
+    public static Settings masterOnlyNode() {
+        return masterOnlyNode(Settings.EMPTY);
+    }
+
+    public static Settings masterOnlyNode(final Settings settings) {
+        return onlyRole(settings, DiscoveryNodeRole.MASTER_ROLE);
+    }
+
+    public static Settings nonMasterNode() {
+        return nonMasterNode(Settings.EMPTY);
+    }
+
+    public static Settings nonMasterNode(final Settings settings) {
+        return removeRoles(settings, Set.of(DiscoveryNodeRole.MASTER_ROLE));
+    }
+
+    public static Settings remoteClusterClientNode() {
+        return remoteClusterClientNode(Settings.EMPTY);
+    }
+
+    public static Settings remoteClusterClientNode(final Settings settings) {
+        return addRoles(settings, Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+    }
+
+    public static Settings nonRemoteClusterClientNode() {
+        return nonRemoteClusterClientNode(Settings.EMPTY);
+    }
+
+    public static Settings nonRemoteClusterClientNode(final Settings settings) {
+        return removeRoles(settings, Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/NodeRoles.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NodeRoles.java
@@ -23,9 +23,8 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.NodeRoleSettings;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,7 +38,7 @@ public class NodeRoles {
     }
 
     public static Settings onlyRole(final Settings settings, final DiscoveryNodeRole role) {
-        return onlyRoles(settings, Set.of(role));
+        return onlyRoles(settings, Collections.singleton(role));
     }
 
     public static Settings onlyRoles(final Set<DiscoveryNodeRole> roles) {
@@ -51,7 +50,7 @@ public class NodeRoles {
             .put(settings)
             .putList(
                 NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
-                roles.stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toUnmodifiableList()))
+                Collections.unmodifiableList(roles.stream().map(DiscoveryNodeRole::roleName).collect(Collectors.toList())))
             .build();
     }
 
@@ -63,11 +62,12 @@ public class NodeRoles {
         final Settings.Builder builder = Settings.builder().put(settings);
         builder.putList(
             NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
-            NodeRoleSettings.NODE_ROLES_SETTING.get(settings)
+            Collections.unmodifiableList(NodeRoleSettings.NODE_ROLES_SETTING.get(settings)
                 .stream()
-                .filter(Predicate.not(roles::contains))
+                .filter(r -> roles.contains(r) == false)
                 .map(DiscoveryNodeRole::roleName)
-                .collect(Collectors.toUnmodifiableList())
+                .collect(Collectors.toList())
+            )
         );
         return builder.build();
     }
@@ -80,10 +80,11 @@ public class NodeRoles {
         final Settings.Builder builder = Settings.builder().put(settings);
         builder.putList(
             NodeRoleSettings.NODE_ROLES_SETTING.getKey(),
-            Stream.concat(NodeRoleSettings.NODE_ROLES_SETTING.get(settings).stream(), roles.stream())
+            Collections.unmodifiableList(Stream.concat(NodeRoleSettings.NODE_ROLES_SETTING.get(settings).stream(), roles.stream())
                 .map(DiscoveryNodeRole::roleName)
                 .distinct()
-                .collect(Collectors.toUnmodifiableList())
+                .collect(Collectors.toList())
+            )
         );
         return builder.build();
     }
@@ -93,7 +94,7 @@ public class NodeRoles {
     }
 
     public static Settings noRoles(final Settings settings) {
-        return Settings.builder().put(settings).putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), List.of()).build();
+        return Settings.builder().put(settings).putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), Collections.emptyList()).build();
     }
 
     public static Settings dataNode() {
@@ -101,7 +102,7 @@ public class NodeRoles {
     }
 
     public static Settings dataNode(final Settings settings) {
-        return addRoles(settings, Set.of(DiscoveryNodeRole.DATA_ROLE));
+        return addRoles(settings, Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
     }
 
     public static Settings dataOnlyNode() {
@@ -117,7 +118,7 @@ public class NodeRoles {
     }
 
     public static Settings nonDataNode(final Settings settings) {
-        return removeRoles(settings, Set.of(DiscoveryNodeRole.DATA_ROLE));
+        return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.DATA_ROLE));
     }
 
     public static Settings ingestNode() {
@@ -125,7 +126,7 @@ public class NodeRoles {
     }
 
     public static Settings ingestNode(final Settings settings) {
-        return addRoles(settings, Set.of(DiscoveryNodeRole.INGEST_ROLE));
+        return addRoles(settings, Collections.singleton(DiscoveryNodeRole.INGEST_ROLE));
     }
 
     public static Settings ingestOnlyNode() {
@@ -141,7 +142,7 @@ public class NodeRoles {
     }
 
     public static Settings nonIngestNode(final Settings settings) {
-        return removeRoles(settings, Set.of(DiscoveryNodeRole.INGEST_ROLE));
+        return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.INGEST_ROLE));
     }
 
     public static Settings masterNode() {
@@ -149,7 +150,7 @@ public class NodeRoles {
     }
 
     public static Settings masterNode(final Settings settings) {
-        return addRoles(settings, Set.of(DiscoveryNodeRole.MASTER_ROLE));
+        return addRoles(settings, Collections.singleton(DiscoveryNodeRole.MASTER_ROLE));
     }
 
     public static Settings masterOnlyNode() {
@@ -165,7 +166,7 @@ public class NodeRoles {
     }
 
     public static Settings nonMasterNode(final Settings settings) {
-        return removeRoles(settings, Set.of(DiscoveryNodeRole.MASTER_ROLE));
+        return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.MASTER_ROLE));
     }
 
     public static Settings remoteClusterClientNode() {
@@ -173,7 +174,7 @@ public class NodeRoles {
     }
 
     public static Settings remoteClusterClientNode(final Settings settings) {
-        return addRoles(settings, Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+        return addRoles(settings, Collections.singleton(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
     }
 
     public static Settings nonRemoteClusterClientNode() {
@@ -181,7 +182,7 @@ public class NodeRoles {
     }
 
     public static Settings nonRemoteClusterClientNode(final Settings settings) {
-        return removeRoles(settings, Set.of(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
+        return removeRoles(settings, Collections.singleton(DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE));
     }
 
 }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
@@ -33,8 +33,10 @@ import org.elasticsearch.xpack.core.ccr.action.PutFollowAction;
 import org.elasticsearch.xpack.core.ccr.client.CcrClient;
 import org.hamcrest.Matchers;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -248,7 +250,13 @@ public class FollowerFailOverIT extends CcrIntegTestCase {
                 .get()
         );
         getFollowerCluster().startNode(
-            onlyRoles(nodeAttributes, Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)));
+            onlyRoles(
+                nodeAttributes,
+                Collections.unmodifiableSet(
+                    new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE))
+                )
+            )
+        );
         followerClient().execute(PutFollowAction.INSTANCE, putFollow("leader-index", "follower-index")).get();
         ensureFollowerGreen("follower-index");
         ClusterService clusterService = leaderCluster.clusterService(dataNode);

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/FollowerFailOverIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -33,12 +34,14 @@ import org.elasticsearch.xpack.core.ccr.client.CcrClient;
 import org.hamcrest.Matchers;
 
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.test.NodeRoles.onlyRoles;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -244,7 +247,8 @@ public class FollowerFailOverIT extends CcrIntegTestCase {
                     .put("index.routing.allocation.require.box", "large"))
                 .get()
         );
-        getFollowerCluster().startDataOnlyNode(nodeAttributes);
+        getFollowerCluster().startNode(
+            onlyRoles(nodeAttributes, Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE)));
         followerClient().execute(PutFollowAction.INSTANCE, putFollow("leader-index", "follower-index")).get();
         ensureFollowerGreen("follower-index");
         ClusterService clusterService = leaderCluster.clusterService(dataNode);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceClusterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceClusterTests.java
@@ -21,7 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
+import java.util.Collections;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
 import static org.elasticsearch.test.NodeRoles.addRoles;
@@ -42,7 +42,7 @@ public class LicenseServiceClusterTests extends AbstractLicensesIntegrationTestC
 
     private Settings.Builder nodeSettingsBuilder(int nodeOrdinal) {
         return Settings.builder()
-            .put(addRoles(super.nodeSettings(nodeOrdinal), Set.of(DiscoveryNodeRole.DATA_ROLE)))
+            .put(addRoles(super.nodeSettings(nodeOrdinal), Collections.singleton(DiscoveryNodeRole.DATA_ROLE)))
             .put("resource.reload.interval.high", "500ms"); // for license mode file watcher
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceClusterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceClusterTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.license;
 
 import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.env.Environment;
@@ -20,8 +21,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
+import static org.elasticsearch.test.NodeRoles.addRoles;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 @ClusterScope(scope = TEST, numDataNodes = 0, numClientNodes = 0, maxNumDataNodes = 0, transportClientRatio = 0)
@@ -39,9 +42,8 @@ public class LicenseServiceClusterTests extends AbstractLicensesIntegrationTestC
 
     private Settings.Builder nodeSettingsBuilder(int nodeOrdinal) {
         return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("node.data", true)
-                .put("resource.reload.interval.high", "500ms"); // for license mode file watcher
+            .put(addRoles(super.nodeSettings(nodeOrdinal), Set.of(DiscoveryNodeRole.DATA_ROLE)))
+            .put("resource.reload.interval.high", "500ms"); // for license mode file watcher
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesTransportTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesTransportTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.protocol.xpack.license.LicensesStatus;
 import org.elasticsearch.protocol.xpack.license.PutLicenseResponse;
@@ -27,6 +26,7 @@ import java.util.UUID;
 import static org.elasticsearch.license.TestUtils.dateMath;
 import static org.elasticsearch.license.TestUtils.generateExpiredNonBasicLicense;
 import static org.elasticsearch.license.TestUtils.generateSignedLicense;
+import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 
@@ -49,7 +49,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
         newSettings.put(XPackSettings.SECURITY_ENABLED.getKey(), false);
 //        newSettings.put(XPackSettings.MONITORING_ENABLED.getKey(), false);
 //        newSettings.put(XPackSettings.WATCHER_ENABLED.getKey(), false);
-        newSettings.put(Node.NODE_DATA_SETTING.getKey(), true);
+        newSettings.put(dataNode());
         return newSettings.build();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -22,8 +23,10 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
+import static org.elasticsearch.test.NodeRoles.addRoles;
 
 @ESIntegTestCase.ClusterScope(scope = SUITE)
 public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase {
@@ -36,9 +39,8 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("node.data", true)
-                .put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "basic").build();
+            .put(addRoles(super.nodeSettings(nodeOrdinal), Set.of(DiscoveryNodeRole.DATA_ROLE)))
+            .put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "basic").build();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartBasicLicenseTests.java
@@ -23,7 +23,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
+import java.util.Collections;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.elasticsearch.test.NodeRoles.addRoles;
@@ -39,7 +39,7 @@ public class StartBasicLicenseTests extends AbstractLicensesIntegrationTestCase 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
-            .put(addRoles(super.nodeSettings(nodeOrdinal), Set.of(DiscoveryNodeRole.DATA_ROLE)))
+            .put(addRoles(super.nodeSettings(nodeOrdinal), Collections.singleton(DiscoveryNodeRole.DATA_ROLE)))
             .put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "basic").build();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartTrialLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartTrialLicenseTests.java
@@ -22,7 +22,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
+import java.util.Collections;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
 import static org.elasticsearch.test.NodeRoles.addRoles;
@@ -39,7 +39,7 @@ public class StartTrialLicenseTests extends AbstractLicensesIntegrationTestCase 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
-            .put(addRoles(super.nodeSettings(nodeOrdinal), Set.of(DiscoveryNodeRole.DATA_ROLE)))
+            .put(addRoles(super.nodeSettings(nodeOrdinal), Collections.singleton(DiscoveryNodeRole.DATA_ROLE)))
             .put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "basic")
             .build();
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartTrialLicenseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/StartTrialLicenseTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
@@ -21,8 +22,10 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
+import static org.elasticsearch.test.NodeRoles.addRoles;
 import static org.hamcrest.Matchers.containsString;
 
 @ESIntegTestCase.ClusterScope(scope = SUITE)
@@ -36,9 +39,9 @@ public class StartTrialLicenseTests extends AbstractLicensesIntegrationTestCase 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("node.data", true)
-                .put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "basic").build();
+            .put(addRoles(super.nodeSettings(nodeOrdinal), Set.of(DiscoveryNodeRole.DATA_ROLE)))
+            .put(LicenseService.SELF_GENERATED_LICENSE_TYPE.getKey(), "basic")
+            .build();
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrunkShardsAllocatedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrunkShardsAllocatedStepTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.node.Node;
+import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.xpack.core.ilm.ClusterStateWaitStep.Result;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
@@ -82,9 +82,10 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
         Index shrinkIndex = shrunkIndexMetadata.getIndex();
 
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
 
         IndexRoutingTable.Builder builder = IndexRoutingTable.builder(shrinkIndex);
         for (int i = 0; i < shrinkNumberOfShards; i++) {
@@ -122,9 +123,10 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
         Index shrinkIndex = shrunkIndexMetadata.getIndex();
 
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
 
         IndexRoutingTable.Builder builder = IndexRoutingTable.builder(shrinkIndex);
         for (int i = 0; i < shrinkNumberOfShards; i++) {
@@ -156,9 +158,10 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
             .build();
 
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(metadata)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.env.Environment;
@@ -125,7 +126,11 @@ class NodeDeprecationChecks {
             settings,
             pluginsAndModules,
             RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
-            Node.NODE_REMOTE_CLUSTER_CLIENT,
+            Setting.boolSetting(
+                "node.remote_cluster_client",
+                RemoteClusterService.ENABLE_REMOTE_CLUSTERS,
+                Property.Deprecated,
+                Property.NodeScope),
             "https://www.elastic.co/guide/en/elasticsearch/reference/7.7/breaking-changes-7.7.html#deprecate-cluster-remote-connect"
         );
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -245,7 +245,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
                 "the setting [%s] is currently set to [%b], instead set [%s] to [%2$b]",
                 RemoteClusterService.ENABLE_REMOTE_CLUSTERS.getKey(),
                 value,
-                Node.NODE_REMOTE_CLUSTER_CLIENT.getKey()
+                "node.remote_cluster_client"
             ));
         assertThat(issues, contains(expected));
         assertSettingDeprecationsAndWarnings(new Setting<?>[]{RemoteClusterService.ENABLE_REMOTE_CLUSTERS});

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -44,6 +43,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.enrich.MatchProcessorTests.mapOf;
+import static org.elasticsearch.test.NodeRoles.ingestOnlyNode;
+import static org.elasticsearch.test.NodeRoles.nonIngestNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -127,12 +128,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
 
     public void testEnrichDedicatedIngestNode() {
         internalCluster().startNode();
-        Settings settings = Settings.builder()
-            .put(Node.NODE_MASTER_SETTING.getKey(), false)
-            .put(Node.NODE_DATA_SETTING.getKey(), false)
-            .put(Node.NODE_INGEST_SETTING.getKey(), true)
-            .build();
-        String ingestOnlyNode = internalCluster().startNode(settings);
+        String ingestOnlyNode = internalCluster().startNode(ingestOnlyNode());
 
         List<String> keys = createSourceIndex(64);
         createAndExecutePolicy();
@@ -141,11 +137,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
     }
 
     public void testEnrichNoIngestNodes() {
-        Settings settings = Settings.builder()
-            .put(Node.NODE_MASTER_SETTING.getKey(), true)
-            .put(Node.NODE_DATA_SETTING.getKey(), true)
-            .put(Node.NODE_INGEST_SETTING.getKey(), false)
-            .build();
+        Settings settings = Settings.builder().put(nonIngestNode()).build();
         internalCluster().startNode(settings);
 
         createSourceIndex(64);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -20,11 +20,11 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.xpack.core.ilm.ErrorStep;
-import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
@@ -131,9 +131,10 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
             .put(IndexMetadata.builder(indexMetadata))
             .build();
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
         clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(metadata)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
@@ -58,7 +59,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.node.Node.NODE_MASTER_SETTING;
 import static org.elasticsearch.xpack.core.ilm.AbstractStepTestCase.randomStepKey;
 import static org.elasticsearch.xpack.core.ilm.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.xpack.core.ilm.LifecyclePolicyTestsUtils.newTestLifecyclePolicy;
@@ -87,9 +87,10 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         nodeId = randomAlphaOfLength(10);
         ExecutorService executorService = mock(ExecutorService.class);
         clusterService = mock(ClusterService.class);
-        masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
         now = randomNonNegativeLong();
         Clock clock = Clock.fixed(Instant.ofEpochMilli(now), ZoneId.of(randomFrom(ZoneId.getAvailableZoneIds())));
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -22,13 +22,13 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.xpack.core.ilm.ErrorStep;
-import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.InitializePolicyContextStep;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
+import org.elasticsearch.xpack.core.ilm.LifecycleExecutionState;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyTests;
@@ -217,9 +217,10 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             logger.info("--> metadata: {}", Strings.toString(builder));
         }
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(metadata)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
@@ -292,9 +293,10 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             .putCustom(IndexLifecycleMetadata.TYPE, lifecycleMetadata)
             .build();
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(metadata)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
@@ -366,9 +368,10 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             logger.info("--> metadata: {}", Strings.toString(builder));
         }
         String nodeId = randomAlphaOfLength(10);
-        DiscoveryNode masterNode = DiscoveryNode.createLocal(settings(Version.CURRENT)
-                .put(Node.NODE_MASTER_SETTING.getKey(), true).build(),
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300), nodeId);
+        DiscoveryNode masterNode = DiscoveryNode.createLocal(
+            NodeRoles.masterNode(settings(Version.CURRENT).build()),
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+            nodeId);
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(metadata)
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -9,6 +9,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
@@ -48,10 +49,14 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.persistent.PersistentTasksClusterService.needsReassignment;
+import static org.elasticsearch.test.NodeRoles.addRoles;
+import static org.elasticsearch.test.NodeRoles.onlyRole;
+import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 
@@ -150,8 +155,8 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
 
     public void testJobAutoClose() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
-        internalCluster().startNode(Settings.builder().put(MachineLearning.ML_ENABLED.getKey(), false));
-        internalCluster().startNode(Settings.builder().put(MachineLearning.ML_ENABLED.getKey(), true));
+        internalCluster().startNode(removeRoles(Set.of(MachineLearning.ML_ROLE)));
+        internalCluster().startNode(addRoles(Set.of(MachineLearning.ML_ROLE)));
 
         client().admin().indices().prepareCreate("data")
                 .addMapping("type", "time", "type=date")
@@ -192,11 +197,11 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
     public void testDedicatedMlNode() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
         // start 2 non ml node that will never get a job allocated. (but ml apis are accessible from this node)
-        internalCluster().startNode(Settings.builder().put(MachineLearning.ML_ENABLED.getKey(), false));
-        internalCluster().startNode(Settings.builder().put(MachineLearning.ML_ENABLED.getKey(), false));
+        internalCluster().startNode(removeRoles(Set.of(MachineLearning.ML_ROLE)));
+        internalCluster().startNode(removeRoles(Set.of(MachineLearning.ML_ROLE)));
         // start ml node
         if (randomBoolean()) {
-            internalCluster().startNode(Settings.builder().put(MachineLearning.ML_ENABLED.getKey(), true));
+            internalCluster().startNode(addRoles(Set.of(MachineLearning.ML_ROLE)));
         } else {
             // the default is based on 'xpack.ml.enabled', which is enabled in base test class.
             internalCluster().startNode();
@@ -224,7 +229,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         });
 
         logger.info("stop the only running ml node");
-        internalCluster().stopRandomNode(settings -> settings.getAsBoolean(MachineLearning.ML_ENABLED.getKey(), true));
+        internalCluster().stopRandomNode(settings -> DiscoveryNode.hasRole(settings, MachineLearning.ML_ROLE));
         ensureStableCluster(2);
         assertBusy(() -> {
             // job should get and remain in a failed state and
@@ -233,7 +238,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         });
 
         logger.info("start ml node");
-        internalCluster().startNode(Settings.builder().put(MachineLearning.ML_ENABLED.getKey(), true));
+        internalCluster().startNode(addRoles(Set.of(MachineLearning.ML_ROLE)));
         ensureStableCluster(3);
         assertBusy(() -> {
             // job should be re-opened:
@@ -246,13 +251,9 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         internalCluster().ensureAtMostNumDataNodes(0);
         // start non ml node, but that will hold the indices
         logger.info("Start non ml node:");
-        String nonMlNode = internalCluster().startNode(Settings.builder()
-                .put(MachineLearning.ML_ENABLED.getKey(), false));
+        String nonMlNode = internalCluster().startNode(removeRoles(Set.of(MachineLearning.ML_ROLE)));
         logger.info("Starting ml nodes");
-        internalCluster().startNodes(numMlNodes, Settings.builder()
-                .put("node.data", false)
-                .put("node.master", false)
-                .put(MachineLearning.ML_ENABLED.getKey(), true).build());
+        internalCluster().startNodes(numMlNodes, onlyRole(MachineLearning.ML_ROLE));
         ensureStableCluster(numMlNodes + 1);
 
         int maxConcurrentJobAllocations = randomIntBetween(1, 4);
@@ -301,8 +302,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
             // fork so stopping all ml nodes proceeds quicker:
             Runnable r = () -> {
                 try {
-                    internalCluster()
-                            .stopRandomNode(settings -> settings.getAsBoolean(MachineLearning.ML_ENABLED.getKey(), false));
+                    internalCluster().stopRandomNode(settings -> DiscoveryNode.hasRole(settings, MachineLearning.ML_ROLE));
                 } catch (IOException e) {
                     logger.error("error stopping node", e);
                 }
@@ -320,10 +320,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         });
 
         logger.info("re-starting ml nodes");
-        internalCluster().startNodes(numMlNodes, Settings.builder()
-                .put("node.data", false)
-                .put("node.master", false)
-                .put(MachineLearning.ML_ENABLED.getKey(), true).build());
+        internalCluster().startNodes(numMlNodes, onlyRole(MachineLearning.ML_ROLE));
 
         ensureStableCluster(1 + numMlNodes);
         assertBusy(checkAllJobsAreAssignedAndOpened(numJobs), 30, TimeUnit.SECONDS);
@@ -340,16 +337,14 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         // start non ml node that will hold the state and results indices
         logger.info("Start non ml node:");
         String nonMLNode = internalCluster().startNode(Settings.builder()
-                .put("node.data", true)
                 .put("node.attr.ml-indices", "state-and-results")
-                .put(MachineLearning.ML_ENABLED.getKey(), false));
+                .put(removeRoles(Set.of(MachineLearning.ML_ROLE))));
         ensureStableCluster(1);
         // start an ml node for the config index
         logger.info("Starting ml node");
         String mlNode = internalCluster().startNode(Settings.builder()
-                .put("node.data", true)
                 .put("node.attr.ml-indices", "config")
-                .put(MachineLearning.ML_ENABLED.getKey(), true));
+                .put(addRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE))));
         ensureStableCluster(2);
 
         // Create the indices (using installed templates) and set the routing to specific nodes
@@ -416,8 +411,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         logger.info("Start data node");
         String nonMlNode = internalCluster().startNode(Settings.builder()
                 .put(nonMLNodeDataPathSettings)
-                .put("node.data", true)
-                .put(MachineLearning.ML_ENABLED.getKey(), false));
+                .put(removeRoles(Set.of(MachineLearning.ML_ROLE))));
         ensureStableCluster(2, mlNode);
         ensureStableCluster(2, nonMlNode);
         ensureYellow(); // at least the primary shards of the indices a job uses should be started

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -56,9 +56,10 @@ import org.elasticsearch.xpack.ml.job.process.autodetect.BlackHoleAutodetectProc
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -96,7 +97,9 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         logger.info("Starting dedicated master node...");
         internalCluster().startMasterOnlyNode();
         logger.info("Starting ml and data node...");
-        String mlAndDataNode = internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)));
+        String mlAndDataNode = internalCluster().startNode(
+            onlyRoles(Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE))))
+        );
         ensureStableClusterOnAllNodes(2);
         run("lose-dedicated-master-node-job", () -> {
             logger.info("Stopping dedicated master node");
@@ -130,9 +133,13 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
     public void testCloseUnassignedJobAndDatafeed() throws Exception {
         internalCluster().ensureAtMostNumDataNodes(0);
         logger.info("Starting data and master node...");
-        internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)));
+        internalCluster().startNode(onlyRoles(
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)))
+        ));
         logger.info("Starting ml and data node...");
-        internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)));
+        internalCluster().startNode(onlyRoles(
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)))
+        ));
         ensureStableClusterOnAllNodes(2);
 
         // index some datafeed data
@@ -206,7 +213,9 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         internalCluster().ensureAtMostNumDataNodes(0);
         logger.info("Starting master/data nodes...");
         for (int count = 0; count < 3; ++count) {
-            internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)));
+            internalCluster().startNode(onlyRoles(
+                Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)))
+            ));
         }
         logger.info("Starting dedicated ml node...");
         internalCluster().startNode(onlyRole(MachineLearning.ML_ROLE));
@@ -316,7 +325,9 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         logger.info("Starting dedicated master node...");
         internalCluster().startMasterOnlyNode();
         logger.info("Starting ml and data node...");
-        internalCluster().startNode(onlyRoles(Set.of(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)));
+        internalCluster().startNode(onlyRoles(
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(DiscoveryNodeRole.DATA_ROLE, MachineLearning.ML_ROLE)))
+        ));
         ensureStableClusterOnAllNodes(2);
 
         // index some datafeed data

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -349,13 +349,13 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
     // Recompile if you want to compare performance with C++ tokenization.
     public static final boolean CATEGORIZATION_TOKENIZATION_IN_JAVA = true;
 
-    public static final Setting<Boolean> ML_ENABLED =
-            Setting.boolSetting("node.ml", XPackSettings.MACHINE_LEARNING_ENABLED, Property.NodeScope);
+    private static final Setting<Boolean> ML_ENABLED =
+            Setting.boolSetting("node.ml", XPackSettings.MACHINE_LEARNING_ENABLED, Property.Deprecated, Property.NodeScope);
 
     public static final DiscoveryNodeRole ML_ROLE = new DiscoveryNodeRole("ml", "l") {
 
         @Override
-        protected Setting<Boolean> roleSetting() {
+        public Setting<Boolean> legacySetting() {
             return ML_ENABLED;
         }
 
@@ -501,7 +501,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin,
         }
 
         Settings.Builder additionalSettings = Settings.builder();
-        Boolean allocationEnabled = ML_ENABLED.get(settings);
+        Boolean allocationEnabled = DiscoveryNode.hasRole(settings, MachineLearning.ML_ROLE);
         if (allocationEnabled != null && allocationEnabled) {
             // TODO: stop setting this attribute in 8.0.0 but disallow it (like mlEnabledNodeAttrName below)
             // The ML UI will need to be changed to check machineMemoryAttrName instead before this is done

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
@@ -29,7 +30,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -109,7 +109,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         this.auditor = auditor;
         this.migrationEligibilityCheck = new MlConfigMigrationEligibilityCheck(settings, clusterService);
         this.xContentRegistry = xContentRegistry;
-        this.remoteClusterClient = Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings);
+        this.remoteClusterClient = DiscoveryNode.isRemoteClusterClient(settings);
     }
 
     static void validate(Job job,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilder.java
@@ -9,11 +9,11 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
@@ -72,7 +72,7 @@ public class DatafeedJobBuilder {
         this.jobResultsProvider = Objects.requireNonNull(jobResultsProvider);
         this.datafeedConfigProvider = Objects.requireNonNull(datafeedConfigProvider);
         this.jobResultsPersister = Objects.requireNonNull(jobResultsPersister);
-        this.remoteClusterClient = Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings);
+        this.remoteClusterClient = DiscoveryNode.isRemoteClusterClient(settings);
         this.nodeName = nodeName;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.mock.orig.Mockito;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -35,6 +34,7 @@ import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.test.NodeRoles.nonRemoteClusterClientNode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -212,7 +212,6 @@ public class DatafeedJobBuilderTests extends ESTestCase {
     }
 
     public void testBuildGivenRemoteIndicesButNoRemoteSearching() throws Exception {
-        Settings settings = Settings.builder().put(Node.NODE_REMOTE_CLUSTER_CLIENT.getKey(), false).build();
         datafeedJobBuilder =
             new DatafeedJobBuilder(
                 client,
@@ -224,7 +223,7 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                 jobResultsProvider,
                 datafeedConfigProvider,
                 jobResultsPersister,
-                settings,
+                nonRemoteClusterClientNode(),
                 "test_node");
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         dataDescription.setTimeField("time");

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MultiNodesStatsTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MultiNodesStatsTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.monitoring;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
@@ -18,7 +17,7 @@ import org.elasticsearch.xpack.monitoring.collector.node.NodeStatsMonitoringDoc;
 import org.elasticsearch.xpack.monitoring.test.MonitoringIntegTestCase;
 import org.junit.After;
 
-
+import static org.elasticsearch.test.NodeRoles.noRoles;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -54,11 +53,7 @@ public class MultiNodesStatsTests extends MonitoringIntegTestCase {
         nodes += n;
 
         n = randomIntBetween(1, 2);
-        internalCluster().startNodes(n,
-                Settings.builder()
-                        .put(Node.NODE_DATA_SETTING.getKey(), false)
-                        .put(Node.NODE_MASTER_SETTING.getKey(), false)
-                        .put(Node.NODE_INGEST_SETTING.getKey(), false).build());
+        internalCluster().startNodes(n, noRoles());
         nodes += n;
 
         n = randomIntBetween(1, 2);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/ServerTransportFilterIntegrationTests.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
+import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForNodePEMFiles;
 import static org.elasticsearch.test.SecuritySettingsSource.addSSLSettingsForPEMFiles;
 import static org.elasticsearch.xpack.security.test.SecurityTestUtils.writeFile;
@@ -103,7 +104,7 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
             .put("xpack.security.transport.ssl.enabled", true)
             .put(XPackSettings.WATCHER_ENABLED.getKey(), false)
             .put("path.home", home)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false);
+            .put(nonMasterNode());
         Collection<Class<? extends Plugin>> mockPlugins = Arrays.asList(LocalStateSecurity.class, MockHttpTransport.TestPlugin.class);
         addSSLSettingsForPEMFiles(
             nodeSettings,
@@ -143,7 +144,7 @@ public class ServerTransportFilterIntegrationTests extends SecurityIntegTestCase
             .put(XPackSettings.WATCHER_ENABLED.getKey(), false)
             .put("discovery.initial_state_timeout", "0s")
             .put("path.home", home)
-            .put(Node.NODE_MASTER_SETTING.getKey(), false);
+            .put(nonMasterNode());
         Collection<Class<? extends Plugin>> mockPlugins = Arrays.asList(LocalStateSecurity.class, MockHttpTransport.TestPlugin.class);
         addSSLSettingsForPEMFiles(
             nodeSettings,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -155,17 +155,23 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
     /**
      * Setting whether transform (the coordinator task) can run on this node.
      */
-    public static final Setting<Boolean> TRANSFORM_ENABLED_NODE = Setting.boolSetting(
+    private static final Setting<Boolean> TRANSFORM_ENABLED_NODE = Setting.boolSetting(
         "node.transform",
         settings -> Boolean.toString(DiscoveryNode.isDataNode(settings)),
+        Property.Deprecated,
         Property.NodeScope
     );
 
     public static final DiscoveryNodeRole TRANSFORM_ROLE = new DiscoveryNodeRole("transform", "t") {
 
         @Override
-        protected Setting<Boolean> roleSetting() {
+        public Setting<Boolean> legacySetting() {
             return TRANSFORM_ENABLED_NODE;
+        }
+
+        @Override
+        public boolean isEnabledByDefault(final Settings settings) {
+            return super.isEnabledByDefault(settings) && DiscoveryNode.isDataNode(settings);
         }
 
     };
@@ -361,7 +367,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
 
         Settings.Builder additionalSettings = Settings.builder();
 
-        additionalSettings.put(transformEnabledNodeAttribute, TRANSFORM_ENABLED_NODE.get(settings));
+        additionalSettings.put(transformEnabledNodeAttribute, DiscoveryNode.hasRole(settings, Transform.TRANSFORM_ROLE));
 
         return additionalSettings.build();
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.inject.Inject;
@@ -35,7 +36,6 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
@@ -122,7 +122,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<
         this.sourceDestValidator = new SourceDestValidator(
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
-            Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings)
+            DiscoveryNode.isRemoteClusterClient(settings)
                 ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
                 : null,
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
@@ -31,7 +32,6 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -137,7 +137,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
         this.sourceDestValidator = new SourceDestValidator(
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
-            Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings)
+            DiscoveryNode.isRemoteClusterClient(settings)
                 ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
                 : null,
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,7 +32,6 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.rest.RestStatus;
@@ -136,7 +136,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
         this.sourceDestValidator = new SourceDestValidator(
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
-            Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings)
+            DiscoveryNode.isRemoteClusterClient(settings)
                 ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
                 : null,
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -30,7 +31,6 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.RemoteClusterLicenseChecker;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -144,7 +144,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
         this.sourceDestValidator = new SourceDestValidator(
             indexNameExpressionResolver,
             transportService.getRemoteClusterService(),
-            Node.NODE_REMOTE_CLUSTER_CLIENT.get(settings)
+            DiscoveryNode.isRemoteClusterClient(settings)
                 ? new RemoteClusterLicenseChecker(client, XPackLicenseState::isTransformAllowedForOperationMode)
                 : null,
             clusterService.getNodeName(),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
@@ -50,7 +50,7 @@ public class TransformTests extends ESTestCase {
             transformEnabled,
             Boolean.parseBoolean(transform.additionalSettings().get("node.attr.transform.node"))
         );
-        if (transformPluginEnabled && useExplicitSetting && useLegacySetting) {
+        if (useExplicitSetting && useLegacySetting) {
             assertSettingDeprecationsAndWarnings(new String[]{"node.transform"});
         }
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
@@ -10,7 +10,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Set;
+import java.util.Collections;
 
 import static org.elasticsearch.test.NodeRoles.addRoles;
 import static org.elasticsearch.test.NodeRoles.removeRoles;
@@ -32,9 +32,9 @@ public class TransformTests extends ESTestCase {
                 builder.put("node.transform", transformEnabled);
             } else {
                 if (transformEnabled) {
-                    builder.put(addRoles(Set.of(Transform.TRANSFORM_ROLE)));
+                    builder.put(addRoles(Collections.singleton(Transform.TRANSFORM_ROLE)));
                 } else {
-                    builder.put(removeRoles(Set.of(Transform.TRANSFORM_ROLE)));
+                    builder.put(removeRoles(Collections.singleton(Transform.TRANSFORM_ROLE)));
                 }
             }
         }

--- a/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePlugin.java
+++ b/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePlugin.java
@@ -3,6 +3,7 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.lucene.util.SetOnce;
@@ -18,13 +19,13 @@ import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
@@ -53,16 +54,23 @@ import java.util.function.Supplier;
 
 public class VotingOnlyNodePlugin extends Plugin implements DiscoveryPlugin, NetworkPlugin, ActionPlugin {
 
-    public static final Setting<Boolean> VOTING_ONLY_NODE_SETTING
-        = Setting.boolSetting("node.voting_only", false, Setting.Property.NodeScope);
+    private static final Setting<Boolean> VOTING_ONLY_NODE_SETTING
+        = Setting.boolSetting("node.voting_only", false, Property.Deprecated, Property.NodeScope);
 
     private static final String VOTING_ONLY_ELECTION_STRATEGY = "supports_voting_only";
 
     static DiscoveryNodeRole VOTING_ONLY_NODE_ROLE = new DiscoveryNodeRole("voting_only", "v") {
+
         @Override
-        protected Setting<Boolean> roleSetting() {
+        public Setting<Boolean> legacySetting() {
             return VOTING_ONLY_NODE_SETTING;
         }
+
+        @Override
+        public boolean isEnabledByDefault(final Settings settings) {
+            return false;
+        }
+
     };
 
     private final Settings settings;
@@ -75,7 +83,7 @@ public class VotingOnlyNodePlugin extends Plugin implements DiscoveryPlugin, Net
     public VotingOnlyNodePlugin(Settings settings) {
         this.settings = settings;
         threadPool = new SetOnce<>();
-        isVotingOnlyNode = VOTING_ONLY_NODE_SETTING.get(settings);
+        isVotingOnlyNode = DiscoveryNode.hasRole(settings, VOTING_ONLY_NODE_ROLE);
         this.transportClientMode = XPackPlugin.transportClientMode(settings);
     }
 
@@ -94,7 +102,7 @@ public class VotingOnlyNodePlugin extends Plugin implements DiscoveryPlugin, Net
 
     @Override
     public Set<DiscoveryNodeRole> getRoles() {
-        if (isVotingOnlyNode && Node.NODE_MASTER_SETTING.get(settings) == false) {
+        if (isVotingOnlyNode && DiscoveryNode.isMasterNode(settings) == false) {
             throw new IllegalStateException("voting-only node must be master-eligible");
         }
         return Collections.singleton(VOTING_ONLY_NODE_ROLE);

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinatorTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinatorTests.java
@@ -11,22 +11,14 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportInterceptor;
-import org.junit.BeforeClass;
 
 import java.util.Collections;
 
 import static java.util.Collections.emptySet;
 
 public class VotingOnlyNodeCoordinatorTests extends AbstractCoordinatorTestCase {
-
-    @BeforeClass
-    public static void setPossibleRolesWithVotingOnly() {
-        DiscoveryNode.setPossibleRoles(
-            Sets.union(DiscoveryNodeRole.BUILT_IN_ROLES, Sets.newHashSet(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
-    }
 
     @Override
     protected TransportInterceptor getTransportInterceptor(DiscoveryNode localNode, ThreadPool threadPool) {

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinatorTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodeCoordinatorTests.java
@@ -14,7 +14,9 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportInterceptor;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 
 import static java.util.Collections.emptySet;
 
@@ -57,8 +59,13 @@ public class VotingOnlyNodeCoordinatorTests extends AbstractCoordinatorTestCase 
             UUIDs.randomBase64UUID(random()), // generated deterministically for repeatable tests
             address.address().getHostString(), address.getAddress(), address, Collections.emptyMap(),
             masterEligible ? DiscoveryNodeRole.BUILT_IN_ROLES :
-                randomBoolean() ? emptySet() : Sets.newHashSet(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.INGEST_ROLE,
-                    DiscoveryNodeRole.MASTER_ROLE, VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE), Version.CURRENT);
+                randomBoolean() ? emptySet() : Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                    DiscoveryNodeRole.DATA_ROLE,
+                    DiscoveryNodeRole.INGEST_ROLE,
+                    DiscoveryNodeRole.MASTER_ROLE,
+                    VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE
+                ))),
+            Version.CURRENT);
     }
 
 }

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
@@ -9,14 +9,12 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Set;
 
 import static org.elasticsearch.test.NodeRoles.addRoles;
 import static org.elasticsearch.test.NodeRoles.onlyRole;

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePluginTests.java
@@ -16,7 +16,10 @@ import org.elasticsearch.test.ESIntegTestCase.Scope;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 
+import static org.elasticsearch.test.NodeRoles.addRoles;
+import static org.elasticsearch.test.NodeRoles.onlyRole;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -33,8 +36,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
     public void testRequireVotingOnlyNodeToBeMasterEligible() {
         internalCluster().setBootstrapMasterNodeIndex(0);
         IllegalStateException ise = expectThrows(IllegalStateException.class, () -> internalCluster().startNode(Settings.builder()
-            .put(Node.NODE_MASTER_SETTING.getKey(), false)
-            .put(VotingOnlyNodePlugin.VOTING_ONLY_NODE_SETTING.getKey(), true)
+            .put(onlyRole(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE))
             .build()));
         assertThat(ise.getMessage(), containsString("voting-only node must be master-eligible"));
     }
@@ -42,7 +44,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
     public void testVotingOnlyNodeStats() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(2);
-        internalCluster().startNode(Settings.builder().put(VotingOnlyNodePlugin.VOTING_ONLY_NODE_SETTING.getKey(), true));
+        internalCluster().startNode(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
         assertBusy(() -> assertThat(client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds(),
             hasSize(3)));
         assertThat(client().admin().cluster().prepareClusterStats().get().getNodesStats().getCounts().getRoles().get(
@@ -54,7 +56,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
     public void testPreferFullMasterOverVotingOnlyNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(2);
-        internalCluster().startNode(Settings.builder().put(VotingOnlyNodePlugin.VOTING_ONLY_NODE_SETTING.getKey(), true).build());
+        internalCluster().startNode(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
         internalCluster().startDataOnlyNodes(randomInt(2));
         assertBusy(() -> assertThat(
             client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
@@ -71,7 +73,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
 
     public void testBootstrapOnlyVotingOnlyNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
-        internalCluster().startNodes(Settings.builder().put(VotingOnlyNodePlugin.VOTING_ONLY_NODE_SETTING.getKey(), true).build(),
+        internalCluster().startNodes(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)),
             Settings.EMPTY, Settings.EMPTY);
         assertBusy(() -> assertThat(
             client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),
@@ -83,7 +85,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
 
     public void testBootstrapOnlySingleVotingOnlyNode() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
-        internalCluster().startNode(Settings.builder().put(VotingOnlyNodePlugin.VOTING_ONLY_NODE_SETTING.getKey(), true)
+        internalCluster().startNode(Settings.builder().put(addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)))
             .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s").build());
         internalCluster().startNode();
         assertBusy(() -> assertThat(client().admin().cluster().prepareState().get().getState().getNodes().getSize(), equalTo(2)));
@@ -95,7 +97,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
     public void testVotingOnlyNodesCannotBeMasterWithoutFullMasterNodes() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNode();
-        internalCluster().startNodes(2, Settings.builder().put(VotingOnlyNodePlugin.VOTING_ONLY_NODE_SETTING.getKey(), true).build());
+        internalCluster().startNodes(2, addRoles(Collections.singleton(VotingOnlyNodePlugin.VOTING_ONLY_NODE_ROLE)));
         internalCluster().startDataOnlyNodes(randomInt(2));
         assertBusy(() -> assertThat(
             client().admin().cluster().prepareState().get().getState().getLastCommittedConfiguration().getNodeIds().size(),

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -18,6 +18,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Booleans;
@@ -43,7 +44,6 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.plugins.ScriptPlugin;
@@ -542,7 +542,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
      * @return A number between 5 and the number of processors
      */
     static int getWatcherThreadPoolSize(final Settings settings) {
-        return getWatcherThreadPoolSize(Node.NODE_DATA_SETTING.get(settings), EsExecutors.allocatedProcessors(settings));
+        return getWatcherThreadPoolSize(DiscoveryNode.isDataNode(settings), EsExecutors.allocatedProcessors(settings));
     }
 
     static int getWatcherThreadPoolSize(final boolean isDataNode, final int allocatedProcessors) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/engine/TickerScheduleTriggerEngine.java
@@ -7,11 +7,11 @@ package org.elasticsearch.xpack.watcher.trigger.schedule.engine;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.xpack.core.watcher.trigger.TriggerEvent;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
 import org.elasticsearch.xpack.watcher.trigger.schedule.Schedule;
@@ -49,7 +49,7 @@ public class TickerScheduleTriggerEngine extends ScheduleTriggerEngine {
     public TickerScheduleTriggerEngine(Settings settings, ScheduleRegistry scheduleRegistry, Clock clock) {
         super(scheduleRegistry, clock);
         this.tickInterval = TICKER_INTERVAL_SETTING.get(settings);
-        this.ticker = new Ticker(Node.NODE_DATA_SETTING.get(settings));
+        this.ticker = new Ticker(DiscoveryNode.isDataNode(settings));
     }
 
     @Override

--- a/x-pack/qa/multi-cluster-search-security/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/build.gradle
@@ -23,7 +23,7 @@ task 'remote-cluster'(type: RestIntegTestTask) {
 testClusters.'remote-cluster' {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
-  setting 'node.remote_cluster_client', "false"
+  setting 'node.roles', '[data,ingest,master]'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
@@ -50,7 +50,6 @@ testClusters.'mixed-cluster' {
     testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
   }
   setting 'cluster.remote.connections_per_cluster', "1"
-  setting 'node.remote_cluster_client', "true"
 
   user username: "test_user", password: "x-pack-test-password"
 }

--- a/x-pack/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/qa/multi-cluster-tests-with-security/build.gradle
@@ -24,7 +24,7 @@ task 'remote-cluster'(type: RestIntegTestTask) {
 testClusters.'remote-cluster' {
   testDistribution = 'DEFAULT'
   numberOfNodes = 2
-  setting 'node.remote_cluster_client', "false"
+  setting 'node.roles', '[data,ingest,master]'
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
@@ -49,7 +49,6 @@ testClusters.'mixed-cluster' {
     testClusters.'remote-cluster'.getAllTransportPortURI().collect { "\"$it\"" }.toString()
   }
   setting 'cluster.remote.connections_per_cluster', "1"
-  setting 'node.remote_cluster_client', "true"
 
   user username: "test_user", password: "x-pack-test-password"
 }


### PR DESCRIPTION
Today we have individual settings for configuring node roles such as node.data and node.master. Additionally, roles are pluggable and we have used this to introduce roles such as node.ml and node.voting_only. As the number of roles is growing, managing these becomes harder for the user. For example, to create a master-only node, today a user has to= configure:
 - node.data: false
 - node.ingest: false
 - node.remote_cluster_client: false
 - node.ml: false

at a minimum if they are relying on defaults, but also add:
 - node.master: true
 - node.transform: false
 - node.voting_only: false

If they want to be explicit. This is also challenging in cases where a user wants to have configure a coordinating-only node which requires disabling all roles, a list which we are adding to, requiring the user to keep checking whether a node has acquired any of these roles.

This commit addresses this by adding a list setting node.roles for which a user has explicit control over the list of roles that a node has. If the setting is configured, the node has exactly the roles in the list, and not any additional roles. This means to configure a master-only node, the setting is merely 'node.roles: [master]', and to configure a coordinating-only node, the setting is merely: 'node.roles: []'.

With this change we deprecate the existing 'node.*' settings such as 'node.data'.

Relates #54998