### PR TITLE
Split license allowed checks into two types (#58704)

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/AnalyticsPlugin.java
@@ -179,7 +179,7 @@ public class AnalyticsPlugin extends Plugin implements SearchPlugin, ActionPlugi
 
     private static <T> ContextParser<String, T> checkLicense(ContextParser<String, T> realParser) {
         return (parser, name) -> {
-            if (getLicenseState().isAllowed(XPackLicenseState.Feature.ANALYTICS) == false) {
+            if (getLicenseState().checkFeature(XPackLicenseState.Feature.ANALYTICS) == false) {
                 throw LicenseUtils.newComplianceException(XPackField.ANALYTICS);
             }
             return realParser.parse(parser, name);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrLicenseChecker.java
@@ -72,7 +72,7 @@ public class CcrLicenseChecker {
      * Constructs a CCR license checker with the default rule based on the license state for checking if CCR is allowed.
      */
     CcrLicenseChecker() {
-        this(() -> XPackPlugin.getSharedLicenseState().isAllowed(XPackLicenseState.Feature.CCR),
+        this(() -> XPackPlugin.getSharedLicenseState().checkFeature(XPackLicenseState.Feature.CCR),
              XPackPlugin.getSharedLicenseState()::isSecurityEnabled);
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollectorTests.java
@@ -46,14 +46,14 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         whenLocalNodeElectedMaster(isElectedMaster);
 
         // this controls the blockage
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(false);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(ccrAllowed);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(ccrAllowed);
 
         final StatsCollector collector = createCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+            verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
         }
     }
 
@@ -61,8 +61,8 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         // regardless of CCR being enabled
         final Settings settings = randomFrom(ccrEnabledSettings(), ccrDisabledSettings());
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -75,8 +75,8 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         // this is controls the blockage
         final Settings settings = ccrDisabledSettings();
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(randomBoolean());
 
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
@@ -86,16 +86,16 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+            verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfCCRIsNotAllowed() {
         final Settings settings = randomFrom(ccrEnabledSettings(), ccrDisabledSettings());
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
         // this is controls the blockage
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -104,22 +104,22 @@ public class StatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+            verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
         final Settings settings = ccrEnabledSettings();
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(true);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.CCR)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.CCR)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final StatsCollector collector = createCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
 
-        verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+        verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -411,7 +411,6 @@ public class XPackLicenseState {
 
     private XPackLicenseState(List<LicenseStateListener> listeners, boolean isSecurityEnabled, boolean isSecurityExplicitlyEnabled,
                               Status status) {
-
         this.listeners = listeners;
         this.isSecurityEnabled = isSecurityEnabled;
         this.isSecurityExplicitlyEnabled = isSecurityExplicitlyEnabled;
@@ -475,6 +474,19 @@ public class XPackLicenseState {
         return checkAgainstStatus(status -> status.active);
     }
 
+    /**
+     * Checks whether the given feature is allowed, tracking the last usage time.
+     */
+    public boolean checkFeature(Feature feature) {
+        // TODO: usage tracking is not yet implemented
+        return isAllowed(feature);
+    }
+
+    /**
+     * Checks whether the given feature is allowed by the current license.
+     * <p>
+     * This method should only be used when serializing whether a feature is allowed for telemetry.
+     */
     public boolean isAllowed(Feature feature) {
         return isAllowedByLicense(feature.minimumOperationMode, feature.needsActive);
     }
@@ -551,7 +563,8 @@ public class XPackLicenseState {
      * is needed for multiple interactions with the license state.
      */
     public XPackLicenseState copyCurrentLicenseState() {
-        return executeAgainstStatus(status -> new XPackLicenseState(listeners, isSecurityEnabled, isSecurityExplicitlyEnabled, status));
+        return executeAgainstStatus(status ->
+            new XPackLicenseState(listeners, isSecurityEnabled, isSecurityExplicitlyEnabled, status));
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapper.java
@@ -63,7 +63,7 @@ public class SecurityIndexReaderWrapper implements CheckedFunction<DirectoryRead
     @Override
     public DirectoryReader apply(final DirectoryReader reader) {
         if (licenseState.isSecurityEnabled() == false ||
-            licenseState.isAllowed(Feature.SECURITY_DLS_FLS) == false) {
+            licenseState.checkFeature(Feature.SECURITY_DLS_FLS) == false) {
             return reader;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/ActionThrottler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/actions/throttler/ActionThrottler.java
@@ -38,7 +38,7 @@ public class ActionThrottler implements Throttler {
 
     @Override
     public Result throttle(String actionId, WatchExecutionContext ctx) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.WATCHER) == false) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.WATCHER) == false) {
             return Result.throttle(LICENSE, "watcher license does not allow action execution");
         }
         if (periodThrottler != null) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseRegistrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseRegistrationTests.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
 
     public void testSelfGeneratedTrialLicense() throws Exception {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(null, licenseState, Settings.EMPTY, "trial");
         when(discoveryNodes.isLocalNodeElectedMaster()).thenReturn(true);
         licenseService.start();
@@ -42,7 +42,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
     }
 
     public void testSelfGeneratedBasicLicense() throws Exception {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(null, licenseState, Settings.EMPTY, "basic");
         when(discoveryNodes.isLocalNodeElectedMaster()).thenReturn(true);
         licenseService.start();
@@ -74,7 +74,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
                 .maxNodes(5);
         License license = TestUtils.generateSignedLicense(builder);
 
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(license, licenseState, Settings.EMPTY);
         when(discoveryNodes.isLocalNodeElectedMaster()).thenReturn(true);
         licenseService.start();
@@ -106,7 +106,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
                 .expiryDate(dateMath("now-2h", now));
         License license = SelfGeneratedLicense.create(builder, License.VERSION_CURRENT);
 
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(license, licenseState, Settings.EMPTY);
         when(discoveryNodes.isLocalNodeElectedMaster()).thenReturn(true);
         licenseService.start();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesAcknowledgementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesAcknowledgementTests.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 public class LicensesAcknowledgementTests extends AbstractLicenseServiceTestCase {
 
     public void testAcknowledgment() throws Exception {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(TestUtils.generateSignedLicense("gold", timeValueHours(2)), licenseState, Settings.EMPTY);
         licenseService.start();
         // try installing a signed license
@@ -42,7 +42,7 @@ public class LicensesAcknowledgementTests extends AbstractLicenseServiceTestCase
     }
 
     public void testRejectUpgradeToProductionWithoutTLS() throws Exception {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(TestUtils.generateSignedLicense("trial", timeValueHours(2)), licenseState, Settings.EMPTY);
         licenseService.start();
         // try installing a signed license
@@ -55,7 +55,7 @@ public class LicensesAcknowledgementTests extends AbstractLicenseServiceTestCase
     }
 
     public void testUpgradeToProductionWithoutTLSAndSecurityDisabled() throws Exception {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(TestUtils.generateSignedLicense("trial", timeValueHours(2)), licenseState, Settings.builder()
                 .put("xpack.security.enabled", false).build());
         licenseService.start();
@@ -74,7 +74,7 @@ public class LicensesAcknowledgementTests extends AbstractLicenseServiceTestCase
     }
 
     public void testUpgradeToProductionWithTLSAndSecurity() throws Exception {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         setInitialState(TestUtils.generateSignedLicense("trial", timeValueHours(2)), licenseState, Settings.builder()
                 .put("xpack.security.enabled", true)
                 .put("xpack.security.transport.ssl.enabled", true).build());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/TestUtils.java
@@ -392,6 +392,10 @@ public class TestUtils {
         }
     }
 
+    public static XPackLicenseState newTestLicenseState() {
+        return new XPackLicenseState(Settings.EMPTY);
+    }
+
     public static void putLicense(Metadata.Builder builder, License license) {
         builder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(license, null));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -33,7 +33,7 @@ public class XPackLicenseStateTests extends ESTestCase {
 
     /** Creates a license state with the given license type and active state, and checks the given method returns expected. */
     void assertAllowed(OperationMode mode, boolean active, Predicate<XPackLicenseState> predicate, boolean expected) {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(mode, active, null);
         assertEquals(expected, predicate.test(licenseState));
     }
@@ -76,41 +76,41 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testSecurityDefaults() {
-        XPackLicenseState licenseState =
-                new XPackLicenseState(Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        Settings settings = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build();
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
 
-        licenseState = new XPackLicenseState(Settings.EMPTY);
+        licenseState = TestUtils.newTestLicenseState();
         assertSecurityNotAllowed(licenseState);
     }
 
     public void testTransportSslDoesNotAutomaticallyEnableSecurityOnTrialLicense() {
+        Settings settings = Settings.builder().put(XPackSettings.TRANSPORT_SSL_ENABLED.getKey(), true).build();
         final XPackLicenseState licenseState;
-        licenseState =
-            new XPackLicenseState(Settings.builder().put(XPackSettings.TRANSPORT_SSL_ENABLED.getKey(), true).build());
+        licenseState = new XPackLicenseState(settings);
         assertSecurityNotAllowed(licenseState);
     }
 
     public void testSecurityBasicWithoutExplicitSecurityEnabled() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(BASIC, true, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SECURITY), is(true));
         assertThat(licenseState.isSecurityEnabled(), is(false));
     }
 
@@ -120,139 +120,145 @@ public class XPackLicenseStateTests extends ESTestCase {
         licenseState.update(BASIC, true, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SECURITY), is(true));
         assertThat(licenseState.isSecurityEnabled(), is(true));
     }
 
     public void testSecurityDefaultBasicExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(BASIC, false, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
     }
 
     public void testSecurityEnabledBasicExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(
-            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        Settings settings = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build();
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(BASIC, false, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
     }
 
     public void testSecurityStandard() {
-        XPackLicenseState licenseState = new XPackLicenseState(randomFrom(Settings.EMPTY,
-                Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build()));
+        Settings settings = randomFrom(Settings.EMPTY,
+            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(STANDARD, true, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
     }
 
     public void testSecurityStandardExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(randomFrom(Settings.EMPTY,
-                Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build()));
+        Settings settings = randomFrom(Settings.EMPTY,
+            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(STANDARD, false, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
     }
 
     public void testSecurityGold() {
-        XPackLicenseState licenseState = new XPackLicenseState(randomFrom(Settings.EMPTY,
-                Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build()));
+        Settings settings = randomFrom(Settings.EMPTY,
+            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(GOLD, true, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
     }
 
     public void testSecurityGoldExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(randomFrom(Settings.EMPTY,
-                Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build()));
+        Settings settings = randomFrom(Settings.EMPTY,
+            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(GOLD, false, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
     }
 
     public void testSecurityPlatinum() {
-        XPackLicenseState licenseState = new XPackLicenseState(randomFrom(Settings.EMPTY,
-                Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build()));
+        Settings settings = randomFrom(Settings.EMPTY,
+            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(PLATINUM, true, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
     }
 
     public void testSecurityPlatinumExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(randomFrom(Settings.EMPTY,
-                Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build()));
+        Settings settings = randomFrom(Settings.EMPTY,
+            Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build());
+        XPackLicenseState licenseState = new XPackLicenseState(settings);
         licenseState.update(PLATINUM, false, null);
 
         assertThat(licenseState.isSecurityEnabled(), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_AUDITING), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_DLS_FLS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE), is(true));
-        assertThat(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_AUDITING), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_DLS_FLS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS), is(false));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE), is(true));
+        assertThat(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE), is(true));
     }
 
     public void testNewTrialDefaultsSecurityOff() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(TRIAL, true, VersionUtils.randomVersionBetween(random(), Version.V_6_3_0, Version.CURRENT));
 
         assertThat(licenseState.isSecurityEnabled(), is(false));
@@ -304,172 +310,172 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testMonitoringAllowed() {
-        assertAllowed(randomMode(), true, s -> s.isAllowed(Feature.MONITORING), true);
-        assertAllowed(randomMode(), false, s -> s.isAllowed(Feature.MONITORING), false);
+        assertAllowed(randomMode(), true, s -> s.checkFeature(Feature.MONITORING), true);
+        assertAllowed(randomMode(), false, s -> s.checkFeature(Feature.MONITORING), false);
     }
 
     public void testMonitoringUpdateRetention() {
-        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
-        assertAllowed(GOLD, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
-        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
-        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), true);
-        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), false);
-        assertAllowed(MISSING, false, s -> s.isAllowed(Feature.MONITORING_UPDATE_RETENTION), false);
+        assertAllowed(STANDARD, true, s -> s.checkFeature(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(GOLD, true, s -> s.checkFeature(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(PLATINUM, true, s -> s.checkFeature(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(TRIAL, true, s -> s.checkFeature(Feature.MONITORING_UPDATE_RETENTION), true);
+        assertAllowed(BASIC, true, s -> s.checkFeature(Feature.MONITORING_UPDATE_RETENTION), false);
+        assertAllowed(MISSING, false, s -> s.checkFeature(Feature.MONITORING_UPDATE_RETENTION), false);
     }
 
     public void testWatcherPlatinumGoldTrialStandard() throws Exception {
-        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.WATCHER), true);
-        assertAllowed(GOLD, true, s -> s.isAllowed(Feature.WATCHER), true);
-        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.WATCHER), true);
-        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.WATCHER), true);
+        assertAllowed(TRIAL, true, s -> s.checkFeature(Feature.WATCHER), true);
+        assertAllowed(GOLD, true, s -> s.checkFeature(Feature.WATCHER), true);
+        assertAllowed(PLATINUM, true, s -> s.checkFeature(Feature.WATCHER), true);
+        assertAllowed(STANDARD, true, s -> s.checkFeature(Feature.WATCHER), true);
     }
 
     public void testWatcherBasicLicense() throws Exception {
-        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.WATCHER), false);
+        assertAllowed(BASIC, true, s -> s.checkFeature(Feature.WATCHER), false);
     }
 
     public void testWatcherInactive() {
-        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.WATCHER), false);
+        assertAllowed(BASIC, false, s -> s.checkFeature(Feature.WATCHER), false);
     }
 
     public void testWatcherInactivePlatinumGoldTrial() throws Exception {
-        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.WATCHER), false);
-        assertAllowed(GOLD, false, s -> s.isAllowed(Feature.WATCHER), false);
-        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.WATCHER), false);
-        assertAllowed(STANDARD, false, s -> s.isAllowed(Feature.WATCHER), false);
+        assertAllowed(TRIAL, false, s -> s.checkFeature(Feature.WATCHER), false);
+        assertAllowed(GOLD, false, s -> s.checkFeature(Feature.WATCHER), false);
+        assertAllowed(PLATINUM, false, s -> s.checkFeature(Feature.WATCHER), false);
+        assertAllowed(STANDARD, false, s -> s.checkFeature(Feature.WATCHER), false);
     }
 
     public void testGraphPlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.GRAPH), true);
