### PR TITLE
EQL: case sensitivity aware integration testing (#58624)

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/eql/EqlSearchRequest.java
@@ -41,6 +41,8 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
     private String timestampField = "@timestamp";
     private String eventCategoryField = "event.category";
     private String implicitJoinKeyField = "agent.id";
+    private boolean isCaseSensitive = true;
+
     private int fetchSize = 50;
     private SearchAfterBuilder searchAfterBuilder;
     private String query;
@@ -56,6 +58,7 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
     static final String KEY_TIEBREAKER_FIELD = "tiebreaker_field";
     static final String KEY_EVENT_CATEGORY_FIELD = "event_category_field";
     static final String KEY_IMPLICIT_JOIN_KEY_FIELD = "implicit_join_key_field";
+    static final String KEY_CASE_SENSITIVE = "case_sensitive";
     static final String KEY_SIZE = "size";
     static final String KEY_SEARCH_AFTER = "search_after";
     static final String KEY_QUERY = "query";
@@ -87,6 +90,8 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
         if (searchAfterBuilder != null) {
             builder.array(KEY_SEARCH_AFTER, searchAfterBuilder.getSortValues());
         }
+
+        builder.field(KEY_CASE_SENSITIVE, isCaseSensitive());
 
         builder.field(KEY_QUERY, query);
         if (waitForCompletionTimeout != null) {
@@ -150,6 +155,15 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
 
     public String implicitJoinKeyField() {
         return this.implicitJoinKeyField;
+    }
+
+    public boolean isCaseSensitive() {
+        return this.isCaseSensitive;
+    }
+
+    public EqlSearchRequest isCaseSensitive(boolean isCaseSensitive) {
+        this.isCaseSensitive = isCaseSensitive;
+        return this;
     }
 
     public EqlSearchRequest implicitJoinKeyField(String implicitJoinKeyField) {
@@ -242,6 +256,7 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
                 Objects.equals(implicitJoinKeyField, that.implicitJoinKeyField) &&
                 Objects.equals(searchAfterBuilder, that.searchAfterBuilder) &&
                 Objects.equals(query, that.query) &&
+                Objects.equals(isCaseSensitive, that.isCaseSensitive) &&
                 Objects.equals(waitForCompletionTimeout, that.waitForCompletionTimeout) &&
                 Objects.equals(keepAlive, that.keepAlive) &&
                 Objects.equals(keepOnCompletion, that.keepOnCompletion);
@@ -255,11 +270,12 @@ public class EqlSearchRequest implements Validatable, ToXContentObject {
             filter,
             fetchSize,
             timestampField,
-                tiebreakerField,
+            tiebreakerField,
             eventCategoryField,
             implicitJoinKeyField,
             searchAfterBuilder,
             query,
+            isCaseSensitive,
             waitForCompletionTimeout,
             keepAlive,
             keepOnCompletion);

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
@@ -9,111 +9,56 @@ package org.elasticsearch.test.eql;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.Build;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.client.EqlClient;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.eql.EqlSearchRequest;
 import org.elasticsearch.client.eql.EqlSearchResponse;
 import org.elasticsearch.client.eql.EqlSearchResponse.Hits;
 import org.elasticsearch.client.eql.EqlSearchResponse.Sequence;
-import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.elasticsearch.test.eql.DataLoader.testIndexName;
 
 public abstract class CommonEqlActionTestCase extends ESRestTestCase {
 
-    private RestHighLevelClient highLevelClient;
-
-    static final String indexPrefix = "endgame";
-    static final String testIndexName = indexPrefix + "-1.4.0";
     protected static final String PARAM_FORMATTING = "%1$s.test -> %2$s";
+    private RestHighLevelClient highLevelClient;
 
     @BeforeClass
     public static void checkForSnapshot() {
         assumeTrue("Only works on snapshot builds for now", Build.CURRENT.isSnapshot());
     }
 
-    private static boolean isSetUp = false;
-    private static int counter = 0;
-
-    @SuppressWarnings("unchecked")
-    private static void setupData(CommonEqlActionTestCase tc) throws Exception {
-        if (isSetUp) {
-            return;
-        }
-
-        CreateIndexRequest request = new CreateIndexRequest(testIndexName)
-                .mapping(Streams.readFully(CommonEqlActionTestCase.class.getResourceAsStream("/mapping-default.json")),
-                        XContentType.JSON);
-
-        tc.highLevelClient().indices().create(request, RequestOptions.DEFAULT);
-
-        BulkRequest bulk = new BulkRequest();
-        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-
-        try (XContentParser parser = tc.createParser(JsonXContent.jsonXContent,
-                CommonEqlActionTestCase.class.getResourceAsStream("/test_data.json"))) {
-            List<Object> list = parser.list();
-            for (Object item : list) {
-                assertThat(item, instanceOf(HashMap.class));
-                Map<String, Object> entry = (Map<String, Object>) item;
-                bulk.add(new IndexRequest(testIndexName).source(entry, XContentType.JSON));
-            }
-        }
-
-        if (bulk.numberOfActions() > 0) {
-            BulkResponse bulkResponse = tc.highLevelClient().bulk(bulk, RequestOptions.DEFAULT);
-            assertEquals(RestStatus.OK, bulkResponse.status());
-            assertFalse(bulkResponse.hasFailures());
-            isSetUp = true;
-        }
-    }
-
-    private static void cleanupData(CommonEqlActionTestCase tc) throws Exception {
-        // Delete index after all tests ran
-        if (isSetUp && (--counter == 0)) {
-            deleteIndex(testIndexName);
-            isSetUp = false;
-        }
-    }
-
-    @Override
-    protected boolean preserveClusterUponCompletion() {
-        // Need to preserve data between parameterized tests runs
-        return true;
-    }
-
     @Before
     public void setup() throws Exception {
-        setupData(this);
+        if (client().performRequest(new Request("HEAD", "/" + testIndexName)).getStatusLine().getStatusCode() == 404) {
+            DataLoader.loadDatasetIntoEs(highLevelClient(), (t, u) -> createParser(t, u));
+        }
     }
 
-    @After
-    public void cleanup() throws Exception {
-        cleanupData(this);
+    @AfterClass
+    public static void cleanup() throws Exception {
+        try {
+            adminClient().performRequest(new Request("DELETE", "/*"));
+        } catch (ResponseException e) {
+            // 404 here just means we had no indexes
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
     }
 
     @ParametersFactory(shuffle = false, argumentFormatting = PARAM_FORMATTING)
@@ -121,7 +66,7 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
 
         // Load EQL validation specs
         List<EqlSpec> specs = EqlSpecLoader.load("/test_queries.toml", true);
-        specs.addAll(EqlSpecLoader.load("/test_queries_supported.toml", true));
+        specs.addAll(EqlSpecLoader.load("/additional_test_queries.toml", true));
         List<EqlSpec> unsupportedSpecs = EqlSpecLoader.load("/test_queries_unsupported.toml", false);
 
         // Validate only currently supported specs
@@ -131,7 +76,7 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
             boolean supported = true;
             // Check if spec is supported, simple iteration, cause the list is short.
             for (EqlSpec unSpec : unsupportedSpecs) {
-                if (spec.query() != null && spec.query().equals(unSpec.query())) {
+                if (spec.equals(unSpec)) {
                     supported = false;
                     break;
                 }
@@ -141,7 +86,6 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
                 filteredSpecs.add(spec);
             }
         }
-        counter = specs.size();
         return asArray(filteredSpecs);
     }
 
@@ -171,7 +115,19 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
     }
 
     public void test() throws Exception {
-        assertResponse(runQuery(testIndexName, spec.query()));
+        // run both tests if case sensitivity doesn't matter
+        if (spec.caseSensitive() == null) {
+            assertResponse(runQuery(testIndexName, spec.query(), true));
+            assertResponse(runQuery(testIndexName, spec.query(), false));
+        }
+        // run only the case sensitive test
+        else if (spec.caseSensitive()) {
+            assertResponse(runQuery(testIndexName, spec.query(), true));
+        }
+        // run only the case insensitive test
+        else {
+            assertResponse(runQuery(testIndexName, spec.query(), false));
+        }
     }
 
     protected void assertResponse(EqlSearchResponse response) {
@@ -187,14 +143,28 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
         }
     }
 
-    protected EqlSearchResponse runQuery(String index, String query) throws Exception {
+    protected EqlSearchResponse runQuery(String index, String query, boolean isCaseSensitive) throws Exception {
         EqlSearchRequest request = new EqlSearchRequest(testIndexName, query);
+        request.isCaseSensitive(isCaseSensitive);
         request.tiebreakerField("event.sequence");
-        return eqlClient().search(request, RequestOptions.DEFAULT);
+        return highLevelClient().eql().search(request, RequestOptions.DEFAULT);
     }
 
-    protected EqlClient eqlClient() {
-        return highLevelClient().eql();
+    private RestHighLevelClient highLevelClient() {
+        if (highLevelClient == null) {
+            highLevelClient = new RestHighLevelClient(
+                    client(),
+                    ignore -> {
+                    },
+                    Collections.emptyList()) {
+            };
+        }
+        return highLevelClient;
+    }
+
+    protected void assertSearchHits(List<SearchHit> events) {
+        assertNotNull(events);
+        assertArrayEquals("unexpected result for spec: [" + spec.toString() + "]", spec.expectedEventIds(), extractIds(events));
     }
 
     private static long[] extractIds(List<SearchHit> events) {
@@ -204,11 +174,6 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
             ids[i] = ((Number) events.get(i).getSourceAsMap().get("serial_event_id")).longValue();
         }
         return ids;
-    }
-
-    protected void assertSearchHits(List<SearchHit> events) {
-        assertNotNull(events);
-        assertArrayEquals("unexpected result for spec: [" + spec.toString() + "]", spec.expectedEventIds(), extractIds(events));
     }
 
     protected void assertSequences(List<Sequence> sequences) {
@@ -228,5 +193,11 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
             };
         }
         return highLevelClient;
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        // Need to preserve data between parameterized tests runs
+        return true;
     }
 }

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/CommonEqlActionTestCase.java
@@ -150,18 +150,6 @@ public abstract class CommonEqlActionTestCase extends ESRestTestCase {
         return highLevelClient().eql().search(request, RequestOptions.DEFAULT);
     }
 
-    private RestHighLevelClient highLevelClient() {
-        if (highLevelClient == null) {
-            highLevelClient = new RestHighLevelClient(
-                    client(),
-                    ignore -> {
-                    },
-                    Collections.emptyList()) {
-            };
-        }
-        return highLevelClient;
-    }
-
     protected void assertSearchHits(List<SearchHit> events) {
         assertNotNull(events);
         assertArrayEquals("unexpected result for spec: [" + spec.toString() + "]", spec.expectedEventIds(), extractIds(events));

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +44,7 @@ public class DataLoader {
                 client,
                 ignore -> {
                 },
-                List.of()) {
+                Collections.emptyList()) {
             }, (t, u) -> createParser(t, u));
         }
     }

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.test.eql;
+
+import org.apache.http.HttpHost;
+import org.apache.logging.log4j.LogManager;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.common.CheckedBiFunction;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+public class DataLoader {
+
+    private static final String TEST_DATA = "/test_data.json";
+    private static final String MAPPING = "/mapping-default.json";
+    static final String indexPrefix = "endgame";
+    static final String testIndexName = indexPrefix + "-1.4.0";
+
+    public static void main(String[] args) throws IOException {
+        try (RestClient client = RestClient.builder(new HttpHost("localhost", 9200)).build()) {
+            loadDatasetIntoEs(new RestHighLevelClient(
+                client,
+                ignore -> {
+                },
+                List.of()) {
+            }, (t, u) -> createParser(t, u));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static void loadDatasetIntoEs(RestHighLevelClient client,
+        CheckedBiFunction<XContent, InputStream, XContentParser, IOException> p) throws IOException {
+
+        CreateIndexRequest request = new CreateIndexRequest(testIndexName)
+            .mapping(Streams.readFully(DataLoader.class.getResourceAsStream(MAPPING)), XContentType.JSON);
+
+        client.indices().create(request, RequestOptions.DEFAULT);
+
+        BulkRequest bulk = new BulkRequest();
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        try (XContentParser parser = p.apply(JsonXContent.jsonXContent, DataLoader.class.getResourceAsStream(TEST_DATA))) {
+            List<Object> list = parser.list();
+            for (Object item : list) {
+                bulk.add(new IndexRequest(testIndexName).source((Map<String, Object>) item, XContentType.JSON));
+            }
+        }
+
+        if (bulk.numberOfActions() > 0) {
+            BulkResponse bulkResponse = client.bulk(bulk, RequestOptions.DEFAULT);
+            if (bulkResponse.hasFailures()) {
+                LogManager.getLogger(DataLoader.class).info("Data FAILED loading");
+            } else {
+                LogManager.getLogger(DataLoader.class).info("Data loaded");
+            }
+        }
+    }
+
+    private static XContentParser createParser(XContent xContent, InputStream data) throws IOException {
+        NamedXContentRegistry contentRegistry = new NamedXContentRegistry(ClusterModule.getNamedXWriteables());
+        return xContent.createParser(contentRegistry, LoggingDeprecationHandler.INSTANCE, data);
+    }
+}

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpec.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpec.java
@@ -9,6 +9,7 @@ package org.elasticsearch.test.eql;
 import org.elasticsearch.common.Strings;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class EqlSpec {
     private String description;
@@ -16,6 +17,12 @@ public class EqlSpec {
     private String[] tags;
     private String query;
     private long[] expectedEventIds;
+
+    // flag to dictate which modes are supported for the test
+    // null -> apply the test to both modes (case sensitive and case insensitive)
+    // TRUE -> case sensitive
+    // FALSE -> case insensitive
+    private Boolean caseSensitive = null;
 
     public String description() {
         return description;
@@ -57,12 +64,24 @@ public class EqlSpec {
         this.expectedEventIds = expectedEventIds;
     }
 
+    public void caseSensitive(Boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public Boolean caseSensitive() {
+        return this.caseSensitive;
+    }
+
     @Override
     public String toString() {
         String str = "";
         str = appendWithComma(str, "query", query);
         str = appendWithComma(str, "description", description);
         str = appendWithComma(str, "note", note);
+
+        if (caseSensitive != null) {
+            str = appendWithComma(str, "case_sensitive", Boolean.toString(caseSensitive));
+        }
 
         if (tags != null) {
             str = appendWithComma(str, "tags", Arrays.toString(tags));
@@ -72,6 +91,27 @@ public class EqlSpec {
             str = appendWithComma(str, "expected_event_ids", Arrays.toString(expectedEventIds));
         }
         return str;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        EqlSpec that = (EqlSpec) other;
+
+        return Objects.equals(this.query(), that.query())
+                && Objects.equals(this.caseSensitive, that.caseSensitive);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.query, this.caseSensitive);
     }
 
     private static String appendWithComma(String str, String name, String append) {

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecLoader.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlSpecLoader.java
@@ -55,6 +55,20 @@ public class EqlSpecLoader {
             spec.note(getTrimmedString(table, "note"));
             spec.description(getTrimmedString(table, "description"));
 
+            Boolean caseSensitive = table.getBoolean("case_sensitive");
+            Boolean caseInsensitive = table.getBoolean("case_insensitive");
+            // if case_sensitive is TRUE and case_insensitive is not TRUE (FALSE or NULL), then the test is case sensitive only
+            if (Boolean.TRUE.equals(caseSensitive)) {
+                if (Boolean.FALSE.equals(caseInsensitive) || caseInsensitive == null) {
+                    spec.caseSensitive(true);
+                }
+            }
+            // if case_sensitive is not TRUE (FALSE or NULL) and case_insensitive is TRUE, then the test is case insensitive only
+            else if (Boolean.TRUE.equals(caseInsensitive)) {
+                spec.caseSensitive(false);
+            }
+            // in all other cases, the test should run no matter the case sensitivity (should test both scenarios)
+
             List<?> arr = table.getList("tags");
             if (arr != null) {
                 String tags[] = new String[arr.size()];

--- a/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/additional_test_queries.toml
@@ -1,5 +1,5 @@
 # This file is populated with additional EQL queries that were not present in the original EQL python implementation
-# test_queries.toml file in order to keep the original unchanges and easier to sync with the EQL reference implementation tests.
+# test_queries.toml file in order to keep the original unchanged and easier to sync with the EQL reference implementation tests.
 
 [[queries]]
 expected_event_ids = [95]
@@ -186,6 +186,28 @@ query = "file where 66.0 / serial_event_id == 1"
 expected_event_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 46]
 query = "process where serial_event_id + ((1 + 3) * 2 / (3 - 1)) * 2 == 54 or 70 + serial_event_id < 100"
 
+[[queries]]
+query = '''
+sequence
+  [process where serial_event_id = 1]
+  [process where serial_event_id = 2]
+'''
+expected_event_ids  = [1, 2]
+
+[[queries]]
+query = '''
+sequence
+  [process where serial_event_id=1] by unique_pid
+  [process where true] by unique_ppid'''
+expected_event_ids  = [1, 2]
+
+[[queries]]
+query = '''
+sequence
+  [process where serial_event_id<3] by unique_pid
+  [process where true] by unique_ppid
+'''
+expected_event_ids  = [1, 2, 2, 3]
 
 [[queries]]
 query = '''

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries.toml
@@ -24,7 +24,7 @@ query = 'process where bad_field == null | head 5'
 
 [[queries]]
 query = '''
-  process where process_name == "impossible name" or (serial_event_id < 4.5 and serial_event_id >= 3.1)
+process where process_name == "impossible name" or (serial_event_id < 4.5 and serial_event_id >= 3.1)
 '''
 expected_event_ids  = [4]
 
@@ -32,14 +32,16 @@ expected_event_ids  = [4]
 tags = ["comparisons", "pipes"]
 query = '''
 process where serial_event_id <= 8 and serial_event_id > 7
-| filter serial_event_id == 8'''
+| filter serial_event_id == 8
+'''
 expected_event_ids  = [8]
 
 [[queries]]
 query = '''
 process where true
 | filter serial_event_id <= 10
-| filter serial_event_id > 6'''
+| filter serial_event_id > 6
+'''
 expected_event_ids  = [7, 8, 9, 10]
 
 [[queries]]
@@ -47,7 +49,8 @@ query = '''
 process where true
 | filter serial_event_id <= 10
 | filter serial_event_id > 6
-| head 2'''
+| head 2
+'''
 expected_event_ids  = [7, 8]
 
 [[queries]]
@@ -67,53 +70,53 @@ process where serial_event_id<=8 and serial_event_id > 7
 expected_event_ids  = [8]
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code >= 0'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where 0 <= exit_code'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code <= 0'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code < 1'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code > -1'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where -1 < exit_code'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids = []
 query = '''
-process where not (exit_code > -1)
+process where null == (exit_code > -1)
   and serial_event_id in (58, 64, 69, 74, 80, 85, 90, 93, 94)
 | head 10
 '''
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [1, 2, 3, 4, 5, 6, 7]
-query = 'process where not (exit_code > -1) | head 7'
+query = 'process where null == (exit_code > -1) | head 7'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [1, 2, 3, 4, 5, 6, 7]
-query = 'process where not (-1 < exit_code) | head 7'
+query = 'process where null == (-1 < exit_code) | head 7'
 
 [[queries]]
 query = 'process where exit_code > 0'
@@ -140,31 +143,115 @@ query = 'process where (serial_event_id<9 and serial_event_id >= 7) or (opcode =
 expected_event_ids  = [7, 8]
 
 [[queries]]
-query = 'process where process_name == "VMACTHLP.exe" and unique_pid == 12 | filter true'
+query = 'process where process_name >= "System" and process_name <= "System Idle Process"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+# test that it works for comparing field <--> field
+case_insensitive = true
+query = 'process where serial_event_id < 5 and process_name <= parent_process_name'
+expected_event_ids  = [2, 3]
+
+[[queries]]
+case_sensitive = true
+query = 'process where serial_event_id < 5 and process_name <= parent_process_name'
+expected_event_ids  = [2]
+
+[[queries]]
+query = 'process where process_name >= "System" and process_name < "System Idle Process"'
+expected_event_ids  = [2]
+
+[[queries]]
+query = 'process where process_name > "System" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+query = 'process where process_name > "System" and process_name < "System Idle Process"'
+expected_event_ids  = []
+
+[[queries]]
+query = 'process where process_name >= "Syste" and process_name <= "Systez"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+query = 'process where process_name > "System" and process_name < "Systez"'
+expected_event_ids  = [1]
+
+[[queries]]
+query = 'process where process_name >= "System Idle Process" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+case_sensitive = true
+notes = "s == 0x73; S == 0x53"
+query = 'process where process_name >= "system idle process" and process_name <= "System Idle Process"'
+expected_event_ids  = []
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "system idle process" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "SYSTE" and process_name < "systex"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "sysT" and process_name < "SYsTeZZZ"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "SYSTE" and process_name <= "systex"'
+expected_event_ids  = [1, 2]
+
+
+[[queries]]
+case_insensitive = true
+query = '''
+process where process_name == "VMACTHLP.exe" and unique_pid == 12
+| filter true
+'''
 expected_event_ids  = [12]
 
 [[queries]]
 query = '''
-process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
-| unique process_name'''
+process where process_name in ("python.exe", "smss.exe", "explorer.exe")
+| unique process_name
+'''
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
+case_insensitive = true
+query = '''
+process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
+| unique process_name
+'''
+expected_event_ids  = [3, 34, 48]
+
+[[queries]]
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "Explorer.exe")
-| unique length(process_name)'''
+| unique length(process_name)
+'''
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
-| unique length(process_name) == length("python.exe")'''
+| unique length(process_name) == length("python.exe")
+'''
 expected_event_ids  = [3, 48]
 
 [[queries]]
+case_insensitive = true
 query = '''
 process where process_name in ("Python.exe", "smss.exe", "explorer.exe")
-| unique process_name != "python.exe"'''
+| unique process_name != "python.exe"
+'''
 expected_event_ids  = [3, 48]
 
 [[queries]]
@@ -172,7 +259,8 @@ query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
 | head 2
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [34]
 
 [[queries]]
@@ -180,32 +268,38 @@ query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
 | tail 2
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [34]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
-| unique process_name parent_process_name'''
+| unique process_name parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
-| unique process_name, parent_process_name'''
+| unique process_name, parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
 | head 5
-| unique process_name parent_process_name'''
+| unique process_name parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54]
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] == "EN"'''
+registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] == "EN"
+'''
 
 [[queries]]
 query = '''
@@ -215,13 +309,8 @@ expected_event_ids  = [79]
 
 [[queries]]
 query = '''
-registry where wildcard(key_path, "*\\MACHINE\\SAM\\SAM\\*\\Account\\Us*ers\\00*03E9\\F")
+process where process_path == "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)
 '''
-expected_event_ids  = [79]
-
-[[queries]]
-query = '''
-process where process_path == "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)'''
 expected_event_ids  = [84, 85]
 
 [[queries]]
@@ -281,42 +370,55 @@ expected_event_ids  = [65, 86]
 [[queries]]
 query = '''
 file where true
-| tail 3'''
+| tail 3
+'''
 expected_event_ids  = [92, 95, 96]
 
 [[queries]]
+query = '''
+process where opcode in (1,3) and process_name in (parent_process_name, "System")
+'''
+expected_event_ids  = [2, 50, 51]
+
+[[queries]]
+case_insensitive = true
 query = '''
 process where opcode in (1,3) and process_name in (parent_process_name, "SYSTEM")
 '''
 expected_event_ids  = [2, 50, 51]
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [92, 95, 96, 91]
 query = '''
 file where true
 | tail 4
-| sort file_path'''
+| sort file_path
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5 event_subtype_full process_name'''
+| sort md5 event_subtype_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5 event_subtype_full null_field process_name'''
+| sort md5 event_subtype_full null_field process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5, event_subtype_full, null_field, process_name'''
+| sort md5, event_subtype_full, null_field, process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1]
@@ -324,7 +426,8 @@ query = '''
 process where true
 | head 5
 | sort md5 event_subtype_full null_field process_name
-| head 2'''
+| head 2
+'''
 
 [[queries]]
 expected_event_ids  = [1, 2, 3, 4, 5]
@@ -332,9 +435,11 @@ query = '''
 process where true
 | head 5
 | sort md5 event_subtype_full null_field process_name
-| sort serial_event_id'''
+| sort serial_event_id
+'''
 
 [[queries]]
+note = "Sequence: 1-1 match"
 query = '''
 sequence
   [process where serial_event_id = 1]
@@ -343,6 +448,7 @@ sequence
 expected_event_ids  = [1, 2]
 
 [[queries]]
+note = "Sequence: many-1 match."
 query = '''
 sequence
   [process where serial_event_id < 5]
@@ -351,13 +457,192 @@ sequence
 expected_event_ids  = [4, 5]
 
 [[queries]]
+note = "Sequence: 1-1-1."
+query = '''
+sequence
+  [process where serial_event_id == 1]
+  [process where serial_event_id == 2]
+  [process where serial_event_id == 3]
+'''
+expected_event_ids  = [1, 2, 3]
+
+
+[[queries]]
+note = "Sequence: 1-many-many."
+query = '''
+sequence
+  [process where serial_event_id == 1]
+  [process where true]
+  [process where true]
+'''
+expected_event_ids  = [1, 2, 3]
+
+[[queries]]
+query = '''
+sequence
+  [process where serial_event_id <= 3]
+  [process where true]
+  [process where true]
+'''
+expected_event_ids = [1, 2, 3,
+                      2, 3, 4,
+                      3, 4, 5]
+[[queries]]
+query = '''
+sequence
+  [process where true]
+  [process where serial_event_id <= 3]
+  [process where true]
+'''
+expected_event_ids = [1, 2, 3,
+                      2, 3, 4]
+[[queries]]
+query = '''
+sequence
+  [process where true]
+  [process where true]
+  [process where serial_event_id <= 3]
+'''
+expected_event_ids  = [1, 2, 3]
+
+[[queries]]
+query = '''
+sequence
+  [process where serial_event_id <= 4]
+  [process where true]
+  [process where true]
+  [process where true]
+'''
+expected_event_ids  = [1, 2, 3, 4,
+                       2, 3, 4, 5,
+                       3, 4, 5, 6,
+                       4, 5, 6, 7]
+
+[[queries]]
+query = '''
+sequence
+  [process where true]
+  [process where serial_event_id <= 4]
+  [process where true]
+  [process where true]
+'''
+expected_event_ids  = [1, 2, 3, 4,
+                       2, 3, 4, 5,
+                       3, 4, 5, 6]
+
+[[queries]]
+query = '''
+sequence
+  [process where true]
+  [process where true]
+  [process where serial_event_id <= 4]
+  [process where true]
+'''
+expected_event_ids  = [1, 2, 3, 4,
+                       2, 3, 4, 5]
+
+[[queries]]
+query = '''
+sequence
+  [process where true]
+  [process where true]
+  [process where true]
+  [process where serial_event_id <= 4]
+'''
+expected_event_ids  = [1, 2, 3, 4]
+
+[[queries]]
+query = '''
+sequence
+  [process where true]        by unique_pid
+  [process where opcode == 1] by unique_ppid
+'''
+expected_event_ids  = [48, 53,
+                       53, 54,
+                       54, 56,
+                       97, 98]
+
+[[queries]]
+query = '''
+sequence
+  [process where true]        by unique_pid,  process_path
+  [process where opcode == 1] by unique_ppid, parent_process_path
+'''
+expected_event_ids  = [48, 53,
+                       53, 54,
+                       54, 56,
+                       97, 98]
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+until
+  [file where opcode == 2]    by unique_pid
+'''
+expected_event_ids  = []
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+until
+  [file where opcode == 200]  by unique_pid
+'''
+expected_event_ids  = [54, 55, 61, 67]
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+'''
+expected_event_ids  = [54, 55, 61, 67]
+
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+'''
+expected_event_ids  = [54, 55, 61, 67]
+
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+until
+  [file where opcode == 200]  by unique_pid,  process_path
+'''
+expected_event_ids  = [54, 55, 61, 67]
+
+[[queries]]
+note = "Sequence: 1-many match with join."
 query = '''
 sequence
   [process where serial_event_id=1] by unique_pid
-  [process where true] by unique_ppid'''
+  [process where true] by unique_ppid
+'''
 expected_event_ids  = [1, 2]
 
+
 [[queries]]
+note = "Sequence: many-many match with join."
 query = '''
 sequence
   [process where serial_event_id<3] by unique_pid
@@ -365,22 +650,37 @@ sequence
 '''
 expected_event_ids  = [1, 2, 2, 3]
 
+
 [[queries]]
+note = "Sequence: non-field based join."
 query = '''
 sequence
   [process where serial_event_id<3] by unique_pid * 2
   [process where true] by unique_ppid * 2
 '''
-expected_event_ids  = [1, 2, 2, 3]
+expected_event_ids  = [1, 2,
+                       2, 3]
 
 
 [[queries]]
+note = "Sequence: multiple non-field based joins."
 query = '''
 sequence
   [process where serial_event_id<3] by unique_pid * 2, length(unique_pid), string(unique_pid)
   [process where true] by unique_ppid * 2, length(unique_ppid), string(unique_ppid)
 '''
-expected_event_ids  = [1, 2, 2, 3]
+expected_event_ids  = [1, 2,
+                       2, 3]
+
+
+[[queries]]
+query = '''
+sequence by unique_pid
+  [process where opcode=1 and process_name == 'MSBuild.exe']
+  [network where true]
+'''
+expected_event_ids  = [75273, 75304]
+description = "test that process sequences are working correctly"
 
 
 [[queries]]
@@ -391,8 +691,10 @@ sequence
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
+| tail 2
+'''
+expected_event_ids  = [67, 68, 69, 70,
+                       72, 73, 74, 75]
 
 [[queries]]
 query = '''
@@ -402,8 +704,10 @@ sequence with maxspan=1d
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
+| tail 2
+'''
+expected_event_ids  = [67, 68, 69, 70,
+                       72, 73, 74, 75]
 
 [[queries]]
 query = '''
@@ -413,8 +717,10 @@ sequence with maxspan=1h
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
+| tail 2
+'''
+expected_event_ids  = [67, 68, 69, 70,
+                       72, 73, 74, 75]
 
 [[queries]]
 query = '''
@@ -424,8 +730,10 @@ sequence with maxspan=1m
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
+| tail 2
+'''
+expected_event_ids  = [67, 68, 69, 70,
+                       72, 73, 74, 75]
 
 [[queries]]
 query = '''
@@ -435,18 +743,21 @@ sequence with maxspan=10s
    [process where opcode == 2] by process_path
    [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
+| tail 2
+'''
+expected_event_ids  = [67, 68, 69, 70,
+                       72, 73, 74, 75]
 
 [[queries]]
 query = '''
-sequence with maxspan=0.5s
+sequence with maxspan=500ms
   [file where event_subtype_full == "file_create_event"] by file_path
   [process where opcode == 1] by process_path
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -455,7 +766,9 @@ sequence
   [process where serial_event_id < 5]
   [process where serial_event_id < 5]
 '''
-expected_event_ids  = [1, 2, 2, 3, 3, 4]
+expected_event_ids  = [1, 2,
+                       2, 3,
+                       3, 4]
 
 [[queries]]
 query = '''
@@ -470,7 +783,8 @@ query = '''
 sequence
   [file where opcode=0] by unique_pid
   [file where opcode=0] by unique_pid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [55, 61]
 
 [[queries]]
@@ -478,7 +792,8 @@ query = '''
 sequence
   [file where opcode=0] by unique_pid
   [file where opcode=0] by unique_pid
-| filter events[1].serial_event_id == 92'''
+| filter events[1].serial_event_id == 92
+'''
 expected_event_ids  = [87, 92]
 
 [[queries]]
@@ -487,7 +802,8 @@ sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=0 and file_name="*.exe"] by unique_pid
 until [process where opcode=5000] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [55, 61]
 
 [[queries]]
@@ -496,7 +812,8 @@ sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=0 and file_name="*.exe"] by unique_pid
 until [process where opcode=1] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -505,7 +822,8 @@ join
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=2 and file_name="*.exe"] by unique_pid
 until [process where opcode=1] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [61, 59]
 
 [[queries]]
@@ -521,7 +839,8 @@ query = '''
 join by unique_pid
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
-  [file where opcode == 0 and file_name == "lsass.exe"]'''
+  [file where opcode == 0 and file_name == "lsass.exe"]
+'''
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
@@ -529,7 +848,8 @@ query = '''
 join by string(unique_pid)
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
-  [file where opcode == 0 and file_name == "lsass.exe"]'''
+  [file where opcode == 0 and file_name == "lsass.exe"]
+'''
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
@@ -538,7 +858,8 @@ join by unique_pid
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
   [file where opcode == 0 and file_name == "lsass.exe"]
-until [file where opcode == 2]'''
+until [file where opcode == 2]
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -547,7 +868,8 @@ join by string(unique_pid), unique_pid, unique_pid * 2
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
   [file where opcode == 0 and file_name == "lsass.exe"]
-until [file where opcode == 2]'''
+until [file where opcode == 2]
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -562,7 +884,8 @@ expected_event_ids  = [55, 56]
 query = '''
 join by unique_pid
   [process where opcode in (1,3) and process_name="python.exe"]
-  [file where file_name == "*.exe"]'''
+  [file where file_name == "*.exe"]
+'''
 expected_event_ids  = [54, 55]
 
 [[queries]]
@@ -584,24 +907,33 @@ expected_event_ids  = [48, 3, 50, 78]
 [[queries]]
 expected_event_ids = []
 query = '''
-process where fake_field == "*"'''
+process where fake_field == "*"
+'''
 
 [[queries]]
-expected_event_ids  = [1, 2, 3, 4]
 query = '''
 process where fake_field != "*"
-| head 4'''
+| head 4
+'''
+# no longer valid, since this returns `null`, and `not null` is still null
+# expected_event_ids  = [1, 2, 3, 4]
+expected_event_ids = []
+
 
 [[queries]]
-expected_event_ids  = [1, 2, 3, 4]
 query = '''
 process where not (fake_field == "*")
-| head 4'''
+| head 4
+'''
+# no longer valid, since this returns `null`, and `not null` is still null
+# expected_event_ids  = [1, 2, 3, 4]
+expected_event_ids = []
 
 [[queries]]
 expected_event_ids = []
 query = '''
-registry where invalid_field_name != null'''
+registry where invalid_field_name != null
+'''
 
 [[queries]]
 expected_event_ids = []
@@ -615,44 +947,51 @@ process where opcode == 1
   and process_name in ("net.exe", "net1.exe")
   and not (parent_process_name == "net.exe"
   and process_name == "net1.exe")
-  and command_line == "*group *admin*" and command_line != "* /add*"'''
+  and command_line == "*group *admin*" and command_line != "* /add*"
+  '''
 expected_event_ids  = [97]
 
 [[queries]]
 expected_event_ids  = [1, 55, 57, 63, 75304]
 query = '''
 any where true
-| unique event_type_full'''
+| unique event_type_full
+'''
 
 [[queries]]
 query = '''
 process where opcode=1 and process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+'''
 expected_event_ids  = [62, 68, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+  '''
 expected_event_ids  = [62, 64, 68, 69, 78, 80]
 
 [[queries]]
 query = '''
 process where opcode=2 and process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+'''
 expected_event_ids  = [64, 69, 80]
 
 [[queries]]
 query = '''
 process where process_name="svchost.exe"
-  and child of [file where file_name="svchost.exe" and opcode=0]'''
+  and child of [file where file_name="svchost.exe" and opcode=0]
+'''
 expected_event_ids  = [56, 58]
 
 [[queries]]
 query = '''
 process where process_name="svchost.exe"
   and not child of [file where file_name="svchost.exe" and opcode=0]
-| head 3'''
+| head 3
+'''
 expected_event_ids  = [11, 13, 15]
 
 [[queries]]
@@ -672,24 +1011,28 @@ file where child of [
       process where child of [process where process_name="*wsmprovhost.exe"]
   ]
 ]
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [91]
 
 [[queries]]
 query = '''
 file where process_name = "python.exe"
-| unique unique_pid'''
+| unique unique_pid
+'''
 expected_event_ids  = [55, 95]
 
 [[queries]]
 query = '''
 file where event of [process where process_name = "python.exe" ]
-| unique unique_pid'''
+| unique unique_pid
+'''
 expected_event_ids  = [55, 95]
 
 [[queries]]
 query = '''
-process where process_name = "python.exe"'''
+process where process_name = "python.exe"
+'''
 expected_event_ids  = [48, 50, 51, 54, 93]
 
 [[queries]]
@@ -727,7 +1070,8 @@ sequence by user_name
   [process where opcode=1] by process_path
   [process where opcode=2] by process_path
   [file where opcode=2] by file_path
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [88, 89, 90, 91]
 
 [[queries]]
@@ -735,7 +1079,8 @@ query = '''
 sequence by user_name
   [file where opcode=0] by pid,file_path
   [file where opcode=2] by pid,file_path
-until [process where opcode=2] by ppid,process_path
+until
+  [process where opcode == 2] by ppid,process_path
 '''
 expected_event_ids = []
 
@@ -744,8 +1089,10 @@ query = '''
 sequence by user_name
   [file where opcode=0] by pid,file_path
   [file where opcode=2] by pid,file_path
-until [process where opcode=5] by ppid,process_path
-| head 2'''
+until
+  [process where opcode == 5] by ppid,process_path
+| head 2
+'''
 expected_event_ids  = [55, 59, 61, 65]
 
 [[queries]]
@@ -755,7 +1102,8 @@ sequence by pid
   [process where opcode=1] by process_path
   [process where opcode=2] by process_path
   [file where opcode=2] by file_path
-| tail 1'''
+| tail 1
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -763,7 +1111,8 @@ query = '''
 join by user_name
   [file where true] by pid,file_path
   [process where true] by ppid,process_path
-| head 2'''
+| head 2
+'''
 expected_event_ids  = [55, 56, 59, 58]
 
 [[queries]]
@@ -772,43 +1121,50 @@ sequence
   [process where true] by unique_pid
   [file where true] fork=true by unique_pid
   [process where true] by unique_ppid
-| head 4'''
+| head 4
+'''
 expected_event_ids  = [54, 55, 56, 54, 61, 62, 54, 67, 68, 54, 72, 73]
 
 [[queries]]
 query = '''
-process where command_line == "*%*" '''
+process where command_line == "*%*"
+'''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 query = '''
-process where command_line == "*%*%*" '''
+process where command_line == "*%*%*"
+'''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 query = '''
-process where command_line == "%*%*" '''
+process where command_line == "%*%*"
+'''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 expected_event_ids  = [11, 60, 63]
 query = '''
 any where process_name == "svchost.exe"
-| unique_count event_type_full process_name'''
+| unique_count event_type_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [63, 60, 11]
 query = '''
 any where process_name == "svchost.exe"
 | sort event_type_full serial_event_id
-| unique_count event_type_full process_name'''
+| unique_count event_type_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [60]
 query = '''
 any where process_name == "svchost.exe"
 | unique_count event_type_full opcode
-| filter count == 7'''
+| filter count == 7
+'''
 
 [[queries]]
 expected_event_ids  = [11]
@@ -818,65 +1174,108 @@ any where process_name == "svchost.exe"
 | filter percent >= .5
 '''
 
-[[queries]]
-expected_event_ids  = [57]
-query = '''
-registry where arrayContains(bytes_written_string_list, 'En-uS')'''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where arrayContains(bytes_written_string_list, 'En')'''
+registry where arrayContains(bytes_written_string_list, 'En-uS')
+'''
 
 [[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where arrayContains(bytes_written_string_list, 'En')
+'''
+
+[[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where length(bytes_written_string_list) > 0 and bytes_written_string_list[0] == 'EN-us'
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[0] == 'EN-us'
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[1] == 'EN'
 '''
 
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where arrayContains(bytes_written_string_list, 'en-US')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where arrayContains(bytes_written_string_list, 'en')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where length(bytes_written_string_list) > 0 and bytes_written_string_list[0] == 'en-US'
+'''
+
+[[queries]]
+expected_event_ids  = [57]
+query = '''
+registry where bytes_written_string_list[0] == 'en-US'
+'''
+
+[[queries]]
+expected_event_ids  = [57]
+query = '''
+registry where bytes_written_string_list[1] == 'en'
+'''
+
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+localgroup\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+localgroup\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w+\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w+\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 expected_event_ids  = [98]
 query = '''
-process where match(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where match(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+[localgrup]{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+[localgrup]{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
+case_insensitive = true
 query = '''
 process where 'net.EXE' == original_file_name
 | filter process_name="net*.exe"
@@ -885,22 +1284,41 @@ expected_event_ids  = [97]
 note = "check that case insensitive comparisons are performed even for lhs strings."
 
 [[queries]]
+case_insensitive = true
 query = '''
-process where process_name == original_file_name
-| filter process_name='net*.exe'
+process where process_name == original_file_name and process_name='net*.exe'
 '''
 expected_event_ids  = [97, 98]
 note = "check that case insensitive comparisons are performed for fields."
 
 [[queries]]
+case_insensitive = true
 query = '''
-process where original_file_name == process_name
-| filter length(original_file_name) > 0
+process where original_file_name == process_name and length(original_file_name) > 0
 '''
 expected_event_ids  = [97, 98, 75273, 75303]
 description = "check that case insensitive comparisons are performed for fields."
 
 [[queries]]
+case_sensitive = true
+query = '''
+file where opcode=0 and startsWith(file_name, 'explorer.')
+'''
+expected_event_ids  = [88]
+description = "check built-in string functions"
+
+
+[[queries]]
+case_insensitive = true
+query = '''
+file where opcode=0 and startsWith(file_name, 'explorer.')
+'''
+expected_event_ids  = [88, 92]
+description = "check built-in string functions"
+
+
+[[queries]]
+case_insensitive = true
 query = '''
 file where opcode=0 and startsWith(file_name, 'exploRER.')
 '''
@@ -908,6 +1326,7 @@ expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
+case_insensitive = true
 query = '''
 file where opcode=0 and startsWith(file_name, 'expLORER.exe')
 '''
@@ -916,25 +1335,32 @@ description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and endsWith(file_name, 'loREr.exe')'''
+file where opcode=0 and endsWith(file_name, 'lorer.exe')
+'''
+expected_event_ids  = [88]
+description = "check built-in string functions"
+
+
+[[queries]]
+case_insensitive = true
+query = '''
+file where opcode=0 and endsWith(file_name, 'loREr.exe')
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and startsWith(file_name, 'explORER.EXE')'''
-expected_event_ids  = [88, 92]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and startsWith('explorer.exeaaaaaaaa', file_name)'''
+file where opcode=0 and startsWith('explorer.exeaaaaaaaa', file_name)
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
+case_insensitive = true
 query = '''
-file where opcode=0 and serial_event_id = 88 and startsWith('explorer.exeaAAAA', 'EXPLORER.exe')'''
+file where opcode=0 and serial_event_id = 88 and startsWith('explorer.exeaAAAA', 'EXPLORER.exe')
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
@@ -946,56 +1372,100 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
+case_insensitive = true
 query = '''
-file where opcode=0 and indexOf(file_name, 'plore') == 2 and not indexOf(file_name, '.pf')
+file where opcode=0 and indexOf(file_name, 'plore') == 2 and indexOf(file_name, '.pf') == null
 '''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.') and indexOf(file_name, 'plore', 100)
+file where opcode=0 and indexOf(file_name, 'explorer.') > 0 and indexOf(file_name, 'plore', 100) > 0
+'''
+expected_event_ids = []
+description = "check built-in string functions"
+
+[[queries]]
+case_sensitive = true
+query = '''
+file where opcode=0 and indexOf(file_name, 'plorer.', 0) == 2
+'''
+expected_event_ids  = [88]
+description = "check built-in string functions"
+
+[[queries]]
+case_insensitive = true
+query = '''
+file where opcode=0 and indexOf(file_name, 'plorer.', 0) == 2
+'''
+expected_event_ids  = [88, 92]
+description = "check built-in string functions"
+
+[[queries]]
+case_sensitive = true
+query = '''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) != null
+'''
+expected_event_ids  = [88]
+description = "check built-in string functions"
+
+[[queries]]
+case_insensitive = true
+query = '''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) != null
+'''
+expected_event_ids  = [88, 92]
+description = "check built-in string functions"
+
+[[queries]]
+query = '''
+file where opcode=0 and indexOf(file_name, 'plorer.', 4) != null
 '''
 expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 0) == 2'''
-expected_event_ids  = [88, 92]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2)'''
-expected_event_ids  = [88, 92]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 4)'''
+file where opcode=0 and indexOf(file_name, 'thing that never happened') != null
+'''
 expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
+case_insensitive = true
 query = '''
-file where opcode=0 and indexOf(file_name, 'thing that never happened')'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2) == 2'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) == 2
+'''
 expected_event_ids  = [88, 92]
 description = "check substring ranges"
 
 [[queries]]
+case_sensitive = true
 query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.', 0) == 0'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) == 2
+'''
+expected_event_ids  = [88]
+description = "check substring ranges"
+
+[[queries]]
+case_sensitive = true
+query = '''
+file where opcode=0 and indexOf(file_name, 'explorer.', 0) == 0
+'''
+expected_event_ids  = [88]
+description = "check substring ranges"
+
+[[queries]]
+case_insensitive = true
+query = '''
+file where opcode=0 and indexOf(file_name, 'explorer.', 0) == 0
+'''
 expected_event_ids  = [88, 92]
 description = "check substring ranges"
 
 [[queries]]
+case_insensitive = true
 query = '''
 file where serial_event_id=88 and substring(file_name, 0, 4) == 'expl'
 '''
@@ -1003,53 +1473,67 @@ expected_event_ids  = [88]
 description = "check substring ranges"
 
 [[queries]]
+case_sensitive = true
 query = '''
-file where serial_event_id=88 and substring(file_name, 1, 3) == 'xp'
+file where substring(file_name, 1, 3) == 'xp'
 '''
-expected_event_ids  = [88]
-description = "chaeck substring ranges"
+expected_event_ids  = [88, 91]
+description = "check substring ranges"
 
 [[queries]]
+case_insensitive = true
 query = '''
-file where serial_event_id=88 and substring(file_name, -4) == '.exe'
+file where substring(file_name, 1, 3) == 'xp'
 '''
-expected_event_ids  = [88]
+expected_event_ids  = [88, 91, 92]
 description = "check substring ranges"
 
 [[queries]]
 query = '''
-file where serial_event_id=88 and substring(file_name, -4, -1) == '.ex'
+file where substring(file_name, -4) == '.exe'
 '''
-expected_event_ids  = [88]
+expected_event_ids  = [55, 59, 61, 65, 67, 70, 72, 75, 76, 81, 83, 86, 88, 91]
 description = "check substring ranges"
 
 [[queries]]
 query = '''
-process where add(serial_event_id, 0) == 1 and add(0, 1) == serial_event_id'''
+file where substring(file_name, -4, -1) == '.ex'
+'''
+expected_event_ids  = [55, 59, 61, 65, 67, 70, 72, 75, 76, 81, 83, 86, 88, 91]
+description = "check substring ranges"
+
+[[queries]]
+query = '''
+process where add(serial_event_id, 0) == 1 and add(0, 1) == serial_event_id
+'''
 expected_event_ids  = [1]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where subtract(serial_event_id, -5) == 6'''
+process where subtract(serial_event_id, -5) == 6
+'''
 expected_event_ids  = [1]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where multiply(6, serial_event_id) == 30 and divide(30, 4.0) == 7.5'''
+process where multiply(6, serial_event_id) == 30 and divide(30, 4.0) == 7.5
+'''
 expected_event_ids  = [5]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where modulo(11, add(serial_event_id, 1)) == serial_event_id'''
+process where modulo(11, add(serial_event_id, 1)) == serial_event_id
+'''
 expected_event_ids  = [1, 2, 3, 5, 11]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where serial_event_id == number('5')'''
+process where serial_event_id == number('5')
+'''
 expected_event_ids  = [5]
 description = "test string/number conversions"
 
@@ -1057,21 +1541,25 @@ description = "test string/number conversions"
 expected_event_ids  = [50]
 description = "test string/number conversions"
 query = '''
-process where serial_event_id == number('0x32', 16)'''
+process where serial_event_id == number('0x32', 16)
+'''
 
 [[queries]]
 expected_event_ids  = [50]
 description = "test string/number conversions"
 query = '''
-process where serial_event_id == number('32', 16)'''
+process where serial_event_id == number('32', 16)
+'''
 
 [[queries]]
 query = '''
-process where number(serial_event_id) == number(5)'''
+process where concat(serial_event_id, ':', process_name, opcode) == '5:wininit.exe3'
+'''
 expected_event_ids  = [5]
-description = "test string/number conversions"
+description = "test string concatenation"
 
 [[queries]]
+case_insensitive = true
 query = '''
 process where concat(serial_event_id, ':', process_name, opcode) == '5:winINIT.exe3'
 '''
@@ -1079,29 +1567,44 @@ expected_event_ids  = [5]
 description = "test string concatenation"
 
 [[queries]]
+case_insensitive = true
 query = '''
-process where process_name != original_file_name
-| filter length(original_file_name) > 0'''
+process where process_name != original_file_name and length(original_file_name) > 0
+'''
 expected_event_ids = []
 description = "check that case insensitive comparisons are performed for fields."
 
-[[queries]]
-query = '''
-sequence by unique_pid [process where opcode=1 and process_name == 'msbuild.exe'] [network where true]'''
-expected_event_ids  = [75273, 75304]
-description = "test that process sequences are working correctly"
 
 [[queries]]
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
-registry where arraySearch(bytes_written_string_list, a, a == 'en-us')'''
+registry where arraySearch(bytes_written_string_list, a, a == 'en-US')
+'''
 
 [[queries]]
+case_sensitive = true
+expected_event_ids  = []
+description = "test arraySearch functionality for lists of strings, and lists of objects"
+query = '''
+registry where arraySearch(bytes_written_string_list, a, a == 'EN-US')
+'''
+
+[[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
-registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))'''
+registry where arraySearch(bytes_written_string_list, a, a == 'en-us')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+description = "test arraySearch functionality for lists of strings, and lists of objects"
+query = '''
+registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))
+'''
 
 [[queries]]
 expected_event_ids  = [75305]
@@ -1176,6 +1679,7 @@ network where safe(divide(process_name, process_name))
 '''
 
 [[queries]]
+case_insensitive = true
 query = '''
 file where serial_event_id == 82 and (true == (process_name in ('svchost.EXE', 'bad.exe', 'bad2.exe')))
 '''
@@ -1183,18 +1687,21 @@ expected_event_ids  = [82]
 description = "nested set comparisons"
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayCount(bytes_written_string_list, s, s == '*-us') == 1
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayCount(bytes_written_string_list, s, s == '*en*') == 2
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayContains(bytes_written_string_list, "missing", "en-US")
@@ -1213,44 +1720,46 @@ expected_event_ids = [82]
 query = "file where serial_event_id * 2 == 164"
 
 [[queries]]
-expected_event_ids = [82]
+expected_event_ids = [82, 83]
 query = "file where serial_event_id / 2 == 41"
+
+[[queries]]
+expected_event_ids = [82]
+query = "file where serial_event_id / 2.0 == 41"
 
 [[queries]]
 expected_event_ids = [82]
 query = "file where serial_event_id % 40 == 2"
 
 [[queries]]
+case_insensitive = true
 expected_event_ids = [1, 2]
 query = '''
 process where between(process_name, "s", "e") == "yst"
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids = [1, 2]
 query = '''
 process where between(process_name, "s", "e", false) == "yst"
 '''
 
 [[queries]]
-expected_event_ids = []
-query = '''
-process where between(process_name, "s", "e", false, true) == "yst"
-'''
-
-[[queries]]
+case_sensitive = true
 expected_event_ids = [1, 2, 42]
 query = '''
-process where between(process_name, "s", "e", false, true) == "t"
+process where between(process_name, "s", "e", false) == "t"
 '''
 
 [[queries]]
-expected_event_ids = [1, 2]
+expected_event_ids = [1]
 query = '''
-process where between(process_name, "S", "e", false, true) == "yst"
+process where between(process_name, "S", "e", true) == "ystem Idle Proc"
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids = [1]
 query = '''
 process where between(process_name, "s", "e", true) == "ystem Idle Proc"
@@ -1259,14 +1768,15 @@ process where between(process_name, "s", "e", true) == "ystem Idle Proc"
 [[queries]]
 expected_event_ids = [95]
 query = '''
-file where between(file_path, "dev", ".json", false) == "\\testlogs\\something"
+file where between(file_path, "dev", ".json", false) == "\\TestLogs\\something"
 '''
 
 [[queries]]
 expected_event_ids = [95]
 query = '''
-file where between(file_path, "dev", ".json", true) == "\\testlogs\\something"
+file where between(file_path, "dev", ".json", true) == "\\TestLogs\\something"
 '''
+
 
 [[queries]]
 expected_event_ids = [75304, 75305]
@@ -1293,6 +1803,14 @@ network where cidrMatch(source_address, "0.0.0.0/0")
 '''
 
 [[queries]]
+case_sensitive = true
+expected_event_ids = [7, 14, 29, 44]
+query = '''
+process where length(between(process_name, 'g', 'e')) > 0
+'''
+
+[[queries]]
+case_insensitive = true
 expected_event_ids = [7, 14, 22, 29, 44]
 query = '''
 process where length(between(process_name, 'g', 'e')) > 0

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_queries_unsupported.toml
@@ -8,37 +8,60 @@
 # in order to allow at least one round-trip test with the test harness.
 # This will be removed once the EQL implementation is wired and actually supports this query.
 
-# [[queries]]
-# query = 'process where serial_event_id = 1'
-# expected_event_ids  = [1]
 
 [[queries]]
 expected_event_ids = []
 query = 'process where missing_field != null'
 
-# fails because of string check - msbuild does not match MSBuild
 [[queries]]
 query = '''
-sequence by unique_pid [process where opcode=1 and process_name == 'msbuild.exe'] [network where true]'''
-expected_event_ids  = [75273, 75304]
-description = "test that process sequences are working correctly"
+sequence
+  [process where true]        by unique_pid
+  [process where opcode == 1] by unique_ppid
+'''
+expected_event_ids  = [48, 53,
+                       53, 54,
+                       54, 56,
+                       97, 98]
+
+[[queries]]
+query = '''
+sequence
+  [process where true]        by unique_pid,  process_path
+  [process where opcode == 1] by unique_ppid, parent_process_path
+'''
+expected_event_ids  = [48, 53,
+                       53, 54,
+                       54, 56,
+                       97, 98]
+
+#############################
+# NOT (YET) SUPPORTED TESTS #
+#############################
 
 [[queries]]
 expected_event_ids = []
 query = 'process where missing_field != null'
+
+[[queries]]
+expected_event_ids  = [1, 2, 3, 4, 5]
+query = 'process where bad_field == null | head 5'
+
 
 [[queries]]
 tags = ["comparisons", "pipes"]
 query = '''
 process where serial_event_id <= 8 and serial_event_id > 7
-| filter serial_event_id == 8'''
+| filter serial_event_id == 8
+'''
 expected_event_ids  = [8]
 
 [[queries]]
 query = '''
 process where true
 | filter serial_event_id <= 10
-| filter serial_event_id > 6'''
+| filter serial_event_id > 6
+'''
 expected_event_ids  = [7, 8, 9, 10]
 
 [[queries]]
@@ -46,7 +69,8 @@ query = '''
 process where true
 | filter serial_event_id <= 10
 | filter serial_event_id > 6
-| head 2'''
+| head 2
+'''
 expected_event_ids  = [7, 8]
 
 [[queries]]
@@ -64,31 +88,82 @@ query = 'process where (serial_event_id<9 and serial_event_id >= 7) or (opcode =
 expected_event_ids  = [7, 8]
 
 [[queries]]
-query = 'process where process_name == "VMACTHLP.exe" and unique_pid == 12 | filter true'
+case_insensitive = true
+query = 'process where serial_event_id < 5 and process_name <= parent_process_name'
+expected_event_ids  = [2, 3]
+
+[[queries]]
+case_sensitive = true
+query = 'process where serial_event_id < 5 and process_name <= parent_process_name'
+expected_event_ids  = [2]
+
+
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "system idle process" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "SYSTE" and process_name < "systex"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "sysT" and process_name < "SYsTeZZZ"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "SYSTE" and process_name <= "systex"'
+expected_event_ids  = [1, 2]
+
+
+[[queries]]
+case_insensitive = true
+query = '''
+process where process_name == "VMACTHLP.exe" and unique_pid == 12
+| filter true
+'''
 expected_event_ids  = [12]
 
 [[queries]]
 query = '''
-process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
-| unique process_name'''
+process where process_name in ("python.exe", "smss.exe", "explorer.exe")
+| unique process_name
+'''
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
+case_insensitive = true
+query = '''
+process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
+| unique process_name
+'''
+expected_event_ids  = [3, 34, 48]
+
+[[queries]]
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "Explorer.exe")
-| unique length(process_name)'''
+| unique length(process_name)
+'''
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
-| unique length(process_name) == length("python.exe")'''
+| unique length(process_name) == length("python.exe")
+'''
 expected_event_ids  = [3, 48]
 
 [[queries]]
+case_insensitive = true
 query = '''
 process where process_name in ("Python.exe", "smss.exe", "explorer.exe")
-| unique process_name != "python.exe"'''
+| unique process_name != "python.exe"
+'''
 expected_event_ids  = [3, 48]
 
 [[queries]]
@@ -96,7 +171,8 @@ query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
 | head 2
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [34]
 
 [[queries]]
@@ -104,32 +180,38 @@ query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
 | tail 2
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [34]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
-| unique process_name parent_process_name'''
+| unique process_name parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
-| unique process_name, parent_process_name'''
+| unique process_name, parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
 | head 5
-| unique process_name parent_process_name'''
+| unique process_name parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54]
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] == "EN"'''
+registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] == "EN"
+'''
 
 [[queries]]
 query = '''
@@ -157,39 +239,59 @@ process where opcode=1 and process_name == "smss.exe"
 '''
 expected_event_ids  = [78]
 
+
 [[queries]]
+query = '''
+file where true
+| tail 3
+'''
+expected_event_ids  = [92, 95, 96]
+
+[[queries]]
+query = '''
+process where opcode in (1,3) and process_name in (parent_process_name, "System")
+'''
+expected_event_ids  = [2, 50, 51]
+
+[[queries]]
+case_insensitive = true
 query = '''
 process where opcode in (1,3) and process_name in (parent_process_name, "SYSTEM")
 '''
 expected_event_ids  = [2, 50, 51]
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [92, 95, 96, 91]
 query = '''
 file where true
 | tail 4
-| sort file_path'''
+| sort file_path
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5 event_subtype_full process_name'''
+| sort md5 event_subtype_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5 event_subtype_full null_field process_name'''
+| sort md5 event_subtype_full null_field process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5, event_subtype_full, null_field, process_name'''
+| sort md5, event_subtype_full, null_field, process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1]
@@ -197,7 +299,8 @@ query = '''
 process where true
 | head 5
 | sort md5 event_subtype_full null_field process_name
-| head 2'''
+| head 2
+'''
 
 [[queries]]
 expected_event_ids  = [1, 2, 3, 4, 5]
@@ -205,79 +308,77 @@ query = '''
 process where true
 | head 5
 | sort md5 event_subtype_full null_field process_name
-| sort serial_event_id'''
+| sort serial_event_id
+'''
+
 
 [[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+until
+  [file where opcode == 2]    by unique_pid
+'''
+expected_event_ids  = []
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+  [file where opcode == 0]    by unique_pid
+until
+  [file where opcode == 200]  by unique_pid
+'''
+expected_event_ids  = [54, 55, 61, 67]
+
+[[queries]]
+query = '''
+sequence
+  [process where opcode == 1] by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+  [file where opcode == 0]    by unique_pid,  process_path
+until
+  [file where opcode == 200]  by unique_pid,  process_path
+'''
+
+
+[[queries]]
+note = "Sequence: non-field based join."
 query = '''
 sequence
   [process where serial_event_id<3] by unique_pid * 2
   [process where true] by unique_ppid * 2
 '''
-expected_event_ids  = [1, 2, 2, 3]
+expected_event_ids  = [1, 2,
+                       2, 3]
 
 
 [[queries]]
+note = "Sequence: multiple non-field based joins."
 query = '''
 sequence
   [process where serial_event_id<3] by unique_pid * 2, length(unique_pid), string(unique_pid)
   [process where true] by unique_ppid * 2, length(unique_ppid), string(unique_ppid)
 '''
-expected_event_ids  = [1, 2, 2, 3]
-
+expected_event_ids  = [1, 2,
+                       2, 3]
 
 [[queries]]
 query = '''
-sequence with maxspan=1d
+sequence with maxspan=500ms
   [file where event_subtype_full == "file_create_event"] by file_path
   [process where opcode == 1] by process_path
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
-
-[[queries]]
-query = '''
-sequence with maxspan=1h
-  [file where event_subtype_full == "file_create_event"] by file_path
-  [process where opcode == 1] by process_path
-  [process where opcode == 2] by process_path
-  [file where event_subtype_full == "file_delete_event"] by file_path
-| head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
-
-[[queries]]
-query = '''
-sequence with maxspan=1m
-  [file where event_subtype_full == "file_create_event"] by file_path
-  [process where opcode == 1] by process_path
-  [process where opcode == 2] by process_path
-  [file where event_subtype_full == "file_delete_event"] by file_path
-| head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
-
-[[queries]]
-query = '''
-sequence with maxspan=10s
-   [file where event_subtype_full == "file_create_event"] by file_path
-   [process where opcode == 1] by process_path
-   [process where opcode == 2] by process_path
-   [file where event_subtype_full == "file_delete_event"] by file_path
-| head 4
-| tail 2'''
-expected_event_ids  = [67, 68, 69, 70, 72, 73, 74, 75]
-
-[[queries]]
-query = '''
-sequence with maxspan=0.5s
-  [file where event_subtype_full == "file_create_event"] by file_path
-  [process where opcode == 1] by process_path
-  [process where opcode == 2] by process_path
-  [file where event_subtype_full == "file_delete_event"] by file_path
-| head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -285,7 +386,8 @@ query = '''
 sequence
   [file where opcode=0] by unique_pid
   [file where opcode=0] by unique_pid
-| filter events[1].serial_event_id == 92'''
+| filter events[1].serial_event_id == 92
+'''
 expected_event_ids  = [87, 92]
 
 [[queries]]
@@ -293,17 +395,9 @@ query = '''
 sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=0 and file_name="*.exe"] by unique_pid
-until [process where opcode=5000] by unique_ppid
-| head 1'''
-expected_event_ids  = [55, 61]
-
-[[queries]]
-query = '''
-sequence
-  [file where opcode=0 and file_name="*.exe"] by unique_pid
-  [file where opcode=0 and file_name="*.exe"] by unique_pid
 until [process where opcode=1] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -312,7 +406,8 @@ join
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=2 and file_name="*.exe"] by unique_pid
 until [process where opcode=1] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [61, 59]
 
 [[queries]]
@@ -328,7 +423,8 @@ query = '''
 join by unique_pid
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
-  [file where opcode == 0 and file_name == "lsass.exe"]'''
+  [file where opcode == 0 and file_name == "lsass.exe"]
+'''
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
@@ -336,7 +432,8 @@ query = '''
 join by string(unique_pid)
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
-  [file where opcode == 0 and file_name == "lsass.exe"]'''
+  [file where opcode == 0 and file_name == "lsass.exe"]
+'''
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
@@ -345,7 +442,8 @@ join by unique_pid
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
   [file where opcode == 0 and file_name == "lsass.exe"]
-until [file where opcode == 2]'''
+until [file where opcode == 2]
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -354,7 +452,8 @@ join by string(unique_pid), unique_pid, unique_pid * 2
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
   [file where opcode == 0 and file_name == "lsass.exe"]
-until [file where opcode == 2]'''
+until [file where opcode == 2]
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -369,7 +468,8 @@ expected_event_ids  = [55, 56]
 query = '''
 join by unique_pid
   [process where opcode in (1,3) and process_name="python.exe"]
-  [file where file_name == "*.exe"]'''
+  [file where file_name == "*.exe"]
+'''
 expected_event_ids  = [54, 55]
 
 [[queries]]
@@ -391,24 +491,32 @@ expected_event_ids  = [48, 3, 50, 78]
 [[queries]]
 expected_event_ids = []
 query = '''
-process where fake_field == "*"'''
+process where fake_field == "*"
+'''
 
 [[queries]]
-expected_event_ids  = [1, 2, 3, 4]
+# no longer valid, since this returns `null`, and `not null` is still null
+# expected_event_ids  = [1, 2, 3, 4]
+expected_event_ids = []
 query = '''
 process where fake_field != "*"
-| head 4'''
+| head 4
+'''
 
 [[queries]]
-expected_event_ids  = [1, 2, 3, 4]
+# no longer valid, since this returns `null`, and `not null` is still null
+# expected_event_ids  = [1, 2, 3, 4]
+expected_event_ids = []
 query = '''
 process where not (fake_field == "*")
-| head 4'''
+| head 4
+'''
 
 [[queries]]
 expected_event_ids = []
 query = '''
-registry where invalid_field_name != null'''
+registry where invalid_field_name != null
+'''
 
 [[queries]]
 expected_event_ids = []
@@ -473,37 +581,43 @@ query = 'process where not (-1 < exit_code) | head 7'
 expected_event_ids  = [1, 55, 57, 63, 75304]
 query = '''
 any where true
-| unique event_type_full'''
+| unique event_type_full
+'''
 
 [[queries]]
 query = '''
 process where opcode=1 and process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+'''
 expected_event_ids  = [62, 68, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+  '''
 expected_event_ids  = [62, 64, 68, 69, 78, 80]
 
 [[queries]]
 query = '''
 process where opcode=2 and process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+'''
 expected_event_ids  = [64, 69, 80]
 
 [[queries]]
 query = '''
 process where process_name="svchost.exe"
-  and child of [file where file_name="svchost.exe" and opcode=0]'''
+  and child of [file where file_name="svchost.exe" and opcode=0]
+'''
 expected_event_ids  = [56, 58]
 
 [[queries]]
 query = '''
 process where process_name="svchost.exe"
   and not child of [file where file_name="svchost.exe" and opcode=0]
-| head 3'''
+| head 3
+'''
 expected_event_ids  = [11, 13, 15]
 
 [[queries]]
@@ -523,20 +637,29 @@ file where child of [
       process where child of [process where process_name="*wsmprovhost.exe"]
   ]
 ]
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [91]
 
 [[queries]]
 query = '''
 file where process_name = "python.exe"
-| unique unique_pid'''
+| unique unique_pid
+'''
 expected_event_ids  = [55, 95]
 
 [[queries]]
 query = '''
 file where event of [process where process_name = "python.exe" ]
-| unique unique_pid'''
+| unique unique_pid
+'''
 expected_event_ids  = [55, 95]
+
+[[queries]]
+query = '''
+process where process_name = "python.exe"
+'''
+expected_event_ids  = [48, 50, 51, 54, 93]
 
 [[queries]]
 query = 'process where event of [process where process_name = "python.exe" ]'
@@ -547,7 +670,8 @@ query = '''
 sequence by user_name
   [file where opcode=0] by pid,file_path
   [file where opcode=2] by pid,file_path
-until [process where opcode=2] by ppid,process_path
+until
+  [process where opcode == 2] by ppid,process_path
 '''
 expected_event_ids = []
 
@@ -556,8 +680,10 @@ query = '''
 sequence by user_name
   [file where opcode=0] by pid,file_path
   [file where opcode=2] by pid,file_path
-until [process where opcode=5] by ppid,process_path
-| head 2'''
+until
+  [process where opcode == 5] by ppid,process_path
+| head 2
+'''
 expected_event_ids  = [55, 59, 61, 65]
 
 [[queries]]
@@ -565,7 +691,8 @@ query = '''
 join by user_name
   [file where true] by pid,file_path
   [process where true] by ppid,process_path
-| head 2'''
+| head 2
+'''
 expected_event_ids  = [55, 56, 59, 58]
 
 [[queries]]
@@ -574,43 +701,32 @@ sequence
   [process where true] by unique_pid
   [file where true] fork=true by unique_pid
   [process where true] by unique_ppid
-| head 4'''
+| head 4
+'''
 expected_event_ids  = [54, 55, 56, 54, 61, 62, 54, 67, 68, 54, 72, 73]
-
-[[queries]]
-query = '''
-process where command_line == "*%*" '''
-expected_event_ids  = [4, 6, 28]
-
-[[queries]]
-query = '''
-process where command_line == "*%*%*" '''
-expected_event_ids  = [4, 6, 28]
-
-[[queries]]
-query = '''
-process where command_line == "%*%*" '''
-expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 expected_event_ids  = [11, 60, 63]
 query = '''
 any where process_name == "svchost.exe"
-| unique_count event_type_full process_name'''
+| unique_count event_type_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [63, 60, 11]
 query = '''
 any where process_name == "svchost.exe"
 | sort event_type_full serial_event_id
-| unique_count event_type_full process_name'''
+| unique_count event_type_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [60]
 query = '''
 any where process_name == "svchost.exe"
 | unique_count event_type_full opcode
-| filter count == 7'''
+| filter count == 7
+'''
 
 [[queries]]
 expected_event_ids  = [11]
@@ -620,65 +736,109 @@ any where process_name == "svchost.exe"
 | filter percent >= .5
 '''
 
-[[queries]]
-expected_event_ids  = [57]
-query = '''
-registry where arrayContains(bytes_written_string_list, 'En-uS')'''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where arrayContains(bytes_written_string_list, 'En')'''
+registry where arrayContains(bytes_written_string_list, 'En-uS')
+'''
 
 [[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where arrayContains(bytes_written_string_list, 'En')
+'''
+
+[[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where length(bytes_written_string_list) > 0 and bytes_written_string_list[0] == 'EN-us'
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[0] == 'EN-us'
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[1] == 'EN'
 '''
 
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where arrayContains(bytes_written_string_list, 'en-US')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where arrayContains(bytes_written_string_list, 'en')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+query = '''
+registry where length(bytes_written_string_list) > 0 and bytes_written_string_list[0] == 'en-US'
+'''
+
+[[queries]]
+expected_event_ids  = [57]
+query = '''
+registry where bytes_written_string_list[0] == 'en-US'
+'''
+
+[[queries]]
+expected_event_ids  = [57]
+query = '''
+registry where bytes_written_string_list[1] == 'en'
+'''
+
+# character classes aren't supported. custom tests made in test_queries_supported.toml
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+localgroup\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+localgroup\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w+\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w+\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
 expected_event_ids  = [98]
 query = '''
-process where match(?'.*?net1\s+\w{4,15}\s+.*?', command_line)
+process where match(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 
 [[queries]]
 query = '''
-process where matchLite(?'.*?net1\s+[localgrup]{4,15}\s+.*?', command_line)
+process where matchLite(command_line, ?'.*?net1\s+[localgrup]{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
+case_insensitive = true
 query = '''
 process where 'net.EXE' == original_file_name
 | filter process_name="net*.exe"
@@ -687,81 +847,38 @@ expected_event_ids  = [97]
 note = "check that case insensitive comparisons are performed even for lhs strings."
 
 [[queries]]
+case_insensitive = true
 query = '''
-process where process_name == original_file_name
-| filter process_name='net*.exe'
+process where process_name == original_file_name and process_name='net*.exe'
 '''
 expected_event_ids  = [97, 98]
 note = "check that case insensitive comparisons are performed for fields."
 
 [[queries]]
+case_insensitive = true
 query = '''
-process where original_file_name == process_name
-| filter length(original_file_name) > 0
+process where original_file_name == process_name and length(original_file_name) > 0
 '''
 expected_event_ids  = [97, 98, 75273, 75303]
 description = "check that case insensitive comparisons are performed for fields."
 
 [[queries]]
+case_insensitive = true
 query = '''
-file where opcode=0 and stringContains('ABCDEFGHIexplorer.exeJKLMNOP', file_name)
+file where substring(file_name, 1, 3) == 'xp'
 '''
-expected_event_ids  = [88]
-description = "check built-in string functions"
+expected_event_ids  = [88, 91, 92]
+description = "check substring ranges"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plore') == 2 and not indexOf(file_name, '.pf')
+process where modulo(11, add(serial_event_id, 1)) == serial_event_id
 '''
-expected_event_ids  = [88]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.') and indexOf(file_name, 'plore', 100)
-'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2)'''
-expected_event_ids  = [88, 92]
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 4)'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
-query = '''
-file where opcode=0 and indexOf(file_name, 'thing that never happened')'''
-expected_event_ids = []
-description = "check built-in string functions"
-
-[[queries]]
-# This query give a different result with ES EQL implementation because it doesn't convert to float data types for division
-expected_event_ids = [82]
-query = "file where serial_event_id / 2 == 41"
-
-[[queries]]
-# Error: Line 1:42: Comparisons against fields are not (currently) supported; offender [serial_event_id] in [==]
-query = '''
-process where modulo(11, add(serial_event_id, 1)) == serial_event_id'''
 expected_event_ids  = [1, 2, 3, 5, 11]
 description = "test built-in math functions"
 
-
-# this should be removed and the number function should be updated to take only strings
 [[queries]]
-query = '''
-process where number(serial_event_id) == number(5)'''
-expected_event_ids  = [5]
-description = "test string/number conversions"
-
-[[queries]]
+case_insensitive = true
 query = '''
 process where concat(serial_event_id, ':', process_name, opcode) == '5:winINIT.exe3'
 '''
@@ -769,23 +886,44 @@ expected_event_ids  = [5]
 description = "test string concatenation"
 
 [[queries]]
+case_insensitive = true
 query = '''
-process where process_name != original_file_name
-| filter length(original_file_name) > 0'''
+process where process_name != original_file_name and length(original_file_name) > 0
+'''
 expected_event_ids = []
 description = "check that case insensitive comparisons are performed for fields."
 
-[[queries]]
-expected_event_ids  = [57]
-description = "test arraySearch functionality for lists of strings, and lists of objects"
-query = '''
-registry where arraySearch(bytes_written_string_list, a, a == 'en-us')'''
 
 [[queries]]
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
-registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))'''
+registry where arraySearch(bytes_written_string_list, a, a == 'en-US')
+'''
+
+[[queries]]
+case_sensitive = true
+expected_event_ids  = []
+description = "test arraySearch functionality for lists of strings, and lists of objects"
+query = '''
+registry where arraySearch(bytes_written_string_list, a, a == 'EN-US')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+description = "test arraySearch functionality for lists of strings, and lists of objects"
+query = '''
+registry where arraySearch(bytes_written_string_list, a, a == 'en-us')
+'''
+
+[[queries]]
+case_insensitive = true
+expected_event_ids  = [57]
+description = "test arraySearch functionality for lists of strings, and lists of objects"
+query = '''
+registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))
+'''
 
 [[queries]]
 expected_event_ids  = [75305]
@@ -860,6 +998,7 @@ network where safe(divide(process_name, process_name))
 '''
 
 [[queries]]
+case_insensitive = true
 query = '''
 file where serial_event_id == 82 and (true == (process_name in ('svchost.EXE', 'bad.exe', 'bad2.exe')))
 '''
@@ -867,49 +1006,47 @@ expected_event_ids  = [82]
 description = "nested set comparisons"
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayCount(bytes_written_string_list, s, s == '*-us') == 1
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayCount(bytes_written_string_list, s, s == '*en*') == 2
 '''
 
 [[queries]]
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayContains(bytes_written_string_list, "missing", "en-US")
 '''
 
-# The following two "between" queries behave slightly different with elasticsearch
-# due to comparison on keyword field would be case-sensitive and would need to be
-# file where between(file_path, "dev", ".json", false) == "\\TestLogs\\something"
-# blacklisted, check for modified query in test_queries_supported.toml
+# TODO: update toggles for this function
 [[queries]]
-expected_event_ids = [95]
+case_sensitive = true
+expected_event_ids = [1, 2, 42]
 query = '''
-file where between(file_path, "dev", ".json", false) == "\\testlogs\\something"
+process where between(process_name, "s", "e", false) == "t"
 '''
 
-# blacklisted, check for modified query in test_queries_supported.toml
+# TODO: add toggles to this function so it's not always insensitive
 [[queries]]
-expected_event_ids = [95]
-query = '''
-file where between(file_path, "dev", ".json", true) == "\\testlogs\\something"
-'''
-
-[[queries]]
-expected_event_ids = [7, 14, 22, 29, 44]
+case_sensitive = true
+expected_event_ids = [7, 14, 29, 44]
 query = '''
 process where length(between(process_name, 'g', 'e')) > 0
 '''
 
-[[queries]]
-expected_event_ids = []
-query = '''
-process where length(between(process_name, 'g', 'z')) > 0
-'''
+# TODO: add toggles to this function so it's not always insensitive
+#[[queries]]
+#case_insensitive = true
+#expected_event_ids = [7, 14, 22, 29, 44]
+#query = '''
+#process where length(between(process_name, 'g', 'e')) > 0
+#'''
 


### PR DESCRIPTION
(backport of https://github.com/elastic/elasticsearch/pull/58624)
* Add DataLoader
* Rewrite case sensitivity settings:
NULL -> run both case sensitive and insensitive tests
TRUE -> run case sensitive test only
FALSE -> run case insensitive test only
* Rename test_queries_supported
* Add more toml tests from the Python client

Co-authored-by: Ross Wolf <31489089+rw-access@users.noreply.github.com>
(cherry picked from commit 34d383421599f060a5c083b40df35f135de49e39)
