### PR TITLE
Fix exists query on unmapped field in query_string

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -23,6 +23,7 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
@@ -136,15 +137,19 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
-        return newFilter(context, fieldName);
+        return newFilter(context, fieldName, true);
     }
 
-    public static Query newFilter(QueryShardContext context, String fieldPattern) {
+    public static Query newFilter(QueryShardContext context, String fieldPattern, boolean checkRewrite) {
 
        Collection<String> fields = getMappedField(context, fieldPattern);
 
         if (fields.isEmpty()) {
-            throw new IllegalStateException("Rewrite first");
+            if (checkRewrite) {
+                throw new IllegalStateException("Rewrite first");
+            } else {
+                return new MatchNoDocsQuery("unmapped field:" + fieldPattern);
+            }
         }
 
         if (fields.size() == 1) {

--- a/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
+++ b/server/src/main/java/org/elasticsearch/index/query/LegacyGeoShapeQueryProcessor.java
@@ -94,7 +94,7 @@ public class LegacyGeoShapeQueryProcessor implements QueryProcessor {
             // before, including creating lucene fieldcache (!)
             // in this case, execute disjoint as exists && !intersects
             BooleanQuery.Builder bool = new BooleanQuery.Builder();
-            Query exists = ExistsQueryBuilder.newFilter(context, fieldName);
+            Query exists = ExistsQueryBuilder.newFilter(context, fieldName,false);
             Query intersects = prefixTreeStrategy.makeQuery(getArgs(shape, ShapeRelation.INTERSECTS));
             bool.add(exists, BooleanClause.Occur.MUST);
             bool.add(intersects, BooleanClause.Occur.MUST_NOT);

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -486,7 +486,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
             }
             // Exists query would fail if the fieldNames field is disabled.
             if (fieldNamesFieldType.isEnabled()) {
-                return ExistsQueryBuilder.newFilter(context, fieldName);
+                return ExistsQueryBuilder.newFilter(context, fieldName, false);
             }
         }
         MappedFieldType mapper = context.fieldMapper(this.fieldName);

--- a/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -632,7 +632,7 @@ public class QueryStringQueryParser extends XQueryParser {
             return new WildcardQuery(new Term(fieldName, "*"));
         }
 
-        return ExistsQueryBuilder.newFilter(context, fieldName);
+        return ExistsQueryBuilder.newFilter(context, fieldName, false);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -113,6 +113,8 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
         IllegalStateException e = expectThrows(IllegalStateException.class,
             () -> queryBuilder.toQuery(context));
         assertEquals("Rewrite first", e.getMessage());
+        Query ret = ExistsQueryBuilder.newFilter(context, "foo", false);
+        assertThat(ret, instanceOf(MatchNoDocsQuery.class));
     }
 
     public void testIllegalArguments() {


### PR DESCRIPTION
Since #55785, exists queries rewrite to MatchNoneQueryBuilder when the field is unmapped.
This change also introduced a bug in the `query_string` query, using an unmapped field
like `_exists_:foo` throws an exception if the field is unmapped. This commit avoids the
exception if the query is built outside of an `ExistsQueryBuilder`.

Closes #58737