### PR TITLE
HLRC: ClearScroll API ignores 404

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -1221,7 +1221,7 @@ public class RestHighLevelClient implements Closeable {
      */
     public final ClearScrollResponse clearScroll(ClearScrollRequest clearScrollRequest, RequestOptions options) throws IOException {
         return performRequestAndParseEntity(clearScrollRequest, RequestConverters::clearScroll, options, ClearScrollResponse::fromXContent,
-                emptySet());
+                singleton(404));
     }
 
     /**
@@ -1237,7 +1237,7 @@ public class RestHighLevelClient implements Closeable {
     public final Cancellable clearScrollAsync(ClearScrollRequest clearScrollRequest, RequestOptions options,
                                               ActionListener<ClearScrollResponse> listener) {
         return performRequestAsyncAndParseEntity(clearScrollRequest, RequestConverters::clearScroll,
-            options, ClearScrollResponse::fromXContent, listener, emptySet());
+            options, ClearScrollResponse::fromXContent, listener, singleton(404));
     }
 
     /**

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -706,6 +706,15 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         }
     }
 
+    public void testClearScrollNotFound() throws Exception {
+        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+        clearScrollRequest.addScrollId("DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==");
+        ClearScrollResponse clearScrollResponse = execute(clearScrollRequest,
+            highLevelClient()::clearScroll, highLevelClient()::clearScrollAsync);
+        assertThat(clearScrollResponse.getNumFreed(), equalTo(0));
+        assertTrue(clearScrollResponse.isSucceeded());
+    }
+
     public void testMultiSearch() throws Exception {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         SearchRequest searchRequest1 = new SearchRequest("index1");


### PR DESCRIPTION
Add 404 to `ignores` in `clearScroll` and `clearScollAsync`.

Resolves #56896.