### PR TITLE
[DOCS] Add data streams to multi search API docs

### DIFF
--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -451,6 +451,20 @@ information for any documents matching the search.
 <4> Primary term for the document
 ====
 
+[source,console]
+----
+GET /*/_msearch
+{}
+{"query" : {"match_all" : {}}}
+----
+// TEST[continued]
+
+[source,console-result]
+----
+{
+}
+----
+
 You can use an <<docs-index_,index API>> request to update an individual
 document. To prevent an accidental overwrite, this request must include valid
 `if_seq_no` and `if_primary_term` arguments.

--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -262,7 +262,7 @@ A reindex can be used to:
 * Convert an existing index alias and collection of time-based indices into a
   data stream.
 
-* Apply a new or updated <<create-a-data-stream-template,composable template>>
+* Apply a new or updated <<create-a-data-stream-template,index template>>
   by reindexing an existing data stream into a new one. This applies mapping
   and setting changes in the template to each document and backing index of the
   data stream destination. See
@@ -450,20 +450,6 @@ information for any documents matching the search.
 <3> Current sequence number for the document
 <4> Primary term for the document
 ====
-
-[source,console]
-----
-GET /*/_msearch
-{}
-{"query" : {"match_all" : {}}}
-----
-// TEST[continued]
-
-[source,console-result]
-----
-{
-}
-----
 
 You can use an <<docs-index_,index API>> request to update an individual
 document. To prevent an accidental overwrite, this request must include valid

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -55,11 +55,14 @@ this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 
 `<target>`::
 (Optional, string)
-Comma-separated list or wildcard (`*`) expression of data streams, indices,
-and index aliases used to limit the request.
+Comma-separated list or wildcard (`*`) expression of the default data streams,
+indices, and index aliases used to limit the request.
 +
-To search all data streams and indices in a cluster, use `_all` or omit this
-parameter.
+To search all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
++
+You can override this default for a specific search using the `<header>`s
+`index` request body parameter.
 
 [[search-multi-search-api-query-params]]
 ==== {api-query-parms-title}
@@ -189,6 +192,9 @@ included in the response. Defaults to `false`.
 (Optional, string or array of strings)
 Data streams, indices, and index aliases used to limit the request. Wildcard
 (`*`) expressions are supported. You can specify multiple targets as an array.
++
+If this parameter is not specified, the `<target>` request path parameter
+is used.
 
 `preference`:::
 (Optional, string)

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -1,5 +1,8 @@
 [[search-multi-search]]
-=== Multi Search API
+=== Multi search API
+++++
+<titleabbrev>Multi search</titleabbrev>
+++++
 
 Executes several searches with a single API request.
 
@@ -16,7 +19,7 @@ GET twitter/_msearch
 [[search-multi-search-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_msearch`
+`GET /<target>/_msearch`
 
 
 [[search-multi-search-api-desc]]
@@ -50,9 +53,13 @@ this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 [[search-multi-search-api-path-params]]
 ==== {api-path-parms-title}
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index]
+`<target>`::
+(Optional, string)
+Comma-separated list or wildcard (`*`) expression of data streams, indices,
+and index aliases used to limit the request.
 +
-To search all indices, use `_all` or omit this parameter.
+To search all data streams and indices in a cluster, omit this parameter or use
+`_all` or `*`.
 
 [[search-multi-search-api-query-params]]
 ==== {api-query-parms-title}
@@ -89,8 +96,8 @@ Maximum number of concurrent shard requests that each sub-search request
 executes per node.  Defaults to `5`.
 
 You can use this parameter to prevent a request from overloading a cluster. For
-example, a default request hits all indices in a cluster. This could cause shard
-request rejections if the number of shards per node is high.
+example, a default request hits all data streams and indices in a cluster. This
+could cause shard request rejections if the number of shards per node is high.
 
 In certain scenarios, parallelism isn't achieved through concurrent requests. In
 those cases, a low value in this  parameter could result in poor performance.
@@ -180,8 +187,8 @@ included in the response. Defaults to `false`.
 
 `index`:::
 (Optional, string or array of strings)
-Index name or <<indices-aliases,alias>> used to limit the request. Wildcard
-expressions are supported. You can specify multiple indices as an array.
+Data streams, indices, and index aliases used to limit the request. Wildcard
+(`*`) expressions are supported. You can specify multiple targets as an array.
 
 `preference`:::
 (Optional, string)
@@ -250,7 +257,8 @@ Number of hits to return. Defaults to `10`.
 [[search-multi-search-api-example]]
 ==== {api-examples-title}
 
-The header part includes which index / indices to search on, the `search_type`,
+The header part includes which data streams, indices, and index aliases to
+search. The header also indicates the `search_type`,
 `preference`, and `routing`. The body includes the typical search body request
 (including the `query`, `aggregations`, `from`, `size`, and so on).
 
@@ -280,9 +288,9 @@ Note, the above includes an example of an empty header (can also be just
 without any content) which is supported as well.
 
 
-The endpoint allows to also search against an index/indices in the URI itself,
-in which case it will be used as the default unless explicitly defined otherwise
-in the header. For example:
+The endpoint also allows you to search against data streams, indices, and index
+aliases in the request path. In this case, it will be used as the default target
+unless explicitly specified in the header's `index` parameter. For example:
 
 [source,console]
 --------------------------------------------------
@@ -297,8 +305,8 @@ GET twitter/_msearch
 // TEST[setup:twitter]
 
 The above will execute the search against the `twitter` index for all the
-requests that don't define an index, and the last one will be executed
-against the `twitter2` index.
+requests that don't define an `index` target in the request body. The last
+search will be executed against the `twitter2` index.
 
 The `search_type` can be set in a similar manner to globally apply to
 all search requests.

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -55,14 +55,13 @@ this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 
 `<target>`::
 (Optional, string)
-Comma-separated list or wildcard (`*`) expression of the default data streams,
-indices, and index aliases used to limit the request.
+Comma-separated list of data streams, indices, and index aliases to search.
 +
-To search all data streams and indices in a cluster, omit this parameter or use
-`_all` or `*`.
+This list acts as a fallback if a search in the request body does not specify an
+`index` target.
 +
-You can override this default for a specific search using the `<header>`s
-`index` request body parameter.
+Wildcard (`*`) expressions are supported. To search all data streams and indices
+in a cluster, omit this parameter or use `_all` or `*`.
 
 [[search-multi-search-api-query-params]]
 ==== {api-query-parms-title}
@@ -190,11 +189,11 @@ included in the response. Defaults to `false`.
 
 `index`:::
 (Optional, string or array of strings)
-Data streams, indices, and index aliases used to limit the request. Wildcard
-(`*`) expressions are supported. You can specify multiple targets as an array.
+Data streams, indices, and index aliases to search. Wildcard (`*`) expressions
+are supported. You can specify multiple targets as an array.
 +
 If this parameter is not specified, the `<target>` request path parameter
-is used.
+is used as a fallback.
 
 `preference`:::
 (Optional, string)

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -58,8 +58,8 @@ this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
 Comma-separated list or wildcard (`*`) expression of data streams, indices,
 and index aliases used to limit the request.
 +
-To search all data streams and indices in a cluster, omit this parameter or use
-`_all` or `*`.
+To search all data streams and indices in a cluster, use `_all` or omit this
+parameter.
 
 [[search-multi-search-api-query-params]]
 ==== {api-query-parms-title}


### PR DESCRIPTION
Makes the existing multi search API docs aware of data streams.