### PR TITLE
Fix two scripted_metric bugs (backport of #58547)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -449,7 +449,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         assertThat(numShardsRun, greaterThan(0));
     }
 
-    public void testInitMapWithParams() {
+    public void testInitMutatesParams() {
         Map<String, Object> varsMap = new HashMap<>();
         varsMap.put("multiplier", 1);
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -232,7 +232,7 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
             compiledInitScript = queryShardContext.compile(initScript, ScriptedMetricAggContexts.InitScript.CONTEXT);
             initScriptParams = initScript.getParams();
         } else {
-            compiledInitScript = (p, a) -> null;
+            compiledInitScript = null;
             initScriptParams = Collections.emptyMap();
         }
 
@@ -241,12 +241,9 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
         Map<String, Object> mapScriptParams = mapScript.getParams();
 
 
-        ScriptedMetricAggContexts.CombineScript.Factory compiledCombineScript;
-        Map<String, Object> combineScriptParams;
-
-        compiledCombineScript = queryShardContext.compile(combineScript,
+        ScriptedMetricAggContexts.CombineScript.Factory compiledCombineScript = queryShardContext.compile(combineScript,
             ScriptedMetricAggContexts.CombineScript.CONTEXT);
-        combineScriptParams = combineScript.getParams();
+        Map<String, Object> combineScriptParams = combineScript.getParams();
 
         return new ScriptedMetricAggregatorFactory(name, compiledMapScript, mapScriptParams, compiledInitScript,
                 initScriptParams, compiledCombineScript, combineScriptParams, reduceScript,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorFactory.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptedMetricAggContexts;
@@ -45,16 +45,26 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
     private final Script reduceScript;
     private final Map<String, Object> aggParams;
     private final SearchLookup lookup;
+    @Nullable
     private final ScriptedMetricAggContexts.InitScript.Factory initScript;
     private final Map<String, Object> initScriptParams;
 
-    ScriptedMetricAggregatorFactory(String name,
-                                    ScriptedMetricAggContexts.MapScript.Factory mapScript, Map<String, Object> mapScriptParams,
-                                    ScriptedMetricAggContexts.InitScript.Factory initScript, Map<String, Object> initScriptParams,
-                                    ScriptedMetricAggContexts.CombineScript.Factory combineScript,
-                                    Map<String, Object> combineScriptParams, Script reduceScript, Map<String, Object> aggParams,
-                                    SearchLookup lookup, QueryShardContext queryShardContext, AggregatorFactory parent,
-                                    AggregatorFactories.Builder subFactories, Map<String, Object> metadata) throws IOException {
+    ScriptedMetricAggregatorFactory(
+        String name,
+        ScriptedMetricAggContexts.MapScript.Factory mapScript,
+        Map<String, Object> mapScriptParams,
+        @Nullable ScriptedMetricAggContexts.InitScript.Factory initScript,
+        Map<String, Object> initScriptParams,
+        ScriptedMetricAggContexts.CombineScript.Factory combineScript,
+        Map<String, Object> combineScriptParams,
+        Script reduceScript,
+        Map<String, Object> aggParams,
+        SearchLookup lookup,
+        QueryShardContext queryShardContext,
+        AggregatorFactory parent,
+        AggregatorFactories.Builder subFactories,
+        Map<String, Object> metadata
+    ) throws IOException {
         super(name, queryShardContext, parent, subFactories, metadata);
         this.mapScript = mapScript;
         this.mapScriptParams = mapScriptParams;
@@ -73,29 +83,19 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
                                         boolean collectsFromSingleBucket,
                                         Map<String, Object> metadata) throws IOException {
         Map<String, Object> aggParams = this.aggParams == null ? org.elasticsearch.common.collect.Map.of() : this.aggParams;
-        Map<String, Object> initialState = new HashMap<String, Object>();
 
-        ScriptedMetricAggContexts.InitScript initScript = this.initScript.newInstance(
-            mergeParams(aggParams, initScriptParams),
-            initialState
-        );
-        if (initScript != null) {
-            initScript.execute();
-            CollectionUtils.ensureNoSelfReferences(initialState, "Scripted metric aggs init script");
-        }
-
-        Map<String, Object> mapParams = mergeParams(aggParams, mapScriptParams); 
-        Map<String, Object> combineParams = mergeParams(aggParams, combineScriptParams); 
         Script reduceScript = deepCopyScript(this.reduceScript, searchContext, aggParams);
 
         return new ScriptedMetricAggregator(
             name,
             lookup,
-            initialState,
+            aggParams,
+            initScript,
+            initScriptParams,
             mapScript,
-            mapParams,
+            mapScriptParams,
             combineScript,
-            combineParams,
+            combineScriptParams,
             reduceScript,
             searchContext,
             parent,
@@ -140,7 +140,7 @@ class ScriptedMetricAggregatorFactory extends AggregatorFactory {
         return clone;
     }
 
-    private static Map<String, Object> mergeParams(Map<String, Object> agg, Map<String, Object> script) {
+    static Map<String, Object> mergeParams(Map<String, Object> agg, Map<String, Object> script) {
         // Start with script params
         Map<String, Object> combined = new HashMap<>(script);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -26,12 +27,17 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -42,9 +48,13 @@ import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.internal.SearchContext;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -58,6 +68,8 @@ import java.util.function.Function;
 
 import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
 
@@ -94,6 +106,13 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap());
     private static final Script COMBINE_SCRIPT_SELF_REF = new Script(ScriptType.INLINE, MockScriptEngine.NAME, "combineScriptSelfRef",
             Collections.emptyMap());
+
+    private static final Script INIT_SCRIPT_MAKING_ARRAY = new Script(
+        ScriptType.INLINE,
+        MockScriptEngine.NAME,
+        "initScriptMakingArray",
+        Collections.emptyMap()
+    );
 
     private static final Map<String, Function<Map<String, Object>, Object>> SCRIPTS = new HashMap<>();
 
@@ -181,6 +200,46 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
            state.put("selfRef", state);
            return state;
         });
+        SCRIPTS.put("initScriptMakingArray", params -> {
+            Map<String, Object> state = (Map<String, Object>) params.get("state");
+            state.put("array", new String[] {"foo", "bar"});
+            state.put("collector", new ArrayList<Integer>());
+            return state;
+         });
+    }
+
+    private CircuitBreakerService circuitBreakerService;
+
+    @Before
+    public void mockBreaker() {
+        circuitBreakerService = mock(CircuitBreakerService.class);
+        when(circuitBreakerService.getBreaker(CircuitBreaker.REQUEST)).thenReturn(new NoopCircuitBreaker(CircuitBreaker.REQUEST) {
+            private long total = 0;
+
+            @Override
+            public double addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+                logger.debug("Used {} grabbing {} for {}", total, bytes, label);
+                total += bytes;
+                return total;
+            }
+
+            @Override
+            public long addWithoutBreaking(long bytes) {
+                logger.debug("Used {} grabbing {}", total, bytes);
+                total += bytes;
+                return total;
+            }
+
+            @Override
+            public long getUsed() {
+                return total;
+            }
+        });
+    }
+
+    @Override
+    protected void afterClose() {
+        assertThat(circuitBreakerService.getBreaker(CircuitBreaker.REQUEST).getUsed(), equalTo(0L));
     }
 
     @Override
@@ -420,8 +479,19 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         }
     }
 
+    public void testInitScriptMakesArray() throws IOException {
+        ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
+        aggregationBuilder.initScript(INIT_SCRIPT_MAKING_ARRAY).mapScript(MAP_SCRIPT)
+            .combineScript(COMBINE_SCRIPT).reduceScript(REDUCE_SCRIPT);
+        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            iw.addDocument(new Document());
+        }, (InternalScriptedMetric r) -> {
+            assertEquals(1, r.aggregation());
+        });
+    }
+
     public void testAsSubAgg() throws IOException {
-        AggregationBuilder aggregationBuilder = new TermsAggregationBuilder("t").field("t")
+        AggregationBuilder aggregationBuilder = new TermsAggregationBuilder("t").field("t").executionHint("map")
             .subAggregation(
                 new ScriptedMetricAggregationBuilder("scripted").initScript(INIT_SCRIPT)
                     .mapScript(MAP_SCRIPT)
@@ -444,6 +514,25 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             assertThat(oddMetric.aggregation(), equalTo(49));
         };
         testCase(aggregationBuilder, new MatchAllDocsQuery(), buildIndex, verify, keywordField("t"), longField("number"));
+    }
+
+    protected <A extends Aggregator> A createAggregator(
+        Query query,
+        AggregationBuilder aggregationBuilder,
+        IndexSearcher indexSearcher,
+        IndexSettings indexSettings,
+        MultiBucketConsumer bucketConsumer,
+        MappedFieldType... fieldTypes
+    ) throws IOException {
+        SearchContext searchContext = createSearchContext(
+            indexSearcher,
+            indexSettings,
+            query,
+            bucketConsumer,
+            circuitBreakerService,
+            fieldTypes
+        );
+        return createAggregator(aggregationBuilder, searchContext);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -237,9 +237,13 @@ public abstract class AggregatorTestCase extends ESTestCase {
                                                         MultiBucketConsumer bucketConsumer,
                                                         MappedFieldType... fieldTypes) throws IOException {
         SearchContext searchContext = createSearchContext(indexSearcher, indexSettings, query, bucketConsumer, fieldTypes);
+        return createAggregator(aggregationBuilder, searchContext);
+    }
+
+    protected <A extends Aggregator> A createAggregator(AggregationBuilder aggregationBuilder, SearchContext searchContext)
+        throws IOException {
         @SuppressWarnings("unchecked")
-        A aggregator = (A) aggregationBuilder
-            .rewrite(searchContext.getQueryShardContext())
+        A aggregator = (A) aggregationBuilder.rewrite(searchContext.getQueryShardContext())
             .build(searchContext.getQueryShardContext(), null)
             .create(searchContext, null, true);
         return aggregator;
@@ -875,6 +879,11 @@ public abstract class AggregatorTestCase extends ESTestCase {
         Releasables.close(releasables);
         releasables.clear();
     }
+
+    /**
+     * Hook for checking things after all {@link Aggregator}s have been closed.
+     */
+    protected void afterClose() {}
 
     /**
      * Make a {@linkplain DateFieldMapper.DateFieldType} for a {@code date}.


### PR DESCRIPTION
Fixes two bugs introduced by #57627:
1. We were not properly letting go of memory from the request breaker
   when the aggregation finished.
2. We no longer supported totally arbitrary stuff produced by the init
   script because we *assumed* that it'd be ok to run the script once
   and clone its results. Sadly, cloning can't clone *anything* that the
   init script can make, like `String` arrays. This runs the init script
   once for every new bucket so we don't need to clone.
