### PR TITLE
Exclude SystemV timezones from randomZone method

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -834,7 +834,6 @@ public abstract class ESTestCase extends LuceneTestCase {
      * because they cannot be converted back to DateTimeZone which we currently
      * still need to do internally e.g. in bwc serialization and in the extract() method
      * //TODO remove once joda is not supported
-     * @param random zoneId from given set of ids but supported by joda
      */
     private static String nonSystemVJavaZoneId(List<String> zoneIds) {
         return randomValueOtherThanMany(id -> JODA_TIMEZONE_IDS.contains(id) == false,

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -823,12 +823,23 @@ public abstract class ESTestCase extends LuceneTestCase {
         if (JavaVersion.current().getVersion().get(0) == 8) {
             ZoneId timeZone;
             do {
-                timeZone = ZoneId.of(randomFrom(JAVA_ZONE_IDS));
+                timeZone = ZoneId.of(nonSystemVJavaZoneId());
             } while (timeZone.equals(ZoneId.of("GMT0")));
             return timeZone;
         } else {
-            return ZoneId.of(randomFrom(JAVA_ZONE_IDS));
+            return ZoneId.of(nonSystemVJavaZoneId());
         }
+    }
+
+    /**
+     * We need to exclude SystemV/* time zones because they cannot be converted
+     * back to DateTimeZone which we currently still need to do internally,
+     * e.g. in bwc serialization and in the extract() method
+     * //TODO remove once joda is not supported
+     */
+    private static String nonSystemVJavaZoneId() {
+        return randomValueOtherThanMany(id -> id.startsWith("SystemV"),
+            () -> randomFrom(JAVA_ZONE_IDS));
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -148,7 +148,9 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.util.CollectionUtils.arrayAsArrayList;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * Base testcase for randomized unit testing with Elasticsearch

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -811,7 +811,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * generate a random TimeZone from the ones available in java.util
      */
     public static TimeZone randomTimeZone() {
-        return TimeZone.getTimeZone(nonSystemVJavaZoneId(JAVA_TIMEZONE_IDS));
+        return TimeZone.getTimeZone(randomJodaAndJavaSupportedTimezone(JAVA_TIMEZONE_IDS));
     }
 
     /**
@@ -823,11 +823,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         if (JavaVersion.current().getVersion().get(0) == 8) {
             ZoneId timeZone;
             do {
-                timeZone = ZoneId.of(nonSystemVJavaZoneId(JAVA_ZONE_IDS));
+                timeZone = ZoneId.of(randomJodaAndJavaSupportedTimezone(JAVA_ZONE_IDS));
             } while (timeZone.equals(ZoneId.of("GMT0")));
             return timeZone;
         } else {
-            return ZoneId.of(nonSystemVJavaZoneId(JAVA_ZONE_IDS));
+            return ZoneId.of(randomJodaAndJavaSupportedTimezone(JAVA_ZONE_IDS));
         }
     }
 
@@ -837,7 +837,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * still need to do internally e.g. in bwc serialization and in the extract() method
      * //TODO remove once joda is not supported
      */
-    private static String nonSystemVJavaZoneId(List<String> zoneIds) {
+    private static String randomJodaAndJavaSupportedTimezone(List<String> zoneIds) {
         return randomValueOtherThanMany(id -> JODA_TIMEZONE_IDS.contains(id) == false,
             () -> randomFrom(zoneIds));
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/AbstractSqlWireSerializingTestCase.java
@@ -32,28 +32,18 @@ public abstract class AbstractSqlWireSerializingTestCase<T extends Writeable> ex
             }
         }
     }
-    
+
     /**
      * Returns a {@link Writeable.Reader} that can be used to de-serialize the instance
      */
     protected abstract Writeable.Reader<T> instanceReader();
 
     protected ZoneId instanceZoneId(T instance) {
-        return randomSafeZone();
+        return randomZone();
     }
 
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         return new NamedWriteableRegistry(Cursors.getNamedWriteables());
-    }
-
-
-    /**
-     * We need to exclude SystemV/* time zones because they cannot be converted
-     * back to DateTimeZone which we currently still need to do internally,
-     * e.g. in bwc serialization and in the extract() method
-     */
-    protected static ZoneId randomSafeZone() {
-        return randomValueOtherThanMany(zi -> zi.getId().startsWith("SystemV"), () -> randomZone());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggregationCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggregationCursorTests.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 public class CompositeAggregationCursorTests extends AbstractSqlWireSerializingTestCase<CompositeAggCursor> {
     public static CompositeAggCursor randomCompositeCursor() {
         int extractorsSize = between(1, 20);
-        ZoneId id = randomSafeZone();
+        ZoneId id = randomZone();
         List<BucketExtractor> extractors = new ArrayList<>(extractorsSize);
         for (int i = 0; i < extractorsSize; i++) {
             extractors.add(randomBucketExtractor(id));
@@ -70,7 +70,7 @@ public class CompositeAggregationCursorTests extends AbstractSqlWireSerializingT
                 return zoneId;
             }
         }
-        return randomSafeZone();
+        return randomZone();
     }
 
     static BitSet randomBitSet(int size) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
@@ -26,7 +26,7 @@ import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
 public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCase<CompositeKeyExtractor> {
 
     public static CompositeKeyExtractor randomCompositeKeyExtractor() {
-        return new CompositeKeyExtractor(randomAlphaOfLength(16), randomFrom(asList(Property.values())), randomSafeZone(), randomBoolean());
+        return new CompositeKeyExtractor(randomAlphaOfLength(16), randomFrom(asList(Property.values())), randomZone(), randomBoolean());
     }
 
     public static CompositeKeyExtractor randomCompositeKeyExtractor(ZoneId zoneId) {
@@ -73,7 +73,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
     }
 
     public void testExtractDate() {
-        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomSafeZone(), true);
+        CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomZone(), true);
 
         long millis = System.currentTimeMillis();
         Bucket bucket = new TestBucket(singletonMap(extractor.key(), millis), randomLong(), new Aggregations(emptyList()));


### PR DESCRIPTION
randomZone test method returns a ZoneId from the set of ids supported by
java. The only difference between joda and java supported timezones are
SystemV* timezones.
These should be excluded from randomZone method as they would break
testing. They also do not bring much confidence when used in testing as
I suspect they are rarely used.
That exclude should be removed for simplification once joda support is removed. 