### PR TITLE
[7.x] [Transform] fix bug in supporting boolean values in pivot (#58741)

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/test/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -125,6 +125,58 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         client().performRequest(new Request("DELETE", "/_data_stream/" + indexName));
     }
 
+    public void testSimpleBooleanPivot() throws Exception {
+        String transformId = "simple-boolean-pivot";
+        String sourceIndex = "boolean_value";
+        String transformIndex = "pivot_boolean_value";
+
+        Request doc1 = new Request("POST", sourceIndex + "/_doc");
+        doc1.setJsonEntity("{\"bool\": true, \"val\": 1.0}");
+        client().performRequest(doc1);
+        Request doc2 = new Request("POST", sourceIndex + "/_doc");
+        doc2.setJsonEntity("{\"bool\": true, \"val\": 0.0}");
+        client().performRequest(doc2);
+        Request doc3 = new Request("POST", sourceIndex + "/_doc");
+        doc3.setJsonEntity("{\"bool\": false, \"val\": 2.0}");
+        client().performRequest(doc3);
+        refreshIndex(sourceIndex);
+
+        setupDataAccessRole(DATA_ACCESS_ROLE, sourceIndex, transformIndex);
+        final Request createTransformRequest = createRequestWithAuth(
+            "PUT",
+            getTransformEndpoint() + transformId,
+            BASIC_AUTH_VALUE_TRANSFORM_ADMIN_WITH_SOME_DATA_ACCESS
+        );
+        String config = ""
+            + "{"
+            + "\"source\":{\"index\": \"boolean_value\"},"
+            + "\"dest\" :{\"index\": \"pivot_boolean_value\"},"
+            + " \"pivot\": {"
+            + "   \"group_by\": {"
+            + "     \"bool\": {"
+            + "       \"terms\": {"
+            + "         \"field\": \"bool\""
+            + " } } },"
+            + "   \"aggregations\": {"
+            + "     \"avg_rating\": {"
+            + "       \"avg\": {"
+            + "         \"field\": \"val\""
+            + " } } } }"
+            + "}";
+
+        createTransformRequest.setJsonEntity(config);
+        Map<String, Object> createTransformResponse = entityAsMap(client().performRequest(createTransformRequest));
+        assertThat(createTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+
+        startAndWaitForTransform(transformId, transformIndex);
+        assertTrue(indexExists(transformIndex));
+        assertOnePivotValue(transformIndex + "/_search?q=bool:true", 0.5);
+        assertOnePivotValue(transformIndex + "/_search?q=bool:false", 2.0);
+
+        Map<String, Object> indexStats = getAsMap(transformIndex + "/_stats");
+        assertEquals(2, XContentMapValues.extractValue("_all.total.docs.count", indexStats));
+    }
+
     public void testSimplePivotWithQuery() throws Exception {
         String transformId = "simple_pivot_with_query";
         String transformIndex = "pivot_reviews_user_id_above_20";

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/IDGenerator.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/IDGenerator.java
@@ -92,6 +92,8 @@ public final class IDGenerator {
             return Numbers.doubleToBytes((Double) value);
         } else if (value instanceof Integer) {
             return Numbers.intToBytes((Integer) value);
+        } else if (value instanceof Boolean) {
+            return new byte[] { (Boolean)value ? (byte)1 : (byte)0 };
         }
 
         throw new IllegalArgumentException("Value of type [" + value.getClass() + "] is not supported");

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/IDGeneratorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/IDGeneratorTests.java
@@ -30,6 +30,8 @@ public class IDGeneratorTests extends ESTestCase {
         id = idGen.getID();
         idGen.add("key7", "");
         assertNotEquals(id, idGen.getID());
+        idGen.add("key8", true);
+        assertNotEquals(id, idGen.getID());
     }
 
     public void testOrderIndependence() {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Transform] fix bug in supporting boolean values in pivot (#58741)