### PR TITLE
[DOCS] Remove data stream refs from create snapshot API docs

### DIFF
--- a/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/create-snapshot-api.asciidoc
@@ -49,15 +49,16 @@ NOTE: You must register a snapshot before performing snapshot and restore operat
 
 The snapshot process is incremental. When creating a snapshot, {es} analyzes the list of files that are already stored in the repository and copies only files that were created or changed since the last snapshot. This process allows multiple snapshots to be preserved in the repository in a compact form.
 
-The snapshot process is executed in non-blocking fashion, so all indexing and searching operations can run concurrently against the data stream or index that {es} is snapshotting. Only one snapshot process can run in the cluster at any time.
+The snapshot process is executed in non-blocking fashion, so all indexing and searching operations can run concurrently against the index that {es} is snapshotting. Only one snapshot process can run in the cluster at any time.
 
-A snapshot represents a point-in-time view of the moment when the snapshot was created. No records that were added to a data stream or index after the snapshot process started will be present in the snapshot.
+A snapshot represents a point-in-time view of the moment when the snapshot was created. No records that were added to an
+index after the snapshot process started will be present in the snapshot.
 
 For primary shards that have not been started and are not currently relocating, the snapshot process starts immediately. If shards are in the process of starting or relocating, {es} waits for these processes to complete before taking a snapshot.
 
 IMPORTANT: While a snapshot of a particular shard is being created, this shard cannot be moved to another node. Relocating a shard during the snapshot process can interfere with rebalancing and allocation filtering. {es} can move a shard to another node (according to the current allocation filtering settings and rebalancing algorithm) only after the snapshot process completes.
 
-Besides creating a copy of each data stream and index, the snapshot process can also store global cluster metadata, including persistent cluster settings and templates. The transient settings and registered snapshot repositories are not stored as part of the snapshot.
+Besides creating a copy of each index, the snapshot process can also store global cluster metadata, including persistent cluster settings and templates. The transient settings and registered snapshot repositories are not stored as part of the snapshot.
 
 [[create-snapshot-api-path-params]]
 ==== {api-path-parms-title}
@@ -76,7 +77,7 @@ Name of the snapshot to create. This name must be unique in the snapshot reposit
 
 `ignore_unavailable`::
 (Optional, boolean)
-If `false`, the request returns an error for any data stream or index that is missing or closed. Defaults to `false`.
+If `false`, the request returns an error for any index that is missing or closed. Defaults to `false`.
 +
 If `true`, the request ignores and indices in `indices` that are missing or closed.
 


### PR DESCRIPTION
Removes several data stream refs 
erroneously added with #58694.