### PR TITLE
[DOCS] EQL: Remove references to partial async EQL results

### DIFF
--- a/docs/reference/eql/get-async-eql-search-api.asciidoc
+++ b/docs/reference/eql/get-async-eql-search-api.asciidoc
@@ -70,8 +70,8 @@ meaning the request waits for complete search results.
 If this parameter is specified and the request completes during this period,
 complete search results are returned.
 +
-If the request does not complete during this period, partial results, if
-available, are returned.
+If the request does not complete during this period, the response returns an
+`is_partial` value of `true` and no search results.
 
 [role="child_attributes"]
 [[get-async-eql-search-api-response-body]]

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -613,7 +613,6 @@ API returns a response that includes:
 * An `is_partial` value of `true`, indicating the response does not contain
   complete search results.
 * An `is_running` value of `true`, indicating the search is async and ongoing.
-* Partial search results, if available, in the `hits` property.
 
 The async search continues to run in the background without blocking
 other requests.
@@ -670,8 +669,9 @@ async EQL search API>> to check the progress of an ongoing async search.
 
 The get async EQL search API also accepts a `wait_for_completion_timeout` query
 parameter. Set the `wait_for_completion_timeout` parameter to a duration you'd
-like to wait for complete search results. If the search does not finish during
-this period, partial search results, if available, are returned.
+like to wait for complete search results. If the request does not complete
+during this period, the response returns an `is_partial` value of `true` and no
+search results.
 
 [%collapsible]
 .*Example*


### PR DESCRIPTION
Removes references to partial results from the async EQL search docs.

If an EQL search does not complete during the `wait_for_completion_timeout`
timeout period, it returns no results.