### PR TITLE
[DOCS] Add data streams to EQL search docs

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -11,7 +11,8 @@ dev::[]
 
 Returns search results for an <<eql,Event Query Language (EQL)>> query.
 
-In {es}, EQL assumes each document in an index corresponds to an event.
+In {es}, EQL assumes each document in a data stream or index corresponds to an
+event.
 
 ////
 [source,console]
@@ -44,9 +45,9 @@ GET /my_index/_eql/search
 [[eql-search-api-request]]
 ==== {api-request-title}
 
-`GET /<index>/_eql/search`
+`GET /<target>/_eql/search`
 
-`POST /<index>/_eql/search`
+`POST /<target>/_eql/search`
 
 [[eql-search-api-prereqs]]
 ==== {api-prereq-title}
@@ -61,12 +62,13 @@ See <<eql-limitations,EQL limitations>>.
 [[eql-search-api-path-params]]
 ==== {api-path-parms-title}
 
-`<index>`::
+`<target>`::
 (Required, string)
-Comma-separated list of index names or <<indices-aliases,index aliases>> used to
-limit the request. Accepts wildcard expressions.
+Comma-separated list of data streams, indices, or <<indices-aliases,index
+aliases>> used to limit the request. Accepts wildcard (`*`) expressions.
 +
-To search all indices, use `_all` or `*`.
+To search all data streams and indices in a cluster, use
+`_all` or `*`.
 
 [[eql-search-api-query-params]]
 ==== {api-query-parms-title}
@@ -157,8 +159,8 @@ Field containing the event classification, such as `process`, `file`, or
 `network`.
 +
 Defaults to `event.category`, as defined in the {ecs-ref}/ecs-event.html[Elastic
-Common Schema (ECS)]. If an index does not contain the `event.category` field,
-this value is required.
+Common Schema (ECS)]. If a data stream or index does not contain the
+`event.category` field, this value is required.
 
 `filter`::
 (Optional, <<query-dsl,query DSL object>>)
@@ -254,8 +256,8 @@ field is used to sort the events in ascending, lexicographic order.
 Field containing event timestamp.
 
 Defaults to `@timestamp`, as defined in the
-{ecs-ref}/ecs-event.html[Elastic Common Schema (ECS)]. If an index does not
-contain the `@timestamp` field, this value is required.
+{ecs-ref}/ecs-event.html[Elastic Common Schema (ECS)]. If a data stream or index
+does not contain the `@timestamp` field, this value is required.
 
 Events in the API response are sorted by this field's value, converted to
 milliseconds since the https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in

--- a/docs/reference/eql/limitations.asciidoc
+++ b/docs/reference/eql/limitations.asciidoc
@@ -13,8 +13,8 @@ dev::[]
 === EQL search on nested fields is not supported
 
 You cannot use EQL to search the values of a <<nested,`nested`>> field or the
-sub-fields of a `nested` field. However, indices containing `nested` field
-mappings are otherwise supported.
+sub-fields of a `nested` field. However, data streams and indices containing
+`nested` field mappings are otherwise supported.
 
 [discrete]
 [[eql-unsupported-syntax]]

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -24,8 +24,8 @@ with core ECS fields by default.
 In {es}, EQL assumes each document in a data stream or index corresponds to an
 event.
 
-To search a data stream or index using EQL, each document must contain the
-following field archetypes:
+To search a data stream or index using EQL, each document in the data stream or
+index must contain the following field archetypes:
 
 Event category::
 A field containing the event classification, such as `process`, `file`, or

--- a/docs/reference/eql/requirements.asciidoc
+++ b/docs/reference/eql/requirements.asciidoc
@@ -21,9 +21,10 @@ with core ECS fields by default.
 [[eql-required-fields]]
 === Required fields
 
-In {es}, EQL assumes each document in an index corresponds to an event.
+In {es}, EQL assumes each document in a data stream or index corresponds to an
+event.
 
-To search an index using EQL, each document in the index must contain the
+To search a data stream or index using EQL, each document must contain the
 following field archetypes:
 
 Event category::

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -7,12 +7,13 @@ dev::[]
 
 To start using EQL in {es}, first ensure your event data meets
 <<eql-requirements,EQL requirements>>. You can then use the <<eql-search-api,EQL
-search API>> to search event data stored in one or more {es} indices.
+search API>> to search event data stored in one or more {es} data streams or
+indices.
 
 .*Example*
 [%collapsible]
 ====
-To get started, ingest or add the data to an {es} index.
+To get started, ingest or add the data to an {es} data stream or index.
 
 The following <<docs-bulk,bulk API>> request adds some example log data to the
 `sec_logs` index. This log data follows the {ecs-ref}[Elastic Common Schema


### PR DESCRIPTION
Makes the existing EQL search docs aware of data streams.