### PR TITLE
Suppress searchable snapshots docs in releases

### DIFF
--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -6,6 +6,7 @@ Phases allowed: delete.
 
 Permanently removes the index.
 
+ifdef::permanently-unreleased-branch[]
 [[ilm-delete-options]]
 ==== Options
 
@@ -15,6 +16,7 @@ Deletes the searchable snapshot created in the cold phase.
 Defaults to `true`.
 This option is applicable when the <<ilm-searchable-snapshot-action,searchable
 snapshot>> action is used in the cold phase.
+endif::[]
 
 [[ilm-delete-action-ex]]
 ==== Example

--- a/docs/reference/ilm/actions/ilm-unfollow.asciidoc
+++ b/docs/reference/ilm/actions/ilm-unfollow.asciidoc
@@ -10,11 +10,20 @@ to be be performed safely on follower indices.
 You can also use unfollow directly when moving follower indices through the lifecycle.
 Has no effect on indices that are not followers, phase execution just moves to the next action.
 
+ifdef::permanently-unreleased-branch[]
 [NOTE]
-This action is triggered automatically by the
-<<ilm-rollover-action, rollover>>, <<ilm-shrink-action, shrink>>, 
-and <<ilm-searchable-snapshot-action, searchable snapshot>>  actions 
-when they are applied to follower indices. 
+This action is triggered automatically by the <<ilm-rollover-action, rollover>>,
+<<ilm-shrink-action, shrink>>, and
+<<ilm-searchable-snapshot-action, searchable snapshot>> actions when they are
+applied to follower indices.
+endif::[]
+
+ifndef::permanently-unreleased-branch[]
+[NOTE]
+This action is triggered automatically by the <<ilm-rollover-action, rollover>>
+and <<ilm-shrink-action, shrink>> actions when they are applied to follower
+indices.
+endif::[]
 
 This action waits until is it safe to convert a follower index into a regular index. 
 The following conditions must be met:

--- a/docs/reference/ilm/ilm-actions.asciidoc
+++ b/docs/reference/ilm/ilm-actions.asciidoc
@@ -25,9 +25,11 @@ Block write operations to the index.
 Remove the index as the write index for the rollover alias and 
 start indexing to a new index.
 
+ifdef::permanently-unreleased-branch[]
 [[ilm-searchable-snapshot-action]]<<ilm-searchable-snapshot, Searchable snapshot>>::
 Take a snapshot of the managed index in the configured repository
 and mount it as a searchable snapshot.
+endif::[]
 
 [[ilm-set-priority-action]]<<ilm-set-priority,Set priority>>::
 Lower the priority of an index as it moves through the lifecycle
@@ -38,7 +40,12 @@ Reduce the number of primary shards by shrinking the index into a new index.
 
 [[ilm-unfollow-action]]<<ilm-unfollow,Unfollow>>::
 Convert a follower index to a regular index.
+ifdef::permanently-unreleased-branch[]
+Performed automatically before a rollover or shrink action.
+endif::[]
+ifndef::permanently-unreleased-branch[]
 Performed automatically before a rollover, shrink, or searchable snapshot action. 
+endif::[]
 
 [[ilm-wait-for-snapshot-action]]<<ilm-wait-for-snapshot,Wait for snapshot>>::
 Ensure that a snapshot exists before deleting the index. 
@@ -49,7 +56,9 @@ include::actions/ilm-forcemerge.asciidoc[]
 include::actions/ilm-freeze.asciidoc[]
 include::actions/ilm-readonly.asciidoc[]
 include::actions/ilm-rollover.asciidoc[]
+ifdef::permanently-unreleased-branch[]
 include::actions/ilm-searchable-snapshot.asciidoc[]
+endif::[]
 include::actions/ilm-set-priority.asciidoc[]
 include::actions/ilm-shrink.asciidoc[]
 include::actions/ilm-unfollow.asciidoc[]

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -32,7 +32,9 @@ endif::[]
 * <<indices-reload-analyzers,Reload Search Analyzers API>>
 * <<rollup-apis,Rollup APIs>>
 * <<search, Search APIs>>
+ifdef::permanently-unreleased-branch[]
 * <<searchable-snapshots-apis, Searchable snapshots APIs>>
+endif::[]
 * <<security-api,Security APIs>>
 * <<snapshot-restore-apis,Snapshot and restore APIs>>
 * <<snapshot-lifecycle-management-api,Snapshot lifecycle management APIs>>
@@ -63,7 +65,9 @@ include::{es-repo-dir}/migration/migration.asciidoc[]
 include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::{es-repo-dir}/rollup/rollup-api.asciidoc[]
 include::{es-repo-dir}/search.asciidoc[]
+ifdef::permanently-unreleased-branch[]
 include::{es-repo-dir}/searchable-snapshots/apis/searchable-snapshots-apis.asciidoc[]
+endif::[]
 include::{xes-repo-dir}/rest-api/security.asciidoc[]
 include::{es-repo-dir}/snapshot-restore/apis/snapshot-restore-apis.asciidoc[]
 include::{es-repo-dir}/slm/apis/slm-api.asciidoc[]


### PR DESCRIPTION
This commit adds conditional logic to the docs to avoid including any
docs on searchable snapshots in released versions.

Rework of #58556 which was reverted.