### PR TITLE
Skip over metadata fields in the field retrieval API.

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldValueRetriever.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldValueRetriever.java
@@ -52,7 +52,7 @@ public class FieldValueRetriever {
 
             Collection<String> concreteFields = mapperService.simpleMatchToFullName(fieldPattern);
             for (String field : concreteFields) {
-                if (fieldMappers.getMapper(field) != null) {
+                if (fieldMappers.getMapper(field) != null && mapperService.isMetadataField(field) == false) {
                     Set<String> sourcePath = mapperService.sourcePath(field);
                     fields.add(new FieldContext(field, sourcePath, format));
                 }
@@ -61,6 +61,7 @@ public class FieldValueRetriever {
 
         return new FieldValueRetriever(fieldMappers, fields);
     }
+
 
     private FieldValueRetriever(DocumentFieldMappers fieldMappers,
                                 List<FieldContext> fieldContexts) {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldValueRetrieverTests.java
@@ -93,6 +93,29 @@ public class FieldValueRetrieverTests extends ESSingleNodeTestCase {
         assertThat(fields.size(), equalTo(0));
     }
 
+    public void testMetadataFields() throws IOException {
+        MapperService mapperService = createMapperService();
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .field("field", "value")
+        .endObject();
+
+        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "_routing");
+        assertTrue(fields.isEmpty());
+    }
+
+    public void testRetrieveAllFields() throws IOException {
+        MapperService mapperService = createMapperService();
+        XContentBuilder source = XContentFactory.jsonBuilder().startObject()
+            .field("field", "value")
+            .startObject("object")
+                .field("field", "other-value")
+            .endObject()
+        .endObject();
+
+        Map<String, DocumentField> fields = retrieveFields(mapperService, source, "*");
+        assertThat(fields.size(), equalTo(2));
+    }
+
     public void testArrayValueMappers() throws IOException {
         MapperService mapperService = createMapperService();
 


### PR DESCRIPTION
This avoids unnecessary lookups, since metadata fields don't have _source
values. Plus, many of them already come back as top-level fields in the search
response, such as `_id`, `_index`, `_routing`, etc.

In the future we can consider support for metadata fields like `_size`, that
must be explicitly retrieved but whose values aren't stored in the document
source.