### PR TITLE
Accounting for model size when models are not cached.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -65,9 +65,14 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                         model.infer(stringObjectMap, request.getUpdate(), chainedTask)));
 
                 typedChainTaskExecutor.execute(ActionListener.wrap(
-                    inferenceResultsInterfaces ->
-                        listener.onResponse(responseBuilder.setInferenceResults(inferenceResultsInterfaces).build()),
-                    listener::onFailure
+                    inferenceResultsInterfaces -> {
+                        model.release();
+                        listener.onResponse(responseBuilder.setInferenceResults(inferenceResultsInterfaces).build());
+                    },
+                    e -> {
+                        model.release();
+                        listener.onFailure(e);
+                    }
                 ));
             },
             listener::onFailure

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InferencePipelineAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/aggs/InferencePipelineAggregator.java
@@ -112,9 +112,11 @@ public class InferencePipelineAggregator extends PipelineAggregator {
                 newBuckets.add(newBucket);
             }
 
+            // the model is released at the end of this block.
+            assert model.getReferenceCount() > 0;
+
             return originalAgg.create(newBuckets);
         }
-
     }
 
     public static Object resolveBucketValue(MultiBucketsAggregation agg,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -205,7 +205,7 @@ public class LocalModel implements Closeable {
         return count;
     }
 
-    long getReferenceCount() {
+    public long getReferenceCount() {
         return referenceCount.get();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -197,4 +197,27 @@ public class LocalModel {
 
         return referenceCount.get();
     }
+
+    /**
+     * Used for translating field names in according to the passed `fieldMappings` parameter.
+     *
+     * This mutates the `fields` parameter in-place.
+     *
+     * Fields are only appended. If the expected field name already exists, it is not created/overwritten.
+     *
+     * Original fields are not deleted.
+     *
+     * @param fields Fields to map against
+     * @param fieldMapping Field originalName to expectedName string mapping
+     */
+    public static void mapFieldsIfNecessary(Map<String, Object> fields, Map<String, String> fieldMapping) {
+        if (fieldMapping != null) {
+            fieldMapping.forEach((src, dest) -> {
+                Object srcValue = MapHelper.dig(src, fields);
+                if (srcValue != null) {
+                    fields.putIfAbsent(dest, srcValue);
+                }
+            });
+        }
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -60,6 +60,12 @@ import java.util.concurrent.TimeUnit;
  * mode the model is not cached. All other uses will cache the model
  *
  * If more than one processor references the same model, that model will only be cached once.
+ *
+ * LocalModels are created with a reference count of 1 accounting for the reference the
+ * cache holds. When models are evicted from the cache the reference count is decremented.
+ * The {@code getModelForX} methods automatically increment the model's reference count
+ * it is up to the consumer to call {@link LocalModel#release()} when the model is no
+ * longer used.
  */
 public class ModelLoadingService implements ClusterStateListener {
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -334,8 +334,6 @@ public class ModelLoadingService implements ClusterStateListener {
                             return;
                         }
 
-                        // Remove the bytes as we cannot control how long the caller will keep the model in memory
-                        trainedModelCircuitBreaker.addWithoutBreaking(-trainedModelConfig.getEstimatedHeapMemory());
                         modelActionListener.onResponse(new LocalModel(
                             trainedModelConfig.getModelId(),
                             localNode,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.ml.inference.loadingservice;
 
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.license.License;
 import org.elasticsearch.test.ESTestCase;
@@ -45,15 +46,10 @@ import java.util.TreeMap;
 
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference.EnsembleInferenceModelTests.serializeFromTrainedModel;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class LocalModelTests extends ESTestCase {
@@ -75,7 +71,8 @@ public class LocalModelTests extends ESTestCase {
             Collections.singletonMap("field.foo", "field.foo.keyword"),
             ClassificationConfig.EMPTY_PARAMS,
             randomFrom(License.OperationMode.values()),
-            modelStatsService);
+            modelStatsService,
+            mock(CircuitBreaker.class));
         Map<String, Object> fields = new HashMap<>() {{
             put("field.foo", 1.0);
             put("field", Collections.singletonMap("bar", 0.5));
@@ -105,7 +102,8 @@ public class LocalModelTests extends ESTestCase {
             Collections.singletonMap("field.foo", "field.foo.keyword"),
             ClassificationConfig.EMPTY_PARAMS,
             License.OperationMode.PLATINUM,
-            modelStatsService);
+            modelStatsService,
+            mock(CircuitBreaker.class));
         result = getSingleValue(model, fields, ClassificationConfigUpdate.EMPTY_PARAMS);
         assertThat(result.value(), equalTo(0.0));
         assertThat(result.valueAsString(), equalTo("not_to_be"));
@@ -148,7 +146,8 @@ public class LocalModelTests extends ESTestCase {
             Collections.singletonMap("field.foo", "field.foo.keyword"),
             ClassificationConfig.EMPTY_PARAMS,
             License.OperationMode.PLATINUM,
-            modelStatsService);
+            modelStatsService,
+            mock(CircuitBreaker.class));
         Map<String, Object> fields = new HashMap<>() {{
             put("field.foo", 1.0);
             put("field.bar", 0.5);
@@ -204,7 +203,8 @@ public class LocalModelTests extends ESTestCase {
             Collections.singletonMap("bar", "bar.keyword"),
             RegressionConfig.EMPTY_PARAMS,
             License.OperationMode.PLATINUM,
-            modelStatsService);
+            modelStatsService,
+            mock(CircuitBreaker.class));
 
         Map<String, Object> fields = new HashMap<>() {{
             put("foo", 1.0);
@@ -232,7 +232,8 @@ public class LocalModelTests extends ESTestCase {
             null,
             RegressionConfig.EMPTY_PARAMS,
             License.OperationMode.PLATINUM,
-            modelStatsService);
+            modelStatsService,
+            mock(CircuitBreaker.class));
 
         Map<String, Object> fields = new HashMap<>() {{
             put("something", 1.0);
@@ -263,7 +264,8 @@ public class LocalModelTests extends ESTestCase {
             null,
             ClassificationConfig.EMPTY_PARAMS,
             License.OperationMode.PLATINUM,
-            modelStatsService
+            modelStatsService,
+            mock(CircuitBreaker.class)
         );
         Map<String, Object> fields = new HashMap<>() {{
             put("field.foo", 1.0);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -334,6 +334,7 @@ public class LocalModelTests extends ESTestCase {
                 new TrainedModelInput(inputFields),
                 null,
                 ClassificationConfig.EMPTY_PARAMS,
+                License.OperationMode.PLATINUM,
                 modelStatsService,
                 breaker
             );
@@ -341,11 +342,13 @@ public class LocalModelTests extends ESTestCase {
             model.release();
             verify(breaker, times(1)).addWithoutBreaking(eq(-definition.ramBytesUsed()));
             verifyNoMoreInteractions(breaker);
+            assertEquals(0L, model.getReferenceCount());
 
             // reacquire
             model.acquire();
             verify(breaker, times(1)).addEstimateBytesAndMaybeBreak(eq(definition.ramBytesUsed()), eq(modelId));
             verifyNoMoreInteractions(breaker);
+            assertEquals(1L, model.getReferenceCount());
         }
 
         {
@@ -356,6 +359,7 @@ public class LocalModelTests extends ESTestCase {
                 new TrainedModelInput(inputFields),
                 null,
                 ClassificationConfig.EMPTY_PARAMS,
+                License.OperationMode.PLATINUM,
                 modelStatsService,
                 breaker
             );
@@ -367,9 +371,7 @@ public class LocalModelTests extends ESTestCase {
             model.release();
             verify(breaker, times(1)).addWithoutBreaking(eq(-definition.ramBytesUsed()));
             verifyNoMoreInteractions(breaker);
-
-            model.release();
-            verifyNoMoreInteractions(breaker);
+            assertEquals(0L, model.getReferenceCount());
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModelTests.java
@@ -46,10 +46,15 @@ import java.util.TreeMap;
 
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference.EnsembleInferenceModelTests.serializeFromTrainedModel;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class LocalModelTests extends ESTestCase {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -451,6 +451,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
         });
     }
 
+    public void testReferenceCounting() {
+
+    }
+
     @SuppressWarnings("unchecked")
     private void withTrainedModel(String modelId, long size) {
         InferenceDefinition definition = mock(InferenceDefinition.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
@@ -451,8 +452,87 @@ public class ModelLoadingServiceTests extends ESTestCase {
         });
     }
 
-    public void testReferenceCounting() {
+    public void testReferenceCounting() throws ExecutionException, InterruptedException, IOException {
+        String modelId = "test-reference-counting";
+        withTrainedModel(modelId, 1L);
 
+        ModelLoadingService modelLoadingService = new ModelLoadingService(trainedModelProvider,
+            auditor,
+            threadPool,
+            clusterService,
+            trainedModelStatsService,
+            Settings.EMPTY,
+            "test-node",
+            circuitBreaker);
+
+        modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
+
+        PlainActionFuture<LocalModel> forPipeline = new PlainActionFuture<>();
+        modelLoadingService.getModelForPipeline(modelId, forPipeline);
+        LocalModel model = forPipeline.get();
+        assertEquals(2, model.getReferenceCount());
+
+        PlainActionFuture<LocalModel> forSearch = new PlainActionFuture<>();
+        modelLoadingService.getModelForPipeline(modelId, forSearch);
+        model = forSearch.get();
+        assertEquals(3, model.getReferenceCount());
+
+        model.release();
+
+        PlainActionFuture<LocalModel> forSearch2 = new PlainActionFuture<>();
+        modelLoadingService.getModelForPipeline(modelId, forSearch2);
+        model = forSearch2.get();
+        assertEquals(3, model.getReferenceCount());
+    }
+
+    public void testReferenceCountingForPipeline() throws ExecutionException, InterruptedException, IOException {
+        String modelId = "test-reference-counting-for-pipeline";
+        withTrainedModel(modelId, 1L);
+
+        ModelLoadingService modelLoadingService = new ModelLoadingService(trainedModelProvider,
+            auditor,
+            threadPool,
+            clusterService,
+            trainedModelStatsService,
+            Settings.EMPTY,
+            "test-node",
+            circuitBreaker);
+
+        modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
+
+        PlainActionFuture<LocalModel> forPipeline = new PlainActionFuture<>();
+        modelLoadingService.getModelForPipeline(modelId, forPipeline);
+        LocalModel model = forPipeline.get();
+        assertEquals(2, model.getReferenceCount());
+
+        PlainActionFuture<LocalModel> forPipeline2 = new PlainActionFuture<>();
+        modelLoadingService.getModelForPipeline(modelId, forPipeline2);
+        model = forPipeline2.get();
+        assertEquals(3, model.getReferenceCount());
+
+        // will cause the model to be evicted
+        modelLoadingService.clusterChanged(ingestChangedEvent());
+
+        assertEquals(2, model.getReferenceCount());
+    }
+
+    public void testReferenceCounting_ModelIsNotCached() throws ExecutionException, InterruptedException {
+        String modelId = "test-reference-counting-not-cached";
+        withTrainedModel(modelId, 1L);
+
+        ModelLoadingService modelLoadingService = new ModelLoadingService(trainedModelProvider,
+            auditor,
+            threadPool,
+            clusterService,
+            trainedModelStatsService,
+            Settings.EMPTY,
+            "test-node",
+            circuitBreaker);
+
+        PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
+        modelLoadingService.getModelForPipeline(modelId, future);
+        LocalModel model = future.get();
+        assertEquals(1, model.getReferenceCount());
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -478,6 +478,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         assertEquals(3, model.getReferenceCount());
 
         model.release();
+        assertEquals(2, model.getReferenceCount());
 
         PlainActionFuture<LocalModel> forSearch2 = new PlainActionFuture<>();
         modelLoadingService.getModelForPipeline(modelId, forSearch2);


### PR DESCRIPTION
When a model is loaded the amount of memory it uses is registered with the circuit breaker. If the model is evicted from the `ModelLoadingService` cache it still uses memory and that memory should not be removed from the circuit breaker until there are no users of the model. 

This is achieved with simple reference counting. When a model is retrieved from the `ModelLoadingService` the count is incremented. It is dependant on the user decrementing the count when the model is not longer required. `LocalModels` are created with a reference count of 1 because of reference held by the `ModelLoadingService` cache. When the model is evicted from the cache the cache decrements the count. 

Note a reference count of 0 does not mean the model has been garbage collected this is best effort circuit breaker accounting not real memory usage.

The `Model` interface wasn't serving much of a purpose, the only class implementing it is `LocalModel` and some of the methods were unused so I deleted it. We have lots of classes named `SomeKindOfModel`, conceptually this is one less class to think about