### PR TITLE
Enable DateUtilsTests.testTimezoneIds

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
@@ -34,7 +34,7 @@ public class DateUtilsTests extends ESTestCase {
     private static final Set<String> IGNORE = new HashSet<>(Arrays.asList(
         "Eire", "Europe/Dublin" // dublin timezone in joda does not account for DST
     ));
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/56343")
+
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));
         assertNull(DateUtils.zoneIdToDateTimeZone(null));


### PR DESCRIPTION
joda upgrade made its timezone db more up to date than joda 
(causing this test to fail), hence it had to be reverted. 
Joda and Java's timezone dbs are in sync now.
revert of joda upgrade #57137
closes #56343