### PR TITLE
Fix template name in mapping composition yml test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_index_template/15_composition.yml
@@ -236,7 +236,7 @@
 
   - do:
       allowed_warnings:
-        - "index template [my-template] has index patterns [baz*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+        - "index template [blue] has index patterns [purple-index] matching patterns from existing older templates [global] with patterns (global => [*]); this template [blue] will take precedence during new index creation"
       indices.put_index_template:
         name: blue
         body:


### PR DESCRIPTION
The warning was copied from elsewhere and just needed to use the correct template and index name.
