### PR TITLE
[7.x][ML] Avoid assertion error on empty string feature values for in…

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceHelpers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceHelpers.java
@@ -96,14 +96,21 @@ public final class InferenceHelpers {
             return ((Number)value).doubleValue();
         }
         if (value instanceof String) {
-            try {
-                return Double.valueOf((String)value);
-            } catch (NumberFormatException nfe) {
-                assert false : "value is not properly formatted double [" + value + "]";
-                return null;
-            }
+            return stringToDouble((String) value);
         }
         return null;
+    }
+
+    private static Double stringToDouble(String value) {
+        if (value.isEmpty()) {
+            return null;
+        }
+        try {
+            return Double.valueOf(value);
+        } catch (NumberFormatException nfe) {
+            assert false : "value is not properly formatted double [" + value + "]";
+            return null;
+        }
     }
 
     public static Map<String, double[]> decodeFeatureImportances(Map<String, String> processedFeatureToOriginalFeatureMap,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceHelpersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceHelpersTests.java
@@ -17,18 +17,18 @@ import static org.hamcrest.Matchers.nullValue;
 public class InferenceHelpersTests extends ESTestCase {
 
     public void testToDoubleFromNumbers() {
-        assertThat(0.5, equalTo(InferenceHelpers.toDouble(0.5)));
-        assertThat(0.5, equalTo(InferenceHelpers.toDouble(0.5)));
-        assertThat(5.0, equalTo(InferenceHelpers.toDouble(5L)));
-        assertThat(5.0, equalTo(InferenceHelpers.toDouble(5)));
-        assertThat(0.5, equalTo(InferenceHelpers.toDouble(0.5f)));
+        assertThat(InferenceHelpers.toDouble(0.5), equalTo(0.5));
+        assertThat(InferenceHelpers.toDouble(5L), equalTo(5.0));
+        assertThat(InferenceHelpers.toDouble(5), equalTo(5.0));
+        assertThat(InferenceHelpers.toDouble(0.5f), equalTo(0.5));
     }
 
     public void testToDoubleFromString() {
-        assertThat(0.5, equalTo(InferenceHelpers.toDouble("0.5")));
-        assertThat(-0.5, equalTo(InferenceHelpers.toDouble("-0.5")));
-        assertThat(5.0, equalTo(InferenceHelpers.toDouble("5")));
-        assertThat(-5.0, equalTo(InferenceHelpers.toDouble("-5")));
+        assertThat(InferenceHelpers.toDouble(""), is(nullValue()));
+        assertThat(InferenceHelpers.toDouble("0.5"), equalTo(0.5));
+        assertThat(InferenceHelpers.toDouble("-0.5"), equalTo(-0.5));
+        assertThat(InferenceHelpers.toDouble("5"), equalTo(5.0));
+        assertThat(InferenceHelpers.toDouble("-5"), equalTo(-5.0));
 
         // if ae are turned off, then we should get a null value
         // otherwise, we should expect an assertion failure telling us that the string is improperly formatted


### PR DESCRIPTION
…ference (#58541)

It is possible for the source document to have an empty string value
for a field that is mapped as numeric. We should treat those as missing
values and avoid throwing an assertion error.

Backport of #58541
