### PR TITLE
[DOCS] Updates results_field description in the inference processor docs

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -42,7 +42,7 @@ Regression configuration for inference.
 
 `results_field`::
 (Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field-processor]
 
 `num_top_feature_importance_values`::
 (Optional, integer)
@@ -65,7 +65,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-classification
 
 `results_field`::
 (Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field-processor]
 
 `top_classes_results_field`::
 (Optional, string)

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -740,7 +740,8 @@ end::inference-config-regression-num-top-feature-importance-values[]
 
 tag::inference-config-results-field[]
 The field that is added to incoming documents to contain the inference
-prediction. Defaults to `predicted_value`.
+prediction. Defaults to the `results_field` value of the {dfanalytics-job} that 
+used to train the model, which defaults to `<dependent_variable>_prediction`.
 end::inference-config-results-field[]
 
 tag::influencers[]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -745,7 +745,7 @@ end::inference-config-results-field[]
 
 tag::inference-config-results-field-processor[]
 The field that is added to incoming documents to contain the inference
-prediction. Defaults to the `results_field` value of the {dfanalytics-job} that 
+prediction. Defaults to the `results_field` value of the {dfanalytics-job} that was
 used to train the model, which defaults to `<dependent_variable>_prediction`.
 end::inference-config-results-field-processor[]
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -740,9 +740,14 @@ end::inference-config-regression-num-top-feature-importance-values[]
 
 tag::inference-config-results-field[]
 The field that is added to incoming documents to contain the inference
+prediction. Defaults to `predicted_value`.
+end::inference-config-results-field[]
+
+tag::inference-config-results-field-processor[]
+The field that is added to incoming documents to contain the inference
 prediction. Defaults to the `results_field` value of the {dfanalytics-job} that 
 used to train the model, which defaults to `<dependent_variable>_prediction`.
-end::inference-config-results-field[]
+end::inference-config-results-field-processor[]
 
 tag::influencers[]
 A comma separated list of influencer field names. Typically these can be the by, 


### PR DESCRIPTION
## Overview

This PR changes the default value of the `results_field` from `predicted_value` to the `results_field` value of the data frame analytics job that trained the inference model.

### Preview

[Inference processor](url)