### PR TITLE
Remove assertions that mappings have one top-level key.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -207,7 +207,6 @@ public class TransportSimulateIndexTemplateAction
                 MapperService mapperService = tempIndexService.mapperService();
                 for (Map<String, Object> mapping : mappings) {
                     if (!mapping.isEmpty()) {
-                        assert mapping.size() == 1 : mapping;
                         mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -844,7 +844,6 @@ public class MetadataCreateIndexService {
         MapperService mapperService = indexService.mapperService();
         for (Map<String, Object> mapping : mappings) {
             if (!mapping.isEmpty()) {
-                assert mapping.size() == 1 : mapping;
                 mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
             }
         }


### PR DESCRIPTION
These were added in #58521 but were incorrect -- at this point the mapping is
not necessarily wrapped in the '_doc' type. The assertion likely didn't trip
before because it's common for mappings to have only a top-level 'properties'
key.