-        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.GRAPH), true);
+        assertAllowed(TRIAL, true, s -> s.checkFeature(Feature.GRAPH), true);
+        assertAllowed(PLATINUM, true, s -> s.checkFeature(Feature.GRAPH), true);
     }
 
     public void testGraphBasic() throws Exception {
-        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.GRAPH), false);
+        assertAllowed(BASIC, true, s -> s.checkFeature(Feature.GRAPH), false);
     }
 
     public void testGraphStandard() throws Exception {
-        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.GRAPH), false);
+        assertAllowed(STANDARD, true, s -> s.checkFeature(Feature.GRAPH), false);
     }
 
     public void testGraphInactiveBasic() {
-        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.GRAPH), false);
+        assertAllowed(BASIC, false, s -> s.checkFeature(Feature.GRAPH), false);
     }
 
     public void testGraphInactivePlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
-        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(TRIAL, false, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
+        assertAllowed(PLATINUM, false, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningPlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), true);
-        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), true);
+        assertAllowed(TRIAL, true, s -> s.checkFeature(Feature.MACHINE_LEARNING), true);
+        assertAllowed(PLATINUM, true, s -> s.checkFeature(Feature.MACHINE_LEARNING), true);
     }
 
     public void testMachineLearningBasic() throws Exception {
-        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(BASIC, true, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningStandard() throws Exception {
-        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(STANDARD, true, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningInactiveBasic() {
-        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(BASIC, false, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
     }
 
     public void testMachineLearningInactivePlatinumTrial() throws Exception {
-        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
-        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.MACHINE_LEARNING), false);
+        assertAllowed(TRIAL, false, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
+        assertAllowed(PLATINUM, false, s -> s.checkFeature(Feature.MACHINE_LEARNING), false);
     }
 
     public void testLogstashPlatinumGoldTrialStandard() throws Exception {
-        assertAllowed(TRIAL, true, s -> s.isAllowed(Feature.LOGSTASH), true);
-        assertAllowed(GOLD, true, s -> s.isAllowed(Feature.LOGSTASH), true);
-        assertAllowed(PLATINUM, true, s -> s.isAllowed(Feature.LOGSTASH), true);
-        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.LOGSTASH), true);
+        assertAllowed(TRIAL, true, s -> s.checkFeature(Feature.LOGSTASH), true);
+        assertAllowed(GOLD, true, s -> s.checkFeature(Feature.LOGSTASH), true);
+        assertAllowed(PLATINUM, true, s -> s.checkFeature(Feature.LOGSTASH), true);
+        assertAllowed(STANDARD, true, s -> s.checkFeature(Feature.LOGSTASH), true);
     }
 
     public void testLogstashBasicLicense() throws Exception {
-        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.LOGSTASH), false);
+        assertAllowed(BASIC, true, s -> s.checkFeature(Feature.LOGSTASH), false);
     }
 
     public void testLogstashInactive() {
-        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.LOGSTASH), false);
-        assertAllowed(TRIAL, false, s -> s.isAllowed(Feature.LOGSTASH), false);
-        assertAllowed(GOLD, false, s -> s.isAllowed(Feature.LOGSTASH), false);
-        assertAllowed(PLATINUM, false, s -> s.isAllowed(Feature.LOGSTASH), false);
-        assertAllowed(STANDARD, false, s -> s.isAllowed(Feature.LOGSTASH), false);
+        assertAllowed(BASIC, false, s -> s.checkFeature(Feature.LOGSTASH), false);
+        assertAllowed(TRIAL, false, s -> s.checkFeature(Feature.LOGSTASH), false);
+        assertAllowed(GOLD, false, s -> s.checkFeature(Feature.LOGSTASH), false);
+        assertAllowed(PLATINUM, false, s -> s.checkFeature(Feature.LOGSTASH), false);
+        assertAllowed(STANDARD, false, s -> s.checkFeature(Feature.LOGSTASH), false);
     }
 
     public void testSqlDefaults() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(true));
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(true));
     }
 
     public void testSqlBasic() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(BASIC, true, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlBasicExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(BASIC, false, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlStandard() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(STANDARD, true, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlStandardExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(STANDARD, false, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlGold() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(GOLD, true, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlGoldExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(GOLD, false, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlPlatinum() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(PLATINUM, true, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(true));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(true));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(true));
     }
 
     public void testSqlPlatinumExpired() {
-        XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         licenseState.update(PLATINUM, false, null);
 
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.SQL), is(false));
-        assertThat(licenseState.isAllowed(XPackLicenseState.Feature.JDBC), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.SQL), is(false));
+        assertThat(licenseState.checkFeature(XPackLicenseState.Feature.JDBC), is(false));
     }
 
     public void testSqlAckAnyToTrialOrPlatinum() {
@@ -481,64 +487,64 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testCcrDefaults() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
-        assertTrue(state.isAllowed(XPackLicenseState.Feature.CCR));
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
+        assertTrue(state.checkFeature(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrBasic() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(BASIC, true, null);
 
-        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
+        assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrBasicExpired() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(BASIC, false, null);
 
-        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
+        assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrStandard() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(STANDARD, true, null);
 
-        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
+        assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrStandardExpired() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(STANDARD, false, null);
 
-        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
+        assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrGold() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(GOLD, true, null);
 
-        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
+        assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrGoldExpired() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(GOLD, false, null);
 
-        assertThat(state.isAllowed(XPackLicenseState.Feature.CCR), is(false));
+        assertThat(state.checkFeature(XPackLicenseState.Feature.CCR), is(false));
     }
 
     public void testCcrPlatinum() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(PLATINUM, true, null);
 
-        assertTrue(state.isAllowed(XPackLicenseState.Feature.CCR));
+        assertTrue(state.checkFeature(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrPlatinumExpired() {
-        final XPackLicenseState state = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState state = TestUtils.newTestLicenseState();
         state.update(PLATINUM, false, null);
 
-        assertFalse(state.isAllowed(XPackLicenseState.Feature.CCR));
+        assertFalse(state.checkFeature(XPackLicenseState.Feature.CCR));
     }
 
     public void testCcrAckAnyToTrialOrPlatinum() {
@@ -550,14 +556,14 @@ public class XPackLicenseStateTests extends ESTestCase {
     }
 
     public void testTransformBasic() throws Exception {
-        assertAllowed(BASIC, true, s -> s.isAllowed(Feature.TRANSFORM), true);
+        assertAllowed(BASIC, true, s -> s.checkFeature(Feature.TRANSFORM), true);
     }
 
     public void testTransformStandard() throws Exception {
-        assertAllowed(STANDARD, true, s -> s.isAllowed(Feature.TRANSFORM), true);
+        assertAllowed(STANDARD, true, s -> s.checkFeature(Feature.TRANSFORM), true);
     }
 
     public void testTransformInactiveBasic() {
-        assertAllowed(BASIC, false, s -> s.isAllowed(Feature.TRANSFORM), false);
+        assertAllowed(BASIC, false, s -> s.checkFeature(Feature.TRANSFORM), false);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -96,7 +96,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
 
         Directory directory = newDirectory();
         IndexWriter iw = new IndexWriter(
@@ -229,7 +229,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
         SecurityIndexReaderWrapper wrapper = new SecurityIndexReaderWrapper(s -> queryShardContext,
                 bitsetCache, securityContext, licenseState, scriptService) {
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperUnitTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperUnitTests.java
@@ -66,7 +66,7 @@ public class SecurityIndexReaderWrapperUnitTests extends ESTestCase {
         ShardId shardId = new ShardId(index, 0);
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
         securityContext = new SecurityContext(Settings.EMPTY, new ThreadContext(Settings.EMPTY));
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.shardId()).thenReturn(shardId);
@@ -115,7 +115,7 @@ public class SecurityIndexReaderWrapperUnitTests extends ESTestCase {
     }
 
     public void testWrapReaderWhenFeatureDisabled() throws Exception {
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(false);
         securityIndexReaderWrapper =
                 new SecurityIndexReaderWrapper(null, null, securityContext, licenseState, scriptService);
         DirectoryReader reader = securityIndexReaderWrapper.apply(esIn);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/watcher/actions/throttler/WatchThrottlerTests.java
@@ -25,7 +25,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result expectedResult = Throttler.Result.throttle(Throttler.Type.ACK, "_reason");
         when(ackThrottler.throttle("_action", ctx)).thenReturn(expectedResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -40,7 +40,7 @@ public class WatchThrottlerTests extends ESTestCase {
         when(periodThrottler.throttle("_action", ctx)).thenReturn(expectedResult);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -56,7 +56,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result ackResult = Throttler.Result.throttle(Throttler.Type.ACK, "_reason_ack");
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -71,7 +71,7 @@ public class WatchThrottlerTests extends ESTestCase {
         when(periodThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(Throttler.Result.NO);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(periodThrottler, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -84,7 +84,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result ackResult = mock(Throttler.Result.class);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(true);
         ActionThrottler throttler = new ActionThrottler(null, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());
@@ -97,7 +97,7 @@ public class WatchThrottlerTests extends ESTestCase {
         Throttler.Result ackResult = mock(Throttler.Result.class);
         when(ackThrottler.throttle("_action", ctx)).thenReturn(ackResult);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.WATCHER)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.WATCHER)).thenReturn(false);
         ActionThrottler throttler = new ActionThrottler(null, ackThrottler, licenseState);
         Throttler.Result result = throttler.throttle("_action", ctx);
         assertThat(result, notNullValue());

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -86,7 +86,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
     @Override
     protected final void masterOperation(final DeprecationInfoAction.Request request, ClusterState state,
                                          final ActionListener<DeprecationInfoAction.Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.DEPRECATION)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.DEPRECATION)) {
 
             NodesDeprecationCheckRequest nodeDepReq = new NodesDeprecationCheckRequest("_all");
             ClientHelper.executeAsyncWithOrigin(client, ClientHelper.DEPRECATION_ORIGIN,

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollectorTests.java
@@ -43,20 +43,20 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         whenLocalNodeElectedMaster(isElectedMaster);
 
         // this controls the blockage
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(false);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(enrichAllowed);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.ENRICH)).thenReturn(enrichAllowed);
 
         final EnrichStatsCollector collector = createCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+            verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
-        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.ENRICH)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -67,9 +67,9 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfEnrichIsNotAllowed() {
         boolean isMonitoringAllowed = randomBoolean();
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(isMonitoringAllowed);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(isMonitoringAllowed);
         // this is controls the blockage
-        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.ENRICH)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -78,20 +78,20 @@ public class EnrichStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+            verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING)).thenReturn(true);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.ENRICH)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.ENRICH)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final EnrichStatsCollector collector = createCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
 
-        verify(licenseState).isAllowed(XPackLicenseState.Feature.MONITORING);
+        verify(licenseState).checkFeature(XPackLicenseState.Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
+++ b/x-pack/plugin/graph/src/main/java/org/elasticsearch/xpack/graph/action/TransportGraphExploreAction.java
@@ -92,7 +92,7 @@ public class TransportGraphExploreAction extends HandledTransportAction<GraphExp
 
     @Override
     protected void doExecute(Task task, GraphExploreRequest request, ActionListener<GraphExploreResponse> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.GRAPH)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.GRAPH)) {
             new AsyncGraphAction(request, listener).start();
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.GRAPH));

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -781,7 +781,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
     private static void assertMLAllowed(boolean expected) {
         for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-            assertEquals(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING), expected);
+            assertEquals(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING), expected);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/InvalidLicenseEnforcer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/InvalidLicenseEnforcer.java
@@ -48,7 +48,7 @@ public class InvalidLicenseEnforcer implements LicenseStateListener {
     @Override
     public void licenseStateChanged() {
         assert licenseStateListenerRegistered;
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             // if the license has expired, close jobs and datafeeds
             threadPool.generic().execute(new AbstractRunnable() {
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportExplainDataFrameAnalyticsAction.java
@@ -69,7 +69,7 @@ public class TransportExplainDataFrameAnalyticsAction
     protected void doExecute(Task task,
                              PutDataFrameAnalyticsAction.Request request,
                              ActionListener<ExplainDataFrameAnalyticsAction.Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -73,7 +73,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             listener::onFailure
         );
 
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             responseBuilder.setLicensed(true);
             this.modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
         } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportOpenJobAction.java
@@ -216,7 +216,7 @@ public class TransportOpenJobAction extends TransportMasterNodeAction<OpenJobAct
         }
 
         OpenJobAction.JobParams jobParams = request.getJobParams();
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
 
             // Clear job finished time once the job is started and respond
             ActionListener<NodeAcknowledgedResponse> clearJobFinishTime = ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDataFrameAnalyticsAction.java
@@ -229,7 +229,7 @@ public class TransportPutDataFrameAnalyticsAction
     @Override
     protected void doExecute(Task task, PutDataFrameAnalyticsAction.Request request,
                              ActionListener<PutDataFrameAnalyticsAction.Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutDatafeedAction.java
@@ -265,7 +265,7 @@ public class TransportPutDatafeedAction extends TransportMasterNodeAction<PutDat
 
     @Override
     protected void doExecute(Task task, PutDatafeedAction.Request request, ActionListener<PutDatafeedAction.Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutJobAction.java
@@ -68,7 +68,7 @@ public class TransportPutJobAction extends TransportMasterNodeAction<PutJobActio
 
     @Override
     protected void doExecute(Task task, PutJobAction.Request request, ActionListener<PutJobAction.Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -220,7 +220,7 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -157,7 +157,7 @@ public class TransportStartDataFrameAnalyticsAction
     @Override
     protected void masterOperation(StartDataFrameAnalyticsAction.Request request, ClusterState state,
                                    ActionListener<NodeAcknowledgedResponse> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -155,7 +155,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
     protected void masterOperation(StartDatafeedAction.Request request, ClusterState state,
                                    ActionListener<NodeAcknowledgedResponse> listener) {
         StartDatafeedAction.DatafeedParams params = request.getParams();
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateDataFrameAnalyticsAction.java
@@ -89,7 +89,7 @@ public class TransportUpdateDataFrameAnalyticsAction
     @Override
     protected void doExecute(Task task, UpdateDataFrameAnalyticsAction.Request request,
                              ActionListener<PutDataFrameAnalyticsAction.Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)) {
             super.doExecute(task, request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningFeatureSetTests.java
@@ -338,7 +338,7 @@ public class MachineLearningFeatureSetTests extends ESTestCase {
     }
 
     public void testUsageWithOrphanedTask() throws Exception {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         Settings.Builder settings = Settings.builder().put(commonSettings);
         settings.put("xpack.ml.enabled", true);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -94,7 +94,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
         public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
             Map<String, Processor.Factory> factoryMap = new HashMap<>();
             XPackLicenseState licenseState = mock(XPackLicenseState.class);
-            when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
+            when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
             factoryMap.put(InferenceProcessor.TYPE,
                 new InferenceProcessor.Factory(parameters.client,
                     parameters.ingestService.getClusterService(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -71,7 +71,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
                 ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING)));
         clusterService = new ClusterService(settings, clusterSettings, tp);
         licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
     }
 
     public void testNumInferenceProcessors() throws Exception {

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterIT.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -649,7 +649,7 @@ public class HttpExporterIT extends MonitoringIntegTestCase {
 
     private HttpExporter createHttpExporter(final Settings settings) {
         final Exporter.Config config =
-                new Exporter.Config("_http", "http", settings, clusterService(), new XPackLicenseState(Settings.EMPTY));
+                new Exporter.Config("_http", "http", settings, clusterService(), TestUtils.newTestLicenseState());
 
         return new HttpExporter(config, new SSLService(settings, environment), new ThreadContext(settings));
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -91,7 +91,7 @@ public class CleanerService extends AbstractLifecycleComponent {
      */
     public TimeValue getRetention() {
         // we only care about their value if they are allowed to set it
-        if (licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION) && globalRetention != null) {
+        if (licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION) && globalRetention != null) {
             return globalRetention;
         }
         else {
@@ -109,7 +109,7 @@ public class CleanerService extends AbstractLifecycleComponent {
      */
     public void setGlobalRetention(TimeValue globalRetention) {
         // notify the user that their setting will be ignored until they get the right license
-        if (licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION) == false) {
+        if (licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION) == false) {
             logger.warn("[{}] setting will be ignored until an appropriate license is applied", MonitoringField.HISTORY_DURATION.getKey());
         }
 
@@ -166,7 +166,7 @@ public class CleanerService extends AbstractLifecycleComponent {
 
         @Override
         protected void doRunInLifecycle() throws Exception {
-            if (licenseState.isAllowed(Feature.MONITORING) == false) {
+            if (licenseState.checkFeature(Feature.MONITORING) == false) {
                 logger.debug("cleaning service is disabled due to invalid license");
                 return;
             }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/Collector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/Collector.java
@@ -73,7 +73,7 @@ public abstract class Collector {
      * @param isElectedMaster true if the current local node is the elected master node
      */
     protected boolean shouldCollect(final boolean isElectedMaster) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.MONITORING) == false) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.MONITORING) == false) {
             logger.trace("collector [{}] can not collect data due to invalid license", name());
             return false;
         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ccr/StatsCollector.java
@@ -65,7 +65,7 @@ public final class StatsCollector extends Collector {
         return isElectedMaster
                 && super.shouldCollect(isElectedMaster)
                 && XPackSettings.CCR_ENABLED_SETTING.get(settings)
-                && licenseState.isAllowed(XPackLicenseState.Feature.CCR);
+                && licenseState.checkFeature(XPackLicenseState.Feature.CCR);
     }
 
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichStatsCollector.java
@@ -48,7 +48,7 @@ public final class EnrichStatsCollector extends Collector {
     protected boolean shouldCollect(final boolean isElectedMaster) {
         return isElectedMaster
             && super.shouldCollect(isElectedMaster)
-            && licenseState.isAllowed(XPackLicenseState.Feature.ENRICH);
+            && licenseState.checkFeature(XPackLicenseState.Feature.ENRICH);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollector.java
@@ -64,7 +64,7 @@ public class JobStatsCollector extends Collector {
         return isElectedMaster
                 && super.shouldCollect(isElectedMaster)
                 && XPackSettings.MACHINE_LEARNING_ENABLED.get(settings)
-                && licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING);
+                && licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING);
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResource.java
@@ -82,7 +82,7 @@ public class ClusterAlertHttpResource extends PublishableHttpResource {
     @Override
     protected void doCheck(final RestClient client, final ActionListener<Boolean> listener) {
         // if we should be adding, then we need to check for existence
-        if (isWatchDefined() && licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)) {
+        if (isWatchDefined() && licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)) {
             final CheckedFunction<Response, Boolean, IOException> watchChecker =
                     (response) -> shouldReplaceClusterAlert(response, XContentType.JSON.xContent(), LAST_UPDATED_VERSION);
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporter.java
@@ -924,7 +924,7 @@ public class HttpExporter extends Exporter {
 
     @Override
     public void openBulk(final ActionListener<ExportBulk> listener) {
-        final boolean canUseClusterAlerts = config.licenseState().isAllowed(Feature.MONITORING_CLUSTER_ALERTS);
+        final boolean canUseClusterAlerts = config.licenseState().checkFeature(Feature.MONITORING_CLUSTER_ALERTS);
 
         // if this changes between updates, then we need to add OR remove the watches
         if (clusterAlertsAllowed.compareAndSet(!canUseClusterAlerts, canUseClusterAlerts)) {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -460,7 +460,7 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
                                                           final AtomicInteger pendingResponses) {
         final XPackClient xpackClient = new XPackClient(client);
         final WatcherClient watcher = xpackClient.watcher();
-        final boolean canAddWatches = licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS);
+        final boolean canAddWatches = licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS);
 
         for (final String watchId : ClusterAlertsUtil.WATCH_IDS) {
             final String uniqueWatchId = ClusterAlertsUtil.createUniqueWatchId(clusterService, watchId);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerServiceTests.java
@@ -66,32 +66,32 @@ public class CleanerServiceTests extends ESTestCase {
         TimeValue expected = TimeValue.timeValueHours(25);
         Settings settings = Settings.builder().put(MonitoringField.HISTORY_DURATION.getKey(), expected.getStringRep()).build();
 
-        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
 
         assertEquals(expected, new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
 
-        verify(licenseState).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
+        verify(licenseState).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testGetRetentionDefaultValueWithNoSettings() {
-        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
 
         assertEquals(MonitoringField.HISTORY_DURATION.get(Settings.EMPTY),
                      new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState).getRetention());
 
-        verify(licenseState).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
+        verify(licenseState).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testGetRetentionDefaultValueWithSettingsButUpdatesNotAllowed() {
         TimeValue notExpected = TimeValue.timeValueHours(25);
         Settings settings = Settings.builder().put(MonitoringField.HISTORY_DURATION.getKey(), notExpected.getStringRep()).build();
 
-        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false);
 
         assertEquals(MonitoringField.HISTORY_DURATION.get(Settings.EMPTY),
                      new CleanerService(settings, clusterSettings, threadPool, licenseState).getRetention());
 
-        verify(licenseState).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
+        verify(licenseState).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testSetGlobalRetention() {
@@ -99,7 +99,7 @@ public class CleanerServiceTests extends ESTestCase {
         // only thing calling this method and it will use the settings object to validate the time value
         TimeValue expected = TimeValue.timeValueHours(2);
 
-        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(true);
 
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState);
 
@@ -107,7 +107,7 @@ public class CleanerServiceTests extends ESTestCase {
 
         assertEquals(expected, service.getRetention());
 
-        verify(licenseState, times(2)).isAllowed(Feature.MONITORING_UPDATE_RETENTION); // once by set, once by get
+        verify(licenseState, times(2)).checkFeature(Feature.MONITORING_UPDATE_RETENTION); // once by set, once by get
     }
 
     public void testSetGlobalRetentionAppliesEvenIfLicenseDisallows() {
@@ -116,7 +116,7 @@ public class CleanerServiceTests extends ESTestCase {
         TimeValue expected = TimeValue.timeValueHours(2);
 
         // required to be true on the second call for it to see it take effect
-        when(licenseState.isAllowed(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING_UPDATE_RETENTION)).thenReturn(false).thenReturn(true);
 
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, threadPool, licenseState);
 
@@ -126,7 +126,7 @@ public class CleanerServiceTests extends ESTestCase {
         // uses allow=true
         assertEquals(expected, service.getRetention());
 
-        verify(licenseState, times(2)).isAllowed(Feature.MONITORING_UPDATE_RETENTION);
+        verify(licenseState, times(2)).checkFeature(Feature.MONITORING_UPDATE_RETENTION);
     }
 
     public void testNextExecutionDelay() {
@@ -158,7 +158,7 @@ public class CleanerServiceTests extends ESTestCase {
 
         logger.debug("--> creates a cleaner service that cleans every second");
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         CleanerService service = new CleanerService(Settings.EMPTY, clusterSettings, licenseState, threadPool,
                 new TestExecutionScheduler(1_000));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
@@ -51,7 +51,7 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -59,23 +59,23 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         final IndexRecoveryCollector collector = new IndexRecoveryCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(false), is(false));
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         final IndexRecoveryCollector collector = new IndexRecoveryCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(true), is(true));
-        verify(licenseState).isAllowed(Feature.MONITORING);
+        verify(licenseState).checkFeature(Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -46,7 +46,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -54,23 +54,23 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         final IndexStatsCollector collector = new IndexStatsCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(false), is(false));
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         final IndexStatsCollector collector = new IndexStatsCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(true), is(true));
-        verify(licenseState).isAllowed(Feature.MONITORING);
+        verify(licenseState).checkFeature(Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/ml/JobStatsCollectorTests.java
@@ -49,14 +49,14 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         whenLocalNodeElectedMaster(isElectedMaster);
 
         // this controls the blockage
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(mlAllowed);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(mlAllowed);
 
         final JobStatsCollector collector = new JobStatsCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
@@ -64,8 +64,8 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         // regardless of ML being enabled
         final Settings settings = randomFrom(mlEnabledSettings(), mlDisabledSettings());
 
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(randomBoolean());
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(randomBoolean());
         // this controls the blockage
         final boolean isElectedMaster = false;
 
@@ -78,8 +78,8 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         // this is controls the blockage
         final Settings settings = mlDisabledSettings();
 
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(randomBoolean());
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(randomBoolean());
 
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
@@ -89,16 +89,16 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfMLIsNotAllowed() {
         final Settings settings = randomFrom(mlEnabledSettings(), mlDisabledSettings());
 
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(randomBoolean());
         // this is controls the blockage
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -107,22 +107,22 @@ public class JobStatsCollectorTests extends BaseCollectorTestCase {
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
 
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
         final Settings settings = mlEnabledSettings();
 
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MACHINE_LEARNING)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final JobStatsCollector collector = new JobStatsCollector(settings, clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
 
-        verify(licenseState).isAllowed(Feature.MONITORING);
+        verify(licenseState).checkFeature(Feature.MONITORING);
     }
 
     public void testDoCollect() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsCollectorTests.java
@@ -39,7 +39,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -47,22 +47,22 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         final boolean isElectedMaster = true;
 
         final NodeStatsCollector collector = new NodeStatsCollector(clusterService, licenseState, client);
 
         assertThat(collector.shouldCollect(isElectedMaster), is(true));
-        verify(licenseState).isAllowed(Feature.MONITORING);
+        verify(licenseState).checkFeature(Feature.MONITORING);
     }
 
     public void testDoCollectWithFailures() throws Exception {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
 
         final TimeValue timeout = TimeValue.parseTimeValue(randomPositiveTimeValue(), NodeStatsCollectorTests.class.getName());
         withCollectionTimeout(NodeStatsCollector.NODE_STATS_TIMEOUT, timeout);
@@ -85,7 +85,7 @@ public class NodeStatsCollectorTests extends BaseCollectorTestCase {
     }
 
     public void testDoCollect() throws Exception {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
 
         final TimeValue timeout = TimeValue.timeValueSeconds(randomIntBetween(1, 120));
         withCollectionTimeout(NodeStatsCollector.NODE_STATS_TIMEOUT, timeout);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
@@ -44,7 +44,7 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
 
     public void testShouldCollectReturnsFalseIfMonitoringNotAllowed() {
         // this controls the blockage
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(false);
         final boolean isElectedMaster = randomBoolean();
         whenLocalNodeElectedMaster(isElectedMaster);
 
@@ -52,12 +52,12 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
 
         assertThat(collector.shouldCollect(isElectedMaster), is(false));
         if (isElectedMaster) {
-            verify(licenseState).isAllowed(Feature.MONITORING);
+            verify(licenseState).checkFeature(Feature.MONITORING);
         }
     }
 
     public void testShouldCollectReturnsFalseIfNotMaster() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         // this controls the blockage
         whenLocalNodeElectedMaster(false);
 
@@ -67,13 +67,13 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
     }
 
     public void testShouldCollectReturnsTrue() {
-        when(licenseState.isAllowed(Feature.MONITORING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.MONITORING)).thenReturn(true);
         whenLocalNodeElectedMaster(true);
 
         final ShardsCollector collector = new ShardsCollector(clusterService, licenseState);
 
         assertThat(collector.shouldCollect(true), is(true));
-        verify(licenseState).isAllowed(Feature.MONITORING);
+        verify(licenseState).checkFeature(Feature.MONITORING);
     }
 
     public void testDoCollectWhenNoClusterState() throws Exception {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/ClusterAlertHttpResourceTests.java
@@ -60,7 +60,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoCheckGetWatchExists() throws IOException {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
 
         final HttpEntity entity = entityForClusterAlert(true, minimumVersion);
 
@@ -68,7 +68,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoCheckGetWatchDoesNotExist() throws IOException {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
 
         if (randomBoolean()) {
             // it does not exist because it's literally not there
@@ -82,7 +82,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
     }
 
     public void testDoCheckWithExceptionGetWatchError() throws IOException {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(true);
 
         if (randomBoolean()) {
             // error because of a server error
@@ -100,7 +100,7 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
         final boolean clusterAlertsAllowed = randomBoolean();
 
         // should not matter
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(clusterAlertsAllowed);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(clusterAlertsAllowed);
 
         assertCheckAsDeleteExists(noWatchResource, "/_watcher/watch", watchId);
     }
@@ -110,19 +110,19 @@ public class ClusterAlertHttpResourceTests extends AbstractPublishableHttpResour
         final boolean clusterAlertsAllowed = randomBoolean();
 
         // should not matter
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(clusterAlertsAllowed);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(clusterAlertsAllowed);
 
         assertCheckAsDeleteWithException(noWatchResource, "/_watcher/watch", watchId);
     }
 
     public void testDoCheckAsDeleteWatchExists() throws IOException {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(false);
 
         assertCheckAsDeleteExists(resource, "/_watcher/watch", watchId);
     }
 
     public void testDoCheckWithExceptionAsDeleteWatchError() throws IOException {
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(false);
 
         assertCheckAsDeleteWithException(resource, "/_watcher/watch", watchId);
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterResourceTests.java
@@ -735,7 +735,7 @@ public class HttpExporterResourceTests extends AbstractPublishableHttpResourceTe
         when(state.metadata()).thenReturn(metadata);
         when(metadata.clusterUUID()).thenReturn("the_clusters_uuid");
 
-        when(licenseState.isAllowed(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(validLicense);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.MONITORING_CLUSTER_ALERTS)).thenReturn(validLicense);
 
         final HttpEntity entity =
                 new StringEntity("{\"features\":{\"watcher\":{\"enabled\":true,\"available\":true}}}", ContentType.APPLICATION_JSON);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTestCase.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.monitoring.exporter.local;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -69,7 +70,7 @@ public abstract class LocalExporterIntegTestCase extends MonitoringIntegTestCase
      */
     protected LocalExporter createLocalExporter() {
         final Settings settings = localExporterSettings();
-        final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY);
+        final XPackLicenseState licenseState = TestUtils.newTestLicenseState();
         final Exporter.Config config = new Exporter.Config(exporterName, "local", settings, clusterService(), licenseState);
         final CleanerService cleanerService =
                 new CleanerService(settings, clusterService().getClusterSettings(), THREADPOOL, licenseState);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -96,7 +96,7 @@ public class TransportPutRollupJobAction extends TransportMasterNodeAction<PutRo
     protected void masterOperation(PutRollupJobAction.Request request, ClusterState clusterState,
                                    ActionListener<AcknowledgedResponse> listener) {
 
-        if (!licenseState.isAllowed(XPackLicenseState.Feature.ROLLUP)) {
+        if (!licenseState.checkFeature(XPackLicenseState.Feature.ROLLUP)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.ROLLUP));
             return;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1035,7 +1035,7 @@ public class Security extends Plugin implements SystemIndexPlugin, IngestPlugin,
         if (enabled) {
             return index -> {
                 XPackLicenseState licenseState = getLicenseState();
-                if (licenseState.isSecurityEnabled() == false || licenseState.isAllowed(Feature.SECURITY_DLS_FLS) == false) {
+                if (licenseState.isSecurityEnabled() == false || licenseState.checkFeature(Feature.SECURITY_DLS_FLS) == false) {
                     return MapperPlugin.NOOP_FIELD_PREDICATE;
                 }
                 IndicesAccessControl indicesAccessControl = threadContext.get().getTransient(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
@@ -73,7 +73,7 @@ public class SecurityActionFilter implements ActionFilter {
          A functional requirement - when the license of security is disabled (invalid/expires), security will continue
          to operate normally, except all read operations will be blocked.
          */
-        if (licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH) == false && LICENSE_EXPIRATION_ACTION_MATCHER.test(action)) {
+        if (licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH) == false && LICENSE_EXPIRATION_ACTION_MATCHER.test(action)) {
             logger.error("blocking [{}] operation due to expired license. Cluster health, cluster stats and indices stats \n" +
                     "operations are blocked on license expiration. All data operations (read and write) continue to work. \n" +
                     "If you have a new license, please update it. Otherwise, please reach out to your support contact.", action);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
@@ -33,7 +33,7 @@ public class AuditTrailService {
 
     public AuditTrail get() {
         if (compositeAuditTrail.isEmpty() == false &&
-            licenseState.isSecurityEnabled() && licenseState.isAllowed(Feature.SECURITY_AUDITING)) {
+            licenseState.isSecurityEnabled() && licenseState.checkFeature(Feature.SECURITY_AUDITING)) {
             return compositeAuditTrail;
         } else {
             return NOOP_AUDIT_TRAIL;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -580,12 +580,12 @@ public class ApiKeyService {
 
     private boolean isEnabled() {
         return enabled && licenseState.isSecurityEnabled() &&
-            licenseState.isAllowed(XPackLicenseState.Feature.SECURITY_API_KEY_SERVICE);
+            licenseState.checkFeature(XPackLicenseState.Feature.SECURITY_API_KEY_SERVICE);
     }
 
     public void ensureEnabled() {
         if (licenseState.isSecurityEnabled() == false ||
-            licenseState.isAllowed(XPackLicenseState.Feature.SECURITY_API_KEY_SERVICE) == false) {
+            licenseState.checkFeature(XPackLicenseState.Feature.SECURITY_API_KEY_SERVICE) == false) {
             throw LicenseUtils.newComplianceException("api keys");
         }
         if (enabled == false) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -119,7 +119,7 @@ public class Realms implements Iterable<Realm> {
         }
 
         // If all realms are allowed, then nothing is unlicensed
-        if (licenseStateSnapshot.isAllowed(Feature.SECURITY_ALL_REALMS)) {
+        if (licenseStateSnapshot.checkFeature(Feature.SECURITY_ALL_REALMS)) {
             return Collections.emptyList();
         }
 
@@ -143,9 +143,9 @@ public class Realms implements Iterable<Realm> {
         if (licenseStateSnapshot.isSecurityEnabled() == false) {
             return Collections.emptyList();
         }
-        if (licenseStateSnapshot.isAllowed(Feature.SECURITY_ALL_REALMS)) {
+        if (licenseStateSnapshot.checkFeature(Feature.SECURITY_ALL_REALMS)) {
             return realms;
-        } else if (licenseStateSnapshot.isAllowed(Feature.SECURITY_STANDARD_REALMS)) {
+        } else if (licenseStateSnapshot.checkFeature(Feature.SECURITY_STANDARD_REALMS)) {
             return standardRealmsOnly;
         } else {
             // native realms are basic licensed, and always allowed, even for an expired license
@@ -337,9 +337,9 @@ public class Realms implements Iterable<Realm> {
     }
 
     public static boolean isRealmTypeAvailable(XPackLicenseState licenseState, String type) {
-        if (licenseState.isAllowed(Feature.SECURITY_ALL_REALMS)) {
+        if (licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)) {
             return true;
-        } else if (licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS)) {
+        } else if (licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)) {
             return InternalRealms.isStandardRealm(type) || ReservedRealm.TYPE.equals(type);
         } else {
             return FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -1568,12 +1568,12 @@ public final class TokenService {
 
     private boolean isEnabled() {
         return enabled && licenseState.isSecurityEnabled() &&
-            licenseState.isAllowed(XPackLicenseState.Feature.SECURITY_TOKEN_SERVICE);
+            licenseState.checkFeature(XPackLicenseState.Feature.SECURITY_TOKEN_SERVICE);
     }
 
     private void ensureEnabled() {
         if (licenseState.isSecurityEnabled() == false ||
-            licenseState.isAllowed(XPackLicenseState.Feature.SECURITY_TOKEN_SERVICE) == false) {
+            licenseState.checkFeature(XPackLicenseState.Feature.SECURITY_TOKEN_SERVICE) == false) {
             throw LicenseUtils.newComplianceException("security tokens");
         }
         if (enabled == false) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupport.java
@@ -81,7 +81,7 @@ public class DelegatedAuthorizationSupport {
      * with a meaningful diagnostic message.
      */
     public void resolve(String username, ActionListener<AuthenticationResult> resultListener) {
-        boolean authzOk = licenseState.isSecurityEnabled() && licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM);
+        boolean authzOk = licenseState.isSecurityEnabled() && licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM);
         if (authzOk == false) {
             resultListener.onResponse(AuthenticationResult.unsuccessful(
                 DelegatedAuthorizationSettings.AUTHZ_REALMS_SUFFIX + " are not permitted",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -367,7 +367,7 @@ public class AuthorizationService {
 
     private AuthorizationEngine getAuthorizationEngineForUser(final User user) {
         if (rbacEngine != authorizationEngine && licenseState.isSecurityEnabled() &&
-            licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)) {
+            licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)) {
             if (ClientReservedRealm.isReserved(user.principal(), settings) || isInternalUser(user)) {
                 return rbacEngine;
             } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/BulkShardRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/BulkShardRequestInterceptor.java
@@ -41,7 +41,7 @@ public class BulkShardRequestInterceptor implements RequestInterceptor {
     @Override
     public void intercept(RequestInfo requestInfo, AuthorizationEngine authzEngine, AuthorizationInfo authorizationInfo,
                           ActionListener<Void> listener) {
-        boolean shouldIntercept = licenseState.isSecurityEnabled() && licenseState.isAllowed(Feature.SECURITY_DLS_FLS);
+        boolean shouldIntercept = licenseState.isSecurityEnabled() && licenseState.checkFeature(Feature.SECURITY_DLS_FLS);
         if (requestInfo.getRequest() instanceof BulkShardRequest && shouldIntercept) {
             IndicesAccessControl indicesAccessControl = threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/FieldAndDocumentLevelSecurityRequestInterceptor.java
@@ -39,7 +39,7 @@ abstract class FieldAndDocumentLevelSecurityRequestInterceptor implements Reques
                           ActionListener<Void> listener) {
         if (requestInfo.getRequest() instanceof IndicesRequest) {
             IndicesRequest indicesRequest = (IndicesRequest) requestInfo.getRequest();
-            boolean shouldIntercept = licenseState.isSecurityEnabled() && licenseState.isAllowed(Feature.SECURITY_DLS_FLS);
+            boolean shouldIntercept = licenseState.isSecurityEnabled() && licenseState.checkFeature(Feature.SECURITY_DLS_FLS);
             if (supports(indicesRequest) && shouldIntercept) {
                 final IndicesAccessControl indicesAccessControl =
                     threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptor.java
@@ -52,7 +52,7 @@ public final class IndicesAliasesRequestInterceptor implements RequestIntercepto
             final XPackLicenseState frozenLicenseState = licenseState.copyCurrentLicenseState();
             final AuditTrail auditTrail = auditTrailService.get();
             if (frozenLicenseState.isSecurityEnabled()) {
-                if (frozenLicenseState.isAllowed(Feature.SECURITY_DLS_FLS)) {
+                if (frozenLicenseState.checkFeature(Feature.SECURITY_DLS_FLS)) {
                     IndicesAccessControl indicesAccessControl =
                         threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
                     for (IndicesAliasesRequest.AliasActions aliasAction : request.getAliasActions()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptor.java
@@ -48,7 +48,7 @@ public final class ResizeRequestInterceptor implements RequestInterceptor {
             final XPackLicenseState frozenLicenseState = licenseState.copyCurrentLicenseState();
             final AuditTrail auditTrail = auditTrailService.get();
             if (frozenLicenseState.isSecurityEnabled()) {
-                if (frozenLicenseState.isAllowed(Feature.SECURITY_DLS_FLS)) {
+                if (frozenLicenseState.checkFeature(Feature.SECURITY_DLS_FLS)) {
                     IndicesAccessControl indicesAccessControl =
                         threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
                     IndicesAccessControl.IndexAccessControl indexAccessControl =

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -166,7 +166,7 @@ public class CompositeRolesStore {
                                     rolesRetrievalResult.getMissingRoles()));
                         }
                         final Set<RoleDescriptor> effectiveDescriptors;
-                        if (licenseState.isAllowed(Feature.SECURITY_DLS_FLS)) {
+                        if (licenseState.checkFeature(Feature.SECURITY_DLS_FLS)) {
                             effectiveDescriptors = rolesRetrievalResult.getRoleDescriptors();
                         } else {
                             effectiveDescriptors = rolesRetrievalResult.getRoleDescriptors().stream()
@@ -321,7 +321,7 @@ public class CompositeRolesStore {
     private void loadRoleDescriptorsAsync(Set<String> roleNames, ActionListener<RolesRetrievalResult> listener) {
         final RolesRetrievalResult rolesResult = new RolesRetrievalResult();
         final List<BiConsumer<Set<String>, ActionListener<RoleRetrievalResult>>> asyncRoleProviders =
-            licenseState.isAllowed(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS) ? allRoleProviders : builtInRoleProviders;
+            licenseState.checkFeature(Feature.SECURITY_CUSTOM_ROLE_PROVIDERS) ? allRoleProviders : builtInRoleProviders;
 
         final ActionListener<RoleRetrievalResult> descriptorsListener =
             ContextPreservingActionListener.wrapPreservingContext(ActionListener.wrap(ignore -> {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
@@ -176,7 +176,7 @@ public class FileRolesStore implements BiConsumer<Set<String>, ActionListener<Ro
         if (Files.exists(path)) {
             try {
                 List<String> roleSegments = roleSegments(path);
-                final boolean flsDlsLicensed = licenseState.isAllowed(Feature.SECURITY_DLS_FLS);
+                final boolean flsDlsLicensed = licenseState.checkFeature(Feature.SECURITY_DLS_FLS);
                 for (String segment : roleSegments) {
                     RoleDescriptor descriptor = parseRoleDescriptor(segment, path, logger, resolvePermission, settings, xContentRegistry);
                     if (descriptor != null) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
@@ -201,7 +201,7 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
     }
 
     public void putRole(final PutRoleRequest request, final RoleDescriptor role, final ActionListener<Boolean> listener) {
-        if (licenseState.isAllowed(Feature.SECURITY_DLS_FLS)) {
+        if (licenseState.checkFeature(Feature.SECURITY_DLS_FLS)) {
             innerPutRole(request, role, listener);
         } else if (role.isUsingDocumentOrFieldLevelSecurity()) {
             listener.onFailure(LicenseUtils.newComplianceException("field and document level security"));
@@ -382,7 +382,7 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
             // we pass true as last parameter because we do not want to reject permissions if the field permissions
             // are given in 2.x syntax
             RoleDescriptor roleDescriptor = RoleDescriptor.parse(name, sourceBytes, true, XContentType.JSON);
-            if (licenseState.isAllowed(Feature.SECURITY_DLS_FLS)) {
+            if (licenseState.checkFeature(Feature.SECURITY_DLS_FLS)) {
                 return roleDescriptor;
             } else {
                 final boolean dlsEnabled =

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/RestDelegatePkiAuthenticationAction.java
@@ -55,7 +55,7 @@ public final class RestDelegatePkiAuthenticationAction extends SecurityBaseRestH
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS)) {
+        } else if (licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)) {
             return null;
         } else {
             logger.info("The '{}' realm is not available under the current license", PkiRealmSettings.TYPE);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandler.java
@@ -68,7 +68,7 @@ public abstract class SecurityBaseRestHandler extends BaseRestHandler {
     protected Exception checkFeatureAvailable(RestRequest request) {
         if (XPackSettings.SECURITY_ENABLED.get(settings) == false) {
             return new IllegalStateException("Security is not enabled but a security rest handler is registered");
-        } else if (licenseState.isAllowed(XPackLicenseState.Feature.SECURITY) == false) {
+        } else if (licenseState.checkFeature(XPackLicenseState.Feature.SECURITY) == false) {
             return LicenseUtils.newComplianceException(XPackField.SECURITY);
         } else if (licenseState.isSecurityEnabled() == false) {
             return new ElasticsearchException("Security must be explicitly enabled when using a [" +

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/ApiKeyBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/ApiKeyBaseRestHandler.java
@@ -30,7 +30,7 @@ abstract class ApiKeyBaseRestHandler extends SecurityBaseRestHandler {
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)) {
+        } else if (licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)) {
             return null;
         } else {
             logger.info("API Keys are not available under the current [{}] license", licenseState.getOperationMode().description());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/TokenBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/TokenBaseRestHandler.java
@@ -31,7 +31,7 @@ abstract class TokenBaseRestHandler extends SecurityBaseRestHandler {
         Exception failedFeature = super.checkFeatureAvailable(request);
         if (failedFeature != null) {
             return failedFeature;
-        } else if (licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)) {
+        } else if (licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)) {
             return null;
         } else {
             logger.info("Security tokens are not available under the current [{}] license", licenseState.getOperationMode().description());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListener.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListener.java
@@ -35,7 +35,7 @@ public class SecurityStatusChangeListener implements LicenseStateListener {
      */
     @Override
     public synchronized void licenseStateChanged() {
-        final boolean newState = licenseState.isAllowed(XPackLicenseState.Feature.SECURITY) && licenseState.isSecurityEnabled();
+        final boolean newState = licenseState.checkFeature(XPackLicenseState.Feature.SECURITY) && licenseState.isSecurityEnabled();
         // old state might be null (undefined) so do Object comparison
         if (Objects.equals(newState, securityEnabled) == false) {
             logger.info("Active license is now [{}]; Security is {}", licenseState.getOperationMode(), newState ? "enabled" : "disabled");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -201,7 +201,7 @@ public class IPFilter {
 
     public boolean accept(String profile, InetSocketAddress peerAddress) {
         if (licenseState.isSecurityEnabled() == false ||
-            licenseState.isAllowed(Feature.SECURITY_IP_FILTERING) == false) {
+            licenseState.checkFeature(Feature.SECURITY_IP_FILTERING) == false) {
             return true;
         }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
@@ -67,7 +67,7 @@ public class SecurityActionFilterTests extends ESTestCase {
         authzService = mock(AuthorizationService.class);
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_STATS_AND_HEALTH)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_STATS_AND_HEALTH)).thenReturn(true);
         ThreadPool threadPool = mock(ThreadPool.class);
         threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
@@ -179,7 +179,7 @@ public class TransportOpenIdConnectLogoutActionTests extends OpenIdConnectTestCa
 
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
 
         tokenService = new TokenService(settings, Clock.systemUTC(), client, licenseState, new SecurityContext(settings, threadContext),
                                         securityIndex, securityIndex, clusterService);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -206,7 +206,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
 
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
 
         final ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
         final SecurityContext securityContext = new SecurityContext(settings, threadContext);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -209,7 +209,7 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
 
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
         final ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
         final SecurityContext securityContext = new SecurityContext(settings, threadContext);
         tokenService = new TokenService(settings, Clock.systemUTC(), client, licenseState, securityContext, securityIndex, securityIndex,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -170,7 +170,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
 
         this.license = mock(XPackLicenseState.class);
         when(license.isSecurityEnabled()).thenReturn(true);
-        when(license.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(license.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportInvalidateTokenActionTests.java
@@ -75,7 +75,7 @@ public class TransportInvalidateTokenActionTests extends ESTestCase {
         this.clusterService = ClusterServiceUtils.createClusterService(threadPool);
         this.license = mock(XPackLicenseState.class);
         when(license.isSecurityEnabled()).thenReturn(true);
-        when(license.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(license.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
     }
 
     public void testInvalidateTokensWhenIndexUnavailable() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -52,7 +52,7 @@ public class AuditTrailServiceTests extends ESTestCase {
         service = new AuditTrailService(auditTrails, licenseState);
         isAuditingAllowed = randomBoolean();
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(isAuditingAllowed);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(isAuditingAllowed);
         token = mock(AuthenticationToken.class);
         request = mock(TransportRequest.class);
         restRequest = mock(RestRequest.class);
@@ -61,7 +61,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailed() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationFailed(requestId, token, "_action", request);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationFailed(requestId, token, "_action", request);
@@ -74,7 +74,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailedNoToken() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationFailed(requestId, "_action", request);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationFailed(requestId, "_action", request);
@@ -87,7 +87,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailedRestNoToken() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationFailed(requestId, restRequest);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationFailed(requestId, restRequest);
@@ -100,7 +100,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailedRest() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationFailed(requestId, token, restRequest);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationFailed(requestId, token, restRequest);
@@ -113,7 +113,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailedRealm() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationFailed(requestId, "_realm", token, "_action", request);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationFailed(requestId, "_realm", token, "_action", request);
@@ -126,7 +126,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAuthenticationFailedRestRealm() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationFailed(requestId, "_realm", token, restRequest);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationFailed(requestId, "_realm", token, restRequest);
@@ -139,7 +139,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     public void testAnonymousAccess() throws Exception {
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().anonymousAccessDenied(requestId, "_action", request);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).anonymousAccessDenied(requestId, "_action", request);
@@ -156,7 +156,7 @@ public class AuditTrailServiceTests extends ESTestCase {
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().accessGranted(requestId, authentication, "_action", request, authzInfo);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).accessGranted(requestId, authentication, "_action", request, authzInfo);
@@ -173,7 +173,7 @@ public class AuditTrailServiceTests extends ESTestCase {
             () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, new String[] { randomAlphaOfLengthBetween(1, 6) });
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().accessDenied(requestId, authentication, "_action", request, authzInfo);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).accessDenied(requestId, authentication, "_action", request, authzInfo);
@@ -187,7 +187,7 @@ public class AuditTrailServiceTests extends ESTestCase {
         InetAddress inetAddress = InetAddress.getLoopbackAddress();
         SecurityIpFilterRule rule = randomBoolean() ? SecurityIpFilterRule.ACCEPT_ALL : IPFilter.DEFAULT_PROFILE_ACCEPT_ALL;
         service.get().connectionGranted(inetAddress, "client", rule);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).connectionGranted(inetAddress, "client", rule);
@@ -201,7 +201,7 @@ public class AuditTrailServiceTests extends ESTestCase {
         InetAddress inetAddress = InetAddress.getLoopbackAddress();
         SecurityIpFilterRule rule = new SecurityIpFilterRule(false, "_all");
         service.get().connectionDenied(inetAddress, "client", rule);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).connectionDenied(inetAddress, "client", rule);
@@ -216,7 +216,7 @@ public class AuditTrailServiceTests extends ESTestCase {
         String realm = "_realm";
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationSuccess(requestId, realm, user, restRequest);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationSuccess(requestId, realm, user, restRequest);
@@ -231,7 +231,7 @@ public class AuditTrailServiceTests extends ESTestCase {
         String realm = "_realm";
         final String requestId = randomAlphaOfLengthBetween(6, 12);
         service.get().authenticationSuccess(requestId, realm, user, "_action", request);
-        verify(licenseState).isAllowed(Feature.SECURITY_AUDITING);
+        verify(licenseState).checkFeature(Feature.SECURITY_AUDITING);
         if (isAuditingAllowed) {
             for (AuditTrail auditTrail : auditTrails) {
                 verify(auditTrail).authenticationSuccess(requestId, realm, user, "_action", request);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -100,7 +100,7 @@ public class ApiKeyServiceTests extends ESTestCase {
     public void setupMocks() {
         this.licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
 
         this.client = mock(Client.class);
         this.securityIndex = SecurityMocks.mockSecurityIndexManager();
@@ -169,7 +169,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         mockKeyDocument(service, id, key, new User(randomAlphaOfLength(6), randomAlphaOfLength(12)));
 
-        when(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(false);
         final AuthenticationResult auth = tryAuthenticate(service, id, key);
         assertThat(auth.getStatus(), is(AuthenticationResult.Status.CONTINUE));
         assertThat(auth.getUser(), nullValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -189,12 +189,12 @@ public class AuthenticationServiceTests extends ESTestCase {
             .put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true)
             .build();
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(true);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
         ReservedRealm reservedRealm = mock(ReservedRealm.class);
         when(reservedRealm.type()).thenReturn("reserved");
         when(reservedRealm.name()).thenReturn("reserved_realm");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -82,18 +82,18 @@ public class RealmsTests extends ESTestCase {
     }
 
     private void allowAllRealms() {
-        when(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)).thenReturn(true);
     }
 
     private void allowOnlyStandardRealms() {
-        when(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS)).thenReturn(false);
-        when(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)).thenReturn(true);
     }
 
     private void allowOnlyNativeRealms() {
-        when(licenseState.isAllowed(Feature.SECURITY_ALL_REALMS)).thenReturn(false);
-        when(licenseState.isAllowed(Feature.SECURITY_STANDARD_REALMS)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_ALL_REALMS)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_STANDARD_REALMS)).thenReturn(false);
     }
 
     public void testWithSettings() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -144,7 +144,7 @@ public class TokenServiceTests extends ESTestCase {
         // License state (enabled by default)
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
 
         // version 7.2 was an "inflection" point in the Token Service development (access_tokens as UUIDS, multiple concurrent refreshes,
         // tokens docs on a separate index), let's test the TokenService works in a mixed cluster with nodes with versions prior to these
@@ -755,7 +755,7 @@ public class TokenServiceTests extends ESTestCase {
     }
 
     public void testCannotValidateTokenIfLicenseDoesNotAllowTokens() throws Exception {
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
         TokenService tokenService = createTokenService(tokenServiceEnabledSettings, Clock.systemUTC());
         Authentication authentication = new Authentication(new User("joe", "admin"), new RealmRef("native_realm", "native", "node1"), null);
         final String userTokenId = UUIDs.randomBase64UUID();
@@ -768,7 +768,7 @@ public class TokenServiceTests extends ESTestCase {
         storeTokenHeader(threadContext, tokenService.prependVersionAndEncodeAccessToken(token.getVersion(), accessToken));
 
         PlainActionFuture<UserToken> authFuture = new PlainActionFuture<>();
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(false);
         tokenService.getAndValidateToken(threadContext, authFuture);
         UserToken authToken = authFuture.actionGet();
         assertThat(authToken, Matchers.nullValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTestCase.java
@@ -85,7 +85,7 @@ public abstract class KerberosRealmTestCase extends ESTestCase {
             writeKeyTab(dir.resolve("key.keytab"), "asa").toString(), 100, "10m", true, randomBoolean());
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -108,7 +108,7 @@ public class LdapRealmTests extends LdapTestCase {
         sslService = new SSLService(defaultGlobalSettings, TestEnvironment.newEnvironment(defaultGlobalSettings));
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
     }
 
     @After

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealmTests.java
@@ -382,7 +382,7 @@ public class OpenIdConnectRealmTests extends OpenIdConnectTestCase {
     private void initializeRealms(Realm... realms) {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
 
         final List<Realm> realmList = Arrays.asList(realms);
         for (Realm realm : realms) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
@@ -76,7 +76,7 @@ public class PkiRealmTests extends ESTestCase {
                 .build();
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
     }
 
     public void testTokenSupport() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRealmTests.java
@@ -298,7 +298,7 @@ public class SamlRealmTests extends SamlTestCase {
     private void initializeRealms(Realm... realms) {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(true);
 
         final List<Realm> realmList = Arrays.asList(realms);
         for (Realm realm : realms) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DelegatedAuthorizationSupportTests.java
@@ -190,7 +190,7 @@ public class DelegatedAuthorizationSupportTests extends ESTestCase {
     private XPackLicenseState getLicenseState(boolean authzRealmsAllowed) {
         final XPackLicenseState license = mock(XPackLicenseState.class);
         when(license.isSecurityEnabled()).thenReturn(true);
-        when(license.isAllowed(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(authzRealmsAllowed);
+        when(license.checkFeature(Feature.SECURITY_AUTHORIZATION_REALM)).thenReturn(authzRealmsAllowed);
         return license;
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -205,7 +205,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         auditTrail = mock(AuditTrail.class);
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
         auditTrailService = new AuditTrailService(Collections.singletonList(auditTrail), licenseState);
         threadContext = new ThreadContext(settings);
         threadPool = mock(ThreadPool.class);
@@ -1457,7 +1457,7 @@ public class AuthorizationServiceTests extends ESTestCase {
 
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
         authorizationService = new AuthorizationService(Settings.EMPTY, rolesStore, clusterService,
             auditTrailService, new DefaultAuthenticationFailureHandler(Collections.emptyMap()), threadPool,
             new AnonymousUser(Settings.EMPTY), engine, Collections.emptySet(), licenseState, new IndexNameExpressionResolver());
@@ -1465,61 +1465,61 @@ public class AuthorizationServiceTests extends ESTestCase {
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             authentication = createAuthentication(new User("test user", "a_all"));
             assertEquals(engine, authorizationService.getAuthorizationEngine(authentication));
-            when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
+            when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
         }
 
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             authentication = createAuthentication(new User("runas", new String[]{"runas_role"}, new User("runner", "runner_role")));
             assertEquals(engine, authorizationService.getAuthorizationEngine(authentication));
             assertEquals(engine, authorizationService.getRunAsAuthorizationEngine(authentication));
-            when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
+            when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
         }
 
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             authentication = createAuthentication(new User("runas", new String[]{"runas_role"}, new ElasticUser(true)));
             assertEquals(engine, authorizationService.getAuthorizationEngine(authentication));
             assertNotEquals(engine, authorizationService.getRunAsAuthorizationEngine(authentication));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
-            when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
+            when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
         }
 
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             authentication = createAuthentication(new User("elastic", new String[]{"superuser"}, new User("runner", "runner_role")));
             assertNotEquals(engine, authorizationService.getAuthorizationEngine(authentication));
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertEquals(engine, authorizationService.getRunAsAuthorizationEngine(authentication));
-            when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
+            when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
         }
 
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             authentication = createAuthentication(new User("kibana", new String[]{"kibana_system"}, new ElasticUser(true)));
             assertNotEquals(engine, authorizationService.getAuthorizationEngine(authentication));
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertNotEquals(engine, authorizationService.getRunAsAuthorizationEngine(authentication));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
-            when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
+            when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
         }
 
-        when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             authentication = createAuthentication(randomFrom(XPackUser.INSTANCE, XPackSecurityUser.INSTANCE,
                 new ElasticUser(true), new KibanaUser(true)));
             assertNotEquals(engine, authorizationService.getRunAsAuthorizationEngine(authentication));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
-            when(licenseState.isAllowed(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
+            when(licenseState.checkFeature(Feature.SECURITY_AUTHORIZATION_ENGINE)).thenReturn(false);
             assertThat(authorizationService.getAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
             assertThat(authorizationService.getRunAsAuthorizationEngine(authentication), instanceOf(RBACEngine.class));
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
@@ -97,7 +97,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
         testSearchContext.scrollContext().scroll = new Scroll(TimeValue.timeValueSeconds(2L));
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         final SecurityContext securityContext = new SecurityContext(Settings.EMPTY, threadContext);
         AuditTrail auditTrail = mock(AuditTrail.class);
@@ -186,7 +186,7 @@ public class SecuritySearchOperationListenerTests extends ESTestCase {
         TransportRequest request = Empty.INSTANCE;
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
         AuditTrail auditTrail = mock(AuditTrail.class);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.singletonList(auditTrail), licenseState);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/IndicesAliasesRequestInterceptorTests.java
@@ -47,8 +47,8 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
         Authentication authentication = new Authentication(new User("john", "role"), new RealmRef(null, null, null),
@@ -106,8 +106,8 @@ public class IndicesAliasesRequestInterceptorTests extends ESTestCase {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(randomBoolean());
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(randomBoolean());
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
         Authentication authentication = new Authentication(new User("john", "role"), new RealmRef(null, null, null),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/ResizeRequestInterceptorTests.java
@@ -51,8 +51,8 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -103,8 +103,8 @@ public class ResizeRequestInterceptorTests extends ESTestCase {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.copyCurrentLicenseState()).thenReturn(licenseState);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
         ThreadPool threadPool = mock(ThreadPool.class);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -119,7 +119,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
     public void testRolesWhenDlsFlsUnlicensed() throws IOException {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(false);
         RoleDescriptor flsRole = new RoleDescriptor("fls", null, new IndicesPrivileges[] {
                 IndicesPrivileges.builder()
                         .grantedFields("*")
@@ -190,7 +190,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
     public void testRolesWhenDlsFlsLicensed() throws IOException {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_DLS_FLS)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_DLS_FLS)).thenReturn(true);
         RoleDescriptor flsRole = new RoleDescriptor("fls", null, new IndicesPrivileges[] {
                 IndicesPrivileges.builder()
                         .grantedFields("*")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
@@ -30,7 +30,7 @@ public class SecurityBaseRestHandlerTests extends ESTestCase {
         final boolean securityDefaultEnabled = randomBoolean();
         final AtomicBoolean consumerCalled = new AtomicBoolean(false);
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(licenseState.isSecurityEnabled()).thenReturn(securityDefaultEnabled);
         when(licenseState.getOperationMode()).thenReturn(
             randomFrom(License.OperationMode.BASIC, License.OperationMode.STANDARD, License.OperationMode.GOLD));
@@ -63,7 +63,7 @@ public class SecurityBaseRestHandlerTests extends ESTestCase {
         verifyZeroInteractions(licenseState);
         handler.handleRequest(fakeRestRequest, fakeRestChannel, client);
 
-        verify(licenseState).isAllowed(XPackLicenseState.Feature.SECURITY);
+        verify(licenseState).checkFeature(XPackLicenseState.Feature.SECURITY);
         if (securityDefaultEnabled) {
             assertTrue(consumerCalled.get());
             assertEquals(0, fakeRestChannel.responses().get());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateApiKeyActionTests.java
@@ -54,9 +54,9 @@ public class RestCreateApiKeyActionTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
         threadPool = new ThreadPool(settings);
-        when(mockLicenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
+        when(mockLicenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(mockLicenseState.isSecurityEnabled()).thenReturn(true);
-        when(mockLicenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
+        when(mockLicenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
@@ -54,9 +54,9 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         settings = Settings.builder().put("path.home", createTempDir().toString()).put("node.name", "test-" + getTestName())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
         threadPool = new ThreadPool(settings);
-        when(mockLicenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
+        when(mockLicenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(mockLicenseState.isSecurityEnabled()).thenReturn(true);
-        when(mockLicenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
+        when(mockLicenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
@@ -54,9 +54,9 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
         threadPool = new ThreadPool(settings);
-        when(mockLicenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
+        when(mockLicenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
         when(mockLicenseState.isSecurityEnabled()).thenReturn(true);
-        when(mockLicenseState.isAllowed(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
+        when(mockLicenseState.checkFeature(Feature.SECURITY_API_KEY_SERVICE)).thenReturn(true);
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesActionTests.java
@@ -42,7 +42,7 @@ public class RestGetUserPrivilegesActionTests extends ESTestCase {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         final RestGetUserPrivilegesAction action =
             new RestGetUserPrivilegesAction(Settings.EMPTY, mock(SecurityContext.class), licenseState);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
         final FakeRestRequest request = new FakeRestRequest();
         final FakeRestChannel channel = new FakeRestChannel(request, true, 1);
         action.handleRequest(request, channel, mock(NodeClient.class));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesActionTests.java
@@ -53,7 +53,7 @@ public class RestHasPrivilegesActionTests extends ESTestCase {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         final RestHasPrivilegesAction action =
             new RestHasPrivilegesAction(Settings.EMPTY, mock(SecurityContext.class), licenseState);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(false);
         try (XContentBuilder bodyBuilder = JsonXContent.contentBuilder().startObject().endObject()) {
             final RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
                 .withPath("/_security/user/_has_privileges/")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityStatusChangeListenerTests.java
@@ -30,7 +30,7 @@ public class SecurityStatusChangeListenerTests extends ESTestCase {
     @Before
     public void setup() throws IllegalAccessException {
         licenseState = Mockito.mock(XPackLicenseState.class);
-        when(licenseState.isAllowed(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
+        when(licenseState.checkFeature(XPackLicenseState.Feature.SECURITY)).thenReturn(true);
 
         listener = new SecurityStatusChangeListener(licenseState);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityMocks.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityMocks.java
@@ -174,7 +174,7 @@ public final class SecurityMocks {
         when(client.threadPool()).thenReturn(threadPool);
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_TOKEN_SERVICE)).thenReturn(true);
         final ClusterService clusterService = mock(ClusterService.class);
 
         final SecurityContext securityContext = new SecurityContext(settings, threadPool.getThreadContext());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -62,8 +62,8 @@ public class IPFilterTests extends ESTestCase {
     public void init() {
         licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_AUDITING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_AUDITING)).thenReturn(true);
         auditTrail = mock(AuditTrail.class);
         auditTrailService = new AuditTrailService(Collections.singletonList(auditTrail), licenseState);
         clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(Arrays.asList(
@@ -253,7 +253,7 @@ public class IPFilterTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put("xpack.security.transport.filter.deny", "_all")
                 .build();
-        when(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING)).thenReturn(false);
+        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(false);
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
 
@@ -264,7 +264,7 @@ public class IPFilterTests extends ESTestCase {
         verifyZeroInteractions(auditTrail);
 
         // for sanity enable license and check that it is denied
-        when(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
@@ -58,7 +58,7 @@ public class IpFilterRemoteAddressFilterTests extends ESTestCase {
                 IPFilter.PROFILE_FILTER_DENY_SETTING)));
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
         IPFilter ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/NioIPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/nio/NioIPFilterTests.java
@@ -61,7 +61,7 @@ public class NioIPFilterTests extends ESTestCase {
             IPFilter.PROFILE_FILTER_DENY_SETTING)));
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         when(licenseState.isSecurityEnabled()).thenReturn(true);
-        when(licenseState.isAllowed(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
+        when(licenseState.checkFeature(Feature.SECURITY_IP_FILTERING)).thenReturn(true);
         AuditTrailService auditTrailService = new AuditTrailService(Collections.emptyList(), licenseState);
         ipFilter = new IPFilter(settings, auditTrailService, clusterSettings, licenseState);
         ipFilter.setBoundTransportAddress(transport.boundAddress(), transport.profileBoundAddresses());

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -107,7 +107,7 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, SearchPlug
         builder.register(GeoCentroidAggregationBuilder.NAME, GeoShapeValuesSourceType.instance(),
             (MetricAggregatorSupplier) (name, valuesSourceConfig, aggregationContext, parent, metadata)
                 -> {
-                if (getLicenseState().isAllowed(XPackLicenseState.Feature.SPATIAL_GEO_CENTROID)) {
+                if (getLicenseState().checkFeature(XPackLicenseState.Feature.SPATIAL_GEO_CENTROID)) {
                     return new GeoShapeCentroidAggregator(name, aggregationContext, parent, valuesSourceConfig, metadata);
                 }
                 throw LicenseUtils.newComplianceException("geo_centroid aggregation on geo_shape fields");
@@ -118,7 +118,7 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, SearchPlug
         builder.register(GeoHashGridAggregationBuilder.NAME, GeoShapeValuesSourceType.instance(),
             (GeoGridAggregatorSupplier) (name, factories, valuesSource, precision, geoBoundingBox, requiredSize, shardSize,
                                          aggregationContext, parent, collectsFromSingleBucket, metadata) -> {
-                if (getLicenseState().isAllowed(XPackLicenseState.Feature.SPATIAL_GEO_GRID)) {
+                if (getLicenseState().checkFeature(XPackLicenseState.Feature.SPATIAL_GEO_GRID)) {
                     final GeoGridTiler tiler;
                     if (geoBoundingBox.isUnbounded()) {
                         tiler = new GeoHashGridTiler();
@@ -138,7 +138,7 @@ public class SpatialPlugin extends GeoPlugin implements MapperPlugin, SearchPlug
         builder.register(GeoTileGridAggregationBuilder.NAME, GeoShapeValuesSourceType.instance(),
             (GeoGridAggregatorSupplier) (name, factories, valuesSource, precision, geoBoundingBox, requiredSize, shardSize,
                                          aggregationContext, parent, collectsFromSingleBucket, metadata) -> {
-                if (getLicenseState().isAllowed(XPackLicenseState.Feature.SPATIAL_GEO_GRID)) {
+                if (getLicenseState().checkFeature(XPackLicenseState.Feature.SPATIAL_GEO_GRID)) {
                     final GeoGridTiler tiler;
                     if (geoBoundingBox.isUnbounded()) {
                         tiler = new GeoTileGridTiler();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
@@ -53,18 +53,18 @@ public class SqlPlugin extends Plugin implements ActionPlugin {
             XPackLicenseState licenseState = getLicenseState();
             switch (mode) {
                 case JDBC:
-                    if (licenseState.isAllowed(XPackLicenseState.Feature.JDBC) == false) {
+                    if (licenseState.checkFeature(XPackLicenseState.Feature.JDBC) == false) {
                         throw LicenseUtils.newComplianceException("jdbc");
                     }
                     break;
                 case ODBC:
-                    if (licenseState.isAllowed(XPackLicenseState.Feature.ODBC) == false) {
+                    if (licenseState.checkFeature(XPackLicenseState.Feature.ODBC) == false) {
                         throw LicenseUtils.newComplianceException("odbc");
                     }
                     break;
                 case PLAIN:
                 case CLI:
-                    if (licenseState.isAllowed(XPackLicenseState.Feature.SQL) == false) {
+                    if (licenseState.checkFeature(XPackLicenseState.Feature.SQL) == false) {
                         throw LicenseUtils.newComplianceException(XPackField.SQL);
                     }
                     break;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -132,7 +132,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<
 
     @Override
     protected void doExecute(Task task, PreviewTransformAction.Request request, ActionListener<PreviewTransformAction.Response> listener) {
-        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
+        if (!licenseState.checkFeature(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -203,7 +203,7 @@ public class TransportPutTransformAction extends TransportMasterNodeAction<Reque
     protected void masterOperation(Request request, ClusterState clusterState, ActionListener<AcknowledgedResponse> listener)
         throws Exception {
 
-        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
+        if (!licenseState.checkFeature(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -161,7 +161,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
         ClusterState state,
         ActionListener<StartTransformAction.Response> listener
     ) throws Exception {
-        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
+        if (!licenseState.checkFeature(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -156,7 +156,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
-        if (!licenseState.isAllowed(XPackLicenseState.Feature.TRANSFORM)) {
+        if (!licenseState.checkFeature(XPackLicenseState.Feature.TRANSFORM)) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.TRANSFORM));
             return;
         }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/WatcherTransportAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/WatcherTransportAction.java
@@ -35,7 +35,7 @@ public abstract class WatcherTransportAction<Request extends ActionRequest, Resp
 
     @Override
     protected final void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        if (licenseState.isAllowed(XPackLicenseState.Feature.WATCHER)) {
+        if (licenseState.checkFeature(XPackLicenseState.Feature.WATCHER)) {
             doExecute(request, listener);
         } else {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.WATCHER));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/AbstractWatcherIntegrationTestCase.java
@@ -536,7 +536,7 @@ public abstract class AbstractWatcherIntegrationTestCase extends ESIntegTestCase
     protected void ensureLicenseEnabled() throws Exception {
         assertBusy(() -> {
             for (XPackLicenseState licenseState : internalCluster().getInstances(XPackLicenseState.class)) {
-                assertThat(licenseState.isAllowed(XPackLicenseState.Feature.WATCHER), is(true));
+                assertThat(licenseState.checkFeature(XPackLicenseState.Feature.WATCHER), is(true));
             }
         });
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchActionTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/ack/TransportAckWatchActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -63,7 +64,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
         client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
         action = new TransportAckWatchAction(transportService, new ActionFilters(Collections.emptySet()),
-            Clock.systemUTC(), new XPackLicenseState(Settings.EMPTY), watchParser, client, createClusterService(threadPool));
+            Clock.systemUTC(), TestUtils.newTestLicenseState(), watchParser, client, createClusterService(threadPool));
     }
 
     public void testWatchNotFound() {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/put/TransportPutWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/put/TransportPutWatchActionTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.protocol.xpack.watcher.PutWatchRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -75,7 +75,7 @@ public class TransportPutWatchActionTests extends ESTestCase {
         }).when(client).execute(any(), any(), any());
 
         action = new TransportPutWatchAction(transportService, threadPool, new ActionFilters(Collections.emptySet()),
-            new ClockMock(), new XPackLicenseState(Settings.EMPTY), parser, client);
+            new ClockMock(), TestUtils.newTestLicenseState(), parser, client);
     }
 
     public void testHeadersAreFilteredWhenPuttingWatches() throws Exception {


### PR DESCRIPTION
The checks on the license state have a singular method, isAllowed, that
returns whether the given feature is allowed by the current license.
However, there are two classes of usages, one which intends to actually
use a feature, and another that intends to return in telemetry whether
the feature is allowed. When feature usage tracking is added, the latter
case should not count as a "usage", so this commit reworks the calls to
isAllowed into 2 methods, checkFeature, which will (eventually) both
check whether a feature is allowed, and keep track of the last usage
time, and isAllowed, which simply determines whether the feature is
allowed.

Note that I considered having a boolean flag on the current method, but
wanted the additional clarity that a different method name provides,
versus a boolean flag which is more easily copied without realizing what
the flag means since it is nameless in call sites.