### PR TITLE
Fix transform test node role warnings

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
@@ -50,7 +50,7 @@ public class TransformTests extends ESTestCase {
             transformEnabled,
             Boolean.parseBoolean(transform.additionalSettings().get("node.attr.transform.node"))
         );
-        if (transformPluginEnabled && useExplicitSetting && useLegacySetting) {
+        if (useExplicitSetting && useLegacySetting) {
             assertSettingDeprecationsAndWarnings(new String[]{"node.transform"});
         }
     }


### PR DESCRIPTION
Warnings are emitted in TransformTests.testNodeAttributes regardless of
whether the plugin is enabled or not.

Relates #54998
