### PR TITLE
Enable mixed cluster smoke test for enrich stats

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/110_enrich.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/110_enrich.yml
@@ -7,14 +7,7 @@
 
   - do:
       node_selector:
-        version: " - 7.99.99"
-      enrich.stats: {}
-
-  - length: { coordinator_stats: 3 }
-
-  - do:
-      node_selector:
-        version: "8.0.0 - "
+        version: "7.9.0 - "
       enrich.stats: {}
 
   - length: { coordinator_stats: 3 }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/110_enrich.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/110_enrich.yml
@@ -1,9 +1,16 @@
 ---
 "Enrich stats query smoke test for mixed cluster":
   - skip:
-      version: " - 7.99.99"
-      reason: "7.9.0 backport pending"
+      version: " - 7.8.99"
+      reason: "Privilege change of enrich stats is backported to 7.9.0"
       features: node_selector
+
+  - do:
+      node_selector:
+        version: " - 7.99.99"
+      enrich.stats: {}
+
+  - length: { coordinator_stats: 3 }
 
   - do:
       node_selector:


### PR DESCRIPTION
Changes are backported to 7.9 with #52196. The tests can now be enabled .