### PR TITLE
Remove vagrant debug logging

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/vagrant/VagrantMachine.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/vagrant/VagrantMachine.java
@@ -75,7 +75,6 @@ public class VagrantMachine {
             execSpec.setEnvironment(System.getenv()); // pass through env
             execSpec.environment("VAGRANT_CWD", vagrantfile.getParentFile().toString());
             execSpec.environment("VAGRANT_VAGRANTFILE", vagrantfile.getName());
-            execSpec.environment("VAGRANT_LOG", "debug");
             extension.getHostEnv().forEach(execSpec::environment);
 
             execSpec.args(vagrantSpec.command);


### PR DESCRIPTION
Previously we had odd issues in CI with vagrant which we attempted to
diagnose by enabling debug logging within our vagrant commands. However,
the debug logging didn't explain anything additional to the failures,
and it is extremely verbose. This commit removes the debug logging.