### PR TITLE
[Test] Fix assertion of deprecation log for node.transform

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformTests.java
@@ -50,7 +50,7 @@ public class TransformTests extends ESTestCase {
             transformEnabled,
             Boolean.parseBoolean(transform.additionalSettings().get("node.attr.transform.node"))
         );
-        if (transformPluginEnabled && useExplicitSetting && useLegacySetting) {
+        if (useExplicitSetting && useLegacySetting) {
             assertSettingDeprecationsAndWarnings(new String[]{"node.transform"});
         }
     }


### PR DESCRIPTION
The assertion for the deprecation log entry regarding node.transform
was previously guarded also by the random boolean enabling the plugin,
and therefore led to errors if the plugin was not enabled but the
setting was:

```
2> java.lang.AssertionError: unexpected warning headers expected null, but was:<[299 Elasticsearch-8.0.0-SNAPSHOT-e33a0dfe77ad530db99bdd203434d16b23999be6 "[node.transform] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."]>
```

Folows: #54998
