### PR TITLE
Mute failing test DataFrameAnalyticsConfigProviderIT.testUpdate_UpdateCannotBeAppliedWhenTaskIsRunning

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
@@ -308,6 +308,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
         assertThat(exceptionHolder.get(), is(instanceOf(ResourceNotFoundException.class)));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/58814")
     public void testUpdate_UpdateCannotBeAppliedWhenTaskIsRunning() throws InterruptedException {
         String configId = "config-id";
         DataFrameAnalyticsConfig initialConfig = DataFrameAnalyticsConfigTests.createRandom(configId);


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/58814