### PR TITLE
Mute CcrRollingUpgradeIT during backport

### DIFF
--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ObjectPath;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,6 +23,11 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
+
+    @Before
+    public void skipForBackportOf58217() {
+        assumeFalse("Skip while back-porting #58217 (see also #58220)", UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_8_1));
+    }
 
     public void testUniDirectionalIndexFollowing() throws Exception {
         logger.info("clusterName={}, upgradeState={}", clusterName, upgradeState);


### PR DESCRIPTION
Mute the CcrRollingUpgradeIT test due to backport of serialization
change.

Relates: #58220, #58217