### PR TITLE
[Backport] Display enterprise license as platinum in /_xpack

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
@@ -49,8 +49,18 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
         if (request.getCategories().contains(XPackInfoRequest.Category.LICENSE)) {
             License license = licenseService.getLicense();
             if (license != null) {
-                licenseInfo = new LicenseInfo(license.uid(), license.type(), license.operationMode().description(),
-                        license.status(), license.expiryDate());
+                String type = license.type();
+                License.OperationMode mode = license.operationMode();
+                if (request.getLicenseVersion() < License.VERSION_ENTERPRISE) {
+                    if (License.LicenseType.ENTERPRISE.getTypeName().equals(type)) {
+                        type = License.LicenseType.PLATINUM.getTypeName();
+                    }
+                    if (mode == License.OperationMode.ENTERPRISE) {
+                        mode = License.OperationMode.PLATINUM;
+                    }
+                }
+                licenseInfo = new LicenseInfo(license.uid(), type, mode.description(), license.status(),
+                    license.expiryDate());
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoRequestBuilder.java
@@ -33,4 +33,8 @@ public class XPackInfoRequestBuilder extends ActionRequestBuilder<XPackInfoReque
         return this;
     }
 
+    public XPackInfoRequestBuilder setLicenseVersion(int licenseVersion) {
+        request.setLicenseVersion(licenseVersion);
+        return this;
+    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rest/action/RestXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rest/action/RestXPackInfoAction.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.core.rest.action;
 
+import org.elasticsearch.license.License;
 import org.elasticsearch.protocol.xpack.XPackInfoRequest;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -36,9 +37,12 @@ public class RestXPackInfoAction extends XPackRestHandler {
 
     @Override
     public RestChannelConsumer doPrepareRequest(RestRequest request, XPackClient client) throws IOException {
-
         // we piggyback verbosity on "human" output
         boolean verbose = request.paramAsBoolean("human", true);
+
+        // Hide enterprise licenses by default, there is an opt-in flag to show them
+        final boolean acceptEnterprise = request.paramAsBoolean("accept_enterprise", false);
+        final int licenseVersion = acceptEnterprise ? License.VERSION_CURRENT : License.VERSION_CRYPTO_ALGORITHMS;
 
         EnumSet<XPackInfoRequest.Category> categories = XPackInfoRequest.Category
                 .toSet(request.paramAsStringArray("categories", new String[] { "_all" }));
@@ -46,6 +50,7 @@ public class RestXPackInfoAction extends XPackRestHandler {
                 client.prepareInfo()
                         .setVerbose(verbose)
                         .setCategories(categories)
+                        .setLicenseVersion(licenseVersion)
                         .execute(new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.info.json
@@ -19,6 +19,10 @@
       "categories":{
         "type":"list",
         "description":"Comma-separated list of info categories. Can be any of: build, license, features"
+      },
+      "accept_enterprise":{
+        "type":"boolean",
+        "description":"If an enterprise license is installed, return the type and mode as 'enterprise' (default: false)"
       }
     }
   }

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/license/30_enterprise_license.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/license/30_enterprise_license.yml
@@ -27,6 +27,13 @@ teardown:
   - match: { license.type: "platinum" }
   - match: { license.max_nodes: 50 }
 
+  ## Check the xpack info API as well
+  - do:
+      xpack.info: {}
+  - match: { license.type: "platinum" }
+  - match: { license.mode: "platinum" }
+ 
+  ## Check the opt-in v5 license type
   - do:
       license.get:
         accept_enterprise: true
@@ -39,6 +46,13 @@ teardown:
   - match: { license.max_resource_units: 50 }
   - match: { license.max_nodes: null }
 
+  ## Check the xpack info API as well
+  - do:
+      xpack.info: 
+        accept_enterprise: true
+  - match: { license.type: "enterprise" }
+  - match: { license.mode: "enterprise" }
+ 
   - do:
       license.get:
         accept_enterprise: false
@@ -49,3 +63,11 @@ teardown:
   ## opt-out of real enterprise type
   - match: { license.type: "platinum" }
   - match: { license.max_nodes: 50 }
+
+  ## Check the xpack info API as well
+  - do:
+      xpack.info: 
+        accept_enterprise: false
+  - match: { license.type: "platinum" }
+  - match: { license.mode: "platinum" }
+

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/20_info.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/xpack/20_info.yml
@@ -1,0 +1,9 @@
+"XPack Info API":
+    - do:
+        xpack.info: {}
+
+    - match: { license.type: "trial" }
+    - match: { license.mode: "trial" }
+    - match: { license.status: "active" }
+
+


### PR DESCRIPTION
The GET /_license endpoint displays "enterprise" licenses as
"platinum" by default so that old clients (including beats, kibana and
logstash) know to interpret this new license type as if it were a
platinum license.

However, this compatibility layer was not applied to the GET /_xpack/
endpoint which also displays a license type & mode.

This commit causes the _xpack API to mimic the _license API and treat
enterprise as platinum by default, with a new accept_enterprise
parameter that will cause the API to return the correct "enterprise"
value.

This BWC layer exists only for the 7.x branch.
This is a breaking change because, since 7.6, the _xpack API has
returned "enterprise" for enterprise licenses, but this has been found
to break old versions of beats and logstash so needs to be corrected.

Backport of: #58217