### PR TITLE
[Transform] fix bug in supporting boolean values in pivot

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -139,6 +139,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         Request doc3 = new Request("POST", sourceIndex + "/_doc");
         doc3.setJsonEntity("{\"bool\": false, \"val\": 2.0}");
         client().performRequest(doc3);
+        refreshIndex(sourceIndex);
 
         setupDataAccessRole(DATA_ACCESS_ROLE, sourceIndex, transformIndex);
         final Request createTransformRequest = createRequestWithAuth(
@@ -169,12 +170,10 @@ public class TransformPivotRestIT extends TransformRestTestCase {
 
         startAndWaitForTransform(transformId, transformIndex);
         assertTrue(indexExists(transformIndex));
-        // get and check some users
         assertOnePivotValue(transformIndex + "/_search?q=bool:true", 0.5);
         assertOnePivotValue(transformIndex + "/_search?q=bool:false", 2.0);
 
         Map<String, Object> indexStats = getAsMap(transformIndex + "/_stats");
-        // Should be less than the total number of users since we filtered every user who had an average review less than or equal to 3.8
         assertEquals(2, XContentMapValues.extractValue("_all.total.docs.count", indexStats));
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/IDGenerator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/IDGenerator.java
@@ -92,6 +92,8 @@ public final class IDGenerator {
             return Numbers.doubleToBytes((Double) value);
         } else if (value instanceof Integer) {
             return Numbers.intToBytes((Integer) value);
+        } else if (value instanceof Boolean) {
+            return new byte[] { (Boolean)value ? (byte)1 : (byte)0 };
         }
 
         throw new IllegalArgumentException("Value of type [" + value.getClass() + "] is not supported");

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/IDGeneratorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/IDGeneratorTests.java
@@ -30,6 +30,8 @@ public class IDGeneratorTests extends ESTestCase {
         id = idGen.getID();
         idGen.add("key7", "");
         assertNotEquals(id, idGen.getID());
+        idGen.add("key8", true);
+        assertNotEquals(id, idGen.getID());
     }
 
     public void testOrderIndependence() {


### PR DESCRIPTION
Since the underlying composite aggs support `boolean` mapped values for terms, transforms should also support them

closes https://github.com/elastic/elasticsearch/issues/58697