### PR TITLE
[7.8] Fix negative limiting with fewer PARTIAL snapshots than minimum required (#58563)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
@@ -186,7 +186,7 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
                 final TimeValue snapshotAge = new TimeValue(nowSupplier.getAsLong() - si.startTime());
 
                 if (this.minimumSnapshotCount != null) {
-                    final long eligibleForExpiration = successfulSnapshotCount - minimumSnapshotCount;
+                    final long eligibleForExpiration = Math.max(0, successfulSnapshotCount - minimumSnapshotCount);
 
                     // Only the oldest N snapshots are actually eligible, since if we went below this we
                     // would fall below the configured minimum number of snapshots to keep

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionConfigurationTests.java
@@ -227,7 +227,6 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         assertThat(conf.getSnapshotDeletionPredicate(infos).test(oldInfo), equalTo(true));
     }
 
-
     public void testMostRecentSuccessfulTimestampIsUsed() {
         boolean failureBeforePartial = randomBoolean();
         SnapshotRetentionConfiguration conf = new SnapshotRetentionConfiguration(() -> 1, null, 2, 2);
@@ -241,6 +240,18 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
         assertThat(conf.getSnapshotDeletionPredicate(infos).test(s3), equalTo(false));
         assertThat(conf.getSnapshotDeletionPredicate(infos).test(s4), equalTo(false));
+    }
+
+    public void testFewerSuccessesThanMinWithPartial() {
+        SnapshotRetentionConfiguration conf = new SnapshotRetentionConfiguration(() -> 1, TimeValue.timeValueSeconds(5), 10, 20);
+        SnapshotInfo s1 = makeInfo(1);
+        SnapshotInfo sP = makePartialInfo(2);
+        SnapshotInfo s2 = makeInfo(3);
+
+        List<SnapshotInfo> infos = Arrays.asList(s1 , sP, s2);
+        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s1), equalTo(false));
+        assertThat(conf.getSnapshotDeletionPredicate(infos).test(sP), equalTo(false));
+        assertThat(conf.getSnapshotDeletionPredicate(infos).test(s2), equalTo(false));
     }
 
     private SnapshotInfo makeInfo(long startTime) {


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Fix negative limiting with fewer PARTIAL snapshots than minimum required (#58563)