### PR TITLE
Preserve templates in rolling-upgrade test cases

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
@@ -57,6 +57,11 @@ public abstract class AbstractRollingTestCase extends ESRestTestCase {
     }
 
     @Override
+    protected boolean preserveTemplatesUponCompletion() {
+        return true;
+    }
+
+    @Override
     protected final Settings restClientSettings() {
         return Settings.builder().put(super.restClientSettings())
             // increase the timeout here to 90 seconds to handle long waits for a green

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/UpgradeClusterClientYamlTestSuiteIT.java
@@ -40,6 +40,11 @@ public class UpgradeClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCa
         return true;
     }
 
+    @Override
+    protected boolean preserveTemplatesUponCompletion() {
+        return true;
+    }
+
     public UpgradeClusterClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }


### PR DESCRIPTION
This commit preserves templates in preperation for adding some rolling upgrade tests for composable
and component templates.
