### PR TITLE
Remove deprecated compileOnly resolution

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -23,6 +23,7 @@ import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.NoticeTask
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin
 import org.elasticsearch.gradle.info.BuildParams
 import org.elasticsearch.gradle.test.rest.RestResourcesPlugin
 import org.elasticsearch.gradle.test.RestIntegTestTask
@@ -55,6 +56,7 @@ class PluginBuildPlugin implements Plugin<Project> {
         project.pluginManager.apply(BuildPlugin)
         project.pluginManager.apply(TestClustersPlugin)
         project.pluginManager.apply(RestResourcesPlugin)
+        project.pluginManager.apply(CompileOnlyResolvePlugin.class);
 
         PluginPropertiesExtension extension = project.extensions.create(PLUGIN_EXTENSION_NAME, PluginPropertiesExtension, project)
         configureDependencies(project)
@@ -210,7 +212,9 @@ class PluginBuildPlugin implements Plugin<Project> {
              * that shadow jar.
              */
             from { project.plugins.hasPlugin(ShadowPlugin) ? project.shadowJar : project.jar }
-            from project.configurations.runtimeClasspath - project.configurations.compileOnly
+            from project.configurations.runtimeClasspath - project.configurations.getByName(
+                CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME
+            )
             // extra files for the plugin to go into the zip
             from('src/main/packaging') // TODO: move all config/bin/_size/etc into packaging
             from('src/main') {


### PR DESCRIPTION
Ideally this should not be required but current runtime classpath requires this as compileOnly has overlapping dependencies that need to be removed. We need to revisit the classpath declarations in detail to be able to remove this type of (in theory) superflous compile only references and kind of misuses of compileOnly. 

Related to #57920