### PR TITLE
Remove Outdated BwC Logic in Snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 
@@ -70,26 +69,14 @@ public class DeleteSnapshotRequest extends MasterNodeRequest<DeleteSnapshotReque
     public DeleteSnapshotRequest(StreamInput in) throws IOException {
         super(in);
         repository = in.readString();
-        if (in.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-            snapshots = in.readStringArray();
-        } else {
-            snapshots = new String[] {in.readString()};
-        }
+        snapshots = in.readStringArray();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(repository);
-        if (out.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-            out.writeStringArray(snapshots);
-        } else {
-            if (snapshots.length != 1) {
-                throw new IllegalArgumentException(
-                    "Can't write snapshot delete with more than one snapshot to version [" + out.getVersion() + "]");
-            }
-            out.writeString(snapshots[0]);
-        }
+        out.writeStringArray(snapshots);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -28,9 +28,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.RepositoryOperation;
-import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
-import org.elasticsearch.snapshots.SnapshotsService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -199,14 +197,8 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
         }
 
         public Entry(StreamInput in) throws IOException {
-            if (in.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-                this.repoName = in.readString();
-                this.snapshots = in.readList(SnapshotId::new);
-            } else {
-                final Snapshot snapshot = new Snapshot(in);
-                this.snapshots = Collections.singletonList(snapshot.getSnapshotId());
-                this.repoName = snapshot.getRepository();
-            }
+            this.repoName = in.readString();
+            this.snapshots = in.readList(SnapshotId::new);
             this.startTime = in.readVLong();
             this.repositoryStateId = in.readLong();
         }
@@ -244,14 +236,8 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getVersion().onOrAfter(SnapshotsService.MULTI_DELETE_VERSION)) {
-                out.writeString(repoName);
-                out.writeCollection(snapshots);
-            } else {
-                assert snapshots.size() == 1 : "Only single deletion allowed in mixed version cluster containing [" + out.getVersion() +
-                        "] but saw " + snapshots;
-                new Snapshot(repoName, snapshots.get(0)).writeTo(out);
-            }
+            out.writeString(repoName);
+            out.writeCollection(snapshots);
             out.writeVLong(startTime);
             out.writeLong(repositoryStateId);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -59,8 +59,6 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
     public static final SnapshotsInProgress EMPTY = new SnapshotsInProgress(List.of());
 
-    private static final Version VERSION_IN_SNAPSHOT_VERSION = Version.V_7_7_0;
-
     public static final String TYPE = "snapshots";
 
     @Override
@@ -545,15 +543,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             final String failure = in.readOptionalString();
             final Map<String, Object> userMetadata = in.readMap();
             final Version version;
-            if (in.getVersion().onOrAfter(VERSION_IN_SNAPSHOT_VERSION)) {
-                version = Version.readVersion(in);
-            } else {
-                // If an older master informs us that shard generations are supported we use the minimum shard generation compatible
-                // version. If shard generations are not supported yet we use a placeholder for a version that does not use shard
-                // generations.
-                version = in.readBoolean() ? SnapshotsService.SHARD_GEN_IN_REPO_DATA_VERSION : SnapshotsService.OLD_SNAPSHOT_FORMAT;
-            }
-
+            version = Version.readVersion(in);
             List<String> dataStreams;
             if (in.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {
                 dataStreams = in.readStringList();
@@ -598,11 +588,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             out.writeLong(entry.repositoryStateId);
             out.writeOptionalString(entry.failure);
             out.writeMap(entry.userMetadata);
-            if (out.getVersion().onOrAfter(VERSION_IN_SNAPSHOT_VERSION)) {
-                Version.writeVersion(entry.version, out);
-            } else {
-                out.writeBoolean(SnapshotsService.useShardGenerations(entry.version));
-            }
+            Version.writeVersion(entry.version, out);
             if (out.getVersion().onOrAfter(DATA_STREAMS_IN_SNAPSHOT)) {
                 out.writeStringCollection(entry.dataStreams);
             }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -119,8 +119,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     public static final Version OLD_SNAPSHOT_FORMAT = Version.V_7_5_0;
 
-    public static final Version MULTI_DELETE_VERSION = Version.V_7_8_0;
-
     private static final Logger logger = LogManager.getLogger(SnapshotsService.class);
 
     public static final String UPDATE_SNAPSHOT_STATUS_ACTION_NAME = "internal:cluster/snapshot/update_snapshot_status";
@@ -853,11 +851,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
-                if (snapshotNames.length > 1 && currentState.nodes().getMinNodeVersion().before(MULTI_DELETE_VERSION)) {
-                    throw new IllegalArgumentException("Deleting multiple snapshots in a single request is only supported in version [ "
-                            + MULTI_DELETE_VERSION + "] but cluster contained node of version [" + currentState.nodes().getMinNodeVersion()
-                            + "]");
-                }
                 final SnapshotsInProgress snapshots = currentState.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY);
                 final SnapshotsInProgress.Entry snapshotEntry = findInProgressSnapshot(snapshots, snapshotNames, repositoryName);
                 final List<SnapshotId> snapshotIds = matchingSnapshotIds(


### PR DESCRIPTION
7.8 is released so we can simplify a few things.
