### PR TITLE
Fix deprecated task input declaration in LazyPropertyMap

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyMap.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/LazyPropertyMap.java
@@ -164,11 +164,13 @@ public class LazyPropertyMap<K, V> extends AbstractLazyPropertyCollection implem
             this.normalization = normalization;
         }
 
+        @Input
         public PropertyNormalization getNormalization() {
             return normalization;
         }
 
         @Override
+        @Input
         public String getName() {
             return getKey().toString();
         }


### PR DESCRIPTION
Fixes deprecation warnings like this: https://gradle-enterprise.elastic.co/s/wjbfspxdq356u/deprecations?expanded=WyIyMzMiXQ

related to #57920