### PR TITLE
[ML] Change inference default field name to <dep_var>_prediction

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Classification.java
@@ -16,6 +16,8 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldAliasMapper;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PredictionFieldType;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
@@ -359,6 +361,17 @@ public class Classification implements DataFrameAnalysis {
     @Override
     public List<String> getProgressPhases() {
         return PROGRESS_PHASES;
+    }
+
+    @Override
+    public InferenceConfig inferenceConfig(FieldInfo fieldInfo) {
+        PredictionFieldType predictionFieldType = getPredictionFieldType(fieldInfo.getTypes(dependentVariable));
+        return ClassificationConfig.builder()
+            .setResultsField(predictionFieldName)
+            .setNumTopClasses(numTopClasses)
+            .setNumTopFeatureImportanceValues(getBoostedTreeParams().getNumTopFeatureImportanceValues())
+            .setPredictionFieldType(predictionFieldType)
+            .build();
     }
 
     public static String extractJobIdFromStateDoc(String stateDocId) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/DataFrameAnalysis.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.dataframe.analyses;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,12 @@ public interface DataFrameAnalysis extends ToXContentObject, NamedWriteable {
      * Returns the progress phases the analysis goes through in order
      */
     List<String> getProgressPhases();
+
+    /**
+     * @return the analysis inference config or {@code null} if inference is not supported
+     */
+    @Nullable
+    InferenceConfig inferenceConfig(FieldInfo fieldInfo);
 
     /**
      * Summarizes information about the fields that is necessary for analysis to generate

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetection.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
@@ -254,6 +255,11 @@ public class OutlierDetection implements DataFrameAnalysis {
     @Override
     public List<String> getProgressPhases() {
         return PROGRESS_PHASES;
+    }
+
+    @Override
+    public InferenceConfig inferenceConfig(FieldInfo fieldInfo) {
+        return null;
     }
 
     public enum Method {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/Regression.java
@@ -16,6 +16,8 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
@@ -263,6 +265,14 @@ public class Regression implements DataFrameAnalysis {
     @Override
     public List<String> getProgressPhases() {
         return PROGRESS_PHASES;
+    }
+
+    @Override
+    public InferenceConfig inferenceConfig(FieldInfo fieldInfo) {
+        return RegressionConfig.builder()
+            .setResultsField(predictionFieldName)
+            .setNumTopFeatureImportanceValues(getBoostedTreeParams().getNumTopFeatureImportanceValues())
+            .build();
     }
 
     public static String extractJobIdFromStateDoc(String stateDocId) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/OutlierDetectionTests.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class OutlierDetectionTests extends AbstractBWCSerializationTestCase<OutlierDetection> {
 
@@ -112,6 +113,11 @@ public class OutlierDetectionTests extends AbstractBWCSerializationTestCase<Outl
         OutlierDetection outlierDetection = createRandom();
         assertThat(outlierDetection.persistsState(), is(false));
         expectThrows(UnsupportedOperationException.class, () -> outlierDetection.getStateDocId("foo"));
+    }
+
+    public void testInferenceConfig() {
+        OutlierDetection outlierDetection = createRandom();
+        assertThat(outlierDetection.inferenceConfig(null), is(nullValue()));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/analyses/RegressionTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -23,6 +25,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -260,5 +263,20 @@ public class RegressionTests extends AbstractBWCSerializationTestCase<Regression
             String json = Strings.toString(builder);
             assertThat(json, containsString("randomize_seed"));
         }
+    }
+
+    public void testInferenceConfig() {
+        Regression regression = createRandom();
+
+        InferenceConfig inferenceConfig = regression.inferenceConfig(null);
+
+        assertThat(inferenceConfig, instanceOf(RegressionConfig.class));
+
+        RegressionConfig regressionConfig = (RegressionConfig) inferenceConfig;
+
+        assertThat(regressionConfig.getResultsField(), equalTo(regression.getPredictionFieldName()));
+        Integer expectedNumTopFeatureImportanceValues = regression.getBoostedTreeParams().getNumTopFeatureImportanceValues() == null ?
+            0 : regression.getBoostedTreeParams().getNumTopFeatureImportanceValues();
+        assertThat(regressionConfig.getNumTopFeatureImportanceValues(), equalTo(expectedNumTopFeatureImportanceValues));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.ml.dataframe.DestinationIndex;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
+import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -237,8 +238,8 @@ public class DataFrameDataExtractor {
         return context.extractedFields.getAllFields().stream().map(ExtractedField::getName).collect(Collectors.toList());
     }
 
-    public List<ExtractedField> getAllExtractedFields() {
-        return context.extractedFields.getAllFields();
+    public ExtractedFields getExtractedFields() {
+        return context.extractedFields;
     }
 
     public DataSummary collectDataSummary() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalysisFieldInfo.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalysisFieldInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.dataframe.process;
+
+import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
+import org.elasticsearch.xpack.ml.extractor.ExtractedField;
+import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public class AnalysisFieldInfo implements DataFrameAnalysis.FieldInfo {
+
+    private final ExtractedFields extractedFields;
+
+    AnalysisFieldInfo(ExtractedFields extractedFields) {
+        this.extractedFields = Objects.requireNonNull(extractedFields);
+    }
+
+    @Override
+    public Set<String> getTypes(String field) {
+        Optional<ExtractedField> extractedField = extractedFields.getAllFields().stream()
+            .filter(f -> f.getName().equals(field))
+            .findAny();
+        return extractedField.isPresent() ? extractedField.get().getTypes() : null;
+    }
+
+    @Override
+    public Long getCardinality(String field) {
+        return extractedFields.getCardinalitiesForFieldsWithConstraints().get(field);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessConfig.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessConfig.java
@@ -9,12 +9,10 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
-import org.elasticsearch.xpack.ml.extractor.ExtractedField;
 import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 public class AnalyticsProcessConfig implements ToXContentObject {
@@ -99,28 +97,6 @@ public class AnalyticsProcessConfig implements ToXContentObject {
             builder.field("parameters", analysis.getParams(new AnalysisFieldInfo(extractedFields)));
             builder.endObject();
             return builder;
-        }
-    }
-
-    private static class AnalysisFieldInfo implements DataFrameAnalysis.FieldInfo {
-
-        private final ExtractedFields extractedFields;
-
-        AnalysisFieldInfo(ExtractedFields extractedFields) {
-            this.extractedFields = Objects.requireNonNull(extractedFields);
-        }
-
-        @Override
-        public Set<String> getTypes(String field) {
-            Optional<ExtractedField> extractedField = extractedFields.getAllFields().stream()
-                .filter(f -> f.getName().equals(field))
-                .findAny();
-            return extractedField.isPresent() ? extractedField.get().getTypes() : null;
-        }
-
-        @Override
-        public Long getCardinality(String field) {
-            return extractedFields.getCardinalitiesForFieldsWithConstraints().get(field);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -463,7 +463,7 @@ public class AnalyticsProcessManager {
                         dataExtractorFactory.newExtractor(true), resultsPersisterService);
             return new AnalyticsResultProcessor(
                 config, dataFrameRowsJoiner, task.getStatsHolder(), trainedModelProvider, auditor, statsPersister,
-                dataExtractor.get().getAllExtractedFields());
+                dataExtractor.get().getExtractedFields());
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessor.java
@@ -25,11 +25,6 @@ import org.elasticsearch.xpack.core.ml.dataframe.stats.regression.RegressionStat
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PredictionFieldType;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.PhaseProgress;
@@ -39,6 +34,7 @@ import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
 import org.elasticsearch.xpack.ml.dataframe.stats.StatsHolder;
 import org.elasticsearch.xpack.ml.dataframe.stats.StatsPersister;
 import org.elasticsearch.xpack.ml.extractor.ExtractedField;
+import org.elasticsearch.xpack.ml.extractor.ExtractedFields;
 import org.elasticsearch.xpack.ml.extractor.MultiField;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
@@ -49,7 +45,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -78,21 +73,21 @@ public class AnalyticsResultProcessor {
     private final TrainedModelProvider trainedModelProvider;
     private final DataFrameAnalyticsAuditor auditor;
     private final StatsPersister statsPersister;
-    private final List<ExtractedField> fieldNames;
+    private final ExtractedFields extractedFields;
     private final CountDownLatch completionLatch = new CountDownLatch(1);
     private volatile String failure;
     private volatile boolean isCancelled;
 
     public AnalyticsResultProcessor(DataFrameAnalyticsConfig analytics, DataFrameRowsJoiner dataFrameRowsJoiner,
                                     StatsHolder statsHolder, TrainedModelProvider trainedModelProvider,
-                                    DataFrameAnalyticsAuditor auditor, StatsPersister statsPersister, List<ExtractedField> fieldNames) {
+                                    DataFrameAnalyticsAuditor auditor, StatsPersister statsPersister, ExtractedFields extractedFields) {
         this.analytics = Objects.requireNonNull(analytics);
         this.dataFrameRowsJoiner = Objects.requireNonNull(dataFrameRowsJoiner);
         this.statsHolder = Objects.requireNonNull(statsHolder);
         this.trainedModelProvider = Objects.requireNonNull(trainedModelProvider);
         this.auditor = Objects.requireNonNull(auditor);
         this.statsPersister = Objects.requireNonNull(statsPersister);
-        this.fieldNames = Collections.unmodifiableList(Objects.requireNonNull(fieldNames));
+        this.extractedFields = Objects.requireNonNull(extractedFields);
     }
 
     @Nullable
@@ -216,6 +211,7 @@ public class AnalyticsResultProcessor {
         String modelId = analytics.getId() + "-" + createTime.toEpochMilli();
         TrainedModelDefinition definition = inferenceModel.build();
         String dependentVariable = getDependentVariable();
+        List<ExtractedField> fieldNames = extractedFields.getAllFields();
         List<String> fieldNamesWithoutDependentVariable = fieldNames.stream()
             .map(ExtractedField::getName)
             .filter(f -> f.equals(dependentVariable) == false)
@@ -239,44 +235,8 @@ public class AnalyticsResultProcessor {
             .setInput(new TrainedModelInput(fieldNamesWithoutDependentVariable))
             .setLicenseLevel(License.OperationMode.PLATINUM.description())
             .setDefaultFieldMap(defaultFieldMapping)
-            .setInferenceConfig(buildInferenceConfig(definition.getTrainedModel().targetType()))
+            .setInferenceConfig(analytics.getAnalysis().inferenceConfig(new AnalysisFieldInfo(extractedFields)))
             .build();
-    }
-
-    private InferenceConfig buildInferenceConfig(TargetType targetType) {
-        switch (targetType) {
-            case CLASSIFICATION:
-                assert analytics.getAnalysis() instanceof Classification;
-                Classification classification = ((Classification)analytics.getAnalysis());
-                PredictionFieldType predictionFieldType = getPredictionFieldType(classification);
-                return ClassificationConfig.builder()
-                    .setNumTopClasses(classification.getNumTopClasses())
-                    .setNumTopFeatureImportanceValues(classification.getBoostedTreeParams().getNumTopFeatureImportanceValues())
-                    .setPredictionFieldType(predictionFieldType)
-                    .build();
-            case REGRESSION:
-                assert analytics.getAnalysis() instanceof Regression;
-                Regression regression = ((Regression)analytics.getAnalysis());
-                return RegressionConfig.builder()
-                    .setNumTopFeatureImportanceValues(regression.getBoostedTreeParams().getNumTopFeatureImportanceValues())
-                    .build();
-            default:
-                throw ExceptionsHelper.serverError(
-                    "process created a model with an unsupported target type [{}]",
-                    null,
-                    targetType);
-        }
-    }
-
-    PredictionFieldType getPredictionFieldType(Classification classification) {
-        String dependentVariable = classification.getDependentVariable();
-        Optional<ExtractedField> extractedField = fieldNames.stream()
-            .filter(f -> f.getName().equals(dependentVariable))
-            .findAny();
-        PredictionFieldType predictionFieldType = Classification.getPredictionFieldType(
-            extractedField.isPresent() ? extractedField.get().getTypes() : null
-        );
-        return predictionFieldType == null ? PredictionFieldType.STRING : predictionFieldType;
     }
 
     private String getDependentVariable() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManagerTests.java
@@ -103,6 +103,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
             OutlierDetectionTests.createRandom()).build();
         dataExtractor = mock(DataFrameDataExtractor.class);
         when(dataExtractor.collectDataSummary()).thenReturn(new DataFrameDataExtractor.DataSummary(NUM_ROWS, NUM_COLS));
+        when(dataExtractor.getExtractedFields()).thenReturn(new ExtractedFields(Collections.emptyList(), Collections.emptyMap()));
         dataExtractorFactory = mock(DataFrameDataExtractorFactory.class);
         when(dataExtractorFactory.newExtractor(anyBoolean())).thenReturn(dataExtractor);
         when(dataExtractorFactory.getExtractedFields()).thenReturn(mock(ExtractedFields.class));
@@ -180,7 +181,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         inOrder.verify(process).isProcessAlive();
         inOrder.verify(task).getParentTaskId();
         inOrder.verify(task).getStatsHolder();
-        inOrder.verify(dataExtractor).getAllExtractedFields();
+        inOrder.verify(dataExtractor).getExtractedFields();
         inOrder.verify(executorServiceForProcess, times(2)).execute(any());  // 'processData' and 'processResults' threads
         verifyNoMoreInteractions(dataExtractor, executorServiceForProcess, process, task);
     }
@@ -239,7 +240,7 @@ public class AnalyticsProcessManagerTests extends ESTestCase {
         inOrder.verify(process).isProcessAlive();
         inOrder.verify(task).getParentTaskId();
         inOrder.verify(task).getStatsHolder();
-        inOrder.verify(dataExtractor).getAllExtractedFields();
+        inOrder.verify(dataExtractor).getExtractedFields();
         // stop
         inOrder.verify(dataExtractor).cancel();
         inOrder.verify(process).kill();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsResultProcessorTests.java
@@ -15,13 +15,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsDest;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsSource;
-import org.elasticsearch.xpack.core.ml.dataframe.analyses.Classification;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.DataFrameAnalysis;
 import org.elasticsearch.xpack.core.ml.dataframe.analyses.Regression;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinitionTests;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PredictionFieldType;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
 import org.elasticsearch.xpack.core.security.user.XPackUser;
 import org.elasticsearch.xpack.ml.dataframe.process.results.AnalyticsResult;
@@ -45,7 +43,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -214,18 +211,6 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
         Mockito.verifyNoMoreInteractions(auditor);
     }
 
-    public void testGetPredictionFieldType() {
-        List<ExtractedField> extractedFieldList = Arrays.asList(
-            new DocValueField("foo", Collections.emptySet()),
-            new DocValueField("bar", Set.of("keyword")),
-            new DocValueField("baz", Set.of("long")),
-            new DocValueField("bingo", Set.of("boolean")));
-        AnalyticsResultProcessor resultProcessor = createResultProcessor(extractedFieldList);
-        assertThat(resultProcessor.getPredictionFieldType(new Classification("foo")), equalTo(PredictionFieldType.STRING));
-        assertThat(resultProcessor.getPredictionFieldType(new Classification("bar")), equalTo(PredictionFieldType.STRING));
-        assertThat(resultProcessor.getPredictionFieldType(new Classification("baz")), equalTo(PredictionFieldType.NUMBER));
-        assertThat(resultProcessor.getPredictionFieldType(new Classification("bingo")), equalTo(PredictionFieldType.BOOLEAN));
-    }
 
     @SuppressWarnings("unchecked")
     public void testProcess_GivenInferenceModelFailedToStore() {
@@ -271,12 +256,13 @@ public class AnalyticsResultProcessorTests extends ESTestCase {
     }
 
     private AnalyticsResultProcessor createResultProcessor(List<ExtractedField> fieldNames) {
+
         return new AnalyticsResultProcessor(analyticsConfig,
             dataFrameRowsJoiner,
             statsHolder,
             trainedModelProvider,
             auditor,
             statsPersister,
-            fieldNames);
+            new ExtractedFields(fieldNames, Collections.emptyMap()));
     }
 }


### PR DESCRIPTION
This changes the default value for the results field of inference
applied on models that are trained via a data frame analytics job.
Previously, the results field default was `predicted_value`. This
commit makes it the same as in the training job itself. The new
default field is `<dependent_variable>_prediction`. Apart from
making inference consistent with the training job the model came
from, it is helpful to preserve the dependent variable name
by default as it provides some context to the user that may
avoid confusion as to which model results came from.
