### PR TITLE
Skip packaging test log file stashing once tests have failed

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -161,7 +161,7 @@ public abstract class PackagingTestCase extends Assert {
     public void teardown() throws Exception {
         // move log file so we can avoid false positives when grepping for
         // messages in logs during test
-        if (installation != null) {
+        if (installation != null && failed == false) {
             if (Files.exists(installation.logs)) {
                 Path logFile = installation.logs.resolve("elasticsearch.log");
                 String prefix = this.getClass().getSimpleName() + "." + testNameRule.getMethodName();


### PR DESCRIPTION
When a packaging test completes, we move the elasticsearch logfile to
another location so that if the next test fails, we have just the
contents of the test that ran. However, once the test fails, we continue
trying to move this file in the subsequent calls to teardown when the
rest of the tests are skipped. This commit skips the teardown step once
we have marked the suite as failed.