### PR TITLE
[DOCS] Suppress searchable snapshots in releases

### DIFF
--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -90,7 +90,9 @@ the rollover criteria, it could be 20 minutes before the rollover is complete.
   - <<ilm-unfollow-action,Unfollow>>
   - <<ilm-allocate,Allocate>>
   - <<ilm-freeze,Freeze>>
+ifdef::permanently-unreleased-branch[]
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
+endif::[]
 * Delete
   - <<ilm-wait-for-snapshot-action,Wait For Snapshot>>
   - <<ilm-delete,Delete>>


### PR DESCRIPTION
Fixes a searchable snapshot reference overlooked in #58652