### PR TITLE
[7.x] [DOCS] EQL: Remove `fields` from EQL search response (#58667)

### DIFF
--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -502,6 +502,7 @@ GET /my_index/_eql/search
   """
 }
 ----
+// TEST[s/search/search\?filter_path\=\-\*\.events\.\*fields/]
 
 The API returns the following response. Matching events in the `hits.events`
 property are sorted by <<eql-search-api-timestamp-field,timestamp>>, converted
@@ -554,12 +555,7 @@ the events in ascending, lexicographic order.
         },
         "sort": [
           1607252647000
-        ],
-        "fields": {
-          "@timestamp": [
-            "1607252647000"
-          ]
-        }
+        ]
       },
       {
         "_index": "my_index",
@@ -590,12 +586,7 @@ the events in ascending, lexicographic order.
         },
         "sort": [
           1607339228000
-        ],
-        "fields": {
-          "@timestamp": [
-            "1607339228000"
-          ]
-        }
+        ]
       }
     ]
   }
@@ -636,6 +627,7 @@ GET /my_index/_eql/search
   """
 }
 ----
+// TEST[s/search/search\?filter_path\=\-\*\.sequences\.\*events\.\*fields/]
 
 The API returns the following response. The `hits.sequences.join_keys` property
 contains the shared `agent.id` value for each matching event. Matching events in
@@ -692,11 +684,6 @@ the events in ascending, lexicographic order.
                 "path": "C:\\Windows\\System32\\cmd.exe"
               }
             },
-            "fields": {
-              "@timestamp": [
-                "1607339228000"
-              ]
-            },
             "sort": [
               1607339228000
             ]
@@ -720,11 +707,6 @@ the events in ascending, lexicographic order.
                 "name": "regsvr32.exe",
                 "path": "C:\\Windows\\System32\\regsvr32.exe"
               }
-            },
-            "fields": {
-              "@timestamp": [
-                "1607339229000"
-              ]
             },
             "sort": [
               1607339229000

--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -58,6 +58,7 @@ GET /sec_logs/_eql/search
   """
 }
 ----
+// TEST[s/search/search\?filter_path\=\-\*\.events\.\*fields/]
 
 Because the `sec_log` index follows the ECS, you don't need to specify the
 required <<eql-required-fields,event category or timestamp>> fields. The request
@@ -99,12 +100,7 @@ https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
             "name": "cmd.exe",
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
-        },
-        "fields": {
-          "@timestamp": [
-            "1607252645000"
-          ]
-        },        
+        },      
         "sort": [
           1607252645000
         ]
@@ -128,11 +124,6 @@ https://en.wikipedia.org/wiki/Unix_time[Unix epoch], in ascending order.
             "name": "cmd.exe",
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
-        },
-        "fields": {
-          "@timestamp": [
-            "1607339167000"
-          ]
         },
         "sort": [
           1607339167000
@@ -298,7 +289,7 @@ GET /sec_logs/_eql/search
   """
 }
 ----
-// TEST[s/search/search\?filter_path\=\-\*\.sequences\.events\.\*fields/]
+// TEST[s/search/search\?filter_path\=\-\*\.sequences\.\*events\.\*fields/]
 
 The API returns the following response. The `hits.sequences.join_keys` property
 contains the shared `agent.id` value for each matching event.
@@ -463,6 +454,7 @@ GET /sec_logs/_eql/search
   """
 }
 ----
+// TEST[s/search/search\?filter_path\=\-\*\.events\.\*fields/]
 
 The API returns the following response. Note the `sort` property of each
 matching event contains an array of two items:
@@ -507,11 +499,6 @@ tiebreaker for events with the same timestamp.
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
         },
-        "fields": {
-          "@timestamp": [
-            "1607252645000"
-          ]
-        },
         "sort": [
           1607252645000,                                <1>
           "edwCRnyD"                                    <2>
@@ -536,11 +523,6 @@ tiebreaker for events with the same timestamp.
             "name": "cmd.exe",
             "path": "C:\\Windows\\System32\\cmd.exe"
           }
-        },
-        "fields": {
-          "@timestamp": [
-            "1607339167000"
-          ]
         },
         "sort": [
           1607339167000,                                <1>


### PR DESCRIPTION
7.x backport of #58667