### PR TITLE
Fix types deprecation warning for put mapping.

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -87,13 +87,15 @@ public class RestPutMappingAction extends BaseRestHandler {
 
         if (request.hasParam(INCLUDE_TYPE_NAME_PARAMETER) == false) {
             deprecationLogger.deprecatedAndMaybeLog("put_mapping_with_types", TYPES_DEPRECATION_MESSAGE);
-        } else if (type != null || isMappingSourceTyped(MapperService.SINGLE_MAPPING_NAME, sourceAsMap)) {
-            throw new IllegalArgumentException("Types cannot be provided in put mapping requests, unless " +
-                "the include_type_name parameter is set to true.");
         }
 
         boolean includeTypeName = request.paramAsBoolean(INCLUDE_TYPE_NAME_PARAMETER,
             DEFAULT_INCLUDE_TYPE_NAME_POLICY);
+        if (includeTypeName == false && (type != null || isMappingSourceTyped(MapperService.SINGLE_MAPPING_NAME, sourceAsMap))) {
+            throw new IllegalArgumentException("Types cannot be provided in put mapping requests, unless " +
+                "the include_type_name parameter is set to true.");
+        }
+
         putMappingRequest.type(includeTypeName ? type : MapperService.SINGLE_MAPPING_NAME);
         putMappingRequest.source(sourceAsMap);
 

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingActionTests.java
@@ -60,7 +60,7 @@ public class RestPutMappingActionTests extends RestActionTestCase {
         assertWarnings(RestPutMappingAction.TYPES_DEPRECATION_MESSAGE);
 
         Map<String, String> params = new HashMap<>();
-        params.put(INCLUDE_TYPE_NAME_PARAMETER, "false");
+        params.put(INCLUDE_TYPE_NAME_PARAMETER, randomFrom("true", "false"));
         RestRequest validRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withMethod(RestRequest.Method.PUT)
             .withPath("/some_index/_mapping")


### PR DESCRIPTION
In #38825, we switched from issuing a types warning if `include_type_name` is
missing or `true`, to only issuing a warning when `include_type_name` is
missing. However we missed the 'put mapping' API in that PR.

Addresses #58675.