### PR TITLE
[DOCS] Change links to refactored Beats getting started docs

### DIFF
--- a/docs/reference/eql/search.asciidoc
+++ b/docs/reference/eql/search.asciidoc
@@ -37,8 +37,8 @@ PUT /sec_logs/_bulk?refresh
 [TIP]
 =====
 You also can set up {beats-ref}/getting-started.html[{beats}], such as
-{auditbeat-ref}/auditbeat-getting-started.html[{auditbeat}] or
-{winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat}], to automatically
+{auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat}] or
+{winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat}], to automatically
 send and index your event data in {es}. See
 {beats-ref}/getting-started.html[Getting started with {beats}].
 =====

--- a/docs/reference/ingest/enrich.asciidoc
+++ b/docs/reference/ingest/enrich.asciidoc
@@ -134,8 +134,8 @@ You can manage source indices just like regular {es} indices using the
 <<docs,document>> and <<indices,index>> APIs.
 
 You also can set up {beats-ref}/getting-started.html[{beats}], such as a
-{filebeat-ref}/filebeat-getting-started.html[{filebeat}], to automatically send
-and index documents to your source indices. See
+{filebeat-ref}/filebeat-installation-configuration.html[{filebeat}], to
+automatically send and index documents to your source indices. See
 {beats-ref}/getting-started.html[Getting started with {beats}].
 
 [[create-enrich-policy]]

--- a/docs/reference/monitoring/configuring-filebeat.asciidoc
+++ b/docs/reference/monitoring/configuring-filebeat.asciidoc
@@ -52,7 +52,7 @@ not appear in the appropriate context in {kib}.
 
 --
 
-. {filebeat-ref}/filebeat-installation.html[Install {filebeat}] on the {es}
+. {filebeat-ref}/filebeat-installation-configuration.html[Install {filebeat}] on the {es}
 nodes that contain logs that you want to monitor.
 
 . Identify where to send the log data.

--- a/docs/reference/monitoring/configuring-metricbeat.asciidoc
+++ b/docs/reference/monitoring/configuring-metricbeat.asciidoc
@@ -44,7 +44,7 @@ view the cluster settings and `manage` cluster privileges to change them.
 For more information, see <<monitoring-settings>> and <<cluster-update-settings>>.
 --
 
-. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
+. {metricbeat-ref}/metricbeat-installation-configuration.html[Install {metricbeat}] on each
 {es} node in the production cluster.
 
 . Enable the {es} {xpack} module in {metricbeat} on each {es} node. +


### PR DESCRIPTION
Updates links to reflect changes added in elastic/beats#19302.

This change applies to 7.9 and later.