### PR TITLE
#55065: Add DATEFORMAT function. 

### DIFF
--- a/docs/reference/sql/functions/index.asciidoc
+++ b/docs/reference/sql/functions/index.asciidoc
@@ -54,6 +54,7 @@
 ** <<sql-functions-datetime-add>>
 ** <<sql-functions-datetime-diff>>
 ** <<sql-functions-datetime-datetimeformat>>
+** <<sql-functions-datetime-dateformat>>
 ** <<sql-functions-datetime-datetimeparse>>
 ** <<sql-functions-datetime-timeparse>>
 ** <<sql-functions-datetime-part>>

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateAdd;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateDiff;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DatePart;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFormat;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateFormat; //modified
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeParse;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTrunc;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayName;
@@ -173,6 +174,7 @@ public class SqlFunctionRegistry extends FunctionRegistry {
                 def(DateDiff.class, DateDiff::new, "DATEDIFF", "DATE_DIFF", "TIMESTAMPDIFF", "TIMESTAMP_DIFF"),
                 def(DatePart.class, DatePart::new, "DATEPART", "DATE_PART"),
                 def(DateTimeFormat.class, DateTimeFormat::new, "DATETIME_FORMAT"),
+                def(DateFormat.class, DateFormat::new, "DATE_FORMAT"),
                 def(DateTimeParse.class, DateTimeParse::new, "DATETIME_PARSE"),
                 def(DateTrunc.class, DateTrunc::new, "DATETRUNC", "DATE_TRUNC"),
                 def(HourOfDay.class, HourOfDay::new, "HOUR_OF_DAY", "HOUR"),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/Processors.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/Processors.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateDiffP
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DatePartProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFormatProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeParseProcessor;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateFormatProcessor; //modified
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTruncProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.NamedDateTimeProcessor;
@@ -57,7 +58,7 @@ public final class Processors {
      */
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
-        
+
         entries.addAll(org.elasticsearch.xpack.ql.expression.processor.Processors.getNamedWriteables());
 
         // base
@@ -84,6 +85,7 @@ public final class Processors {
         entries.add(new Entry(Processor.class, DateTimeFormatProcessor.NAME, DateTimeFormatProcessor::new));
         entries.add(new Entry(Processor.class, DateTimeParseProcessor.NAME, DateTimeParseProcessor::new));
         entries.add(new Entry(Processor.class, DateTimeProcessor.NAME, DateTimeProcessor::new));
+        entries.add(new Entry(Processor.class, DateTimeFormatProcessor.NAME, DateFormatProcessor::new)); //modified
         entries.add(new Entry(Processor.class, DateTruncProcessor.NAME, DateTruncProcessor::new));
         entries.add(new Entry(Processor.class, NamedDateTimeProcessor.NAME, NamedDateTimeProcessor::new));
         entries.add(new Entry(Processor.class, NonIsoDateTimeProcessor.NAME, NonIsoDateTimeProcessor::new));

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormat.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormat.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+    import org.elasticsearch.xpack.ql.expression.Expression;
+    import org.elasticsearch.xpack.ql.tree.NodeInfo;
+    import org.elasticsearch.xpack.ql.tree.Source;
+    import java.time.ZoneId;
+
+public class DateFormat extends DateTimeFormat {
+
+    public DateFormat(Source source, Expression timestamp, Expression pattern, ZoneId zoneId) {
+        super(source, timestamp, pattern, zoneId);
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, DateFormat::new, left(), right(), zoneId());
+    }
+
+
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormatProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormatProcessor.java
@@ -1,0 +1,105 @@
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+import org.apache.lucene.queryparser.flexible.core.util.StringUtils;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.xpack.ql.expression.gen.processor.Processor;
+import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+import org.locationtech.jts.util.StringUtil;
+
+import java.io.IOException;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+
+import static org.elasticsearch.xpack.sql.util.DateUtils.UTC;
+
+public class DateFormatProcessor extends DateTimeFormatProcessor {
+
+    private static Map<String,String> formatMap = null;
+
+    private static Map<String, String> getPatternMap() {
+
+        if (formatMap != null) {
+            return formatMap;
+        }
+
+        formatMap = new HashMap<>();
+        formatMap.put("%a", "EEE");
+        formatMap.put("%b", "MMM");
+        formatMap.put("%c", "MM");
+        formatMap.put("%D", "dd");
+        formatMap.put("%d", "dd");
+        formatMap.put("%e", "dd");
+        formatMap.put("%H", "HH");
+        formatMap.put("%h", "hh");
+        formatMap.put("%I", "hh");
+        formatMap.put("%i", "mm");
+        formatMap.put("%j", "DDD");
+        formatMap.put("%k", "H");
+        formatMap.put("%l", "hh");
+        formatMap.put("%M", "MMMM");
+        formatMap.put("%m", "MM");
+        formatMap.put("%p", "a");
+        formatMap.put("%r", "hh:mm:ss a");
+        formatMap.put("%S", "ss");
+        formatMap.put("%s", "ss");
+        formatMap.put("%W", "EEEE");
+        formatMap.put("%w", "F");
+        formatMap.put("%Y", "yyyy");
+        formatMap.put("%y", "yy");
+        formatMap.put("%U", "w");
+        formatMap.put("%u", "w");
+        formatMap.put("%V", "w");
+        formatMap.put("%v", "w");
+        formatMap.put("%T", "HH:mm:ss a");
+        formatMap.put("%X", "w");
+        formatMap.put("%x", "w");
+        return formatMap;
+    }
+
+    public DateFormatProcessor(Processor source1, Processor source2, ZoneId zoneId) {
+        super(source1, source2, zoneId);
+    }
+
+    public DateFormatProcessor(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public static final String NAME = "dformat";
+
+    public static Object process(Object timestamp, String pattern) {
+        formatMap = DateFormatProcessor.getPatternMap();
+        ZoneId zoneId = UTC;
+        if (pattern == null || pattern.isEmpty()) {
+            return null;
+        }
+
+        pattern = transformSqlFormatToJavaFormat(pattern);
+        return DateTimeFormatProcessor.process(timestamp, pattern, zoneId);
+    }
+
+    public static String transformSqlFormatToJavaFormat(String pattern) {
+        return formatMap
+            .entrySet()
+            .stream()
+            .reduce(pattern, (s, e) -> s.replace(e.getKey(), e.getValue()), (s, s2) -> s);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected Object doProcess(Object timestamp, Object pattern) {
+        return process(timestamp, pattern, zoneId());
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/whitelist/InternalSqlScriptUtils.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.ql.expression.function.scalar.whitelist.InternalQ
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateAddProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateDiffProcessor;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateFormatProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DatePartProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFormatProcessor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeFunction;
@@ -288,6 +289,10 @@ public class InternalSqlScriptUtils extends InternalQlScriptUtils {
         return (String) DateTimeFormatProcessor.process(asDateTime(dateTime), pattern, ZoneId.of(tzId));
     }
 
+    public static String dateFormat(Object dateTime, String pattern) {
+        return (String) DateFormatProcessor.process(asDateTime(dateTime), pattern);
+    }
+
     public static Object dateTimeParse(String dateField, String pattern, String tzId) {
         return Parser.DATE_TIME.parse(dateField, pattern, ZoneId.of(tzId));
     }
@@ -295,7 +300,7 @@ public class InternalSqlScriptUtils extends InternalQlScriptUtils {
     public static Object timeParse(String dateField, String pattern, String tzId) {
         return Parser.TIME.parse(dateField, pattern, ZoneId.of(tzId));
     }
-    
+
     public static ZonedDateTime asDateTime(Object dateTime) {
         return (ZonedDateTime) asDateTime(dateTime, false);
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormatProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateFormatProcessorTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+    import org.elasticsearch.common.io.stream.Writeable.Reader;
+    import org.elasticsearch.test.ESTestCase;
+    import org.elasticsearch.xpack.ql.expression.gen.processor.ConstantProcessor;
+    import org.elasticsearch.xpack.ql.tree.Source;
+    import org.elasticsearch.xpack.sql.AbstractSqlWireSerializingTestCase;
+    import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
+
+    import java.time.ZonedDateTime;
+
+    import static java.time.ZoneOffset.UTC;
+    import static org.elasticsearch.xpack.ql.expression.Literal.NULL;
+    import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTestUtils.l;
+    import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTestUtils.randomDatetimeLiteral;
+    import static org.elasticsearch.xpack.ql.expression.function.scalar.FunctionTestUtils.randomStringLiteral;
+    import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.dateTime;
+    import static org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeTestUtils.time;
+
+public class DateFormatProcessorTests extends AbstractSqlWireSerializingTestCase<DateFormatProcessor> {
+
+    public static DateFormatProcessor randomDateFormatProcessor() {
+        return new DateFormatProcessor(
+            new ConstantProcessor(DateTimeTestUtils.nowWithMillisResolution()),
+            new ConstantProcessor(randomRealisticUnicodeOfLengthBetween(0, 128)),
+            randomZone()
+        );
+    }
+
+    /*public static Literal randomTimeLiteral() {
+        return l(OffsetTime.ofInstant(Instant.ofEpochMilli(ESTestCase.randomLong()), ESTestCase.randomZone()), TIME);
+    }*/
+
+    @Override
+    protected DateFormatProcessor createTestInstance() {
+        return randomDateFormatProcessor();
+    }
+
+    @Override
+    protected Reader<DateFormatProcessor> instanceReader() {
+        return DateFormatProcessor::new;
+    }
+
+    @Override
+    protected DateFormatProcessor mutateInstance(DateFormatProcessor instance) {
+        return new DateFormatProcessor(
+            new ConstantProcessor(DateTimeTestUtils.nowWithMillisResolution()),
+            new ConstantProcessor(ESTestCase.randomRealisticUnicodeOfLength(128)),
+            randomValueOtherThan(instance.zoneId(), ESTestCase::randomZone)
+        );
+    }
+
+    public void testInvalidInputs() {
+        SqlIllegalArgumentException siae = expectThrows(
+            SqlIllegalArgumentException.class,
+            () -> new DateFormat(Source.EMPTY, l("foo"), randomStringLiteral(), randomZone()).makePipe().asProcessor().process(null)
+        );
+        assertEquals("A date/datetime/time is required; received [foo]", siae.getMessage());
+
+        siae = expectThrows(
+            SqlIllegalArgumentException.class,
+            () -> new DateFormat(Source.EMPTY, randomDatetimeLiteral(), l(5), randomZone()).makePipe().asProcessor().process(null)
+        );
+        assertEquals("A string is required; received [5]", siae.getMessage());
+
+        siae = expectThrows(
+            SqlIllegalArgumentException.class,
+            () -> new DateTimeFormat(Source.EMPTY, l(dateTime(2019, 9, 3, 18, 10, 37, 0)), l("invalid"), randomZone()).makePipe()
+                .asProcessor()
+                .process(null)
+        );
+        assertEquals(
+            "Invalid pattern [invalid] is received for formatting date/time [2019-09-03T18:10:37Z]; Unknown pattern letter: i",
+            siae.getMessage()
+        );
+
+        siae = expectThrows(
+            SqlIllegalArgumentException.class,
+            () -> new DateTimeFormat(Source.EMPTY, l(time(18, 10, 37, 123000000)), l("MM/dd"), randomZone()).makePipe()
+                .asProcessor()
+                .process(null)
+        );
+        assertEquals(
+            "Invalid pattern [MM/dd] is received for formatting date/time [18:10:37.123Z]; Unsupported field: MonthOfYear",
+            siae.getMessage()
+        );
+    }
+
+    public void testWithNulls() {
+        assertNull(new DateTimeFormat(Source.EMPTY, randomDatetimeLiteral(), NULL, UTC).makePipe().asProcessor().process(null));
+        assertNull(new DateTimeFormat(Source.EMPTY, randomDatetimeLiteral(), l(""), UTC).makePipe().asProcessor().process(null));
+        assertNull(new DateTimeFormat(Source.EMPTY, NULL, randomStringLiteral(), UTC).makePipe().asProcessor().process(null));
+    }
+
+    public void testFormatting() {
+        ZonedDateTime dateTime = dateTime(2019, 9, 3, 18, 10, 37, 123456789);
+        assertEquals("2019 09 03", DateFormatProcessor.process(dateTime, "%Y %m %e"));
+        assertEquals("September", DateFormatProcessor.process(dateTime, "%M"));
+        assertEquals("Tue", DateFormatProcessor.process(dateTime, "%a"));
+        assertEquals("Sep", DateFormatProcessor.process(dateTime, "%b"));
+        assertEquals("09", DateFormatProcessor.process(dateTime, "%c"));
+        assertEquals("03", DateFormatProcessor.process(dateTime, "%D"));
+        assertEquals("03", DateFormatProcessor.process(dateTime, "%d"));
+        assertEquals("03", DateFormatProcessor.process(dateTime, "%e"));
+        assertEquals("18", DateFormatProcessor.process(dateTime, "%H"));
+        assertEquals("06", DateFormatProcessor.process(dateTime, "%h"));
+        assertEquals("06", DateFormatProcessor.process(dateTime, "%I"));
+        assertEquals("10", DateFormatProcessor.process(dateTime, "%i"));
+        assertEquals("246", DateFormatProcessor.process(dateTime, "%j"));
+        assertEquals("18", DateFormatProcessor.process(dateTime, "%k"));
+        assertEquals("06", DateFormatProcessor.process(dateTime, "%l"));
+        assertEquals("September", DateFormatProcessor.process(dateTime, "%M"));
+        assertEquals("09", DateFormatProcessor.process(dateTime, "%m"));
+        assertEquals("PM", DateFormatProcessor.process(dateTime, "%p"));
+        assertEquals("06:10:37 PM", DateFormatProcessor.process(dateTime, "%r"));
+        assertEquals("37", DateFormatProcessor.process(dateTime, "%S"));
+        assertEquals("37", DateFormatProcessor.process(dateTime, "%s"));
+        assertEquals("18:10:37 PM", DateFormatProcessor.process(dateTime, "%T"));
+        assertEquals("36", DateFormatProcessor.process(dateTime, "%U"));
+        assertEquals("36", DateFormatProcessor.process(dateTime, "%u"));
+        assertEquals("36", DateFormatProcessor.process(dateTime, "%V"));
+        assertEquals("36", DateFormatProcessor.process(dateTime, "%v"));
+        assertEquals("Tuesday", DateFormatProcessor.process(dateTime, "%W"));
+        assertEquals("3", DateFormatProcessor.process(dateTime, "%w"));
+        assertEquals("36", DateFormatProcessor.process(dateTime, "%X"));
+        assertEquals("2019", DateFormatProcessor.process(dateTime, "%Y"));
+        assertEquals("19", DateFormatProcessor.process(dateTime, "%y"));
+
+
+    }
+}


### PR DESCRIPTION
_**Add: Date Format Function**_

Issue #55065

_Add a date function that allows the MySQL format and makes the translation to Java format._

**Modified files:**
     - Create DateFormat class.
     - Create DateFormatProcessor class.

**Documentation:**
     - MySQL format: https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html
     - Java format: https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.html

