### PR TITLE
[ML] manually create alias to fix inference stats tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/inference_stats_crud.yml
@@ -105,6 +105,16 @@ setup:
         body: >
           {
           }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.put_alias:
+        index: .ml-stats-000001
+        name: .ml-stats-write
+        body:
+          is_write_index: true
+          is_hidden: true
+
   # reference and then de-reference a model to flush the stats
   - do:
       headers:


### PR DESCRIPTION
Manually creating the index is not the real answer. For some reason `.ml-stats-write` is being created as a concrete index in our tests.

This is a big problem and needs to be fixed. 

Investigating.

closes https://github.com/elastic/elasticsearch/issues/58662