### PR TITLE
Reinstate separation of cryption and signature keys for FIPS

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlResponseHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlResponseHandlerTests.java
@@ -106,7 +106,7 @@ public class SamlResponseHandlerTests extends SamlTestCase {
     public static void initCredentials() throws Exception {
         idpSigningCertificatePair = readRandomKeyPair(SamlResponseHandlerTests.randomSigningAlgorithm());
         spSigningCertificatePair = readRandomKeyPair(SamlResponseHandlerTests.randomSigningAlgorithm());
-        spEncryptionCertificatePairs = Arrays.asList(readKeyPair("RSA_2048"), readKeyPair("RSA_4096"));
+        spEncryptionCertificatePairs = Arrays.asList(readKeyPair("ENCRYPTION_RSA_2048"), readKeyPair("ENCRYPTION_RSA_4096"));
     }
 
     protected static String randomSigningAlgorithm() {


### PR DESCRIPTION
Fix an error introduced by merging master into the PR branch which accidentally undone the separation of cryption and signature keys used by FIPS tests.

Resolves: #58651