### PR TITLE
Fail variable_width_histogram that collects from many

### DIFF
--- a/docs/reference/aggregations/bucket/variablewidthhistogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/variablewidthhistogram-aggregation.asciidoc
@@ -57,6 +57,8 @@ Response:
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 
+IMPORTANT: This aggregation cannot currently be nested under any aggregation that collects from more than a single bucket.
+
 ==== Clustering Algorithm
 Each shard fetches the first `initial_buffer` documents and stores them in memory. Once the buffer is full, these documents
 are sorted and linearly separated into `3/4 * shard_size buckets`.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorFactory.java
@@ -65,6 +65,13 @@ public class VariableWidthHistogramAggregatorFactory extends ValuesSourceAggrega
                                           Aggregator parent,
                                           boolean collectsFromSingleBucket,
                                           Map<String, Object> metadata) throws IOException{
+        if (collectsFromSingleBucket == false) {
+            throw new IllegalArgumentException(
+                "["
+                    + VariableWidthHistogramAggregationBuilder.NAME
+                    + "] cannot be nested inside an aggregation that collects more than a single bucket."
+            );
+        }
         AggregatorSupplier aggregatorSupplier = queryShardContext.getValuesSourceRegistry().getAggregator(config,
             VariableWidthHistogramAggregationBuilder.NAME);
         if (aggregatorSupplier instanceof VariableWidthHistogramAggregatorSupplier == false) {


### PR DESCRIPTION
Adds an explicit check to `variable_width_histogram` to stop it from
trying to collect from many buckets because it can't. I tried to make it
do so but that is more than an afternoon's project, sadly. So for now we
just disallow it.

Relates to #42035
