### PR TITLE
[ML] fix ml inference stats tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
@@ -96,6 +96,40 @@ setup:
               }
             ]
           }
+  # automatically create concrete index so shards get allocated
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      index:
+        index: .ml-stats-000001
+        body: >
+          {
+          }
+  # reference and then de-reference a model to flush the stats
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ingest.put_pipeline:
+        id: "regression-model-pipeline-2"
+        body:  >
+          {
+            "processors": [
+              {
+                "inference" : {
+                  "model_id" : "a-unused-regression-model",
+                  "inference_config": {"regression": {}},
+                  "target_field": "regression_field",
+                  "field_map": {}
+                }
+              }
+            ]
+          }
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ingest.delete_pipeline:
+        id: "regression-model-pipeline-2"
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser


### PR DESCRIPTION
Inference _stats calls require to read the `.ml-stats-*` indices if they exist. 

The `.ml-stats-*` index is created out-of-band of inference calls and it may or may not be in the middle of creating when a call to `_stats` is made. To prevent test flakiness, this commits adds the following set up:
 - a direct call to the concrete `.ml-stats-*` index 
 - flushes the inference stats 

closes: https://github.com/elastic/elasticsearch/issues/58662