### PR TITLE
Fix resolveAllDependencies after compile usage removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -433,7 +433,10 @@ allprojects {
       dependsOn tasks.withType(ComposePull)
     }
     doLast {
-      configurations.findAll { it.isCanBeResolved() && !it.name.equals("testCompile") }.each { it.resolve() }
+      configurations.findAll { it.isCanBeResolved() &&
+        it.name.equals("testCompile") == false &&
+        it.name.equals("compile") == false
+      }.each { it.resolve() }
     }
   }
 


### PR DESCRIPTION
- Required after removing and failing on compile config usage