### PR TITLE
[7.x] [DOCS] Remove `composable index template` refs (#58567)

### DIFF
--- a/docs/reference/data-streams/change-mappings-and-settings.asciidoc
+++ b/docs/reference/data-streams/change-mappings-and-settings.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Change mappings and settings</titleabbrev>
 ++++
 
-Each data stream has an <<create-a-data-stream-template,associated composable
+Each data stream has a <<create-a-data-stream-template,matching index
 template>>. Mappings and index settings from this template are applied to new
 backing indices created for the stream. This includes the stream's first
 backing index, which is auto-generated when the stream is created.
@@ -14,17 +14,17 @@ mappings and settings to include in this template. However, if you later need to
 change the mappings or settings of a data stream's backing indices, you have a
 couple options:
 
-* To apply changes to future backing indices, simply update the composable
-template associated with the data stream. Mapping and setting changes will be
+* To apply changes to future backing indices, simply update the index
+template used by the data stream. Mapping and setting changes will be
 automatically applied to any backing indices created after the update.
 +
 .*Example*
 [%collapsible]
 ====
-`logs_data_stream` is an existing composable template associated with the
+`logs_data_stream` is an existing index template used by the
 `logs` data stream.
 
-The following <<indices-templates,put composable template API>> makes several
+The following <<indices-templates,put index template API>> makes several
 changes to the `logs_data_stream` template:
 
 * It changes the `@timestamp` field mapping from the `date` field datatype to
@@ -148,9 +148,9 @@ See <<data-streams-use-reindex-to-change-mappings-settings>>.
 === Use reindex to change mappings or settings
 
 To change the mappings or settings for every backing index in a data stream, you
-must first create or update a composable template so that it contains the
-changes. You can then reindex the existing data stream into a new one associated
-with the template. This applies the mapping and setting changes in the template
+must first create or update an index template so that it contains the
+changes. You can then reindex the existing data stream into a new one matching
+the template. This applies the mapping and setting changes in the template
 to each document and backing index of the data stream destination. These changes
 also affect any future backing index created by the new stream.
 
@@ -189,11 +189,11 @@ this pattern.
 ----
 ====
 
-. Create or update a composable template. This template should contain the
+. Create or update an index template. This template should contain the
 mappings and settings you'd like to apply to the new data stream's backing
 indices.
 +
-This composable template must meet the
+This index template must meet the
 <<create-a-data-stream-template,requirements for a data stream template>>. It
 should also contain your previously chosen name or wildcard pattern in the
 `index_patterns` property.
@@ -204,11 +204,11 @@ new template by copying an existing one and modifying it as needed.
 .*Example*
 [%collapsible]
 ====
-`logs_data_stream` is an existing composable template associated with the
+`logs_data_stream` is an existing index template used by the
 `logs` data stream.
 
-The following <<indices-templates,put composable template API>> request creates
-a new composable template, `new_logs_data_stream`. `new_logs_data_stream`
+The following <<indices-templates,put index template API>> request creates
+a new index template, `new_logs_data_stream`. `new_logs_data_stream`
 uses the `logs_data_stream` template as its basis, with the following changes:
 
 * The `index_patterns` wildcard pattern matches any index or data stream

--- a/docs/reference/data-streams/data-streams-overview.asciidoc
+++ b/docs/reference/data-streams/data-streams-overview.asciidoc
@@ -10,8 +10,8 @@ documents.
 
 image::images/data-streams/data-streams-diagram.svg[align="center"]
 
-The creation of a data stream requires an associated
-<<indices-templates,composable template>>. This template acts as a blueprint for
+The creation of a data stream requires a matching
+<<indices-templates,index template>>. This template acts as a blueprint for
 the stream's backing indices. It contains:
 
 * A name or wildcard (`*`) pattern for the data stream.
@@ -22,7 +22,7 @@ the stream's backing indices. It contains:
 
 * The mappings and settings applied to each backing index when it's created.
 
-The same composable template can be used to create multiple data streams.
+The same index template can be used to create multiple data streams.
 See <<set-up-a-data-stream>>.
 
 [discrete]

--- a/docs/reference/data-streams/data-streams.asciidoc
+++ b/docs/reference/data-streams/data-streams.asciidoc
@@ -23,7 +23,7 @@ You can submit indexing and search requests directly to a data stream. The
 stream automatically routes the requests to a collection of hidden,
 auto-generated indices that store the stream's data.
 
-You can use a <<indices-templates,composable template>> and
+You can use an <<indices-templates,index template>> and
 <<index-lifecycle-management,{ilm} ({ilm-init})>> to automate the management of
 these hidden indices. You can use {ilm-init} to spin up new indices, allocate
 indices to different hardware, delete old indices, and take other automatic

--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -93,12 +93,12 @@ PUT /_ilm/policy/logs_policy
 
 [discrete]
 [[create-a-data-stream-template]]
-=== Create a composable template for a data stream
+=== Create an index template for a data stream
 
-Each data stream requires a <<indices-templates,composable template>>. The data
+Each data stream requires an <<indices-templates,index template>>. The data
 stream uses this template to create its backing indices.
 
-Composable templates for data streams must contain:
+Index templates for data streams must contain:
 
 * A name or wildcard (`*`) pattern for the data stream in the `index_patterns`
 property.
@@ -161,7 +161,7 @@ settings of a stream's backing indices may require reindexing. See
 .*Example*
 [%collapsible]
 ====
-The following <<indices-templates,put composable template API>> request
+The following <<indices-templates,put index template API>> request
 configures the `logs_data_stream` template.
 
 [source,console]
@@ -189,14 +189,14 @@ PUT /_index_template/logs_data_stream
 // TEST[continued]
 ====
 
-NOTE: You cannot delete a composable template that's in use by a data stream.
+NOTE: You cannot delete an index template that's in use by a data stream.
 This would prevent the data stream from creating new backing indices.
 
 [discrete]
 [[create-a-data-stream]]
 === Create a data stream
 
-With a composable template, you can create a data stream using one of two
+With an index template, you can create a data stream using one of two
 methods:
 
 * Submit an <<add-documents-to-a-data-stream,indexing request>> to a target

--- a/docs/reference/data-streams/use-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/use-a-data-stream.asciidoc
@@ -262,7 +262,7 @@ A reindex can be used to:
 * Convert an existing index alias and collection of time-based indices into a
   data stream.
 
-* Apply a new or updated <<create-a-data-stream-template,composable template>>
+* Apply a new or updated <<create-a-data-stream-template,index template>>
   by reindexing an existing data stream into a new one. This applies mapping
   and setting changes in the template to each document and backing index of the
   data stream destination. See

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -31,8 +31,8 @@ containing the document. See <<update-delete-docs-in-a-data-stream>>.
 `<target>`::
 (Required, string) Name of the data stream or index to target.
 +
-If the target doesn't exist and matches the name or wildcard (`*`) pattern of a
-<<create-a-data-stream-template,composable template with a `data_stream`
+If the target doesn't exist and matches the name or wildcard (`*`) pattern of an
+<<create-a-data-stream-template,index template with a `data_stream`
 definition>>, this request creates the data stream. See
 <<set-up-a-data-stream>>.
 +
@@ -143,8 +143,8 @@ exist. To update an existing document, you must use the `_doc` resource.
 [[index-creation]]
 ===== Automatically create data streams and indices
 
-If request's target doesn't exist and matches a
-<<create-a-data-stream-template,composable template with a `data_stream`
+If request's target doesn't exist and matches an
+<<create-a-data-stream-template,index template with a `data_stream`
 definition>>, the index operation automatically creates the data stream. See
 <<set-up-a-data-stream>>.
 

--- a/docs/reference/glossary.asciidoc
+++ b/docs/reference/glossary.asciidoc
@@ -273,9 +273,6 @@ Creates a new index for a rollover target when the existing index reaches a cert
 A rollover target can be either an <<indices-aliases, index alias>> or a <<data-streams, data stream>>.
 // end::rollover-def-short[]
 
-The new index is automatically configured according to any matching <<glossary-index-template,index templates>> or
-respectively, a <<indices-templates,composable index template>> if the rollover target is a
-<<data-streams, data stream>>.
 For example, if you're indexing log data, you might use rollover to create daily or weekly indices.
 See the {ref}/indices-rollover-index.html[rollover index API].
 // end::rollover-def[]

--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -28,7 +28,7 @@ To automate rollover and management of a data stream with {ilm-init}, you:
 
 . <<ilm-gs-create-policy, Create a lifecycle policy>> that defines the appropriate
 phases and actions.
-. <<ilm-gs-apply-policy, Create a composable template>> to create the data stream and
+. <<ilm-gs-apply-policy, Create an index template>> to create the data stream and
 apply the ILM policy and the indices settings and mappings configurations for the backing
 indices.
 . <<ilm-gs-check-progress, Verify indices are moving through the lifecycle phases>>
@@ -98,9 +98,9 @@ For the complete list of actions that {ilm} can perform, see <<ilm-actions>>.
 
 [discrete]
 [[ilm-gs-apply-policy]]
-=== Create a composable template to create the data stream and apply the lifecycle policy
+=== Create an index template to create the data stream and apply the lifecycle policy
 
-To set up a data stream, first create a composable template to specify the lifecycle policy. Because
+To set up a data stream, first create an index template to specify the lifecycle policy. Because
 the template is for a data stream, it must also include a `data_stream` definition.
 
 For example, you might create a `timeseries_template` to use for a future data stream
@@ -111,7 +111,7 @@ To enable the {ilm-init} to manage the data stream, the template configures one 
 * `index.lifecycle.name` specifies the name of the lifecycle policy to apply to the data stream.
 
 You can use the {kib} Create template wizard to add the template.
-This wizard invokes the put _index_template API to create the <<indices-templates,composable index template>>
+This wizard invokes the put _index_template API to create the <<indices-templates,index template>>
 with the options you specify.
 
 The underlying request looks like this:
@@ -156,7 +156,7 @@ You can also invoke this API directly to add templates.
 === Create the data stream
 
 To get things started, index a document into the name or wildcard pattern defined
-in the `index_patterns` of the <<indices-templates,composable index template>>. As long
+in the `index_patterns` of the <<indices-templates,index template>>. As long
 as an existing data stream, index, or index alias does not already use the name, the index
 request automatically creates a corresponding data stream with a single backing index.
 {es} automatically indexes the request's documents into this backing index, which also
@@ -179,7 +179,7 @@ POST timeseries/_doc
 When a rollover condition in the lifecycle policy is met, the `rollover` action:
 
 * Creates the second generation backing index, named `.ds-timeseries-000002`.
-Because it is a backing index of the `timeseries` data stream, the configuration from the `timeseries_template` composable template is applied to the new index.
+Because it is a backing index of the `timeseries` data stream, the configuration from the `timeseries_template` index template is applied to the new index.
 * As it is the latest generation index of the `timeseries` data stream, the newly created
 backing index `.ds-timeseries-000002` becomes the data stream's write index.
 

--- a/docs/reference/ilm/index-rollover.asciidoc
+++ b/docs/reference/ilm/index-rollover.asciidoc
@@ -15,7 +15,7 @@ Using rolling indices enables you to:
 We recommend using <<indices-create-data-stream, data streams>> to manage time-series
 data. Data streams automatically track the write index while keeping configuration to a minimum.
 
-Each data stream requires a <<indices-templates,composable index template>> that contains:
+Each data stream requires an <<indices-templates,index template>> that contains:
 
 * A name or wildcard (`*`) pattern for the data stream.
 

--- a/docs/reference/indices/create-data-stream.asciidoc
+++ b/docs/reference/indices/create-data-stream.asciidoc
@@ -6,7 +6,7 @@
 
 Creates a new <<data-streams,data stream>>.
 
-Data streams require an associated <<indices-templates,composable template>>.
+Data streams require a matching <<indices-templates,index template>>.
 See <<set-up-a-data-stream>>.
 
 ////


### PR DESCRIPTION
7.x backport of #58567